### PR TITLE
feat(collectors): tqdm + summary for remaining 4 collectors (#272)

### DIFF
--- a/nuri/collectors/ark.py
+++ b/nuri/collectors/ark.py
@@ -9,6 +9,7 @@ ARK Invest 매매 추적 수집기.
 사용법:
     python -m nuri.collectors.ark
 """
+
 import csv
 import io
 import logging
@@ -65,10 +66,16 @@ class ARKCollector(BaseCollector):
         '오늘 날짜의 보유 비중' (held=hold) 스냅샷만 기록한다.
         """
         import yfinance as yf
+        from tqdm import tqdm
 
         records = []
+        succeeded: list[str] = []
+        failed: list[str] = []
         today = today_str()
-        for etf in ARK_ETFS:
+
+        self.logger.info(f"ARK ETF holdings 수집: {len(ARK_ETFS)}개 ETF")
+        iterator = tqdm(ARK_ETFS, desc="  ARK ETFs", unit="etf", disable=len(ARK_ETFS) < 5)
+        for etf in iterator:
             try:
                 t = yf.Ticker(etf)
                 # yfinance 0.2.x: funds_data.top_holdings → DataFrame
@@ -86,17 +93,28 @@ class ARKCollector(BaseCollector):
                     if sym not in held_tickers:
                         continue
                     weight = float(row[weight_col]) * 100 if weight_col else 0.0
-                    records.append({
-                        "date": today,
-                        "ticker": sym,
-                        "direction": "Hold",  # 매매 내역 X, 보유 스냅샷
-                        "shares": 0.0,
-                        "weight": weight,
-                        "fund": etf,
-                    })
+                    records.append(
+                        {
+                            "date": today,
+                            "ticker": sym,
+                            "direction": "Hold",  # 매매 내역 X, 보유 스냅샷
+                            "shares": 0.0,
+                            "weight": weight,
+                            "fund": etf,
+                        }
+                    )
+                succeeded.append(etf)
             except Exception as e:
+                failed.append(etf)
                 self.logger.debug("ARK yfinance %s 실패: %s", etf, e)
                 continue
+
+        self.logger.info(
+            "📊 ARK ETF holdings: ✅ %d 성공 / ❌ %d 실패 — total %d holdings recorded",
+            len(succeeded),
+            len(failed),
+            len(records),
+        )
         return records
 
     def _collect_csv(self, url: str, held_tickers: set) -> list[dict]:
@@ -127,14 +145,16 @@ class ARKCollector(BaseCollector):
             weight_raw = row.get("% of ETF", row.get("weight", "0"))
             weight = float(str(weight_raw).replace("%", "").replace(",", "")) if weight_raw else 0.0
 
-            records.append({
-                "date": date,
-                "ticker": ticker,
-                "direction": row.get("Direction", row.get("direction", "")).strip(),
-                "shares": shares,
-                "weight": weight,
-                "fund": row.get("Fund", row.get("fund", "")).strip(),
-            })
+            records.append(
+                {
+                    "date": date,
+                    "ticker": ticker,
+                    "direction": row.get("Direction", row.get("direction", "")).strip(),
+                    "shares": shares,
+                    "weight": weight,
+                    "fund": row.get("Fund", row.get("fund", "")).strip(),
+                }
+            )
 
         self.logger.info(f"ARK 매매 {len(records)}건 (보유 종목 필터)")
         return records

--- a/nuri/collectors/etf_flows.py
+++ b/nuri/collectors/etf_flows.py
@@ -7,6 +7,7 @@ AUM 변화를 주기적으로 수집하여 섹터 자금흐름(rotation)을 추�
 사용법:
     python -m nuri.collectors.etf_flows
 """
+
 import logging
 from typing import Any
 
@@ -50,17 +51,28 @@ class EtfFlowsCollector(BaseCollector):
         super().__init__("etf_flows")
 
     def collect(self, **kwargs) -> list[dict]:
-        """OpenBB etf.info로 ETF 정보 수집."""
+        """OpenBB etf.info로 ETF 정보 수집.
+
+        Note: 2026-04 기준 OpenBB OBBject_EtfCountries import 깨짐 (#274). 모든 fetch 실패.
+        """
         import warnings
 
         from openbb import obb
+        from tqdm import tqdm
+
         warnings.filterwarnings("ignore")
 
         from nuri.core.timezone import today_kst
+
         today = today_kst()
         results = []
+        failed: list[str] = []
 
-        for ticker, label in ALL_ETFS.items():
+        etfs_list = list(ALL_ETFS.items())
+        self.logger.info(f"ETF 정보 수집: {len(etfs_list)}개")
+        iterator = tqdm(etfs_list, desc="  etf_flows", unit="etf", disable=len(etfs_list) < 10)
+
+        for ticker, label in iterator:
             try:
                 r = obb.etf.info(ticker, provider="yfinance")
                 df = r.to_df()
@@ -68,20 +80,33 @@ class EtfFlowsCollector(BaseCollector):
                     continue
 
                 row = df.iloc[0]
-                results.append({
-                    "ticker": ticker,
-                    "date": today,
-                    "name": str(row.get("name", label))[:100],
-                    "total_assets": float(row["total_assets"]) if pd.notna(row.get("total_assets")) else None,
-                    "volume_avg": float(row["volume_avg"]) if pd.notna(row.get("volume_avg")) else None,
-                    "nav_price": float(row["nav_price"]) if pd.notna(row.get("nav_price")) else None,
-                })
-                self.logger.info(f"  {ticker} ({label}): AUM=${row.get('total_assets', 0) / 1e9:.1f}B")
+                results.append(
+                    {
+                        "ticker": ticker,
+                        "date": today,
+                        "name": str(row.get("name", label))[:100],
+                        "total_assets": float(row["total_assets"]) if pd.notna(row.get("total_assets")) else None,
+                        "volume_avg": float(row["volume_avg"]) if pd.notna(row.get("volume_avg")) else None,
+                        "nav_price": float(row["nav_price"]) if pd.notna(row.get("nav_price")) else None,
+                    }
+                )
+                if len(etfs_list) < 10:
+                    self.logger.info(f"  {ticker} ({label}): AUM=${row.get('total_assets', 0) / 1e9:.1f}B")
 
             except Exception as e:
-                self.logger.warning(f"{ticker}: 수집 실패 — {e}")
+                failed.append(ticker)
+                self.logger.debug(f"{ticker}: 수집 실패 — {e}")
                 continue
 
+        sample = ", ".join(failed[:5]) + (f" 외 {len(failed) - 5}개" if len(failed) > 5 else "")
+        self.logger.info(
+            "📊 ETF flows: ✅ %d 성공 / ❌ %d 실패 (총 %d) — failed: %s%s",
+            len(results),
+            len(failed),
+            len(etfs_list),
+            sample or "없음",
+            "  [⚠️ OpenBB #274 깨짐 — 모두 실패 정상]" if len(failed) == len(etfs_list) else "",
+        )
         return results
 
     def save(self, data: Any) -> int:
@@ -150,14 +175,16 @@ def analyze_sector_rotation(days: int = 30, db_path=None) -> pd.DataFrame | None
         else:
             vol_trend = 0.0
 
-        results.append({
-            "ticker": ticker,
-            "sector": SECTOR_ETFS[ticker],
-            "aum_current": aum_current,
-            "aum_prev": aum_prev,
-            "aum_change_pct": round(aum_change_pct, 2),
-            "volume_trend_pct": round(vol_trend, 2),
-        })
+        results.append(
+            {
+                "ticker": ticker,
+                "sector": SECTOR_ETFS[ticker],
+                "aum_current": aum_current,
+                "aum_prev": aum_prev,
+                "aum_change_pct": round(aum_change_pct, 2),
+                "volume_trend_pct": round(vol_trend, 2),
+            }
+        )
 
     if not results:
         return None
@@ -180,8 +207,10 @@ def print_sector_rotation(df: pd.DataFrame | None) -> None:
 
     for _, row in df.iterrows():
         aum_b = row["aum_current"] / 1e9 if row["aum_current"] else 0
-        print(f"  {row['ticker']:<6} {row['sector']:<25} "
-              f"{aum_b:>9.1f} {row['aum_change_pct']:>+9.1f}% {row['volume_trend_pct']:>+9.1f}%")
+        print(
+            f"  {row['ticker']:<6} {row['sector']:<25} "
+            f"{aum_b:>9.1f} {row['aum_change_pct']:>+9.1f}% {row['volume_trend_pct']:>+9.1f}%"
+        )
     print()
 
 

--- a/nuri/collectors/finviz.py
+++ b/nuri/collectors/finviz.py
@@ -7,6 +7,7 @@ FINVIZ에서 시장 전반 기술적 지표를 수집하여 market-wide 스캔�
 사용법:
     python -m nuri.collectors.finviz
 """
+
 import logging
 
 from nuri.collectors.base import BaseCollector, today_str
@@ -14,11 +15,11 @@ from nuri.core.db import get_db
 
 # finvizfinance 시그널 이름 → 내부 시그널 ID 매핑
 FINVIZ_SIGNALS = {
-    "oversold_rsi": "Oversold",          # RSI < 30
-    "overbought_rsi": "Overbought",      # RSI > 70
-    "new_high": "New High",              # 52주 신고가
-    "new_low": "New Low",                # 52주 신저가
-    "most_volatile": "Most Volatile",    # 고변동성
+    "oversold_rsi": "Oversold",  # RSI < 30
+    "overbought_rsi": "Overbought",  # RSI > 70
+    "new_high": "New High",  # 52주 신고가
+    "new_low": "New Low",  # 52주 신저가
+    "most_volatile": "Most Volatile",  # 고변동성
     "unusual_volume": "Unusual Volume",  # 비정상 거래량
 }
 
@@ -36,27 +37,46 @@ class FINVIZCollector(BaseCollector):
             self.logger.warning("보유 US 종목 없음")
             return []
 
+        from tqdm import tqdm
+
         records = []
         today = today_str()
+        succeeded: list[str] = []
+        failed: list[str] = []
 
-        for signal_name, finviz_signal in FINVIZ_SIGNALS.items():
+        signals_list = list(FINVIZ_SIGNALS.items())
+        self.logger.info(f"FINVIZ 시그널 스캔: {len(signals_list)}개 시그널")
+        iterator = tqdm(signals_list, desc="  FINVIZ signals", unit="sig", disable=len(signals_list) < 5)
+
+        for signal_name, finviz_signal in iterator:
             try:
                 tickers = self._fetch_signal_tickers(finviz_signal)
                 # 보유 종목과 교집합
                 matched = tickers & held_tickers
                 for ticker in matched:
-                    records.append({
-                        "date": today,
-                        "ticker": ticker,
-                        "signal": signal_name,
-                        "source": "FINVIZ",
-                    })
-                if matched:
+                    records.append(
+                        {
+                            "date": today,
+                            "ticker": ticker,
+                            "signal": signal_name,
+                            "source": "FINVIZ",
+                        }
+                    )
+                succeeded.append(signal_name)
+                if matched and len(signals_list) < 5:
                     self.logger.info("FINVIZ %s: %s", signal_name, ", ".join(sorted(matched)))
             except Exception as e:
-                self.logger.warning("FINVIZ %s 수집 실패: %s", signal_name, e)
+                failed.append(signal_name)
+                self.logger.debug("FINVIZ %s 수집 실패: %s", signal_name, e)
 
-        self.logger.info("FINVIZ 시그널 %d건 (보유 종목 필터)", len(records))
+        sample = ", ".join(failed[:3]) + (f" 외 {len(failed) - 3}개" if len(failed) > 3 else "")
+        self.logger.info(
+            "📊 FINVIZ 시그널: ✅ %d 성공 / ❌ %d 실패 — %d matches in portfolio — failed: %s",
+            len(succeeded),
+            len(failed),
+            len(records),
+            sample or "없음",
+        )
         return records
 
     def _fetch_signal_tickers(self, signal: str) -> set[str]:
@@ -64,6 +84,7 @@ class FINVIZCollector(BaseCollector):
         # 1차: finvizfinance 라이브러리
         try:
             from finvizfinance.screener.ticker import Ticker
+
             screener = Ticker()
             screener.set_filter(signal=signal)
             result = screener.screener_view(limit=500, verbose=0, sleep_sec=0.5)
@@ -124,8 +145,6 @@ class FINVIZCollector(BaseCollector):
                 data,
             )
             return len(data)
-
-
 
 
 if __name__ == "__main__":

--- a/nuri/collectors/news.py
+++ b/nuri/collectors/news.py
@@ -4,6 +4,7 @@
 사용법:
     python -m nuri.collectors.news
 """
+
 import logging
 
 from nuri.collectors.base import BaseCollector
@@ -16,14 +17,26 @@ class NewsCollector(BaseCollector):
     def __init__(self):
         super().__init__("news")
 
-    def collect(self, **kwargs) -> list[dict]:
-        """보유 미국 종목 뉴스 수집."""
+    def collect(self, source: str = "portfolio", **kwargs) -> list[dict]:
+        """뉴스 수집. source='universe' 시 universe.yaml 전체.
+
+        Note: 2026-04 기준 OpenBB OBBject_CompanyNews import 깨짐 (#274). 모든 fetch 실패.
+        구조는 유지하되 실제 작동은 #274 fix 후 가능.
+        """
         from openbb import obb
+        from tqdm import tqdm
 
-        tickers = self._get_tickers(market="us")
+        tickers = self._get_tickers(market="us", source=source)
         records = []
+        failed: list[str] = []
 
-        for ticker in tickers:
+        if not tickers:
+            return []
+
+        self.logger.info(f"뉴스 수집 대상: {len(tickers)} 종목 (source={source})")
+        iterator = tqdm(tickers, desc=f"  news [{source}]", unit="tk", disable=len(tickers) < 20)
+
+        for ticker in iterator:
             try:
                 result = obb.news.company(symbol=ticker, provider="yfinance", limit=10)
                 df = result.to_dataframe()
@@ -42,21 +55,36 @@ class NewsCollector(BaseCollector):
                         date = str(row["date"])[:10]
                     else:
                         from nuri.core.timezone import today_kst
+
                         date = today_kst()
 
-                    records.append({
-                        "ticker": ticker,
-                        "date": date,
-                        "title": str(row.get("title", ""))[:500],
-                        "url": str(url)[:1000],
-                        "source": str(row.get("source", ""))[:100],
-                        "sentiment": None,
-                    })
+                    records.append(
+                        {
+                            "ticker": ticker,
+                            "date": date,
+                            "title": str(row.get("title", ""))[:500],
+                            "url": str(url)[:1000],
+                            "source": str(row.get("source", ""))[:100],
+                            "sentiment": None,
+                        }
+                    )
 
             except Exception as e:
+                failed.append(ticker)
                 self.logger.debug(f"{ticker}: 뉴스 수집 실패 — {e}")
 
-        self.logger.info(f"뉴스 {len(records)}건 수집")
+        if len(tickers) >= 20:
+            sample = ", ".join(failed[:5]) + (f" 외 {len(failed) - 5}개" if len(failed) > 5 else "")
+            self.logger.info(
+                "📊 뉴스: %d 건 수집 / ❌ %d 종목 실패 (총 %d) — failed: %s%s",
+                len(records),
+                len(failed),
+                len(tickers),
+                sample or "없음",
+                "  [⚠️ OpenBB #274 깨짐 — 대부분 실패 정상]" if len(failed) > len(tickers) * 0.5 else "",
+            )
+        else:
+            self.logger.info(f"뉴스 {len(records)}건 수집")
         return records
 
     def save(self, data: list[dict]) -> int:


### PR DESCRIPTION
## Summary

Continuation after PR #278 merged. Apply same UX pattern (tqdm + 요약) to remaining collectors for consistency.

## Changes

| Collector | Loop | Notes |
|-----------|------|-------|
| **ark.py** | over 5-10 ARK ETFs | Summary: ✅ N succeeded / ❌ M failed / total holdings |
| **finviz.py** | over ~10 FINVIZ signals | Summary with portfolio match count |
| **news.py** | over US tickers | Accept --source. Hint about #274 (OpenBB broken) |
| **etf_flows.py** | over ALL_ETFS | Hint about #274. Both will work cleanly when #274 fixed |

## Skipped (intentional)

- **reddit.py**: 5-page pagination, no per-ticker loop
- **kis_realtime.py**: portfolio-only by design (user balance, source param irrelevant)

## Tests

- 440 collector tests pass (no regression)
- Lint clean

## Out of scope

- Actually fixing news/etf_flows OpenBB compat → that's #274
- This PR just makes the UX consistent so when #274 is fixed,
  they fit the same pattern automatically

## Related

- Builds on #278 (Phase 2b BaseCollector universe mode, just merged)
- Tracks #272 Phase 2b cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)