### PR TITLE
feat: portfolio import/export API — CSV upload + CSV/YAML download (#62)

### DIFF
--- a/nuri/api/routes/portfolio.py
+++ b/nuri/api/routes/portfolio.py
@@ -1,10 +1,14 @@
 """포트폴리오 + 리스크 API."""
+import csv
+import io
 import logging
 import re
 from enum import Enum
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator
 
 from nuri.api.auth import require_write_auth
@@ -219,6 +223,147 @@ def update_holding(account: str, ticker: str, update: HoldingUpdate, user=Depend
               user_id=user.get("sub", "unknown"))
     _try_sync_yaml()
     return {"ok": True, "ticker": ticker, "updated": changes}
+
+
+# ─── Import / Export ───
+
+_CSV_REQUIRED = {"account", "ticker", "quantity", "avg_price"}
+_CSV_OPTIONAL = {"currency", "sector"}
+_CSV_ALL = _CSV_REQUIRED | _CSV_OPTIONAL
+_MAX_IMPORT_ROWS = 500
+
+
+@router.post("/portfolio/import")
+def import_portfolio(file: UploadFile, user=Depends(require_write_auth)):
+    """CSV 파일로 포트폴리오 일괄 등록 (인증 필요).
+
+    CSV 필수 컬럼: account, ticker, quantity, avg_price
+    CSV 선택 컬럼: currency (default USD), sector (default "")
+    """
+    if not file.filename or not file.filename.endswith(".csv"):
+        raise HTTPException(status_code=400, detail="CSV 파일만 지원합니다 (.csv)")
+
+    try:
+        content = file.file.read().decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="UTF-8 인코딩 파일만 지원합니다")
+
+    reader = csv.DictReader(io.StringIO(content))
+    if not reader.fieldnames:
+        raise HTTPException(status_code=400, detail="CSV 헤더가 없습니다")
+
+    headers = {h.strip().lower() for h in reader.fieldnames}
+    missing = _CSV_REQUIRED - headers
+    if missing:
+        raise HTTPException(status_code=400, detail=f"필수 컬럼 누락: {', '.join(sorted(missing))}")
+
+    records = []
+    errors = []
+    for i, row in enumerate(reader, start=2):
+        if i - 1 > _MAX_IMPORT_ROWS:
+            raise HTTPException(status_code=400, detail=f"최대 {_MAX_IMPORT_ROWS}행까지 지원")
+
+        # 공백 정리 + 키 소문자화
+        row = {k.strip().lower(): v.strip() for k, v in row.items() if k}
+
+        # 필수 필드 비어있는지 체크
+        empty = [col for col in _CSV_REQUIRED if not row.get(col)]
+        if empty:
+            errors.append(f"행 {i}: 빈 필드 {', '.join(empty)}")
+            continue
+
+        ticker = row["ticker"].upper()
+        if not _TICKER_PATTERN.match(ticker):
+            errors.append(f"행 {i}: 유효하지 않은 ticker '{ticker}'")
+            continue
+
+        account = row["account"].lower()
+        if account not in _VALID_ACCOUNTS:
+            errors.append(f"행 {i}: 유효하지 않은 계좌 '{account}'")
+            continue
+
+        try:
+            qty = float(row["quantity"])
+            avg = float(row["avg_price"])
+        except ValueError:
+            errors.append(f"행 {i}: 숫자 변환 실패 (quantity/avg_price)")
+            continue
+
+        if qty <= 0 or avg <= 0:
+            errors.append(f"행 {i}: quantity/avg_price는 0보다 커야 합니다")
+            continue
+
+        records.append({
+            "account": account,
+            "ticker": ticker,
+            "quantity": qty,
+            "avg_price": avg,
+            "currency": row.get("currency", "USD").upper() or "USD",
+            "sector": row.get("sector", ""),
+        })
+
+    if not records and errors:
+        raise HTTPException(status_code=400, detail=f"유효한 행 없음: {'; '.join(errors[:5])}")
+
+    count = upsert_portfolio(records)
+    audit_log("IMPORT", "portfolio", f"{count} records",
+              f"file={file.filename}", user_id=user.get("sub", "unknown"))
+    _try_sync_yaml()
+    return {"ok": True, "imported": count, "errors": errors}
+
+
+@router.get("/portfolio/export")
+def export_portfolio(format: str = "csv"):
+    """포트폴리오 CSV/YAML 다운로드."""
+    rows = query(
+        "SELECT account, ticker, quantity, avg_price, currency, sector "
+        "FROM portfolio ORDER BY account, ticker"
+    )
+
+    if format == "yaml":
+        # 계좌별 그룹핑
+        accounts: dict = {}
+        for r in rows:
+            acct = r["account"]
+            if acct not in accounts:
+                accounts[acct] = {"currency": r["currency"], "holdings": []}
+            accounts[acct]["holdings"].append({
+                "ticker": r["ticker"],
+                "qty": r["quantity"],
+                "avg": r["avg_price"],
+                **({"sector": r["sector"]} if r["sector"] else {}),
+            })
+        from nuri.core.portfolio_sync import _HoldingFlowDumper
+        content = yaml.dump(
+            {"accounts": accounts}, Dumper=_HoldingFlowDumper,
+            allow_unicode=True, default_flow_style=False, sort_keys=False,
+        )
+        return StreamingResponse(
+            io.BytesIO(content.encode("utf-8")),
+            media_type="application/x-yaml",
+            headers={"Content-Disposition": "attachment; filename=portfolio.yaml"},
+        )
+
+    if format != "csv":
+        raise HTTPException(status_code=400, detail="format은 csv 또는 yaml만 지원")
+
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=["account", "ticker", "quantity", "avg_price", "currency", "sector"])
+    writer.writeheader()
+    for r in rows:
+        writer.writerow({
+            "account": r["account"],
+            "ticker": r["ticker"],
+            "quantity": r["quantity"],
+            "avg_price": r["avg_price"],
+            "currency": r["currency"],
+            "sector": r["sector"] or "",
+        })
+    return StreamingResponse(
+        io.BytesIO(output.getvalue().encode("utf-8")),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=portfolio.csv"},
+    )
 
 
 @router.get("/risk")

--- a/tests/test_portfolio_sync.py
+++ b/tests/test_portfolio_sync.py
@@ -350,3 +350,155 @@ class TestYamlSync:
         # holdings 업데이트
         assert len(kp["holdings"]) == 1
         assert kp["holdings"][0]["ticker"] == "TSLA"
+
+
+# ─── Import / Export Tests ───
+
+
+def _csv_file(content: str, filename: str = "test.csv"):
+    """테스트용 CSV UploadFile 생성."""
+    return {"file": (filename, content.encode("utf-8"), "text/csv")}
+
+
+class TestImport:
+    """POST /api/portfolio/import 테스트."""
+
+    def test_import_csv(self, client):
+        """정상 CSV import."""
+        csv_content = "account,ticker,quantity,avg_price,currency,sector\ntoss,AAPL,10,180.0,USD,Tech\nkakaopay,NVDA,5,130.0,USD,Semiconductor\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is True
+        assert data["imported"] == 2
+        assert data["errors"] == []
+
+        # DB 반영 확인
+        r2 = client.get("/api/portfolio")
+        assert r2.json()["count"] == 2
+
+    def test_import_minimal_columns(self, client):
+        """필수 컬럼만 있는 CSV — currency/sector 기본값."""
+        csv_content = "account,ticker,quantity,avg_price\ntoss,MSFT,3,400.0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 200
+        assert r.json()["imported"] == 1
+
+    def test_import_missing_required_column(self, client):
+        """필수 컬럼 누락 → 400."""
+        csv_content = "account,ticker,quantity\ntoss,AAPL,10\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 400
+        assert "avg_price" in r.json()["detail"]
+
+    def test_import_not_csv(self, client):
+        """CSV가 아닌 파일 → 400."""
+        r = client.post("/api/portfolio/import",
+                        files={"file": ("data.txt", b"hello", "text/plain")})
+        assert r.status_code == 400
+        assert "CSV" in r.json()["detail"]
+
+    def test_import_empty_header(self, client):
+        """빈 CSV → 400."""
+        r = client.post("/api/portfolio/import", files=_csv_file(""))
+        assert r.status_code == 400
+
+    def test_import_invalid_ticker(self, client):
+        """유효하지 않은 ticker → errors에 포함."""
+        csv_content = "account,ticker,quantity,avg_price\ntoss,invalid!,10,100.0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 400  # 유효한 행 0개
+        assert "ticker" in r.json()["detail"]
+
+    def test_import_invalid_account(self, client):
+        """유효하지 않은 계좌 → errors에 포함."""
+        csv_content = "account,ticker,quantity,avg_price\nfake,AAPL,10,100.0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 400
+
+    def test_import_invalid_number(self, client):
+        """숫자 변환 실패 → errors에 포함."""
+        csv_content = "account,ticker,quantity,avg_price\ntoss,AAPL,abc,100.0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 400
+
+    def test_import_zero_quantity(self, client):
+        """quantity 0 → errors에 포함."""
+        csv_content = "account,ticker,quantity,avg_price\ntoss,AAPL,0,100.0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 400
+
+    def test_import_partial_errors(self, client):
+        """일부 행만 유효 → 유효한 행만 import, errors 반환."""
+        csv_content = "account,ticker,quantity,avg_price\ntoss,AAPL,10,180.0\nfake,BAD!,0,0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 200
+        data = r.json()
+        assert data["imported"] == 1
+        assert len(data["errors"]) > 0
+
+    def test_import_empty_field(self, client):
+        """필수 필드가 비어있는 행 → errors."""
+        csv_content = "account,ticker,quantity,avg_price\ntoss,,10,100.0\n"
+        r = client.post("/api/portfolio/import", files=_csv_file(csv_content))
+        assert r.status_code == 400
+
+    def test_import_non_utf8(self, client):
+        """비UTF-8 파일 → 400."""
+        # EUC-KR 바이트 시퀀스 (UTF-8로 디코딩 불가)
+        bad_bytes = b"\xc7\xd1\xb1\xdb"
+        r = client.post("/api/portfolio/import",
+                        files={"file": ("test.csv", bad_bytes, "text/csv")})
+        assert r.status_code == 400
+        assert "UTF-8" in r.json()["detail"]
+
+    def test_import_over_max_rows(self, client):
+        """500행 초과 → 400."""
+        header = "account,ticker,quantity,avg_price\n"
+        rows = "".join(f"toss,T{i:04d},1,100.0\n" for i in range(501))
+        r = client.post("/api/portfolio/import", files=_csv_file(header + rows))
+        assert r.status_code == 400
+        assert "500" in r.json()["detail"]
+
+
+class TestExport:
+    """GET /api/portfolio/export 테스트."""
+
+    def test_export_csv_empty(self, client):
+        """빈 포트폴리오 CSV export."""
+        r = client.get("/api/portfolio/export?format=csv")
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "text/csv; charset=utf-8"
+        content = r.text
+        assert "account" in content  # 헤더는 있음
+
+    def test_export_csv_with_data(self, seeded_client):
+        """데이터 있는 CSV export."""
+        r = seeded_client.get("/api/portfolio/export?format=csv")
+        assert r.status_code == 200
+        lines = r.text.strip().split("\n")
+        assert len(lines) == 2  # 헤더 + 데이터 1행
+        assert "AAPL" in lines[1]
+
+    def test_export_yaml_with_data(self, seeded_client):
+        """데이터 있는 YAML export."""
+        r = seeded_client.get("/api/portfolio/export?format=yaml")
+        assert r.status_code == 200
+        assert "yaml" in r.headers["content-type"]
+        data = yaml.safe_load(r.text)
+        assert "accounts" in data
+        assert "toss" in data["accounts"]
+        holdings = data["accounts"]["toss"]["holdings"]
+        assert len(holdings) == 1
+        assert holdings[0]["ticker"] == "AAPL"
+
+    def test_export_invalid_format(self, client):
+        """지원하지 않는 format → 400."""
+        r = client.get("/api/portfolio/export?format=json")
+        assert r.status_code == 400
+
+    def test_export_default_csv(self, client):
+        """format 미지정 → CSV 기본값."""
+        r = client.get("/api/portfolio/export")
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "text/csv; charset=utf-8"


### PR DESCRIPTION
## Summary
- **POST /api/portfolio/import** — CSV 파일 업로드로 포트폴리오 일괄 등록 (최대 500행, 필수/선택 컬럼 검증)
- **GET /api/portfolio/export?format=csv|yaml** — 포트폴리오 CSV/YAML 다운로드
- 변경 모듈 **100% 커버리지** (18개 신규 테스트, 전체 810개)

### Import CSV 스펙
- 필수 컬럼: `account`, `ticker`, `quantity`, `avg_price`
- 선택 컬럼: `currency` (기본 USD), `sector` (기본 "")
- 행별 검증: ticker 포맷, 계좌명, 숫자 변환, 양수 체크
- 부분 성공 지원: 유효 행만 import, errors 배열 반환

## Test plan
- [x] CSV import 정상/최소 컬럼 (2개)
- [x] Import 에러: 누락 컬럼, 비CSV, 빈 헤더, 잘못된 ticker/계좌/숫자/0값, 비UTF-8, 500행 초과 (9개)
- [x] Import 부분 성공 + 빈 필드 (2개)
- [x] Export CSV 빈/데이터, YAML 데이터, 잘못된 format, 기본값 (5개)
- [x] 전체 810 tests 통과, lint 클린

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)