### PR TITLE
docs: update counts and config after Action-First PRs (#264-#266)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,7 @@ ALPACA_BASE_URL=https://paper-api.alpaca.markets
 # 6. API Server
 # ───────────────────────────────────────────────────────────────
 API_PORT=8001
+# NURI_DB_PATH=data/portfolio.db           # SQLite DB 경로 (기본값: data/portfolio.db)
 # API_AUTH_ENABLED=true                  # JWT/API key 인증 활성화
 # API_KEY=                               # Bearer token
 # API_SECRET_KEY=                        # JWT 서명 키 (미설정 시 랜덤 생성)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ nuri/
 │   ├── recommend/     # Candidates, rebalance, tracker, price_targets
 │   ├── swing/         # Market-wide scanner + rules
 │   └── execution/     # Broker interface (Alpaca paper + DryRun)
-├── api/               # FastAPI REST API (65 endpoints, routes/)
+├── api/               # FastAPI REST API (68 endpoints, routes/ incl. actions/opportunities/market-context)
 ├── alerts/            # Discord daily report + bot, Telegram alerts
 └── llm/               # LLM report (Ollama) + OpenAI wrapper + event classifier
 ```

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ flowchart TD
   end
 
   subgraph Serve["Interface"]
-    API("FastAPI :8001\n60 endpoints + SSE")
-    Dashboard("Next.js 16 :3000\n17 pages\nTailwind 4 + shadcn/ui")
+    API("FastAPI :8001\n68 endpoints + SSE")
+    Dashboard("Next.js 16 :3000\n17 pages\nAction-First dashboard")
     Discord("Discord/Telegram\nalerts + daily report")
   end
 
@@ -159,23 +159,25 @@ flowchart TD
 | `nuri/trading/engine/` | Certify | SIEGE 11-gate (v2: asset-class-aware), conflict detection, learning memory |
 | `nuri/trading/recommend/` | Certify+Track | Candidates, price targets, rebalance advisor, outcome tracker (30/60/90d) |
 | `nuri/llm/` | Classify | Event classifier (OpenAI/regex), LLM report (Ollama, dormant), OpenAI wrapper |
-| `nuri/api/` | Serve | FastAPI REST + SSE on **:8001** (60 endpoints). Swagger at `/docs` |
-| `frontend/` | Serve | Next.js 16 + React 19 + Tailwind 4 + shadcn/ui on **:3000** (17 routes, dark theme) |
+| `nuri/api/` | Serve | FastAPI REST + SSE on **:8001** (68 endpoints incl. `/actions`, `/opportunities`, `/market-context`). Swagger at `/docs` |
+| `frontend/` | Serve | Next.js 16 + React 19 + Tailwind 4 + shadcn/ui on **:3000** (17 routes, Action-First dashboard, dark theme) |
 | `nuri/core/` | Foundation | db.py (sole SQLite), events.py (journal), freshness.py (SLA), timezone.py (KST), rules.py, signal_config.py |
 | `config/*.yaml` | Foundation | rules, agents, signals, universe, stock_types, portfolio (gitignored) |
 
 ## Dashboard
 
-The dashboard at `:3000/` is a **composition-first overview**, not a row-level decision tool. Inspired by Snowball Analytics' Korean retail layout. Vertical hierarchy:
+The dashboard at `:3000/` answers **"what should I do today?"** — an Action-First design that prioritizes actionable intelligence over raw data. Pension/IRP holdings are filtered out (monthly rebalancing, not daily).
 
-1. **Hero** — 4 stats: 총 자산 · 오늘 P&L · 누적 수익률 · 승률 (winners/losers ratio)
-2. **Market context strip** — verdict · trend · VIX · 심리 · 경제 · 실제/권장 비중 (1 row, null-safe)
-3. **Status strips** — collapsible 알림 / 이벤트 / 신규 후보
-4. **Composition section** — Recharts donut (320px, standard 12-o'clock clockwise) + tabs (자산/섹터/계좌) + rich legend (label · meta · $value · weight % · daily delta)
-5. **Mini cards strip** — Movers + 집중도 (HHI)
-6. **Holdings table (drilldown)** — sorted by `positionPct` desc, top 8 visible by default with `?holdings=expanded` toggle
+1. **Hero** — 4 stats: 총 자산 · 오늘 P&L · 누적 수익률 · 승률
+2. **System Health** — 4 cards: SIEGE score · Regime · Macro score · Data freshness (links to detail pages)
+3. **Macro Events** — Recent high-impact news with 한국어 category labels (지정학/실적/유가 등), deduplicated
+4. **Action Items** — 🔴 즉시 실행 (SIEGE violations, stop-loss) · 🟡 오늘 확인 (take-profit, short squeeze) · ✅ 유지 (compact chips)
+5. **Market context strip** — VIX · 심리 · 경제 · 실제/권장 비중
+6. **Composition** — Recharts donut + tabs (자산/섹터/계좌) + rich legend
+7. **Holdings table** — sorted by `positionPct` desc, top 8 + expand toggle
+8. **Opportunity Explorer** — top 3 non-portfolio tickers with pros/cons/verdict + "10-Agent 분석" button + /scan link
 
-The composition section is the visual centerpiece. Holdings table is demoted to drilldown — the dashboard's structural job is "where is my money + how is it doing", not "act on every row". For row-level decisions see `/portfolio` and `/advisor`.
+Korean tickers show names (삼성전자) instead of numbers (005930.KS). For row-level decisions see `/portfolio` and `/advisor`.
 
 ## Tech Stack
 
@@ -222,8 +224,8 @@ make scan-extended  # Weekly scan (us_core + S&P 500, ~339 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (2,674 backend + 817 frontend)
-make test-fast  # backend only, slow tests excluded (~24s, ~52% faster)
+make test       # full suite (2,763 backend + 876 frontend + 39 e2e)
+make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,9 +74,18 @@ Trade execution API (`nuri/api/routes/trades.py`):
 
 `/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display.
 
-## API (57 endpoints)
+## API (68 endpoints)
 
-`nuri/api/routes/` — 60 REST endpoints on port **8001**. Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval).
+`nuri/api/routes/` — 68 REST endpoints on port **8001**. Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval).
+
+### Action-First Dashboard APIs (PR #264-#266)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/actions` | GET | 우선순위 분류된 오늘의 액션 (🔴urgent/🟡check/✅hold). 연금/IRP 제외, 중복 제거 |
+| `/api/opportunities` | GET | 비보유 이슈 종목 탐색 — scan + WSB + events 기반 찬성/반대/판정 |
+| `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
+| `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 
 ## Scheduler
 
@@ -90,6 +99,7 @@ Configured in `.env` (see `.env.example`):
 - `DISCORD_TOKEN` — bot mode alerts (optional)
 - `FINNHUB_API_KEY` — US institutional flows (optional)
 - `OLLAMA_HOST` / `OLLAMA_MODEL` — LLM report (default: localhost:11434, qwen3.5)
+- `NURI_DB_PATH` — SQLite DB location override (optional; default: `data/portfolio.db`)
 - `DASHBOARD_PASSWORD` — Next.js auth (optional; unset = public)
 - `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` — Telegram alerts (optional)
 - `ALPACA_API_KEY` / `ALPACA_SECRET_KEY` — Paper trading (optional; DryRun fallback)
@@ -98,7 +108,7 @@ Configured in `.env` (see `.env.example`):
 
 ## DB Schema (SQLite, WAL mode)
 
-31 tables total (15 migrations). Key tables:
+31 tables total (17 migrations). Key tables:
 
 | Table | Purpose |
 |-------|---------|

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -151,9 +151,9 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,705 tests, 129 files |
-| Frontend tests | 목표 ≥ 90% | 818 tests, 55 files |
-| E2E | 핵심 flow 커버 | 25 Playwright tests (5 spec) |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,763 tests, 130 files |
+| Frontend tests | 목표 ≥ 90% | 876 tests, 58 files |
+| E2E | 핵심 flow 커버 | 39 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 의존 | 금지 | conftest.py에서 yfinance/외부 API mock |
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (818 tests, 55 files)
+npm run test           # vitest run (876 tests, 58 files)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```
@@ -22,7 +22,7 @@ npx vitest run -t "renders verdict"                    # single test by name
 
 All pages are **Server Components** with `force-dynamic`. Data fetched server-side via `fetchAPI()` (`src/lib/api.ts`).
 
-Three Client Components only: `/report` (LLM generation), `/pipeline` (ReactFlow DAG), `<CompositionDonut>` (Recharts pie).
+Client Components: `/report` (LLM generation), `/pipeline` (ReactFlow DAG), `<CompositionDonut>` (Recharts pie), `<ActionItems>` (expand/collapse), `<OpportunityExplorer>` (10-Agent fetch), `<PriceChart>` (period selector).
 
 ## 17 Routes
 
@@ -36,11 +36,11 @@ Three Client Components only: `/report` (LLM generation), `/pipeline` (ReactFlow
 
 **Conventions**: `async function Section()` in `<Suspense>`, `animate-pulse` skeletons, color semantics (emerald=BUY, red=SELL, amber=warning, blue=WATCH, zinc=HOLD), `text-[10px]` sub-labels.
 
-## Dashboard Layout (#224)
+## Dashboard Layout (#264 Action-First)
 
-Hero (4 stats) → market context strip → CollapsibleStrips (alerts/events/candidates) → CompositionSection (320px Recharts donut + tabs `?comp=ticker|sector|account`) → mini cards strip (Movers + concentration) → Holdings table (top 8 + `?holdings=expanded`) → footer.
+Hero (4 stats) → **SystemHealth 4-card** (SIEGE/regime/macro/freshness) → **MacroEvents** (한국어 카테고리) → **ActionItems** (🔴urgent/🟡check/✅hold, 연금 제외) → market context strip → CompositionSection (320px donut + tabs) → Holdings table (top 8) → **OpportunityExplorer** (상위 3개 + /scan 링크) → footer.
 
-Data flows through `summarizeHoldings()` in `src/lib/holdings-summary.ts`.
+Data flows through `summarizeHoldings()` in `src/lib/holdings-summary.ts`. Action data from `/api/actions`, `/api/opportunities`, `/api/market-context`.
 
 ## Auth
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,22 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Nuri-Quant Frontend
 
-## Getting Started
+Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 
-First, run the development server:
+## Commands
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm run dev            # Dev server (:3000)
+npm run build          # Production build
+npm run test           # vitest (876 tests, 58 files)
+npx playwright test    # E2E (39 tests, 6 specs)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Architecture
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+See [`CLAUDE.md`](CLAUDE.md) for full details. Key points:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- **17 routes** — Server Components with `force-dynamic`
+- **Action-First dashboard** — SystemHealth, ActionItems, OpportunityExplorer, MarketContext
+- **API proxy** — Next.js rewrites `/api/*` to FastAPI `:8001`
+- **i18n** — `src/lib/strings.ts` (Korean UI constants, not next-intl)
+- **Tests** — `src/__tests__/{components,lib,pages}/` + `e2e/`


### PR DESCRIPTION
## Summary

- Update test counts: 2,763 backend / 876 frontend / 39 e2e
- Update endpoint count: 68 (was 57/60)
- ARCHITECTURE.md: add Action-First API section, 17 migrations, NURI_DB_PATH
- .env.example: add NURI_DB_PATH
- frontend/README.md: replace Next.js boilerplate with project info

🤖 Generated with [Claude Code](https://claude.com/claude-code)