### PR TITLE
fix(frontend): extract missed Korean strings in pipeline + ticker pages

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -121,7 +121,7 @@ function parseAlert(al: { level: string; message: string }): { label: string; hr
   if (nearMatch) return { label: `${nearMatch[1]} ${nearMatch[2]} ${SIGNAL.NEAR_SUFFIX}`, href: `/ticker/${nearMatch[1]}` };
   // 충돌
   const conflictMatch = translated.match(/충돌\s+(\d+)건/);
-  if (conflictMatch) return { label: `충돌 ${conflictMatch[1]}건`, href: "/decisions" };
+  if (conflictMatch) return { label: `${SIGNAL.CONFLICT_SHORT} ${conflictMatch[1]}${COMMON.COUNT_SUFFIX}`, href: "/decisions" };
   // 시그널 성과
   if (translated.includes("성과 하락")) return { label: translated.slice(0, 30), href: "/signals" };
   // 기타

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { API_BASE } from "@/lib/api";
+import { PIPELINE as PL } from "@/lib/strings";
 
 // === Types ===
 interface PipelineStep {
@@ -369,11 +370,11 @@ export default function PipelinePage() {
           {runningSteps.size > 0 && (
             <div className="flex items-center gap-1.5 px-2 py-0.5 rounded bg-blue-400/10 text-blue-400 text-[10px] font-medium">
               <span className="inline-flex h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
-              <span>{runningSteps.size}개 실행 중</span>
+              <span>{runningSteps.size}{PL.RUNNING_SUFFIX}</span>
             </div>
           )}
           {/* 자동 새로고침 표시 */}
-          <span className="text-[10px] text-muted-foreground/50">10초 자동 갱신</span>
+          <span className="text-[10px] text-muted-foreground/50">{PL.AUTO_REFRESH}</span>
         </div>
       </div>
 
@@ -405,19 +406,19 @@ export default function PipelinePage() {
       <div className="flex items-center gap-6 text-[10px] text-muted-foreground">
         <div className="flex items-center gap-1.5">
           <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500" />
-          <span>정상</span>
+          <span>{PL.LEGEND_OK}</span>
         </div>
         <div className="flex items-center gap-1.5">
           <span className="inline-flex h-2 w-2 rounded-full bg-amber-500" />
-          <span>경고 / 대기</span>
+          <span>{PL.LEGEND_WARN}</span>
         </div>
         <div className="flex items-center gap-1.5">
           <span className="inline-flex h-2 w-2 rounded-full bg-red-500" />
-          <span>에러</span>
+          <span>{PL.LEGEND_ERROR}</span>
         </div>
         <div className="flex items-center gap-1.5">
           <span className="inline-flex h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
-          <span>실행 중</span>
+          <span>{PL.LEGEND_RUNNING}</span>
         </div>
       </div>
 
@@ -425,10 +426,10 @@ export default function PipelinePage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {/* 이벤트 타임라인 */}
         <div className="rounded-xl border border-border bg-card p-4">
-          <p className="text-xs text-muted-foreground mb-3">이벤트 타임라인</p>
+          <p className="text-xs text-muted-foreground mb-3">{PL.EVENT_TIMELINE}</p>
           {timeline.length === 0 ? (
             <p className="text-xs text-muted-foreground/50 py-6 text-center">
-              아직 이벤트 없음 &mdash; 파이프라인 스텝을 실행하세요
+              {PL.NO_EVENTS} &mdash; {PL.RUN_STEP_HINT}
             </p>
           ) : (
             <div className="space-y-1.5 max-h-[400px] overflow-y-auto">
@@ -472,7 +473,7 @@ export default function PipelinePage() {
           <p className="text-xs text-muted-foreground mb-3">Gate Conditions</p>
           {allConditions.length === 0 ? (
             <p className="text-xs text-muted-foreground/50 py-6 text-center">
-              게이트 조건 로딩 중...
+              {PL.GATE_LOADING}
             </p>
           ) : (
             <div className="space-y-1.5 max-h-[400px] overflow-y-auto">

--- a/frontend/src/app/ticker/[symbol]/page.tsx
+++ b/frontend/src/app/ticker/[symbol]/page.tsx
@@ -7,6 +7,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { Metric } from "@/components/ui/metric";
 import { PriceChart } from "@/components/ui/price-chart";
+import { TICKER_DETAIL as TD } from "@/lib/strings";
 
 async function TickerDetail({ symbol }: { symbol: string }) {
   const [data, priceData, targets, external] = await Promise.all([
@@ -201,12 +202,12 @@ async function TickerDetail({ symbol }: { symbol: string }) {
             <CardContent className="pt-5">
               <p className="text-xs text-muted-foreground mb-3">Price Targets ({targets.stock_type})</p>
               <div className="space-y-1.5 text-xs">
-                <div className="flex justify-between"><span className="text-muted-foreground">손절가</span><span className="text-red-400">${targets.stop_loss?.toFixed(2)} ({targets.stop_loss_pct}%)</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">1차 익절</span><span className="text-emerald-400">${targets.target_1?.toFixed(2)} (+{targets.target_1_pct}%)</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">2차 익절</span><span className="text-emerald-400">${targets.target_2?.toFixed(2)} (+{targets.target_2_pct}%)</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">트레일링</span><span className="text-muted-foreground">{targets.trailing_stop_pct}% from high</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.STOP_LOSS}</span><span className="text-red-400">${targets.stop_loss?.toFixed(2)} ({targets.stop_loss_pct}%)</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TARGET_1}</span><span className="text-emerald-400">${targets.target_1?.toFixed(2)} (+{targets.target_1_pct}%)</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TARGET_2}</span><span className="text-emerald-400">${targets.target_2?.toFixed(2)} (+{targets.target_2_pct}%)</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TRAILING}</span><span className="text-muted-foreground">{targets.trailing_stop_pct}% from high</span></div>
                 {targets.analyst_target && (
-                  <div className="flex justify-between"><span className="text-muted-foreground">애널리스트</span><span className="text-blue-400">${targets.analyst_target?.toFixed(2)} ({targets.analyst_upside_pct > 0 ? "+" : ""}{targets.analyst_upside_pct}%)</span></div>
+                  <div className="flex justify-between"><span className="text-muted-foreground">{TD.ANALYST}</span><span className="text-blue-400">${targets.analyst_target?.toFixed(2)} ({targets.analyst_upside_pct > 0 ? "+" : ""}{targets.analyst_upside_pct}%)</span></div>
                 )}
               </div>
             </CardContent>

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -178,6 +178,7 @@ export const SIGNAL = {
   CONFLICT_REPLACE: "매수·매도 신호 충돌",
   STOP_SUFFIX: "손절",
   NEAR_SUFFIX: "근접",
+  CONFLICT_SHORT: "충돌",
 } as const;
 
 /* ── Sparkline ──────────────────────────────────────────────── */
@@ -261,6 +262,29 @@ export const REPORT = {
 export const DECISIONS = {
   EMPTY: "아직 기록된 의사결정 없음.",
   SUBTITLE: "의사결정 저널 — 모든 BUY/SELL 판단의 근거와 결과를 추적합니다.",
+} as const;
+
+/* ── Pipeline Page ──────────────────────────────────────────── */
+export const PIPELINE = {
+  RUNNING_SUFFIX: "개 실행 중",
+  AUTO_REFRESH: "10초 자동 갱신",
+  LEGEND_OK: "정상",
+  LEGEND_WARN: "경고 / 대기",
+  LEGEND_ERROR: "에러",
+  LEGEND_RUNNING: "실행 중",
+  EVENT_TIMELINE: "이벤트 타임라인",
+  NO_EVENTS: "아직 이벤트 없음",
+  RUN_STEP_HINT: "파이프라인 스텝을 실행하세요",
+  GATE_LOADING: "게이트 조건 로딩 중...",
+} as const;
+
+/* ── Ticker Detail Page ─────────────────────────────────────── */
+export const TICKER_DETAIL = {
+  STOP_LOSS: "손절가",
+  TARGET_1: "1차 익절",
+  TARGET_2: "2차 익절",
+  TRAILING: "트레일링",
+  ANALYST: "애널리스트",
 } as const;
 
 /* ── Common ─────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Follow-up to #230 — two pages were missed in the initial i18n extraction:

- **pipeline/page.tsx**: 9 Korean strings (legend labels, auto-refresh, event timeline, gate loading)
- **ticker/[symbol]/page.tsx**: 5 Korean strings (price target labels: 손절가, 1차 익절, 2차 익절, 트레일링, 애널리스트)
- **page.tsx (dashboard)**: 1 remaining rendered label (`충돌 N건`)

Adds `PIPELINE` and `TICKER_DETAIL` groups to `lib/strings.ts`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 766/766 passed
- [x] Full Korean string scan confirms no remaining hardcoded rendered text

🤖 Generated with [Claude Code](https://claude.com/claude-code)