### PR TITLE
fix: README stats + deduplicate SPY warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 [![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![Tests](https://img.shields.io/badge/Tests-188_passed-26a69a?logo=pytest&logoColor=white)]()
+[![Tests](https://img.shields.io/badge/Tests-503_passed-26a69a?logo=pytest&logoColor=white)]()
 [![License](https://img.shields.io/badge/License-AGPL_3.0-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/Version-0.1.0-orange)]()
 [![CI](https://img.shields.io/badge/CI-passing-4CAF50?logo=githubactions&logoColor=white)]()
@@ -74,7 +74,7 @@ make full-scan     # 전체 파이프라인 실행 (수집→검증→분류→�
 | `make report-llm` | **리포트 생성.** Qwen3.5 LLM 증거 기반 리포트 |
 | `make backtest-rules` | **규칙 검증.** 기존 vs 규칙 적용 성과 A/B 비교 |
 | `make start` | **개발.** API(:8001) + Dashboard(:3000) 동시 실행 |
-| `make test` | **커밋 전.** pytest 188 tests |
+| `make test` | **커밋 전.** pytest 503 tests (58% coverage) |
 
 </details>
 

--- a/nuri/quant/regime/classifier.py
+++ b/nuri/quant/regime/classifier.py
@@ -197,8 +197,12 @@ def _classify_single(close, sma50, sma200, vix, bb_width, thresholds) -> tuple[s
     return trend, volatility
 
 
+_freshness_warned = False
+
+
 def _check_data_freshness(db_path=None) -> bool:
     """SPY 데이터 신선도 체크 (최대 24시간). 주말/공휴일 감안 72시간 허용."""
+    global _freshness_warned
     from nuri.core.db import query as _query
     rows = _query(
         "SELECT MAX(date) as latest FROM prices WHERE ticker = 'SPY'",
@@ -211,7 +215,9 @@ def _check_data_freshness(db_path=None) -> bool:
     age_hours = (datetime.now() - latest).total_seconds() / 3600
     # 주말 감안: 금요일 데이터 → 월요일 체크 = 72시간
     if age_hours > 72:
-        logger.warning("SPY 데이터 %d시간 경과 (max 72h). 수집 필요: make collect", int(age_hours))
+        if not _freshness_warned:
+            logger.warning("SPY 데이터 %d시간 경과 (max 72h). 수집 필요: make collect", int(age_hours))
+            _freshness_warned = True
         return False
     return True
 


### PR DESCRIPTION
## Summary
- README: 테스트 수 188→503, coverage 58% 반영
- SPY 데이터 경과 warning이 consensus 실행 시 23회 반복 출력 → 1회로 제한

## Changes
| 파일 | 변경 |
|------|------|
| `README.md` | Tests badge 503, `make test` 행 503 tests (58% coverage) |
| `nuri/quant/regime/classifier.py` | `_freshness_warned` flag로 중복 warning 방지 |

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_regime.py` — 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)