### PR TITLE
docs: rigorous README + STRATEGY.md + CLAUDE.md refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,9 @@ data/
 
 ## Testing
 
-2,601 backend tests across 128 files (`tests/{alerts,analysis,api,collectors,core,llm,quant,scripts,trading/}` subdirs + `test_scheduler.py`) + 606 frontend vitest (46 files) + 25 Playwright E2E (5 spec files). Uses `pytest-xdist` for parallel execution (`-n auto --dist worksteal`). Coverage policy: no fixed minimum — Codecov gates on a 1% relative regression vs prior commit (`codecov.yml` `target: auto`). Tests use `tmp_path` fixture for isolated SQLite databases:
+2,633 backend tests across 128 files (`tests/{alerts,analysis,api,collectors,core,llm,quant,scripts,trading/}` subdirs + `test_scheduler.py`) + 634 frontend vitest (46 files) + 25 Playwright E2E (5 spec files). Uses `pytest-xdist` for parallel execution (`-n auto --dist worksteal`). Coverage policy: no fixed minimum — Codecov gates on a 1% relative regression vs prior commit (`codecov.yml` `target: auto`). Tests use `tmp_path` fixture for isolated SQLite databases:
+
+**Slow marker** (PR #206): ~12 LLM/heavy tests are marked `@pytest.mark.slow`. PR CI excludes them via `-m "not slow"` (~24% wall time savings); main push runs the full suite. Use `make test-fast` locally for the same fast subset, `make test-slow` for slow only.
 ```python
 @pytest.fixture
 def db_path(tmp_path):
@@ -439,7 +441,7 @@ Multi-account portfolio mixes USD and KRW. Exchange rate fallback chain: DB `mac
 cd frontend
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (610 tests, 46 files)
+npm run test           # vitest run (634 tests, 46 files)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```
@@ -455,9 +457,9 @@ All pages are **Server Components** with `force-dynamic`. Data fetched server-si
 
 **Conventions**: `async function Section()` in `<Suspense>`, `animate-pulse` skeletons, color semantics (emerald=BUY, red=SELL, amber=warning, blue=WATCH, zinc=HOLD), `text-[10px]` sub-labels.
 
-**Frontend testing** (610 vitest, 46 files): Mock `@/lib/api` + `next/navigation`. Recharts mock hoisting caveat: keep recharts-dependent and recharts-free tests in separate files.
+**Frontend testing** (634 vitest, 46 files): Mock `@/lib/api` + `next/navigation`. Recharts mock hoisting caveat: keep recharts-dependent and recharts-free tests in separate files.
 
-**Auth**: `src/middleware.ts` — SHA256 cookie-based, active only when `DASHBOARD_PASSWORD` is set.
+**Auth**: `src/middleware.ts` — HMAC-SHA256 keyed cookie auth (Edge Runtime compatible), active only when `DASHBOARD_PASSWORD` is set.
 
 ## Portfolio Action Plan Format
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@
 
 </div>
 
-데이터로 투자 판단의 **근거를 증명**하는 오픈소스 퀀트 플랫폼.
+An open-source quant platform that **proves the evidence behind every investment decision**.
 
-수집 → 분석 → 합의 → 검증 파이프라인이 매 추천마다 실행되며, 모든 BUY/SELL 의사결정은 시장 컨텍스트와 에이전트 근거와 함께 기록되고, 30/60/90일 후 실제 성과가 자동 추적됩니다.
+Every BUY/SELL recommendation runs through a **collect → analyze → consensus → certify → track** pipeline. Each decision is recorded with its market context and per-agent reasoning, then automatically scored against actual outcomes after 30/60/90 days. The system gets more accurate as outcomes accumulate — agent weights adjust within a ±30% band based on hit rate.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    A["<b>Collect</b><br/>24 collectors"]
+    A["<b>Collect</b><br/>24 collectors<br/>419 ticker universe"]
     B["<b>Analyze</b><br/>20 signals · 10 regimes"]
-    C["<b>Consensus</b><br/>10 agents voting"]
+    C["<b>Consensus</b><br/>10 agents weighted vote"]
     D["<b>Certify</b><br/>SIEGE 11-gate"]
-    E["<b>Track</b><br/>outcome learning"]
+    E["<b>Track</b><br/>30/60/90d outcome"]
 
     A -- DB --> B -- CSV --> C -- DB --> D -- DB --> E
     E -. "weight feedback" .-> C
@@ -34,49 +34,34 @@ flowchart LR
 
 | Layer | Role |
 |-------|------|
-| `nuri/collectors/` | 24 data collectors (OpenBB, pykrx, FRED, edgartools, FINVIZ, etc.) |
-| `nuri/quant/` | Signal backtest, regime classifier, multi-factor scoring, VectorBT |
-| `nuri/trading/agents/` | 10 specialist agents + weighted consensus (risk agent veto power) |
+| `nuri/collectors/` | 24 data collectors (OpenBB, pykrx, FRED, edgartools, FINVIZ, KIS Open API) |
+| `nuri/quant/` | Signal backtest (20 signals), regime classifier (10 regimes), multi-factor scoring, VectorBT |
+| `nuri/trading/agents/` | 10 specialist agents + weighted consensus (risk agent has SELL veto at confidence ≥ 80) |
 | `nuri/trading/engine/` | SIEGE 11-gate certification + Decision Intelligence + learning memory |
-| `nuri/api/` | FastAPI REST (57 endpoints) + SSE streaming |
+| `nuri/api/` | FastAPI REST + SSE streaming on port 8001 |
 | `frontend/` | Next.js 16 dashboard (16 pages, dark theme, Tailwind 4 + shadcn/ui) |
-| `nuri/core/db.py` | Sole SQLite gateway (31 tables, WAL mode). All modules go through here |
+| `nuri/core/db.py` | Sole SQLite gateway (31 tables, WAL mode). Every other module reads/writes through here |
+| `config/` | All thresholds and rules — `rules.yaml`, `agents.yaml`, `signals.yaml`, `universe.yaml` (419 tickers) |
 
 ## Tech Stack
 
-**Backend**
-![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)
-![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
-![SQLite](https://img.shields.io/badge/SQLite_WAL-003B57?logo=sqlite&logoColor=white)
-![Pydantic](https://img.shields.io/badge/Pydantic-E92063?logo=pydantic&logoColor=white)
+| Layer | Stack |
+|-------|-------|
+| **Backend** | Python 3.12 · FastAPI · SQLite (WAL) · uv |
+| **Frontend** | Next.js 16 · React 19 · Tailwind 4 · shadcn/ui |
+| **Quant** | pandas · TA-Lib · VectorBT · OpenBB · Riskfolio-Lib · yfinance |
+| **CI/CD** | GitHub Actions · pytest (xdist + shard) · Vitest · Playwright · Ruff · Codecov · Trivy |
 
-**Frontend**
-![Next.js](https://img.shields.io/badge/Next.js_16-000000?logo=next.js&logoColor=white)
-![React](https://img.shields.io/badge/React_19-61DAFB?logo=react&logoColor=black)
-![Tailwind](https://img.shields.io/badge/Tailwind_4-06B6D4?logo=tailwindcss&logoColor=white)
-![shadcn/ui](https://img.shields.io/badge/shadcn/ui-000000)
+### LLM (optional, off by default)
 
-**Quant**
-![pandas](https://img.shields.io/badge/pandas-150458?logo=pandas&logoColor=white)
-![TA-Lib](https://img.shields.io/badge/TA--Lib-FF5722)
-![VectorBT](https://img.shields.io/badge/VectorBT-9C27B0)
-![OpenBB](https://img.shields.io/badge/OpenBB-00C853)
-![Riskfolio](https://img.shields.io/badge/Riskfolio--Lib-2196F3)
+Both LLM integrations are **wired but inactive** unless you set the corresponding environment variable. The system runs without any LLM and falls back to regex/rule-based logic. See [`docs/STRATEGY.md`](docs/STRATEGY.md#443-외부-llm-egress-policy-152) §4.4.3 for the egress policy.
 
-**LLM**
-![Ollama](https://img.shields.io/badge/Ollama_(local)-000000?logo=ollama&logoColor=white)
-![OpenAI](https://img.shields.io/badge/OpenAI_gpt--5.4--nano-412991?logo=openai&logoColor=white)
+| Provider | Purpose | Activation | Data class |
+|----------|---------|------------|------------|
+| **Ollama** (local) | Daily LLM report (`make report-llm`) | `OLLAMA_HOST` set + Ollama running locally | Tier 2 (portfolio) — local only, never leaves machine |
+| **OpenAI gpt-5.4-nano** | RSS headline classification | `OPENAI_API_KEY` set | Tier 0 (public news only). ~$3.51/yr at 100 headlines/day |
 
-> Ollama: 포트폴리오/의사결정 데이터 분석 (로컬 전용, 외부 전송 금지). OpenAI: 공개 RSS 헤드라인 분류만 (Tier 0, ~$3.51/yr). [상세 정책](docs/STRATEGY.md)
-
-**CI/CD**
-![GitHub Actions](https://img.shields.io/badge/Actions-2088FF?logo=githubactions&logoColor=white)
-![pytest](https://img.shields.io/badge/pytest-0A9EDC?logo=pytest&logoColor=white)
-![Vitest](https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white)
-![Playwright](https://img.shields.io/badge/Playwright-2EAD33?logo=playwright&logoColor=white)
-![Ruff](https://img.shields.io/badge/Ruff-D7FF64?logo=ruff&logoColor=black)
-![Codecov](https://img.shields.io/badge/Codecov-F01F7A?logo=codecov&logoColor=white)
-![Trivy](https://img.shields.io/badge/Trivy-1904DA)
+The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper logs every external call to the `external_llm_calls` table (timestamp/model/tokens, **no content**), and `NURI_DISABLE_EXTERNAL_LLM=1` raises immediately.
 
 ## Getting Started
 
@@ -89,35 +74,68 @@ git clone https://github.com/researcherhojin/nuri-quant.git && cd nuri-quant
 make setup                                              # backend (uv venv + deps + DB init)
 cd frontend && npm ci && cd ..                          # frontend
 cp .env.example .env                                    # API keys (all optional)
-cp config/portfolio.example.yaml config/portfolio.yaml  # your holdings
+cp config/portfolio.example.yaml config/portfolio.yaml  # your holdings (gitignored)
 
 # Run
-make start       # API (:8001) + Dashboard (:3000)
-make full-scan   # 8-phase pipeline end-to-end
-make consensus   # 10-agent analysis + decision recording
-make certify     # SIEGE 11-gate certification
+make start          # API (:8001) + Dashboard (:3000)
+make full-scan      # 8-phase pipeline end-to-end
+make consensus      # 10-agent analysis + decision recording
+make certify        # SIEGE 11-gate certification
+make scan           # Daily scan (us_core, ~85 tickers)
+make scan-extended  # Weekly scan (us_core + S&P 500, ~339 tickers)
+```
+
+### Test commands
+
+```bash
+make test       # full suite (2,633 backend + 634 frontend)
+make test-fast  # backend only, slow tests excluded (~24s, ~52% faster)
+make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```
 
 ## Investment Rules
 
-`config/rules.yaml` — [O'Neil](https://www.investors.com/) + [Minervini](https://www.minervini.com/) + [처분효과 연구 (Shefrin 1985)](https://onlinelibrary.wiley.com/doi/10.1111/j.1540-6261.1985.tb05002.x)
+Defined in `config/rules.yaml` and loaded via `nuri/core/rules.py`. Sources: O'Neil (CAN SLIM), Minervini (SEPA), Shefrin & Statman (1985, 처분효과 / disposition effect).
 
-| | Growth | Value | Swing |
-|---|--------|-------|-------|
-| **Stop-Loss** | -7% | -10% | -5% |
-| **Take-Profit** | +20%/+40% | +15%/+30% | +5%/+10% |
-| **Trailing** | -15% | -15% | — |
+### Account strategy profiles
 
-VIX > 30 → 신규 매수 차단 · 슈퍼투자자 ≥ 3명 · PE < 100 · 멀티팩터 상위 50%
+Each account in `config/portfolio.yaml` selects one strategy via the `strategy` field. Stricter strategies cut losses earlier and limit concentration; looser strategies allow winners to grow.
+
+| Strategy | Stop-Loss | Max Single Position | Notes |
+|----------|-----------|---------------------|-------|
+| `core` | -7% | 15% | Default. Strict O'Neil-style discipline |
+| `active` | -10% | 25% | + `trailing_stop_arm: 15` — trailing stop auto-arms at +15% to protect winners |
+| `swing` | -15% | 30% | Short-term rotations only |
+| `long_term` | -20% | 25% | Buy-and-hold ETFs |
+| `pension` | -30% | 40% | Long-horizon retirement allocations |
+
+### Take-profit by stock type
+
+Each ticker is tagged growth/value via `config/stock_types.yaml`. Take-profit and trailing-stop levels apply per type.
+
+| Type | 1st Target | 2nd Target | Trailing |
+|------|-----------|-----------|----------|
+| Growth | +20% (sell 50%) | +40% (sell 25%) | -15% from HWM |
+| Value | +15% (sell 50%) | +30% (sell 25%) | -15% from HWM |
+
+### Hard gates (always-on, no override)
+
+- **VIX > 30** → new buys blocked
+- **execution_priority** → stop-loss → take-profit → trailing → new-buy (loss largest first)
+- **Buy checklist** → TipRanks ≥ Moderate Buy · superinvestors ≥ 3 · PE < 100 · revenue > $0 · multi-factor top 50%
+- **SIEGE 11-gate** → 1 error grade failure = REJECTED, no manual override
 
 ## References
 
 | Source | Usage |
 |--------|-------|
-| [SIEGE Engine](https://github.com/nutshells3/Swarm-Intelligence-Engine-with-Gated-Execution) | 11-gate certification |
-| [Palantir Foundry](https://www.palantir.com/docs/foundry/data-lineage/overview) | Decision Intelligence |
-| [Dagster](https://docs.dagster.io/guides/observe/asset-freshness-policies) | Freshness SLA |
-| [TradingAgents](https://github.com/TauricResearch/TradingAgents) | Multi-agent consensus |
+| [SIEGE Engine](https://github.com/nutshells3/Swarm-Intelligence-Engine-with-Gated-Execution) | 11-gate certification, event journal |
+| [Palantir Foundry](https://www.palantir.com/docs/foundry/data-lineage/overview) | Decision Intelligence pattern |
+| [Dagster](https://docs.dagster.io/guides/observe/asset-freshness-policies) | Freshness SLA (PASS/WARN/FAIL) |
+| [TradingAgents](https://github.com/TauricResearch/TradingAgents) | Multi-agent consensus pattern |
+| [VectorBT](https://vectorbt.dev/) | Vectorized backtest |
+| [Riskfolio-Lib](https://riskfolio-lib.readthedocs.io/) | Portfolio optimization |
+| [OpenBB](https://docs.openbb.co/) | Unified financial data abstraction |
 
 ## License
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -68,7 +68,7 @@
 | 선택 | 이유 |
 |------|------|
 | SQLite (not Postgres) | 별도 서버 불필요. WAL 모드로 동시 읽기. `tmp_path`로 테스트 격리. |
-| **Hybrid LLM stack** | (a) 본인 portfolio·narrative·의사결정 데이터는 **local Ollama 한정** (data sovereignty 유지). (b) 공개 RSS 헤드라인 분류는 **OpenAI gpt-5.4-nano** 허용 — Ollama Qwen3.5가 production hardware에서 hang되는 hardware-bound 문제 회피 + 멀티-토픽 헤드라인 nuance 회복. 연간 \$3.51 (일 100 헤드라인 기준). 공개 데이터만 외부로 나가므로 §4.4 룰 위반 없음. 자세한 정책은 §4.4.3. |
+| **Hybrid LLM stack** (현재 휴면) | 정책: (a) portfolio·narrative·의사결정은 **local Ollama 한정** (data sovereignty). (b) 공개 RSS 헤드라인은 **OpenAI gpt-5.4-nano** 허용 (Tier 0, ~\$3.51/yr). **현재 상태**: production에서 LLM은 비활성. `OLLAMA_HOST` 미설정 → `make report-llm` 실패; `OPENAI_API_KEY` 미설정 → event_classifier가 regex fallback. 코드는 wired되어 있고 환경변수만 추가하면 즉시 활성화됨. §4.4.3 참조. |
 | OpenBB + yfinance (not Bloomberg) | 무료 데이터. OpenBB 추상화 → provider 교체 용이. yfinance는 폴백. |
 | GitHub Actions (not Jenkins) | 오픈소스 무료 tier. lint + test + coverage + security 자동화. |
 
@@ -209,6 +209,14 @@ PR을 올리기 전 이 기준을 확인한다.
 
 **History cleanup (Stage 2 — 별도 작업)**:
 이 enforcement는 main HEAD를 깨끗하게 유지. 그러나 leak이 처음 들어간 이전 commit(들)은 force push 또는 GitHub Support 요청 없이는 제거 불가. STRATEGY.md §5.4 (스코프 팽창) + CLAUDE.md (force push to main 금지)를 동시에 준수하기 위해 별도 작업으로 분리. 권장 순서: GitHub Support 요청 (비파괴) → 만족 못 하면 `git filter-repo` (사용자 명시 force-push 승인 필수).
+
+**알려진 미정리 leak (Stage 2 후보)**:
+
+| commit | 내용 | 상태 |
+|--------|------|------|
+| PR #202 (squash 머지) | commit message body에 사용자 보유 종목 + 손실률 (TEM/RKLB/TSLA/PL + PnL) | main git history에 박힘. Stage 2 미실행 |
+
+§4.4.1 enforcement는 **scanner pattern 사각지대**가 있음: ticker name + PnL 조합은 broker name도 monetary literal도 아니므로 차단되지 않음. Tier 2에 "Privacy scanner ticker+PnL pattern" 등록 (§7).
 
 #### 4.4.2 외부 데이터 처리 원칙
 
@@ -434,7 +442,8 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 | 1 | 티커 기반 First-Run 온보딩 UX | [#133](https://github.com/researcherhojin/nuri-quant/issues/133) | feat(frontend) | 신규 사용자 0분 가치 체험. `/analyze?ticker=NVDA` |
 | 2 | 포트폴리오 온보딩 UI (YAML → Dashboard) | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 수동 yaml 편집 제거 |
 | 3 | 백테스트 인터랙티브 equity curve | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 파라미터 sliders + 실시간 시뮬레이션 |
-| 4 | CI fast/slow marker 분리 | [#88](https://github.com/researcherhojin/nuri-quant/issues/88) | ci | PR feedback 가속 (~3분 → ~1분) |
+| 4 | **Privacy scanner ticker+PnL pattern** | — | security | 현재 broker name + monetary literal만 차단. ticker와 PnL이 같은 commit message/PR 본문에 있을 때 패턴 감지 추가. PR #202 commit message leak 같은 경우 방지 |
+| 5 | **LLM 휴면 코드 결정** | — | refactor | `nuri/llm/{report,event_classifier,openai_client}.py` 현재 production 비활성 (OLLAMA_HOST/OPENAI_API_KEY 미설정). 유지 vs 제거 vs 재활성화 결정 필요 |
 
 ### Tier 3 — 다음 분기 (P2)
 
@@ -444,13 +453,15 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 |---|------|------|---------|------|
 | 1 | Alpaca 실전 연동 (Paper → Live) | [#17](https://github.com/researcherhojin/nuri-quant/issues/17) | feat(execution) | 자동 매도 실행. SIEGE CERTIFIED 종목만 |
 | 2 | KIS Open API 한국 실전 연동 | — | feat(execution) | `kis_realtime.py` 기 구현. 매매 endpoint 미연결 |
-| 3 | pytest fast/slow marker 분리 | [#88](https://github.com/researcherhojin/nuri-quant/issues/88) | ci | PR feedback 가속 |
+| 3 | **PR #202 commit message Stage 2 history cleanup** | — | security | 사용자 보유 종목 + 손실률이 PR #202 commit message에 노출되어 main git history에 박힘 (TEM/RKLB/PL 등 + PnL). §4.4.1 Stage 2 절차 (GitHub Support 또는 `git filter-repo`) 적용 결정 필요 |
+| 4 | **Universe 추가 확장 (Russell 2000)** | — | feat(scanner) | 현재 419 (us_core 85 + us_sp500 254 + kospi200 80). 중소형주 발굴 위해 Russell 2000 (~2,000) 추가 검토 |
 
 ### 영구 배경 작업 (낮은 우선순위, 발견 시 처리)
 
 | 항목 | 이슈 | 비고 |
 |------|------|------|
 | TestGate flake on push (PR-only pass) | [#85](https://github.com/researcherhojin/nuri-quant/issues/85) | classify_regime mock leak 수정 완료 (#188). 재발 시 추가 조사 |
+| portfolio.yaml 데이터 정합성 모니터링 | — | 수동 매매 후 portfolio.yaml 동기화 필요. 평균가 drift 발견 시 즉시 교정 (사례: PR #204 세션에서 Sub RKLB avg \$60→\$87.7 발견) |
 
 ### 작업 규칙 (변경 없음)
 


### PR DESCRIPTION
## Summary
이번 세션의 8 PRs로 발견한 모든 stale/gap 정리.

## README.md (호진님 지적: 가독성 + 엄밀성 부족)
- **LLM 섹션 정직화**: \"Ollama 분석\"이 아닌 \"wired-but-inactive default\" — OLLAMA_HOST/OPENAI_API_KEY 미설정 시 graceful fallback
- **Investment Rules 분리**: 5개 strategy (core/active/swing/long_term/pension) + take-profit (growth/value)
- **active strategy 추가**: \`trailing_stop_arm: 15\` 신규 필드 명시
- **Hard gates 신규 섹션**: VIX>30, execution_priority, buy checklist, SIEGE 11-gate
- **Tech Stack 가독성**: badge 나열 → 1개 표로 통합 (Pydantic 제거 — FastAPI에 implicit)
- **Architecture 풍부화**: 419 ticker universe + 30/60/90d outcome tracking 명시
- **Make targets**: scan-extended, test-fast/test-slow 예시 추가
- **References**: OpenBB, VectorBT, Riskfolio 추가
- **언어 일관성**: 남아있던 한국어 설명 영문 변환 (project README rule 준수)

## STRATEGY.md (이번 세션 발견 모두 반영)
- **§2.5**: hybrid LLM stack을 \"production 비활성\"으로 솔직 표시
- **§4.4.1**: 미정리 leak 표 추가 (PR #202 squash commit body) + scanner pattern 사각지대 (ticker+PnL 미커버) 명시
- **§7 Tier 2 (신규 추가)**: Privacy scanner ticker+PnL pattern, LLM 휴면 코드 결정
- **§7 Tier 3 (신규 추가)**: Stage 2 history cleanup, Russell 2000 universe 확장
- **§7 Tier 2/3 (정리)**: PR #206이 close한 #88 fast/slow markers 중복 제거
- **§7 background tasks**: portfolio.yaml 데이터 정합성 모니터링

## CLAUDE.md drift fix
- Backend tests: 2,601 → **2,633**
- Frontend tests: 606/610 → **634**
- Slow marker 섹션 추가 (PR #206)
- Auth: SHA256 → **HMAC-SHA256**

## Closes
- #196 (README rigorous refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)