### PR TITLE
feat: investment rules UI — take-profit highlight + VIX banner (#42)

### DIFF
--- a/frontend/src/app/consensus/page.tsx
+++ b/frontend/src/app/consensus/page.tsx
@@ -6,19 +6,41 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ConsensusTable } from "@/components/ui/consensus-table";
 import { StatusBadge } from "@/components/ui/status-badge";
 
+function VixBanner({ vix }: { vix: number | null }) {
+  if (!vix || vix < 25) return null;
+
+  const isBlocked = vix >= 30;
+  return (
+    <div className={`rounded-lg px-4 py-2.5 text-sm flex items-center gap-2 ${
+      isBlocked ? "bg-red-500/10 border border-red-500/20 text-red-400"
+                : "bg-amber-500/10 border border-amber-500/20 text-amber-400"
+    }`}>
+      <span className="font-medium">
+        {isBlocked ? `VIX ${vix.toFixed(1)} > 30 — 신규 매수 차단` : `VIX ${vix.toFixed(1)} (25-30) — 반포지션 적용 중`}
+      </span>
+      <span className="text-xs opacity-70">
+        {isBlocked ? "win rate 붕괴 구간, 모든 BUY 차단" : "BUY 종목 confidence ×0.5, 수량 절반만 진입"}
+      </span>
+    </div>
+  );
+}
+
 async function ConsensusSection() {
-  const data = await fetchAPI<{ results: any[]; count: number }>("/api/consensus");
+  const data = await fetchAPI<{ regime: any; results: any[]; count: number }>("/api/consensus");
   const sorted = [...data.results].sort((a, b) => b.final_confidence - a.final_confidence);
 
   return (
-    <Card className="bg-card border-border">
-      <CardContent className="pt-5">
-        <p className="text-xs text-muted-foreground mb-3">
-          10-Agent Consensus — {data.count} tickers × 10 agents = {data.count * 10} verdicts
-        </p>
-        <ConsensusTable data={sorted} />
-      </CardContent>
-    </Card>
+    <>
+      <VixBanner vix={data.regime?.vix ?? null} />
+      <Card className="bg-card border-border">
+        <CardContent className="pt-5">
+          <p className="text-xs text-muted-foreground mb-3">
+            10-Agent Consensus — {data.count} tickers × 10 agents = {data.count * 10} verdicts
+          </p>
+          <ConsensusTable data={sorted} />
+        </CardContent>
+      </Card>
+    </>
   );
 }
 

--- a/frontend/src/app/targets/page.tsx
+++ b/frontend/src/app/targets/page.tsx
@@ -40,16 +40,20 @@ async function TargetsSection() {
     return <p className="text-red-400 text-sm">API 연결 실패. make api 실행 필요.</p>;
   }
 
-  const valid = data.targets.filter((t) => !t.error);
-  const growth = valid.filter((t) => t.stock_type === "growth");
-  const value = valid.filter((t) => t.stock_type === "value");
+  const valid = data.targets.filter((t: any) => !t.error);
+  const growth = valid.filter((t: any) => t.stock_type === "growth");
+  const value = valid.filter((t: any) => t.stock_type === "value");
+  const tpTriggered = valid.filter((t: any) => t.take_profit_triggered);
+  const tsTriggered = valid.filter((t: any) => t.trailing_stop_triggered);
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
         <Metric label="전체 종목" value={`${valid.length}개`} />
         <Metric label="성장주" value={`${growth.length}개`} sub="SL -7% / TP +20%/+40%" color="green" />
         <Metric label="가치주" value={`${value.length}개`} sub="SL -10% / TP +15%/+30%" />
+        <Metric label="익절 도달" value={`${tpTriggered.length}개`} sub={tpTriggered.length > 0 ? "매도 필요" : ""} color={tpTriggered.length > 0 ? "green" : "default"} />
+        <Metric label="트레일링 스톱" value={`${tsTriggered.length}개`} sub={tsTriggered.length > 0 ? "즉시 매도" : ""} color={tsTriggered.length > 0 ? "red" : "default"} />
       </div>
 
       <Card className="bg-card border-border">

--- a/frontend/src/components/ui/client-table.tsx
+++ b/frontend/src/components/ui/client-table.tsx
@@ -92,6 +92,12 @@ const VARIANTS: Record<string, any[]> = {
     { key: "target_1", label: "1차 익절", align: "right", render: (v: number) => <span className="text-emerald-400">{price(v)}</span> },
     { key: "target_2", label: "2차 익절", align: "right", render: (v: number) => <span className="text-emerald-400">{price(v)}</span> },
     { key: "analyst_target", label: "목표가", align: "right", render: (v: number) => v ? <span className="text-blue-400">{price(v)}</span> : dim("—") },
+    { key: "take_profit_triggered", label: "시그널", align: "center", render: (_v: string | null, row: any) => {
+      if (row.trailing_stop_triggered) return <span className="text-red-400 text-[10px] font-medium">TRAIL STOP</span>;
+      if (_v === "target_2") return <span className="text-amber-400 text-[10px] font-medium">TP2 ({row.take_profit_sell_pct}%)</span>;
+      if (_v === "target_1") return <span className="text-emerald-400 text-[10px] font-medium">TP1 ({row.take_profit_sell_pct}%)</span>;
+      return dim("—");
+    }},
   ],
   swing: [
     { key: "ticker", label: "Ticker", render: ticker },

--- a/nuri/api/routes/agents.py
+++ b/nuri/api/routes/agents.py
@@ -19,7 +19,23 @@ def get_consensus():
 
     from nuri.trading.agents.consensus import analyze_portfolio
     results = analyze_portfolio()
+
+    # VIX/regime 정보 (반포지션 배너용)
+    regime_info = None
+    try:
+        from nuri.quant.regime.classifier import classify_regime
+        regime = classify_regime()
+        if regime:
+            regime_info = {
+                "regime": regime.regime, "trend": regime.trend,
+                "vix": regime.details.get("vix") if regime.details else None,
+                "fear_greed": regime.details.get("fear_greed") if regime.details else None,
+            }
+    except Exception:
+        pass
+
     data = {
+        "regime": regime_info,
         "results": [
             {
                 "ticker": r.ticker,

--- a/nuri/api/routes/targets.py
+++ b/nuri/api/routes/targets.py
@@ -6,9 +6,24 @@ router = APIRouter(tags=["targets"])
 
 @router.get("/targets")
 def get_portfolio_targets():
-    """전 종목 매수가/손절가/익절가 계산."""
-    from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+    """전 종목 매수가/손절가/익절가 + 익절/트레일링 시그널."""
+    from nuri.trading.recommend.price_targets import (
+        calculate_portfolio_targets,
+        check_take_profit_signals,
+        check_trailing_stop_signals,
+    )
     targets = calculate_portfolio_targets()
+
+    # 익절/트레일링 도달 종목 태깅
+    tp_signals = {s["ticker"]: s for s in check_take_profit_signals()}
+    ts_signals = {s["ticker"]: s for s in check_trailing_stop_signals()}
+    for t in targets:
+        tp = tp_signals.get(t["ticker"])
+        ts = ts_signals.get(t["ticker"])
+        t["take_profit_triggered"] = tp["level"] if tp else None
+        t["take_profit_sell_pct"] = tp["sell_pct"] if tp else None
+        t["trailing_stop_triggered"] = ts is not None
+
     return {"targets": targets, "count": len(targets)}
 
 


### PR DESCRIPTION
## Summary
- `/api/targets`: 익절/트레일링 스톱 도달 여부를 응답에 포함 (`take_profit_triggered`, `trailing_stop_triggered`)
- `/api/consensus`: regime 정보 (VIX, fear_greed) 추가
- `/consensus` 페이지: VIX 25-30 반포지션 배너, VIX>30 매수 차단 배너
- `/targets` 페이지: TP1/TP2/TRAIL STOP 시그널 컬럼 + 익절/트레일링 카운트 메트릭

## Test plan
- [x] 752 tests pass, lint clean
- [x] tsc --noEmit pass (equity-curve-chart.tsx는 #48 브랜치에서 별도 처리)
- [ ] `/targets` 페이지 visual check (requires running server)
- [ ] `/consensus` VIX banner visual check (requires running server)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)