### PR TITLE
test: scheduler health coverage + heartbeat testability refactor

### DIFF
--- a/nuri/api/routes/pipeline.py
+++ b/nuri/api/routes/pipeline.py
@@ -9,13 +9,20 @@ router = APIRouter(tags=["pipeline"])
 
 VALID_STEPS = ("collect", "validate", "classify", "diagnose", "recommend", "track")
 
+_HEARTBEAT_PATH = None  # 테스트에서 monkeypatch 가능
+
+
+def _get_heartbeat_path():
+    if _HEARTBEAT_PATH:
+        return _HEARTBEAT_PATH
+    from pathlib import Path
+    return Path(__file__).parent.parent.parent.parent / "data" / ".scheduler_heartbeat"
+
 
 @router.get("/scheduler/health")
 def get_scheduler_health():
     """스케줄러 heartbeat 상태. 마지막 heartbeat 시각 + 경과 시간."""
-    from pathlib import Path
-
-    heartbeat_path = Path(__file__).parent.parent.parent.parent / "data" / ".scheduler_heartbeat"
+    heartbeat_path = _get_heartbeat_path()
     if not heartbeat_path.exists():
         return {"status": "unknown", "detail": "heartbeat 파일 없음 (스케줄러 미실행?)"}
 

--- a/tests/test_pipeline_api.py
+++ b/tests/test_pipeline_api.py
@@ -5,6 +5,7 @@ TestClient로 파이프라인/대시보드/신선도 엔드포인트를 검증�
 """
 import json
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -449,25 +450,48 @@ class TestCoreFreshness:
 
 
 class TestSchedulerHealth:
-    def test_no_heartbeat_file(self, client):
+    def test_no_heartbeat_file(self, client, monkeypatch):
         """heartbeat 파일 없으면 unknown."""
+        import nuri.api.routes.pipeline as pipe_mod
+        monkeypatch.setattr(pipe_mod, "_HEARTBEAT_PATH", Path("/nonexistent/.hb"))
+        resp = client.get("/api/scheduler/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "unknown"
+
+    def test_heartbeat_fresh(self, client, tmp_path, monkeypatch):
+        """최근 heartbeat → ok."""
+        from datetime import datetime
+
+        import nuri.api.routes.pipeline as pipe_mod
+        hb = tmp_path / ".hb"
+        hb.write_text(datetime.now().isoformat())
+        monkeypatch.setattr(pipe_mod, "_HEARTBEAT_PATH", hb)
         resp = client.get("/api/scheduler/health")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] in ("unknown", "ok", "stale", "error")
+        assert data["status"] == "ok"
+        assert data["age_seconds"] < 10
 
-    def test_heartbeat_parsing(self, tmp_path):
-        """heartbeat 파일 파싱 로직 검증."""
+    def test_heartbeat_stale(self, client, tmp_path, monkeypatch):
+        """오래된 heartbeat → stale."""
         from datetime import datetime
 
-        hb_path = tmp_path / ".hb"
-        hb_path.write_text(datetime.now().isoformat())
+        import nuri.api.routes.pipeline as pipe_mod
+        hb = tmp_path / ".hb"
+        old = (datetime.now() - timedelta(minutes=15)).isoformat()
+        hb.write_text(old)
+        monkeypatch.setattr(pipe_mod, "_HEARTBEAT_PATH", hb)
+        resp = client.get("/api/scheduler/health")
+        assert resp.json()["status"] == "stale"
 
-        last = datetime.fromisoformat(hb_path.read_text().strip())
-        age = (datetime.now() - last).total_seconds()
-        assert age < 5
-        status = "ok" if age < 600 else "stale"
-        assert status == "ok"
+    def test_heartbeat_corrupt(self, client, tmp_path, monkeypatch):
+        """손상된 heartbeat → error."""
+        import nuri.api.routes.pipeline as pipe_mod
+        hb = tmp_path / ".hb"
+        hb.write_text("not-a-date")
+        monkeypatch.setattr(pipe_mod, "_HEARTBEAT_PATH", hb)
+        resp = client.get("/api/scheduler/health")
+        assert resp.json()["status"] == "error"
 
 
 class TestWriteHeartbeat:


### PR DESCRIPTION
## Summary
- `_HEARTBEAT_PATH` 변수 추출로 monkeypatch 가능하게 리팩토링
- 4개 scheduler health 테스트: no file(unknown), fresh(ok), stale, corrupt(error)
- pipeline.py coverage: 64% → 73%
- 763 tests pass

## Test plan
- [x] 763 tests, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)