### PR TITLE
fix(coverage): KR 'n/a (US-only)' label for source-limited tables

### DIFF
--- a/nuri/core/coverage.py
+++ b/nuri/core/coverage.py
@@ -40,6 +40,22 @@ DATA_THRESHOLDS: dict[str, float] = {
 # Spec §2.1 — universe self-coverage (always 1.0 for now)
 UNIVERSE_THRESHOLD = 0.95
 
+# 데이터 소스가 KR 종목을 지원하지 않는 테이블.
+# - analyst_ratings: yfinance .KS는 애널리스트 데이터 미제공
+# - insider_trades: SEC Form 4 — US 상장사 한정
+# - superinvestors: SEC 13F — US 자산운용사 한정
+# - estimates: yfinance .KS는 컨센서스 미제공 (estimates.py 자동 스킵)
+# - earnings_surprises: yfinance .KS earnings 미제공
+US_ONLY_TABLES: frozenset[str] = frozenset(
+    {
+        "analyst_ratings",
+        "insider_trades",
+        "superinvestors",
+        "estimates",
+        "earnings_surprises",
+    }
+)
+
 
 @dataclass
 class CoverageCheck:
@@ -125,6 +141,8 @@ def compute_data_coverage(
     pct = len(matched) / len(us_uni)
     status = "PASS" if pct >= threshold else "FAIL"
     detail = f"{len(matched)}/{len(us_uni)} US tickers"
+    if table in US_ONLY_TABLES:
+        detail += " (KR n/a — 소스 미지원)"
     return CoverageCheck(
         name=f"data.{table}",
         actual_pct=pct,

--- a/scripts/check_universe_coverage.py
+++ b/scripts/check_universe_coverage.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import yaml
 
+from nuri.core.coverage import US_ONLY_TABLES
 from nuri.core.db import query
 
 
@@ -73,17 +74,25 @@ def main() -> None:
             rows = query(f"SELECT DISTINCT ticker FROM {table}")
             tickers_db = {r["ticker"] for r in rows}
             us_match = len(tickers_db & us_uni)
-            kr_match = len(tickers_db & kr_uni)
             us_pct = us_match / max(len(us_uni), 1)
-            kr_pct = kr_match / max(len(kr_uni), 1)
             # status: US 기준 (대부분 데이터가 US 위주)
             flag = "✅ PASS" if us_pct >= threshold else "🔴 FAIL"
             us_str = f"{us_match}/{len(us_uni)} ({us_pct:.0%})"
-            kr_str = f"{kr_match}/{len(kr_uni)} ({kr_pct:.0%})"
+            # KR 표시: 데이터 소스가 KR 미지원이면 "n/a (소스 미제공)" — 0%로 표시하면
+            # 수집 실패처럼 보임. 실제로는 yfinance .KS / SEC EDGAR 한계.
+            if table in US_ONLY_TABLES:
+                kr_str = "n/a (US-only)"
+            else:
+                kr_match = len(tickers_db & kr_uni)
+                kr_pct = kr_match / max(len(kr_uni), 1)
+                kr_str = f"{kr_match}/{len(kr_uni)} ({kr_pct:.0%})"
             print(f"  {table:22} {us_str:>15} {kr_str:>15} {f'≥{threshold:.0%}':>12} {flag:>8}")
         except Exception as e:
             print(f"  {table:22} ⚠️  err: {str(e)[:50]}")
 
+    print()
+    print("  주: KR 'n/a (US-only)' = 데이터 소스(yfinance .KS / SEC EDGAR)가")
+    print("      KR 종목을 지원하지 않음. 수집 실패가 아닌 소스 한계.")
     print()
 
 


### PR DESCRIPTION
## Summary
- analyst_ratings/insider_trades/superinvestors/estimates/earnings_surprises의 KR 컬럼이 \`0/203 (0%)\`로 표시되어 수집 실패처럼 보이던 문제 수정
- 실제로는 yfinance .KS (애널리스트/실적 미제공) + SEC EDGAR (Form 4/13F US-only) 데이터 소스 한계
- KR 컬럼: \`n/a (US-only)\` 로 변경 + footer에 사유 명시

## Why
사용자 피드백: \"미제공으로 보이게 조치를 해야하지 저렇게 보이면 아예 못 한 거 같잖아요\"

수집 실패 (버그) vs 소스 한계 (사양)를 시각적으로 구분해야 운영 시 혼동 제거.

## Before / After

\`\`\`
# Before
analyst_ratings    528/543 (97%)    0/203 (0%)    ≥70%   ✅ PASS
insider_trades     526/543 (97%)    0/203 (0%)    ≥50%   ✅ PASS
superinvestors     524/543 (97%)    0/203 (0%)    ≥80%   ✅ PASS

# After
analyst_ratings    528/543 (97%)   n/a (US-only)  ≥70%   ✅ PASS
insider_trades     526/543 (97%)   n/a (US-only)  ≥50%   ✅ PASS
superinvestors     524/543 (97%)   n/a (US-only)  ≥80%   ✅ PASS

  주: KR 'n/a (US-only)' = 데이터 소스(yfinance .KS / SEC EDGAR)가
      KR 종목을 지원하지 않음. 수집 실패가 아닌 소스 한계.
\`\`\`

## Test plan
- [x] tests/core/test_coverage.py 19 PASS
- [x] tests/collectors/test_universe_sync.py 30 PASS
- [x] \`scripts/check_universe_coverage.py\` live 실행 — 신규 라벨 표시 확인
- [x] \`scripts/validate_universe.py --no-fetch\` — 5/5 PASS 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)