### PR TITLE
docs: README restructure + verify all numeric claims against codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ python -m nuri.quant.regime.strategy_map     # regime + macro + strategy
 make validate                           # signal + superinvestor + analyst + scorecard
 
 # Regime classification (Phase D)
-make regime                             # 6-regime classifier + strategy map
+make regime                             # regime classifier (6 base + 4 special) + strategy map
 
 # Recommendations (Phase E)
 make recommend                          # candidates + tracker (signal-based buy/sell)
@@ -74,7 +74,7 @@ make mean-reversion   # mean-reversion scan + backtest
 make pairs            # pairs trading scan + backtest
 
 # Swing Trade
-make scan             # 89종목 스캔 → 시그널 필터
+make scan             # 88종목 스캔 (UNIVERSE) → 시그널 필터
 make swing            # 스캔 + 에이전트 합의 → 진입 저장
 make swing-check      # 진행중 스윙 트레이드 상태 확인
 
@@ -294,7 +294,7 @@ Additional: `ark`, `events`, `news`, `institutional_flows`, `etf_flows`, `regime
 
 ### Config files (`config/`)
 
-- `portfolio.yaml` — 7 accounts (kakaopay/mirae/toss/pension/irp/test/sample), 30+ holdings
+- `portfolio.yaml` — 7 accounts (kakaopay/mirae/toss/pension/irp/test/sample), 30 holdings (kakaopay 17 + mirae 10 + toss 3)
 - `stock_types.yaml` — Manual growth/value override per ticker. Controls stop-loss/take-profit thresholds (growth: -7%/+20%/+40%, value: -10%/+15%/+30%). Swing type is auto-tagged by scanner.
 - `agents.yaml` — Agent thresholds (RSI 30/70, PE 15/40, confidence caps, etc.) loaded via `nuri/core/agent_config.py`. Includes `confidence_normalization` scales for uniform 0-100 mapping.
 - `alerts.yaml` — Thresholds (price swing 3%, Fear&Greed bounds 20/80), report timing
@@ -326,7 +326,7 @@ data/
 
 ## Testing
 
-2928 backend tests across 32 domain files + 585 frontend vitest + 21 Playwright E2E (v11 migrations). Uses `pytest-xdist` for parallel execution (`-n auto`). Backend 98% coverage, frontend 95% coverage. Tests use `tmp_path` fixture for isolated SQLite databases:
+2,928 backend tests across 32 domain files + 585 frontend vitest (44 files) + 21 Playwright E2E (4 spec files). Uses `pytest-xdist` for parallel execution (`-n auto`). Backend 98% coverage, frontend 95% coverage. CI minimum thresholds in `docs/STRATEGY.md` §4.1. Tests use `tmp_path` fixture for isolated SQLite databases:
 ```python
 @pytest.fixture
 def db_path(tmp_path):
@@ -336,6 +336,29 @@ def db_path(tmp_path):
 ```
 
 Pass `db_path` to all DB functions in tests. `conftest.py` (autouse) mocks `yfinance.download` → empty DataFrame and `yfinance.Ticker` → stub with None attributes. All tests run network-free.
+
+### Verifying numeric claims
+
+All counts in this doc are verified against code. Re-run after major changes — drift here causes future sessions to make decisions on stale facts.
+
+```bash
+# Tests
+.venv/bin/python -m pytest tests/ --collect-only -q | tail -1   # backend
+ls tests/test_*.py | wc -l                                       # backend test files
+cd frontend && npx vitest run | tail -5                          # frontend (Test Files / Tests)
+grep -rhE "^\s*test\(" frontend/e2e/ | wc -l                     # Playwright E2E
+
+# Architectural counts
+ls nuri/collectors/*.py | grep -vE 'base|__init__' | wc -l       # collectors
+ls nuri/trading/agents/*.py | grep -vE 'base|__init__|consensus|config' | wc -l  # agents
+.venv/bin/python -c "from nuri.quant.validation.signal_backtest import SIGNAL_DEFINITIONS; print(len(SIGNAL_DEFINITIONS))"  # signals
+.venv/bin/python -c "from nuri.trading.strategy.longshort import REGIME_ALLOCATION; print(len(REGIME_ALLOCATION))"  # regimes
+grep -rhE "@router\.(get|post|put|delete|patch)" nuri/api/routes/ | wc -l  # API endpoints
+grep -c "CREATE TABLE" nuri/core/db.py                           # DB tables
+find frontend/src/app -name "page.tsx" | wc -l                   # frontend routes
+```
+
+If any of these disagree with the numbers stated above, **fix the doc** — do not weaken the claim to be drift-immune. Precise numbers are load-bearing for trust.
 
 ### DB Migrations
 
@@ -424,7 +447,7 @@ All pages are **Server Components** with `force-dynamic`. Data fetched server-si
 
 **Conventions**: `async function Section()` in `<Suspense>`, `animate-pulse` skeletons, color semantics (emerald=BUY, red=SELL, amber=warning, blue=WATCH, zinc=HOLD), `text-[10px]` sub-labels.
 
-**Frontend testing** (585 vitest, 44 files, 97% coverage): Mock `@/lib/api` + `next/navigation`. Recharts mock hoisting caveat: keep recharts-dependent and recharts-free tests in separate files.
+**Frontend testing** (585 vitest, 44 files, 95% coverage): Mock `@/lib/api` + `next/navigation`. Recharts mock hoisting caveat: keep recharts-dependent and recharts-free tests in separate files.
 
 **Auth**: `src/middleware.ts` — SHA256 cookie-based, active only when `DASHBOARD_PASSWORD` is set.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ graph LR
 ![bcrypt](https://img.shields.io/badge/bcrypt-5.0.0-004D40)
 ![slowapi](https://img.shields.io/badge/slowapi-0.1.9-FF7043)
 
-> 60 endpoints · 27 tables (v11 migrations) · SSE streaming · JWT + bcrypt + slowapi rate limiting
+> 54 endpoints · 27 tables (v11 migrations) · SSE streaming · JWT + bcrypt + slowapi rate limiting
 
 **Frontend**<br/>
 ![Next.js](https://img.shields.io/badge/Next.js-16.2.2-000000?logo=next.js&logoColor=white)
@@ -247,7 +247,7 @@ nuri/
 │   ├── recommend/ # Candidates, price targets, rebalance, tracker
 │   ├── swing/     # Market-wide scanner + entry/exit rules
 │   └── execution/ # Broker interface (Alpaca paper + DryRun)
-├── api/           # FastAPI REST (60 endpoints) + SSE streaming
+├── api/           # FastAPI REST (54 endpoints) + SSE streaming
 ├── alerts/        # Discord + Telegram notifications
 └── llm/           # Ollama LLM reports + SIEGE certification
 ```

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -322,7 +322,7 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 
 - 8-phase 파이프라인 (Collect → Notify) 전체 동작
 - 21 collectors, 15 signals, 10 regimes, 10 agents, SIEGE 10-gate
-- 60 API endpoints, 27 tables (v11 migrations)
+- 54 API endpoints, 27 tables (v11 migrations)
 - 15-page 대시보드 (Pipeline DAG, Portfolio CRUD, Evidence 차트)
 - 2,928 backend (98%) + 585 frontend (95%) + 21 E2E tests
 


### PR DESCRIPTION
## Summary

두 개의 관련 docs 변경을 한 PR에 묶어 올립니다. 둘 다 `.md` 파일만 건드리고 코드는 건드리지 않습니다.

### Commit 1 — `docs(readme): restructure README` ([5ba9898](../commit/5ba9898))

README의 구조적 리팩토링 (사실 변경 없음, 재배치/정리만):

- **Key Features 이동** — 원래 Multi-machine Workflow 뒤에 있어 product/dev-tooling 흐름이 뒤섞였음. Pipeline 직후로 이동
- **Phase details `<details>` 표 제거** — 위의 mermaid 다이어그램이 이미 phase + modules + edges를 모두 표현
- **헤더 subtitle 정리** — `After make start: ...` runtime URL을 Run 섹션으로 이동
- **Auto-pull receiver run-on 문장 분리** — 한 문장 → 4단계 번호 리스트
- **Phase A mermaid 수정** — "signals" → "technicals" (signals는 DB 테이블 & 트레이딩 시그널 개념이고 collector가 아님)

### Commit 2 — `docs: verify all numeric claims` ([2a23f74](../commit/2a23f74))

코드베이스 실측 후 drift 발견 → doc 수정:

| 항목 | Before | After | 근거 |
|---|---|---|---|
| API endpoints (README × 2, STRATEGY × 1) | 60 | **54** | `grep @router. nuri/api/routes/` |
| Frontend coverage (CLAUDE.md) | 97% | **95%** | STRATEGY.md §4.1 일치 |
| `make regime` 설명 | "6-regime classifier" | "regime classifier (6 base + 4 special)" | `REGIME_ALLOCATION` len == 10 |
| `make scan` 설명 | "89종목" | **88종목** | `UNIVERSE` 리스트 길이 |
| portfolio.yaml | "30+ holdings" | "30 holdings (kakaopay 17 + mirae 10 + toss 3)" | YAML 실측 |
| Test count line | `2928 backend tests ...` | `2,928 backend tests across 32 domain files + 585 frontend vitest (44 files) + 21 Playwright E2E (4 spec files)` | collect-only 실측 |

또한 CLAUDE.md에 **§"Verifying numeric claims"** 블록 신규 추가 — 모든 카운트의 정확한 검증 명령과 함께 "drift 발견 시 doc을 고쳐라, claim을 약화시키지 말라"는 원칙 명시.

## Test plan

- [ ] CI — ruff lint 통과
- [ ] CI — backend pytest 통과 (`2928 tests collected`)
- [ ] CI — frontend tsc + vitest 통과
- [ ] CI — Trivy security scan 통과
- [ ] CI — Codecov 업로드
- [ ] 수동 — 렌더된 README/CLAUDE.md 읽어 구조 확인
- [ ] 수동 — mermaid 다이어그램 GitHub에서 렌더 확인

## 전수 검증한 카운트

| 항목 | Doc | 실측 |
|---|---|---|
| backend tests | 2,928 | 2,928 ✓ |
| backend test files | 32 | 32 ✓ |
| frontend vitest | 585 (44 files) | 585 / 44 ✓ |
| Playwright E2E | 21 (4 spec files) | 21 / 4 ✓ |
| collectors | 21 (19 subclass + 2 standalone) | 21 / 19+2 ✓ |
| agents | 10 | 10 ✓ |
| signals | 15 (10 price + 3 macro + 2 data) | 15 ✓ |
| regimes | 10 (6 base + 4 special) | 10 ✓ |
| endpoints | 54 | 54 ✓ |
| DB tables | 27 (v11 migrations) | 27 / 11 ✓ |
| frontend routes | 15 | 15 ✓ |
| scheduler jobs | 18 | 18 ✓ |
| UNIVERSE (swing) | 88 | 88 ✓ |
| holdings | 30 | 30 ✓ |
| accounts | 7 | 7 ✓ |
| CI coverage min | 40% | 40% (main-ci-cd.yml:175) ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)