### PR TITLE
ci: upgrade actions to Node 24 — eliminate deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,13 @@ on:
     branches: [main]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   PYTHON_VERSION: "3.12"
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
         with:
           args: "check nuri/ tests/ scripts/"
@@ -22,20 +21,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: false
 
       - name: Cache TA-Lib
         id: cache-talib
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         continue-on-error: true
         with:
           path: /tmp/talib-installed
@@ -63,7 +62,7 @@ jobs:
 
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml') }}
@@ -102,7 +101,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,14 +4,11 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   quick-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -50,7 +47,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Summary
- Node.js 20 deprecation warnings 제거
- actions/checkout v4→v5, actions/cache v4→v5, setup-uv v4→v6
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env 제거 (불필요)

## Changes
| Action | Before | After | Node |
|--------|--------|-------|------|
| `actions/checkout` | v4 | **v5** | 24 native |
| `actions/cache` | v4 | **v5** | 24 native |
| `astral-sh/setup-uv` | v4 | **v6** | 24 native |
| `actions/setup-python` | v5 | v5 (유지) | runner forced |
| `actions/setup-node` | v4 | v4 (유지) | runner forced |
| `codecov/codecov-action` | v5 | v5 (유지) | runner forced |
| `actions/github-script` | v7 | v7 (유지) | runner forced |

Node 24 native 버전이 없는 action은 runner가 강제 실행하므로 기능 문제 없음.

## Test plan
- [ ] CI warnings에서 "Node.js 20 is deprecated" 메시지 감소 확인
- [ ] 503 tests passed
- [ ] Coverage ≥ 40%

🤖 Generated with [Claude Code](https://claude.com/claude-code)