### PR TITLE
fix(macro): add recency weighting and min event threshold for regime hint

### DIFF
--- a/nuri/quant/regime/event_score.py
+++ b/nuri/quant/regime/event_score.py
@@ -9,6 +9,7 @@ macro_score.py의 9번째 입력으로 사용.
 """
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -48,6 +49,9 @@ SCORE_MAX = 20.0
 # 이 신뢰도 미만의 이벤트는 스코어 계산에서 제외 — 노이즈 방지 (#137)
 CONFIDENCE_FLOOR = 0.3
 
+# regime_hint를 신뢰하기 위한 최소 이벤트 수 — 1~2개로 레짐 전환 방지 (#137)
+MIN_EVENTS_FOR_REGIME_HINT = 3
+
 
 @dataclass
 class EventScore:
@@ -58,6 +62,25 @@ class EventScore:
     category_breakdown: dict  # {category: contribution}
     dominant_category: str | None  # 가장 영향력 큰 카테고리
     regime_hint: str | None   # dominant category의 regime hint
+
+
+def _compute_recency(published_at: str | None, ref_date: str, lookback_days: int) -> float:
+    """이벤트 최신도 가중치: 1.0(오늘) → 0.5(lookback 끝) 선형 감소."""
+    if not published_at:
+        return 0.75  # 날짜 없으면 중간값
+    try:
+        pub_date = datetime.fromisoformat(published_at).strftime("%Y-%m-%d")
+        ref = datetime.strptime(ref_date, "%Y-%m-%d")
+        pub = datetime.strptime(pub_date, "%Y-%m-%d")
+        age_days = (ref - pub).days
+    except (ValueError, TypeError):
+        return 0.75
+    if age_days <= 0:
+        return 1.0
+    if age_days >= lookback_days:
+        return 0.5
+    # 선형 보간: 0일 → 1.0, lookback_days → 0.5
+    return 1.0 - 0.5 * (age_days / lookback_days)
 
 
 def compute_event_score(
@@ -76,7 +99,7 @@ def compute_event_score(
 
     rows = query(
         """
-        SELECT category, sentiment, confidence, regime_hint
+        SELECT category, sentiment, confidence, regime_hint, published_at
         FROM macro_events
         WHERE published_at >= date(?, '-' || ? || ' days')
           AND category IS NOT NULL
@@ -97,7 +120,7 @@ def compute_event_score(
     if len(filtered) < len(rows):
         logger.debug("이벤트 %d건 중 %d건 신뢰도 미달 제외 (< %.1f)", len(rows), len(rows) - len(filtered), CONFIDENCE_FLOOR)
 
-    # 카테고리별 기여 합산
+    # 카테고리별 기여 합산 (시간 가중 적용)
     breakdown: dict[str, float] = {}
     for row in filtered:
         cat = row["category"]
@@ -109,7 +132,10 @@ def compute_event_score(
         # 카테고리 방향(weight)이 이미 부호를 내포하므로,
         # sentiment은 강도(절대값)만 사용. 이중 부정 방지.
         intensity = abs(sentiment) if abs(sentiment) > 0.01 else 0.5
-        contribution = weight * intensity * confidence
+
+        # 시간 가중: 최근 이벤트일수록 높은 가중 (1.0 → 0.5 선형 감소, #137)
+        recency = _compute_recency(row.get("published_at"), ref_date, lookback_days)
+        contribution = weight * intensity * confidence * recency
 
         breakdown[cat] = breakdown.get(cat, 0.0) + contribution
 
@@ -127,9 +153,11 @@ def compute_event_score(
     # dominant category 결정
     dominant = max(breakdown, key=lambda k: abs(breakdown[k])) if breakdown else None
     regime_hint = None
-    if dominant:
+    if dominant and event_count >= MIN_EVENTS_FOR_REGIME_HINT:
         from nuri.llm.event_classifier import REGIME_HINT_BY_CATEGORY
         regime_hint = REGIME_HINT_BY_CATEGORY.get(dominant)
+    elif dominant and event_count < MIN_EVENTS_FOR_REGIME_HINT:
+        logger.debug("이벤트 %d건 < %d → regime_hint 무효화", event_count, MIN_EVENTS_FOR_REGIME_HINT)
 
     return EventScore(
         date=ref_date,

--- a/tests/quant/test_regime_event_score.py
+++ b/tests/quant/test_regime_event_score.py
@@ -7,6 +7,7 @@ from nuri.core.db import get_db, init_db
 from nuri.quant.regime.event_score import (
     CATEGORY_WEIGHT,
     EventScore,
+    _compute_recency,
     compute_event_score,
     print_event_score,
 )
@@ -151,12 +152,23 @@ class TestComputeEventScore:
         assert es.score > 0  # Still positive because category weight is positive
 
     def test_regime_hint_from_dominant(self, db_path):
-        """Dominant category maps to regime hint."""
+        """Dominant category maps to regime hint (3+ events required)."""
         _insert_events(db_path, [
-            {"category": "geopolitical_de_escalation", "sentiment": 0.5, "confidence": 0.8},
+            {"category": "geopolitical_de_escalation", "sentiment": 0.5, "confidence": 0.8, "url": "http://t/rh1"},
+            {"category": "geopolitical_de_escalation", "sentiment": 0.4, "confidence": 0.7, "url": "http://t/rh2"},
+            {"category": "geopolitical_de_escalation", "sentiment": 0.6, "confidence": 0.9, "url": "http://t/rh3"},
         ])
         es = compute_event_score(db_path=db_path, date="2026-04-09")
         assert es.regime_hint == "recovery"
+
+    def test_regime_hint_none_when_few_events(self, db_path):
+        """이벤트 < 3개면 regime_hint는 None (#137)."""
+        _insert_events(db_path, [
+            {"category": "geopolitical_escalation", "sentiment": -0.9, "confidence": 0.95},
+        ])
+        es = compute_event_score(db_path=db_path, date="2026-04-09")
+        assert es.dominant_category == "geopolitical_escalation"
+        assert es.regime_hint is None  # 1개 이벤트 → regime_hint 무효
 
     def test_category_breakdown_populated(self, db_path):
         """Breakdown shows per-category contributions."""
@@ -171,12 +183,49 @@ class TestComputeEventScore:
         assert es.category_breakdown["trade_war"] < 0
 
 
+class TestRecency:
+    """시간 가중: 최근 이벤트일수록 기여가 큼 (#137)."""
+
+    def test_today_is_full_weight(self):
+        assert _compute_recency("2026-04-09T12:00:00+00:00", "2026-04-09", 3) == 1.0
+
+    def test_old_event_is_half_weight(self):
+        assert _compute_recency("2026-04-06T12:00:00+00:00", "2026-04-09", 3) == 0.5
+
+    def test_midpoint_is_interpolated(self):
+        # 1.5일 전 → 1.0 - 0.5*(1.5/3) = 0.75
+        recency = _compute_recency("2026-04-08T00:00:00+00:00", "2026-04-09", 3)
+        assert 0.7 < recency < 0.9
+
+    def test_none_returns_default(self):
+        assert _compute_recency(None, "2026-04-09", 3) == 0.75
+
+    def test_recency_affects_score(self, db_path):
+        """오래된 이벤트는 최근 이벤트보다 스코어 기여가 작다."""
+        # 같은 카테고리, 같은 신뢰도 — 날짜만 다름
+        _insert_events(db_path, [
+            {"category": "earnings_beat", "sentiment": 0.7, "confidence": 0.8,
+             "published_at": "2026-04-09", "url": "http://t/recent"},
+        ])
+        es_recent = compute_event_score(db_path=db_path, date="2026-04-09")
+
+        _insert_events(db_path, [
+            {"category": "earnings_beat", "sentiment": 0.7, "confidence": 0.8,
+             "published_at": "2026-04-07", "url": "http://t/old"},
+        ])
+        es_both = compute_event_score(db_path=db_path, date="2026-04-09")
+        # 2개 이벤트 합산이지만 오래된 것은 가중치가 낮으므로 2배가 안 됨
+        assert es_both.score < es_recent.score * 2
+
+
 class TestNewCategories:
     """#137 신규 카테고리 가중치 검증."""
 
     def test_export_surge_positive(self, db_path):
         _insert_events(db_path, [
             {"category": "export_surge", "sentiment": 0.7, "confidence": 0.8, "url": "http://t/export1"},
+            {"category": "export_surge", "sentiment": 0.6, "confidence": 0.75, "url": "http://t/export2"},
+            {"category": "export_surge", "sentiment": 0.5, "confidence": 0.7, "url": "http://t/export3"},
         ])
         es = compute_event_score(db_path=db_path, date="2026-04-09")
         assert es.score > 0
@@ -186,6 +235,8 @@ class TestNewCategories:
     def test_demand_growth_positive(self, db_path):
         _insert_events(db_path, [
             {"category": "demand_growth", "sentiment": 0.6, "confidence": 0.85, "url": "http://t/demand1"},
+            {"category": "demand_growth", "sentiment": 0.5, "confidence": 0.8, "url": "http://t/demand2"},
+            {"category": "demand_growth", "sentiment": 0.7, "confidence": 0.9, "url": "http://t/demand3"},
         ])
         es = compute_event_score(db_path=db_path, date="2026-04-09")
         assert es.score > 0


### PR DESCRIPTION
## Summary
- **Recency weighting**: events decay linearly from 1.0 (today) to 0.5 (lookback boundary). Yesterday's Iran ceasefire matters more than 3-day-old article.
- **Minimum event threshold**: `regime_hint` requires 3+ events to activate. Prevents a single misclassified article from triggering regime shift. Score still computed for 1-2 events, but regime_hint stays None.

Closes part of #137

## Test plan
- [x] 80 tests pass (existing + 8 new)
- [x] `test_today_is_full_weight` — recency = 1.0 for today
- [x] `test_old_event_is_half_weight` — recency = 0.5 at boundary
- [x] `test_midpoint_is_interpolated` — linear decay verified
- [x] `test_recency_affects_score` — old events contribute less than recent
- [x] `test_regime_hint_none_when_few_events` — 1 event = no regime_hint
- [x] `test_regime_hint_from_dominant` — 3 events = regime_hint works
- [x] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)