### PR TITLE
docs(strategy): mark auto-trading as permanently deferred (user opt-out)

### DIFF
--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -451,10 +451,19 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 
 | # | 항목 | 이슈 | 카테고리 | 비고 |
 |---|------|------|---------|------|
-| 1 | Alpaca 실전 연동 (Paper → Live) | [#17](https://github.com/researcherhojin/nuri-quant/issues/17) | feat(execution) | 자동 매도 실행. SIEGE CERTIFIED 종목만 |
-| 2 | KIS Open API 한국 실전 연동 | — | feat(execution) | `kis_realtime.py` 기 구현. 매매 endpoint 미연결 |
-| 3 | **PR #202 commit message Stage 2 history cleanup** | — | security | 사용자 보유 종목 + 손실률이 PR #202 commit message에 노출되어 main git history에 박힘 (TEM/RKLB/PL 등 + PnL). §4.4.1 Stage 2 절차 (GitHub Support 또는 `git filter-repo`) 적용 결정 필요 |
-| 4 | **Universe 추가 확장 (Russell 2000)** | — | feat(scanner) | 현재 419 (us_core 85 + us_sp500 254 + kospi200 80). 중소형주 발굴 위해 Russell 2000 (~2,000) 추가 검토 |
+| 1 | **PR #202 commit message Stage 2 history cleanup** | — | security | 사용자 보유 종목 + 손실률이 PR #202 commit message에 노출되어 main git history에 박힘 (TEM/RKLB/PL 등 + PnL). §4.4.1 Stage 2 절차 (GitHub Support 또는 `git filter-repo`) 적용 결정 필요 |
+| 2 | **Universe 추가 확장 (Russell 2000)** | — | feat(scanner) | 현재 419 (us_core 85 + us_sp500 254 + kospi200 80). 중소형주 발굴 위해 Russell 2000 (~2,000) 추가 검토 |
+
+### 자동 매매 — 영구 deferred (사용자 opt-out)
+
+| 항목 | 이슈 | 결정 사유 |
+|------|------|---------|
+| Alpaca 실전 연동 (Paper → Live) | [#17](https://github.com/researcherhojin/nuri-quant/issues/17) | **영구 보류**. 2026-04-11 사용자 결정 — 자동 매매로 인한 손실 책임소재 이슈. 시스템 추천(확률적)과 실제 매매(결정적) 사이의 책임 경계가 모호해지는 걸 차단. |
+| KIS Open API 한국 실전 매매 endpoint | — | **영구 보류** (동일 사유). `kis_realtime.py`의 **read** endpoint(잔고/가격/drift 모니터링)는 그대로 사용. 매매 endpoint만 연결하지 않음. |
+
+**원칙**: 시스템은 추천과 알림에만 관여한다. 실제 주문은 호진님이 직접 카카오페이/토스/KIS 등에서 수동 실행한다. `DryRun` mode 및 paper trading 시뮬레이션은 백테스트/검증 용도로 계속 사용 가능.
+
+이 결정을 뒤집으려면 STRATEGY.md 개정 PR + 명시적 재승인 필요.
 
 ### 영구 배경 작업 (낮은 우선순위, 발견 시 처리)
 


### PR DESCRIPTION
## Summary

사용자가 2026-04-11에 자동 매매(Alpaca live, KIS write endpoints)를 **영구적으로** 도입하지 않기로 결정. 책임소재(liability) 문제 — 시스템 추천(확률적)과 실제 매매(결정적) 사이의 책임 경계가 모호해지는 걸 차단.

## What changed

### STRATEGY.md §7

**Before**: Tier 3 항목 #1 Alpaca 실전 연동 + #2 KIS Open API 한국 실전 연동이 \"다음 분기 (P2)\"로 등재.

**After**:
- Tier 3에서 제거.
- 새 소섹션 **자동 매매 — 영구 deferred (사용자 opt-out)** 추가.
- 결정 사유, 적용 범위, 예외 (read endpoints / DryRun / paper trading), 뒤집는 조건을 명시.

### 유지되는 것
- **KIS read endpoints** — 잔고 조회, 가격 fetch, portfolio.yaml drift 모니터링 등은 계속 사용
- **Alpaca DryRun mode + paper trading simulation** — 백테스트/검증 목적만
- 관련 코드 (\`nuri/trading/execution/\`, \`nuri/collectors/kis_*\`)는 삭제하지 않음

### 차단되는 것
- Alpaca live trading endpoint 연동
- KIS write/order endpoint 연동
- 자동 매수/매도 실행 로직

### 뒤집는 조건
이 결정을 번복하려면 **STRATEGY.md 개정 PR + 사용자 명시적 재승인**이 필요 — §4.4 (외부 LLM Egress Policy 등)과 동일한 opt-in 패턴.

## Why

- 자동 매매 손실에 대한 책임이 사용자 → 시스템/개발자로 transfer될 가능성을 원천 차단
- 시스템은 \"추천과 알림\"에만 관여. 주문은 호진님이 직접 카카오페이/토스/KIS 등에서 수동 실행
- 세션 메모리에도 반영됨 (feedback_no_auto_trading.md)

## Test plan

- [x] STRATEGY.md 수정 1파일만 — 코드 변경 없음
- [x] \`ruff\` / \`pytest\` 실행 불필요 (docs only)
- [ ] CI: markdown lint + privacy scan

## 관련

- 사용자 결정 2026-04-11 세션
- 메모리: \`feedback_no_auto_trading.md\` (세션 간 지속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)