### PR TITLE
fix(ci): remove duplicate scope in dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
       - "backend"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       # Bundle all dev tooling (ruff/pytest/coverage) into one PR
       python-dev:
@@ -66,7 +65,6 @@ updates:
       - "frontend"
     commit-message:
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       # Bundle all @types/* into one PR (always safe)
       types:
@@ -108,7 +106,6 @@ updates:
       - "ci"
     commit-message:
       prefix: "chore(ci)"
-      include: "scope"
     groups:
       # Bundle all GitHub Actions updates into one PR per month
       actions:


### PR DESCRIPTION
## Summary
- Fix `chore(deps)(deps):` → `chore(deps):` in dependabot commit messages
- Root cause: `include: "scope"` with `prefix: "chore(deps)"` duplicates the scope
- Removed `include: "scope"` from all 3 ecosystems (pip, npm, github-actions)

## Test plan
- [x] Config-only change, no code impact
- [x] Next dependabot PR will use correct `chore(deps):` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)