### PR TITLE
docs: sync #226/#227 issue numbers + dashboard architecture into STRATEGY/CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,7 @@ data/
 
 ## Testing
 
-2,638 backend tests across 128 files (`tests/{alerts,analysis,api,collectors,core,llm,quant,scripts,trading/}` subdirs + `test_scheduler.py`) + 634 frontend vitest (46 files) + 25 Playwright E2E (5 spec files). Uses `pytest-xdist` for parallel execution (`-n auto --dist worksteal`). Coverage policy: no fixed minimum — Codecov gates on a 1% relative regression vs prior commit (`codecov.yml` `target: auto`). Tests use `tmp_path` fixture for isolated SQLite databases:
+2,661 backend tests across 128 files (`tests/{alerts,analysis,api,collectors,core,llm,quant,scripts,trading/}` subdirs + `test_scheduler.py`) + 766 frontend vitest (53 files, organized into `__tests__/{components,lib,pages,coverage}/` + 2 root system tests) + 25 Playwright E2E (5 spec files). Uses `pytest-xdist` for parallel execution (`-n auto --dist worksteal`). Coverage policy: no fixed minimum — Codecov gates on a 1% relative regression vs prior commit (`codecov.yml` `target: auto`). Tests use `tmp_path` fixture for isolated SQLite databases:
 
 **Slow marker** (PR #206): ~12 LLM/heavy tests are marked `@pytest.mark.slow`. PR CI excludes them via `-m "not slow"` (~24% wall time savings); main push runs the full suite. Use `make test-fast` locally for the same fast subset, `make test-slow` for slow only.
 ```python
@@ -457,14 +457,16 @@ Multi-account portfolio mixes USD and KRW. Exchange rate fallback chain: DB `mac
 cd frontend
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (634 tests, 46 files)
+npm run test           # vitest run (766 tests, 53 files)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```
 
-All pages are **Server Components** with `force-dynamic`. Data fetched server-side via `fetchAPI()` (`src/lib/api.ts`). Two Client Components: `/report` (LLM generation) and `/pipeline` (ReactFlow DAG).
+All pages are **Server Components** with `force-dynamic`. Data fetched server-side via `fetchAPI()` (`src/lib/api.ts`). Three Client Components: `/report` (LLM generation), `/pipeline` (ReactFlow DAG), and `<CompositionDonut>` (Recharts pie inside the dashboard composition section).
 
 **16 routes**: `/` (dashboard), `/signals`, `/consensus`, `/scan`, `/strategy`, `/rebalance`, `/engine`, `/pipeline`, `/report`, `/evidence`, `/portfolio`, `/targets`, `/advisor`, `/decisions`, `/login`, `/ticker/[symbol]`.
+
+**Dashboard layout** (composition-first overview, #224): Hero (4 stats: 총자산 / 오늘 P&L / 누적 / 승률) → market context strip (1 row, null-safe) → CollapsibleStrips (알림/이벤트/후보) → CompositionSection (320px Recharts donut + tabs `?comp=ticker|sector|account` + rich legend with daily delta) → mini cards strip (Movers + 집중도) → Holdings table (drilldown, sorted positionPct desc, top 8 + `?holdings=expanded` toggle) → footer. Data flows through `summarizeHoldings()` in `src/lib/holdings-summary.ts` which produces TodayPnL / CumulativePnL / WinRateSummary / SectorSlice[] / TickerSlice[] / AccountSlice[] / movers / concentration in one pass.
 
 **Design system** — 3 shared components enforce visual consistency:
 - `DataTable` — Universal table with column config, renderers, `rowClassName`, compact mode
@@ -473,7 +475,7 @@ All pages are **Server Components** with `force-dynamic`. Data fetched server-si
 
 **Conventions**: `async function Section()` in `<Suspense>`, `animate-pulse` skeletons, color semantics (emerald=BUY, red=SELL, amber=warning, blue=WATCH, zinc=HOLD), `text-[10px]` sub-labels.
 
-**Frontend testing** (634 vitest, 46 files): Mock `@/lib/api` + `next/navigation`. Recharts mock hoisting caveat: keep recharts-dependent and recharts-free tests in separate files.
+**Frontend testing** (766 vitest, 53 files): Mock `@/lib/api` + `next/navigation`. Recharts mock hoisting caveat: keep recharts-dependent and recharts-free tests in separate files. Dashboard tests mock recharts at file level to avoid jsdom suspense on `CompositionDonut`. Test files organized into `__tests__/{components,lib,pages,coverage}/` subdirs.
 
 **Auth**: `src/middleware.ts` — HMAC-SHA256 keyed cookie auth (Edge Runtime compatible), active only when `DASHBOARD_PASSWORD` is set.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -151,8 +151,8 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,633 tests, 128 files |
-| Frontend tests | 목표 ≥ 90% | 634 tests, 46 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,661 tests, 128 files |
+| Frontend tests | 목표 ≥ 90% | 766 tests, 53 files |
 | E2E | 핵심 flow 커버 | 25 Playwright tests (5 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 의존 | 금지 | conftest.py에서 yfinance/외부 API mock |
@@ -428,8 +428,8 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 
 | # | 항목 | 이슈 | 카테고리 | 비고 |
 |---|------|------|---------|------|
-| 1 | **연 배당금 / 배당 수익률 데이터** | — | feat(collectors) | `fundamentals` 테이블에 `annual_dividend_usd` + `dividend_yield_pct` 컬럼 추가, yfinance/OpenBB 에서 수집. 단타 위주 호진님 use case 에는 배당 metric 이 hero 자리 차지할 만큼은 아니지만 필요 시 surface 가능 (#221 iter 7a 노트 참조). |
-| 2 | **i18n constants extraction** | — | refactor(frontend) | 컴포넌트 + 테스트 양쪽에 하드코딩된 한국어 라벨을 `lib/strings.ts` 단일 source 로 추출. 풀 i18n (next-intl) 은 호진님 single-user, 한국어 only 컨텍스트에는 오버킬. PR #224 머지 후 작업. |
+| 1 | **i18n constants extraction** | [#226](https://github.com/researcherhojin/nuri-quant/issues/226) | refactor(frontend) | 컴포넌트 + 테스트 양쪽에 하드코딩된 한국어 라벨을 `lib/strings.ts` 단일 source 로 추출. 풀 i18n (next-intl) 은 single-user / Korean-only 컨텍스트에 오버킬. ~30 파일, 1 PR. |
+| 2 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | feat(collectors) | `fundamentals` 테이블에 `annual_dividend_usd` + `dividend_yield_pct` 컬럼 추가, yfinance `Ticker.info.dividendRate / dividendYield` 에서 수집. 단타 위주 active 계좌에는 hero 자리 차지할 만큼은 아니지만 별도 surface 가능 (#221 iter 7a 노트 참조). UI surface 는 별도 issue. |
 
 > 대시보드 composition-first restructure 완료 — PR #221/#222/#223/#224 로 holdings table → composition 중심 overview 전환. 각 PR 의 자세한 변경은 git log 참조.
 


### PR DESCRIPTION
Doc-only sync after #225.

## Why

#225 updated STRATEGY.md §7 Tier 1 with the new follow-ups (i18n constants, dividend collector) but the issues didn't exist yet. After #225 merged I filed #226 (i18n) and #227 (dividend) — this PR backfills the issue numbers + a few other stale references.

## What

- **STRATEGY.md §7 Tier 1**: link #226 + #227, swap order (i18n first as it has no data deps)
- **STRATEGY.md §4.1 Testing table**: backend 2,633 → 2,661, frontend 634/46 → 766/53
- **CLAUDE.md**: frontend test count 634 → 766 (3 places), test dir layout note, new \"Dashboard layout\" paragraph describing the composition-first structure (#224), \"Two Client Components\" → \"Three\" (added CompositionDonut), recharts mock-at-file-level note

NEXT_SESSION.md (gitignored) updated separately.

## Test plan

- [x] No production code changes
- [x] All numeric claims verified against code

🤖 Generated with [Claude Code](https://claude.com/claude-code)