### PR TITLE
docs: rigorous architecture refactor + missing post-202 additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,10 @@ make optimize         # grid search parameter tuning
 make mean-reversion   # mean-reversion scan + backtest
 make pairs            # pairs trading scan + backtest
 
-# Swing Trade
-make scan             # 88종목 스캔 (UNIVERSE) → 시그널 필터
+# Swing Trade / Market Scan
+make scan             # us_core 스캔 (~85종목, 일일, ~5초)
+make scan-extended    # us_core + S&P 500 (~339종목, 주간 풀스캔)
+make scan-kr          # KOSPI 200 (~80종목)
 make swing            # 스캔 + 에이전트 합의 → 진입 저장
 make swing-check      # 진행중 스윙 트레이드 상태 확인
 
@@ -97,7 +99,9 @@ make report-llm       # Qwen3.5 LLM 리포트 생성 + 자동 저장
 # Lint + Test
 make lint             # ruff check
 make lint-fix         # ruff check --fix
-make test             # pytest tests/ -v --cov=nuri
+make test             # pytest tests/ -v --cov=nuri (full suite, ~50s local)
+make test-fast        # -m "not slow" — slow LLM tests 제외 (~24s, PR CI 기본)
+make test-slow        # slow tests only
 make verify-quick     # fast pre-commit check: tests + regime (~10s, no network)
 make verify-all       # full verification with network (커밋 전 필수)
 .venv/bin/python -m pytest tests/test_db.py -v                                    # single file
@@ -404,9 +408,21 @@ Security: Trivy vulnerability scan (CRITICAL severity) runs in `main-ci-cd.yml` 
 
 ## Investment Rules
 
-Defined in `config/rules.yaml`, loaded via `nuri/core/rules.py`. Full rule table with academic sources: `docs/STRATEGY.md` §3.4 and §6.
+Defined in `config/rules.yaml`, loaded via `nuri/core/rules.py`. Full rule table with academic sources: `docs/STRATEGY.md` §3.4, §3.5, and §6.
 
 Core principle: **3:1 profit-to-loss ratio** (growth: -7% stop / +20%/+40% targets, value: -10% stop / +15%/+30% targets).
+
+**Account strategy profiles** (5): each `portfolio.yaml` account selects one via `strategy:` field.
+
+| Strategy | stop_loss | max_single_position | Notes |
+|----------|-----------|---------------------|-------|
+| `core` | -7% | 15% | Default. Strict O'Neil discipline |
+| `active` | -10% | 25% | + `trailing_stop_arm: 15` — auto-arms trailing at +15% (PR #202) |
+| `swing` | -15% | 30% | Short-term rotations |
+| `long_term` | -20% | 25% | Buy-and-hold |
+| `pension` | -30% | 40% | Retirement allocations |
+
+**execution_priority** (PR #200): mechanical action ordering — `stop_loss → take_profit → trailing_stop_set → new_buy`. Within stop_loss, sort by loss% desc; within take_profit, sort by excess% desc. Reasoning: declining momentum loses more per hour delayed; rising momentum is forgiving.
 
 Automated enforcement in `price_targets.py`: take-profit signals, trailing stop (HWM-based), portfolio MDD check. Buy checklist: TipRanks >= Moderate Buy, superinvestors >= 3, PE < 100, revenue > $0, factor score top 50%.
 

--- a/README.md
+++ b/README.md
@@ -14,34 +14,48 @@ Every BUY/SELL recommendation runs through a **collect → analyze → consensus
 
 ## Architecture
 
+The pipeline has **8 phases** organized into 5 conceptual stages. Phases never import each other — they communicate **only through DB tables and CSV files** (loose coupling, see [`docs/STRATEGY.md`](docs/STRATEGY.md#23-느슨한-결합-loose-coupling-via-data) §2.3). Re-running an upstream phase automatically refreshes downstream consumers.
+
 ```mermaid
 flowchart LR
-    A["<b>Collect</b><br/>24 collectors<br/>419 ticker universe"]
-    B["<b>Analyze</b><br/>20 signals · 10 regimes"]
-    C["<b>Consensus</b><br/>10 agents weighted vote"]
-    D["<b>Certify</b><br/>SIEGE 11-gate"]
-    E["<b>Track</b><br/>30/60/90d outcome"]
+    A["<b>1. Collect</b><br/>24 collectors<br/>419 ticker universe"]
+    B["<b>2. Analyze</b><br/>20 signals<br/>10 regimes<br/>multi-factor"]
+    C["<b>3. Consensus</b><br/>10 agents<br/>weighted vote<br/>risk veto"]
+    D["<b>4. Certify</b><br/>SIEGE 11-gate<br/>error gate=REJECTED"]
+    E["<b>5. Track</b><br/>30/60/90d outcomes<br/>weight feedback"]
 
-    A -- DB --> B -- CSV --> C -- DB --> D -- DB --> E
-    E -. "weight feedback" .-> C
+    A -- "prices, macro, fundamentals, signals tables" --> B
+    B -- "signal_results.csv, scorecard.csv" --> C
+    C -- "recommendations + decisions tables" --> D
+    D -- "audit_log table" --> E
+    E -. "strategy_memory snapshot<br/>±30% weight band" .-> C
 
-    style A fill:#1e293b,stroke:#6366f1,color:#e2e8f0
-    style B fill:#1e293b,stroke:#10b981,color:#e2e8f0
-    style C fill:#1e293b,stroke:#f59e0b,color:#e2e8f0
-    style D fill:#1e293b,stroke:#ef4444,color:#e2e8f0
-    style E fill:#1e293b,stroke:#8b5cf6,color:#e2e8f0
+    style A fill:#1e293b,stroke:#6366f1,color:#e2e8f0,stroke-width:2px
+    style B fill:#1e293b,stroke:#10b981,color:#e2e8f0,stroke-width:2px
+    style C fill:#1e293b,stroke:#f59e0b,color:#e2e8f0,stroke-width:2px
+    style D fill:#1e293b,stroke:#ef4444,color:#e2e8f0,stroke-width:2px
+    style E fill:#1e293b,stroke:#8b5cf6,color:#e2e8f0,stroke-width:2px
 ```
 
-| Layer | Role |
-|-------|------|
-| `nuri/collectors/` | 24 data collectors (OpenBB, pykrx, FRED, edgartools, FINVIZ, KIS Open API) |
-| `nuri/quant/` | Signal backtest (20 signals), regime classifier (10 regimes), multi-factor scoring, VectorBT |
-| `nuri/trading/agents/` | 10 specialist agents + weighted consensus (risk agent has SELL veto at confidence ≥ 80) |
-| `nuri/trading/engine/` | SIEGE 11-gate certification + Decision Intelligence + learning memory |
-| `nuri/api/` | FastAPI REST + SSE streaming on port 8001 |
-| `frontend/` | Next.js 16 dashboard (16 pages, dark theme, Tailwind 4 + shadcn/ui) |
-| `nuri/core/db.py` | Sole SQLite gateway (31 tables, WAL mode). Every other module reads/writes through here |
-| `config/` | All thresholds and rules — `rules.yaml`, `agents.yaml`, `signals.yaml`, `universe.yaml` (419 tickers) |
+### Key architectural decisions
+
+- **`nuri/core/db.py` is the sole SQLite gateway** — the only module that imports `sqlite3`. Every other module reads/writes through `query()`, `query_df()`, `upsert_*()`, `get_db()`. This makes WAL conflicts, transactions, schema migrations, and test isolation tractable. 31 tables total.
+- **Config-driven, code-static** — all thresholds, rules, and signal metadata live in `config/*.yaml`. Changing a stop-loss percentage means editing YAML, not Python. See `rules.yaml`, `agents.yaml`, `signals.yaml`, `universe.yaml`.
+- **DB-only integration between phases** — the only cross-phase coupling is data, not function calls. This is what makes the system rerun-safe and scheduler-friendly.
+
+### Code layout
+
+| Path | Pipeline phase | Role |
+|------|----------------|------|
+| `nuri/collectors/` | 1. Collect | 24 collectors. Each subclasses `BaseCollector(collect → save)`. Sources: OpenBB, pykrx, FRED, edgartools, FINVIZ, KIS Open API |
+| `nuri/quant/` | 2. Analyze | Signal backtest (20 signals), regime classifier (6 base + 4 special), multi-factor scoring, VectorBT |
+| `nuri/trading/agents/` | 3. Consensus | 10 specialist agents + weighted consensus. Risk agent has SELL veto at confidence ≥ 80 |
+| `nuri/trading/engine/` | 4. Certify | SIEGE 11-gate certification, conflict detection, learning memory |
+| `nuri/trading/recommend/` | 4-5 | Candidates, price targets, rebalance advisor, outcome tracker |
+| `nuri/api/` | Serve | FastAPI REST + SSE streaming on **:8001** |
+| `frontend/` | Serve | Next.js 16 dashboard on **:3000** (16 pages, dark theme, Tailwind 4 + shadcn/ui) |
+| `nuri/core/db.py` | All | **Sole** SQLite gateway. 31 tables, WAL mode |
+| `config/*.yaml` | All | Thresholds, rules, signal metadata, scan universe |
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
호진님 지적: 아키텍처 설명도 더 엄밀하게.

## README.md Architecture (사용자 지적: \"아키텍처 부분도\")

### Before
- Mermaid에 \"DB\", \"CSV\"만 라벨 — 어떤 테이블/파일인지 모름
- 8-phase/5-stage 구조 미설명
- 느슨한 결합 원칙(STRATEGY.md §2.3) 미언급
- DB가 sole integration point임 — 표 마지막에 작게 있음
- Layer 표가 pipeline flow와 순서 안 맞음
- API/Dashboard 포트가 흩어져 있음

### After
- **인트로 추가**: 8 phases / 5 stages, 느슨한 결합 원칙 명시 + STRATEGY 링크
- **Mermaid 라벨 정확화**: 
  - \`prices, macro, fundamentals, signals tables\` (1→2)
  - \`signal_results.csv, scorecard.csv\` (2→3)
  - \`recommendations + decisions tables\` (3→4)
  - \`audit_log table\` (4→5)
  - \`strategy_memory snapshot ±30% weight band\` (5→3 feedback)
- **Key architectural decisions 신규 섹션**:
  - sole SQLite gateway pattern
  - config-driven philosophy
  - DB-only phase integration
- **Code layout 표 재구성**:
  - Pipeline phase 컬럼 추가
  - 순서를 데이터 흐름대로 (1→Serve)
  - \`nuri/trading/recommend\` 누락 추가
  - 포트 번호 강조 (:8001 / :3000)

## CLAUDE.md (post-PR-202/204/206 누락분 채움)

이전 \`/init\` 시 발견했지만 미반영된 항목들:
- **Account strategies 5-profile 표** 추가 (active 신규 + trailing_stop_arm)
- **execution_priority rule** (PR #200) 추가
- **\`make scan-extended\`, \`make scan-kr\`** Make 타겟 추가
- **\`make test-fast\`, \`make test-slow\`** 추가

## Verification
- [x] 모든 숫자 정확 (24 collectors, 419 universe, 20 signals, 10 regimes, 31 tables, 16 pages)
- [x] Mermaid 라벨이 실제 DB 테이블/CSV 이름과 일치
- [x] 새 active strategy spec이 rules.yaml과 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)