### PR TITLE
refactor(kis): move KIS credentials from ~/KIS/ into config/kis/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@
 # 발급: https://apiportal.koreainvestment.com
 # 신규 신청 후 3일간 초당 3건 제한
 #
+# 자격 증명 위치 우선순위:
+#   1) 아래 env 변수 (권장)
+#   2) config/kis/kis_devlp.yaml (프로젝트 내 gitignored, KIS SDK 호환)
+#   3) ~/KIS/config/kis_devlp.yaml (레거시 위치, 하위 호환)
+#
 # 모의투자 (paper / vps) — 기본 사용
 KIS_PAPER_APP_KEY=
 KIS_PAPER_APP_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,20 @@
 .env.*.local
 .envrc
 
-# KIS Open API 자격 증명 (절대 git 금지)
+# KIS Open API 자격 증명 (절대 git 금지) — 다층 방어
+# 1) 파일명 패턴 — 어디 있든 차단
 **/kis_devlp.yaml
 **/kis_devlp.yml
-.kis/
+# 2) config/ 내부의 kis_ prefixed 파일
 config/kis_*.yaml
 config/kis_*.yml
+# 3) config/kis/ 디렉토리 내부 전체 (credentials + token cache)
+#    파일명이 바뀌어도, 새 secret이 추가되어도 안전
+#    .gitkeep만 tracking해서 디렉토리 자체는 repo에 보존
+config/kis/*
+!config/kis/.gitkeep
+# 4) 레거시 ~/KIS 참조 (프로젝트 외부지만 안전장치)
+.kis/
 
 # 토큰 캐시 (런타임 생성)
 **/token_*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ Configured in `.env` (see `.env.example`):
 - `DASHBOARD_PASSWORD` — Next.js dashboard auth (optional; unset = public)
 - `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` — Telegram alerts (optional)
 - `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` — Paper trading (optional; DryRun fallback)
-- `KIS_PROD_APP_KEY` / `KIS_PROD_APP_SECRET` — KIS Open API live mode (optional; falls back to `~/KIS/config/kis_devlp.yaml`)
+- `KIS_PROD_APP_KEY` / `KIS_PROD_APP_SECRET` — KIS Open API live mode (optional; falls back to `config/kis/kis_devlp.yaml`, gitignored)
 - `KIS_PAPER_APP_KEY` / `KIS_PAPER_APP_SECRET` — KIS Open API paper mode (optional)
 
 ## DB Schema (SQLite, WAL mode)
@@ -338,7 +338,7 @@ data/
 
 ## Testing
 
-2,633 backend tests across 128 files (`tests/{alerts,analysis,api,collectors,core,llm,quant,scripts,trading/}` subdirs + `test_scheduler.py`) + 634 frontend vitest (46 files) + 25 Playwright E2E (5 spec files). Uses `pytest-xdist` for parallel execution (`-n auto --dist worksteal`). Coverage policy: no fixed minimum — Codecov gates on a 1% relative regression vs prior commit (`codecov.yml` `target: auto`). Tests use `tmp_path` fixture for isolated SQLite databases:
+2,638 backend tests across 128 files (`tests/{alerts,analysis,api,collectors,core,llm,quant,scripts,trading/}` subdirs + `test_scheduler.py`) + 634 frontend vitest (46 files) + 25 Playwright E2E (5 spec files). Uses `pytest-xdist` for parallel execution (`-n auto --dist worksteal`). Coverage policy: no fixed minimum — Codecov gates on a 1% relative regression vs prior commit (`codecov.yml` `target: auto`). Tests use `tmp_path` fixture for isolated SQLite databases:
 
 **Slow marker** (PR #206): ~12 LLM/heavy tests are marked `@pytest.mark.slow`. PR CI excludes them via `-m "not slow"` (~24% wall time savings); main push runs the full suite. Use `make test-fast` locally for the same fast subset, `make test-slow` for slow only.
 ```python

--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,8 @@ clean:
 clean-all: clean
 	@echo "=== Clean: __pycache__ + 토큰 캐시 ==="
 	@find . -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
-	@rm -rf ~/KIS/cache/token_*.json 2>/dev/null || true
+	@rm -rf config/kis/cache/token_*.json 2>/dev/null || true
+	@rm -rf ~/KIS/cache/token_*.json 2>/dev/null || true  # legacy 위치도 정리
 	@echo "=== ✓ Clean-all complete ==="
 
 clean-deep: clean-all

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ Each ticker is tagged growth/value via `config/stock_types.yaml`. Take-profit an
 | [Riskfolio-Lib](https://riskfolio-lib.readthedocs.io/) | Portfolio optimization |
 | [OpenBB](https://docs.openbb.co/) | Unified financial data abstraction |
 
+## Further Documentation
+
+- [`docs/STRATEGY.md`](docs/STRATEGY.md) — project philosophy, architectural decisions, investment rules, roadmap
+- [`docs/KIS_INTEGRATION.md`](docs/KIS_INTEGRATION.md) — KIS (Korea Investment & Securities) Open API integration
+- [`CLAUDE.md`](CLAUDE.md) — Claude Code agent guide (commands, architecture, gotchas)
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — development workflow, PR discipline
+- [`SECURITY.md`](SECURITY.md) — security policy, LLM egress rules, credential handling
+
 ## License
 
 [AGPL-3.0](LICENSE)

--- a/docs/KIS_INTEGRATION.md
+++ b/docs/KIS_INTEGRATION.md
@@ -14,7 +14,8 @@ nuri/collectors/
 
 ### 우선순위
 1. **`.env` 파일** (권장 — git ignored)
-2. **`~/KIS/config/kis_devlp.yaml`** (KIS Open API SDK 호환 fallback)
+2. **`config/kis/kis_devlp.yaml`** (프로젝트 내 gitignored, KIS Open API SDK 호환)
+3. **`~/KIS/config/kis_devlp.yaml`** (레거시 위치, 하위 호환 fallback)
 
 ### .env 변수
 
@@ -33,9 +34,9 @@ KIS_PAPER_ACCOUNT=...
 KIS_HTS_ID=your_hts_id
 ```
 
-### YAML fallback (`~/KIS/config/kis_devlp.yaml`)
+### YAML fallback (`config/kis/kis_devlp.yaml`)
 
-KIS Open API 공식 SDK와 호환되는 형식. SDK 사용자는 추가 설정 없이 동작.
+KIS Open API 공식 SDK와 호환되는 형식. nuri-quant는 프로젝트 내 `config/kis/` 하위에 파일을 두는 것을 권장 (gitignored). 레거시 위치 `~/KIS/config/kis_devlp.yaml`도 자동 감지.
 
 ```yaml
 my_app: "실전 앱키"
@@ -47,6 +48,22 @@ my_acct_stock: "1000000"        # 실전 종합계좌
 my_paper_stock: "1000000"       # 모의 종합계좌
 my_prod: "01"                    # 종합계좌 (01) / 선물옵션 (03) / 해외선물옵션 (08)
 ```
+
+#### KIS Open API 공식 SDK와 동시 사용 시
+
+KIS 공식 SDK (`pykis` 등)는 hardcoded `~/KIS/config/kis_devlp.yaml` 경로를 사용합니다. nuri-quant와 공식 SDK를 동시에 쓰려면 두 위치에 파일이 모두 있어야 합니다:
+
+**옵션 1 — symlink (권장, 1개 파일)**:
+```bash
+mkdir -p ~/KIS/config ~/KIS/cache
+ln -sf "$(pwd)/config/kis/kis_devlp.yaml" ~/KIS/config/kis_devlp.yaml
+ln -sf "$(pwd)/config/kis/cache" ~/KIS/cache
+```
+
+**옵션 2 — legacy only (nuri-quant fallback 활용)**:
+`~/KIS/config/kis_devlp.yaml`에 파일을 두고 `config/kis/`는 비워두면 nuri-quant가 legacy 경로를 자동 감지. SDK는 기본 경로에서 읽음.
+
+**옵션 3 — SDK 미사용**: nuri-quant만 쓰면 `config/kis/`만으로 충분.
 
 ## 사용법
 
@@ -135,8 +152,8 @@ KIS는 토큰 발급 시 1분당 1회 제한. 연속 호출 시 거부됨.
 
 | 경로 | 형식 | TTL |
 |---|---|---|
-| `~/KIS/cache/token_prod.json` | `{access_token, issued_at, expires_in}` | 23h (실제 24h, 마진 1h) |
-| `~/KIS/cache/token_paper.json` | 동일 | 동일 |
+| `config/kis/cache/token_prod.json` | `{access_token, issued_at, expires_in}` | 23h (실제 24h, 마진 1h) |
+| `config/kis/cache/token_paper.json` | 동일 | 동일 |
 
 ### Cooldown 응답 감지
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -198,7 +198,7 @@ PR을 올리기 전 이 기준을 확인한다.
 | Suspect monetary literal | 7자리 이상 정수 (`>= 1_000_000`) 가 동일 라인에 `total_invested`, `cash_balance`, `deposit`, `withdraw`, `principal`, `net_worth`, `buying_power` 키와 함께 존재 | round million 값 (`1_000_000`, `5_000_000`, …, `100_000_000`)은 placeholder로 자동 허용 |
 
 **의도적 제외**:
-- `한국투자증권` (KIS) 은 Open API 통합 대상으로 코드베이스에 합법적으로 등장 (`nuri/collectors/kis_*`, `docs/KIS_INTEGRATION.md`). 사용자 개인 KIS 계좌가 leak되는 경로는 `~/KIS/config/kis_devlp.yaml` (gitignored, 위치 자체가 repo 밖) — broker name 패턴이 아닌 credential file 패턴이 막아야 할 surface.
+- `한국투자증권` (KIS) 은 Open API 통합 대상으로 코드베이스에 합법적으로 등장 (`nuri/collectors/kis_*`, `docs/KIS_INTEGRATION.md`). 사용자 개인 KIS 자격 증명 위치는 `config/kis/kis_devlp.yaml` (프로젝트 내 gitignored by `config/kis/*` 패턴, `~/KIS/` 레거시 위치도 하위 호환으로 자동 감지). broker name 패턴이 아닌 **credential file 패턴** + **디렉토리 whitelist 패턴** 두 층으로 차단.
 
 **방어 layer 3개** (defense in depth):
 1. `scripts/check_privacy_leak.py` — 핵심 scanner. stdlib only, no deps.

--- a/nuri/collectors/kis_realtime.py
+++ b/nuri/collectors/kis_realtime.py
@@ -2,12 +2,13 @@
 
 자격 증명 우선순위:
     1. .env: KIS_PROD_APP_KEY/SECRET (실전), KIS_PAPER_APP_KEY/SECRET (모의)
-    2. ~/KIS/config/kis_devlp.yaml (KIS Open API SDK 호환 fallback)
+    2. config/kis/kis_devlp.yaml (프로젝트 내 gitignored, KIS Open API SDK 호환)
+    3. ~/KIS/config/kis_devlp.yaml (레거시 위치 fallback, 하위 호환)
 
 기능:
     - --check-creds: 자격 증명 확인만 (호출 X)
     - 보유 종목의 현재가 inquire-price (한국+미국)
-    - 24h token 캐시 (1분 cooldown 회피, ~/KIS/cache/)
+    - 24h token 캐시 (1분 cooldown 회피, config/kis/cache/)
     - DB upsert (prices 테이블)
 
 사용법:
@@ -41,12 +42,35 @@ logger = logging.getLogger(__name__)
 PROD_BASE = "https://openapi.koreainvestment.com:9443"
 PAPER_BASE = "https://openapivts.koreainvestment.com:29443"
 
-TOKEN_CACHE_DIR = Path.home() / "KIS" / "cache"
 TOKEN_CACHE_TTL_SEC = 23 * 3600  # 23h (실제 24h, 마진 1h)
 TOKEN_COOLDOWN_SEC = 60          # KIS 1분 cooldown
 
-# KIS Open API SDK 호환 yaml fallback
-KIS_YAML_PATH = Path.home() / "KIS" / "config" / "kis_devlp.yaml"
+# KIS 자격 증명 + token cache 위치 (우선순위 순):
+#   1) config/kis/ — 프로젝트 내 gitignored, 권장
+#   2) ~/KIS/ — 레거시 위치, 하위 호환 fallback
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_KIS_NEW_DIR = _PROJECT_ROOT / "config" / "kis"
+_KIS_LEGACY_DIR = Path.home() / "KIS"
+
+
+def _resolve_kis_paths(new_dir: Path, legacy_dir: Path) -> tuple[Path, Path]:
+    """KIS yaml / cache 경로 결정. 새 위치 우선, 없으면 레거시 fallback.
+
+    Args:
+        new_dir: 프로젝트 내 KIS 디렉토리 (config/kis/)
+        legacy_dir: 레거시 위치 (~/KIS/)
+
+    Returns:
+        (kis_yaml_path, token_cache_dir) 튜플
+    """
+    if (new_dir / "kis_devlp.yaml").exists():
+        return new_dir / "kis_devlp.yaml", new_dir / "cache"
+    # 레거시 또는 아예 없는 경우: legacy 위치 default (테스트 patch 호환)
+    return legacy_dir / "config" / "kis_devlp.yaml", legacy_dir / "cache"
+
+
+# Module load 시 1회 결정. 테스트는 KIS_YAML_PATH를 monkeypatch.
+KIS_YAML_PATH, TOKEN_CACHE_DIR = _resolve_kis_paths(_KIS_NEW_DIR, _KIS_LEGACY_DIR)
 
 # KIS rate limit (KIS 공지 2026.03.20 + 실측):
 #   - 실전(prod) 신규: 초당 3건 → 0.4s 간격 (초당 2.5건, 안전 마진)
@@ -82,7 +106,7 @@ class KISCredentials:
 
 
 def load_credentials(mode: str = "prod") -> KISCredentials | None:
-    """KIS 자격 증명 로드. 우선순위: .env → ~/KIS/config/kis_devlp.yaml.
+    """KIS 자격 증명 로드. 우선순위: .env → config/kis/kis_devlp.yaml → ~/KIS/config/kis_devlp.yaml.
 
     Args:
         mode: "prod" (실전) | "paper" (모의)
@@ -98,7 +122,7 @@ def load_credentials(mode: str = "prod") -> KISCredentials | None:
     if creds.is_valid():
         return creds
 
-    # YAML fallback (KIS SDK 호환)
+    # YAML fallback (KIS SDK 호환) — module-level KIS_YAML_PATH 사용 (테스트 patch 호환)
     if KIS_YAML_PATH.exists():
         try:
             import yaml
@@ -115,7 +139,12 @@ def load_credentials(mode: str = "prod") -> KISCredentials | None:
                 mode=mode,
             )
             if creds.is_valid():
-                logger.info("KIS 자격 증명 로드: ~/KIS/config/kis_devlp.yaml (%s)", mode)
+                # 경로 로깅 — 프로젝트 내부면 상대경로, 외부면 generic 표기 (사용자명 노출 방지)
+                try:
+                    rel_path = KIS_YAML_PATH.relative_to(_PROJECT_ROOT)
+                    logger.info("KIS 자격 증명 로드: %s (%s)", rel_path, mode)
+                except ValueError:
+                    logger.info("KIS 자격 증명 로드: ~/KIS/config/kis_devlp.yaml (%s)", mode)
                 return creds
         except Exception as e:
             logger.warning("KIS YAML 로드 실패: %s", e)
@@ -336,7 +365,7 @@ class KISRealtimeCollector(BaseCollector):
         """자격 증명 확인 (API 호출 X)."""
         self.creds = load_credentials(self.mode)
         if not self.creds:
-            self.logger.error("KIS 자격 증명 없음 (.env 또는 ~/KIS/config/kis_devlp.yaml 확인)")
+            self.logger.error("KIS 자격 증명 없음 (.env 또는 config/kis/kis_devlp.yaml 확인)")
             return False
         masked_key = self.creds.app_key[:8] + "..." if len(self.creds.app_key) > 8 else "***"
         self.logger.info("KIS 자격 증명 OK [%s] app_key=%s account=%s",

--- a/scripts/check_privacy_leak.py
+++ b/scripts/check_privacy_leak.py
@@ -76,10 +76,11 @@ NC = "\033[0m"
 #
 # 한국투자증권 (KIS) is intentionally OMITTED — it appears legitimately in
 # the codebase as an Open API integration target (`nuri/collectors/kis_*`,
-# `docs/KIS_INTEGRATION.md`). Personal account credentials live outside
-# the repo at `~/KIS/config/kis_devlp.yaml` (gitignored by location).
-# If a user account at KIS leaks, it would be via the credential file
-# pattern, not the broker name.
+# `docs/KIS_INTEGRATION.md`). Personal account credentials live at
+# `config/kis/kis_devlp.yaml` (gitignored by `config/kis/*` directory pattern
+# AND by `**/kis_devlp.yaml` filename pattern). Legacy `~/KIS/` is auto-detected
+# as fallback. If a KIS credential leaks, it would be via the file pattern,
+# not the broker name.
 BROKER_NAMES_KO: tuple[str, ...] = (
     "카카오페이",
     "미래에셋",

--- a/tests/collectors/test_kis_realtime.py
+++ b/tests/collectors/test_kis_realtime.py
@@ -259,3 +259,117 @@ class TestKISRealtimeCollector:
             result = collector.collect()
             assert isinstance(result, pd.DataFrame)
             assert result.empty
+
+
+# ═══════════════════════════════════════════════════════
+# _resolve_kis_paths — 경로 결정 로직
+# ═══════════════════════════════════════════════════════
+
+
+class TestResolveKISPaths:
+    """모듈 로드 시 KIS_YAML_PATH / TOKEN_CACHE_DIR을 결정하는 함수."""
+
+    def test_new_location_exists_takes_precedence(self, tmp_path):
+        """config/kis/kis_devlp.yaml가 존재하면 그 경로 사용."""
+        from nuri.collectors.kis_realtime import _resolve_kis_paths
+
+        new_dir = tmp_path / "project" / "config" / "kis"
+        legacy_dir = tmp_path / "home" / "KIS"
+        new_dir.mkdir(parents=True)
+        (new_dir / "kis_devlp.yaml").write_text("test: data")
+
+        yaml_path, cache_dir = _resolve_kis_paths(new_dir, legacy_dir)
+        assert yaml_path == new_dir / "kis_devlp.yaml"
+        assert cache_dir == new_dir / "cache"
+
+    def test_fallback_to_legacy_when_new_missing(self, tmp_path):
+        """새 위치가 없으면 legacy 경로 반환 (파일 존재 여부와 무관)."""
+        from nuri.collectors.kis_realtime import _resolve_kis_paths
+
+        new_dir = tmp_path / "project" / "config" / "kis"  # 존재 안 함
+        legacy_dir = tmp_path / "home" / "KIS"
+
+        yaml_path, cache_dir = _resolve_kis_paths(new_dir, legacy_dir)
+        assert yaml_path == legacy_dir / "config" / "kis_devlp.yaml"
+        assert cache_dir == legacy_dir / "cache"
+
+    def test_returns_tuple_of_two_paths(self, tmp_path):
+        """반환 형식: (yaml_path, cache_dir)."""
+        from pathlib import Path
+
+        from nuri.collectors.kis_realtime import _resolve_kis_paths
+
+        result = _resolve_kis_paths(tmp_path / "new", tmp_path / "legacy")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert all(isinstance(p, Path) for p in result)
+
+
+class TestLoadCredentialsLogPath:
+    """load_credentials가 로깅 시 경로 format을 올바르게 선택하는지."""
+
+    @pytest.fixture
+    def env_off(self, monkeypatch):
+        for k in ["KIS_PROD_APP_KEY", "KIS_PROD_APP_SECRET",
+                  "KIS_PAPER_APP_KEY", "KIS_PAPER_APP_SECRET",
+                  "KIS_PROD_ACCOUNT", "KIS_PAPER_ACCOUNT", "KIS_HTS_ID"]:
+            monkeypatch.delenv(k, raising=False)
+
+    def test_log_uses_relative_path_when_inside_project(self, env_off, tmp_path, caplog):
+        """KIS_YAML_PATH가 프로젝트 내부면 상대 경로로 로깅."""
+        import logging
+
+        from nuri.collectors import kis_realtime
+
+        # 가짜 프로젝트 구조
+        project_root = tmp_path / "fake_project"
+        kis_dir = project_root / "config" / "kis"
+        kis_dir.mkdir(parents=True)
+        yaml_path = kis_dir / "kis_devlp.yaml"
+        yaml_path.write_text(
+            "my_app: test_key_01234567\n"
+            "my_sec: test_secret_01234567\n"
+            "my_acct_stock: '12345678'\n"
+            "my_htsid: test_hts\n"
+        )
+
+        with patch.object(kis_realtime, "KIS_YAML_PATH", yaml_path), \
+             patch.object(kis_realtime, "_PROJECT_ROOT", project_root), \
+             caplog.at_level(logging.INFO, logger="nuri.collectors.kis_realtime"):
+            creds = load_credentials(mode="prod")
+
+        assert creds is not None
+        assert creds.is_valid()
+        # 상대 경로 사용 (절대 경로 아님)
+        assert "config/kis/kis_devlp.yaml" in caplog.text
+        # 전체 tmp_path 절대 경로는 로그에 없어야 함
+        assert str(yaml_path) not in caplog.text
+
+    def test_log_uses_legacy_label_when_outside_project(self, env_off, tmp_path, caplog):
+        """KIS_YAML_PATH가 프로젝트 외부면 generic label 사용 (사용자명 보호)."""
+        import logging
+
+        from nuri.collectors import kis_realtime
+
+        # 프로젝트 외부에 fake legacy 파일
+        outside_path = tmp_path / "home" / "KIS" / "config" / "kis_devlp.yaml"
+        outside_path.parent.mkdir(parents=True)
+        outside_path.write_text(
+            "my_app: test_key_01234567\n"
+            "my_sec: test_secret_01234567\n"
+            "my_acct_stock: '12345678'\n"
+            "my_htsid: test_hts\n"
+        )
+
+        # _PROJECT_ROOT는 outside_path와 관련 없는 경로로 patch
+        fake_project = tmp_path / "unrelated_project"
+        fake_project.mkdir()
+
+        with patch.object(kis_realtime, "KIS_YAML_PATH", outside_path), \
+             patch.object(kis_realtime, "_PROJECT_ROOT", fake_project), \
+             caplog.at_level(logging.INFO, logger="nuri.collectors.kis_realtime"):
+            creds = load_credentials(mode="prod")
+
+        assert creds is not None
+        # generic label 사용 (사용자 절대 경로 노출 방지)
+        assert "~/KIS/config/kis_devlp.yaml" in caplog.text


### PR DESCRIPTION
## Summary
KIS 자격 증명 위치를 \`~/KIS/\` (\$HOME 외부) → \`config/kis/\` (프로젝트 내 gitignored)로 이동.

## Why
이전 세션 NEXT_SESSION.md에 "~/KIS 디렉토리 → 프로젝트 내 이동 + .gitignore" 로 등록되어 있던 deferred 항목. Mac mini 세션에서 즉시 처리.

- **프로젝트 자체 완결성**: KIS 설정이 더 이상 \$HOME 구조에 의존하지 않음
- **Discoverability**: 새 개발자가 repo에서 \`config/kis/.gitkeep\` 를 바로 발견
- **하위 호환**: 레거시 \`~/KIS/\` 위치도 자동 감지 (migration 안전)
- **보안 강화**: 2중 방어
  - 파일명 패턴 (\`**/kis_devlp.yaml\`) — 기존
  - 디렉토리 패턴 (\`config/kis/*\`) — 신규

## Changes

### \`.gitignore\`
\`\`\`
config/kis/*
!config/kis/.gitkeep
\`\`\`
디렉토리 전체를 차단하되 \`.gitkeep\`만 예외 허용 (repo에서 디렉토리 존재 보장).

### \`nuri/collectors/kis_realtime.py\`
- \`KIS_YAML_PATH\` / \`TOKEN_CACHE_DIR\` module load 시 자동 감지
- 새 위치 (\`config/kis/\`) 우선, 없으면 레거시 (\`~/KIS/\`) fallback
- 로그에서 프로젝트 상대 경로 사용 (사용자명 노출 방지)

### 문서 업데이트 (3개 파일)
- \`docs/KIS_INTEGRATION.md\`: 경로 3곳 update
- \`docs/STRATEGY.md §4.4.1\`: credential file surface description
- \`scripts/check_privacy_leak.py\`: KIS 주석 update
- \`CLAUDE.md\`: KIS env var fallback 경로

## Security Verification
- [x] \`git check-ignore config/kis/kis_devlp.yaml\` → gitignored ✓
- [x] \`git check-ignore config/kis/cache/token_vps.json\` → gitignored ✓
- [x] \`git status\` — staged에 .gitkeep만 있음 (secret 없음)
- [x] Privacy scanner clean
- [x] 사용자 \$HOME/KIS/ 제거됨

## Test
- [x] KIS tests: 26/26 pass
- [x] \`make collect-kis-check\` 정상 동작 (새 경로에서 자격 증명 자동 로드)
- [x] ruff clean

## Migration (이미 완료됨)
\`\`\`bash
mv ~/KIS/config/kis_devlp.yaml config/kis/
mv ~/KIS/cache config/kis/
rm -rf ~/KIS
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)