### PR TITLE
feat: API security — global rate limit + pipeline protection (#47)

### DIFF
--- a/nuri/api/main.py
+++ b/nuri/api/main.py
@@ -39,11 +39,19 @@ from nuri.api.routes import (
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("nuri.api")
 # yfinance 404/401 에러 로그 억제 (ETF/KS 종목에서 대량 발생)
 logging.getLogger("yfinance").setLevel(logging.CRITICAL)
 
+# ─── 보안 경고 ───
+if not os.getenv("API_SECRET_KEY"):
+    logger.warning("API_SECRET_KEY 미설정 — 재시작 시 JWT 무효화됩니다. .env에 설정하세요.")
+
 # ─── Rate Limiter ───
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["60/minute"],  # 전역 기본: 읽기 60/min
+)
 
 app = FastAPI(
     title="Nuri-Quant API",
@@ -86,6 +94,8 @@ app.include_router(signals.router, prefix="/api")
 app.include_router(rebalance.router, prefix="/api")
 app.include_router(engine.router, prefix="/api")
 app.include_router(pipeline.router, prefix="/api")
+# pipeline 실행에 엄격한 rate limit (2/min)
+pipeline.run_pipeline_step = limiter.limit("2/minute")(pipeline.run_pipeline_step)
 app.include_router(agents.router, prefix="/api")
 app.include_router(swing.router, prefix="/api")
 app.include_router(ticker.router, prefix="/api")

--- a/nuri/api/routes/pipeline.py
+++ b/nuri/api/routes/pipeline.py
@@ -2,7 +2,7 @@
 import logging
 import time
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["pipeline"])
@@ -36,7 +36,7 @@ def get_pipeline_timeline(
 
 
 @router.post("/pipeline/{step}/run")
-def run_pipeline_step(step: str):
+def run_pipeline_step(step: str, request: Request):  # noqa: ARG001 — request needed by slowapi
     """특정 파이프라인 스텝 실행 (동기)."""
     if step not in VALID_STEPS:
         raise HTTPException(status_code=400, detail=f"Invalid step: {step}. Valid: {', '.join(VALID_STEPS)}")


### PR DESCRIPTION
## Summary
- 전역 rate limit 60/min (slowapi `default_limits`)
- Pipeline 실행 `/pipeline/{step}/run`: 2/min (무분별한 실행 방지)
- `API_SECRET_KEY` 미설정 시 시작 로그에 경고

## Test plan
- [x] 752 tests pass, lint clean
- [x] 기존 auth rate limit (5/15min) 유지 확인

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)