### PR TITLE
fix(collectors): use yfinance directly for earnings calendar

### DIFF
--- a/nuri/collectors/events.py
+++ b/nuri/collectors/events.py
@@ -53,26 +53,19 @@ class EventsCollector(BaseCollector):
         return records
 
     def _collect_ticker_events(self, ticker: str) -> list[dict]:
-        """OpenBB로 종목별 실적/배당 일정 수집."""
-        from openbb import obb
+        """yfinance로 종목별 실적/배당 일정 수집."""
+        import yfinance as yf
 
         records = []
         try:
-            # 실적발표일
-            result = obb.equity.calendar.earnings(
-                symbol=ticker, provider="yfinance",
-            )
-            df = result.to_dataframe()
-            if not df.empty:
-                for _, row in df.iterrows():
-                    date_val = row.get("report_date", row.get("date"))
+            # 실적발표일 — yfinance 직접 호출 (OpenBB 추상화 우회)
+            t = yf.Ticker(ticker)
+            cal = t.calendar
+            if cal:
+                earnings_dates = cal.get("Earnings Date") or []
+                for date_val in earnings_dates:
                     if date_val is None:
-                        # index가 날짜일 수 있음
-                        if hasattr(row.name, "strftime"):
-                            date_val = row.name
-                        else:
-                            continue
-
+                        continue
                     date_str = date_val.strftime("%Y-%m-%d") if hasattr(date_val, "strftime") else str(date_val)[:10]
                     records.append({
                         "date": date_str,
@@ -85,14 +78,10 @@ class EventsCollector(BaseCollector):
             self.logger.debug(f"{ticker}: 실적 캘린더 조회 실패 — {e}")
 
         try:
-            # 배당 일정
-            result = obb.equity.calendar.dividend(
-                symbol=ticker, provider="yfinance",
-            )
-            df = result.to_dataframe()
-            if not df.empty:
-                row = df.iloc[0]
-                ex_date = row.get("ex_dividend_date", row.get("date"))
+            # 배당 일정 — yfinance Ticker.calendar에 ex-dividend date 포함
+            cal = t.calendar if "t" in dir() else yf.Ticker(ticker).calendar
+            if cal:
+                ex_date = cal.get("Ex-Dividend Date")
                 if ex_date:
                     date_str = ex_date.strftime("%Y-%m-%d") if hasattr(ex_date, "strftime") else str(ex_date)[:10]
                     records.append({

--- a/tests/collectors/test_events.py
+++ b/tests/collectors/test_events.py
@@ -28,42 +28,36 @@ class TestEventsCollectorFOMCAndEarnings:
         assert len(fomc) == 8
 
     def test_collect_ticker_events_earnings(self, monkeypatch, db_with_portfolio):
+        from datetime import date
+
         from nuri.collectors.events import EventsCollector
 
-        earnings_df = pd.DataFrame({"report_date": pd.to_datetime(["2025-04-25"])})
-        dividend_df = pd.DataFrame({"ex_dividend_date": pd.to_datetime(["2025-05-10"])})
-        mock_obb = MagicMock()
-        mock_obb.equity.calendar.earnings.return_value = MagicMock(to_dataframe=MagicMock(return_value=earnings_df))
-        mock_obb.equity.calendar.dividend.return_value = MagicMock(to_dataframe=MagicMock(return_value=dividend_df))
-        import sys
-
-        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+        mock_ticker = MagicMock()
+        mock_ticker.calendar = {"Earnings Date": [date(2025, 4, 25)], "Ex-Dividend Date": date(2025, 5, 10)}
+        monkeypatch.setattr("yfinance.Ticker", lambda t: mock_ticker)
         results = EventsCollector()._collect_ticker_events("AAPL")
         assert len(results) == 2
+        assert any(r["event_type"] == "earnings" for r in results)
+        assert any(r["event_type"] == "ex_dividend" for r in results)
 
-    def test_collect_ticker_events_with_index_date(self, monkeypatch, db_with_portfolio):
+    def test_collect_ticker_events_earnings_only(self, monkeypatch, db_with_portfolio):
+        from datetime import date
+
         from nuri.collectors.events import EventsCollector
 
-        earnings_df = pd.DataFrame({"dummy": [1]}, index=pd.to_datetime(["2025-04-25"]))
-        mock_obb = MagicMock()
-        mock_obb.equity.calendar.earnings.return_value = MagicMock(to_dataframe=MagicMock(return_value=earnings_df))
-        mock_obb.equity.calendar.dividend.side_effect = Exception("no dividend")
-        import sys
-
-        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+        mock_ticker = MagicMock()
+        mock_ticker.calendar = {"Earnings Date": [date(2025, 4, 25)]}
+        monkeypatch.setattr("yfinance.Ticker", lambda t: mock_ticker)
         results = EventsCollector()._collect_ticker_events("AAPL")
         assert len(results) == 1
+        assert results[0]["event_type"] == "earnings"
 
-    def test_collect_ticker_events_no_date(self, monkeypatch, db_with_portfolio):
+    def test_collect_ticker_events_no_calendar(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.events import EventsCollector
 
-        earnings_df = pd.DataFrame({"dummy": [1]}, index=[0])
-        mock_obb = MagicMock()
-        mock_obb.equity.calendar.earnings.return_value = MagicMock(to_dataframe=MagicMock(return_value=earnings_df))
-        mock_obb.equity.calendar.dividend.return_value = MagicMock(to_dataframe=MagicMock(return_value=pd.DataFrame()))
-        import sys
-
-        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+        mock_ticker = MagicMock()
+        mock_ticker.calendar = None
+        monkeypatch.setattr("yfinance.Ticker", lambda t: mock_ticker)
         assert EventsCollector()._collect_ticker_events("AAPL") == []
 
     def test_save(self, db_with_portfolio):
@@ -89,12 +83,9 @@ class TestEventsCollectorDividendNoDate:
     def test_dividend_no_date(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.events import EventsCollector
 
-        mock_obb = MagicMock()
-        mock_obb.equity.calendar.earnings.return_value = MagicMock(to_dataframe=MagicMock(return_value=pd.DataFrame()))
-        mock_obb.equity.calendar.dividend.return_value = MagicMock(to_dataframe=MagicMock(return_value=pd.DataFrame({"ex_dividend_date": [None]})))
-        import sys
-
-        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+        mock_ticker = MagicMock()
+        mock_ticker.calendar = {"Earnings Date": [], "Ex-Dividend Date": None}
+        monkeypatch.setattr("yfinance.Ticker", lambda t: mock_ticker)
         assert isinstance(EventsCollector()._collect_ticker_events("AAPL"), list)
 
 


### PR DESCRIPTION
## Summary
- OpenBB \`equity.calendar.earnings\` via yfinance provider was silently failing
- Switched to direct \`yf.Ticker(ticker).calendar\` for reliable earnings/dividend dates
- Verified: TSLA 4/23, NVDA 5/21, TEM 5/6, MSFT 4/30, GOOGL 4/30, AMD 5/6

## Why
2026-04-11 분석에서 발견: \`events\` 테이블에 종목별 실적 발표 일정이 0건.
원인은 OpenBB의 yfinance provider가 silently 실패하고 있었기 때문.
직접 yfinance 호출로 우회하니 정상 동작.

## Test plan
- [x] 9/9 tests pass (test_events.py)
- [x] ruff clean
- [x] Manual verification: \`make collect\` 후 events 테이블에 10건 earnings 데이터 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)