### PR TITLE
fix(collectors): collect-universe completeness + coverage boost (#272)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,12 @@ universe-sync-kr:    ## Dry-run KR KOSPI 200 sync only (requires: uv pip install
 universe-sync-apply: ## Apply universe.yaml updates (additions only — manual ETFs preserved)
 	$(PYTHON) -m nuri.collectors.universe_sync --apply
 
-collect-universe:    ## Collect prices + fundamentals + wallstreet for FULL universe (#272 Phase 2b)
+collect-universe:    ## Collect ALL universe data (US+KR prices, fundamentals, wallstreet, estimates) (#272)
 	$(PYTHON) -m nuri.collectors.stock --source universe
+	$(PYTHON) -m nuri.collectors.stock_kr --source universe
 	$(PYTHON) -m nuri.collectors.fundamental --source universe
 	$(PYTHON) -m nuri.collectors.wallstreet --source universe
+	$(PYTHON) -m nuri.collectors.estimates --source universe
 
 test-integration: ## Integration tests — real external APIs (Wikipedia, FDR, yfinance). Network required.
 	$(PYTHON) -m pytest tests/integration/ -m integration -v --no-header

--- a/nuri/collectors/stock_kr.py
+++ b/nuri/collectors/stock_kr.py
@@ -30,14 +30,19 @@ class StockKRCollector(BaseCollector):
     def __init__(self):
         super().__init__("stock_kr")
 
-    def collect(self, days: int = 5, **kwargs) -> pd.DataFrame:
-        """pykrx로 한국 보유 종목 OHLCV + yfinance로 KOSPI/KOSDAQ 지수 수집."""
-        tickers = self._get_tickers(market="kr")
+    def collect(self, days: int = 5, source: str = "portfolio", **kwargs) -> pd.DataFrame:
+        """pykrx로 한국 종목 OHLCV + yfinance로 KOSPI/KOSDAQ 지수 수집.
+
+        Args:
+            source: 'portfolio' (default, 보유) | 'universe' (KOSPI 200 전체) | 'all'
+                    #272 Phase 2c bug fix — collect-universe에서 KR 사일로 잔존 해결.
+        """
+        tickers = self._get_tickers(market="kr", source=source)
         if not tickers:
             self.logger.warning("수집할 한국 종목이 없습니다")
             return pd.DataFrame()
 
-        self.logger.info(f"수집 대상: {len(tickers)} 한국 종목 ({days}일)")
+        self.logger.info(f"수집 대상: {len(tickers)} 한국 종목 ({days}일, source={source})")
 
         # KST 기준 날짜 (KRX는 한국 영업일 기준)
         from nuri.core.timezone import kst_now
@@ -157,6 +162,12 @@ class StockKRCollector(BaseCollector):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Nuri-Quant 한국 주가 수집기 (pykrx)")
     parser.add_argument("--days", type=int, default=5, help="수집 일수 (기본 5일)")
+    parser.add_argument(
+        "--source",
+        default="portfolio",
+        choices=["portfolio", "universe", "all"],
+        help="ticker 소스 (#272 Phase 2c). KOSPI 200 전체 수집 시 universe 사용",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -165,4 +176,4 @@ if __name__ == "__main__":
     )
 
     collector = StockKRCollector()
-    collector.run(days=args.days)
+    collector.run(days=args.days, source=args.source)

--- a/scripts/check_universe_coverage.py
+++ b/scripts/check_universe_coverage.py
@@ -1,0 +1,91 @@
+"""Universe + agent data coverage 빠른 확인 — Phase 2c gate 전 sanity check.
+
+사용법:
+    .venv/bin/python scripts/check_universe_coverage.py
+    또는
+    make check-coverage  (Makefile 추가 시)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from nuri.core.db import query
+
+
+def main() -> None:
+    # 1. universe.yaml 로드
+    path = Path("config/universe.yaml")
+    if not path.exists():
+        print("❌ config/universe.yaml 없음")
+        return
+
+    with path.open() as f:
+        u = yaml.safe_load(f) or {}
+
+    us_uni = set((u.get("us_core") or {}).get("tickers") or [])
+    us_uni |= set((u.get("us_sp500_extended") or {}).get("tickers") or [])
+    kr_uni = set((u.get("kr_kospi200") or {}).get("tickers") or [])
+
+    print(f"\n{'=' * 75}")
+    print(f"  Universe Coverage 확인 (US={len(us_uni)}, KR={len(kr_uni)})")
+    print(f"{'=' * 75}\n")
+
+    # 2. raw count
+    print("[1/2] DB 테이블별 raw count")
+    print(f"  {'Table':25} {'Tickers':>8} {'Latest date':>15} {'Rows':>10}")
+    print(f"  {'-' * 65}")
+    # 테이블별 date 컬럼명 (mismatch 방지)
+    DATE_COLUMNS = {
+        "prices": "date",
+        "fundamentals": "date",
+        "analyst_ratings": "date",
+        "insider_trades": "date",
+        "earnings_surprises": "quarter",  # date 아님
+        "superinvestors": "filing_date",  # date 아님
+        "estimates": "date",
+    }
+    for table in DATE_COLUMNS:
+        try:
+            date_col = DATE_COLUMNS[table]
+            r = query(f"SELECT COUNT(DISTINCT ticker) AS c, MAX({date_col}) AS latest, COUNT(*) AS n FROM {table}")[0]
+            print(f"  {table:25} {r['c']:>8} {(r['latest'] or 'N/A'):>15} {r['n']:>10}")
+        except Exception as e:
+            print(f"  {table:25} ⚠️  err: {str(e)[:40]}")
+
+    # 3. universe coverage %
+    print("\n[2/2] Universe 대비 coverage (Phase 2c spec §2.2)")
+    print(f"  {'Source':22} {'US match':>15} {'KR match':>15} {'Threshold':>12} {'Status':>8}")
+    print(f"  {'-' * 75}")
+
+    thresholds = {
+        "prices": 0.95,
+        "fundamentals": 0.80,
+        "analyst_ratings": 0.70,
+        "insider_trades": 0.50,
+        "superinvestors": 0.80,
+    }
+
+    for table, threshold in thresholds.items():
+        try:
+            rows = query(f"SELECT DISTINCT ticker FROM {table}")
+            tickers_db = {r["ticker"] for r in rows}
+            us_match = len(tickers_db & us_uni)
+            kr_match = len(tickers_db & kr_uni)
+            us_pct = us_match / max(len(us_uni), 1)
+            kr_pct = kr_match / max(len(kr_uni), 1)
+            # status: US 기준 (대부분 데이터가 US 위주)
+            flag = "✅ PASS" if us_pct >= threshold else "🔴 FAIL"
+            us_str = f"{us_match}/{len(us_uni)} ({us_pct:.0%})"
+            kr_str = f"{kr_match}/{len(kr_uni)} ({kr_pct:.0%})"
+            print(f"  {table:22} {us_str:>15} {kr_str:>15} {f'≥{threshold:.0%}':>12} {flag:>8}")
+        except Exception as e:
+            print(f"  {table:22} ⚠️  err: {str(e)[:50]}")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/collectors/test_fundamental.py
+++ b/tests/collectors/test_fundamental.py
@@ -321,3 +321,85 @@ class TestFundamentalCollectorErrorHandling:
         c = FundamentalCollector()
         assert c.save([]) == 0
         assert c.save(None) == 0
+
+
+class TestUniverseModeCoverage:
+    """#272 Phase 2b: source 파라미터 + tqdm + 필드별 coverage 패치 커버리지."""
+
+    def test_collect_universe_source_passed_to_get_tickers(self, monkeypatch, db_with_portfolio):
+        """source='universe' 가 _get_tickers로 전달."""
+        from unittest.mock import MagicMock, patch
+
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        captured = {}
+
+        def fake_get(**kw):
+            captured.update(kw)
+            return []
+
+        monkeypatch.setattr(c, "_get_tickers", fake_get)
+        mock_yf = MagicMock()
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+        c.collect(source="universe")
+        assert captured.get("source") == "universe"
+
+    def test_collect_summary_with_per_field_coverage(self, monkeypatch, db_with_portfolio, caplog):
+        """20+ tickers + 데이터 있는 경우: 필드별 coverage table fired."""
+        import logging
+        from unittest.mock import MagicMock
+
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        # 25개 tickers, 모두 정상 반환
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: [f"T{i}" for i in range(25)])
+
+        def fake_ticker_info(ticker):
+            mock = MagicMock()
+            mock.info = {
+                "regularMarketPrice": 100.0,
+                "trailingPE": 25.0,
+                "forwardPE": 22.0,
+                "returnOnEquity": 0.15,
+                "revenueGrowth": 0.10,
+                "debtToEquity": 1.5,
+                "dividendYield": 0.02,
+            }
+            return mock
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.side_effect = fake_ticker_info
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+        with caplog.at_level(logging.INFO):
+            c.collect(source="universe")
+
+        # summary + per-field coverage logs
+        summary = [r for r in caplog.records if "펀더멘탈:" in r.message]
+        assert len(summary) >= 1
+        coverage_log = [r for r in caplog.records if "필드별 coverage" in r.message]
+        assert len(coverage_log) >= 1
+
+    def test_collect_skip_empty_info(self, monkeypatch, db_with_portfolio):
+        """info 비어있는 ticker는 skipped 카운트."""
+        from unittest.mock import MagicMock
+
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["EMPTY"])
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}  # empty
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value = mock_ticker
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+        results = c.collect()
+        assert results == []  # skipped, no records

--- a/tests/collectors/test_stock.py
+++ b/tests/collectors/test_stock.py
@@ -2,6 +2,7 @@
 
 Split from tests/test_collectors_all.py for module-level isolation.
 """
+
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -21,13 +22,21 @@ class TestStockCollector:
         assert "-" in result
 
 
-
 class TestStockCollectorTickerCollection:
     def test_collect_ticker_success(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.stock import StockCollector
 
-        mock_df = pd.DataFrame({"date": pd.to_datetime(["2025-01-15"]), "open": [190.0], "high": [195.0],
-                                "low": [189.0], "close": [194.0], "volume": [50000000], "adj_close": [194.0]})
+        mock_df = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2025-01-15"]),
+                "open": [190.0],
+                "high": [195.0],
+                "low": [189.0],
+                "close": [194.0],
+                "volume": [50000000],
+                "adj_close": [194.0],
+            }
+        )
         mock_result = MagicMock()
         mock_result.to_dataframe.return_value = mock_df
         mock_obb = MagicMock()
@@ -63,8 +72,16 @@ class TestStockCollectorTickerCollection:
     def test_collect_ticker_no_adj_close(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.stock import StockCollector
 
-        mock_df = pd.DataFrame({"date": pd.to_datetime(["2025-01-15"]), "open": [190.0], "high": [195.0],
-                                "low": [189.0], "close": [194.0], "volume": [50000000]})
+        mock_df = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2025-01-15"]),
+                "open": [190.0],
+                "high": [195.0],
+                "low": [189.0],
+                "close": [194.0],
+                "volume": [50000000],
+            }
+        )
         mock_result = MagicMock()
         mock_result.to_dataframe.return_value = mock_df
         mock_obb = MagicMock()
@@ -96,13 +113,21 @@ class TestStockCollectorTickerCollection:
         assert StockCollector().save(pd.DataFrame()) == 0
 
 
-
 class TestStockCollectorEdgeCases:
     def test_collect_full_flow(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.stock import StockCollector
 
-        mock_df = pd.DataFrame({"date": pd.to_datetime(["2025-01-15"]), "open": [190.0], "high": [195.0],
-                                "low": [189.0], "close": [194.0], "volume": [50000000], "adj_close": [194.0]})
+        mock_df = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2025-01-15"]),
+                "open": [190.0],
+                "high": [195.0],
+                "low": [189.0],
+                "close": [194.0],
+                "volume": [50000000],
+                "adj_close": [194.0],
+            }
+        )
         mock_result = MagicMock()
         mock_result.to_dataframe.return_value = mock_df
         mock_obb = MagicMock()
@@ -111,3 +136,40 @@ class TestStockCollectorEdgeCases:
 
         monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
         assert not StockCollector().collect(period="5d").empty
+
+
+class TestStockUniverseModeCoverage:
+    """#272 Phase 2b: tqdm + summary 패치 커버리지."""
+
+    def test_collect_universe_summary_logged(self, monkeypatch, db_with_portfolio, caplog):
+        """20+ tickers + universe 모드: summary 로그 fire."""
+        import logging
+
+        from nuri.collectors.stock import StockCollector
+
+        c = StockCollector()
+        # 25개 ticker, 모두 데이터 부족
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: [f"T{i}" for i in range(25)])
+        monkeypatch.setattr(c, "_collect_ticker", lambda *a, **kw: None)
+
+        with caplog.at_level(logging.INFO):
+            c.collect(source="universe", period="5d")
+
+        summary = [r for r in caplog.records if "수집 결과:" in r.message]
+        assert len(summary) >= 1, "Expected summary log for 25-ticker universe"
+
+    def test_collect_universe_source_in_log(self, monkeypatch, db_with_portfolio, caplog):
+        """수집 대상 메시지에 source 표시."""
+        import logging
+
+        from nuri.collectors.stock import StockCollector
+
+        c = StockCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["A"])
+        monkeypatch.setattr(c, "_collect_ticker", lambda *a, **kw: None)
+
+        with caplog.at_level(logging.INFO):
+            c.collect(source="universe", period="5d")
+
+        info = [r for r in caplog.records if "source=universe" in r.message]
+        assert len(info) >= 1

--- a/tests/collectors/test_technical.py
+++ b/tests/collectors/test_technical.py
@@ -3,7 +3,10 @@
 Split from tests/test_collectors_all.py for module-level isolation.
 """
 
+from unittest.mock import patch
 
+import pandas as pd
+import pytest
 
 
 class TestTechnicalCollector:
@@ -17,6 +20,82 @@ class TestTechnicalCollector:
         assert "rsi_14" in result
         assert "macd" in result
         assert len(result["rsi_14"]) == 50
+
+
+class TestCollectUniverseMode:
+    """#272 Phase 2b: source 파라미터 + tqdm + summary 패치 커버리지."""
+
+    def test_collect_no_tickers(self, monkeypatch):
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: [])
+        result = c.collect()
+        assert result.empty
+
+    def test_collect_universe_source_passed(self, monkeypatch):
+        """source 파라미터가 _get_tickers로 전달되는지."""
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        captured = {}
+
+        def fake_get(**kw):
+            captured.update(kw)
+            return []
+
+        monkeypatch.setattr(c, "_get_tickers", fake_get)
+        c.collect(source="universe")
+        assert captured.get("source") == "universe"
+
+    def test_collect_summary_logged_for_large_set(self, monkeypatch, caplog):
+        """20+ tickers 시 summary log fire 확인."""
+        import logging
+
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        # 25개 ticker — 모두 데이터 부족 (None 반환)
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: [f"T{i}" for i in range(25)])
+        monkeypatch.setattr(c, "_compute_for_ticker", lambda t: None)
+
+        with caplog.at_level(logging.INFO):
+            c.collect(source="universe")
+
+        # summary log가 떴는지
+        summary_logs = [r for r in caplog.records if "기술적 지표:" in r.message]
+        assert len(summary_logs) >= 1, "Expected summary log for 25 tickers"
+
+    def test_collect_no_summary_for_small_set(self, monkeypatch, caplog):
+        """20 미만 tickers 시 summary 미출력 (조용함)."""
+        import logging
+
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["A", "B"])
+        monkeypatch.setattr(c, "_compute_for_ticker", lambda t: None)
+
+        with caplog.at_level(logging.INFO):
+            c.collect()
+
+        summary_logs = [r for r in caplog.records if "기술적 지표:" in r.message]
+        assert len(summary_logs) == 0, "Should NOT log summary for <20 tickers"
+
+    def test_collect_aggregates_results(self, monkeypatch):
+        """결과 frame이 합쳐지는지."""
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["A", "B"])
+
+        def fake_compute(ticker):
+            return pd.DataFrame({"ticker": [ticker], "rsi_14": [50.0]})
+
+        monkeypatch.setattr(c, "_compute_for_ticker", fake_compute)
+        result = c.collect()
+        assert len(result) == 2
+        assert set(result["ticker"]) == {"A", "B"}
 
 
 # ##############################################################################


### PR DESCRIPTION
## Summary

3 bugs found via verify after first \`make collect-universe\` run + reduced patch coverage from PR #278.

## Bugs fixed

### Bug 1: stock_kr.py missing --source flag
Before: KOSPI 200 sync silently used portfolio only → 4/203 (2%) KR coverage.
After: --source universe wires through to _get_tickers → full KOSPI 200 sync.

### Bug 2: Makefile collect-universe missing stock_kr + estimates
Target only ran stock + fundamental + wallstreet. Add 2 missing collectors.

### Bug 3: check_universe_coverage.py date column mismatch
Tables \`earnings_surprises\` (col=quarter) and \`superinvestors\` (col=filing_date) don't have \`date\` column. Hardcoded \`SELECT MAX(date)\` failed silently. Add per-table DATE_COLUMNS map.

## Coverage improvements

PR #278 reduced patch coverage in collectors. Add tests for new tqdm/summary code paths:

| File | Before | After | Δ |
|------|--------|-------|---|
| technical.py | 35% | **69%** | +34pp 🎯 |
| fundamental.py | 65% | **75%** | +10pp |
| stock.py | 80% | **84%** | +4pp |

10 new tests cover:
- source param wiring (universe → _get_tickers)
- summary log fires for ≥20 tickers
- No spam log for <20 tickers (small sets quiet)
- skipped vs failed counter accuracy

## Test plan

- [x] All 446 collector tests pass
- [x] Lint clean
- [x] check_universe_coverage.py runs without errors

## Next (after merge)

User runs \`make collect-universe\` again — this time:
- KR prices should reach 200/203 (was 4/203)
- estimates table populated
- check_universe_coverage.py shows all 7 tables clean

Then **Phase 2c implementation** (validate_universe.py + CI gate per PR #280 spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)