### PR TITLE
fix(scripts): replace hardcoded paths and ports with env vars

### DIFF
--- a/scripts/auto_deploy.sh
+++ b/scripts/auto_deploy.sh
@@ -25,7 +25,7 @@
 
 set -u   # set -e 사용 안 함 — 한 단계 실패가 launchd 전체를 멈추게 하면 안 됨
 
-REPO="/Users/ehbebe/workspace/nuri-quant"
+REPO="${NURI_REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
 LOG="$HOME/Library/Logs/nuri-quant-autopull.log"
 
 mkdir -p "$(dirname "$LOG")"

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -115,8 +115,9 @@ fi
 # ── 8. API 응답 ──
 echo ""
 echo "🌐 API health..."
-if curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/api/health 2>/dev/null | grep -q "200"; then
-    pass "API responding (port 8001)"
+_API_PORT="${API_PORT:-8001}"
+if curl -s -o /dev/null -w "%{http_code}" "http://localhost:${_API_PORT}/api/health" 2>/dev/null | grep -q "200"; then
+    pass "API responding (port ${_API_PORT})"
 else
     warn "API not responding (start: make api)"
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -9,8 +9,11 @@ source "$(dirname "$0")/_common.sh"
 
 banner "Nuri-Quant Service Starting"
 
+API_PORT="${API_PORT:-8001}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+
 # 포트 충돌 확인
-for PORT in 8001 3000; do
+for PORT in $API_PORT $FRONTEND_PORT; do
     if lsof -i ":$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
         PID=$(lsof -i ":$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1)
         echo -e "  ⚠ Port $PORT already in use (PID: $PID). Kill with: make ports-kill"
@@ -19,14 +22,14 @@ for PORT in 8001 3000; do
 done
 
 # Backend (FastAPI)
-echo -e "${GREEN}Starting FastAPI backend on :8001...${NC}"
-$PYTHON -m uvicorn nuri.api.main:app --host 0.0.0.0 --port 8001 &
+echo -e "${GREEN}Starting FastAPI backend on :${API_PORT}...${NC}"
+$PYTHON -m uvicorn nuri.api.main:app --host 0.0.0.0 --port "$API_PORT" &
 API_PID=$!
 echo "  API PID: $API_PID"
 
 # Wait for API to be ready
 sleep 2
-if curl -s http://localhost:8001/api/health > /dev/null 2>&1; then
+if curl -s "http://localhost:${API_PORT}/api/health" > /dev/null 2>&1; then
     echo -e "  ${GREEN}✓ API ready${NC}"
 else
     echo "  Waiting for API..."
@@ -34,7 +37,7 @@ else
 fi
 
 # Frontend (Next.js)
-echo -e "${GREEN}Starting Next.js dashboard on :3000...${NC}"
+echo -e "${GREEN}Starting Next.js dashboard on :${FRONTEND_PORT}...${NC}"
 cd frontend && npm run dev &
 NEXT_PID=$!
 echo "  Next.js PID: $NEXT_PID"
@@ -43,8 +46,8 @@ cd ..
 echo ""
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${GREEN}  Services running:${NC}"
-echo "    API:       http://localhost:8001/docs"
-echo "    Dashboard: http://localhost:3000"
+echo "    API:       http://localhost:${API_PORT}/docs"
+echo "    Dashboard: http://localhost:${FRONTEND_PORT}"
 echo ""
 echo "  Press Ctrl+C to stop both services"
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"


### PR DESCRIPTION
## Summary

- `auto_deploy.sh`: `/Users/ehbebe/workspace/nuri-quant` → `${NURI_REPO:-$(cd ../.. && pwd)}`
- `start.sh`: `8001`/`3000` → `${API_PORT:-8001}`/`${FRONTEND_PORT:-3000}`
- `pre-deploy-check.sh`: `localhost:8001` → `localhost:${API_PORT:-8001}`

All defaults unchanged — just configurable now.

## Test plan

- [x] Grep confirms no remaining hardcoded paths in scripts/
- [x] Default behavior identical (env vars default to same values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)