### PR TITLE
feat(frontend): dashboard UX phase 2-A — structural redesign

### DIFF
--- a/frontend/src/__tests__/pages/dashboard.test.tsx
+++ b/frontend/src/__tests__/pages/dashboard.test.tsx
@@ -83,6 +83,7 @@ describe("DashboardPage", () => {
       if (path.includes("/api/dashboard")) return Promise.resolve(overrides.dashboard ?? mockDashboardData);
       if (path.includes("/api/freshness")) return Promise.resolve(overrides.freshness ?? mockFreshness);
       if (path.includes("/api/pipeline/status")) return Promise.resolve(overrides.pipeline ?? mockPipelineStatus);
+      if (path.includes("/api/portfolio/history")) return Promise.resolve({ history: [] });
       if (path.includes("/api/portfolio")) return Promise.resolve(overrides.portfolio ?? mockPortfolio);
       if (path.includes("/api/certify")) return Promise.resolve(overrides.siege ?? mockSiege);
       if (path.includes("/api/rebalance-advisor")) return Promise.resolve(overrides.advisor ?? mockAdvisor);
@@ -106,8 +107,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.getByText("통과")).toBeInTheDocument();
-      expect(screen.getByText("9/10")).toBeInTheDocument();
+      expect(screen.getByText(/품질 검증 9\/10 통과/)).toBeInTheDocument();
     });
   });
 
@@ -121,9 +121,8 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.getByText("미통과")).toBeInTheDocument();
+      expect(screen.getByText(/품질 검증 미통과/)).toBeInTheDocument();
       expect(screen.getByText("4/10")).toBeInTheDocument();
-      expect(screen.getByText(/품질검증 미통과/)).toBeInTheDocument();
     });
   });
 
@@ -150,7 +149,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.getByText(/오늘의 매매/)).toBeInTheDocument();
+      expect(screen.getByText(/오늘의 할 일/)).toBeInTheDocument();
       expect(screen.getByText("매수")).toBeInTheDocument();
       expect(screen.getByText("매도")).toBeInTheDocument();
       expect(screen.getByText("NVDA")).toBeInTheDocument();
@@ -171,7 +170,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.getByText(/위험 관리/)).toBeInTheDocument();
+      expect(screen.getByText(/주의 사항/)).toBeInTheDocument();
       expect(screen.getByText(/TSLA 손절선 돌파/)).toBeInTheDocument();
       expect(screen.getByText(/매도 검토하여 손실 제한/)).toBeInTheDocument();
     });
@@ -191,7 +190,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.getByText("시장 현황")).toBeInTheDocument();
+      expect(screen.getByText("시장 온도")).toBeInTheDocument();
       expect(screen.getByText(/상승/)).toBeInTheDocument();
       expect(screen.getByText("18.5")).toBeInTheDocument();
     });
@@ -227,7 +226,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.getByText("3건")).toBeInTheDocument();
+      expect(screen.getByText(/규칙 위반 3건/)).toBeInTheDocument();
     });
   });
 
@@ -236,7 +235,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      expect(screen.queryByText("품질검증")).not.toBeInTheDocument();
+      expect(screen.queryByText(/품질 검증/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/pages/dashboard.test.tsx
+++ b/frontend/src/__tests__/pages/dashboard.test.tsx
@@ -238,4 +238,446 @@ describe("DashboardPage", () => {
       expect(screen.queryByText(/품질 검증/)).not.toBeInTheDocument();
     });
   });
+
+  /* ── vixZone helper coverage ── */
+  it("renders VIX null as dash", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, vix: undefined },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      // vixZone(null) returns label "—"
+      const vixLabels = screen.getAllByText("—");
+      expect(vixLabels.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("renders VIX < 12 as 안정", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, vix: 10 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("안정")).toBeInTheDocument();
+    });
+  });
+
+  it("renders VIX < 17 as 낮음", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, vix: 14 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("낮음")).toBeInTheDocument();
+    });
+  });
+
+  it("renders VIX 18.5 as 보통", async () => {
+    // Default mock has vix: 18.5 which hits the v < 23 branch.
+    // macro score 65 also maps to 보통, so we expect at least 2 occurrences.
+    setupMocks();
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      const matches = screen.getAllByText("보통");
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("renders VIX >= 33 as 위험", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, vix: 40 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("위험")).toBeInTheDocument();
+    });
+  });
+
+  /* ── fgLabel / fgColor helper coverage ── */
+  it("renders fear_greed < 25 as 극도 공포", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, fear_greed: 15 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("극도 공포")).toBeInTheDocument();
+    });
+  });
+
+  it("renders fear_greed < 45 as 공포", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, fear_greed: 35 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("공포")).toBeInTheDocument();
+    });
+  });
+
+  it("renders fear_greed 55 as 중립", async () => {
+    // Default mock has fear_greed: 55 which hits fg <= 55
+    setupMocks();
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("중립")).toBeInTheDocument();
+    });
+  });
+
+  it("renders fear_greed 70 as 탐욕", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, fear_greed: 70 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("탐욕")).toBeInTheDocument();
+    });
+  });
+
+  it("renders fear_greed > 75 as 극도 탐욕", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, fear_greed: 90 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("극도 탐욕")).toBeInTheDocument();
+    });
+  });
+
+  it("renders fear_greed null as dash", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, fear_greed: undefined },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      const dashes = screen.getAllByText("—");
+      expect(dashes.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  /* ── macroLevel helper coverage ── */
+  it("renders macro score >= 70 as 양호", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        macro: { score: 75, interpretation: "Positive" },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("양호")).toBeInTheDocument();
+    });
+  });
+
+  it("renders macro score < 30 as 취약", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        macro: { score: 20, interpretation: "Negative" },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("취약")).toBeInTheDocument();
+    });
+  });
+
+  it("renders macro score 35 as 부진", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        macro: { score: 35, interpretation: "Below average" },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("부진")).toBeInTheDocument();
+    });
+  });
+
+  /* ── displayName helper coverage ── */
+  it("renders holding name when available", async () => {
+    setupMocks({
+      portfolio: {
+        count: 2,
+        holdings: [
+          { ticker: "AAPL", name: "Apple Inc", quantity: 10, avg_price: 150, latest_price: 200, currency: "USD" },
+          { ticker: "GOOG", quantity: 5, avg_price: 100, latest_price: 80, currency: "USD" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText(/Apple Inc/)).toBeInTheDocument();
+    });
+  });
+
+  it("strips .KS suffix for Korean tickers in displayName", async () => {
+    setupMocks({
+      portfolio: {
+        count: 2,
+        holdings: [
+          { ticker: "005930.KS", quantity: 10, avg_price: 50000, latest_price: 60000, currency: "KRW" },
+          { ticker: "TSLA", quantity: 5, avg_price: 100, latest_price: 80, currency: "USD" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      // displayName strips .KS, so "005930" should appear instead of "005930.KS"
+      expect(screen.getByText(/005930/)).toBeInTheDocument();
+    });
+  });
+
+  /* ── account_values rendering ── */
+  it("renders account_values when present", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        account_values: [
+          { account: "Main", value: 5000 },
+          { account: "Pension", value: 3000 },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText(/Main \$5,000/)).toBeInTheDocument();
+      expect(screen.getByText(/Pension \$3,000/)).toBeInTheDocument();
+    });
+  });
+
+  it("does not render account_values row when absent", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        account_values: undefined,
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("$8,850")).toBeInTheDocument();
+      // No per-account breakdown text
+      expect(screen.queryByText(/Main \$/)).not.toBeInTheDocument();
+    });
+  });
+
+  /* ── account-grouped actions ── */
+  it("renders Main/Sub actions in grouped section", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actions: [
+          { action: "BUY", ticker: "AAPL", confidence: 85, agreement: 90, reason: "Momentum", account: "Main" },
+          { action: "SELL", ticker: "GOOG", confidence: 60, agreement: 70, reason: "Weakness", account: "Sub" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+      expect(screen.getByText("GOOG")).toBeInTheDocument();
+      expect(screen.getByText("Main")).toBeInTheDocument();
+      expect(screen.getByText("Sub")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Pension actions as '월말 매수 대기' when not month-end", async () => {
+    // Default date (April 11) is not within 3 days of month end (April 30)
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actions: [
+          { action: "BUY", ticker: "SPY", confidence: 70, agreement: 80, reason: "Rebalance", account: "Pension" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText(/월말 매수 대기/)).toBeInTheDocument();
+      // SPY should not appear as a clickable action (pension hidden mid-month)
+      expect(screen.queryByText("SPY")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders Pension actions expanded at month-end", async () => {
+    // Mock Date so new Date() returns April 29 (1 day before month end → isMonthEnd = true)
+    // Use a class-based mock to keep real timer functionality for waitFor
+    const RealDate = globalThis.Date;
+    const fakeNow = new RealDate(2026, 3, 29, 12, 0, 0).getTime(); // April 29
+    class MockDate extends RealDate {
+      constructor(...args: any[]) {
+        if (args.length === 0) { super(fakeNow); } else { super(...(args as [any])); }
+      }
+      static override now() { return fakeNow; }
+    }
+    vi.stubGlobal("Date", MockDate);
+
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actions: [
+          { action: "BUY", ticker: "SPY", confidence: 70, agreement: 80, reason: "Rebalance", account: "Pension" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("SPY")).toBeInTheDocument();
+      expect(screen.getByText("연금")).toBeInTheDocument();
+      expect(screen.queryByText(/월말 매수 대기/)).not.toBeInTheDocument();
+    });
+
+    vi.stubGlobal("Date", RealDate);
+  });
+
+  it("renders 'other' actions (no account or Toss)", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actions: [
+          { action: "BUY", ticker: "MSFT", confidence: 75, agreement: 85, reason: "Factor score", account: "Toss" },
+          { action: "BUY", ticker: "AMZN", confidence: 65, agreement: 75, reason: "Breakout" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("MSFT")).toBeInTheDocument();
+      expect(screen.getByText("AMZN")).toBeInTheDocument();
+      expect(screen.getByText("Toss")).toBeInTheDocument();
+    });
+  });
+
+  /* ── exchange_rate fallback ── */
+  it("uses fallback exchange rate 1400 when exchange_rate is null", async () => {
+    // KRW holding: 4 * 210000 / 1400 = 600; USD holding: 33 * 250 = 8250; total = 8850
+    setupMocks({
+      dashboard: { ...mockDashboardData, exchange_rate: null },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("$8,850")).toBeInTheDocument();
+    });
+  });
+
+  it("uses provided exchange_rate when present", async () => {
+    // KRW holding: 4 * 210000 / 1300 = ~646.15; USD holding: 33 * 250 = 8250; total ≈ 8896
+    setupMocks({
+      dashboard: { ...mockDashboardData, exchange_rate: 1300 },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("$8,896")).toBeInTheDocument();
+    });
+  });
+
+  /* ── VIX 주의 zone (v < 33) ── */
+  it("renders VIX 25 as 주의 zone", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        regime: { ...mockDashboardData.regime, vix: 25 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      // vixZone(25) → label "주의" — but "주의" also appears in verdict label
+      // Check that VIX value 25 is rendered
+      expect(screen.getByText("25")).toBeInTheDocument();
+    });
+  });
+
+  /* ── mixed account actions (all groups present) ── */
+  it("renders all account groups together", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actions: [
+          { action: "BUY", ticker: "AAPL", confidence: 85, agreement: 90, reason: "Momentum", account: "Main" },
+          { action: "BUY", ticker: "GOOG", confidence: 70, agreement: 80, reason: "Rebalance", account: "Pension" },
+          { action: "BUY", ticker: "MSFT", confidence: 75, agreement: 85, reason: "Factor", account: "Toss" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      // Main action rendered
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+      // Toss (other) action rendered
+      expect(screen.getByText("MSFT")).toBeInTheDocument();
+      // Pension is mid-month → collapsed
+      expect(screen.getByText(/월말 매수 대기/)).toBeInTheDocument();
+    });
+  });
+
+  /* ── action with name field ── */
+  it("renders action name and ticker when name is present", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actions: [
+          { action: "BUY", ticker: "NVDA", name: "NVIDIA Corp", confidence: 80, agreement: 90, reason: "AI growth", account: "Main" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("NVIDIA Corp")).toBeInTheDocument();
+      expect(screen.getByText("NVDA")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,20 +14,19 @@ interface DashboardData {
   regime: { regime: string; trend: string; volatility?: string; confidence: number; vix?: number; fear_greed?: number };
   macro: { score: number; interpretation: string };
   allocation: { long: number; short: number; cash: number };
-  actions: Array<{ action: string; ticker: string; name?: string | null; confidence: number; agreement: number; reason: string }>;
+  actions: Array<{ action: string; ticker: string; name?: string | null; confidence: number; agreement: number; reason: string; account?: string }>;
   alerts: Array<{ level: string; message: string }>;
   gate_score: number;
   n_positions: number;
   exchange_rate: number | null;
+  account_values?: Array<{ account: string; value: number }>;
 }
 
 interface FreshnessData {
   items?: FreshnessItem[];
   details?: FreshnessItem[];
   overall?: "PASS" | "WARN" | "FAIL";
-  pass?: number;
-  warn?: number;
-  fail?: number;
+  pass?: number; warn?: number; fail?: number;
 }
 
 interface PipelineStatusData {
@@ -37,90 +36,64 @@ interface PipelineStatusData {
 const verdictLabels: Record<string, string> = {
   aggressive: "공격", neutral: "관망", cautious: "주의", defensive: "방어",
 };
-
-const levelStyles: Record<string, { bg: string; border: string; text: string }> = {
-  aggressive: { bg: "bg-emerald-950/50", border: "border-emerald-700", text: "text-emerald-400" },
-  neutral:    { bg: "bg-card",           border: "border-input",       text: "text-muted-foreground" },
-  cautious:   { bg: "bg-amber-950/50",   border: "border-amber-700",   text: "text-amber-400" },
-  defensive:  { bg: "bg-red-950/50",     border: "border-red-700",     text: "text-red-400" },
+const levelStyles: Record<string, { text: string }> = {
+  aggressive: { text: "text-emerald-400" },
+  neutral:    { text: "text-zinc-400" },
+  cautious:   { text: "text-amber-400" },
+  defensive:  { text: "text-red-400" },
 };
-
 const pipelineStatusColors: Record<string, string> = {
   idle: "bg-zinc-500", running: "bg-blue-500 animate-pulse", done: "bg-emerald-500", error: "bg-red-500",
 };
 
-/* ── Gauge bar component ── */
-function Gauge({ value, max, color, label, sub }: { value: number; max: number; color: string; label: string; sub: string }) {
-  const pct = Math.min(100, Math.max(0, (value / max) * 100));
-  return (
-    <div>
-      <div className="flex items-baseline justify-between mb-1">
-        <span className="text-[10px] text-muted-foreground">{label}</span>
-        <span className={`text-sm font-semibold ${color}`}>{value}</span>
-      </div>
-      <div className="h-1.5 bg-muted/50 rounded-full overflow-hidden">
-        <div className={`h-full rounded-full transition-all ${color.replace("text-", "bg-")}`} style={{ width: `${pct}%` }} />
-      </div>
-      <p className="text-[10px] text-muted-foreground/70 mt-0.5">{sub}</p>
-    </div>
-  );
+/* ── 헬퍼 ── */
+function trendKo(t: string) { return t === "bull" ? "상승" : t === "bear" ? "하락" : "횡보"; }
+function vixZone(v: number | null): { label: string; color: string } {
+  if (v == null) return { label: "—", color: "text-zinc-500" };
+  if (v < 12) return { label: "안정", color: "text-blue-400" };
+  if (v < 17) return { label: "낮음", color: "text-emerald-400" };
+  if (v < 23) return { label: "보통", color: "text-zinc-300" };
+  if (v < 33) return { label: "주의", color: "text-orange-400" };
+  return { label: "위험", color: "text-red-400" };
 }
-
-/* ── Confidence bar (inline) ── */
-function ConfBar({ value }: { value: number }) {
-  const pct = Math.min(100, value);
-  const color = pct >= 80 ? "bg-emerald-500" : pct >= 50 ? "bg-amber-500" : "bg-red-500";
-  return (
-    <div className="flex items-center gap-1.5">
-      <div className="h-1 w-12 bg-muted/50 rounded-full overflow-hidden">
-        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
-      </div>
-      <span className="text-xs font-semibold tabular-nums">{value}</span>
-    </div>
-  );
+function fgLabel(fg: number | null): string {
+  if (fg == null) return "—";
+  if (fg < 25) return "극도 공포"; if (fg < 45) return "공포";
+  if (fg <= 55) return "중립"; if (fg <= 75) return "탐욕";
+  return "극도 탐욕";
 }
-
-/* ── Alert message translation ── */
+function fgColor(fg: number | null): string {
+  if (fg == null) return "bg-zinc-700 text-zinc-400";
+  if (fg < 25) return "bg-red-500/20 text-red-400";
+  if (fg < 45) return "bg-orange-500/20 text-orange-400";
+  if (fg <= 55) return "bg-yellow-500/20 text-yellow-400";
+  if (fg <= 75) return "bg-lime-500/20 text-lime-400";
+  return "bg-emerald-500/20 text-emerald-400";
+}
+function macroLevel(s: number): { label: string; color: string } {
+  if (s >= 70) return { label: "양호", color: "text-emerald-400" };
+  if (s >= 50) return { label: "보통", color: "text-zinc-300" };
+  if (s >= 30) return { label: "부진", color: "text-orange-400" };
+  return { label: "취약", color: "text-red-400" };
+}
 function translateAlert(msg: string): string {
   return msg
     .replace("시그널 성과 급락:", "매매 신호 성과 하락:")
     .replace(/BUY\/SELL 충돌 (\d+)건:/, "매수·매도 신호 충돌 $1건:")
-    .replace("bb_bounce", "볼린저밴드 반등")
-    .replace("macd_bullish_turn", "MACD 상승전환")
-    .replace("macd_bearish_turn", "MACD 하락전환")
-    .replace("macd_golden", "MACD 골든크로스")
-    .replace("macd_dead", "MACD 데드크로스")
-    .replace("rsi_oversold", "RSI 과매도")
-    .replace("rsi_overbought", "RSI 과매수")
-    .replace("sma_golden", "이동평균 골든크로스")
-    .replace("sma_dead", "이동평균 데드크로스")
-    .replace("volume_spike", "거래량 급증")
-    .replace("gap_up", "갭 상승")
-    .replace("gap_down", "갭 하락")
-    .replace("bb_squeeze_breakout", "볼린저밴드 돌파")
-    .replace("near_52w_low_bounce", "52주 저점 반등")
+    .replace("bb_bounce", "볼린저밴드 반등").replace("macd_bullish_turn", "MACD 상승전환")
+    .replace("macd_bearish_turn", "MACD 하락전환").replace("macd_golden", "MACD 골든크로스")
+    .replace("macd_dead", "MACD 데드크로스").replace("rsi_oversold", "RSI 과매도")
+    .replace("rsi_overbought", "RSI 과매수").replace("sma_golden", "이동평균 골든크로스")
+    .replace("sma_dead", "이동평균 데드크로스").replace("volume_spike", "거래량 급증")
+    .replace("gap_up", "갭 상승").replace("gap_down", "갭 하락")
+    .replace("bb_squeeze_breakout", "볼린저밴드 돌파").replace("near_52w_low_bounce", "52주 저점 반등")
     .replace("volume_profile_resistance", "거래량 저항선");
 }
+function displayName(h: { name?: string | null; ticker?: string }) {
+  return h?.name || (h?.ticker?.endsWith(".KS") ? h.ticker.replace(".KS", "") : h?.ticker) || "";
+}
 
-/* ── Market helpers ── */
-function trendKo(t: string): string {
-  return t === "bull" ? "상승" : t === "bear" ? "하락" : "횡보";
-}
-function vixDesc(v: number | null): string {
-  if (v == null) return "데이터 없음";
-  if (v < 15) return "안정 — 매수에 유리한 구간";
-  if (v > 30) return "극도 불안 — 신규 매수 자제";
-  if (v > 25) return "불안정 — 주의 필요";
-  return "보통 — 정상 범위";
-}
-function fgDesc(fg: number | null): string {
-  if (fg == null) return "데이터 없음";
-  if (fg < 25) return "극도 공포 — 역발상 매수 구간";
-  if (fg < 45) return "공포 — 매수 기회 가능";
-  if (fg <= 55) return "중립";
-  if (fg <= 75) return "탐욕 — 과열 주의";
-  return "극도 탐욕 — 매수 자제";
-}
+/* ══════════════════════════════════════════════════════ */
 
 async function Dashboard() {
   const [d, freshness, pipelineStatus, portfolio, siege, advisor] = await Promise.all([
@@ -136,19 +109,15 @@ async function Dashboard() {
   ]);
 
   const holdingCount = portfolio?.count ?? portfolio?.holdings?.length ?? 0;
-  if (holdingCount === 0) {
-    redirect("/portfolio?onboarding=true");
-  }
+  if (holdingCount === 0) redirect("/portfolio?onboarding=true");
 
   const style = levelStyles[d.verdict_level] || levelStyles.neutral;
   const verdictLabel = verdictLabels[d.verdict_level] || "관망";
-
   const KRW_RATE = d.exchange_rate || 1400;
   const totalValue = portfolio?.holdings?.reduce((sum: number, h: any) => {
     const price = h.latest_price || 0;
     const qty = h.quantity || 0;
-    const isKr = h.ticker?.endsWith(".KS");
-    return sum + (isKr ? price * qty / KRW_RATE : price * qty);
+    return sum + (h.ticker?.endsWith(".KS") ? price * qty / KRW_RATE : price * qty);
   }, 0) || 0;
 
   const vix = d.regime.vix ?? null;
@@ -160,240 +129,281 @@ async function Dashboard() {
   const nBuys = d.actions.filter(a => a.action === "BUY").length;
   const nSells = d.actions.filter(a => a.action === "SELL").length;
 
-  // 수익/손실 종목 요약
   const holdings = portfolio?.holdings || [];
   const winners = holdings.filter((h: any) => h.latest_price && h.avg_price && h.latest_price > h.avg_price);
   const losers = holdings.filter((h: any) => h.latest_price && h.avg_price && h.latest_price < h.avg_price);
   const topWinner = winners.sort((a: any, b: any) => ((b.latest_price / b.avg_price) - (a.latest_price / a.avg_price)))[0];
   const topLoser = losers.sort((a: any, b: any) => ((a.latest_price / a.avg_price) - (b.latest_price / b.avg_price)))[0];
-  // 종목 표시명: name 필드 → ticker에서 .KS 제거 → ticker 그대로
-  const displayName = (h: any) => h?.name || (h?.ticker?.endsWith(".KS") ? h.ticker.replace(".KS", "") : h?.ticker) || "";
+  const vixInfo = vixZone(vix);
+  const macroInfo = macroLevel(d.macro.score);
+  const accountValues = d.account_values || [];
+
+  // 계좌별 액션 그룹핑
+  const mainActions = d.actions.filter(a => a.account === "Main" || a.account === "Sub");
+  const pensionActions = d.actions.filter(a => a.account === "Pension");
+  const otherActions = d.actions.filter(a => !a.account || (a.account !== "Main" && a.account !== "Sub" && a.account !== "Pension"));
+  const now = new Date();
+  const isMonthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate() - now.getDate() <= 3;
 
   return (
-    <div className="space-y-3">
-      {/* ── 데이터 상태 ── */}
-      <div className="flex items-center gap-4 flex-wrap">
+    <div className="flex flex-col gap-4 min-h-0">
+      {/* ── 파이프라인 + 시장 온도 (1줄 통합) ── */}
+      <div className="flex items-center gap-3 flex-wrap">
         {((freshness?.items?.length ?? 0) > 0 || (freshness?.details?.length ?? 0) > 0) && (
-          <div className="flex items-center gap-2">
-            <span className="text-[10px] text-muted-foreground/70 shrink-0">데이터</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] text-zinc-600 shrink-0">데이터</span>
             <FreshnessBar items={freshness?.items ?? freshness?.details ?? []} />
           </div>
         )}
         {pipelineStatus.steps.length > 0 && (
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1">
             {pipelineStatus.steps.map((s, i) => (
-              <div key={s.step} className="flex items-center gap-1">
-                <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted/30" title={`${s.label}: ${s.record_count.toLocaleString()}건`}>
+              <div key={s.step} className="flex items-center gap-0.5">
+                <div className="flex items-center gap-0.5 px-1 py-0.5 rounded bg-zinc-800/50" title={`${s.label}: ${s.record_count.toLocaleString()}건`}>
                   <span className={`inline-flex h-1.5 w-1.5 rounded-full ${pipelineStatusColors[s.status] || "bg-zinc-500"}`} />
-                  <span className="text-[10px] text-muted-foreground">{s.label}</span>
+                  <span className="text-[9px] text-zinc-500">{s.label}</span>
                 </div>
-                {i < pipelineStatus.steps.length - 1 && <span className="text-muted-foreground/30 text-[10px]">&rarr;</span>}
+                {i < pipelineStatus.steps.length - 1 && <span className="text-zinc-700 text-[9px]">&rarr;</span>}
               </div>
             ))}
-            <Link href="/pipeline" className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground ml-1">&rarr;</Link>
+            <Link href="/pipeline" className="text-[9px] text-zinc-600 hover:text-zinc-400 ml-0.5">&rarr;</Link>
           </div>
         )}
       </div>
 
-      {/* ── 오늘의 판단 + 시장 현황 ── */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        {/* 오늘의 판단 — 3/5 width */}
-        <Card className={`${style.bg} ${style.border} border`}>
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-xs font-semibold text-foreground/80">오늘의 판단</span>
+      {/* ═══ 상단: 히어로 + 시장 온도 (2열) ═══ */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-4 items-start">
+        {/* 좌: 총 평가액 + 판단 */}
+        <div>
+          <p className="text-[10px] text-zinc-500 mb-0.5">총 평가액</p>
+          <div className="flex items-baseline gap-3">
+            <span className="text-4xl font-semibold tabular-nums tracking-tight text-zinc-100">
+              ${totalValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            </span>
+            <StatusBadge status={verdictLabel} size="lg" />
+          </div>
+          {/* 계좌별 평가액 */}
+          {accountValues.length > 0 && (
+            <div className="flex items-center gap-3 mt-1 text-[10px] text-zinc-500">
+              {accountValues.map(av => (
+                <span key={av.account}>{av.account} ${av.value.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span>
+              ))}
             </div>
-            <div className="flex items-center gap-3 mb-2">
-              <StatusBadge status={verdictLabel} size="lg" />
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                <span>총 평가액 <span className="font-semibold text-foreground">${totalValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span></span>
-                {siegeTotal > 0 && (
-                  <span>품질검증 <span className={`font-semibold ${siege?.certified ? "text-emerald-400" : "text-red-400"}`}>{siege?.certified ? "통과" : "미통과"}</span> <span className="text-muted-foreground/70">{siege?.passed || 0}/{siegeTotal}</span></span>
-                )}
-                {(advisor?.total_violations || 0) > 0 && (
-                  <span>규칙 위반 <span className="font-semibold text-red-400">{advisor.total_violations}건</span></span>
-                )}
-              </div>
-            </div>
-
-            {/* 판단 이유 + 요약 */}
-            <p className={`text-sm ${style.text} mb-1`}>{d.verdict}</p>
-            {/* 포트폴리오 수익/손실 요약 */}
-            <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] mb-3">
-              {winners.length > 0 && (
-                <span className="text-emerald-400/80">
-                  수익 {winners.length}종목
-                  {topWinner && ` (최고 ${displayName(topWinner)} +${((topWinner.latest_price / topWinner.avg_price - 1) * 100).toFixed(0)}%)`}
-                </span>
-              )}
-              {losers.length > 0 && (
-                <span className="text-red-400/80">
-                  손실 {losers.length}종목
-                  {topLoser && ` (최대 ${displayName(topLoser)} ${((topLoser.latest_price / topLoser.avg_price - 1) * 100).toFixed(0)}%)`}
-                </span>
-              )}
-              {nBuys > 0 && <span className="text-muted-foreground/60">매수 신호 {nBuys}건</span>}
-              {nSells > 0 && <span className="text-muted-foreground/60">매도 신호 {nSells}건</span>}
-              {alertCount > 0 && <span className="text-amber-400/60">위험 {alertCount}건</span>}
-            </div>
-
-            {/* 비중 바 */}
-            <div className="flex h-4 rounded overflow-hidden text-[10px] font-medium">
-              {d.allocation.long > 0 && (
-                <div className="bg-emerald-600 flex items-center justify-center" style={{ width: `${d.allocation.long}%` }}>
-                  {d.allocation.long >= 15 && `투자 ${d.allocation.long}%`}
-                </div>
-              )}
-              {d.allocation.short > 0 && (
-                <div className="bg-red-600 flex items-center justify-center" style={{ width: `${d.allocation.short}%` }}>
-                  {d.allocation.short >= 10 && `숏 ${d.allocation.short}%`}
-                </div>
-              )}
-              {d.allocation.cash > 0 && (
-                <div className="bg-muted flex items-center justify-center text-muted-foreground" style={{ width: `${d.allocation.cash}%` }}>
-                  현금 {d.allocation.cash}%
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* 시장 현황 — 2/5 width, gauge bars */}
-        <Card className="bg-card border-border">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-xs font-semibold text-foreground/80">시장 현황</span>
-              <span className={`text-xs font-semibold ${trend === "bull" ? "text-emerald-400" : trend === "bear" ? "text-red-400" : "text-muted-foreground"}`}>
-                {trendKo(trend)} {trend === "bull" ? "\u2197" : trend === "bear" ? "\u2198" : "\u2194"}
+          )}
+          <p className={`text-xs ${style.text} mt-1.5 line-clamp-1`}>{d.verdict}</p>
+          <div className="flex items-center gap-3 mt-1 text-[10px]">
+            {winners.length > 0 && (
+              <span className="text-emerald-400/80">
+                수익 {winners.length}종목
+                {topWinner && <span className="text-zinc-500"> &middot; {displayName(topWinner)} +{((topWinner.latest_price / topWinner.avg_price - 1) * 100).toFixed(0)}%</span>}
               </span>
-            </div>
-            <div className="space-y-3">
-              <Gauge
-                label="변동성 지수 (VIX)"
-                value={vix != null ? Math.round(vix * 10) / 10 : 0}
-                max={50}
-                color={vix == null ? "text-zinc-400" : vix < 15 ? "text-emerald-400" : vix > 25 ? "text-red-400" : "text-zinc-200"}
-                sub={vixDesc(vix)}
-              />
-              <Gauge
-                label="공포·탐욕 지수"
-                value={fg ?? 0}
-                max={100}
-                color={fg == null ? "text-zinc-400" : fg < 25 ? "text-red-400" : fg > 75 ? "text-red-400" : fg >= 40 && fg <= 60 ? "text-emerald-400" : "text-zinc-200"}
-                sub={fgDesc(fg)}
-              />
-              <div className="flex items-baseline justify-between">
-                <span className="text-[10px] text-muted-foreground">경제 지표</span>
-                <span className={`text-sm font-semibold ${d.macro.score >= 60 ? "text-emerald-400" : d.macro.score < 40 ? "text-red-400" : "text-zinc-200"}`}>
-                  {d.macro.score}<span className="text-muted-foreground/50 font-normal text-xs">/100</span>
+            )}
+            {losers.length > 0 && (
+              <span className="text-red-400/80">
+                손실 {losers.length}종목
+                {topLoser && <span className="text-zinc-500"> &middot; {displayName(topLoser)} {((topLoser.latest_price / topLoser.avg_price - 1) * 100).toFixed(0)}%</span>}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* 우: 시장 온도 (컴팩트 카드) */}
+        <Card className="bg-zinc-900/50 border-zinc-800 min-w-[280px]">
+          <CardContent className="px-3 py-2">
+            <h2 className="text-[9px] text-zinc-600 uppercase tracking-wider mb-1.5">시장 온도</h2>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] text-zinc-600">추세</span>
+                <span className={`text-xs font-semibold ${trend === "bull" ? "text-emerald-400" : trend === "bear" ? "text-red-400" : "text-amber-400"}`}>{trendKo(trend)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] text-zinc-600">VIX</span>
+                <span className="flex items-center gap-1">
+                  <span className={`text-xs font-semibold tabular-nums ${vixInfo.color}`}>{vix != null ? Math.round(vix * 10) / 10 : "—"}</span>
+                  <span className={`text-[9px] ${vixInfo.color}`}>{vixInfo.label}</span>
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] text-zinc-600">심리</span>
+                <span className="flex items-center gap-1">
+                  <span className={`inline-flex items-center justify-center h-5 w-5 rounded-full text-[10px] font-bold tabular-nums ${fgColor(fg)}`}>{fg ?? "—"}</span>
+                  <span className="text-[9px] text-zinc-500">{fgLabel(fg)}</span>
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] text-zinc-600">경제</span>
+                <span className="flex items-center gap-1">
+                  <span className={`text-xs font-semibold tabular-nums ${macroInfo.color}`}>{d.macro.score}</span>
+                  <span className={`text-[9px] ${macroInfo.color}`}>{macroInfo.label}</span>
                 </span>
               </div>
             </div>
+            <p className="text-[9px] text-zinc-600 mt-1.5">{d.regime.regime} &middot; 신뢰도 {d.regime.confidence}%</p>
           </CardContent>
         </Card>
       </div>
 
-      {/* ── 오늘의 매매 + 위험 관리 ── */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        {/* 오늘의 매매 — 3/5 */}
-        <Card className="bg-card border-border">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-xs font-semibold text-foreground/80">
-                오늘의 매매
-                {d.actions.length > 0 && <span className="ml-1.5 text-muted-foreground font-normal">{d.actions.length}건</span>}
-              </p>
-              {d.actions.length > 0 && <span className="text-[10px] text-muted-foreground/50">클릭하면 상세 분석</span>}
-            </div>
-            {d.actions.length > 0 ? (
-              <div className="space-y-1">
-                {d.actions.map((a, i) => (
+      {/* 비중 바 */}
+      <div className="flex h-4 rounded overflow-hidden text-[9px] font-medium">
+        {d.allocation.long > 0 && (
+          <div className="bg-emerald-600/80 flex items-center justify-center text-emerald-100" style={{ width: `${d.allocation.long}%` }}>
+            {d.allocation.long >= 15 && `투자 ${d.allocation.long}%`}
+          </div>
+        )}
+        {d.allocation.short > 0 && (
+          <div className="bg-red-600/80 flex items-center justify-center text-red-100" style={{ width: `${d.allocation.short}%` }}>
+            {d.allocation.short >= 10 && `숏 ${d.allocation.short}%`}
+          </div>
+        )}
+        {d.allocation.cash > 0 && (
+          <div className="bg-zinc-800 flex items-center justify-center text-zinc-400" style={{ width: `${d.allocation.cash}%` }}>
+            현금 {d.allocation.cash}%
+          </div>
+        )}
+      </div>
+
+      {/* ═══ 오늘의 할 일 — 계좌별 그룹핑 ═══ */}
+      <div className="flex-1 min-h-0">
+        <div className="flex items-center justify-between mb-1.5">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-zinc-200">오늘의 할 일</h2>
+            {d.actions.length > 0 && (
+              <span className="text-[10px] text-zinc-600">
+                {nBuys > 0 && `매수 ${nBuys}`}{nBuys > 0 && nSells > 0 && " \u00B7 "}{nSells > 0 && `매도 ${nSells}`}
+              </span>
+            )}
+          </div>
+          {d.actions.length > 0 && (
+            <Link href="/decisions" className="text-[9px] text-zinc-600 hover:text-zinc-400">기록 &rarr;</Link>
+          )}
+        </div>
+
+        {d.actions.length > 0 ? (
+          <div className="space-y-2">
+            {/* Main + Sub 액션 */}
+            {mainActions.length > 0 && (
+              <div>
+                {mainActions.map((a, i) => (
                   <Link key={`${a.ticker}-${i}`} href={`/ticker/${a.ticker}`}
-                    className="block px-2.5 py-2 rounded-lg hover:bg-muted/50 transition-colors group">
-                    <div className="flex items-center gap-2">
-                      <StatusBadge status={a.action === "BUY" ? "매수" : "매도"} />
-                      <span className="font-medium text-sm group-hover:text-white transition-colors">
-                        {a.name || a.ticker}
-                      </span>
-                      {a.name && <span className="text-[10px] text-muted-foreground/40">{a.ticker}</span>}
-                      <div className="ml-auto flex items-center gap-3">
-                        <div className="text-right">
-                          <ConfBar value={a.confidence} />
-                          <p className="text-[9px] text-muted-foreground/50 mt-0.5">신뢰도</p>
-                        </div>
-                        <div className="text-right" title="10개 AI 에이전트 중 동의한 수">
-                          <span className="text-xs font-semibold tabular-nums">{Math.round((a.agreement || 0) / 10)}/10</span>
-                          <p className="text-[9px] text-muted-foreground/50">AI 동의</p>
-                        </div>
-                      </div>
+                    className={`flex items-center gap-2 px-2 py-1.5 rounded border-l-2 hover:bg-zinc-800/50 transition-colors ${
+                      a.action === "BUY" ? "border-emerald-500" : "border-red-500"
+                    }`}>
+                    <StatusBadge status={a.action === "BUY" ? "매수" : "매도"} />
+                    {a.account && <span className="text-[9px] text-zinc-600 min-w-[2rem]">{a.account}</span>}
+                    <span className="font-medium text-xs text-zinc-100 truncate">{a.name || a.ticker}</span>
+                    {a.name && <span className="text-[10px] text-zinc-600 shrink-0">{a.ticker}</span>}
+                    {a.reason && <span className="text-[10px] text-zinc-600 truncate hidden lg:inline">{a.reason}</span>}
+                    <div className="ml-auto flex items-center gap-2 shrink-0">
+                      <span className={`inline-flex items-center justify-center w-7 h-5 rounded text-[10px] font-bold tabular-nums ${
+                        a.confidence >= 80 ? "bg-emerald-500/15 text-emerald-400" :
+                        a.confidence >= 50 ? "bg-amber-500/15 text-amber-400" :
+                        "bg-red-500/15 text-red-400"
+                      }`}>{a.confidence}</span>
+                      <span className="text-[10px] text-zinc-500 tabular-nums">{Math.round((a.agreement || 0) / 10)}/10</span>
                     </div>
-                    {a.reason && (
-                      <p className="text-[11px] text-muted-foreground/60 mt-1 pl-[52px] line-clamp-1">{a.reason}</p>
-                    )}
                   </Link>
                 ))}
               </div>
-            ) : (
-              <p className="text-xs text-muted-foreground/70 py-6 text-center">매매 신호 없음 &mdash; 현재 포지션 유지</p>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* 위험 관리 — 2/5 */}
-        <Card className="bg-card border-border">
-          <CardContent className="pt-4 pb-3">
-            <p className="text-xs font-semibold text-foreground/80 mb-2">
-              위험 관리
-              {alertCount > 0 && <span className="ml-1.5 text-red-400 font-normal">{alertCount}건</span>}
-            </p>
-            {alertCount > 0 ? (
-              <div className="space-y-1.5">
-                {d.alerts.map((al, i) => (
-                  <div key={i} className={`text-xs px-2 py-1.5 rounded ${
-                    al.level === "critical" ? "bg-red-500/10 text-red-400" :
-                    al.level === "warning" ? "bg-amber-500/10 text-amber-400" :
-                    "bg-muted text-muted-foreground"
-                  }`}>
-                    <span>{translateAlert(al.message)}</span>
-                    {al.level === "critical" && al.message.includes("손절") && (
-                      <span className="block text-[10px] mt-0.5 opacity-70">조치: 매도 검토하여 손실 제한</span>
-                    )}
-                    {al.level === "warning" && al.message.includes("손절") && (
-                      <span className="block text-[10px] mt-0.5 opacity-70">조치: 추가 하락 시 매도 준비</span>
-                    )}
-                    {al.message.includes("시그널") && (
-                      <span className="block text-[10px] mt-0.5 opacity-70">조치: 시그널 신뢰도 재확인</span>
-                    )}
-                    {al.message.includes("충돌") && (
-                      <span className="block text-[10px] mt-0.5 opacity-70">조치: 신호 충돌 — 명확해질 때까지 대기</span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="text-xs text-emerald-400/70 py-2 flex items-center gap-1.5">
-                <span className="inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                위험 요소 없음 &mdash; 모든 규칙 준수 중
-              </div>
             )}
 
-            {siegeFailed.length > 0 && (
-              <div className="mt-3 pt-3 border-t border-border/40">
-                <p className="text-[10px] text-red-400/80 mb-1.5">품질검증 미통과 ({siegeFailed.length}건)</p>
-                <div className="space-y-0.5">
-                  {siegeFailed.slice(0, 5).map((c: any, i: number) => (
-                    <p key={i} className="text-[11px] text-muted-foreground">
-                      <span className={c.severity === "error" ? "text-red-400" : "text-amber-400"}>
-                        {c.severity === "error" ? "\u2716" : "\u25B3"}
-                      </span>{" "}
-                      {c.description} &mdash; {c.detail}
-                    </p>
-                  ))}
+            {/* Other 액션 (Toss 등) */}
+            {otherActions.length > 0 && otherActions.map((a, i) => (
+              <Link key={`o-${a.ticker}-${i}`} href={`/ticker/${a.ticker}`}
+                className={`flex items-center gap-2 px-2 py-1.5 rounded border-l-2 hover:bg-zinc-800/50 transition-colors ${
+                  a.action === "BUY" ? "border-emerald-500" : "border-red-500"
+                }`}>
+                <StatusBadge status={a.action === "BUY" ? "매수" : "매도"} />
+                {a.account && <span className="text-[9px] text-zinc-600 min-w-[2rem]">{a.account}</span>}
+                <span className="font-medium text-xs text-zinc-100 truncate">{a.name || a.ticker}</span>
+                <div className="ml-auto flex items-center gap-2 shrink-0">
+                  <span className={`inline-flex items-center justify-center w-7 h-5 rounded text-[10px] font-bold tabular-nums ${
+                    a.confidence >= 80 ? "bg-emerald-500/15 text-emerald-400" :
+                    a.confidence >= 50 ? "bg-amber-500/15 text-amber-400" :
+                    "bg-red-500/15 text-red-400"
+                  }`}>{a.confidence}</span>
+                  <span className="text-[10px] text-zinc-500 tabular-nums">{Math.round((a.agreement || 0) / 10)}/10</span>
                 </div>
-              </div>
+              </Link>
+            ))}
+
+            {/* Pension — 월말 아니면 축소 */}
+            {pensionActions.length > 0 && !isMonthEnd && (
+              <p className="text-[10px] text-zinc-600 px-2">연금 {pensionActions.length}건 &mdash; 월말 매수 대기</p>
             )}
-          </CardContent>
-        </Card>
+            {pensionActions.length > 0 && isMonthEnd && pensionActions.map((a, i) => (
+              <Link key={`p-${a.ticker}-${i}`} href={`/ticker/${a.ticker}`}
+                className={`flex items-center gap-2 px-2 py-1.5 rounded border-l-2 hover:bg-zinc-800/50 transition-colors ${
+                  a.action === "BUY" ? "border-emerald-500" : "border-red-500"
+                }`}>
+                <StatusBadge status={a.action === "BUY" ? "매수" : "매도"} />
+                <span className="text-[9px] text-zinc-600">연금</span>
+                <span className="font-medium text-xs text-zinc-100 truncate">{a.name || a.ticker}</span>
+                <div className="ml-auto flex items-center gap-2 shrink-0">
+                  <span className={`inline-flex items-center justify-center w-7 h-5 rounded text-[10px] font-bold tabular-nums ${
+                    a.confidence >= 80 ? "bg-emerald-500/15 text-emerald-400" :
+                    a.confidence >= 50 ? "bg-amber-500/15 text-amber-400" :
+                    "bg-red-500/15 text-red-400"
+                  }`}>{a.confidence}</span>
+                  <span className="text-[10px] text-zinc-500 tabular-nums">{Math.round((a.agreement || 0) / 10)}/10</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-zinc-500 py-4 text-center">매매 신호 없음 &mdash; 현재 포지션 유지</p>
+        )}
+
+        {/* 주의 사항 — 컴팩트 */}
+        {alertCount > 0 && (
+          <div className="mt-2 pt-2 border-t border-zinc-800/60">
+            <p className="text-[10px] font-semibold text-zinc-400 mb-1">주의 사항 <span className="text-zinc-600 font-normal">{alertCount}건</span></p>
+            <div className="space-y-0.5">
+              {d.alerts.map((al, i) => (
+                <div key={i} className={`text-[10px] ${
+                  al.level === "critical" ? "text-red-400" : al.level === "warning" ? "text-amber-400" : "text-zinc-400"
+                }`}>
+                  <span>{translateAlert(al.message)}</span>
+                  {al.level === "critical" && al.message.includes("손절") && (
+                    <span className="text-zinc-500"> &mdash; 매도 검토하여 손실 제한</span>
+                  )}
+                  {al.level === "warning" && al.message.includes("손절") && (
+                    <span className="text-zinc-500"> &mdash; 추가 하락 시 매도 준비</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {alertCount === 0 && (
+          <div className="mt-2 pt-2 border-t border-zinc-800/60 flex items-center gap-1.5 text-[10px]">
+            <span className="inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            <span className="text-zinc-400">위험 요소 없음 — 모든 규칙 준수 중</span>
+          </div>
+        )}
+
+        {/* 푸터 */}
+        <div className="mt-2 pt-2 border-t border-zinc-800/60 flex items-center gap-3 flex-wrap text-[10px]">
+          {siegeTotal > 0 && siegeFailed.length === 0 && (
+            <span className="text-zinc-400"><span className="text-emerald-500">&#10003;</span> 품질 검증 {siege?.passed || 0}/{siegeTotal} 통과</span>
+          )}
+          {siegeTotal > 0 && siegeFailed.length > 0 && (
+            <span className="text-red-400"><span className="text-red-500">&#10007;</span> 품질 검증 미통과 ({siegeFailed.length}건) <span className="text-zinc-600">{siege?.passed || 0}/{siegeTotal}</span></span>
+          )}
+          {(advisor?.total_violations || 0) > 0 && (
+            <span className="text-red-400">규칙 위반 {advisor.total_violations}건</span>
+          )}
+          <Link href="/portfolio" className="text-zinc-600 hover:text-zinc-400 ml-auto">포트폴리오 상세 &rarr;</Link>
+        </div>
+        {siegeTotal > 0 && siegeFailed.length > 0 && (
+          <div className="mt-1 space-y-0.5">
+            {siegeFailed.slice(0, 3).map((c: any, i: number) => (
+              <p key={i} className="text-[10px] text-zinc-400 pl-3">
+                <span className={c.severity === "error" ? "text-red-400" : "text-amber-400"}>{c.severity === "error" ? "\u2716" : "\u25B3"}</span>{" "}
+                {c.description} &mdash; <span className="text-zinc-600">{c.detail}</span>
+              </p>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -401,16 +411,11 @@ async function Dashboard() {
 
 function LoadingSkeleton() {
   return (
-    <div className="space-y-3">
-      <div className="h-7 bg-card rounded border border-border animate-pulse" />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        <div className="h-36 bg-card rounded-xl border border-border animate-pulse" />
-        <div className="h-36 bg-card rounded-xl border border-border animate-pulse" />
-      </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        <div className="h-48 bg-card rounded-xl border border-border animate-pulse" />
-        <div className="h-48 bg-card rounded-xl border border-border animate-pulse" />
-      </div>
+    <div className="flex flex-col gap-4">
+      <div className="h-6 bg-zinc-900 rounded animate-pulse" />
+      <div className="h-20 bg-zinc-900/50 rounded animate-pulse" />
+      <div className="h-4 bg-zinc-800 rounded animate-pulse" />
+      <div className="h-48 bg-zinc-900/50 rounded animate-pulse" />
     </div>
   );
 }

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -168,13 +168,28 @@ def _get_ticker_account_map() -> dict[str, str]:
     return mapping
 
 
-# 계좌 표시명 (privacy: 실제 broker명 노출 금지)
-_ACCOUNT_LABELS = {
-    "kakaopay": "Main",
-    "kakaopay_sub": "Sub",
-    "pension": "Pension",
-    "toss": "Toss",
-}
+def _get_account_labels() -> dict[str, str]:
+    """계좌명 → 표시 라벨 매핑. portfolio.yaml strategy 필드 기반 (broker명 노출 금지)."""
+    from pathlib import Path  # noqa: E402
+
+    import yaml  # noqa: E402
+
+    _STRATEGY_LABELS = {"core": "Main", "swing": "Sub", "pension": "Pension", "longterm": "Long"}
+    portfolio_path = Path(__file__).parent.parent.parent.parent / "config" / "portfolio.yaml"
+    try:
+        with open(portfolio_path, encoding="utf-8") as f:
+            portfolio = yaml.safe_load(f)
+        labels: dict[str, str] = {}
+        seen: dict[str, int] = {}
+        for acc, info in (portfolio.get("accounts") or {}).items():
+            strategy_name = (info or {}).get("strategy", "core")
+            base_label = _STRATEGY_LABELS.get(strategy_name, strategy_name.title())
+            count = seen.get(base_label, 0)
+            seen[base_label] = count + 1
+            labels[acc] = base_label if count == 0 else f"{base_label} {count + 1}"
+        return labels
+    except Exception:
+        return {}
 
 
 def _get_latest_actions() -> list[dict]:
@@ -192,6 +207,7 @@ def _get_latest_actions() -> list[dict]:
             return []
 
         ticker_account = _get_ticker_account_map()
+        account_labels = _get_account_labels()
 
         actions = []
         for row in rows:
@@ -199,7 +215,7 @@ def _get_latest_actions() -> list[dict]:
             confidence = round(row["confidence"] * 100) if row["confidence"] and row["confidence"] <= 1 else round(row["confidence"] or 0)
             reason, agreement_rate = _extract_reason(row.get("signals"))
             raw_account = ticker_account.get(row["ticker"], "")
-            account_label = _ACCOUNT_LABELS.get(raw_account, raw_account)
+            account_label = account_labels.get(raw_account, raw_account)
 
             if action == "BUY" and confidence >= 50:
                 actions.append({
@@ -253,8 +269,9 @@ def _get_account_values(exchange_rate: float | None) -> list[dict]:
         val = price * qty / rate if is_kr else price * qty
         totals[acc] = totals.get(acc, 0) + val
 
+    account_labels = _get_account_labels()
     return [
-        {"account": _ACCOUNT_LABELS.get(acc, acc), "value": round(v, 2)}
+        {"account": account_labels.get(acc, acc), "value": round(v, 2)}
         for acc, v in sorted(totals.items(), key=lambda x: -x[1])
     ]
 

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -77,6 +77,9 @@ def _build_dashboard() -> dict:
     rate_row = query("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1")
     exchange_rate = rate_row[0]["value"] if rate_row else None
 
+    # ── 8. 계좌별 평가액 ──
+    account_values = _get_account_values(exchange_rate)
+
     return {
         "verdict": verdict,
         "verdict_level": verdict_level,
@@ -90,6 +93,7 @@ def _build_dashboard() -> dict:
         "freshness": freshness,
         "pipeline_status": pipeline_status,
         "exchange_rate": exchange_rate,
+        "account_values": account_values,
     }
 
 
@@ -153,6 +157,26 @@ def _extract_reason(signals_raw: str | None) -> tuple[str, float | None]:
         return signals_raw[:60], None
 
 
+def _get_ticker_account_map() -> dict[str, str]:
+    """ticker → account 매핑 (첫 번째 계좌 기준)."""
+    from nuri.core.db import query
+    rows = query("SELECT ticker, account FROM portfolio ORDER BY account")
+    mapping: dict[str, str] = {}
+    for r in rows:
+        if r["ticker"] not in mapping:
+            mapping[r["ticker"]] = r["account"]
+    return mapping
+
+
+# 계좌 표시명 (privacy: 실제 broker명 노출 금지)
+_ACCOUNT_LABELS = {
+    "kakaopay": "Main",
+    "kakaopay_sub": "Sub",
+    "pension": "Pension",
+    "toss": "Toss",
+}
+
+
 def _get_latest_actions() -> list[dict]:
     """recommendations 테이블에서 최신 추천 조회 — analyze_portfolio() 대체."""
     from nuri.core.db import query
@@ -167,11 +191,15 @@ def _get_latest_actions() -> list[dict]:
         if not rows:
             return []
 
+        ticker_account = _get_ticker_account_map()
+
         actions = []
         for row in rows:
             action = row["action"]
             confidence = round(row["confidence"] * 100) if row["confidence"] and row["confidence"] <= 1 else round(row["confidence"] or 0)
             reason, agreement_rate = _extract_reason(row.get("signals"))
+            raw_account = ticker_account.get(row["ticker"], "")
+            account_label = _ACCOUNT_LABELS.get(raw_account, raw_account)
 
             if action == "BUY" and confidence >= 50:
                 actions.append({
@@ -181,6 +209,7 @@ def _get_latest_actions() -> list[dict]:
                     "confidence": confidence,
                     "reason": reason,
                     "agreement": round(agreement_rate * 100) if agreement_rate is not None else None,
+                    "account": account_label,
                 })
             elif action == "SELL" and confidence >= 70:
                 actions.append({
@@ -190,6 +219,7 @@ def _get_latest_actions() -> list[dict]:
                     "confidence": confidence,
                     "reason": reason,
                     "agreement": round(agreement_rate * 100) if agreement_rate is not None else None,
+                    "account": account_label,
                 })
 
         # 상위 5개만
@@ -199,6 +229,34 @@ def _get_latest_actions() -> list[dict]:
     except Exception as e:
         logger.debug(f"Actions from DB: {e}")
         return []
+
+
+def _get_account_values(exchange_rate: float | None) -> list[dict]:
+    """계좌별 평가액 계산."""
+    from nuri.core.db import query
+    rate = exchange_rate or 1400
+    rows = query("""
+        SELECT p.account, p.ticker, p.quantity,
+               pr.close as latest_price
+        FROM portfolio p
+        LEFT JOIN (
+            SELECT ticker, close FROM prices
+            WHERE (ticker, date) IN (SELECT ticker, MAX(date) FROM prices GROUP BY ticker)
+        ) pr ON p.ticker = pr.ticker
+    """)
+    totals: dict[str, float] = {}
+    for r in rows:
+        acc = r["account"]
+        price = r["latest_price"] or 0
+        qty = r["quantity"] or 0
+        is_kr = r["ticker"].endswith(".KS")
+        val = price * qty / rate if is_kr else price * qty
+        totals[acc] = totals.get(acc, 0) + val
+
+    return [
+        {"account": _ACCOUNT_LABELS.get(acc, acc), "value": round(v, 2)}
+        for acc, v in sorted(totals.items(), key=lambda x: -x[1])
+    ]
 
 
 def _get_gate_score() -> int:

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -452,3 +452,363 @@ class TestDashboard_R27:
         import nuri.api.routes.dashboard as dash_mod
         result = dash_mod._get_latest_actions()
         assert isinstance(result, list)
+
+
+class TestTickerAccountMap:
+    """Tests for _get_ticker_account_map()."""
+
+    def test_empty_portfolio(self, db_path):
+        """Empty portfolio returns empty mapping."""
+        from nuri.api.routes.dashboard import _get_ticker_account_map
+        result = _get_ticker_account_map()
+        assert result == {}
+
+    def test_single_account(self, db_path, _seed_portfolio):
+        """Portfolio entries in same account are mapped correctly."""
+        from nuri.api.routes.dashboard import _get_ticker_account_map
+        result = _get_ticker_account_map()
+        assert result["AAPL"] == "test"
+        assert result["MSFT"] == "test"
+
+    def test_multiple_accounts(self, db_path):
+        """Tickers in different accounts get correct mapping; first account wins for dupes."""
+        from nuri.api.routes.dashboard import _get_ticker_account_map
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("alpha", "AAPL", 10, 150.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("beta", "MSFT", 5, 300.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("beta", "AAPL", 20, 160.0, "USD", "Tech"),
+            )
+        result = _get_ticker_account_map()
+        # ORDER BY account → 'alpha' comes before 'beta', so AAPL maps to 'alpha'
+        assert result["AAPL"] == "alpha"
+        assert result["MSFT"] == "beta"
+
+    def test_kr_tickers_included(self, db_path):
+        """Korean tickers (.KS suffix) are included in the mapping."""
+        from nuri.api.routes.dashboard import _get_ticker_account_map
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("pension", "005930.KS", 100, 70000, "KRW", "Tech"),
+            )
+        result = _get_ticker_account_map()
+        assert result["005930.KS"] == "pension"
+
+
+class TestAccountLabels:
+    """Tests for _get_account_labels()."""
+
+    def test_happy_path(self, monkeypatch):
+        """YAML with strategy fields maps to correct labels."""
+        from nuri.api.routes.dashboard import _get_account_labels
+
+        mock_yaml = {
+            "accounts": {
+                "main_account": {"strategy": "core", "tickers": []},
+                "swing_account": {"strategy": "swing", "tickers": []},
+                "pension_account": {"strategy": "pension", "tickers": []},
+                "longterm_account": {"strategy": "longterm", "tickers": []},
+            }
+        }
+
+        import builtins
+        original_open = builtins.open
+
+        def mock_open(path, *args, **kwargs):
+            if "portfolio.yaml" in str(path):
+                from io import StringIO
+                return StringIO(yaml.dump(mock_yaml))
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", mock_open)
+        result = _get_account_labels()
+        assert result["main_account"] == "Main"
+        assert result["swing_account"] == "Sub"
+        assert result["pension_account"] == "Pension"
+        assert result["longterm_account"] == "Long"
+
+    def test_duplicate_strategy_gets_numbered(self, monkeypatch):
+        """Two accounts with same strategy get numbered labels (Main, Main 2)."""
+        from nuri.api.routes.dashboard import _get_account_labels
+
+        mock_yaml = {
+            "accounts": {
+                "acc_a": {"strategy": "core"},
+                "acc_b": {"strategy": "core"},
+            }
+        }
+
+        import builtins
+        original_open = builtins.open
+
+        def mock_open(path, *args, **kwargs):
+            if "portfolio.yaml" in str(path):
+                from io import StringIO
+                return StringIO(yaml.dump(mock_yaml))
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", mock_open)
+        result = _get_account_labels()
+        assert result["acc_a"] == "Main"
+        assert result["acc_b"] == "Main 2"
+
+    def test_unknown_strategy_uses_title(self, monkeypatch):
+        """Strategy not in _STRATEGY_LABELS gets Title-cased."""
+        from nuri.api.routes.dashboard import _get_account_labels
+
+        mock_yaml = {
+            "accounts": {
+                "custom_acc": {"strategy": "experimental"},
+            }
+        }
+
+        import builtins
+        original_open = builtins.open
+
+        def mock_open(path, *args, **kwargs):
+            if "portfolio.yaml" in str(path):
+                from io import StringIO
+                return StringIO(yaml.dump(mock_yaml))
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", mock_open)
+        result = _get_account_labels()
+        assert result["custom_acc"] == "Experimental"
+
+    def test_missing_strategy_defaults_to_core(self, monkeypatch):
+        """Account without strategy field defaults to 'core' -> 'Main'."""
+        from nuri.api.routes.dashboard import _get_account_labels
+
+        mock_yaml = {
+            "accounts": {
+                "no_strategy_acc": {"tickers": ["AAPL"]},
+            }
+        }
+
+        import builtins
+        original_open = builtins.open
+
+        def mock_open(path, *args, **kwargs):
+            if "portfolio.yaml" in str(path):
+                from io import StringIO
+                return StringIO(yaml.dump(mock_yaml))
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", mock_open)
+        result = _get_account_labels()
+        assert result["no_strategy_acc"] == "Main"
+
+    def test_file_not_found_returns_empty(self, monkeypatch):
+        """When portfolio.yaml does not exist, returns empty dict."""
+        import builtins
+
+        from nuri.api.routes.dashboard import _get_account_labels
+        original_open = builtins.open
+
+        def mock_open(path, *args, **kwargs):
+            if "portfolio.yaml" in str(path):
+                raise FileNotFoundError("no such file")
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", mock_open)
+        result = _get_account_labels()
+        assert result == {}
+
+    def test_malformed_yaml_returns_empty(self, monkeypatch):
+        """Malformed YAML returns empty dict (exception path)."""
+        import builtins
+
+        from nuri.api.routes.dashboard import _get_account_labels
+        original_open = builtins.open
+
+        def mock_open(path, *args, **kwargs):
+            if "portfolio.yaml" in str(path):
+                from io import StringIO
+                return StringIO("not: [valid: yaml: {{")
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", mock_open)
+        result = _get_account_labels()
+        # yaml.safe_load may parse this or raise; either way should not crash
+        assert isinstance(result, dict)
+
+
+class TestAccountValues:
+    """Tests for _get_account_values()."""
+
+    def test_empty_portfolio(self, db_path, monkeypatch):
+        """Empty portfolio returns empty list."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {})
+        result = dash_mod._get_account_values(exchange_rate=1300)
+        assert result == []
+
+    def test_usd_tickers(self, db_path, _seed_portfolio, _seed_prices, monkeypatch):
+        """USD tickers have value = close * quantity."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"test": "Main"})
+        result = dash_mod._get_account_values(exchange_rate=1300)
+        assert len(result) == 1
+        assert result[0]["account"] == "Main"
+        assert result[0]["value"] > 0
+
+    def test_kr_ticker_divided_by_exchange_rate(self, db_path, monkeypatch):
+        """Korean .KS tickers are divided by exchange rate to convert to USD."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"kr_acc": "Pension"})
+
+        # Insert KR portfolio entry and price
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("kr_acc", "005930.KS", 100, 70000, "KRW", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+                ("005930.KS", "2025-04-01", 69000, 71000, 68000, 70000, 5000000, 70000),
+            )
+        result = dash_mod._get_account_values(exchange_rate=1400)
+        assert len(result) == 1
+        assert result[0]["account"] == "Pension"
+        # 70000 * 100 / 1400 = 5000.0
+        assert result[0]["value"] == 5000.0
+
+    def test_exchange_rate_none_uses_fallback(self, db_path, monkeypatch):
+        """exchange_rate=None falls back to 1400."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"kr_acc": "Pension"})
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("kr_acc", "005930.KS", 100, 70000, "KRW", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+                ("005930.KS", "2025-04-01", 69000, 71000, 68000, 70000, 5000000, 70000),
+            )
+        result = dash_mod._get_account_values(exchange_rate=None)
+        assert len(result) == 1
+        # 70000 * 100 / 1400 = 5000.0
+        assert result[0]["value"] == 5000.0
+
+    def test_mixed_accounts_sorted_descending(self, db_path, monkeypatch):
+        """Multiple accounts are sorted by value descending."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"big": "Main", "small": "Sub"})
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("big", "AAPL", 100, 150.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("small", "MSFT", 1, 300.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+                ("AAPL", "2025-04-01", 149, 151, 148, 150, 1000000, 150),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+                ("MSFT", "2025-04-01", 299, 301, 298, 300, 800000, 300),
+            )
+        result = dash_mod._get_account_values(exchange_rate=1400)
+        assert len(result) == 2
+        # big: 150 * 100 = 15000, small: 300 * 1 = 300
+        assert result[0]["account"] == "Main"
+        assert result[0]["value"] > result[1]["value"]
+
+    def test_unlabeled_account_uses_raw_name(self, db_path, monkeypatch):
+        """Account not in labels dict falls back to raw account name."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {})
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("unknown_acc", "AAPL", 10, 150.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+                ("AAPL", "2025-04-01", 149, 151, 148, 150, 1000000, 150),
+            )
+        result = dash_mod._get_account_values(exchange_rate=1400)
+        assert len(result) == 1
+        assert result[0]["account"] == "unknown_acc"
+
+
+class TestLatestActionsAccountField:
+    """Tests that _get_latest_actions() includes the account field."""
+
+    def test_buy_action_has_account(self, db_path, monkeypatch):
+        """BUY action includes account label from portfolio mapping."""
+        import nuri.api.routes.dashboard as dash_mod
+        import nuri.core.db as db_mod
+        monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+
+        # Insert portfolio entry for AAPL
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("main_acc", "AAPL", 10, 150.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals) VALUES (?,?,?,?,?,?)",
+                ("2025-04-01", "AAPL", "BUY", 0.80, "bull_low_vol", "rsi_oversold"),
+            )
+
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"main_acc": "Main"})
+        result = dash_mod._get_latest_actions()
+        buys = [a for a in result if a["action"] == "BUY"]
+        assert len(buys) >= 1
+        assert buys[0]["account"] == "Main"
+
+    def test_sell_action_has_account(self, db_path, monkeypatch):
+        """SELL action includes account label from portfolio mapping."""
+        import nuri.api.routes.dashboard as dash_mod
+        import nuri.core.db as db_mod
+        monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("swing_acc", "TSLA", 8, 250.0, "USD", "Auto"),
+            )
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals) VALUES (?,?,?,?,?,?)",
+                ("2025-04-01", "TSLA", "SELL", 0.90, "bear_high_vol", "macd_dead"),
+            )
+
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"swing_acc": "Sub"})
+        result = dash_mod._get_latest_actions()
+        sells = [a for a in result if a["action"] == "SELL"]
+        assert len(sells) >= 1
+        assert sells[0]["account"] == "Sub"
+
+    def test_action_without_portfolio_entry_has_empty_account(self, db_path, monkeypatch):
+        """Ticker not in portfolio gets empty string for account."""
+        import nuri.api.routes.dashboard as dash_mod
+        import nuri.core.db as db_mod
+        monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals) VALUES (?,?,?,?,?,?)",
+                ("2025-04-01", "GOOG", "BUY", 0.85, "bull_low_vol", "rsi_oversold"),
+            )
+
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {})
+        result = dash_mod._get_latest_actions()
+        buys = [a for a in result if a["action"] == "BUY"]
+        assert len(buys) >= 1
+        assert buys[0]["account"] == ""


### PR DESCRIPTION
## Summary

- Dashboard 구조 근본 재설계: 4-column grid + 2-column 50/50 → **세로 1-column 스택**
- SemiGauge/ZoneBar/ConfBar 삭제 (120줄), 색상 텍스트 + TipRanks 숫자 배지로 대체
- 계좌별 액션 그룹핑 (Main/Sub/Pension) + 연금 월말 축소
- API: `account` 필드 + `account_values` 계좌별 평가액 추가

## What changed

| 영역 | Before | After |
|------|--------|-------|
| 시장 지표 | SemiGauge + ZoneBar 4열 grid | 인라인 텍스트 + F&G 원형 배지 |
| 히어로 | Card 안에 text-3xl, 2열 중 1칸 | 풀 너비 최상단 text-4xl |
| 신뢰도 | h-1.5 w-16 progress bar | 색상 숫자 배지 (TipRanks) |
| 액션 | 계좌 구분 없음 | Main/Sub/Pension 그룹핑 |
| 연금 | 매일 표시 | 월말 3일 전에만 확장 |

## Phase 2-B (next session)

이번 PR은 구조 변경만. 다음 세션에서 PM→와이어프레임→승인→구현 프로세스로:
- 반응형 레이아웃 (14인치 ↔ 27인치)
- 시각적 polish + 여백 조정
- 정보 위계 최적화

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 606/606 pass
- [x] `.venv/bin/ruff check` — 0 errors
- [x] 14인치 맥북 + 27인치 모니터 스크린샷 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)