### PR TITLE
fix(dashboard): show actual cash allocation + total wealth (#213)

### DIFF
--- a/frontend/src/__tests__/pages/dashboard.test.tsx
+++ b/frontend/src/__tests__/pages/dashboard.test.tsx
@@ -97,7 +97,7 @@ describe("DashboardPage", () => {
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
       expect(screen.getByText("주의")).toBeInTheDocument();
-      expect(screen.getByText(/총 평가액/)).toBeInTheDocument();
+      expect(screen.getByText(/총 자산/)).toBeInTheDocument();
       expect(screen.getByText("$8,850")).toBeInTheDocument();
     });
   });
@@ -153,6 +153,61 @@ describe("DashboardPage", () => {
       expect(screen.getByText("매수")).toBeInTheDocument();
       expect(screen.getByText("매도")).toBeInTheDocument();
       expect(screen.getByText("NVDA")).toBeInTheDocument();
+    });
+  });
+
+  it("hero total includes cash from portfolio.cash (#213)", async () => {
+    // holdings $8,850 + cash $5,000 = total $13,850
+    setupMocks({
+      portfolio: {
+        count: 2,
+        holdings: [
+          { ticker: "TSLA", quantity: 33, avg_price: 343, latest_price: 250, currency: "USD" },
+          { ticker: "005930.KS", quantity: 4, avg_price: 200500, latest_price: 210000, currency: "KRW" },
+        ],
+        cash: {
+          accounts: [{ account: "Main", cash_usd: 5000, cash_krw: 0, total_usd: 5000 }],
+          total_cash_usd: 5000,
+        },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("$13,850")).toBeInTheDocument();
+      expect(screen.getByText(/총 자산/)).toBeInTheDocument();
+      // Hero sub-line shows holdings amount + cash amount (specific dollar values)
+      expect(screen.getByText("$8,850")).toBeInTheDocument();
+      expect(screen.getByText("$5,000")).toBeInTheDocument();
+    });
+  });
+
+  it("renders actual + target allocation bars (#213)", async () => {
+    setupMocks({
+      dashboard: {
+        ...mockDashboardData,
+        actual_allocation: { long: 46, short: 0, cash: 54 },
+        target_allocation: { long: 20, short: 0, cash: 80 },
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText(/실제/)).toBeInTheDocument();
+      expect(screen.getByText(/권장 \(레짐\)/)).toBeInTheDocument();
+      expect(screen.getByText(/투자 46% · 현금 54%/)).toBeInTheDocument();
+      expect(screen.getByText(/투자 20% · 현금 80%/)).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to holdings-only total when portfolio.cash is absent (#213)", async () => {
+    // No cash in portfolio → hero shows $8,850, no breakdown sub-line
+    setupMocks();
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      expect(screen.getByText("$8,850")).toBeInTheDocument();
+      expect(screen.queryByText(/보유 \$/)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,12 @@ interface DashboardData {
   regime: { regime: string; trend: string; volatility?: string; confidence: number; vix?: number; fear_greed?: number };
   macro: { score: number; interpretation: string };
   allocation: { long: number; short: number; cash: number };
+  target_allocation?: { long: number; short: number; cash: number };
+  actual_allocation?: { long: number; short: number; cash: number };
+  cash_summary?: {
+    accounts: Array<{ account: string; cash_usd: number; cash_krw: number; total_usd: number }>;
+    total_cash_usd: number;
+  };
   actions: Array<{ action: string; ticker: string; name?: string | null; confidence: number; agreement: number; reason: string; account?: string }>;
   alerts: Array<{ level: string; message: string }>;
   gate_score: number;
@@ -139,11 +145,14 @@ async function Dashboard() {
   const style = levelStyles[d.verdict_level] || levelStyles.neutral;
   const verdictLabel = verdictLabels[d.verdict_level] || "관망";
   const KRW_RATE = d.exchange_rate || 1400;
-  const totalValue = portfolio?.holdings?.reduce((sum: number, h: any) => {
+  const holdingsValue = portfolio?.holdings?.reduce((sum: number, h: any) => {
     const price = h.latest_price || 0;
     const qty = h.quantity || 0;
     return sum + (h.ticker?.endsWith(".KS") ? price * qty / KRW_RATE : price * qty);
   }, 0) || 0;
+  // #213: 총 자산 = holdings + cash. cash는 portfolio.yaml 기반 /api/portfolio에서 옴.
+  const cashTotalUsd = portfolio?.cash?.total_cash_usd ?? d.cash_summary?.total_cash_usd ?? 0;
+  const totalValue = holdingsValue + cashTotalUsd;
 
   const vix = d.regime.vix ?? null;
   const fg = d.regime.fear_greed ?? null;
@@ -189,18 +198,24 @@ async function Dashboard() {
 
   return (
     <div className="flex flex-col gap-4 h-full">
-      {/* ═══ 히어로: 총 평가액 + 판단 ═══ */}
+      {/* ═══ 히어로: 총 자산 (holdings + cash) + 판단 ═══ */}
       <div>
-        <p className="text-[10px] text-zinc-500 mb-0.5">총 평가액</p>
+        <p className="text-[10px] text-zinc-500 mb-0.5">총 자산</p>
         <div className="flex items-baseline gap-3">
           <span className="text-4xl font-semibold tabular-nums tracking-tight text-zinc-100">
             ${totalValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
           </span>
           <StatusBadge status={verdictLabel} size="lg" />
         </div>
-        {accountValues.length > 0 && (
-          <div className="flex items-center gap-3 mt-1 text-[10px] text-zinc-500">
-            {accountValues.map(av => (
+        {(cashTotalUsd > 0 || accountValues.length > 0) && (
+          <div className="flex items-center gap-3 mt-1 text-[10px] text-zinc-500 flex-wrap">
+            {cashTotalUsd > 0 && (
+              <>
+                <span>보유 <span className="tabular-nums text-zinc-400">${holdingsValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span></span>
+                <span>현금 <span className="tabular-nums text-zinc-400">${cashTotalUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span></span>
+              </>
+            )}
+            {accountValues.length > 0 && accountValues.map(av => (
               <span key={av.account}>{av.account} ${av.value.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span>
             ))}
           </div>
@@ -220,24 +235,57 @@ async function Dashboard() {
         </div>
       </div>
 
-      {/* 비중 바 */}
-      <div className="flex h-3.5 rounded overflow-hidden text-[9px] font-medium">
-        {d.allocation.long > 0 && (
-          <div className="bg-emerald-600/80 flex items-center justify-center text-emerald-100" style={{ width: `${d.allocation.long}%` }}>
-            {d.allocation.long >= 15 && `투자 ${d.allocation.long}%`}
+      {/* 비중 바 — 실제 (holdings+cash 기반) + 권장 (regime 기반) 2줄 */}
+      {(() => {
+        const actual = d.actual_allocation ?? { long: 0, short: 0, cash: 100 };
+        const target = d.target_allocation ?? d.allocation;
+        return (
+          <div className="space-y-1.5">
+            {/* 실제 */}
+            <div>
+              <div className="flex items-center justify-between mb-0.5">
+                <span className="text-[9px] text-zinc-500">실제</span>
+                <span className="text-[9px] text-zinc-600 tabular-nums">투자 {actual.long}% · 현금 {actual.cash}%</span>
+              </div>
+              <div className="flex h-3 rounded overflow-hidden text-[9px] font-medium">
+                {actual.long > 0 && (
+                  <div className="bg-emerald-600/80 flex items-center justify-center text-emerald-100" style={{ width: `${actual.long}%` }}>
+                    {actual.long >= 20 && `${actual.long}%`}
+                  </div>
+                )}
+                {actual.short > 0 && (
+                  <div className="bg-red-600/80 flex items-center justify-center text-red-100" style={{ width: `${actual.short}%` }}>
+                    {actual.short >= 10 && `${actual.short}%`}
+                  </div>
+                )}
+                {actual.cash > 0 && (
+                  <div className="bg-zinc-800 flex items-center justify-center text-zinc-400" style={{ width: `${actual.cash}%` }}>
+                    {actual.cash >= 20 && `${actual.cash}%`}
+                  </div>
+                )}
+              </div>
+            </div>
+            {/* 권장 (regime) */}
+            <div>
+              <div className="flex items-center justify-between mb-0.5">
+                <span className="text-[9px] text-zinc-600">권장 (레짐)</span>
+                <span className="text-[9px] text-zinc-700 tabular-nums">투자 {target.long}% · 현금 {target.cash}%</span>
+              </div>
+              <div className="flex h-1.5 rounded overflow-hidden text-[9px] font-medium opacity-60">
+                {target.long > 0 && (
+                  <div className="bg-emerald-700/60" style={{ width: `${target.long}%` }} />
+                )}
+                {target.short > 0 && (
+                  <div className="bg-red-700/60" style={{ width: `${target.short}%` }} />
+                )}
+                {target.cash > 0 && (
+                  <div className="bg-zinc-700" style={{ width: `${target.cash}%` }} />
+                )}
+              </div>
+            </div>
           </div>
-        )}
-        {d.allocation.short > 0 && (
-          <div className="bg-red-600/80 flex items-center justify-center text-red-100" style={{ width: `${d.allocation.short}%` }}>
-            {d.allocation.short >= 10 && `숏 ${d.allocation.short}%`}
-          </div>
-        )}
-        {d.allocation.cash > 0 && (
-          <div className="bg-zinc-800 flex items-center justify-center text-zinc-400" style={{ width: `${d.allocation.cash}%` }}>
-            현금 {d.allocation.cash}%
-          </div>
-        )}
-      </div>
+        );
+      })()}
 
       {/* ═══ 알림 — 개별 라인, 클릭 시 상세 이동 ═══ */}
       {alertCount > 0 && (

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -89,12 +89,21 @@ def _build_dashboard() -> dict:
     account_labels_map = _get_account_labels()
     ticker_accounts = {t: account_labels_map.get(acc, acc) for t, acc in _get_ticker_account_map().items()}
 
+    # ── 11. Cash + 실제 자산 배분 (#213) ──
+    # `allocation`은 regime **권장** 비율 (legacy). `actual_allocation`은 현재 portfolio의
+    # holdings + cash로 계산한 **실제** 비율. Hero의 총 자산도 cash 포함.
+    cash_summary = _get_cash_balances(exchange_rate)
+    actual_allocation = _compute_actual_allocation(account_values, cash_summary["total_cash_usd"])
+
     return {
         "verdict": verdict,
         "verdict_level": verdict_level,
         "regime": regime_data,
         "macro": macro_data,
-        "allocation": allocation,
+        "allocation": allocation,                   # target (regime 권장) — legacy 이름, backward compat
+        "target_allocation": allocation,            # explicit 이름 — regime 권장 비율
+        "actual_allocation": actual_allocation,     # 현재 portfolio 실제 비율 (holdings + cash)
+        "cash_summary": cash_summary,               # 계좌별 cash + 총 cash USD
         "actions": actions,
         "alerts": alerts,
         "gate_score": gate_score,
@@ -286,6 +295,76 @@ def _get_account_values(exchange_rate: float | None) -> list[dict]:
         {"account": account_labels.get(acc, acc), "value": round(v, 2)}
         for acc, v in sorted(totals.items(), key=lambda x: -x[1])
     ]
+
+
+def _get_cash_balances(exchange_rate: float | None = None) -> dict:
+    """portfolio.yaml의 계좌별 cash 잔액을 USD로 환산 합산 (#213).
+
+    Returns:
+        {
+            "accounts": [
+                {"account": "<label>", "cash_usd": N, "cash_krw": N, "total_usd": N},
+                ...
+            ],
+            "total_cash_usd": N,
+        }
+
+    portfolio.yaml의 각 계좌 레벨 `cash_usd` / `cash_krw` 필드가 있을 때 합산한다.
+    환율 누락 시 1400 기본값 (기존 dashboard 로직과 일치).
+    broker 이름은 노출하지 않고 `_get_account_labels()`의 익명 라벨로 치환한다.
+    """
+    from pathlib import Path
+
+    import yaml
+
+    portfolio_path = Path(__file__).parent.parent.parent.parent / "config" / "portfolio.yaml"
+    try:
+        with open(portfolio_path, encoding="utf-8") as f:
+            portfolio = yaml.safe_load(f) or {}
+    except Exception as e:
+        logger.debug("portfolio.yaml cash read failed: %s", e)
+        return {"accounts": [], "total_cash_usd": 0.0}
+
+    rate = exchange_rate or 1400.0
+    labels = _get_account_labels()
+    accounts_out: list[dict] = []
+    total_usd = 0.0
+
+    for raw_acc, info in (portfolio.get("accounts") or {}).items():
+        if not isinstance(info, dict):
+            continue
+        cash_usd = float(info.get("cash_usd") or 0)
+        cash_krw = float(info.get("cash_krw") or 0)
+        acc_total = cash_usd + (cash_krw / rate if rate > 0 else 0)
+        if acc_total <= 0:
+            continue
+        accounts_out.append({
+            "account": labels.get(raw_acc, raw_acc),
+            "cash_usd": round(cash_usd, 2),
+            "cash_krw": round(cash_krw, 2),
+            "total_usd": round(acc_total, 2),
+        })
+        total_usd += acc_total
+
+    return {"accounts": accounts_out, "total_cash_usd": round(total_usd, 2)}
+
+
+def _compute_actual_allocation(account_values: list[dict], cash_total_usd: float) -> dict:
+    """실제 포트폴리오 구성 비율 — holdings vs cash (USD 기준, #213).
+
+    `_get_allocation()`은 regime이 권장하는 **target** 비율을 반환하는 반면
+    이 함수는 현재 portfolio의 **actual** 구성 비율을 계산한다.
+
+    Returns:
+        {"long": 46, "short": 0, "cash": 54}  — 백분율, 합 100
+    """
+    holdings_usd = sum(av.get("value", 0) for av in account_values)
+    total = holdings_usd + cash_total_usd
+    if total <= 0:
+        return {"long": 0, "short": 0, "cash": 100}
+    long_pct = round((holdings_usd / total) * 100)
+    cash_pct = 100 - long_pct  # 반올림 오차는 cash 쪽으로 흡수
+    return {"long": long_pct, "short": 0, "cash": cash_pct}
 
 
 def _get_gate_score() -> int:

--- a/nuri/api/routes/portfolio.py
+++ b/nuri/api/routes/portfolio.py
@@ -132,7 +132,8 @@ def _try_sync_yaml():
 
 @router.get("/portfolio")
 def get_portfolio():
-    """종목별 보유 현황."""
+    """종목별 보유 현황 + 계좌별 cash 잔액 (#213)."""
+    from nuri.api.routes.dashboard import _get_cash_balances
     from nuri.core.ticker_names import get_ticker_name
     rows = query("""
         SELECT p.ticker, p.account, p.quantity, p.avg_price, p.currency, p.sector,
@@ -147,7 +148,13 @@ def get_portfolio():
     holdings = [dict(r) for r in rows]
     for h in holdings:
         h["name"] = get_ticker_name(h["ticker"])
-    return {"holdings": holdings, "count": len(holdings)}
+
+    # 환율 조회 (cash 환산용)
+    rate_row = query("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1")
+    exchange_rate = rate_row[0]["value"] if rate_row else None
+    cash = _get_cash_balances(exchange_rate)
+
+    return {"holdings": holdings, "count": len(holdings), "cash": cash}
 
 
 @router.post("/portfolio")

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -55,6 +55,102 @@ class TestDashboardAPI:
         assert "account_labels" in result
         assert isinstance(result["account_labels"], dict)
 
+    def test_dashboard_exposes_actual_allocation_and_cash(self, db_path):
+        """#213: dashboard 응답이 actual_allocation + cash_summary + target_allocation을 노출."""
+        from nuri.api.routes.dashboard import _build_dashboard
+        result = _build_dashboard()
+        assert "actual_allocation" in result
+        assert "target_allocation" in result
+        assert "cash_summary" in result
+        actual = result["actual_allocation"]
+        assert set(actual.keys()) == {"long", "short", "cash"}
+        assert actual["long"] + actual["short"] + actual["cash"] == 100
+        cs = result["cash_summary"]
+        assert "accounts" in cs and isinstance(cs["accounts"], list)
+        assert "total_cash_usd" in cs and isinstance(cs["total_cash_usd"], (int, float))
+
+
+class TestCashBalances:
+    """#213: _get_cash_balances() — portfolio.yaml에서 cash 파싱."""
+
+    def test_compute_actual_allocation_holdings_only(self):
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+        result = _compute_actual_allocation([{"value": 10000}], 0)
+        assert result == {"long": 100, "short": 0, "cash": 0}
+
+    def test_compute_actual_allocation_cash_only(self):
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+        result = _compute_actual_allocation([], 5000)
+        assert result == {"long": 0, "short": 0, "cash": 100}
+
+    def test_compute_actual_allocation_empty_portfolio(self):
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+        result = _compute_actual_allocation([], 0)
+        assert result == {"long": 0, "short": 0, "cash": 100}
+
+    def test_compute_actual_allocation_mixed(self):
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+        # holdings 46, cash 54 → 46% / 54%
+        result = _compute_actual_allocation([{"value": 4600}], 5400)
+        assert result["long"] == 46
+        assert result["cash"] == 54
+        assert result["short"] == 0
+
+    def test_compute_actual_allocation_rounds_to_100(self):
+        """반올림 오차 흡수로 long + cash = 100 보장."""
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+        # 333/1000 = 33.3%, 667/1000 = 66.7% → round(33.3)=33, cash=67
+        result = _compute_actual_allocation([{"value": 333}], 667)
+        assert result["long"] + result["cash"] == 100
+
+    def test_get_cash_balances_missing_yaml(self, tmp_path, monkeypatch):
+        """portfolio.yaml 없으면 빈 cash 반환 (graceful)."""
+        import nuri.api.routes.dashboard as dash_mod
+        monkeypatch.setattr(
+            dash_mod,
+            "__file__",
+            str(tmp_path / "fake_dashboard.py"),
+        )
+        # tmp_path에 portfolio.yaml 없음 → FileNotFoundError → 빈 dict 반환
+        result = dash_mod._get_cash_balances(exchange_rate=1400)
+        assert result == {"accounts": [], "total_cash_usd": 0.0}
+
+    def test_get_cash_balances_parses_usd_and_krw(self, tmp_path, monkeypatch):
+        """cash_usd + cash_krw 파싱 → USD 환산."""
+        import nuri.api.routes.dashboard as dash_mod
+
+        # 임시 portfolio.yaml 생성
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        portfolio_yaml = config_dir / "portfolio.yaml"
+        portfolio_yaml.write_text(
+            "accounts:\n"
+            "  acct_a:\n"
+            "    name: Test A\n"
+            "    strategy: core\n"
+            "    cash_usd: 1000.0\n"
+            "    cash_krw: 1400000\n"
+            "  acct_b:\n"
+            "    name: Test B\n"
+            "    strategy: active\n"
+            "    cash_usd: 500.0\n",
+            encoding="utf-8",
+        )
+        # __file__을 tmp_path 하위로 패치 → config/portfolio.yaml resolve 위치 변경
+        # dashboard.py의 경로 계산: Path(__file__).parent.parent.parent.parent / "config" / "portfolio.yaml"
+        # 즉 __file__이 tmp_path/level1/level2/level3/level4.py 이면 tmp_path/config/portfolio.yaml로 resolve
+        fake_file = tmp_path / "l1" / "l2" / "l3" / "dashboard.py"
+        fake_file.parent.mkdir(parents=True)
+        fake_file.touch()
+        monkeypatch.setattr(dash_mod, "__file__", str(fake_file))
+
+        result = dash_mod._get_cash_balances(exchange_rate=1400)
+        # acct_a: 1000 + 1400000/1400 = 2000 USD
+        # acct_b: 500 USD
+        # total: 2500
+        assert result["total_cash_usd"] == 2500.0
+        assert len(result["accounts"]) == 2
+
     def test_cache_mechanism(self, db_path, monkeypatch):
         """캐시 동작 확인."""
         import nuri.api.routes.dashboard as dash_mod

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -151,6 +151,37 @@ class TestCashBalances:
         assert result["total_cash_usd"] == 2500.0
         assert len(result["accounts"]) == 2
 
+    def test_get_cash_balances_skips_non_dict_entries(self, tmp_path, monkeypatch):
+        """malformed yaml — accounts 아래에 dict가 아닌 값이 있으면 건너뜀 (방어적 guard).
+
+        covers dashboard.py line 335 (`if not isinstance(info, dict): continue`).
+        실전에서 portfolio.yaml이 `accounts: null` 이거나 잘못된 YAML을 먹었을 때 crash 방지.
+        """
+        import nuri.api.routes.dashboard as dash_mod
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        portfolio_yaml = config_dir / "portfolio.yaml"
+        # 하나는 dict, 하나는 null, 하나는 string — 모두 yaml 파싱 가능하지만 non-dict
+        portfolio_yaml.write_text(
+            "accounts:\n"
+            "  good:\n"
+            "    strategy: core\n"
+            "    cash_usd: 500.0\n"
+            "  broken_null: null\n"
+            "  broken_str: unexpected string\n",
+            encoding="utf-8",
+        )
+        fake_file = tmp_path / "l1" / "l2" / "l3" / "dashboard.py"
+        fake_file.parent.mkdir(parents=True)
+        fake_file.touch()
+        monkeypatch.setattr(dash_mod, "__file__", str(fake_file))
+
+        # 예외 없이 good 계정만 집계되어야 함
+        result = dash_mod._get_cash_balances(exchange_rate=1400)
+        assert result["total_cash_usd"] == 500.0
+        assert len(result["accounts"]) == 1
+
     def test_cache_mechanism(self, db_path, monkeypatch):
         """캐시 동작 확인."""
         import nuri.api.routes.dashboard as dash_mod

--- a/tests/api/test_portfolio.py
+++ b/tests/api/test_portfolio.py
@@ -26,6 +26,17 @@ class TestPortfolio:
         assert "count" in data
         assert data["count"] == 0
 
+    def test_portfolio_exposes_cash(self, client):
+        """#213: /api/portfolio 응답이 cash 필드를 포함해야 함."""
+        r = client.get("/api/portfolio")
+        assert r.status_code == 200
+        data = r.json()
+        assert "cash" in data
+        cash = data["cash"]
+        assert "accounts" in cash
+        assert "total_cash_usd" in cash
+        assert isinstance(cash["accounts"], list)
+
     def test_add_holding(self, client):
         r = client.post("/api/portfolio", json={
             "account": "sample", "ticker": "AAPL",


### PR DESCRIPTION
Closes #213.

## Summary

Dashboard의 비중 바가 사용자 실제 현금과 맞지 않던 long-standing 버그 수정. Root cause는 두 가지:

1. **비중 바는 regime 권장값** — \`_get_allocation(regime)\`이 \`REGIME_ALLOCATION[현재 레짐]\`의 target 비율을 반환하는데, dashboard는 이를 마치 사용자 portfolio composition처럼 표시.
2. **Hero 총 평가액에 cash 누락** — \`portfolio.yaml\`에 \`cash_usd\`/\`cash_krw\` 필드가 있지만 어느 code path도 읽지 않아서 dashboard 전체가 cash를 무시.

## What changed

### Backend (\`feat(api)\`)

- **\`_get_cash_balances(exchange_rate)\`** — portfolio.yaml 읽어 계좌별 cash를 USD로 환산 합산. broker 이름은 \`_get_account_labels()\`의 익명 라벨로 치환 (§4.4.1 privacy).
- **\`_compute_actual_allocation(account_values, cash_total_usd)\`** — holdings+cash로 실제 비율 계산. 반올림 오차는 cash 쪽에 흡수해서 long+cash == 100 보장.
- **\`/api/dashboard\`** 응답 확장:
  - \`actual_allocation\` — 새 필드, holdings+cash 기반
  - \`target_allocation\` — \`allocation\`의 explicit alias (regime 권장)
  - \`cash_summary\` — 계좌별 cash + total
  - \`allocation\` — 기존 이름 유지 (backward compat)
- **\`/api/portfolio\`** 응답에 \`cash\` 필드 추가 — portfolio 상태는 portfolio endpoint가 자연스러운 위치.

### Frontend (\`feat(dashboard)\`)

- **Hero**:
  - 라벨 \`총 평가액\` → \`총 자산\` (이제 cash 포함)
  - \`totalValue = holdings + cash\`
  - cash > 0 또는 account_values가 있으면 sub-line에 breakdown (\`보유 \$X · 현금 \$Y · <account lines>\`). cash 0 + account_values 없으면 sub-line 숨김 (기존 holdings-only 테스트와 구조 호환).
- **비중 바 — 2줄 layout**:
  - **실제** (prominent, h-3): \`actual_allocation\` — \`투자 X% · 현금 Y%\` 라벨. 현재 호진님이 실제로 보유한 비율.
  - **권장 (레짐)** (subtle, h-1.5, opacity-60): \`target_allocation\` — 현재 레짐이 권장하는 비율.
  - 이 두 줄을 나란히 보면 \"내 비중이 레짐 권장값과 얼마나 차이 나는가\"를 한눈에 파악 가능.

### 예시 (실제 사용자 케이스)

| 항목 | Before | After |
|---|---|---|
| Hero | \"총 평가액 \$33,996\" (holdings만) | \"총 자산 \$74,299\" (holdings + cash) |
| Hero sub-line | (없음) | \"보유 \$33,996 · 현금 \$40,303\" |
| 비중 바 | \"투자 20% / 현금 80%\" (레짐 권장) | **실제** \"투자 46% · 현금 54%\" + **권장 (레짐)** \"투자 20% · 현금 80%\" |

## Why 2-row bar instead of \"replace\"

사용자 결정 (D4 in wireframe PM): 실제 vs 권장 둘 다 보여주는 게 의사결정에 도움. \"내가 지금 20% 권장인데 54% 현금이네 → 방어적 성향\"같은 판단 가능. 단일 바로 바꾸면 regime guidance 정보가 사라짐.

## Test plan

- [x] **Backend** — 9 new tests in \`tests/api/test_dashboard.py\` + 1 in \`test_portfolio.py\`:
  - \`_compute_actual_allocation\` — holdings-only / cash-only / empty / mixed / rounding
  - \`_get_cash_balances\` — missing yaml / USD+KRW parsing
  - \`/api/dashboard\` 응답에 \`actual_allocation\`, \`target_allocation\`, \`cash_summary\` 포함
  - \`/api/portfolio\` 응답에 \`cash\` 포함
  - Total: 124 passed in tests/api/test_dashboard.py + test_portfolio.py
- [x] **Frontend** — 3 new tests in \`dashboard.test.tsx\`:
  - Hero가 cash 포함한 total wealth 표시
  - Actual + target allocation 2-row 렌더링
  - Fallback: portfolio.cash 없으면 holdings-only로 회귀
  - Total: 669 passed
- [x] \`tsc --noEmit\` — clean
- [x] \`ruff check\` — clean
- [ ] Visual verification — 호진님이 \`make start\` 후 확인 필요 (hero에 실제 총 자산 + 2줄 비중 바가 나오는지)
- [ ] CI: lint + test + privacy scan

## Files

- \`nuri/api/routes/dashboard.py\` — +2 helpers, extended response (backward-compat)
- \`nuri/api/routes/portfolio.py\` — cash 필드 추가
- \`tests/api/test_dashboard.py\` — 8 new tests
- \`tests/api/test_portfolio.py\` — 1 new test
- \`frontend/src/app/page.tsx\` — hero + allocation bar rewrite
- \`frontend/src/__tests__/pages/dashboard.test.tsx\` — 3 new tests + 1 update

## Out of scope

- UX polish for multi-currency display (KRW cash를 어떻게 hero에 보여줄지) — 일단 \"환산 USD 합계\"로 표시
- Cash 편집 UI — 여전히 \`portfolio.yaml\` 수동 편집 (후속 이슈 #25가 다룰 영역)
- Hidden 양의 broker 이름 정보 — 현재 privacy 규칙대로 label만 사용

## 의존성

- **#212 (#199 Phase 2-C)** — 독립. #213은 allocation/hero 영역이라 holdings 테이블 영역과 겹치지 않음. 서로 diff 없음. 어느 것이 먼저 머지돼도 무방.

🤖 Generated with [Claude Code](https://claude.com/claude-code)