### PR TITLE
fix(audit): factor scores persistence + swing.rules in full-scan + LLM doc drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ full-scan:
 	$(PYTHON) -m nuri.trading.recommend.candidates
 	$(PYTHON) -m nuri.trading.agents.consensus
 	$(PYTHON) -m nuri.trading.swing.scanner
+	$(PYTHON) -m nuri.trading.swing.rules
 	@echo "\n=== Phase F: 가격 타겟 + 리밸런스 ==="
 	$(PYTHON) -m nuri.trading.recommend.price_targets
 	$(PYTHON) -m nuri.analysis.rebalance_advisor

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -68,7 +68,7 @@
 | 선택 | 이유 |
 |------|------|
 | SQLite (not Postgres) | 별도 서버 불필요. WAL 모드로 동시 읽기. `tmp_path`로 테스트 격리. |
-| **Hybrid LLM stack** (현재 휴면) | 정책: (a) portfolio·narrative·의사결정은 **local Ollama 한정** (data sovereignty). (b) 공개 RSS 헤드라인은 **OpenAI gpt-5.4-nano** 허용 (Tier 0, ~\$3.51/yr). **현재 상태**: production에서 LLM은 비활성. `OLLAMA_HOST` 미설정 → `make report-llm` 실패; `OPENAI_API_KEY` 미설정 → event_classifier가 regex fallback. 코드는 wired되어 있고 환경변수만 추가하면 즉시 활성화됨. §4.4.3 참조. |
+| **Hybrid LLM stack** | 정책: (a) portfolio·narrative·의사결정은 **local Ollama 한정** (data sovereignty). (b) 공개 RSS 헤드라인은 **OpenAI gpt-5.4-nano** 허용 (Tier 0, ~\$3.51/yr). **현재 상태**: OpenAI **active** (event_classifier 매일 ~100건, 2026-04-14 기준 누적 737 calls). Ollama는 휴면 (`OLLAMA_HOST` 미설정 → `make report-llm` 실패). 비활성화 원하면 `NURI_DISABLE_EXTERNAL_LLM=1`. §4.4.3 참조. |
 | OpenBB + yfinance (not Bloomberg) | 무료 데이터. OpenBB 추상화 → provider 교체 용이. yfinance는 폴백. |
 | GitHub Actions (not Jenkins) | 오픈소스 무료 tier. lint + test + coverage + security 자동화. |
 
@@ -422,15 +422,14 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 
 이 섹션은 **앞으로 할 일**만 기록한다. 완료된 항목은 git log + closed PR + closed issue가 진실 source. 새 작업을 시작하기 전에 이 순서를 확인하고, 새 발견은 GitHub 이슈로 등록한 뒤 이 표에 추가한다.
 
-### Tier 1 — 완료 (2026-04-13)
+### Tier 1 — 완료 (2026-04-13 ~ 04-14)
 
 | # | 항목 | 이슈 | PR | 비고 |
 |---|------|------|----|------|
 | 1 | **i18n constants extraction** | [#226](https://github.com/researcherhojin/nuri-quant/issues/226) | #230, #231 | `lib/strings.ts` 에 ~145개 한국어 상수 추출. 19 파일 마이그레이션 완료. |
 | 2 | **하네스 계층화** | — | #229 | Fowler Guide/Sensor 기반 구조화: CLAUDE.md 슬림 (511→238줄) + 7 scoped CLAUDE.md + AGENTS.md + 4 hooks |
 | 3 | **티커 기반 First-Run 온보딩 UX** | [#133](https://github.com/researcherhojin/nuri-quant/issues/133) | #234, #235 | `/explore` 페이지 + 티커 검색/분석 API. 커버리지 보강 포함. |
-
-> #227 (배당 데이터)은 active 계좌 단타 전략에서 의사결정 변수가 아니므로 Tier 2로 강등 (2026-04-13 결정).
+| 4 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | #270 | `dividendRate` (연 배당금 USD) + `dividend_yield_pct` (백분율) 컬럼 추가. fundamentals 테이블 마이그레이션 18-19. 2026-04-14 머지. |
 
 ### Tier 2 — 다음 1 달 (P1)
 
@@ -441,8 +440,7 @@ PR 검증      pr-checks.yml — merge conflict, conventional commit, 5MB 파일
 | 1 | 포트폴리오 온보딩 UI (YAML → Dashboard) | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 수동 yaml 편집 제거 |
 | 2 | 백테스트 인터랙티브 equity curve | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 파라미터 sliders + 실시간 시뮬레이션 |
 | 3 | **Privacy scanner ticker+PnL pattern** | — | security | 현재 broker name + monetary literal만 차단. ticker와 PnL이 같은 commit message/PR 본문에 있을 때 패턴 감지 추가. PR #202 commit message leak 같은 경우 방지 |
-| 4 | **LLM 휴면 코드 결정** | — | refactor | `nuri/llm/{report,event_classifier,openai_client}.py` 현재 production 비활성 (OLLAMA_HOST/OPENAI_API_KEY 미설정). 유지 vs 제거 vs 재활성화 결정 필요 |
-| 5 | **연 배당금 / 배당 수익률 데이터** | [#227](https://github.com/researcherhojin/nuri-quant/issues/227) | feat(collectors) | Tier 1에서 강등 후 PR [#270](https://github.com/researcherhojin/nuri-quant/pull/270) 진행 중 (`feat/227-dividend-data` 브랜치). pension 계좌 별도 surface 필요 시 재평가 |
+| 4 | **Ollama LLM 휴면 코드 결정** | — | refactor | `nuri/llm/report.py` Ollama 의존 (현재 OLLAMA_HOST 미설정으로 비활성). OpenAI event_classifier는 active (737 calls 누적). Ollama 부분 유지 vs 제거 결정 필요 |
 
 ### Tier 3 — 다음 분기 (P2)
 

--- a/nuri/quant/factors/composite.py
+++ b/nuri/quant/factors/composite.py
@@ -3,11 +3,13 @@
 사용법:
     python -m nuri.quant.factors.composite
 """
+
 import logging
 
 import pandas as pd
 
-from nuri.core.db import query
+from nuri.core.db import get_db, query
+from nuri.core.timezone import today_kst
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +33,7 @@ def compute_composite() -> pd.DataFrame:
     quality = compute_quality()
 
     # 센티먼트: Fear & Greed 기반 (전체 시장)
-    fg_rows = query(
-        "SELECT value FROM macro WHERE indicator = 'fear_greed' ORDER BY date DESC LIMIT 1"
-    )
+    fg_rows = query("SELECT value FROM macro WHERE indicator = 'fear_greed' ORDER BY date DESC LIMIT 1")
     fg_score = (fg_rows[0]["value"] / 100) if fg_rows else 0.5
 
     # 합산
@@ -49,21 +49,18 @@ def compute_composite() -> pd.DataFrame:
         q = quality.loc[ticker, "quality_score"] if ticker in quality.index else 0.5
         s = fg_score  # 시장 전체 센티먼트
 
-        composite = (
-            m * WEIGHTS["momentum"] +
-            v * WEIGHTS["value"] +
-            q * WEIGHTS["quality"] +
-            s * WEIGHTS["sentiment"]
-        )
+        composite = m * WEIGHTS["momentum"] + v * WEIGHTS["value"] + q * WEIGHTS["quality"] + s * WEIGHTS["sentiment"]
 
-        results.append({
-            "ticker": ticker,
-            "momentum_score": round(m, 4),
-            "value_score": round(v, 4),
-            "quality_score": round(q, 4),
-            "sentiment_score": round(s, 4),
-            "composite_score": round(composite, 4),
-        })
+        results.append(
+            {
+                "ticker": ticker,
+                "momentum_score": round(m, 4),
+                "value_score": round(v, 4),
+                "quality_score": round(q, 4),
+                "sentiment_score": round(s, 4),
+                "composite_score": round(composite, 4),
+            }
+        )
 
     df = pd.DataFrame(results).set_index("ticker").sort_values("composite_score", ascending=False)
     return df
@@ -76,19 +73,52 @@ def print_composite(df: pd.DataFrame) -> None:
         return
 
     print(f"\n{'=' * 70}")
-    print(f"  멀티팩터 스코어 (M:{WEIGHTS['momentum']*100:.0f}% V:{WEIGHTS['value']*100:.0f}% "
-          f"Q:{WEIGHTS['quality']*100:.0f}% S:{WEIGHTS['sentiment']*100:.0f}%)")
+    print(
+        f"  멀티팩터 스코어 (M:{WEIGHTS['momentum'] * 100:.0f}% V:{WEIGHTS['value'] * 100:.0f}% "
+        f"Q:{WEIGHTS['quality'] * 100:.0f}% S:{WEIGHTS['sentiment'] * 100:.0f}%)"
+    )
     print(f"{'=' * 70}")
     print(f"  {'Ticker':<12} {'종합':>8} {'모멘텀':>8} {'가치':>8} {'퀄리티':>8} {'센티':>8}")
     print(f"  {'-' * 48}")
     for ticker, row in df.iterrows():
-        print(f"  {ticker:<12} {row['composite_score']:>7.3f} "
-              f"{row['momentum_score']:>7.3f} {row['value_score']:>7.3f} "
-              f"{row['quality_score']:>7.3f} {row['sentiment_score']:>7.3f}")
+        print(
+            f"  {ticker:<12} {row['composite_score']:>7.3f} "
+            f"{row['momentum_score']:>7.3f} {row['value_score']:>7.3f} "
+            f"{row['quality_score']:>7.3f} {row['sentiment_score']:>7.3f}"
+        )
     print()
+
+
+def save_composite(df: pd.DataFrame) -> int:
+    """팩터 스코어를 factors 테이블에 멱등 저장 (date+ticker UNIQUE)."""
+    if df.empty:
+        return 0
+    date = today_kst()
+    rows = [
+        {
+            "ticker": ticker,
+            "date": date,
+            "momentum_score": row["momentum_score"],
+            "value_score": row["value_score"],
+            "quality_score": row["quality_score"],
+            "sentiment_score": row["sentiment_score"],
+            "composite_score": row["composite_score"],
+        }
+        for ticker, row in df.iterrows()
+    ]
+    with get_db() as conn:
+        conn.executemany(
+            """INSERT OR REPLACE INTO factors
+               (ticker, date, momentum_score, value_score, quality_score, sentiment_score, composite_score)
+               VALUES (:ticker, :date, :momentum_score, :value_score, :quality_score, :sentiment_score, :composite_score)""",
+            rows,
+        )
+    logger.info(f"factors 테이블에 {len(rows)}건 저장")
+    return len(rows)
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     df = compute_composite()
     print_composite(df)
+    save_composite(df)


### PR DESCRIPTION
## Summary

2026-04-14 시스템 audit 발견사항 정리. 3가지 데이터 무결성/문서 issues 한 번에 fix.

## Findings + Fixes

### 1. `factors` 테이블 0 rows — composite computes but never saves
`nuri.quant.factors.composite` 가 멀티팩터 스코어를 계산하지만 `INSERT INTO factors` 코드가 없어서 stdout 출력만 하고 종료. → `save_composite()` 추가 + `__main__` 에서 호출. After fix: **31 rows persisted per run**.

### 2. `swing_trades` 0 rows in full-scan output
`make full-scan` Phase E 가 `nuri.trading.swing.scanner` (출력만) 호출하고 `swing.rules` (실제 진입 저장) 를 누락. → Makefile 1줄 추가. After fix: 매일 ~14건 진입 후보 자동 저장.

### 3. STRATEGY.md \"Hybrid LLM stack (현재 휴면)\" 표기 부정확
실제로 `external_llm_calls` 테이블에 OpenAI gpt-5.4-nano **737건** 호출 누적, event_classifier 매일 ~100건 active. \"휴면\" → \"OpenAI active, Ollama 휴면\" 으로 정정. 비활성화 escape hatch (`NURI_DISABLE_EXTERNAL_LLM=1`) 명시.

### Bonus: Tier 1/2 housekeeping
- §7 Tier 1 #4 추가: #227 (annual dividend, PR #270) 머지 반영
- §7 Tier 2 #4 rename: \"LLM 휴면 코드 결정\" → \"Ollama LLM 휴면 코드 결정\" (scope 좁힘)
- §7 Tier 1 날짜 범위 2026-04-13 ~ 04-14 로 확장

## Test plan

- [x] `make lint` PASS
- [x] `python -m nuri.quant.factors.composite` → 31 rows in factors table
- [x] `python -m nuri.trading.swing.rules` → 14 rows in swing_trades
- [x] `make analyze` / `make gate` / `make certify` 무영향 검증
- [ ] CI checks

## Out of scope (별도 작업)

- OpenBB 30+ 패키지 버전 정렬 (news + etf_flows 깨짐) → 별도 issue 예정
- audit_log + DASHBOARD_PASSWORD 활성화 → 사용자 .env 설정 필요
- universe.yaml S&P 500 expansion (339 → 543) → #272 Phase 2 PR

## Related

- audit context: #272 (Universe + Agent Data Coverage)
- 사용자 confirmed bugs (2026-04-14 세션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)