### PR TITLE
feat: SIEGE event journal + data freshness + pipeline orchestration (Layer 2a)

### DIFF
--- a/nuri/core/db.py
+++ b/nuri/core/db.py
@@ -442,6 +442,20 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
     (6, "add scoring_detail to recommendations", """
         ALTER TABLE recommendations ADD COLUMN scoring_detail TEXT;
     """),
+    (7, "create pipeline_events table", """
+        CREATE TABLE IF NOT EXISTS pipeline_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+            event_type TEXT NOT NULL,
+            step TEXT,
+            payload TEXT,
+            duration_ms INTEGER,
+            record_count INTEGER,
+            causation_id INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_pipeline_events_step ON pipeline_events(step, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_pipeline_events_type ON pipeline_events(event_type, timestamp);
+    """),
 ]
 
 

--- a/nuri/core/events.py
+++ b/nuri/core/events.py
@@ -1,0 +1,144 @@
+"""파이프라인 이벤트 저널 — SIEGE Event Journal 패턴.
+
+모든 파이프라인 상태 전환을 append-only 기록.
+대시보드와 Pipeline UI는 이 이벤트의 projection으로 동작.
+"""
+import json
+from pathlib import Path
+from typing import Optional
+
+from nuri.core.db import get_db, query
+
+# 허용 이벤트 타입
+EVENT_TYPES = {
+    "step_started",
+    "step_completed",
+    "step_failed",
+    "step_blocked",
+    "gate_evaluated",
+    "regime_changed",
+    "certification_result",
+    "conflict_detected",
+    "drift_detected",
+}
+
+# 6-step 파이프라인
+PIPELINE_STEPS = {"collect", "validate", "classify", "diagnose", "recommend", "track"}
+
+
+def emit_event(
+    event_type: str,
+    step: str | None = None,
+    payload: dict | str | None = None,
+    duration_ms: int | None = None,
+    record_count: int | None = None,
+    causation_id: int | None = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """이벤트를 pipeline_events 테이블에 기록하고 event ID 반환."""
+    payload_str = None
+    if payload is not None:
+        payload_str = json.dumps(payload, ensure_ascii=False) if isinstance(payload, dict) else str(payload)
+
+    with get_db(db_path) as conn:
+        cursor = conn.execute(
+            """INSERT INTO pipeline_events (event_type, step, payload, duration_ms, record_count, causation_id)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (event_type, step, payload_str, duration_ms, record_count, causation_id),
+        )
+        return cursor.lastrowid
+
+
+def get_step_status(step: str, db_path: Optional[Path] = None) -> dict:
+    """특정 스텝의 최신 이벤트 조회 → {status, timestamp, payload}."""
+    rows = query(
+        """SELECT event_type, timestamp, payload
+           FROM pipeline_events
+           WHERE step = ?
+           ORDER BY timestamp DESC, id DESC
+           LIMIT 1""",
+        (step,),
+        db_path,
+    )
+    if not rows:
+        return {"step": step, "status": "unknown", "timestamp": None, "payload": None}
+
+    row = rows[0]
+    # event_type → status 매핑
+    status_map = {
+        "step_started": "running",
+        "step_completed": "completed",
+        "step_failed": "failed",
+        "step_blocked": "blocked",
+    }
+    status = status_map.get(row["event_type"], row["event_type"])
+    payload = json.loads(row["payload"]) if row["payload"] else None
+    return {"step": step, "status": status, "timestamp": row["timestamp"], "payload": payload}
+
+
+def get_pipeline_status(db_path: Optional[Path] = None) -> dict:
+    """전체 6-step 파이프라인 상태 조회."""
+    result = {}
+    for step in PIPELINE_STEPS:
+        result[step] = get_step_status(step, db_path)
+    return result
+
+
+def get_timeline(
+    limit: int = 50,
+    step: str | None = None,
+    db_path: Optional[Path] = None,
+) -> list[dict]:
+    """최근 이벤트 타임라인 (timestamp desc)."""
+    if step:
+        rows = query(
+            """SELECT id, timestamp, event_type, step, payload, duration_ms, record_count, causation_id
+               FROM pipeline_events
+               WHERE step = ?
+               ORDER BY timestamp DESC, id DESC
+               LIMIT ?""",
+            (step, limit),
+            db_path,
+        )
+    else:
+        rows = query(
+            """SELECT id, timestamp, event_type, step, payload, duration_ms, record_count, causation_id
+               FROM pipeline_events
+               ORDER BY timestamp DESC, id DESC
+               LIMIT ?""",
+            (limit,),
+            db_path,
+        )
+    result = []
+    for row in rows:
+        entry = dict(row)
+        if entry["payload"]:
+            try:
+                entry["payload"] = json.loads(entry["payload"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        result.append(entry)
+    return result
+
+
+def get_step_history(step: str, limit: int = 10, db_path: Optional[Path] = None) -> list[dict]:
+    """특정 스텝의 실행 이력 (완료/실패 이벤트만)."""
+    rows = query(
+        """SELECT id, timestamp, event_type, payload, duration_ms, record_count, causation_id
+           FROM pipeline_events
+           WHERE step = ? AND event_type IN ('step_completed', 'step_failed')
+           ORDER BY timestamp DESC, id DESC
+           LIMIT ?""",
+        (step, limit),
+        db_path,
+    )
+    result = []
+    for row in rows:
+        entry = dict(row)
+        if entry["payload"]:
+            try:
+                entry["payload"] = json.loads(entry["payload"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        result.append(entry)
+    return result

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -1,0 +1,135 @@
+"""데이터 신선도 체크 — Dagster PASS/WARN/FAIL + Palantir TSLU 패턴."""
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from nuri.core.db import query
+from nuri.core.timezone import KST, kst_now
+
+FRESHNESS_POLICIES = {
+    "prices": {
+        "query": "SELECT MAX(date) FROM prices WHERE ticker = 'SPY'",
+        "warn_hours": 18,
+        "fail_hours": 30,
+        "label": "주가 데이터",
+    },
+    "macro_vix": {
+        "query": "SELECT MAX(date) FROM macro WHERE indicator = 'vix'",
+        "warn_hours": 24,
+        "fail_hours": 72,
+        "label": "VIX",
+    },
+    "macro_fear_greed": {
+        "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
+        "warn_hours": 24,
+        "fail_hours": 48,
+        "label": "Fear & Greed",
+    },
+    "consensus": {
+        "query": "SELECT MAX(timestamp) FROM pipeline_events WHERE step = 'diagnose' AND event_type = 'step_completed'",
+        "warn_hours": 24,
+        "fail_hours": 48,
+        "label": "에이전트 합의",
+    },
+    "certification": {
+        "query": "SELECT MAX(timestamp) FROM pipeline_events WHERE event_type = 'certification_result'",
+        "warn_hours": 24,
+        "fail_hours": 48,
+        "label": "SIEGE 인증",
+    },
+}
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """날짜/시간 문자열 파싱 (YYYY-MM-DD 또는 ISO datetime)."""
+    # ISO datetime (YYYY-MM-DD HH:MM:SS 또는 YYYY-MM-DDTHH:MM:SS)
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(value.strip(), fmt)
+            # 타임존이 없으면 KST로 간주
+            return dt.replace(tzinfo=KST)
+        except ValueError:
+            continue
+    raise ValueError(f"지원하지 않는 날짜 형식: {value}")
+
+
+def check_freshness(key: str, db_path: Optional[Path] = None) -> dict:
+    """단일 데이터 소스의 신선도 체크."""
+    policy = FRESHNESS_POLICIES[key]
+    now = kst_now()
+
+    try:
+        rows = query(policy["query"], db_path=db_path)
+    except Exception:
+        return {
+            "key": key,
+            "label": policy["label"],
+            "status": "FAIL",
+            "last_updated": None,
+            "age_hours": None,
+            "message": "쿼리 실행 실패",
+        }
+
+    # 결과에서 값 추출 (MAX() 결과는 첫 번째 컬럼)
+    value = None
+    if rows:
+        row = rows[0]
+        # dict에서 첫 번째 값 추출
+        value = list(row.values())[0]
+
+    if value is None:
+        return {
+            "key": key,
+            "label": policy["label"],
+            "status": "FAIL",
+            "last_updated": None,
+            "age_hours": None,
+            "message": "데이터 없음",
+        }
+
+    try:
+        last_dt = _parse_timestamp(str(value))
+    except ValueError:
+        return {
+            "key": key,
+            "label": policy["label"],
+            "status": "FAIL",
+            "last_updated": str(value),
+            "age_hours": None,
+            "message": f"날짜 파싱 실패: {value}",
+        }
+
+    age_hours = (now - last_dt).total_seconds() / 3600
+
+    if age_hours <= policy["warn_hours"]:
+        status = "PASS"
+        message = f"최신 ({age_hours:.1f}h)"
+    elif age_hours <= policy["fail_hours"]:
+        status = "WARN"
+        message = f"업데이트 필요 ({age_hours:.1f}h)"
+    else:
+        status = "FAIL"
+        message = f"오래됨 ({age_hours:.1f}h)"
+
+    return {
+        "key": key,
+        "label": policy["label"],
+        "status": status,
+        "last_updated": str(value),
+        "age_hours": round(age_hours, 1),
+        "message": message,
+    }
+
+
+def check_all_freshness(db_path: Optional[Path] = None) -> list[dict]:
+    """모든 정책에 대한 신선도 체크."""
+    return [check_freshness(key, db_path) for key in FRESHNESS_POLICIES]
+
+
+def get_freshness_summary(db_path: Optional[Path] = None) -> dict:
+    """신선도 요약 → {pass: N, warn: N, fail: N, details: [...]}."""
+    details = check_all_freshness(db_path)
+    counts = {"pass": 0, "warn": 0, "fail": 0}
+    for d in details:
+        counts[d["status"].lower()] += 1
+    return {**counts, "details": details}

--- a/nuri/core/pipeline.py
+++ b/nuri/core/pipeline.py
@@ -1,0 +1,77 @@
+"""파이프라인 스텝 의존성 + 실행 래퍼.
+
+6-step 파이프라인: Collect → Validate → Classify → Diagnose → Recommend → Track
+각 스텝은 의존성 충족 시에만 실행 가능.
+"""
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Optional
+
+from nuri.core.events import emit_event, get_step_status
+
+STEP_DEPENDENCIES: dict[str, list[str]] = {
+    "collect": [],
+    "validate": ["collect"],
+    "classify": ["collect"],
+    "diagnose": ["collect", "validate", "classify"],
+    "recommend": ["diagnose"],
+    "track": ["recommend"],
+}
+
+
+def check_dependencies(step: str, db_path: Optional[Path] = None) -> dict:
+    """스텝 의존성 확인 → {ready: bool, missing: [...], details: {...}}."""
+    deps = STEP_DEPENDENCIES.get(step, [])
+    if not deps:
+        return {"ready": True, "missing": [], "details": {}}
+
+    missing = []
+    details = {}
+    for dep in deps:
+        status = get_step_status(dep, db_path)
+        details[dep] = status
+        if status["status"] != "completed":
+            missing.append(dep)
+
+    return {"ready": len(missing) == 0, "missing": missing, "details": details}
+
+
+def run_step(step: str, func: Callable[..., Any], db_path: Optional[Path] = None, **kwargs) -> dict:
+    """파이프라인 스텝 실행 + 이벤트 기록 + 의존성 체크."""
+    # 1. 의존성 체크
+    deps = check_dependencies(step, db_path)
+    if not deps["ready"]:
+        emit_event("step_blocked", step, {"blocked_by": deps["missing"]}, db_path=db_path)
+        return {"status": "blocked", "missing": deps["missing"]}
+
+    # 2. 시작 이벤트
+    start_id = emit_event("step_started", step, db_path=db_path)
+    start_time = time.time()
+
+    # 3. 실행
+    try:
+        result = func(**kwargs)
+        duration = int((time.time() - start_time) * 1000)
+        record_count = result if isinstance(result, int) else None
+        emit_event(
+            "step_completed",
+            step,
+            payload={"summary": str(result)[:500] if result else None},
+            duration_ms=duration,
+            record_count=record_count,
+            causation_id=start_id,
+            db_path=db_path,
+        )
+        return {"status": "success", "duration_ms": duration, "result": result}
+    except Exception as e:
+        duration = int((time.time() - start_time) * 1000)
+        emit_event(
+            "step_failed",
+            step,
+            payload={"error": str(e)[:500]},
+            duration_ms=duration,
+            causation_id=start_id,
+            db_path=db_path,
+        )
+        return {"status": "failed", "error": str(e)}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -177,9 +177,9 @@ class TestSchemaMigration:
         assert len(tables) == 1
 
     def test_get_schema_version_initial(self, db_path):
-        """마이그레이션 적용 후 최신 버전."""
+        """마이그레이션 적용 후 최신 버전 — MAX(version) 기준."""
         from nuri.core.db import _MIGRATIONS
-        expected = len(_MIGRATIONS)
+        expected = max(v for v, _, _ in _MIGRATIONS)
         assert get_schema_version(db_path) == expected
 
     def test_idempotent_with_migrations(self, db_path):

--- a/tests/test_pipeline_events.py
+++ b/tests/test_pipeline_events.py
@@ -1,0 +1,430 @@
+"""파이프라인 이벤트 저널 + 신선도 + 의존성 + run_step 테스트."""
+from datetime import timedelta
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.core.events import (
+    emit_event,
+    get_pipeline_status,
+    get_step_history,
+    get_step_status,
+    get_timeline,
+)
+from nuri.core.freshness import (
+    check_all_freshness,
+    check_freshness,
+    get_freshness_summary,
+)
+from nuri.core.pipeline import check_dependencies, run_step
+from nuri.core.timezone import kst_now
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """임시 DB 경로 픽스처."""
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+# ═══════════════════════════════════════════════════════
+# emit_event + get_timeline
+# ═══════════════════════════════════════════════════════
+
+
+class TestEmitEvent:
+    def test_emit_returns_id(self, db_path):
+        """emit_event가 양수 event ID를 반환."""
+        event_id = emit_event("step_started", "collect", db_path=db_path)
+        assert event_id > 0
+
+    def test_emit_multiple_sequential_ids(self, db_path):
+        """여러 이벤트의 ID가 순차 증가."""
+        id1 = emit_event("step_started", "collect", db_path=db_path)
+        id2 = emit_event("step_completed", "collect", duration_ms=100, db_path=db_path)
+        assert id2 > id1
+
+    def test_emit_with_payload(self, db_path):
+        """payload가 JSON으로 저장/조회."""
+        emit_event("step_completed", "collect", payload={"rows": 42}, db_path=db_path)
+        timeline = get_timeline(limit=1, db_path=db_path)
+        assert timeline[0]["payload"] == {"rows": 42}
+
+    def test_emit_with_string_payload(self, db_path):
+        """문자열 payload도 저장 가능."""
+        emit_event("step_failed", "collect", payload="error message", db_path=db_path)
+        timeline = get_timeline(limit=1, db_path=db_path)
+        assert timeline[0]["payload"] == "error message"
+
+    def test_emit_with_all_fields(self, db_path):
+        """모든 필드가 정상 저장."""
+        event_id = emit_event(
+            "step_completed",
+            "collect",
+            payload={"summary": "ok"},
+            duration_ms=1500,
+            record_count=100,
+            causation_id=1,
+            db_path=db_path,
+        )
+        timeline = get_timeline(limit=1, db_path=db_path)
+        evt = timeline[0]
+        assert evt["id"] == event_id
+        assert evt["event_type"] == "step_completed"
+        assert evt["step"] == "collect"
+        assert evt["duration_ms"] == 1500
+        assert evt["record_count"] == 100
+        assert evt["causation_id"] == 1
+
+
+class TestGetTimeline:
+    def test_timeline_order_desc(self, db_path):
+        """타임라인이 최신순으로 정렬."""
+        emit_event("step_started", "collect", db_path=db_path)
+        emit_event("step_completed", "collect", db_path=db_path)
+        emit_event("step_started", "validate", db_path=db_path)
+        timeline = get_timeline(db_path=db_path)
+        assert len(timeline) == 3
+        # ID 기준 내림차순 (최신이 먼저)
+        assert timeline[0]["step"] == "validate"
+        assert timeline[1]["step"] == "collect"
+        assert timeline[1]["event_type"] == "step_completed"
+
+    def test_timeline_limit(self, db_path):
+        """limit 파라미터 작동."""
+        for i in range(10):
+            emit_event("step_started", "collect", db_path=db_path)
+        timeline = get_timeline(limit=3, db_path=db_path)
+        assert len(timeline) == 3
+
+    def test_timeline_filter_by_step(self, db_path):
+        """step 필터링 작동."""
+        emit_event("step_started", "collect", db_path=db_path)
+        emit_event("step_started", "validate", db_path=db_path)
+        emit_event("step_completed", "collect", db_path=db_path)
+        timeline = get_timeline(step="collect", db_path=db_path)
+        assert len(timeline) == 2
+        assert all(e["step"] == "collect" for e in timeline)
+
+    def test_timeline_empty(self, db_path):
+        """이벤트 없으면 빈 리스트."""
+        timeline = get_timeline(db_path=db_path)
+        assert timeline == []
+
+
+# ═══════════════════════════════════════════════════════
+# get_step_status
+# ═══════════════════════════════════════════════════════
+
+
+class TestGetStepStatus:
+    def test_returns_latest(self, db_path):
+        """최신 이벤트의 status 반환."""
+        emit_event("step_started", "collect", db_path=db_path)
+        emit_event("step_completed", "collect", duration_ms=500, db_path=db_path)
+        status = get_step_status("collect", db_path)
+        assert status["status"] == "completed"
+        assert status["step"] == "collect"
+
+    def test_unknown_when_no_events(self, db_path):
+        """이벤트 없으면 unknown."""
+        status = get_step_status("collect", db_path)
+        assert status["status"] == "unknown"
+        assert status["timestamp"] is None
+
+    def test_running_status(self, db_path):
+        """started 이벤트만 있으면 running."""
+        emit_event("step_started", "collect", db_path=db_path)
+        status = get_step_status("collect", db_path)
+        assert status["status"] == "running"
+
+    def test_failed_status(self, db_path):
+        """failed 이벤트 반영."""
+        emit_event("step_started", "collect", db_path=db_path)
+        emit_event("step_failed", "collect", payload={"error": "timeout"}, db_path=db_path)
+        status = get_step_status("collect", db_path)
+        assert status["status"] == "failed"
+        assert status["payload"]["error"] == "timeout"
+
+
+# ═══════════════════════════════════════════════════════
+# get_pipeline_status
+# ═══════════════════════════════════════════════════════
+
+
+class TestGetPipelineStatus:
+    def test_all_six_steps(self, db_path):
+        """6개 스텝 전체 상태 반환."""
+        status = get_pipeline_status(db_path)
+        assert len(status) == 6
+        expected_steps = {"collect", "validate", "classify", "diagnose", "recommend", "track"}
+        assert set(status.keys()) == expected_steps
+
+    def test_mixed_states(self, db_path):
+        """각 스텝별 상태가 독립적."""
+        emit_event("step_completed", "collect", db_path=db_path)
+        emit_event("step_failed", "validate", db_path=db_path)
+        status = get_pipeline_status(db_path)
+        assert status["collect"]["status"] == "completed"
+        assert status["validate"]["status"] == "failed"
+        assert status["classify"]["status"] == "unknown"
+
+
+# ═══════════════════════════════════════════════════════
+# get_step_history
+# ═══════════════════════════════════════════════════════
+
+
+class TestGetStepHistory:
+    def test_only_completed_and_failed(self, db_path):
+        """완료/실패 이벤트만 포함."""
+        emit_event("step_started", "collect", db_path=db_path)
+        emit_event("step_completed", "collect", duration_ms=100, db_path=db_path)
+        emit_event("step_started", "collect", db_path=db_path)
+        emit_event("step_failed", "collect", payload={"error": "err"}, db_path=db_path)
+        history = get_step_history("collect", db_path=db_path)
+        assert len(history) == 2
+        assert all(h["event_type"] in ("step_completed", "step_failed") for h in history)
+
+    def test_history_limit(self, db_path):
+        """limit 작동."""
+        for _ in range(5):
+            emit_event("step_completed", "collect", db_path=db_path)
+        history = get_step_history("collect", limit=2, db_path=db_path)
+        assert len(history) == 2
+
+
+# ═══════════════════════════════════════════════════════
+# check_freshness
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckFreshness:
+    def test_pass_status(self, db_path):
+        """최근 데이터 → PASS."""
+        now = kst_now()
+        date_str = now.strftime("%Y-%m-%d")
+        # prices 테이블에 SPY 데이터 삽입
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("SPY", date_str, 500.0),
+            )
+        result = check_freshness("prices", db_path)
+        assert result["status"] == "PASS"
+        assert result["key"] == "prices"
+        assert result["age_hours"] is not None
+        assert result["age_hours"] < 24
+
+    def test_warn_status(self, db_path):
+        """warn_hours 초과 → WARN."""
+        # 20시간 전 데이터 (prices warn_hours=18)
+        now = kst_now()
+        old_date = (now - timedelta(hours=20)).strftime("%Y-%m-%d %H:%M:%S")
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("SPY", old_date, 500.0),
+            )
+        result = check_freshness("prices", db_path)
+        assert result["status"] == "WARN"
+
+    def test_fail_status(self, db_path):
+        """fail_hours 초과 → FAIL."""
+        # 48시간 전 데이터 (prices fail_hours=30)
+        now = kst_now()
+        old_date = (now - timedelta(hours=48)).strftime("%Y-%m-%d %H:%M:%S")
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("SPY", old_date, 500.0),
+            )
+        result = check_freshness("prices", db_path)
+        assert result["status"] == "FAIL"
+
+    def test_fail_no_data(self, db_path):
+        """데이터 없음 → FAIL."""
+        result = check_freshness("prices", db_path)
+        assert result["status"] == "FAIL"
+        assert result["last_updated"] is None
+        assert result["message"] == "데이터 없음"
+
+    def test_consensus_freshness(self, db_path):
+        """pipeline_events 기반 consensus 신선도 체크."""
+        emit_event("step_completed", "diagnose", db_path=db_path)
+        result = check_freshness("consensus", db_path)
+        assert result["status"] == "PASS"
+        assert result["key"] == "consensus"
+
+    def test_certification_freshness_fail(self, db_path):
+        """certification 이벤트 없음 → FAIL."""
+        result = check_freshness("certification", db_path)
+        assert result["status"] == "FAIL"
+
+
+class TestCheckAllFreshness:
+    def test_returns_all_policies(self, db_path):
+        """모든 정책 결과 반환."""
+        results = check_all_freshness(db_path)
+        assert len(results) == 5
+        keys = {r["key"] for r in results}
+        assert keys == {"prices", "macro_vix", "macro_fear_greed", "consensus", "certification"}
+
+
+class TestGetFreshnessSummary:
+    def test_summary_counts(self, db_path):
+        """pass/warn/fail 카운트 합계."""
+        summary = get_freshness_summary(db_path)
+        assert summary["pass"] + summary["warn"] + summary["fail"] == 5
+        assert len(summary["details"]) == 5
+
+    def test_all_fail_when_empty(self, db_path):
+        """빈 DB → 전부 FAIL."""
+        summary = get_freshness_summary(db_path)
+        assert summary["fail"] == 5
+        assert summary["pass"] == 0
+        assert summary["warn"] == 0
+
+
+# ═══════════════════════════════════════════════════════
+# check_dependencies
+# ═══════════════════════════════════════════════════════
+
+
+class TestCheckDependencies:
+    def test_collect_no_deps(self, db_path):
+        """collect는 의존성 없음 → 항상 ready."""
+        result = check_dependencies("collect", db_path)
+        assert result["ready"] is True
+        assert result["missing"] == []
+
+    def test_validate_needs_collect(self, db_path):
+        """validate는 collect 완료 필요."""
+        result = check_dependencies("validate", db_path)
+        assert result["ready"] is False
+        assert "collect" in result["missing"]
+
+    def test_validate_ready_after_collect(self, db_path):
+        """collect 완료 후 validate가 ready."""
+        emit_event("step_completed", "collect", db_path=db_path)
+        result = check_dependencies("validate", db_path)
+        assert result["ready"] is True
+        assert result["missing"] == []
+
+    def test_diagnose_needs_three(self, db_path):
+        """diagnose는 collect + validate + classify 필요."""
+        result = check_dependencies("diagnose", db_path)
+        assert result["ready"] is False
+        assert set(result["missing"]) == {"collect", "validate", "classify"}
+
+    def test_diagnose_partially_ready(self, db_path):
+        """일부 의존성만 충족 → 여전히 blocked."""
+        emit_event("step_completed", "collect", db_path=db_path)
+        emit_event("step_completed", "validate", db_path=db_path)
+        result = check_dependencies("diagnose", db_path)
+        assert result["ready"] is False
+        assert result["missing"] == ["classify"]
+
+    def test_diagnose_fully_ready(self, db_path):
+        """모든 의존성 충족 → ready."""
+        emit_event("step_completed", "collect", db_path=db_path)
+        emit_event("step_completed", "validate", db_path=db_path)
+        emit_event("step_completed", "classify", db_path=db_path)
+        result = check_dependencies("diagnose", db_path)
+        assert result["ready"] is True
+
+    def test_failed_dep_not_ready(self, db_path):
+        """의존성이 failed면 ready 아님."""
+        emit_event("step_failed", "collect", db_path=db_path)
+        result = check_dependencies("validate", db_path)
+        assert result["ready"] is False
+        assert "collect" in result["missing"]
+
+
+# ═══════════════════════════════════════════════════════
+# run_step
+# ═══════════════════════════════════════════════════════
+
+
+class TestRunStep:
+    def test_success_path(self, db_path):
+        """정상 실행 → success + 이벤트 2개 (started + completed)."""
+        def my_func():
+            return 42
+
+        result = run_step("collect", my_func, db_path=db_path)
+        assert result["status"] == "success"
+        assert result["result"] == 42
+        assert "duration_ms" in result
+
+        # 이벤트 확인
+        timeline = get_timeline(db_path=db_path)
+        assert len(timeline) == 2
+        assert timeline[0]["event_type"] == "step_completed"
+        assert timeline[1]["event_type"] == "step_started"
+
+    def test_success_with_int_result_records_count(self, db_path):
+        """int 결과 → record_count에 기록."""
+        def my_func():
+            return 100
+
+        run_step("collect", my_func, db_path=db_path)
+        timeline = get_timeline(db_path=db_path)
+        completed = [e for e in timeline if e["event_type"] == "step_completed"][0]
+        assert completed["record_count"] == 100
+
+    def test_failure_path(self, db_path):
+        """예외 발생 → failed + 이벤트 2개 (started + failed)."""
+        def failing_func():
+            raise ValueError("something broke")
+
+        result = run_step("collect", failing_func, db_path=db_path)
+        assert result["status"] == "failed"
+        assert "something broke" in result["error"]
+
+        timeline = get_timeline(db_path=db_path)
+        assert len(timeline) == 2
+        assert timeline[0]["event_type"] == "step_failed"
+        assert timeline[1]["event_type"] == "step_started"
+
+    def test_blocked_path(self, db_path):
+        """의존성 미충족 → blocked."""
+        def my_func():
+            return "should not run"
+
+        result = run_step("validate", my_func, db_path=db_path)
+        assert result["status"] == "blocked"
+        assert "collect" in result["missing"]
+
+        # blocked 이벤트 확인
+        timeline = get_timeline(db_path=db_path)
+        assert len(timeline) == 1
+        assert timeline[0]["event_type"] == "step_blocked"
+
+    def test_kwargs_passed_to_func(self, db_path):
+        """kwargs가 func에 전달."""
+        def my_func(x, y):
+            return x + y
+
+        result = run_step("collect", my_func, db_path=db_path, x=3, y=7)
+        assert result["status"] == "success"
+        assert result["result"] == 10
+
+    def test_causation_id_links(self, db_path):
+        """completed 이벤트의 causation_id가 started ID와 연결."""
+        def my_func():
+            return "ok"
+
+        run_step("collect", my_func, db_path=db_path)
+        timeline = get_timeline(db_path=db_path)
+        completed = [e for e in timeline if e["event_type"] == "step_completed"][0]
+        started = [e for e in timeline if e["event_type"] == "step_started"][0]
+        assert completed["causation_id"] == started["id"]
+
+    def test_chained_steps(self, db_path):
+        """collect → validate 순서대로 실행 가능."""
+        run_step("collect", lambda: 10, db_path=db_path)
+        result = run_step("validate", lambda: 5, db_path=db_path)
+        assert result["status"] == "success"
+        assert result["result"] == 5


### PR DESCRIPTION
## Summary
- `pipeline_events` 테이블 (append-only): step_started/completed/failed/blocked + causation_id
- `core/events.py`: emit_event(), get_pipeline_status(), get_timeline(), get_step_history()
- `core/freshness.py`: Dagster PASS/WARN/FAIL 패턴, 5개 데이터 소스 SLA 체크
- `core/pipeline.py`: STEP_DEPENDENCIES DAG, check_dependencies(), run_step() wrapper
- DB 마이그레이션 v7 (pipeline_events + indexes)
- 40개 테스트

## Test plan
- [x] 543 tests passed (40 new)

Addresses #35 (tasks 2-1~2-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)