### PR TITLE
fix: UTC/KST timezone utility + remove hardcoded exchange rate (Layer 0)

### DIFF
--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -17,23 +17,49 @@ from nuri.core.db import query, query_df
 logger = logging.getLogger(__name__)
 
 
+class StaleExchangeRateError(Exception):
+    """환율 데이터가 DB에 없을 때 발생하는 에러."""
+
+
 def get_exchange_rate() -> float:
-    """USD/KRW 환율 조회. DB에 없으면 기본값 사용."""
+    """USD/KRW 환율 조회. 7일 이상 오래되면 WARNING, DB에 없으면 에러."""
     rows = query(
-        "SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1"
+        "SELECT value, date FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1"
     )
     if rows:
-        return rows[0]["value"]
-    # 폴백: OpenBB로 환율 조회
+        rate = rows[0]["value"]
+        rate_date = rows[0]["date"]
+
+        # 신선도 체크: 7일 초과 시 경고
+        from datetime import datetime
+
+        from nuri.core.timezone import kst_now
+
+        latest = datetime.strptime(rate_date, "%Y-%m-%d")
+        age_days = (kst_now().replace(tzinfo=None) - latest).days
+        if age_days > 7:
+            logger.warning(
+                "USD/KRW 환율 %d일 경과 (날짜: %s, 값: %.1f). "
+                "'make collect'으로 갱신 권장",
+                age_days, rate_date, rate,
+            )
+        return rate
+
+    # DB에 환율 없음 -> OpenBB 시도
     try:
         from openbb import obb
+
         result = obb.currency.price.historical("USDKRW", provider="yfinance", start_date="2026-01-01")
         df = result.to_dataframe()
         if not df.empty:
             return float(df["close"].iloc[-1])
     except Exception:
         pass
-    return 1450.0  # 기본값
+
+    raise StaleExchangeRateError(
+        "USD/KRW 환율을 찾을 수 없습니다. "
+        "'python -m nuri.collectors.macro'로 환율 데이터를 수집하세요."
+    )
 
 
 def analyze_portfolio() -> pd.DataFrame:

--- a/nuri/collectors/base.py
+++ b/nuri/collectors/base.py
@@ -35,8 +35,10 @@ def parse_date(raw: str) -> str | None:
 
 
 def today_str() -> str:
-    """오늘 날짜 YYYY-MM-DD 문자열."""
-    return datetime.now().strftime("%Y-%m-%d")
+    """오늘 날짜 YYYY-MM-DD 문자열 (KST 기준 — Mac Mini가 한국 시간대)."""
+    from nuri.core.timezone import today_kst
+
+    return today_kst()
 
 
 def fetch_json(url: str, params: dict | None = None, headers: dict | None = None, timeout: int = 20) -> dict:

--- a/nuri/collectors/stock.py
+++ b/nuri/collectors/stock.py
@@ -11,7 +11,7 @@ OpenBB가 다중 프로바이더(yfinance, polygon, tiingo 등)를 지원하며,
 """
 import argparse
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 
 import pandas as pd
@@ -44,8 +44,10 @@ class StockCollector(BaseCollector):
 
         self.logger.info(f"수집 대상: {len(tickers)} 미국 종목 ({period})")
 
-        # 기간 계산
-        end_date = datetime.now().strftime("%Y-%m-%d")
+        # 기간 계산 (KST 기준 — 수집은 한국 시간대에서 실행)
+        from nuri.core.timezone import kst_now
+
+        end_date = kst_now().strftime("%Y-%m-%d")
         start_date = self._period_to_start_date(period)
 
         frames = []
@@ -97,8 +99,10 @@ class StockCollector(BaseCollector):
 
     @staticmethod
     def _period_to_start_date(period: str) -> str:
-        """기간 문자열 → 시작 날짜."""
-        now = datetime.now()
+        """기간 문자열 -> 시작 날짜 (KST 기준)."""
+        from nuri.core.timezone import kst_now
+
+        now = kst_now()
         mapping = {
             "1d": 1, "5d": 5, "1mo": 30, "3mo": 90,
             "6mo": 180, "1y": 365, "2y": 730, "3y": 1095,

--- a/nuri/collectors/stock_kr.py
+++ b/nuri/collectors/stock_kr.py
@@ -10,7 +10,7 @@ pykrx는 KRX/네이버 금융 데이터를 사용하며, EOD(종가) 데이터�
 """
 import argparse
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 
 import pandas as pd
@@ -35,8 +35,12 @@ class StockKRCollector(BaseCollector):
 
         self.logger.info(f"수집 대상: {len(tickers)} 한국 종목 ({days}일)")
 
-        end_date = datetime.now().strftime("%Y%m%d")
-        start_date = (datetime.now() - timedelta(days=days)).strftime("%Y%m%d")
+        # KST 기준 날짜 (KRX는 한국 영업일 기준)
+        from nuri.core.timezone import kst_now
+
+        now_kst = kst_now()
+        end_date = now_kst.strftime("%Y%m%d")
+        start_date = (now_kst - timedelta(days=days)).strftime("%Y%m%d")
 
         frames = []
         for ticker_with_suffix in tickers:

--- a/nuri/core/timezone.py
+++ b/nuri/core/timezone.py
@@ -1,0 +1,33 @@
+"""타임존 유틸리티 -- UTC 기반 내부 시간, KST 표시용 변환."""
+from datetime import datetime, timedelta, timezone
+
+KST = timezone(timedelta(hours=9))
+ET = timezone(timedelta(hours=-5))  # EST (DST 미적용 -- 단순화)
+UTC = timezone.utc
+
+
+def utc_now() -> datetime:
+    """현재 UTC 시간."""
+    return datetime.now(UTC)
+
+
+def kst_now() -> datetime:
+    """현재 KST 시간."""
+    return datetime.now(KST)
+
+
+def today_utc() -> str:
+    """오늘 날짜 (UTC) YYYY-MM-DD."""
+    return utc_now().strftime("%Y-%m-%d")
+
+
+def today_kst() -> str:
+    """오늘 날짜 (KST) YYYY-MM-DD."""
+    return kst_now().strftime("%Y-%m-%d")
+
+
+def to_kst(dt: datetime) -> datetime:
+    """UTC datetime -> KST 변환."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(KST)

--- a/nuri/quant/regime/classifier.py
+++ b/nuri/quant/regime/classifier.py
@@ -11,7 +11,6 @@ D-1: 시장 레짐 분류기 — Bull/Bear/Sideways x High/Low Volatility.
 import argparse
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -211,8 +210,12 @@ def _check_data_freshness(db_path=None) -> bool:
     if not rows or not rows[0]["latest"]:
         return False
     from datetime import datetime
+
+    from nuri.core.timezone import kst_now
+
     latest = datetime.strptime(rows[0]["latest"], "%Y-%m-%d")
-    age_hours = (datetime.now() - latest).total_seconds() / 3600
+    # KST 기준으로 신선도 비교 (naive datetime 통일)
+    age_hours = (kst_now().replace(tzinfo=None) - latest).total_seconds() / 3600
     # 주말 감안: 금요일 데이터 → 월요일 체크 = 72시간
     if age_hours > 72:
         if not _freshness_warned:
@@ -449,7 +452,9 @@ if __name__ == "__main__":
         print_history(history)
 
         if history:
-            today = datetime.now().strftime("%Y-%m-%d")
+            from nuri.core.timezone import today_kst
+
+            today = today_kst()
             output_dir = REPORT_DIR / today
             output_dir.mkdir(parents=True, exist_ok=True)
             pd.DataFrame([asdict(s) for s in history]).to_csv(

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -60,7 +60,9 @@ class Certificate:
 
     def __post_init__(self):
         if not self.timestamp:
-            self.timestamp = datetime.now().isoformat()
+            from nuri.core.timezone import kst_now
+
+            self.timestamp = kst_now().isoformat()
 
 
 def _check_position_limits(db_path=None) -> CertCondition:
@@ -204,8 +206,11 @@ def _check_data_freshness(db_path=None) -> CertCondition:
     rows = query("SELECT MAX(date) as latest FROM prices WHERE ticker='SPY'", db_path=db_path)
     if not rows or not rows[0]["latest"]:
         return CertCondition("data_fresh", "데이터 신선도 (72h)", False, "SPY 데이터 없음")
+    from nuri.core.timezone import kst_now
+
     latest = datetime.strptime(rows[0]["latest"], "%Y-%m-%d")
-    age_hours = (datetime.now() - latest).total_seconds() / 3600
+    # KST 기준으로 신선도 비교 (naive datetime 통일)
+    age_hours = (kst_now().replace(tzinfo=None) - latest).total_seconds() / 3600
     if age_hours <= 72:
         return CertCondition("data_fresh", "데이터 신선도 (72h)", True,
                             f"SPY {age_hours:.0f}시간 전")
@@ -250,8 +255,10 @@ def certify(db_path=None) -> Certificate:
     certified = failed == 0
     score = round(passed / total * 100, 1) if total > 0 else 0
 
+    from nuri.core.timezone import kst_now
+
     return Certificate(
-        timestamp=datetime.now().isoformat(),
+        timestamp=kst_now().isoformat(),
         total_conditions=total,
         passed=passed,
         failed=failed,

--- a/nuri/trading/recommend/tracker.py
+++ b/nuri/trading/recommend/tracker.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 def save_recommendations(candidates=None, actions=None, db_path=None) -> int:
     """E-1 후보 + E-2 액션을 recommendations 테이블에 저장."""
-    today = datetime.now().strftime("%Y-%m-%d")
+    from nuri.core.timezone import today_kst
+
+    today = today_kst()
     records = []
 
     # E-1 후보에서 regime_fit인 것만
@@ -84,7 +86,10 @@ def save_recommendations(candidates=None, actions=None, db_path=None) -> int:
 
 def track_outcomes(db_path=None) -> int:
     """과거 추천의 30/60/90일 수익률을 업데이트."""
-    now = datetime.now()
+    from nuri.core.timezone import kst_now
+
+    # naive datetime으로 통일 (DB 날짜는 naive)
+    now = kst_now().replace(tzinfo=None)
     updated = 0
 
     # 아직 추적 안 된 추천 조회

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -40,8 +40,11 @@ def populated_db(db_path):
     ])
     upsert_prices(prices, db_path)
 
-    # VIX 정상 범위
-    upsert_macro([{"indicator": "vix", "date": today, "value": 18.0, "source": "test"}], db_path)
+    # VIX 정상 범위 + 환율
+    upsert_macro([
+        {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
+        {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
+    ], db_path)
 
     return db_path
 

--- a/tests/test_coverage_extra.py
+++ b/tests/test_coverage_extra.py
@@ -41,6 +41,7 @@ def market_db(db_path):
     upsert_macro([
         {"indicator": "vix", "date": today, "value": 16.0, "source": "test"},
         {"indicator": "fear_greed", "date": today, "value": 60.0, "source": "test"},
+        {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
     ], db_path)
     return db_path
 

--- a/tests/test_coverage_push.py
+++ b/tests/test_coverage_push.py
@@ -37,9 +37,11 @@ def price_db(db_path):
         upsert_prices(df, db_path)
 
     from datetime import datetime
+    today = datetime.now().strftime("%Y-%m-%d")
     upsert_macro([
-        {"indicator": "vix", "date": datetime.now().strftime("%Y-%m-%d"), "value": 16.0, "source": "test"},
-        {"indicator": "fear_greed", "date": datetime.now().strftime("%Y-%m-%d"), "value": 55.0, "source": "test"},
+        {"indicator": "vix", "date": today, "value": 16.0, "source": "test"},
+        {"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"},
+        {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
     ], db_path)
     return db_path
 

--- a/tests/test_sixty_percent.py
+++ b/tests/test_sixty_percent.py
@@ -73,6 +73,7 @@ def full_db(db_path):
         {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
         {"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"},
         {"indicator": "sp500_yoy", "date": today, "value": 15.0, "source": "test"},
+        {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
     ], db_path)
 
     return db_path

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,96 @@
+"""nuri/core/timezone.py 테스트 — UTC/KST 타임존 유틸리티."""
+from datetime import datetime, timedelta
+
+from nuri.core.timezone import ET, KST, UTC, kst_now, to_kst, today_kst, today_utc, utc_now
+
+
+class TestTimezoneConstants:
+    def test_kst_offset(self):
+        """KST는 UTC+9."""
+        assert KST.utcoffset(None) == timedelta(hours=9)
+
+    def test_et_offset(self):
+        """ET는 UTC-5 (EST)."""
+        assert ET.utcoffset(None) == timedelta(hours=-5)
+
+    def test_utc_offset(self):
+        """UTC는 오프셋 0."""
+        assert UTC.utcoffset(None) == timedelta(0)
+
+
+class TestUtcNow:
+    def test_returns_aware_datetime(self):
+        """utc_now()는 timezone-aware datetime을 반환."""
+        dt = utc_now()
+        assert dt.tzinfo is not None
+        assert dt.tzinfo == UTC
+
+    def test_close_to_real_time(self):
+        """utc_now()는 실제 현재 시간과 거의 동일."""
+        dt = utc_now()
+        ref = datetime.now(UTC)
+        diff = abs((ref - dt).total_seconds())
+        assert diff < 1.0
+
+
+class TestKstNow:
+    def test_returns_aware_datetime(self):
+        """kst_now()는 timezone-aware datetime을 반환."""
+        dt = kst_now()
+        assert dt.tzinfo is not None
+
+    def test_kst_offset_from_utc(self):
+        """kst_now()는 utc_now()보다 9시간 앞."""
+        utc = utc_now()
+        kst = kst_now()
+        # 같은 시점이므로 UTC timestamp 기준 1초 이내 차이
+        diff = abs(utc.timestamp() - kst.timestamp())
+        assert diff < 1.0
+        # KST 시간은 UTC보다 9시간 큰 값
+        kst_as_utc = kst.astimezone(UTC)
+        assert abs((kst_as_utc - utc).total_seconds()) < 1.0
+
+
+class TestTodayFunctions:
+    def test_today_utc_format(self):
+        """today_utc()는 YYYY-MM-DD 형식."""
+        result = today_utc()
+        assert len(result) == 10
+        datetime.strptime(result, "%Y-%m-%d")
+
+    def test_today_kst_format(self):
+        """today_kst()는 YYYY-MM-DD 형식."""
+        result = today_kst()
+        assert len(result) == 10
+        datetime.strptime(result, "%Y-%m-%d")
+
+
+class TestToKst:
+    def test_naive_datetime_treated_as_utc(self):
+        """tzinfo 없는 datetime은 UTC로 간주."""
+        naive = datetime(2026, 1, 1, 0, 0, 0)
+        kst = to_kst(naive)
+        assert kst.tzinfo is not None
+        assert kst.hour == 9  # UTC 0시 -> KST 9시
+
+    def test_utc_to_kst_conversion(self):
+        """UTC datetime -> KST 변환."""
+        utc_dt = datetime(2026, 3, 15, 15, 0, 0, tzinfo=UTC)
+        kst = to_kst(utc_dt)
+        assert kst.hour == 0  # UTC 15시 -> KST 다음날 0시
+        assert kst.day == 16
+
+    def test_already_kst_no_change(self):
+        """이미 KST인 datetime은 값 유지."""
+        kst_dt = datetime(2026, 1, 1, 9, 0, 0, tzinfo=KST)
+        result = to_kst(kst_dt)
+        assert result.hour == 9
+        assert result.day == 1
+
+    def test_et_to_kst_conversion(self):
+        """ET -> KST 변환 (14시간 차이)."""
+        et_dt = datetime(2026, 3, 15, 10, 0, 0, tzinfo=ET)
+        kst = to_kst(et_dt)
+        # ET 10:00 = UTC 15:00 = KST 00:00 (다음날)
+        assert kst.hour == 0
+        assert kst.day == 16


### PR DESCRIPTION
## Summary
- `nuri/core/timezone.py` 신규: `utc_now()`, `kst_now()`, `today_kst()`, `to_kst()` 유틸리티
- `datetime.now()` 6곳 → 명시적 KST 타임존으로 교체 (base.py, stock.py, stock_kr.py, tracker.py, classifier.py, certification.py)
- 환율 하드코딩 `1450.0` 제거 → 7일 초과 경고, 데이터 없으면 `StaleExchangeRateError`
- 13개 타임존 유틸리티 테스트

## Test plan
- [x] 516 tests passed (13 new)
- [x] `today_utc()=03-29`, `today_kst()=03-30` 날짜 차이 검증

Addresses #33 (tasks 0-1, 0-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)