### PR TITLE
ci: Phase 2c-2 universe-check workflow job (warning-only) (#272)

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -183,6 +183,45 @@ jobs:
       - name: Scan for personal financial data leaks
         run: python3 scripts/check_privacy_leak.py
 
+  # ── Universe + Agent Coverage Validation (#272 Phase 2c) ──
+  # Validates universe.yaml ↔ upstream sync + per-table coverage thresholds.
+  # Currently warning-only (continue-on-error) until user runs make collect-universe
+  # to populate data tables. Will become required after first PASS run.
+  universe-check:
+    name: Universe Coverage Validation
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true  # warning-only initially per spec §6 stage 1
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install minimal deps (no full uv sync needed)
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml pandas pytest
+      - name: Validate universe (cache mode — no network)
+        run: |
+          # CI에는 DB가 없으므로 universe.yaml 자체 sanity check만
+          python -c "
+          import yaml
+          from pathlib import Path
+          u = yaml.safe_load(Path('config/universe.yaml').read_text())
+          us = set((u.get('us_core') or {}).get('tickers') or [])
+          us |= set((u.get('us_sp500_extended') or {}).get('tickers') or [])
+          kr = set((u.get('kr_kospi200') or {}).get('tickers') or [])
+          print(f'US universe: {len(us)} tickers')
+          print(f'KR universe: {len(kr)} tickers')
+          # Sanity thresholds (spec §2.1: ≥95%)
+          assert len(us) >= 478, f'US universe {len(us)} < 478 (95% of S&P 500 503)'
+          assert len(kr) >= 190, f'KR universe {len(kr)} < 190 (95% of KOSPI 200)'
+          print('✅ Universe sanity check PASS')
+          "
+
   # ── Backend Tests (sharded matrix) ──
   # Tests are split across 2 shards via pytest-shard, each running on its own
   # 4-core runner. Wall time roughly halves vs the single-job design.


### PR DESCRIPTION
## Summary

Phase 2c-2 of #272. CI integration for universe + coverage validation per spec docs/SPEC_phase2c_validate.md §3.3.

## Changes

\`.github/workflows/main-ci-cd.yml\` — new job:

\`\`\`yaml
universe-check:
  name: Universe Coverage Validation
  needs: changes
  if: needs.changes.outputs.python == 'true'
  runs-on: ubuntu-latest
  timeout-minutes: 5
  continue-on-error: true  # warning-only initially
\`\`\`

Validates universe.yaml ticker counts:
- US ≥478 (95% of S&P 500 503)
- KR ≥190 (95% of KOSPI 200)

## Why warning-only initially

Per spec §6 phased enforcement (stages 1-4):
- **Stage 1 (this PR)**: warning-only, no merge block
- **Stage 2 (deferred)**: full validate_universe.py with DB seeding
- **Stage 3 (user manual)**: branch protection toggle to required

DB tables aren't populated in CI runner, so full \`validate_universe.py\` would always FAIL. Universe.yaml sanity check IS achievable without DB.

## Verified locally

\`\`\`
US universe: 543 tickers
KR universe: 203 tickers
✅ Universe sanity check PASS
\`\`\`

## Why not require yet

Setting required check before user runs \`make collect-universe\` would block ALL PRs. Must verify 5/5 PASS first. After user confirmation, toggle in branch protection (1-click in GitHub Settings).

## Test plan

- [x] Local sanity passes (543 US, 203 KR)
- [x] yaml-only deps (no uv sync needed)
- [x] continue-on-error → no merge block
- [ ] CI run on this PR will demonstrate the workflow works

## Related

- Spec: PR #280 (merged)
- Implementation: PR #284 (merged) — \`scripts/validate_universe.py\`
- Closes Phase 2c-2 of #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)