### PR TITLE
feat: deploy safety — disk/scheduler/API checks + backup checksum (#46)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,7 +17,11 @@ fi
 mkdir -p "$BACKUP_DIR"
 cp "$DB_FILE" "$BACKUP_DIR/portfolio_${DATE}.db"
 
+# SHA256 checksum 기록
+shasum -a 256 "$BACKUP_DIR/portfolio_${DATE}.db" > "$BACKUP_DIR/portfolio_${DATE}.db.sha256"
+
 # 30일 이전 백업 삭제
 find "$BACKUP_DIR" -name "portfolio_*.db" -mtime +30 -delete
+find "$BACKUP_DIR" -name "portfolio_*.db.sha256" -mtime +30 -delete
 
-echo "Backup complete: portfolio_${DATE}.db"
+echo "Backup complete: portfolio_${DATE}.db (checksum recorded)"

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -101,7 +101,36 @@ else
     fail "frontend/package.json not found"
 fi
 
-# ── 6. 포트 충돌 ──
+# ── 6. 디스크 용량 ──
+echo ""
+echo "💿 Disk space..."
+AVAIL_MB=$(df -m . | tail -1 | awk '{print $4}')
+if [ "$AVAIL_MB" -gt 1000 ]; then
+    pass "Disk: ${AVAIL_MB}MB available"
+else
+    fail "Disk: only ${AVAIL_MB}MB available (need >1GB)"
+fi
+
+# ── 7. 스케줄러 프로세스 ──
+echo ""
+echo "⏰ Scheduler process..."
+if pgrep -f "nuri.scheduler" >/dev/null 2>&1; then
+    SCHED_PID=$(pgrep -f "nuri.scheduler" | head -1)
+    pass "Scheduler running (PID: $SCHED_PID)"
+else
+    warn "Scheduler not running (start: python -m nuri.scheduler)"
+fi
+
+# ── 8. API 응답 ──
+echo ""
+echo "🌐 API health..."
+if curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/api/health 2>/dev/null | grep -q "200"; then
+    pass "API responding (port 8001)"
+else
+    warn "API not responding (start: make api)"
+fi
+
+# ── 9. 포트 충돌 ──
 echo ""
 echo "🔌 Port availability..."
 for PORT in 8001 3000; do

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════
+# Nuri-Quant DB 복원 — 백업에서 portfolio.db 복원
+#
+# 사용법:
+#   bash scripts/restore_db.sh                    # 최신 백업 복원
+#   bash scripts/restore_db.sh portfolio_20260330_120000.db  # 특정 백업 복원
+# ═══════════════════════════════════════════════════════
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+BACKUP_DIR="$PROJECT_DIR/data/backups"
+DB_FILE="$PROJECT_DIR/data/portfolio.db"
+
+# 백업 파일 선택
+if [ -n "$1" ]; then
+    BACKUP_FILE="$BACKUP_DIR/$1"
+else
+    BACKUP_FILE=$(ls -t "$BACKUP_DIR"/portfolio_*.db 2>/dev/null | head -1)
+fi
+
+if [ -z "$BACKUP_FILE" ] || [ ! -f "$BACKUP_FILE" ]; then
+    echo "❌ 백업 파일 없음: $BACKUP_FILE"
+    echo "사용 가능한 백업:"
+    ls -lt "$BACKUP_DIR"/portfolio_*.db 2>/dev/null | head -5 || echo "  (없음)"
+    exit 1
+fi
+
+echo "복원할 백업: $(basename "$BACKUP_FILE")"
+
+# checksum 검증
+CHECKSUM_FILE="${BACKUP_FILE}.sha256"
+if [ -f "$CHECKSUM_FILE" ]; then
+    if shasum -a 256 -c "$CHECKSUM_FILE" >/dev/null 2>&1; then
+        echo "✅ Checksum 검증 통과"
+    else
+        echo "❌ Checksum 불일치 — 백업 파일 손상 가능"
+        exit 1
+    fi
+else
+    echo "⚠️  Checksum 파일 없음 (검증 생략)"
+fi
+
+# 현재 DB 백업 (안전장치)
+if [ -f "$DB_FILE" ]; then
+    SAFE_BACKUP="$BACKUP_DIR/pre_restore_$(date +%Y%m%d_%H%M%S).db"
+    cp "$DB_FILE" "$SAFE_BACKUP"
+    echo "현재 DB 백업: $(basename "$SAFE_BACKUP")"
+fi
+
+# 복원
+cp "$BACKUP_FILE" "$DB_FILE"
+echo "✅ 복원 완료: $(basename "$BACKUP_FILE") → portfolio.db"


### PR DESCRIPTION
## Summary
- `pre-deploy-check.sh`: 디스크 용량(>1GB), 스케줄러 프로세스, API health 체크 추가
- `backup.sh`: SHA256 checksum 기록 + 오래된 checksum 파일도 정리
- `scripts/restore_db.sh` 신규: checksum 검증 + 복원 전 현재 DB 자동 백업

## Test plan
- [x] 763 tests pass, lint clean
- [x] Shell scripts syntax valid

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)