### PR TITLE
fix(dashboard): 2xl layout polish — w-fit row, sector text-left

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -444,7 +444,14 @@ async function Dashboard({
 
       {/* ═══ 보유 종목 — full-width (사이드바 제거 후) ═══ */}
       {enrichedHoldings.length > 0 && (
-        <section className="flex-1 min-h-0 flex flex-col">
+        <section className="flex-1 min-h-0 flex flex-col items-start">
+          {/*
+            w-fit wrapper — 제목 바 + 테이블 이 모두 테이블의 natural width (현재 breakpoint 의
+            column sum)에 맞춰 shrink 한다. 덕분에 period toggle + 상세 링크가 테이블의 우측
+            가장자리에 정확히 정렬되어, 우측에 떠 있는 "disconnected toolbar" 문제가 사라진다.
+            max-w-full 은 narrow viewport safety net.
+          */}
+          <div className="w-fit max-w-full">
           <div className="flex items-center justify-between mb-1.5 gap-3">
             <div className="flex items-center gap-2 min-w-0">
               <h2 className="text-sm font-semibold text-zinc-200">보유 종목</h2>
@@ -496,9 +503,10 @@ async function Dashboard({
               overflow-x-auto는 narrow viewport safety net. */}
           <div className="overflow-x-auto">
             <div className="min-w-0">
-              {/* 컬럼 헤더 — sm+ (< sm은 헤더 없이 row aria-label 만으로 충분) */}
-              <div className="hidden sm:flex items-center gap-2 px-2 pb-1 text-[9px] text-zinc-600 uppercase">
-                <span className="w-10 shrink-0">계좌</span>
+              {/* 컬럼 헤더 — sm+ (< sm은 헤더 없이 row aria-label 만으로 충분).
+                  w-fit 이라 rows 의 w-fit 과 정확히 같은 폭을 차지 → hover 정렬 + 우측 dead zone 제거. */}
+              <div className="hidden sm:flex w-fit items-center gap-2 px-2 pb-1 text-[9px] text-zinc-600 uppercase">
+                <span className="w-10 2xl:w-16 shrink-0">계좌</span>
                 <span className="w-20 shrink-0">종목</span>
                 <span className="hidden md:flex w-[72px] text-right shrink-0 leading-tight justify-end">
                   현재/<span className="text-zinc-700">평단</span>
@@ -514,8 +522,8 @@ async function Dashboard({
                 <span className="hidden xl:inline-block w-20 2xl:w-60 text-left shrink-0">
                   추세
                 </span>
-                {/* #218 (PR #219): 2xl+ 27" 전용 초광폭 컬럼 */}
-                <span className="hidden 2xl:inline-block w-[96px] text-right shrink-0">섹터</span>
+                {/* #218 (PR #219): 2xl+ 27" 전용 초광폭 컬럼. Sector 는 label 이라 text-left. */}
+                <span className="hidden 2xl:inline-block w-[96px] text-left shrink-0">섹터</span>
                 <span className="hidden 2xl:inline-block w-[56px] text-right shrink-0">비중</span>
               </div>
               <div className="space-y-0.5">
@@ -524,6 +532,7 @@ async function Dashboard({
                 ))}
               </div>
             </div>
+          </div>
           </div>
         </section>
       )}

--- a/frontend/src/components/ui/holding-row.tsx
+++ b/frontend/src/components/ui/holding-row.tsx
@@ -340,10 +340,11 @@ export function HoldingRow({ holding: h, href }: HoldingRowProps) {
       href={linkHref}
       data-testid="holding-row"
       data-status={h.status.kind}
-      className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-zinc-800/50 text-xs group"
+      className="flex w-fit items-center gap-2 px-2 py-1.5 rounded hover:bg-zinc-800/50 text-xs group"
     >
-      {/* account */}
-      <span className="text-[9px] text-zinc-600 uppercase w-10 shrink-0 truncate" title={h.account}>
+      {/* account — wider at 2xl+ so labels like "LONG_TERM" don't truncate. Stays w-10 below
+          2xl to keep the lg (1024) row width under the content budget (752 content). */}
+      <span className="text-[9px] text-zinc-600 uppercase w-10 2xl:w-16 shrink-0 truncate" title={h.account}>
         {h.account}
       </span>
       {/* name */}
@@ -429,9 +430,9 @@ export function HoldingRow({ holding: h, href }: HoldingRowProps) {
           baseline={h.avgPrice}
         />
       </span>
-      {/* #218: 섹터 — 2xl+ (1536px+) 27" 모니터용 */}
+      {/* #218: 섹터 — 2xl+ (1536px+) 27" 모니터용. Label 데이터라 text-left. */}
       <span
-        className="hidden 2xl:inline-block w-[96px] text-right text-[10px] text-zinc-500 truncate shrink-0"
+        className="hidden 2xl:inline-block w-[96px] text-left text-[10px] text-zinc-500 truncate shrink-0"
         aria-label="섹터"
         data-testid="sector-cell"
         title={h.sector ?? undefined}


### PR DESCRIPTION
## Summary

GAN-loop review of the dashboard at 1680×1000 (27" 2xl breakpoint) via a Playwright probe found four layout awkwardnesses that were visible but hard to articulate. All four fixed in one tight commit.

## What changed

1. **Row hover dead zone 254 → 8px** — Row Link + column header are now `w-fit` so hover highlight matches content width, not parent width.
2. **Section toolbar alignment** — New `w-fit max-w-full` wrapper around section header + table (with `items-start` on the section) keeps period toggle + 상세 link exactly at the rightmost column's edge instead of floating at the viewport right.
3. **Sector cell `text-right` → `text-left`** — 섹터 is label data; right-align + truncate put the ellipsis on the wrong side for long names like "Consumer Discretionary".
4. **Account column `w-10` → `w-10 2xl:w-16`** — Fits "LONG_TERM" and similar at 2xl without pushing lg (1024) row into horizontal scroll (lg has a 6px slack).

## Geometry before → after (row 1, 1680×1000)

| | Before | After |
|---|---|---|
| Row width | 1408 | 1186 |
| Last cell end | x=1402 | x=1426 |
| Dead space right | 254px | 8px |
| Sparkline start | x=994 | x=1018 |
| Sector start | x=1242 | x=1266 |

Verified at lg (1024) / xl (1280) / 2xl (1680). Row widths 746 / 834 / 1186, all within content budgets, no horizontal scroll.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` → 719/719 pass
- [x] Playwright probe at lg/xl/2xl — all three clean layouts, before/after screenshots archived locally
- [ ] Visual verification on 27" monitor after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)