### PR TITLE
fix(macro): add data quality gates to macro event pipeline

### DIFF
--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -428,6 +428,7 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 |---|------|------|----|------|
 | 1 | **i18n constants extraction** | [#226](https://github.com/researcherhojin/nuri-quant/issues/226) | #230, #231 | `lib/strings.ts` 에 ~145개 한국어 상수 추출. 19 파일 마이그레이션 완료. |
 | 2 | **하네스 계층화** | — | #229 | Fowler Guide/Sensor 기반 구조화: CLAUDE.md 슬림 (511→238줄) + 7 scoped CLAUDE.md + AGENTS.md + 4 hooks |
+| 3 | **티커 기반 First-Run 온보딩 UX** | [#133](https://github.com/researcherhojin/nuri-quant/issues/133) | #234, #235 | `/explore` 페이지 + 티커 검색/분석 API. 커버리지 보강 포함. |
 
 > #227 (배당 데이터)은 active 계좌 단타 전략에서 의사결정 변수가 아니므로 Tier 2로 강등 (2026-04-13 결정).
 
@@ -437,12 +438,11 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 
 | # | 항목 | 이슈 | 카테고리 | 비고 |
 |---|------|------|---------|------|
-| 1 | 티커 기반 First-Run 온보딩 UX | [#133](https://github.com/researcherhojin/nuri-quant/issues/133) | feat(frontend) | 신규 사용자 0분 가치 체험. `/analyze?ticker=NVDA` |
-| 2 | 포트폴리오 온보딩 UI (YAML → Dashboard) | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 수동 yaml 편집 제거 |
-| 3 | 백테스트 인터랙티브 equity curve | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 파라미터 sliders + 실시간 시뮬레이션 |
-| 4 | **Privacy scanner ticker+PnL pattern** | — | security | 현재 broker name + monetary literal만 차단. ticker와 PnL이 같은 commit message/PR 본문에 있을 때 패턴 감지 추가. PR #202 commit message leak 같은 경우 방지 |
-| 5 | **LLM 휴면 코드 결정** | — | refactor | `nuri/llm/{report,event_classifier,openai_client}.py` 현재 production 비활성 (OLLAMA_HOST/OPENAI_API_KEY 미설정). 유지 vs 제거 vs 재활성화 결정 필요 |
-| 6 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | feat(collectors) | Tier 1에서 강등. pension 계좌 별도 surface 필요 시 재평가 |
+| 1 | 포트폴리오 온보딩 UI (YAML → Dashboard) | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 수동 yaml 편집 제거 |
+| 2 | 백테스트 인터랙티브 equity curve | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 파라미터 sliders + 실시간 시뮬레이션 |
+| 3 | **Privacy scanner ticker+PnL pattern** | — | security | 현재 broker name + monetary literal만 차단. ticker와 PnL이 같은 commit message/PR 본문에 있을 때 패턴 감지 추가. PR #202 commit message leak 같은 경우 방지 |
+| 4 | **LLM 휴면 코드 결정** | — | refactor | `nuri/llm/{report,event_classifier,openai_client}.py` 현재 production 비활성 (OLLAMA_HOST/OPENAI_API_KEY 미설정). 유지 vs 제거 vs 재활성화 결정 필요 |
+| 5 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | feat(collectors) | Tier 1에서 강등. pension 계좌 별도 surface 필요 시 재평가 |
 
 ### Tier 3 — 다음 분기 (P2)
 

--- a/nuri/collectors/macro_news.py
+++ b/nuri/collectors/macro_news.py
@@ -16,6 +16,7 @@ Phase B/C에서 별도 PR로 통합한다 (#142, #143).
 import logging
 import re
 import xml.etree.ElementTree as ET  # noqa: N817 — stdlib alias
+from datetime import timedelta
 from email.utils import parsedate_to_datetime
 from urllib.parse import quote_plus
 
@@ -46,6 +47,8 @@ KEYWORDS: tuple[str, ...] = (
 GOOGLE_NEWS_RSS = "https://news.google.com/rss/search"
 RSS_TIMEOUT_SEC = 15
 MAX_ITEMS_PER_KEYWORD = 10
+# 이 기간보다 오래된 기사는 수집 단계에서 DROP — 시스템에 stale 데이터가 유입되지 않도록.
+MAX_ARTICLE_AGE_DAYS = 7
 
 
 class MacroNewsCollector(BaseCollector):
@@ -58,7 +61,9 @@ class MacroNewsCollector(BaseCollector):
 
     def collect(self, **kwargs) -> list[dict]:
         """모든 키워드에 대해 RSS 수집 + 분류."""
+        cutoff = (kst_now() - timedelta(days=MAX_ARTICLE_AGE_DAYS)).isoformat(timespec="seconds")
         records: list[dict] = []
+        stale_count = 0
         for keyword in KEYWORDS:
             try:
                 items = self._fetch_rss(keyword)
@@ -67,6 +72,11 @@ class MacroNewsCollector(BaseCollector):
                 continue
 
             for item in items:
+                # 7일 초과 기사 DROP — stale 데이터 유입 방지 (#137)
+                if item["published_at"] < cutoff:
+                    stale_count += 1
+                    continue
+
                 classified = classify_event(item["headline"], use_llm=self.use_llm)
                 records.append(
                     {
@@ -79,10 +89,13 @@ class MacroNewsCollector(BaseCollector):
                         "sentiment": classified["sentiment"],
                         "confidence": classified["confidence"],
                         "regime_hint": classified["regime_hint"],
+                        "classification_method": classified.get("classification_method", "unknown"),
                         "raw_json": None,
                     }
                 )
 
+        if stale_count:
+            self.logger.info("[%s] %d개 stale 기사 필터링 (>%d일)", self.name, stale_count, MAX_ARTICLE_AGE_DAYS)
         self.logger.info(
             "[%s] %d개 키워드 → %d개 raw items 수집",
             self.name,

--- a/nuri/core/db.py
+++ b/nuri/core/db.py
@@ -539,6 +539,9 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         );
         CREATE INDEX IF NOT EXISTS idx_decision_evidence_decision ON decision_evidence(decision_id);
     """),
+    (16, "add classification_method to macro_events for #137 data quality", """
+        ALTER TABLE macro_events ADD COLUMN classification_method TEXT;
+    """),
 ]
 
 
@@ -731,18 +734,24 @@ def upsert_macro_events(records: list[dict], db_path: Optional[Path] = None) -> 
     """매크로 이벤트 upsert (URL 기준 중복 제거).
 
     레코드 키: published_at, source, query_keyword, headline, url,
-              category, sentiment, confidence, regime_hint, raw_json
+              category, sentiment, confidence, regime_hint, raw_json,
+              classification_method (optional)
     URL이 이미 존재하면 INSERT OR IGNORE로 스킵.
     """
     if not records:
         return 0
+    # classification_method가 없는 레코드 호환 처리
+    for r in records:
+        r.setdefault("classification_method", None)
     with get_db(db_path) as conn:
         cursor = conn.executemany(
             """INSERT OR IGNORE INTO macro_events
                (published_at, source, query_keyword, headline, url,
-                category, sentiment, confidence, regime_hint, raw_json)
+                category, sentiment, confidence, regime_hint, raw_json,
+                classification_method)
                VALUES (:published_at, :source, :query_keyword, :headline, :url,
-                       :category, :sentiment, :confidence, :regime_hint, :raw_json)""",
+                       :category, :sentiment, :confidence, :regime_hint, :raw_json,
+                       :classification_method)""",
             records,
         )
         return cursor.rowcount if cursor.rowcount >= 0 else len(records)

--- a/nuri/llm/event_classifier.py
+++ b/nuri/llm/event_classifier.py
@@ -136,6 +136,7 @@ def _classify_with_regex(headline: str) -> dict:
                 "sentiment": sentiment,
                 "confidence": 0.5,  # regex는 신뢰도 mid — LLM보다 낮음
                 "regime_hint": REGIME_HINT_BY_CATEGORY[category],
+                "classification_method": "regex",
             }
     return _neutral_result()
 
@@ -176,7 +177,7 @@ def _normalize(parsed: dict) -> dict:
     category = parsed.get("category", "neutral")
     if category not in CATEGORIES:
         # 미지의 카테고리 → neutral로 강제 (신뢰도 낮춤)
-        return {**_neutral_result(), "confidence": 0.2}
+        return {**_neutral_result(), "confidence": 0.2, "classification_method": "normalized_invalid"}
 
     sentiment = float(parsed.get("sentiment", 0.0))
     sentiment = max(-1.0, min(1.0, sentiment))
@@ -189,6 +190,7 @@ def _normalize(parsed: dict) -> dict:
         "sentiment": sentiment,
         "confidence": confidence,
         "regime_hint": REGIME_HINT_BY_CATEGORY[category],
+        "classification_method": "openai",
     }
 
 
@@ -198,4 +200,5 @@ def _neutral_result() -> dict:
         "sentiment": 0.0,
         "confidence": 0.3,
         "regime_hint": None,
+        "classification_method": "neutral_default",
     }

--- a/nuri/quant/regime/event_score.py
+++ b/nuri/quant/regime/event_score.py
@@ -42,6 +42,9 @@ LOOKBACK_DAYS = 3
 SCORE_MIN = -20.0
 SCORE_MAX = 20.0
 
+# 이 신뢰도 미만의 이벤트는 스코어 계산에서 제외 — 노이즈 방지 (#137)
+CONFIDENCE_FLOOR = 0.3
+
 
 @dataclass
 class EventScore:
@@ -86,9 +89,14 @@ def compute_event_score(
             category_breakdown={}, dominant_category=None, regime_hint=None,
         )
 
+    # 저신뢰 이벤트 필터링 — regex fallback이나 분류 실패로 인한 노이즈 제거
+    filtered = [r for r in rows if (r["confidence"] or 0.0) >= CONFIDENCE_FLOOR]
+    if len(filtered) < len(rows):
+        logger.debug("이벤트 %d건 중 %d건 신뢰도 미달 제외 (< %.1f)", len(rows), len(rows) - len(filtered), CONFIDENCE_FLOOR)
+
     # 카테고리별 기여 합산
     breakdown: dict[str, float] = {}
-    for row in rows:
+    for row in filtered:
         cat = row["category"]
         sentiment = row["sentiment"] or 0.0
         confidence = row["confidence"] or 0.5
@@ -106,7 +114,7 @@ def compute_event_score(
     raw_sum = sum(breakdown.values())
     # 이벤트 수가 많을수록 효과 감소 (diminishing returns)
     # √(event_count)로 정규화하여 1개 이벤트와 100개 이벤트의 차이를 줄임
-    event_count = len(rows)
+    event_count = len(filtered)
     normalized = raw_sum / (event_count ** 0.5) if event_count > 0 else 0.0
 
     # 20점 스케일로 변환 (경험적 스케일링 팩터)

--- a/tests/collectors/test_macro_news.py
+++ b/tests/collectors/test_macro_news.py
@@ -4,6 +4,8 @@ Network-free:
 - requests.get는 monkeypatch로 mock된 fixture XML 반환
 - classify_event는 use_llm=False로 regex만 사용
 """
+from datetime import timedelta
+from email.utils import format_datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,6 +16,12 @@ from nuri.collectors.macro_news import (
     _parse_rss_items,
 )
 from nuri.core.db import query
+from nuri.core.timezone import kst_now
+
+
+def _recent_date_rfc822() -> str:
+    """테스트용 — stale 필터를 통과하는 최근 날짜 RFC 822 문자열."""
+    return format_datetime(kst_now() - timedelta(hours=6))
 
 # 최소 fixture — Reuters source 분리, source 없는 item, 빈 link 등 edge case 포함
 RSS_FIXTURE = (
@@ -106,6 +114,41 @@ class TestCollect:
         assert records[0]["sentiment"] > 0
         # 둘째는 fed_dovish (rate cut 매칭)
         assert records[1]["category"] == "fed_dovish"
+        # classification_method 필드 존재 확인
+        assert records[0]["classification_method"] == "regex"
+
+    def test_collect_filters_stale_articles(self, monkeypatch, db_path):
+        """7일 초과 기사는 DROP된다."""
+        # 2025년 11월 기사를 포함하는 RSS
+        stale_rss = (
+            b'<?xml version="1.0"?>'
+            b'<rss version="2.0"><channel>'
+            b'<item>'
+            b'<title>Very old article about yen carry trade</title>'
+            b'<link>https://news.google.com/articles/old1</link>'
+            b'<pubDate>Thu, 19 Nov 2025 08:00:00 GMT</pubDate>'
+            b'<source url="https://example.com">Example</source>'
+            b'</item>'
+            b'<item>'
+            b'<title>Iran agrees to ceasefire today</title>'
+            b'<link>https://news.google.com/articles/fresh1</link>'
+            b'<pubDate>' + _recent_date_rfc822().encode() + b'</pubDate>'
+            b'<source url="https://reuters.com">Reuters</source>'
+            b'</item>'
+            b'</channel></rss>'
+        )
+        mock_resp = MagicMock()
+        mock_resp.content = stale_rss
+        mock_resp.raise_for_status = MagicMock()
+
+        import nuri.collectors.macro_news as mod
+        monkeypatch.setattr(mod.requests, "get", MagicMock(return_value=mock_resp))
+        monkeypatch.setattr(mod, "KEYWORDS", ("test",))
+
+        records = MacroNewsCollector(use_llm=False).collect()
+        # stale 기사는 필터링되고 최근 기사만 남아야 함
+        assert len(records) == 1
+        assert "ceasefire" in records[0]["headline"].lower()
 
     def test_collect_handles_keyword_failure(self, monkeypatch, db_path):
         """한 키워드 실패가 다른 키워드를 막지 않음."""

--- a/tests/quant/test_regime_event_score.py
+++ b/tests/quant/test_regime_event_score.py
@@ -171,6 +171,40 @@ class TestComputeEventScore:
         assert es.category_breakdown["trade_war"] < 0
 
 
+class TestConfidenceFloor:
+    """신뢰도 < 0.3 이벤트는 스코어 계산에서 제외 (#137)."""
+
+    def test_low_confidence_events_excluded(self, db_path):
+        """confidence < 0.3 이벤트는 무시된다."""
+        _insert_events(db_path, [
+            # 저신뢰 이벤트 — 제외되어야 함
+            {"category": "geopolitical_escalation", "sentiment": -0.8, "confidence": 0.2, "url": "http://t/low1"},
+            {"category": "sector_selloff", "sentiment": -0.9, "confidence": 0.1, "url": "http://t/low2"},
+        ])
+        es = compute_event_score(db_path=db_path, date="2026-04-09")
+        assert es.event_count == 0  # 둘 다 제외
+        assert es.score == 0.0
+
+    def test_mixed_confidence_only_high_counted(self, db_path):
+        """고신뢰만 스코어에 반영, 저신뢰는 제외."""
+        _insert_events(db_path, [
+            {"category": "earnings_beat", "sentiment": 0.7, "confidence": 0.8, "url": "http://t/high1"},
+            {"category": "sector_selloff", "sentiment": -0.9, "confidence": 0.15, "url": "http://t/low1"},
+        ])
+        es = compute_event_score(db_path=db_path, date="2026-04-09")
+        assert es.event_count == 1  # 고신뢰만
+        assert es.score > 0  # earnings_beat만 반영 → 양수
+
+    def test_threshold_boundary(self, db_path):
+        """confidence == 0.3 이벤트는 포함 (>=)."""
+        _insert_events(db_path, [
+            {"category": "fed_dovish", "sentiment": 0.5, "confidence": 0.3, "url": "http://t/boundary"},
+        ])
+        es = compute_event_score(db_path=db_path, date="2026-04-09")
+        assert es.event_count == 1
+        assert es.score > 0
+
+
 class TestSimulation:
     """B5: 시뮬레이션 검증 — 복합 이벤트 시나리오."""
 


### PR DESCRIPTION
## Summary
- Filter stale articles (>7 days old) at collection time — prevents Nov 2025 articles from entering April 2026 pipeline
- Add confidence floor (>=0.3) to event_score — low-confidence regex fallback events no longer dilute signal
- Track `classification_method` (openai/regex/neutral_default) per event for audit trail
- DB migration 16: `classification_method` column on `macro_events`
- STRATEGY.md §7: move #133 (explore page) to Tier 1 completed

Closes part of #137

## Test plan
- [x] 39 tests pass (35 existing + 4 new)
- [x] `test_collect_filters_stale_articles` — verifies 5-month-old article is dropped
- [x] `test_low_confidence_events_excluded` — confidence 0.2 events ignored
- [x] `test_mixed_confidence_only_high_counted` — only high-confidence events affect score
- [x] `test_threshold_boundary` — confidence == 0.3 is included (>=)
- [x] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)