### PR TITLE
docs: dedup harness principles + sync #227 PR status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Harness Principles
 
-```
-1. 모르면 읽는다         — 가정하지 않는다
-2. 2번 실패하면 접근을 바꾼다  — 같은 시도 3회 금지
-3. 수정 후 실행한다       — 논리적 확신을 신뢰하지 않는다
-4. 스코프를 지킨다       — 요청된 것만 한다
-5. 숫자를 grep한다       — 한 곳만 고치지 않는다
-6. 시스템이 차단한다      — 문서가 아닌 린터/CI/게이트가 강제한다
-```
+See `docs/STRATEGY.md` §5.8 — six principles (모르면 읽는다 / 2번 실패하면 접근을 바꾼다 / 수정 후 실행한다 / 스코프를 지킨다 / 숫자를 grep한다 / 시스템이 차단한다). STRATEGY.md is the canonical source; do not duplicate the list here.
 
 ## Project
 
@@ -235,6 +228,8 @@ This project uses layered context files. Root files load every session; director
 | `frontend/CLAUDE.md` | Next.js 16, design system, testing gotchas | When editing frontend/ |
 | `tests/CLAUDE.md` | Fixtures, mocks, testing gotchas | When editing tests/ |
 | `config/CLAUDE.md` | YAML structure, change procedures | When editing config/ |
+
+User-scoped auto-memory lives outside the repo at `~/.claude/projects/-Users-ehbebe-workspace-nuri-quant/memory/` (`MEMORY.md` index + per-topic files). Auto-loaded each session for cross-conversation continuity; not committed.
 
 ### Mechanical Enforcement (Hooks + CI)
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -442,7 +442,7 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 | 2 | 백테스트 인터랙티브 equity curve | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 파라미터 sliders + 실시간 시뮬레이션 |
 | 3 | **Privacy scanner ticker+PnL pattern** | — | security | 현재 broker name + monetary literal만 차단. ticker와 PnL이 같은 commit message/PR 본문에 있을 때 패턴 감지 추가. PR #202 commit message leak 같은 경우 방지 |
 | 4 | **LLM 휴면 코드 결정** | — | refactor | `nuri/llm/{report,event_classifier,openai_client}.py` 현재 production 비활성 (OLLAMA_HOST/OPENAI_API_KEY 미설정). 유지 vs 제거 vs 재활성화 결정 필요 |
-| 5 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | feat(collectors) | Tier 1에서 강등. pension 계좌 별도 surface 필요 시 재평가 |
+| 5 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | feat(collectors) | Tier 1에서 강등 후 PR [#270](https://github.com/researcherhojin/nuri-quant/pull/270) 진행 중 (`feat/227-dividend-data` 브랜치). pension 계좌 별도 surface 필요 시 재평가 |
 
 ### Tier 3 — 다음 분기 (P2)
 


### PR DESCRIPTION
## Summary

직전 세션에서 발견한 문서 드리프트 3건 정리. PR #270 스코프와 독립된 별도 PR.

- **CLAUDE.md 하네스 원칙 중복 제거**: 6줄 블록이 `docs/STRATEGY.md` §5.8과 정확히 중복. STRATEGY.md를 canonical source로 두고 CLAUDE.md는 한 줄 참조로 변경.
- **CLAUDE.md auto-memory 노트 추가**: `~/.claude/projects/.../memory/` 시스템이 Harness File Map에 미언급. 미래 세션이 cross-conversation 메모리 존재를 인지하도록 한 줄 추가.
- **STRATEGY.md §7 Tier 2 #5 동기화**: #227 행이 "미착수"로 표시되어 있었으나 PR #270이 실제 진행 중. PR 링크 + 브랜치 명시.

## Debug notes

`/init` 세션에서 처음 제기한 드리프트 4건 중 2건은 잘못된 주장이었음:
- ❌ "PR #231이 #227을 ship" → PR #231은 i18n, #227은 PR #270에서 진행 중
- ❌ "24 collector modules 검증 필요" → 실제 24개 정확

위 2건은 fix 대상에서 제외. 나머지 2건 + 새로 발견한 1건만 반영.

## Test plan

- [x] `git diff` 스코프 확인 (-9 / +4 줄, 2 files)
- [ ] CI lint/test 통과 확인 (문서 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)