### PR TITLE
feat(llm): primary OpenAI gpt-5.4-nano for daily report (§4.4.3 Tier 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,18 +42,26 @@ KIS_HTS_ID=                              # HTS ID (WebSocket 사용 시 필수)
 # ───────────────────────────────────────────────────────────────
 # 2. LLM Providers
 # ───────────────────────────────────────────────────────────────
-# OpenAI (gpt-5.4-nano — 공개 RSS 헤드라인 분류 전용, docs/STRATEGY.md §4.4.3)
+# OpenAI (gpt-5.4-nano) — 2026-04-14 STRATEGY §4.4.3 개정 후 용도:
+#   (a) Tier 0: 공개 RSS 헤드라인 분류 (event_classifier) — ZDR 불필요
+#   (b) Tier 2: 일간 LLM 리포트 (report.py) — ZDR 필수, 프로토타입 단계
 # 발급: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 #
-# Ollama (local, 무료 — portfolio/narrative 데이터는 반드시 로컬)
-OLLAMA_HOST=http://localhost:11434
-OLLAMA_MODEL=qwen3.5
+# Tier 2 전용: OpenAI Zero Data Retention 승인 attestation
+# ZDR 요청 완료 후에만 설정. 미설정 시 Tier 2 호출은 ExternalLLMPolicyViolation raise.
+# 요청 방법: https://platform.openai.com/docs/models/how-we-use-your-data
+# OPENAI_ZDR_APPROVED=1
 #
-# llama.cpp (선택, GGUF 직접 실행)
+# 로컬 폴백 (선택) — OpenAI 호출 실패 또는 NURI_DISABLE_EXTERNAL_LLM=1 시 사용
+# Ollama (HTTP API, `ollama serve` 실행 후 사용 가능)
+# OLLAMA_HOST=http://localhost:11434
+# OLLAMA_MODEL=qwen3.5
+#
+# llama.cpp (GGUF 직접 실행)
 # LLAMA_MODEL_PATH=/path/to/model.gguf
 #
-# 외부 LLM 비활성화 (CI, 오프라인 모드)
+# 외부 LLM 전체 비활성화 (CI, 오프라인 모드)
 # NURI_DISABLE_EXTERNAL_LLM=1
 
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -68,7 +68,7 @@
 | 선택 | 이유 |
 |------|------|
 | SQLite (not Postgres) | 별도 서버 불필요. WAL 모드로 동시 읽기. `tmp_path`로 테스트 격리. |
-| **Hybrid LLM stack** | 정책: (a) portfolio·narrative·의사결정은 **local Ollama 한정** (data sovereignty). (b) 공개 RSS 헤드라인은 **OpenAI gpt-5.4-nano** 허용 (Tier 0, ~\$3.51/yr). **현재 상태**: OpenAI **active** (event_classifier 매일 ~100건, 2026-04-14 기준 누적 737 calls). Ollama는 휴면 (`OLLAMA_HOST` 미설정 → `make report-llm` 실패). 비활성화 원하면 `NURI_DISABLE_EXTERNAL_LLM=1`. §4.4.3 참조. |
+| **Hybrid LLM stack** | 정책 (2026-04-14 개정): (a) 공개 RSS 헤드라인 분류 → **OpenAI gpt-5.4-nano** (Tier 0, ~\$3.51/yr). (b) 일간 LLM 리포트 → **OpenAI gpt-5.4-nano** (Tier 2, ZDR 필수, 프로토타입 단계 임시 허용). (c) 사용자 narrative / Tier 1 → 현재 미허용. **로컬 LLM 전환 계획**: 사용자가 Ollama/llama.cpp 인프라 확정 시 (b)를 local로 이관. 비활성화: `NURI_DISABLE_EXTERNAL_LLM=1`. 상세: §4.4.3. |
 | OpenBB + yfinance (not Bloomberg) | 무료 데이터. OpenBB 추상화 → provider 교체 용이. yfinance는 폴백. |
 | GitHub Actions (not Jenkins) | 오픈소스 무료 tier. lint + test + coverage + security 자동화. |
 
@@ -236,35 +236,44 @@ PR을 올리기 전 이 기준을 확인한다.
 
 §4.4.1 broker name / monetary literal 차단은 Tier 2 데이터의 leak 방지가 직접적 목적. §4.4.3 외부 LLM Egress Policy는 Tier 0 데이터의 명시적 화이트리스트.
 
-#### 4.4.3 외부 LLM Egress Policy (#152)
+#### 4.4.3 외부 LLM Egress Policy (#152, 2026-04-14 개정)
 
-사용자 portfolio·narrative 데이터는 외부 LLM에 절대 전송하지 않는다. 이 정책은 **공개 데이터(Tier 0)에 한정한 외부 LLM 사용 화이트리스트**다.
+외부 LLM 사용은 **화이트리스트** 방식. 모든 호출은 `nuri/llm/openai_client.py` 단일 관문을 거친다.
 
-**현재 등재 provider (1개)**
+**등재 provider + 데이터 클래스**
 
-| Provider | Model | 허용 데이터 | 단가 (in/out per 1M tokens) | 비고 |
-|---|---|---|---|---|
-| OpenAI | `gpt-5.4-nano` | 공개 RSS 헤드라인 분류 | $0.20 / $1.25 | 일 100 헤드라인 기준 연 ~$3.51 |
+| Provider | Model | 허용 데이터 클래스 | 단가 (in/out per 1M) | ZDR | 비고 |
+|---|---|---|---|---|---|
+| OpenAI | `gpt-5.4-nano` | **Tier 0** (공개 RSS 헤드라인 분류) | $0.20 / $1.25 | 권장 | 일 100 헤드라인 기준 연 ~$3.51 |
+| OpenAI | `gpt-5.4-nano` | **Tier 2** (LLM 일간 리포트 — 보유 종목/손익/전략) | $0.20 / $1.25 | **필수** | 일 1회, ~3K in + 2K out = 연 ~$0.10. 2026-04-14 사용자 명시 승인 (프로토타입 단계; 향후 local LLM 전환 계획) |
 
-**필수 운영 룰**
+**Tier 2 허용의 전제조건 (2026-04-14 추가)**
 
-1. **모든 외부 LLM 호출은 `nuri/llm/openai_client.py` wrapper를 거쳐야 한다** (Step 1에서 구현). 직접 `import openai` 금지.
-2. **Per-call audit log** — wrapper가 `external_llm_calls` DB 테이블에 기록: `timestamp, provider, model, endpoint, prompt_tokens, completion_tokens, latency_ms`. **content는 절대 저장하지 않는다** (audit log 자체가 leak surface가 되지 않도록).
-3. **Opt-out** — 환경변수 `NURI_DISABLE_EXTERNAL_LLM=1` 설정 시 wrapper는 호출 즉시 raise. 오프라인 / 개인정보 보호 모드 / CI 등에서 활용.
-4. **Failure 정책** — OpenAI 실패 시 wrapper는 명시적으로 raise한다. 실리언트 fallback 금지. caller(`event_classifier` 등)가 graceful degradation 책임 (예: 단일 헤드라인 실패 → 그 헤드라인만 regex로 fallback, 나머지는 정상 처리).
-5. **Provider 추가** — 신규 provider 등재는 STRATEGY 개정 PR 필요. PR 본문에 단가, 데이터 클래스, retention 정책, 등재 사유 명시.
-6. **데이터 클래스 확장** — 현재는 Tier 0 (공개 헤드라인)만. Tier 1 (narrative) 또는 Tier 2 (portfolio) 추가는 별도 STRATEGY 개정 + 본인 명시 승인 + retention 정책 결정 (ZDR 사용 여부 등). 현 시점 두 Tier 모두 미허용.
+사용자가 Option C(본인 명시 승인)를 선택하면서 Tier 2 → `gpt-5.4-nano` 송신이 허용됨. 전제:
+
+1. **ZDR(Zero Data Retention) 필수** — OpenAI에 ZDR 승인 요청이 완료되어야 첫 Tier 2 호출 가능. 미승인 상태에서 Tier 2 호출 시 wrapper가 환경변수 `OPENAI_ZDR_APPROVED=1` 미설정으로 인해 raise.
+2. **`NURI_DISABLE_EXTERNAL_LLM=1`로 즉시 opt-out 가능** — 오프라인/CI/심사 모드에서 일괄 차단.
+3. **프롬프트 로그 금지** — wrapper는 토큰 수·지연·에러 타입만 기록, **content는 절대 DB에 남기지 않는다**.
+4. **로컬 LLM 전환 계획** — 프로토타입 단계 임시 허용. 사용자가 Ollama/llama.cpp로 전환하는 시점에 Tier 2 제거 PR 예정.
+
+**필수 운영 룰 (전 Tier 공통)**
+
+1. 모든 외부 LLM 호출은 wrapper(`openai_client.get_client()`)를 거친다. 직접 `import openai` 금지.
+2. **Per-call audit log** — `external_llm_calls` 테이블에 `timestamp, provider, model, endpoint, prompt_tokens, completion_tokens, latency_ms, success, error_type` 기록. **content는 금지**.
+3. **Opt-out** — `NURI_DISABLE_EXTERNAL_LLM=1` 시 wrapper는 `ExternalLLMDisabled` raise.
+4. **Failure loud** — OpenAI 실패 시 wrapper는 명시적으로 raise (silent fallback 금지). caller가 graceful degradation 책임 (예: `nuri/llm/report.py`는 OpenAI 실패 시 "[LLM 연결 실패]" 문자열 반환 + Ollama가 설정되어 있으면 secondary로 시도).
+5. **Provider 추가** — 신규 provider 등재는 STRATEGY 개정 PR 필요.
+6. **데이터 클래스 확장** — Tier 1 (narrative) 또는 추가 Tier 2 경로 확장은 별도 STRATEGY 개정 + 본인 명시 승인.
 
 **의도적 비결정 사항 (deferred until needed)**
 
-- **OpenAI 30-day retention 수용 여부** — 현재 Tier 0만 보내므로 영향 없음. Tier 1/2 도입 시 결정.
-- **Ollama secondary fallback** — wrapper가 raise할 때 자동으로 Ollama로 떨어지는 chain. 오늘은 raise loud 정책. 추가는 future work.
 - **Narrative input UI** — Tier 1 정책 결정 이후에 설계.
 - **외부 LLM 비용 모니터링 대시보드** — `external_llm_calls` 테이블 기반. 월/모델별 비용 + token 추이. 일일 사용량이 예상치 초과 시 알림. 필요 시점에 추가.
+- **Tier 2 → local LLM 전환 시점** — 사용자가 Ollama/llama.cpp 운영 인프라 확정 후.
 
 **모니터링 시작 트리거**
 
-이 정책은 #152가 닫히는 시점(Step 2 머지)부터 발효한다. Step 2 머지 후 1주일 동안 `external_llm_calls` 테이블의 row 수와 누적 token이 예상 (~700 calls / week, ~$0.07 / week)에 부합하는지 확인하고, 부합하면 (2)/(3) Tier 확장 토론 시작.
+이 정책은 #152가 닫히는 시점(Step 2 머지)부터 발효. 2026-04-14 Tier 2 추가 이후 1주일 동안 `external_llm_calls` 테이블의 LLM 리포트 호출 비용이 예상치 (~$0.02/주) 대비 10배 초과 시 사용자 알림 + 즉시 `NURI_DISABLE_EXTERNAL_LLM=1` 복귀 권장.
 
 ---
 

--- a/nuri/llm/openai_client.py
+++ b/nuri/llm/openai_client.py
@@ -41,6 +41,7 @@ Usage:
         # Network/API failure — caller falls back
         ...
 """
+
 from __future__ import annotations
 
 import json
@@ -65,24 +66,19 @@ DEFAULT_MODEL = "gpt-5.4-nano"
 # When OpenAI changes prices, update both this table and the STRATEGY row.
 # Future: if we add more models or providers, move this to config/llm_pricing.yaml.
 MODEL_PRICING_USD_PER_1M: dict[str, dict[str, float]] = {
-    "gpt-5.4-nano":      {"input": 0.20, "output": 1.25},
-    "gpt-5.4-mini":      {"input": 0.75, "output": 4.50},
-    "gpt-5.4":           {"input": 2.50, "output": 15.00},
-    "gpt-5.4-pro":       {"input": 30.00, "output": 180.00},
+    "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
+    "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
+    "gpt-5.4": {"input": 2.50, "output": 15.00},
+    "gpt-5.4-pro": {"input": 30.00, "output": 180.00},
 }
 
 
-def estimate_cost_usd(
-    model: str, prompt_tokens: int, completion_tokens: int
-) -> float | None:
+def estimate_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> float | None:
     """Compute estimated USD cost for a single call. None if model unknown."""
     pricing = MODEL_PRICING_USD_PER_1M.get(model)
     if pricing is None:
         return None
-    return (
-        prompt_tokens / 1_000_000 * pricing["input"]
-        + completion_tokens / 1_000_000 * pricing["output"]
-    )
+    return prompt_tokens / 1_000_000 * pricing["input"] + completion_tokens / 1_000_000 * pricing["output"]
 
 
 class ExternalLLMError(Exception):
@@ -114,6 +110,16 @@ class ExternalLLMResponseError(ExternalLLMError):
     """
 
 
+class ExternalLLMPolicyViolation(ExternalLLMError):
+    """Raised when a caller tries to send a data tier not permitted by policy.
+
+    STRATEGY.md §4.4.3 whitelists data classes per endpoint. Tier 2
+    (portfolio) requires `OPENAI_ZDR_APPROVED=1` as a runtime attestation
+    that the user obtained ZDR from OpenAI. Without that flag, the wrapper
+    refuses to send. This is an explicit safety gate — not a network error.
+    """
+
+
 def is_disabled() -> bool:
     """True if external LLM is opted out via env var."""
     val = os.getenv("NURI_DISABLE_EXTERNAL_LLM", "").strip().lower()
@@ -123,6 +129,16 @@ def is_disabled() -> bool:
 def has_credentials() -> bool:
     """True if OPENAI_API_KEY is present (not necessarily valid)."""
     return bool(os.getenv("OPENAI_API_KEY", "").strip())
+
+
+def zdr_approved() -> bool:
+    """True if user has attested OpenAI ZDR approval (Tier 2 prerequisite).
+
+    Set `OPENAI_ZDR_APPROVED=1` after obtaining ZDR from OpenAI. Required
+    for any call declaring `data_tier='tier2'`. See STRATEGY.md §4.4.3.
+    """
+    val = os.getenv("OPENAI_ZDR_APPROVED", "").strip().lower()
+    return val in ("1", "true", "yes", "on")
 
 
 class OpenAIClient:
@@ -146,15 +162,12 @@ class OpenAIClient:
             )
         if not has_credentials():
             raise ExternalLLMUnavailable(
-                "OPENAI_API_KEY missing from environment. Set it in .env or "
-                "set NURI_DISABLE_EXTERNAL_LLM=1 to opt out."
+                "OPENAI_API_KEY missing from environment. Set it in .env or set NURI_DISABLE_EXTERNAL_LLM=1 to opt out."
             )
         try:
             from openai import OpenAI
         except ImportError as e:
-            raise ExternalLLMUnavailable(
-                f"openai SDK not installed: {e}"
-            ) from e
+            raise ExternalLLMUnavailable(f"openai SDK not installed: {e}") from e
         self._sdk_client = OpenAI()
         return self._sdk_client
 
@@ -202,15 +215,17 @@ class OpenAIClient:
             error_type = type(e).__name__
             try:
                 log_external_llm_call(
-                    provider=PROVIDER, model=chosen_model, endpoint=endpoint,
-                    latency_ms=latency_ms, success=False, error_type=error_type,
+                    provider=PROVIDER,
+                    model=chosen_model,
+                    endpoint=endpoint,
+                    latency_ms=latency_ms,
+                    success=False,
+                    error_type=error_type,
                     db_path=db_path,
                 )
             except Exception:  # noqa: BLE001 — audit log failure must not mask the real error
                 logger.debug("audit log write failed", exc_info=True)
-            raise ExternalLLMUnavailable(
-                f"OpenAI {endpoint} call failed: {error_type}: {str(e)[:200]}"
-            ) from e
+            raise ExternalLLMUnavailable(f"OpenAI {endpoint} call failed: {error_type}: {str(e)[:200]}") from e
 
         latency_ms = int((time.monotonic() - t0) * 1000)
         usage = resp.usage
@@ -239,7 +254,12 @@ class OpenAIClient:
         cost_str = f"${cost_usd:.6f}" if cost_usd is not None else "$?(unknown model)"
         logger.info(
             "[external_llm] %s/%s: %d→%d tokens, %dms, %s",
-            PROVIDER, chosen_model, prompt_tok, completion_tok, latency_ms, cost_str,
+            PROVIDER,
+            chosen_model,
+            prompt_tok,
+            completion_tok,
+            latency_ms,
+            cost_str,
         )
 
         # Parse JSON body
@@ -248,9 +268,111 @@ class OpenAIClient:
             return json.loads(raw)
         except json.JSONDecodeError as e:
             raise ExternalLLMResponseError(
-                f"OpenAI {chosen_model} returned non-JSON in JSON mode: "
-                f"{raw[:100]!r}"
+                f"OpenAI {chosen_model} returned non-JSON in JSON mode: {raw[:100]!r}"
             ) from e
+
+    def chat_text(
+        self,
+        *,
+        system: str,
+        user: str,
+        model: Optional[str] = None,
+        temperature: float = 0.3,
+        max_tokens: int = 2000,
+        data_tier: str = "tier0",
+        db_path: Optional[Any] = None,
+    ) -> str:
+        """Plain-text chat completion (no JSON mode).
+
+        Used for narrative outputs like the LLM daily report. Follows the
+        same audit-log + opt-out contract as `chat_json`, plus an extra
+        `data_tier` gate: `data_tier='tier2'` requires `OPENAI_ZDR_APPROVED=1`
+        (STRATEGY.md §4.4.3 precondition).
+
+        Args:
+            data_tier: 'tier0' (public) or 'tier2' (portfolio). Tier 2
+                requires ZDR attestation. Tier 1 is not currently permitted.
+
+        Raises:
+            ExternalLLMPolicyViolation: data_tier='tier2' without ZDR, or
+                data_tier not in the whitelist.
+            ExternalLLMDisabled: opt-out via NURI_DISABLE_EXTERNAL_LLM=1
+            ExternalLLMUnavailable: network/auth/SDK install failure
+        """
+        if data_tier not in ("tier0", "tier2"):
+            raise ExternalLLMPolicyViolation(f"data_tier={data_tier!r} not permitted. See STRATEGY.md §4.4.3.")
+        if data_tier == "tier2" and not zdr_approved():
+            raise ExternalLLMPolicyViolation(
+                "Tier 2 (portfolio) calls require OPENAI_ZDR_APPROVED=1 — set "
+                "this env var after obtaining ZDR from OpenAI. See "
+                "STRATEGY.md §4.4.3 Tier 2 precondition (1)."
+            )
+
+        sdk = self._ensure_sdk()
+        chosen_model = model or self.default_model
+        endpoint = f"chat.completions({data_tier})"
+
+        t0 = time.monotonic()
+        try:
+            resp = sdk.chat.completions.create(
+                model=chosen_model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                temperature=temperature,
+                max_completion_tokens=max_tokens,
+            )
+        except Exception as e:
+            latency_ms = int((time.monotonic() - t0) * 1000)
+            error_type = type(e).__name__
+            try:
+                log_external_llm_call(
+                    provider=PROVIDER,
+                    model=chosen_model,
+                    endpoint=endpoint,
+                    latency_ms=latency_ms,
+                    success=False,
+                    error_type=error_type,
+                    db_path=db_path,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("audit log write failed", exc_info=True)
+            raise ExternalLLMUnavailable(f"OpenAI {endpoint} call failed: {error_type}: {str(e)[:200]}") from e
+
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        usage = resp.usage
+        prompt_tok = usage.prompt_tokens if usage else 0
+        completion_tok = usage.completion_tokens if usage else 0
+        try:
+            log_external_llm_call(
+                provider=PROVIDER,
+                model=chosen_model,
+                endpoint=endpoint,
+                prompt_tokens=prompt_tok if usage else None,
+                completion_tokens=completion_tok if usage else None,
+                latency_ms=latency_ms,
+                success=True,
+                error_type=None,
+                db_path=db_path,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("audit log write failed", exc_info=True)
+
+        cost_usd = estimate_cost_usd(chosen_model, prompt_tok, completion_tok)
+        cost_str = f"${cost_usd:.6f}" if cost_usd is not None else "$?(unknown model)"
+        logger.info(
+            "[external_llm] %s/%s [%s]: %d→%d tokens, %dms, %s",
+            PROVIDER,
+            chosen_model,
+            data_tier,
+            prompt_tok,
+            completion_tok,
+            latency_ms,
+            cost_str,
+        )
+
+        return resp.choices[0].message.content or ""
 
 
 _singleton: Optional[OpenAIClient] = None

--- a/nuri/llm/report.py
+++ b/nuri/llm/report.py
@@ -1,19 +1,28 @@
 """
-Ollama 기반 LLM 리포트 생성기 — SIEGE Certification 패턴 적용.
+LLM 리포트 생성기 — SIEGE Certification 패턴 적용.
 
+생성 경로 (우선순위 순):
+1. OpenAI `gpt-5.4-nano` (Tier 2, ZDR 필수) — 기본값 (2026-04-14 STRATEGY 개정 후)
+2. llama.cpp GGUF 로컬 모델 — `LLAMA_MODEL_PATH` 설정 시 사용
+3. Ollama HTTP API — `OLLAMA_HOST` 설정 시 사용
+
+모든 경로에서 동일한 파이프라인:
 1. Gate 검증 → 데이터 완성도 확인
 2. 전체 데이터 소스 수집 → 구조화된 컨텍스트
 3. LLM 생성 → 자연어 리포트
 4. Output Validation → 환각 검증 (입력에 없는 숫자/티커 감지)
 5. 면책 조항 + 데이터 완성도 경고 자동 첨부
 
+Opt-out: `NURI_DISABLE_EXTERNAL_LLM=1` → OpenAI 스킵, 로컬 경로만 시도.
+
 사용법:
     python -m nuri.llm.report
 """
+
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from dotenv import load_dotenv
 
@@ -21,10 +30,13 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+# ─── External (OpenAI — primary per STRATEGY §4.4.3) ────────────
+OPENAI_REPORT_MODEL = os.getenv("OPENAI_REPORT_MODEL", "gpt-5.4-nano")
+
+# ─── Local fallbacks (optional) ─────────────────────────────────
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "")  # empty = disabled
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen3.5")
-# llama.cpp GGUF 모델 경로 (설정 시 Ollama 대신 직접 실행)
-LLAMA_MODEL_PATH = os.getenv("LLAMA_MODEL_PATH", "")
+LLAMA_MODEL_PATH = os.getenv("LLAMA_MODEL_PATH", "")  # GGUF path
 
 DISCLAIMER = (
     "⚠️ 본 리포트는 Nuri-Quant 시스템이 수집한 데이터와 AI(LLM)가 생성한 분석입니다. "
@@ -71,8 +83,9 @@ drift 상태별 시그널 정리. 최근 부진한 시그널 경고.
 @dataclass
 class ReportContext:
     """LLM에 전달하는 구조화된 컨텍스트."""
+
     gate_summary: str
-    gate_score: float           # 0~1
+    gate_score: float  # 0~1
     regime_section: str
     macro_section: str
     risk_section: str
@@ -82,15 +95,9 @@ class ReportContext:
     consensus_section: str
     strategy_section: str
     external_section: str = ""  # 외부 데이터 요약
-    rebalance_section: str = "" # 리밸런스 어드바이저 요약
-    known_tickers: set[str] = None
-    known_numbers: set[str] = None
-
-    def __post_init__(self):
-        if self.known_tickers is None:
-            self.known_tickers = set()
-        if self.known_numbers is None:
-            self.known_numbers = set()
+    rebalance_section: str = ""  # 리밸런스 어드바이저 요약
+    known_tickers: set[str] = field(default_factory=set)
+    known_numbers: set[str] = field(default_factory=set)
 
 
 def gather_context(db_path=None) -> ReportContext:
@@ -101,7 +108,7 @@ def gather_context(db_path=None) -> ReportContext:
     def _track(text: str) -> str:
         """텍스트에서 티커와 숫자를 추출하여 검증용 세트에 추가."""
         # 숫자 추출 (소수점 포함)
-        for m in re.findall(r'\d+\.?\d*', text):
+        for m in re.findall(r"\d+\.?\d*", text):
             known_numbers.add(m)
         return text
 
@@ -110,6 +117,7 @@ def gather_context(db_path=None) -> ReportContext:
     gate_score = 0.0
     try:
         from nuri.trading.engine.gate import check_all_gates
+
         gates = check_all_gates(db_path)
         lines = []
         total_pass = total_all = 0
@@ -132,6 +140,7 @@ def gather_context(db_path=None) -> ReportContext:
     regime_section = "레짐 데이터 없음"
     try:
         from nuri.quant.regime.classifier import classify_regime
+
         regime = classify_regime(db_path=db_path)
         if regime:
             d = regime.details
@@ -151,6 +160,7 @@ def gather_context(db_path=None) -> ReportContext:
     macro_section = "매크로 데이터 없음"
     try:
         from nuri.quant.regime.macro_score import compute_macro_score
+
         macro = compute_macro_score(db_path=db_path)
         det = macro.details
         macro_section = _track(
@@ -171,16 +181,14 @@ def gather_context(db_path=None) -> ReportContext:
     risk_section = "리스크 데이터 없음"
     try:
         from nuri.analysis.risk import analyze_risk
+
         metrics = analyze_risk()
         if metrics:
             sharpe = metrics.get("sharpe_ratio", "N/A")
             mdd = metrics.get("max_drawdown_pct", "N/A")
             var95 = metrics.get("var_95_daily_pct", "N/A")
             cvar95 = metrics.get("cvar_95_daily_pct", "N/A")
-            risk_section = _track(
-                f"Sharpe: {sharpe}, MDD: {mdd}%\n"
-                f"VaR(95%): {var95}%, CVaR(95%): {cvar95}%"
-            )
+            risk_section = _track(f"Sharpe: {sharpe}, MDD: {mdd}%\nVaR(95%): {var95}%, CVaR(95%): {cvar95}%")
             alerts = metrics.get("stop_loss_alerts", [])
             if alerts:
                 for a in alerts:
@@ -193,6 +201,7 @@ def gather_context(db_path=None) -> ReportContext:
     candidates_section = "매매 후보 없음"
     try:
         from nuri.trading.recommend.candidates import screen_candidates
+
         candidates = screen_candidates(lookback_days=5, db_path=db_path)
         buys = [c for c in candidates if c.direction == "BUY" and c.regime_fit]
         sells = [c for c in candidates if c.direction == "SELL" and c.regime_fit]
@@ -217,6 +226,7 @@ def gather_context(db_path=None) -> ReportContext:
     conflicts_section = "충돌 없음"
     try:
         from nuri.trading.engine.conflicts import detect_conflicts
+
         conflicts = detect_conflicts(db_path=db_path)
         if conflicts:
             lines = [f"시그널 충돌 {len(conflicts)}건:"]
@@ -235,6 +245,7 @@ def gather_context(db_path=None) -> ReportContext:
     drift_section = "성과 변화 데이터 없음"
     try:
         from nuri.trading.engine.memory import detect_drift
+
         drifts = detect_drift(db_path=db_path)
         if drifts:
             lines = ["시그널 성과 변화 (전체 기간 vs 최근 90일):"]
@@ -254,14 +265,13 @@ def gather_context(db_path=None) -> ReportContext:
     consensus_section = "에이전트 합의 데이터 없음"
     try:
         from nuri.trading.agents.consensus import analyze_portfolio as agent_analyze
+
         results = agent_analyze(db_path=db_path)
         if results:
             lines = [f"멀티 에이전트 합의 ({len(results)}종목):"]
             for r in sorted(results, key=lambda x: x.final_confidence, reverse=True)[:10]:
                 known_tickers.add(r.ticker)
-                agent_summary = ", ".join(
-                    f"{v.agent_name}={v.action}" for v in r.verdicts
-                )
+                agent_summary = ", ".join(f"{v.agent_name}={v.action}" for v in r.verdicts)
                 lines.append(
                     f"  {r.ticker}: {r.final_action} (신뢰도 {r.final_confidence:.0f}, "
                     f"동의율 {r.agreement_rate:.0%}) [{agent_summary}]"
@@ -277,6 +287,7 @@ def gather_context(db_path=None) -> ReportContext:
     strategy_section = "전략 데이터 없음"
     try:
         from nuri.quant.regime.strategy_map import map_regime_to_strategy
+
         rec = map_regime_to_strategy(db_path=db_path)
         if rec:
             strategy_section = _track(
@@ -293,6 +304,7 @@ def gather_context(db_path=None) -> ReportContext:
     external_section = "외부 데이터 없음"
     try:
         from nuri.collectors.external import get_external_summary
+
         ext_summary = get_external_summary(db_path)
         if ext_summary["total_records"] > 0:
             lines = [f"총 {ext_summary['total_records']}건 ({len(ext_summary['sources'])}개 소스)"]
@@ -306,9 +318,12 @@ def gather_context(db_path=None) -> ReportContext:
     rebalance_section = "리밸런스 데이터 없음"
     try:
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         report = generate_advisor_report(db_path)
         if report["total_violations"] > 0:
-            lines = [f"위반 {report['total_violations']}건 (critical {report['violations_by_severity'].get('critical', 0)}건)"]
+            lines = [
+                f"위반 {report['total_violations']}건 (critical {report['violations_by_severity'].get('critical', 0)}건)"
+            ]
             lines.append(f"총 회수 가능: ${report['total_recovery_usd']:,.0f}")
             for a in report["actions"][:5]:
                 lines.append(f"  {a['ticker']}: {a['reason']} (${a['sell_value_usd']:,.0f})")
@@ -334,10 +349,9 @@ def gather_context(db_path=None) -> ReportContext:
     )
 
 
-def format_prompt(ctx: ReportContext) -> str:
-    """컨텍스트를 LLM 프롬프트로 조립."""
+def _build_user_payload(ctx: ReportContext) -> str:
+    """OpenAI 스타일 user content: SYSTEM 은 별도 role, DATA만 여기에."""
     return (
-        f"{SYSTEM_PROMPT}\n\n"
         f"[DATA]\n"
         f"## 1. 데이터 완성도\n{ctx.gate_summary}\n\n"
         f"## 2. 시장 레짐\n{ctx.regime_section}\n\n"
@@ -356,6 +370,11 @@ def format_prompt(ctx: ReportContext) -> str:
     )
 
 
+def format_prompt(ctx: ReportContext) -> str:
+    """legacy 단일-문자열 프롬프트 (llama.cpp/Ollama 호환)."""
+    return f"{SYSTEM_PROMPT}\n\n{_build_user_payload(ctx)}"
+
+
 # ═══════════════════════════════════════════════════════
 # Output Validation (SIEGE Certification 패턴)
 # ═══════════════════════════════════════════════════════
@@ -364,6 +383,7 @@ def format_prompt(ctx: ReportContext) -> str:
 @dataclass
 class ValidationResult:
     """LLM 출력 검증 결과."""
+
     passed: bool
     hallucinated_tickers: list[str]  # 입력에 없는 티커 언급
     warnings: list[str]
@@ -382,29 +402,65 @@ def validate_output(text: str, ctx: ReportContext) -> ValidationResult:
     hallucinated = []
 
     # ── 1. 티커 환각 검증 ──
-    mentioned_tickers = set(re.findall(r'(?<![A-Za-z])([A-Z]{2,5})(?![A-Za-z])', text))
+    mentioned_tickers = set(re.findall(r"(?<![A-Za-z])([A-Z]{2,5})(?![A-Za-z])", text))
     common_words = {
-        "BUY", "SELL", "HOLD", "RSI", "MACD", "SMA", "VIX", "ETF",
-        "PF", "MDD", "PE", "ROE", "CPI", "GDP", "FOMC", "USD", "KRW",
-        "VOL", "OK", "ALL", "TOP", "MAX", "MIN", "AVG", "SPY",
-        "THE", "AND", "FOR", "NOT", "ARE", "BUT", "HAS", "WAS",
-        "BB", "EMA", "READY", "BLOCKED", "FAIL",
-        "DATA", "GATE", "PASS", "WARN", "NOTE", "CVaR", "VaR",
+        "BUY",
+        "SELL",
+        "HOLD",
+        "RSI",
+        "MACD",
+        "SMA",
+        "VIX",
+        "ETF",
+        "PF",
+        "MDD",
+        "PE",
+        "ROE",
+        "CPI",
+        "GDP",
+        "FOMC",
+        "USD",
+        "KRW",
+        "VOL",
+        "OK",
+        "ALL",
+        "TOP",
+        "MAX",
+        "MIN",
+        "AVG",
+        "SPY",
+        "THE",
+        "AND",
+        "FOR",
+        "NOT",
+        "ARE",
+        "BUT",
+        "HAS",
+        "WAS",
+        "BB",
+        "EMA",
+        "READY",
+        "BLOCKED",
+        "FAIL",
+        "DATA",
+        "GATE",
+        "PASS",
+        "WARN",
+        "NOTE",
+        "CVaR",
+        "VaR",
     }
     suspicious = mentioned_tickers - ctx.known_tickers - common_words
     for t in suspicious:
         if len(t) <= 5 and t.isalpha():
             hallucinated.append(t)
     if hallucinated:
-        warnings.append(
-            f"입력 데이터에 없는 티커 언급: {', '.join(hallucinated)}. "
-            f"LLM 환각 가능성."
-        )
+        warnings.append(f"입력 데이터에 없는 티커 언급: {', '.join(hallucinated)}. LLM 환각 가능성.")
 
     # ── 2. 숫자 환각 검증 ──
     # "승률 XX%" 패턴 추출 후 입력 데이터와 비교
-    wr_claims = re.findall(r'승률\s*(\d+)%', text)
-    pf_claims = re.findall(r'PF\s*(\d+\.?\d*)', text)
+    wr_claims = re.findall(r"승률\s*(\d+)%", text)
+    pf_claims = re.findall(r"PF\s*(\d+\.?\d*)", text)
     fabricated_numbers = []
 
     for wr in wr_claims:
@@ -425,34 +481,22 @@ def validate_output(text: str, ctx: ReportContext) -> ValidationResult:
 
     for pf in pf_claims:
         pf_val = float(pf)
-        found = any(
-            abs(float(k) - pf_val) < 0.15
-            for k in ctx.known_numbers
-            if k.replace(".", "").isdigit()
-        )
+        found = any(abs(float(k) - pf_val) < 0.15 for k in ctx.known_numbers if k.replace(".", "").isdigit())
         if not found and pf_val > 0:
             fabricated_numbers.append(f"PF {pf}")
 
     if fabricated_numbers:
-        warnings.append(
-            f"입력 데이터와 불일치하는 수치: {', '.join(fabricated_numbers)}. "
-            f"LLM 숫자 환각 의심."
-        )
+        warnings.append(f"입력 데이터와 불일치하는 수치: {', '.join(fabricated_numbers)}. LLM 숫자 환각 의심.")
 
     # ── 3. 데이터 완성도 경고 ──
     if ctx.gate_score < 0.5:
-        warnings.append(
-            f"데이터 완성도 {ctx.gate_score:.0%}로 낮음. "
-            f"리포트 신뢰도 제한적."
-        )
+        warnings.append(f"데이터 완성도 {ctx.gate_score:.0%}로 낮음. 리포트 신뢰도 제한적.")
 
     # ── 4. 구조 검증: 7단 섹션 키워드 존재 확인 ──
     required_topics = ["완성도", "시장", "리스크", "시그널", "후보", "전략", "주의"]
     missing_topics = [t for t in required_topics if t not in text]
     if len(missing_topics) >= 4:
-        warnings.append(
-            f"리포트 구조 불완전: {', '.join(missing_topics)} 섹션 누락."
-        )
+        warnings.append(f"리포트 구조 불완전: {', '.join(missing_topics)} 섹션 누락.")
 
     passed = len(hallucinated) == 0 and len(fabricated_numbers) == 0 and ctx.gate_score >= 0.3
     return ValidationResult(passed=passed, hallucinated_tickers=hallucinated, warnings=warnings)
@@ -463,15 +507,57 @@ def validate_output(text: str, ctx: ReportContext) -> ValidationResult:
 # ═══════════════════════════════════════════════════════
 
 
+def _generate_openai(system: str, user: str) -> str:
+    """OpenAI gpt-5.4-nano로 리포트 생성 (Tier 2, ZDR 필수).
+
+    STRATEGY.md §4.4.3: `openai_client` wrapper 단일 관문을 거친다.
+    `data_tier='tier2'` → wrapper가 `OPENAI_ZDR_APPROVED=1` 미설정 시 raise.
+    `NURI_DISABLE_EXTERNAL_LLM=1` → wrapper가 Disabled raise → 로컬 폴백.
+    """
+    from nuri.llm.openai_client import (
+        ExternalLLMDisabled,
+        ExternalLLMPolicyViolation,
+        ExternalLLMUnavailable,
+        get_client,
+    )
+
+    try:
+        client = get_client()
+        return client.chat_text(
+            system=system,
+            user=user,
+            model=OPENAI_REPORT_MODEL,
+            temperature=0.3,
+            max_tokens=2000,
+            data_tier="tier2",
+        )
+    except ExternalLLMDisabled:
+        logger.info("OpenAI opt-out (NURI_DISABLE_EXTERNAL_LLM=1) — 로컬 폴백 시도")
+        return ""
+    except ExternalLLMPolicyViolation as e:
+        logger.warning("OpenAI 정책 차단: %s", e)
+        return ""
+    except ExternalLLMUnavailable as e:
+        logger.warning("OpenAI 호출 실패: %s — 로컬 폴백 시도", e)
+        return ""
+
+
 def _generate_llamacpp(prompt: str) -> str:
     """llama.cpp로 직접 생성 (GGUF 모델 필요)."""
     if not LLAMA_MODEL_PATH:
         return ""
     try:
         from llama_cpp import Llama
+
         llm = Llama(model_path=LLAMA_MODEL_PATH, n_ctx=4096, n_gpu_layers=-1, verbose=False)
-        output = llm(prompt, max_tokens=1024, temperature=0.3, stop=["[/DATA]"])
-        return output["choices"][0]["text"].strip()
+        # stream=False (default) returns dict; the overloaded signature can
+        # otherwise resolve to Iterator[CreateCompletionStreamResponse] which
+        # breaks `output["choices"]` indexing (pylance reportIndexIssue).
+        output = llm(prompt, max_tokens=1024, temperature=0.3, stop=["[/DATA]"], stream=False)
+        if isinstance(output, dict):
+            return output["choices"][0]["text"].strip()
+        logger.warning("llama.cpp unexpected response type: %s", type(output).__name__)
+        return ""
     except ImportError:
         logger.warning("llama-cpp-python 미설치")
         return ""
@@ -482,7 +568,10 @@ def _generate_llamacpp(prompt: str) -> str:
 
 def _generate_ollama(prompt: str) -> str:
     """Ollama HTTP API로 생성. Qwen3.5 thinking 모델 호환."""
+    if not OLLAMA_HOST:
+        return ""
     import requests as _requests
+
     try:
         resp = _requests.post(
             f"{OLLAMA_HOST}/api/generate",
@@ -498,18 +587,13 @@ def _generate_ollama(prompt: str) -> str:
         data = resp.json()
         response = data.get("response", "")
 
-        # Qwen3.5 thinking 모델 처리:
-        # 1. response가 있으면 그대로 사용 (thinking 제외)
-        # 2. response가 비어있으면 thinking에서 실제 리포트 부분만 추출
+        # Qwen3.5 thinking 모델 처리
         if response.strip():
-            # thinking 잔여물 제거: "## 1." 이전 내용 필터링
             for marker in ["## 1.", "# 1. "]:
                 idx = response.find(marker)
                 if idx > 0:
                     response = response[idx:]
                     break
-            # "*   **## " 형식의 thinking indent 제거
-            import re
             response = re.sub(r"\s*\*\s*\*\*", "\n", response)
             response = re.sub(r"\*\*\s*$", "", response, flags=re.MULTILINE)
         elif data.get("thinking"):
@@ -524,15 +608,10 @@ def _generate_ollama(prompt: str) -> str:
 
         return response
     except _requests.ConnectionError:
-        return (
-            f"[LLM 연결 실패]\n"
-            f"방법 1: LLAMA_MODEL_PATH=모델.gguf 설정 (llama.cpp 직접)\n"
-            f"방법 2: ollama serve 실행 후 ollama pull {OLLAMA_MODEL}"
-        )
+        return ""
     except Exception:
-        # Avoid leaking exception details to API responses (CodeQL py/stack-trace-exposure).
         logger.exception("Ollama LLM 호출 실패")
-        return "[LLM 오류] 자세한 내용은 서버 로그 참고"
+        return ""
 
 
 def generate_llm_report(db_path=None) -> dict:
@@ -556,13 +635,26 @@ def generate_llm_report(db_path=None) -> dict:
 
     prompt = format_prompt(ctx)
 
-    # llama.cpp 우선 → Ollama 폴백
-    raw_report = ""
-    if LLAMA_MODEL_PATH:
+    # 생성 경로: OpenAI gpt-5.4-nano (primary) → llama.cpp → Ollama → error note.
+    # STRATEGY §4.4.3 Tier 2 허용 조건: `OPENAI_ZDR_APPROVED=1` 설정.
+    # `NURI_DISABLE_EXTERNAL_LLM=1` 시 OpenAI 스킵 → 로컬 경로만 시도.
+    raw_report = _generate_openai(SYSTEM_PROMPT, _build_user_payload(ctx))
+
+    if not raw_report and LLAMA_MODEL_PATH:
         raw_report = _generate_llamacpp(prompt)
 
-    if not raw_report:
+    if not raw_report and OLLAMA_HOST:
         raw_report = _generate_ollama(prompt)
+
+    if not raw_report:
+        raw_report = (
+            "[LLM 생성 실패]\n"
+            "설정 필요 (다음 중 하나):\n"
+            "  - OPENAI_API_KEY + OPENAI_ZDR_APPROVED=1  (primary, Tier 2)\n"
+            "  - LLAMA_MODEL_PATH=모델.gguf  (로컬 llama.cpp)\n"
+            "  - OLLAMA_HOST=http://localhost:11434  (로컬 Ollama)\n"
+            "오프라인 전용: NURI_DISABLE_EXTERNAL_LLM=1"
+        )
 
     # Output Validation
     validation = validate_output(raw_report, ctx)
@@ -622,6 +714,7 @@ if __name__ == "__main__":
         # 자동 저장
         from datetime import date
         from pathlib import Path
+
         report_dir = Path("data/reports") / str(date.today())
         report_dir.mkdir(parents=True, exist_ok=True)
         out_path = report_dir / "llm_report.md"

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -1,0 +1,28 @@
+"""tests/llm/ — shared fixtures for LLM tests.
+
+Context
+-------
+After the 2026-04-14 OpenAI-primary refactor (§4.4.3 Tier 2), `_generate_ollama`
+returns "" immediately when `OLLAMA_HOST` is empty. Most pre-existing Ollama
+success-path tests were written assuming the helper would always contact the
+mocked `requests.post`, so on CI (where `.env` has no OLLAMA_HOST) those tests
+bypass their mocks and see "".
+
+Rather than patching ~8 individual tests, set a non-empty OLLAMA_HOST for the
+entire `tests/llm/` module. The actual HTTP call is mocked in every test, so
+the value is never used for real network traffic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _default_ollama_host(monkeypatch):
+    """Ensure _generate_ollama's OLLAMA_HOST guard is satisfied under CI.
+
+    Tests that need to assert the guard behavior (empty host → empty output)
+    can still override via monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "").
+    """
+    monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")

--- a/tests/llm/test_openai_client.py
+++ b/tests/llm/test_openai_client.py
@@ -479,3 +479,75 @@ class TestChatTextContent:
         monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
         out = OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
         assert out == ""
+
+
+class TestChatTextErrorPaths:
+    """Coverage for SDK exception + audit log failure branches (lines 326-341, 359-360)."""
+
+    def test_sdk_exception_raises_unavailable_and_writes_audit(self, monkeypatch, db_path):
+        """SDK call fails → wrapper raises ExternalLLMUnavailable + audit row with error_type."""
+        import nuri.llm.openai_client as mod
+        from nuri.llm.openai_client import ExternalLLMUnavailable, OpenAIClient
+
+        fake_sdk = MagicMock()
+        fake_sdk.chat.completions.create.side_effect = RuntimeError("boom")
+        fake_module = MagicMock()
+        fake_module.OpenAI = MagicMock(return_value=fake_sdk)
+        monkeypatch.setitem(__import__("sys").modules, "openai", fake_module)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+        monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
+        mod._singleton = None
+
+        with pytest.raises(ExternalLLMUnavailable, match="RuntimeError"):
+            OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+
+        # Audit row must record the failure (error_type, success=False)
+        rows = query("SELECT * FROM external_llm_calls", db_path=db_path)
+        assert len(rows) == 1
+        row = dict(rows[0])
+        assert row["success"] == 0
+        assert row["error_type"] == "RuntimeError"
+        assert row["endpoint"] == "chat.completions(tier2)"
+        # Content never written
+        assert "boom" not in json.dumps(row)
+
+    def test_sdk_exception_with_audit_failure_still_raises_unavailable(self, monkeypatch, db_path):
+        """If both SDK fails AND audit log write fails, primary error still surfaces."""
+        import nuri.llm.openai_client as mod
+        from nuri.llm.openai_client import ExternalLLMUnavailable, OpenAIClient
+
+        fake_sdk = MagicMock()
+        fake_sdk.chat.completions.create.side_effect = RuntimeError("network down")
+        fake_module = MagicMock()
+        fake_module.OpenAI = MagicMock(return_value=fake_sdk)
+        monkeypatch.setitem(__import__("sys").modules, "openai", fake_module)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+        monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
+        mod._singleton = None
+
+        # Make audit log itself raise — wrapper must still raise primary error
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(mod, "log_external_llm_call", boom)
+
+        with pytest.raises(ExternalLLMUnavailable, match="RuntimeError"):
+            OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+
+    def test_success_path_audit_failure_does_not_mask_result(self, fake_openai_text_success, db_path, monkeypatch):
+        """If SDK succeeds but audit log write fails, the response still reaches the caller."""
+        import nuri.llm.openai_client as mod
+        from nuri.llm.openai_client import OpenAIClient
+
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+
+        def boom(*a, **kw):
+            raise OSError("readonly fs")
+
+        monkeypatch.setattr(mod, "log_external_llm_call", boom)
+
+        result = OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+        # Content returned despite audit log failure — observable contract upheld.
+        assert "데이터 완성도" in result

--- a/tests/llm/test_openai_client.py
+++ b/tests/llm/test_openai_client.py
@@ -9,6 +9,7 @@ The wrapper's contract is verified at three levels:
 2. **Failure modes** — opt-out, missing creds, network error, JSON parse error
 3. **Privacy invariant** — content is never written to the audit log row
 """
+
 from __future__ import annotations
 
 import json
@@ -56,6 +57,7 @@ def fake_openai_success(monkeypatch):
 
     # Reset singleton so each test gets a fresh client wrapping the fake
     import nuri.llm.openai_client as mod
+
     mod._singleton = None
 
     return fake_sdk
@@ -64,28 +66,33 @@ def fake_openai_success(monkeypatch):
 class TestStateChecks:
     def test_is_disabled_default_false(self, monkeypatch):
         from nuri.llm.openai_client import is_disabled
+
         monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
         assert is_disabled() is False
 
     @pytest.mark.parametrize("value", ["1", "true", "True", "yes", "ON"])
     def test_is_disabled_truthy_values(self, monkeypatch, value):
         from nuri.llm.openai_client import is_disabled
+
         monkeypatch.setenv("NURI_DISABLE_EXTERNAL_LLM", value)
         assert is_disabled() is True
 
     @pytest.mark.parametrize("value", ["0", "false", "no", ""])
     def test_is_disabled_falsy_values(self, monkeypatch, value):
         from nuri.llm.openai_client import is_disabled
+
         monkeypatch.setenv("NURI_DISABLE_EXTERNAL_LLM", value)
         assert is_disabled() is False
 
     def test_has_credentials_present(self, monkeypatch):
         from nuri.llm.openai_client import has_credentials
+
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-x")
         assert has_credentials() is True
 
     def test_has_credentials_missing(self, monkeypatch):
         from nuri.llm.openai_client import has_credentials
+
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         assert has_credentials() is False
 
@@ -93,6 +100,7 @@ class TestStateChecks:
 class TestChatJsonSuccess:
     def test_returns_parsed_json(self, fake_openai_success, db_path):
         from nuri.llm.openai_client import OpenAIClient
+
         client = OpenAIClient()
         result = client.chat_json(system="sys", user="usr", db_path=db_path)
         assert result == {
@@ -103,6 +111,7 @@ class TestChatJsonSuccess:
 
     def test_writes_audit_row(self, fake_openai_success, db_path):
         from nuri.llm.openai_client import OpenAIClient
+
         OpenAIClient().chat_json(system="sys", user="usr", db_path=db_path)
         rows = query("SELECT * FROM external_llm_calls", db_path=db_path)
         assert len(rows) == 1
@@ -117,11 +126,10 @@ class TestChatJsonSuccess:
         assert row["success"] == 1
         assert row["error_type"] is None
 
-    def test_audit_row_does_not_contain_content(
-        self, fake_openai_success, db_path
-    ):
+    def test_audit_row_does_not_contain_content(self, fake_openai_success, db_path):
         """Content invariant — neither prompt nor response in DB."""
         from nuri.llm.openai_client import OpenAIClient
+
         OpenAIClient().chat_json(
             system="this is a secret system prompt",
             user="this is a secret user message",
@@ -133,29 +141,29 @@ class TestChatJsonSuccess:
         assert "secret user message" not in row_str
         assert "fed_dovish" not in row_str  # response content not stored either
 
-    def test_uses_default_model_when_unspecified(
-        self, fake_openai_success, db_path
-    ):
+    def test_uses_default_model_when_unspecified(self, fake_openai_success, db_path):
         from nuri.llm.openai_client import DEFAULT_MODEL, OpenAIClient
+
         OpenAIClient().chat_json(system="s", user="u", db_path=db_path)
         call = fake_openai_success.chat.completions.create.call_args
         assert call.kwargs["model"] == DEFAULT_MODEL
 
-    def test_uses_explicit_model_override(
-        self, fake_openai_success, db_path
-    ):
+    def test_uses_explicit_model_override(self, fake_openai_success, db_path):
         from nuri.llm.openai_client import OpenAIClient
+
         OpenAIClient().chat_json(
-            system="s", user="u", model="gpt-5.4-mini", db_path=db_path,
+            system="s",
+            user="u",
+            model="gpt-5.4-mini",
+            db_path=db_path,
         )
         call = fake_openai_success.chat.completions.create.call_args
         assert call.kwargs["model"] == "gpt-5.4-mini"
 
-    def test_uses_max_completion_tokens_not_max_tokens(
-        self, fake_openai_success, db_path
-    ):
+    def test_uses_max_completion_tokens_not_max_tokens(self, fake_openai_success, db_path):
         """gpt-5.x series renamed the parameter; regression guard."""
         from nuri.llm.openai_client import OpenAIClient
+
         OpenAIClient().chat_json(system="s", user="u", db_path=db_path)
         call = fake_openai_success.chat.completions.create.call_args
         assert "max_completion_tokens" in call.kwargs
@@ -163,28 +171,26 @@ class TestChatJsonSuccess:
 
 
 class TestOptOut:
-    def test_disabled_raises_external_llm_disabled(
-        self, monkeypatch, db_path
-    ):
+    def test_disabled_raises_external_llm_disabled(self, monkeypatch, db_path):
         import nuri.llm.openai_client as mod
         from nuri.llm.openai_client import (
             ExternalLLMDisabled,
             OpenAIClient,
         )
+
         mod._singleton = None
         monkeypatch.setenv("NURI_DISABLE_EXTERNAL_LLM", "1")
         client = OpenAIClient()
         with pytest.raises(ExternalLLMDisabled):
             client.chat_json(system="s", user="u", db_path=db_path)
 
-    def test_disabled_does_not_write_audit_row(
-        self, monkeypatch, db_path
-    ):
+    def test_disabled_does_not_write_audit_row(self, monkeypatch, db_path):
         import nuri.llm.openai_client as mod
         from nuri.llm.openai_client import (
             ExternalLLMDisabled,
             OpenAIClient,
         )
+
         mod._singleton = None
         monkeypatch.setenv("NURI_DISABLE_EXTERNAL_LLM", "1")
         client = OpenAIClient()
@@ -196,14 +202,13 @@ class TestOptOut:
 
 
 class TestMissingCredentials:
-    def test_missing_key_raises_unavailable(
-        self, monkeypatch, db_path
-    ):
+    def test_missing_key_raises_unavailable(self, monkeypatch, db_path):
         import nuri.llm.openai_client as mod
         from nuri.llm.openai_client import (
             ExternalLLMUnavailable,
             OpenAIClient,
         )
+
         mod._singleton = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
@@ -213,14 +218,13 @@ class TestMissingCredentials:
 
 
 class TestNetworkFailure:
-    def test_sdk_exception_raises_unavailable_and_logs_failure(
-        self, monkeypatch, db_path
-    ):
+    def test_sdk_exception_raises_unavailable_and_logs_failure(self, monkeypatch, db_path):
         import nuri.llm.openai_client as mod
         from nuri.llm.openai_client import (
             ExternalLLMUnavailable,
             OpenAIClient,
         )
+
         mod._singleton = None
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
@@ -243,14 +247,13 @@ class TestNetworkFailure:
 
 
 class TestMalformedResponse:
-    def test_invalid_json_raises_response_error(
-        self, monkeypatch, db_path
-    ):
+    def test_invalid_json_raises_response_error(self, monkeypatch, db_path):
         import nuri.llm.openai_client as mod
         from nuri.llm.openai_client import (
             ExternalLLMResponseError,
             OpenAIClient,
         )
+
         mod._singleton = None
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
@@ -280,8 +283,10 @@ class TestMalformedResponse:
 class TestSingleton:
     def test_get_client_returns_same_instance(self, monkeypatch):
         import nuri.llm.openai_client as mod
+
         mod._singleton = None
         from nuri.llm.openai_client import get_client
+
         a = get_client()
         b = get_client()
         assert a is b
@@ -292,6 +297,7 @@ class TestCostEstimation:
 
     def test_estimate_cost_known_model(self):
         from nuri.llm.openai_client import estimate_cost_usd
+
         # gpt-5.4-nano: $0.20/1M in, $1.25/1M out
         # 1000 prompt + 500 completion = 0.001*0.20 + 0.0005*1.25 = $0.000825
         cost = estimate_cost_usd("gpt-5.4-nano", 1000, 500)
@@ -300,15 +306,15 @@ class TestCostEstimation:
 
     def test_estimate_cost_unknown_model_returns_none(self):
         from nuri.llm.openai_client import estimate_cost_usd
+
         assert estimate_cost_usd("nonexistent-model-x", 100, 100) is None
 
     def test_estimate_cost_zero_tokens(self):
         from nuri.llm.openai_client import estimate_cost_usd
+
         assert estimate_cost_usd("gpt-5.4-nano", 0, 0) == 0.0
 
-    def test_chat_json_emits_info_log_with_cost(
-        self, fake_openai_success, db_path, caplog
-    ):
+    def test_chat_json_emits_info_log_with_cost(self, fake_openai_success, db_path, caplog):
         """Every successful call must produce one INFO line with the cost."""
         import logging
 
@@ -318,10 +324,7 @@ class TestCostEstimation:
             OpenAIClient().chat_json(system="s", user="u", db_path=db_path)
 
         # Find the external_llm log line
-        external_lines = [
-            r for r in caplog.records
-            if "[external_llm]" in r.getMessage()
-        ]
+        external_lines = [r for r in caplog.records if "[external_llm]" in r.getMessage()]
         assert len(external_lines) == 1, f"expected 1 external_llm log, got {len(external_lines)}"
         msg = external_lines[0].getMessage()
         # Format: "[external_llm] openai/gpt-5.4-nano: 42→18 tokens, Nms, $0.xxxxxx"
@@ -331,9 +334,7 @@ class TestCostEstimation:
         assert "tokens" in msg
         assert "$0." in msg  # cost present
 
-    def test_chat_json_log_uses_unknown_marker_for_unpriced_model(
-        self, fake_openai_success, db_path, caplog
-    ):
+    def test_chat_json_log_uses_unknown_marker_for_unpriced_model(self, fake_openai_success, db_path, caplog):
         import logging
 
         from nuri.llm.openai_client import OpenAIClient
@@ -341,7 +342,9 @@ class TestCostEstimation:
         # Override default model to one not in MODEL_PRICING_USD_PER_1M
         with caplog.at_level(logging.INFO, logger="nuri.llm.openai_client"):
             OpenAIClient().chat_json(
-                system="s", user="u", model="hypothetical-future-v9",
+                system="s",
+                user="u",
+                model="hypothetical-future-v9",
                 db_path=db_path,
             )
 
@@ -349,3 +352,130 @@ class TestCostEstimation:
         assert len(msgs) == 1
         assert "hypothetical-future-v9" in msgs[0]
         assert "$?(unknown model)" in msgs[0]
+
+
+# ═══════════════════════════════════════════════════════
+# chat_text (plain text completion + ZDR / tier gate)
+# ═══════════════════════════════════════════════════════
+
+
+@pytest.fixture()
+def fake_openai_text_success(monkeypatch):
+    """Replace openai.OpenAI() with a mock that returns plain-text content."""
+    fake_message = MagicMock()
+    fake_message.content = "## 1. 데이터 완성도\n리포트 본문"
+    fake_choice = MagicMock()
+    fake_choice.message = fake_message
+    fake_resp = MagicMock()
+    fake_resp.choices = [fake_choice]
+    fake_resp.usage = MagicMock(prompt_tokens=100, completion_tokens=50)
+
+    fake_sdk = MagicMock()
+    fake_sdk.chat.completions.create.return_value = fake_resp
+
+    fake_module = MagicMock()
+    fake_module.OpenAI = MagicMock(return_value=fake_sdk)
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_module)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key-not-real")
+    monkeypatch.delenv("NURI_DISABLE_EXTERNAL_LLM", raising=False)
+
+    import nuri.llm.openai_client as mod
+
+    mod._singleton = None
+
+    return fake_sdk
+
+
+class TestZdrApproved:
+    def test_zdr_approved_default_false(self, monkeypatch):
+        from nuri.llm.openai_client import zdr_approved
+
+        monkeypatch.delenv("OPENAI_ZDR_APPROVED", raising=False)
+        assert zdr_approved() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "YES"])
+    def test_zdr_approved_truthy(self, monkeypatch, value):
+        from nuri.llm.openai_client import zdr_approved
+
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", value)
+        assert zdr_approved() is True
+
+
+class TestChatTextTierGate:
+    """STRATEGY §4.4.3 enforcement — ZDR/tier checks happen BEFORE SDK call."""
+
+    def test_unknown_tier_raises_policy_violation(self, fake_openai_text_success, db_path):
+        from nuri.llm.openai_client import ExternalLLMPolicyViolation, OpenAIClient
+
+        with pytest.raises(ExternalLLMPolicyViolation, match="not permitted"):
+            OpenAIClient().chat_text(system="s", user="u", data_tier="tier99", db_path=db_path)
+
+    def test_tier1_not_permitted(self, fake_openai_text_success, db_path):
+        """Tier 1 (narrative) explicitly rejected per current policy."""
+        from nuri.llm.openai_client import ExternalLLMPolicyViolation, OpenAIClient
+
+        with pytest.raises(ExternalLLMPolicyViolation):
+            OpenAIClient().chat_text(system="s", user="u", data_tier="tier1", db_path=db_path)
+
+    def test_tier2_without_zdr_raises(self, fake_openai_text_success, db_path, monkeypatch):
+        from nuri.llm.openai_client import ExternalLLMPolicyViolation, OpenAIClient
+
+        monkeypatch.delenv("OPENAI_ZDR_APPROVED", raising=False)
+        with pytest.raises(ExternalLLMPolicyViolation, match="OPENAI_ZDR_APPROVED"):
+            OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+
+    def test_tier2_with_zdr_succeeds(self, fake_openai_text_success, db_path, monkeypatch):
+        from nuri.llm.openai_client import OpenAIClient
+
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+        result = OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+        assert "데이터 완성도" in result
+
+    def test_tier0_needs_no_zdr(self, fake_openai_text_success, db_path, monkeypatch):
+        """Public data (Tier 0) is freely sendable without ZDR."""
+        from nuri.llm.openai_client import OpenAIClient
+
+        monkeypatch.delenv("OPENAI_ZDR_APPROVED", raising=False)
+        result = OpenAIClient().chat_text(system="s", user="u", data_tier="tier0", db_path=db_path)
+        assert "리포트" in result
+
+    def test_tier2_call_logs_endpoint_with_tier(self, fake_openai_text_success, db_path, monkeypatch):
+        """Audit log endpoint should mark the tier so we can filter in monitoring."""
+        from nuri.llm.openai_client import OpenAIClient
+
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+        OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+        rows = query(
+            "SELECT endpoint FROM external_llm_calls ORDER BY id DESC LIMIT 1",
+            db_path=db_path,
+        )
+        assert rows[0]["endpoint"] == "chat.completions(tier2)"
+
+    def test_tier_gate_runs_before_sdk_construction(self, fake_openai_text_success, db_path, monkeypatch):
+        """ZDR check must fail-fast without contacting the SDK (no audit row)."""
+        from nuri.llm.openai_client import ExternalLLMPolicyViolation, OpenAIClient
+
+        monkeypatch.delenv("OPENAI_ZDR_APPROVED", raising=False)
+        with pytest.raises(ExternalLLMPolicyViolation):
+            OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+        # No audit row written — the gate ran before `_ensure_sdk`
+        rows = query("SELECT COUNT(*) AS c FROM external_llm_calls", db_path=db_path)
+        assert rows[0]["c"] == 0
+
+
+class TestChatTextContent:
+    def test_returns_plain_content(self, fake_openai_text_success, db_path, monkeypatch):
+        from nuri.llm.openai_client import OpenAIClient
+
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+        out = OpenAIClient().chat_text(system="sys", user="body", data_tier="tier2", db_path=db_path)
+        assert out == "## 1. 데이터 완성도\n리포트 본문"
+
+    def test_empty_content_returns_empty_string(self, fake_openai_text_success, db_path, monkeypatch):
+        """OpenAI can return message.content=None (e.g., max_tokens hit early)."""
+        fake_openai_text_success.chat.completions.create.return_value.choices[0].message.content = None
+        from nuri.llm.openai_client import OpenAIClient
+
+        monkeypatch.setenv("OPENAI_ZDR_APPROVED", "1")
+        out = OpenAIClient().chat_text(system="s", user="u", data_tier="tier2", db_path=db_path)
+        assert out == ""

--- a/tests/llm/test_report.py
+++ b/tests/llm/test_report.py
@@ -4,6 +4,7 @@ Network-free: every Ollama/llama_cpp call is mocked. Split from the legacy
 tests/test_llm_all.py; all 24 classes covered only nuri.llm.report. The
 event_classifier tests live in tests/llm/test_event_classifier.py.
 """
+
 import sys
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,7 @@ from nuri.core.db import get_db, init_db, upsert_macro, upsert_portfolio, upsert
 @pytest.fixture
 def db_path(tmp_path, monkeypatch):
     import nuri.core.db as db_mod
+
     path = tmp_path / "test.db"
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
@@ -37,43 +39,91 @@ def rich_db(tmp_path, monkeypatch):
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10,
-         "avg_price": 190, "currency": "USD", "sector": "Tech"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5,
-         "avg_price": 130, "currency": "USD", "sector": "Semiconductor"},
-        {"account": "test", "ticker": "BBB", "quantity": 96,
-         "avg_price": 20.0, "currency": "USD", "sector": "SectorB"},
-        {"account": "test", "ticker": "005930.KS", "quantity": 4,
-         "avg_price": 60000, "currency": "KRW", "sector": "Semiconductor"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 190,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 130,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+            {
+                "account": "test",
+                "ticker": "BBB",
+                "quantity": 96,
+                "avg_price": 20.0,
+                "currency": "USD",
+                "sector": "SectorB",
+            },
+            {
+                "account": "test",
+                "ticker": "005930.KS",
+                "quantity": 4,
+                "avg_price": 60000,
+                "currency": "KRW",
+                "sector": "Semiconductor",
+            },
+        ],
+        path,
+    )
 
     dates = pd.date_range("2024-01-02", periods=500, freq="B")
     rows = []
-    for t in ["SPY", "AAPL", "NVDA", "BBB", "005930.KS",
-              "XLK", "XLF", "XLE", "XLV", "XLI", "XLP", "XLU", "XLY", "XLC", "XLRE", "VOO"]:
-        base = {"SPY": 450, "AAPL": 170, "NVDA": 120, "BBB": 15,
-                "005930.KS": 58000, "VOO": 440}.get(t, 100)
+    for t in [
+        "SPY",
+        "AAPL",
+        "NVDA",
+        "BBB",
+        "005930.KS",
+        "XLK",
+        "XLF",
+        "XLE",
+        "XLV",
+        "XLI",
+        "XLP",
+        "XLU",
+        "XLY",
+        "XLC",
+        "XLRE",
+        "VOO",
+    ]:
+        base = {"SPY": 450, "AAPL": 170, "NVDA": 120, "BBB": 15, "005930.KS": 58000, "VOO": 440}.get(t, 100)
         for i, d in enumerate(dates):
             p = base + i * 0.2 + np.sin(i / 20) * 5
-            rows.append({"ticker": t, "date": d.strftime("%Y-%m-%d"),
-                         "open": p - 0.5, "high": p + 3, "low": p - 2,
-                         "close": p + 1, "volume": 50_000_000, "adj_close": p + 1})
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p - 0.5,
+                    "high": p + 3,
+                    "low": p - 2,
+                    "close": p + 1,
+                    "volume": 50_000_000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
 
     macros = []
     for i, d in enumerate(dates):
         ds = d.strftime("%Y-%m-%d")
-        macros.append({"indicator": "vix", "date": ds,
-                       "value": 15 + np.sin(i / 30) * 8, "source": "test"})
-        macros.append({"indicator": "fear_greed", "date": ds,
-                       "value": 50 + np.sin(i / 25) * 30, "source": "test"})
-        macros.append({"indicator": "us_10y_yield", "date": ds,
-                       "value": 4.2 + np.sin(i / 40) * 0.5, "source": "test"})
-        macros.append({"indicator": "us_3m_yield", "date": ds,
-                       "value": 5.0 - np.sin(i / 40) * 0.3, "source": "test"})
-        macros.append({"indicator": "put_call_ratio", "date": ds,
-                       "value": 0.8 + np.sin(i / 15) * 0.4, "source": "test"})
+        macros.append({"indicator": "vix", "date": ds, "value": 15 + np.sin(i / 30) * 8, "source": "test"})
+        macros.append({"indicator": "fear_greed", "date": ds, "value": 50 + np.sin(i / 25) * 30, "source": "test"})
+        macros.append({"indicator": "us_10y_yield", "date": ds, "value": 4.2 + np.sin(i / 40) * 0.5, "source": "test"})
+        macros.append({"indicator": "us_3m_yield", "date": ds, "value": 5.0 - np.sin(i / 40) * 0.3, "source": "test"})
+        macros.append(
+            {"indicator": "put_call_ratio", "date": ds, "value": 0.8 + np.sin(i / 15) * 0.4, "source": "test"}
+        )
     upsert_macro(macros, path)
     return path
 
@@ -82,15 +132,40 @@ def rich_db(tmp_path, monkeypatch):
 def full_db(tmp_path, monkeypatch):
     """Enriched DB with portfolio, prices, macro, superinvestors, estimates, recommendations, external."""
     import nuri.core.db as db_mod
+
     path = tmp_path / "test.db"
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10, "avg_price": 190, "currency": "USD", "sector": "Tech"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5, "avg_price": 130, "currency": "USD", "sector": "Semiconductor"},
-        {"account": "test", "ticker": "TSLA", "quantity": 8, "avg_price": 250, "currency": "USD", "sector": "SectorA"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 190,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 130,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+            {
+                "account": "test",
+                "ticker": "TSLA",
+                "quantity": 8,
+                "avg_price": 250,
+                "currency": "USD",
+                "sector": "SectorA",
+            },
+        ],
+        path,
+    )
 
     dates = pd.date_range("2024-06-01", periods=500, freq="B")
     rows = []
@@ -98,9 +173,18 @@ def full_db(tmp_path, monkeypatch):
         base = {"SPY": 450, "AAPL": 170, "NVDA": 120, "TSLA": 200}[t]
         for i, d in enumerate(dates):
             p = base + i * 0.2 + np.sin(i / 20) * 5
-            rows.append({"ticker": t, "date": d.strftime("%Y-%m-%d"),
-                         "open": p, "high": p + 3, "low": p - 2,
-                         "close": p + 1, "volume": 50000000, "adj_close": p + 1})
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 3,
+                    "low": p - 2,
+                    "close": p + 1,
+                    "volume": 50000000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
 
     macro = []
@@ -113,21 +197,27 @@ def full_db(tmp_path, monkeypatch):
     upsert_macro(macro, path)
 
     with get_db(path) as conn:
-        conn.executemany("""INSERT OR REPLACE INTO superinvestors
+        conn.executemany(
+            """INSERT OR REPLACE INTO superinvestors
             (investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name)
-            VALUES (?, ?, ?, ?, ?, ?, ?)""", [
-            ("Buffett", "2025-08-15", "AAPL", 900000000, 171e9, 48.5, "Apple Inc"),
-            ("Buffett", "2025-02-15", "AAPL", 905000000, 165e9, 49.0, "Apple Inc"),
-            ("Dalio", "2025-08-15", "NVDA", 5000000, 650e6, 3.2, "NVIDIA Corp"),
-        ])
+            VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            [
+                ("Buffett", "2025-08-15", "AAPL", 900000000, 171e9, 48.5, "Apple Inc"),
+                ("Buffett", "2025-02-15", "AAPL", 905000000, 165e9, 49.0, "Apple Inc"),
+                ("Dalio", "2025-08-15", "NVDA", 5000000, 650e6, 3.2, "NVIDIA Corp"),
+            ],
+        )
 
     with get_db(path) as conn:
-        conn.executemany("""INSERT OR REPLACE INTO estimates
+        conn.executemany(
+            """INSERT OR REPLACE INTO estimates
             (ticker, date, recommendation, target_high, target_low, target_mean, target_median, num_analysts, current_price)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""", [
-            ("AAPL", "2025-06-01", "buy", 250, 180, 220, 215, 30, 190),
-            ("NVDA", "2025-06-01", "strong_buy", 200, 100, 170, 165, 25, 130),
-        ])
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                ("AAPL", "2025-06-01", "buy", 250, 180, 220, 215, 30, 190),
+                ("NVDA", "2025-06-01", "strong_buy", 200, 100, 170, 165, 25, 130),
+            ],
+        )
 
     with get_db(path) as conn:
         conn.execute("""INSERT OR REPLACE INTO recommendations
@@ -148,10 +238,10 @@ def full_db(tmp_path, monkeypatch):
 
 
 class TestReportContext:
-
     def test_context_has_all_sections(self, db_path):
         """빈 DB에서도 모든 섹션이 존재."""
         from nuri.llm.report import gather_context
+
         ctx = gather_context(db_path=db_path)
         assert ctx.gate_summary
         assert ctx.regime_section
@@ -164,12 +254,14 @@ class TestReportContext:
 
     def test_gate_score_range(self, db_path):
         from nuri.llm.report import gather_context
+
         ctx = gather_context(db_path=db_path)
         assert 0.0 <= ctx.gate_score <= 1.0
 
     def test_prompt_contains_data_tags(self, db_path):
         """프롬프트에 [DATA]...[/DATA] 구조가 있어야 함."""
         from nuri.llm.report import format_prompt, gather_context
+
         ctx = gather_context(db_path=db_path)
         prompt = format_prompt(ctx)
         assert "[DATA]" in prompt
@@ -177,15 +269,21 @@ class TestReportContext:
 
 
 class TestOutputValidation:
-
     def test_clean_output_passes(self, db_path):
         """입력 데이터와 일치하는 출력은 통과."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.7,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="TSLA BUY", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.7,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="TSLA BUY",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"TSLA", "NVDA"},
             known_numbers={"100", "50.5"},
         )
@@ -196,11 +294,18 @@ class TestOutputValidation:
     def test_hallucinated_ticker_detected(self, db_path):
         """입력에 없는 티커를 LLM이 언급하면 감지."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.7,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="TSLA BUY", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.7,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="TSLA BUY",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"TSLA"},
             known_numbers=set(),
         )
@@ -211,12 +316,20 @@ class TestOutputValidation:
     def test_low_gate_score_warning(self):
         """게이트 점수 낮으면 경고."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.3,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers=set(), known_numbers=set(),
+            gate_summary="",
+            gate_score=0.3,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers=set(),
+            known_numbers=set(),
         )
         result = validate_output("리포트 내용", ctx)
         assert any("완성도" in w for w in result.warnings)
@@ -224,15 +337,16 @@ class TestOutputValidation:
     def test_gate_blocked_below_30pct(self, db_path):
         """게이트 30% 미만이면 리포트 생성 차단."""
         from nuri.llm.report import gather_context
+
         ctx = gather_context(db_path=db_path)
         # 빈 DB → gate_score가 매우 낮을 것
         assert ctx.gate_score < 0.5
 
 
 class TestDisclaimer:
-
     def test_disclaimer_exists(self):
         from nuri.llm.report import DISCLAIMER
+
         assert "투자 조언이 아니며" in DISCLAIMER
         assert "투자자 본인" in DISCLAIMER
 
@@ -245,12 +359,14 @@ class TestDisclaimer:
 class TestLLMReport_R3:
     def test_gather_context(self, db_path):
         from nuri.llm.report import gather_context
+
         ctx = gather_context()
         assert hasattr(ctx, "gate_summary")
         assert hasattr(ctx, "regime_section")
 
     def test_format_prompt(self, db_path):
         from nuri.llm.report import format_prompt, gather_context
+
         ctx = gather_context()
         prompt = format_prompt(ctx)
         assert isinstance(prompt, str)
@@ -258,6 +374,7 @@ class TestLLMReport_R3:
 
     def test_validate_output(self, db_path):
         from nuri.llm.report import ValidationResult, gather_context, validate_output
+
         ctx = gather_context()
         result = validate_output("This is a test report about AAPL.", ctx)
         assert isinstance(result, ValidationResult)
@@ -265,8 +382,11 @@ class TestLLMReport_R3:
     def test_generate_llm_report_no_server(self, db_path):
         """Ollama 서버 없을 때 graceful error."""
         from nuri.llm.report import generate_llm_report
-        with patch("requests.post", side_effect=ConnectionError("no ollama")), \
-             patch("requests.get", side_effect=ConnectionError("no ollama")):
+
+        with (
+            patch("requests.post", side_effect=ConnectionError("no ollama")),
+            patch("requests.get", side_effect=ConnectionError("no ollama")),
+        ):
             result = generate_llm_report()
         assert "error" in result or isinstance(result, dict)
 
@@ -281,6 +401,7 @@ class TestLLMReportDeep:
     def test_format_prompt_structure(self, rich_db):
         """프롬프트에 필수 섹션 포함."""
         from nuri.llm.report import format_prompt, gather_context
+
         ctx = gather_context()
         prompt = format_prompt(ctx)
         assert "레짐" in prompt or "regime" in prompt.lower() or len(prompt) > 100
@@ -288,6 +409,7 @@ class TestLLMReportDeep:
     def test_validate_output_short(self, rich_db):
         """짧은 출력 → 검증 실패."""
         from nuri.llm.report import gather_context, validate_output
+
         ctx = gather_context()
         result = validate_output("too short", ctx)
         assert result.passed is False or result.passed is True  # 검증 결과 존재
@@ -295,6 +417,7 @@ class TestLLMReportDeep:
     def test_validate_output_hallucination(self, rich_db):
         """없는 종목 언급 → 환각 감지."""
         from nuri.llm.report import gather_context, validate_output
+
         ctx = gather_context()
         text = "FAKECORP의 PE ratio는 999999이며 매수를 추천합니다. " * 10
         result = validate_output(text, ctx)
@@ -311,17 +434,28 @@ class TestLLMReportDeep:
 class TestLLMDeep:
     def test_report_context_all_sections(self, rich_db):
         from nuri.llm.report import gather_context
+
         ctx = gather_context()
-        sections = ["gate_summary", "regime_section", "macro_section",
-                     "risk_section", "candidates_section", "conflicts_section",
-                     "drift_section", "consensus_section", "strategy_section",
-                     "external_section", "rebalance_section"]
+        sections = [
+            "gate_summary",
+            "regime_section",
+            "macro_section",
+            "risk_section",
+            "candidates_section",
+            "conflicts_section",
+            "drift_section",
+            "consensus_section",
+            "strategy_section",
+            "external_section",
+            "rebalance_section",
+        ]
         for s in sections:
             assert hasattr(ctx, s), f"missing section: {s}"
             assert isinstance(getattr(ctx, s), str)
 
     def test_known_tickers_set(self, rich_db):
         from nuri.llm.report import gather_context
+
         ctx = gather_context()
         assert "AAPL" in ctx.known_tickers
         assert "NVDA" in ctx.known_tickers
@@ -329,6 +463,7 @@ class TestLLMDeep:
     def test_generate_ollama_mock(self, rich_db):
         """Ollama API mock으로 LLM 생성."""
         from nuri.llm.report import _generate_ollama
+
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"response": "## 시장 분석\n테스트 리포트입니다."}
@@ -339,14 +474,17 @@ class TestLLMDeep:
     def test_generate_llm_report_full(self, rich_db):
         """전체 리포트 생성 (Ollama mock)."""
         from nuri.llm.report import generate_llm_report
+
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {
             "response": "## 1. 완성도\nGate Score: 30%\n## 2. 시장\nbull\n## 3. 리스크\nlow\n"
-                        "## 4. 시그널\nnone\n## 5. 후보\nnone\n## 6. 전략\nhold\n## 7. 주의\nnone",
+            "## 4. 시그널\nnone\n## 5. 후보\nnone\n## 6. 전략\nhold\n## 7. 주의\nnone",
         }
-        with patch("requests.post", return_value=mock_resp), \
-             patch("requests.get", return_value=MagicMock(status_code=200)):
+        with (
+            patch("requests.post", return_value=mock_resp),
+            patch("requests.get", return_value=MagicMock(status_code=200)),
+        ):
             result = generate_llm_report()
         assert isinstance(result, dict)
 
@@ -359,17 +497,21 @@ class TestLLMDeep:
 class TestLLMValidation:
     def test_validate_good_report(self, rich_db):
         from nuri.llm.report import gather_context, validate_output
+
         ctx = gather_context()
         # 좋은 리포트 (알려진 종목 + 숫자 사용)
-        good = ("## 1. 완성도\nGate Score: 30%\n## 2. 시장\n"
-                "AAPL은 현재 bull_low_vol 레짐에서 190달러입니다.\n"
-                "## 3. 리스크\nSharpe 1.5\n## 4. 시그널\nrsi_oversold\n"
-                "## 5. 후보\nAAPL BUY\n## 6. 전략\naggressive\n## 7. 주의\n없음")
+        good = (
+            "## 1. 완성도\nGate Score: 30%\n## 2. 시장\n"
+            "AAPL은 현재 bull_low_vol 레짐에서 190달러입니다.\n"
+            "## 3. 리스크\nSharpe 1.5\n## 4. 시그널\nrsi_oversold\n"
+            "## 5. 후보\nAAPL BUY\n## 6. 전략\naggressive\n## 7. 주의\n없음"
+        )
         result = validate_output(good, ctx)
         assert hasattr(result, "passed")
 
     def test_validate_empty_report(self, rich_db):
         from nuri.llm.report import gather_context, validate_output
+
         ctx = gather_context()
         result = validate_output("", ctx)
         # 빈 리포트도 구조 검증은 통과할 수 있음 (warnings에 기록)
@@ -386,6 +528,7 @@ class TestLLMSections:
     def test_context_sections_content(self, rich_db):
         """gather_context returns valid context sections (may be empty if no SPY data)."""
         from nuri.llm.report import gather_context
+
         ctx = gather_context(db_path=rich_db)
         # Context should always return valid strings (even if empty due to missing SPY data)
         assert isinstance(ctx.regime_section, str)
@@ -396,6 +539,7 @@ class TestLLMSections:
     def test_llamacpp_generate(self):
         """_generate_llamacpp mock."""
         from nuri.llm.report import _generate_llamacpp
+
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"content": "테스트 리포트"}
@@ -407,6 +551,7 @@ class TestLLMSections:
     def test_generate_ollama_error(self):
         """Ollama 에러 응답."""
         from nuri.llm.report import _generate_ollama
+
         mock_resp = MagicMock()
         mock_resp.status_code = 500
         mock_resp.text = "Internal Server Error"
@@ -426,20 +571,32 @@ class TestLLMSections:
 class TestLLMReportFlow:
     def test_full_report_with_sections(self, rich_db):
         from nuri.llm.report import generate_llm_report
+
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        sections = "\n".join([
-            "## 1. 완성도", "Gate Score: 30%",
-            "## 2. 시장 환경", "bull_low_vol 레짐",
-            "## 3. 리스크", "Sharpe 1.5, MDD -5%",
-            "## 4. 시그널", "rsi_oversold 감지",
-            "## 5. 매수/매도 후보", "AAPL BUY",
-            "## 6. 전략", "aggressive",
-            "## 7. 주의사항", "VIX 모니터링 필요",
-        ])
+        sections = "\n".join(
+            [
+                "## 1. 완성도",
+                "Gate Score: 30%",
+                "## 2. 시장 환경",
+                "bull_low_vol 레짐",
+                "## 3. 리스크",
+                "Sharpe 1.5, MDD -5%",
+                "## 4. 시그널",
+                "rsi_oversold 감지",
+                "## 5. 매수/매도 후보",
+                "AAPL BUY",
+                "## 6. 전략",
+                "aggressive",
+                "## 7. 주의사항",
+                "VIX 모니터링 필요",
+            ]
+        )
         mock_resp.json.return_value = {"response": sections}
-        with patch("requests.post", return_value=mock_resp), \
-             patch("requests.get", return_value=MagicMock(status_code=200)):
+        with (
+            patch("requests.post", return_value=mock_resp),
+            patch("requests.get", return_value=MagicMock(status_code=200)),
+        ):
             result = generate_llm_report()
         assert isinstance(result, dict)
         assert "report" in result or "error" in result
@@ -454,18 +611,21 @@ class TestLLMReportFlow:
 class TestLLMEnriched:
     def test_context_with_recommendations(self, full_db):
         from nuri.llm.report import gather_context
+
         ctx = gather_context()
         # candidates 섹션에 BUY 포함
         assert "BUY" in ctx.candidates_section or "0건" in ctx.candidates_section
 
     def test_context_with_external(self, full_db):
         from nuri.llm.report import gather_context
+
         ctx = gather_context()
         # external 섹션
         assert "tipranks" in ctx.external_section.lower() or "외부" in ctx.external_section
 
     def test_context_known_numbers(self, full_db):
         from nuri.llm.report import gather_context
+
         ctx = gather_context()
         assert len(ctx.known_numbers) > 0
         assert len(ctx.known_tickers) >= 3
@@ -481,12 +641,18 @@ class TestReportContext_R19:
 
     def test_defaults_none_to_empty_sets(self):
         from nuri.llm.report import ReportContext
+
         ctx = ReportContext(
-            gate_summary="test", gate_score=0.5,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="test",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         assert isinstance(ctx.known_tickers, set)
         assert isinstance(ctx.known_numbers, set)
@@ -494,12 +660,18 @@ class TestReportContext_R19:
 
     def test_explicit_known(self):
         from nuri.llm.report import ReportContext
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"AAPL", "NVDA"},
             known_numbers={"42", "3.14"},
         )
@@ -512,6 +684,7 @@ class TestFormatPrompt:
 
     def test_contains_all_sections(self):
         from nuri.llm.report import ReportContext, format_prompt
+
         ctx = ReportContext(
             gate_summary="Gate OK 5/5",
             gate_score=1.0,
@@ -536,12 +709,18 @@ class TestFormatPrompt:
 
     def test_system_prompt_included(self):
         from nuri.llm.report import SYSTEM_PROMPT, ReportContext, format_prompt
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.5,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         prompt = format_prompt(ctx)
         assert SYSTEM_PROMPT in prompt
@@ -552,12 +731,18 @@ class TestValidateOutput:
 
     def test_clean_output_passes(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"AAPL", "NVDA"},
             known_numbers={"50", "0.65", "1.5"},
         )
@@ -576,12 +761,18 @@ class TestValidateOutput:
 
     def test_hallucinated_ticker_detected(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"AAPL"},
             known_numbers=set(),
         )
@@ -594,12 +785,18 @@ class TestValidateOutput:
 
     def test_low_gate_score_warning(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.2,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.2,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         result = validate_output("완성도 시장 리스크 시그널 후보 전략 주의", ctx)
         assert result.passed is False
@@ -607,24 +804,36 @@ class TestValidateOutput:
 
     def test_missing_sections_warning(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         result = validate_output("hello world", ctx)
         assert any("구조 불완전" in w for w in result.warnings)
 
     def test_fabricated_win_rate_detected(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers={"0.65"},  # 65%
         )
@@ -635,12 +844,18 @@ class TestValidateOutput:
 
     def test_fabricated_pf_detected(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers={"1.5"},
         )
@@ -655,30 +870,33 @@ class TestGenerateOllama:
     def test_connection_refused(self):
 
         from nuri.llm.report import _generate_ollama
+
         with patch("nuri.llm.report._generate_ollama.__module__", "nuri.llm.report"):
             # Mock requests inside the function
             mock_post = MagicMock(side_effect=__import__("requests").ConnectionError("refused"))
-            with patch.dict("sys.modules", {}), \
-                 patch("requests.post", mock_post):
+            with patch.dict("sys.modules", {}), patch("requests.post", mock_post):
                 # The function does lazy import of requests
                 result = _generate_ollama("test prompt")
         assert "연결 실패" in result or isinstance(result, str)
 
-    def test_connection_error_returns_help_message(self):
+    def test_connection_error_returns_empty(self, monkeypatch):
+        """New architecture: _generate_ollama returns '' on any failure.
+        The helpful error message moved to generate_llm_report() top level."""
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         from nuri.llm.report import _generate_ollama
+
         mock_requests = MagicMock()
         mock_requests.ConnectionError = ConnectionError
         mock_requests.post.side_effect = ConnectionError("refused")
         with patch.dict("sys.modules", {"requests": mock_requests}):
             result = _generate_ollama("test prompt")
-        assert "연결 실패" in result
+        assert result == ""
 
     def test_successful_response(self):
         from nuri.llm.report import _generate_ollama
+
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "response": "## 1. 데이터 완성도\n리포트 내용입니다."
-        }
+        mock_resp.json.return_value = {"response": "## 1. 데이터 완성도\n리포트 내용입니다."}
         mock_resp.raise_for_status = MagicMock()
         mock_requests = MagicMock()
         mock_requests.ConnectionError = ConnectionError
@@ -690,11 +908,9 @@ class TestGenerateOllama:
     def test_thinking_model_response(self):
         """Qwen3.5 thinking model: response empty, thinking has content."""
         from nuri.llm.report import _generate_ollama
+
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "response": "",
-            "thinking": "blah blah ## 1. 데이터 완성도\n실제 리포트"
-        }
+        mock_resp.json.return_value = {"response": "", "thinking": "blah blah ## 1. 데이터 완성도\n실제 리포트"}
         mock_resp.raise_for_status = MagicMock()
         mock_requests = MagicMock()
         mock_requests.ConnectionError = ConnectionError
@@ -703,14 +919,17 @@ class TestGenerateOllama:
             result = _generate_ollama("test prompt")
         assert "데이터 완성도" in result
 
-    def test_generic_exception(self):
+    def test_generic_exception(self, monkeypatch):
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         from nuri.llm.report import _generate_ollama
+
         mock_requests = MagicMock()
         mock_requests.ConnectionError = ConnectionError
         mock_requests.post.side_effect = RuntimeError("timeout")
         with patch.dict("sys.modules", {"requests": mock_requests}):
             result = _generate_ollama("test prompt")
-        assert "오류" in result
+        # New architecture: returns "" on any failure; error surfaces at top level
+        assert result == ""
 
 
 class TestGenerateLlmReport:
@@ -718,12 +937,18 @@ class TestGenerateLlmReport:
 
     def test_gate_blocked_low_score(self):
         from nuri.llm.report import ReportContext, generate_llm_report
+
         mock_ctx = ReportContext(
-            gate_summary="low data", gate_score=0.1,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="low data",
+            gate_score=0.1,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         with patch("nuri.llm.report.gather_context", return_value=mock_ctx):
             result = generate_llm_report()
@@ -732,17 +957,28 @@ class TestGenerateLlmReport:
 
     def test_full_flow_with_mock_ollama(self):
         from nuri.llm.report import ReportContext, generate_llm_report
+
         mock_ctx = ReportContext(
-            gate_summary="OK 8/10", gate_score=0.8,
-            regime_section="bull_low_vol", macro_section="macro 60",
-            risk_section="Sharpe 1.2", candidates_section="BUY AAPL",
-            conflicts_section="", drift_section="stable",
-            consensus_section="", strategy_section="aggressive",
-            known_tickers={"AAPL"}, known_numbers={"60", "1.2"},
+            gate_summary="OK 8/10",
+            gate_score=0.8,
+            regime_section="bull_low_vol",
+            macro_section="macro 60",
+            risk_section="Sharpe 1.2",
+            candidates_section="BUY AAPL",
+            conflicts_section="",
+            drift_section="stable",
+            consensus_section="",
+            strategy_section="aggressive",
+            known_tickers={"AAPL"},
+            known_numbers={"60", "1.2"},
         )
-        with patch("nuri.llm.report.gather_context", return_value=mock_ctx), \
-             patch("nuri.llm.report._generate_ollama",
-                   return_value="## 1. 데이터 완성도\n시장 리스크 시그널 후보 전략 주의"):
+        with (
+            patch("nuri.llm.report.gather_context", return_value=mock_ctx),
+            patch(
+                "nuri.llm.report._generate_ollama",
+                return_value="## 1. 데이터 완성도\n시장 리스크 시그널 후보 전략 주의",
+            ),
+        ):
             result = generate_llm_report()
         assert result["gate_blocked"] is False
         assert result["report"] is not None
@@ -750,26 +986,40 @@ class TestGenerateLlmReport:
 
     def test_low_gate_score_adds_warning_to_report(self):
         from nuri.llm.report import ReportContext, generate_llm_report
+
         mock_ctx = ReportContext(
-            gate_summary="partial", gate_score=0.5,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="partial",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
-        with patch("nuri.llm.report.gather_context", return_value=mock_ctx), \
-             patch("nuri.llm.report._generate_ollama", return_value="report text"):
+        with (
+            patch("nuri.llm.report.gather_context", return_value=mock_ctx),
+            patch("nuri.llm.report._generate_ollama", return_value="report text"),
+        ):
             result = generate_llm_report()
         assert "완성도" in result["report"]
 
     def test_sync_alias(self):
         from nuri.llm.report import ReportContext, generate_llm_report_sync
+
         mock_ctx = ReportContext(
-            gate_summary="", gate_score=0.1,
-            regime_section="", macro_section="",
-            risk_section="", candidates_section="",
-            conflicts_section="", drift_section="",
-            consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.1,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         with patch("nuri.llm.report.gather_context", return_value=mock_ctx):
             result = generate_llm_report_sync()
@@ -786,6 +1036,7 @@ class TestFormatPrompt_R21:
 
     def test_basic_prompt_structure(self):
         from nuri.llm.report import ReportContext, format_prompt
+
         ctx = ReportContext(
             gate_summary="PASS 10/10",
             gate_score=1.0,
@@ -806,12 +1057,18 @@ class TestFormatPrompt_R21:
 
     def test_prompt_includes_all_sections(self):
         from nuri.llm.report import ReportContext, format_prompt
+
         ctx = ReportContext(
-            gate_summary="G", gate_score=0.5,
-            regime_section="R", macro_section="M",
-            risk_section="Ri", candidates_section="C",
-            conflicts_section="Co", drift_section="D",
-            consensus_section="Cn", strategy_section="S",
+            gate_summary="G",
+            gate_score=0.5,
+            regime_section="R",
+            macro_section="M",
+            risk_section="Ri",
+            candidates_section="C",
+            conflicts_section="Co",
+            drift_section="D",
+            consensus_section="Cn",
+            strategy_section="S",
             external_section="외부 데이터 요약",
             rebalance_section="위반 3건",
         )
@@ -825,11 +1082,18 @@ class TestValidateOutput_R21:
 
     def test_clean_output_passes(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="pass", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="pass",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"AAPL", "NVDA"},
             known_numbers={"0.65", "1.5"},
         )
@@ -845,11 +1109,18 @@ class TestValidateOutput_R21:
 
     def test_hallucinated_ticker_detected(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers={"AAPL"},
             known_numbers=set(),
         )
@@ -861,11 +1132,18 @@ class TestValidateOutput_R21:
 
     def test_fabricated_win_rate_detected(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers={"0.55"},  # 55% in input
         )
@@ -877,11 +1155,18 @@ class TestValidateOutput_R21:
 
     def test_fabricated_pf_detected(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers={"1.2"},
         )
@@ -892,11 +1177,18 @@ class TestValidateOutput_R21:
 
     def test_low_gate_score_warning(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.3,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.3,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers=set(),
         )
@@ -906,11 +1198,18 @@ class TestValidateOutput_R21:
 
     def test_missing_sections_warning(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers=set(),
         )
@@ -921,11 +1220,18 @@ class TestValidateOutput_R21:
 
     def test_very_low_gate_score_fails_validation(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.1,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.1,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers=set(),
         )
@@ -936,11 +1242,18 @@ class TestValidateOutput_R21:
 
     def test_win_rate_close_match_passes(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
             known_tickers=set(),
             known_numbers={"0.64"},  # 64%
         )
@@ -970,11 +1283,16 @@ class TestGenerateLLMReport:
         from nuri.llm.report import ReportContext, generate_llm_report
 
         ctx = ReportContext(
-            gate_summary="PASS", gate_score=0.8,
-            regime_section="bull", macro_section="good",
-            risk_section="low", candidates_section="BUY AAPL",
-            conflicts_section="none", drift_section="stable",
-            consensus_section="합의", strategy_section="공격적",
+            gate_summary="PASS",
+            gate_score=0.8,
+            regime_section="bull",
+            macro_section="good",
+            risk_section="low",
+            candidates_section="BUY AAPL",
+            conflicts_section="none",
+            drift_section="stable",
+            consensus_section="합의",
+            strategy_section="공격적",
             known_tickers={"AAPL"},
             known_numbers={"0.8"},
         )
@@ -985,8 +1303,10 @@ class TestGenerateLLMReport:
             "## 6. 리밸런스 필요 사항\n없음\n## 7. 전략 요약\n공격적\n"
             "## 8. 주의사항\n없음"
         )
-        with patch("nuri.llm.report.gather_context", return_value=ctx), \
-             patch("nuri.llm.report._generate_ollama", return_value=mock_report):
+        with (
+            patch("nuri.llm.report.gather_context", return_value=ctx),
+            patch("nuri.llm.report._generate_ollama", return_value=mock_report),
+        ):
             result = generate_llm_report()
             assert result["gate_blocked"] is False
             assert result["report"] is not None
@@ -996,13 +1316,21 @@ class TestGenerateLLMReport:
         from nuri.llm.report import ReportContext, generate_llm_report
 
         ctx = ReportContext(
-            gate_summary="PASS", gate_score=0.5,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="PASS",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
-        with patch("nuri.llm.report.gather_context", return_value=ctx), \
-             patch("nuri.llm.report._generate_ollama", return_value=""):
+        with (
+            patch("nuri.llm.report.gather_context", return_value=ctx),
+            patch("nuri.llm.report._generate_ollama", return_value=""),
+        ):
             result = generate_llm_report()
             assert result["gate_blocked"] is False
             # Empty report still includes disclaimer
@@ -1012,13 +1340,21 @@ class TestGenerateLLMReport:
         from nuri.llm.report import ReportContext, generate_llm_report
 
         ctx = ReportContext(
-            gate_summary="LOW", gate_score=0.5,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="LOW",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
-        with patch("nuri.llm.report.gather_context", return_value=ctx), \
-             patch("nuri.llm.report._generate_ollama", return_value="report text"):
+        with (
+            patch("nuri.llm.report.gather_context", return_value=ctx),
+            patch("nuri.llm.report._generate_ollama", return_value="report text"),
+        ):
             result = generate_llm_report()
             # gate_score < 0.7 → includes completeness warning
             assert "완성도" in result["report"]
@@ -1033,27 +1369,34 @@ class TestGenerateLLMReport:
         mock_resp.json.return_value = mock_response
         mock_resp.raise_for_status = MagicMock()
 
-        with patch("nuri.llm.report._requests.post" if hasattr(
-            __import__("nuri.llm.report", fromlist=["_generate_ollama"]), "_requests"
-        ) else "requests.post", side_effect=Exception("direct test")):
+        with patch(
+            "nuri.llm.report._requests.post"
+            if hasattr(__import__("nuri.llm.report", fromlist=["_generate_ollama"]), "_requests")
+            else "requests.post",
+            side_effect=Exception("direct test"),
+        ):
             # Test via the function logic directly
             pass
 
-    def test_ollama_connection_error(self):
+    def test_ollama_connection_error(self, monkeypatch):
+        """New architecture: _generate_ollama returns '' on failure.
+        Helpful message now emitted at generate_llm_report() top level."""
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         import requests
 
         from nuri.llm.report import _generate_ollama
 
         with patch("requests.post", side_effect=requests.ConnectionError("refused")):
             result = _generate_ollama("test prompt")
-            assert "LLM 연결 실패" in result
+            assert result == ""
 
-    def test_ollama_generic_error(self):
+    def test_ollama_generic_error(self, monkeypatch):
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         from nuri.llm.report import _generate_ollama
 
         with patch("requests.post", side_effect=RuntimeError("boom")):
             result = _generate_ollama("test prompt")
-            assert "LLM 오류" in result
+            assert result == ""
 
     def test_ollama_thinking_only_response(self):
         from nuri.llm.report import _generate_ollama
@@ -1083,6 +1426,7 @@ class TestGenerateLLMReport:
 
     def test_generate_llm_report_sync(self):
         from nuri.llm.report import generate_llm_report_sync
+
         mock_ctx = MagicMock()
         mock_ctx.gate_score = 0.1
         mock_ctx.gate_summary = "blocked"
@@ -1096,23 +1440,38 @@ class TestReportContextPostInit:
 
     def test_defaults_to_empty_sets(self):
         from nuri.llm.report import ReportContext
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.5,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         assert ctx.known_tickers == set()
         assert ctx.known_numbers == set()
 
     def test_preserves_provided_sets(self):
         from nuri.llm.report import ReportContext
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.5,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers={"AAPL"}, known_numbers={"1.5"},
+            gate_summary="",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers={"AAPL"},
+            known_numbers={"1.5"},
         )
         assert "AAPL" in ctx.known_tickers
         assert "1.5" in ctx.known_numbers
@@ -1123,6 +1482,7 @@ class TestOllamaResponseProcessing:
 
     def test_response_with_thinking_indent(self):
         from nuri.llm.report import _generate_ollama
+
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = {
@@ -1135,6 +1495,7 @@ class TestOllamaResponseProcessing:
 
     def test_response_with_h1_marker(self):
         from nuri.llm.report import _generate_ollama
+
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = {
@@ -1152,6 +1513,7 @@ class TestGatherContext:
     def test_gather_context_all_failures_graceful(self):
         """When every sub-module import fails, gather_context should still return valid ctx."""
         from nuri.llm.report import gather_context
+
         # All imports inside gather_context will fail since no DB exists
         # but the function catches all exceptions and returns defaults
         ctx = gather_context(db_path=None)
@@ -1179,11 +1541,15 @@ class TestGatherContext:
 
         mock_gates = {
             "collect": MockGateResult(
-                ready=True, passed=3, total=3,
+                ready=True,
+                passed=3,
+                total=3,
                 conditions=[MockCondition(True, "prices", "OK")],
             ),
             "analyze": MockGateResult(
-                ready=False, passed=1, total=2,
+                ready=False,
+                passed=1,
+                total=2,
                 conditions=[
                     MockCondition(True, "portfolio", "OK"),
                     MockCondition(False, "risk", "데이터 부족"),
@@ -1211,14 +1577,21 @@ class TestGatherContext:
             regime="bull_low_vol",
             confidence=0.85,
             details={
-                "spy_close": 520.0, "sma50": 510.0, "sma200": 490.0,
-                "sma_diff_pct": 4.1, "vix": 14.5, "fear_greed": 65,
-                "rsi": 58, "thresholds": {"vix_threshold": 20, "sideways_pct": 2.5, "bb_width_threshold": 0.05},
+                "spy_close": 520.0,
+                "sma50": 510.0,
+                "sma200": 490.0,
+                "sma_diff_pct": 4.1,
+                "vix": 14.5,
+                "fear_greed": 65,
+                "rsi": 58,
+                "thresholds": {"vix_threshold": 20, "sideways_pct": 2.5, "bb_width_threshold": 0.05},
             },
         )
 
-        with patch("nuri.trading.engine.gate.check_all_gates", side_effect=Exception("skip")), \
-             patch("nuri.quant.regime.classifier.classify_regime", return_value=mock_regime):
+        with (
+            patch("nuri.trading.engine.gate.check_all_gates", side_effect=Exception("skip")),
+            patch("nuri.quant.regime.classifier.classify_regime", return_value=mock_regime),
+        ):
             ctx = gather_context(db_path=None)
             assert "bull_low_vol" in ctx.regime_section
             assert "520" in ctx.regime_section
@@ -1242,19 +1615,33 @@ class TestGatherContext:
             details: dict
 
         mock_macro = MockMacroScore(
-            total_score=72, interpretation="moderate",
-            yield_curve_score=60, yield_spread_3m10y_score=50,
-            vix_score=80, put_call_ratio_score=70,
-            sentiment_score=65, employment_score=75,
-            inflation_score=60, monetary_score=55,
-            details={"spread": 0.5, "spread_3m10y": -0.2, "vix": 15,
-                     "put_call_ratio": 0.8, "fear_greed": 60,
-                     "unemployment": 3.7, "cpi_yoy": 3.1, "fed_funds": 5.25},
+            total_score=72,
+            interpretation="moderate",
+            yield_curve_score=60,
+            yield_spread_3m10y_score=50,
+            vix_score=80,
+            put_call_ratio_score=70,
+            sentiment_score=65,
+            employment_score=75,
+            inflation_score=60,
+            monetary_score=55,
+            details={
+                "spread": 0.5,
+                "spread_3m10y": -0.2,
+                "vix": 15,
+                "put_call_ratio": 0.8,
+                "fear_greed": 60,
+                "unemployment": 3.7,
+                "cpi_yoy": 3.1,
+                "fed_funds": 5.25,
+            },
         )
 
-        with patch("nuri.trading.engine.gate.check_all_gates", side_effect=Exception("skip")), \
-             patch("nuri.quant.regime.classifier.classify_regime", side_effect=Exception("skip")), \
-             patch("nuri.quant.regime.macro_score.compute_macro_score", return_value=mock_macro):
+        with (
+            patch("nuri.trading.engine.gate.check_all_gates", side_effect=Exception("skip")),
+            patch("nuri.quant.regime.classifier.classify_regime", side_effect=Exception("skip")),
+            patch("nuri.quant.regime.macro_score.compute_macro_score", return_value=mock_macro),
+        ):
             ctx = gather_context(db_path=None)
             assert "72" in ctx.macro_section
             assert "moderate" in ctx.macro_section
@@ -1279,21 +1666,25 @@ class TestGatherContext:
 
         mock_results = [
             MockConsensus(
-                ticker="AAPL", final_action="BUY",
-                final_confidence=78, agreement_rate=0.8,
+                ticker="AAPL",
+                final_action="BUY",
+                final_confidence=78,
+                agreement_rate=0.8,
                 verdicts=[MockVerdict("technical", "BUY"), MockVerdict("risk", "HOLD")],
                 dissent=["risk agent disagrees"],
             ),
         ]
 
-        with patch("nuri.trading.engine.gate.check_all_gates", side_effect=Exception("skip")), \
-             patch("nuri.quant.regime.classifier.classify_regime", side_effect=Exception("skip")), \
-             patch("nuri.quant.regime.macro_score.compute_macro_score", side_effect=Exception("skip")), \
-             patch("nuri.analysis.risk.analyze_risk", side_effect=Exception("skip")), \
-             patch("nuri.trading.recommend.candidates.screen_candidates", side_effect=Exception("skip")), \
-             patch("nuri.trading.engine.conflicts.detect_conflicts", side_effect=Exception("skip")), \
-             patch("nuri.trading.engine.memory.detect_drift", side_effect=Exception("skip")), \
-             patch("nuri.trading.agents.consensus.analyze_portfolio", return_value=mock_results):
+        with (
+            patch("nuri.trading.engine.gate.check_all_gates", side_effect=Exception("skip")),
+            patch("nuri.quant.regime.classifier.classify_regime", side_effect=Exception("skip")),
+            patch("nuri.quant.regime.macro_score.compute_macro_score", side_effect=Exception("skip")),
+            patch("nuri.analysis.risk.analyze_risk", side_effect=Exception("skip")),
+            patch("nuri.trading.recommend.candidates.screen_candidates", side_effect=Exception("skip")),
+            patch("nuri.trading.engine.conflicts.detect_conflicts", side_effect=Exception("skip")),
+            patch("nuri.trading.engine.memory.detect_drift", side_effect=Exception("skip")),
+            patch("nuri.trading.agents.consensus.analyze_portfolio", return_value=mock_results),
+        ):
             ctx = gather_context(db_path=None)
             assert "AAPL" in ctx.consensus_section
             assert "BUY" in ctx.consensus_section
@@ -1308,12 +1699,14 @@ class TestGatherContext:
 class TestLlmReport:
     def test_report_context_defaults(self):
         from nuri.llm.report import ReportContext
+
         ctx = ReportContext("gate", 0.5, "regime", "macro", "risk", "cand", "confl", "drift", "cons", "strat")
         assert ctx.known_tickers == set()
         assert ctx.known_numbers == set()
 
     def test_format_prompt(self):
         from nuri.llm.report import ReportContext, format_prompt
+
         ctx = ReportContext("gate", 0.5, "regime", "macro", "risk", "cand", "confl", "drift", "cons", "strat")
         prompt = format_prompt(ctx)
         assert "[DATA]" in prompt
@@ -1321,22 +1714,27 @@ class TestLlmReport:
 
     def test_validate_output_clean(self):
         from nuri.llm.report import ReportContext, validate_output
-        ctx = ReportContext("g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s",
-                           known_tickers={"AAPL"}, known_numbers={"50", "0.75"})
+
+        ctx = ReportContext(
+            "g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s", known_tickers={"AAPL"}, known_numbers={"50", "0.75"}
+        )
         text = "## 1. 완성도\n시장 환경 리스크 시그널 후보 전략 주의\nAAPL 승률 75%"
         result = validate_output(text, ctx)
         assert isinstance(result.passed, bool)
 
     def test_validate_output_hallucination(self):
         from nuri.llm.report import ReportContext, validate_output
-        ctx = ReportContext("g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s",
-                           known_tickers=set(), known_numbers=set())
+
+        ctx = ReportContext(
+            "g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s", known_tickers=set(), known_numbers=set()
+        )
         text = "ZZZQ is great 완성도 시장 리스크 시그널 후보 전략 주의"
         result = validate_output(text, ctx)
         assert len(result.hallucinated_tickers) > 0
 
     def test_validate_output_low_gate(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext("g", 0.2, "r", "m", "ri", "c", "co", "d", "co", "s")
         text = "완성도 시장 리스크 시그널 후보 전략 주의"
         result = validate_output(text, ctx)
@@ -1344,6 +1742,7 @@ class TestLlmReport:
 
     def test_validate_output_missing_sections(self):
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext("g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s")
         text = "nothing here at all"
         result = validate_output(text, ctx)
@@ -1351,8 +1750,8 @@ class TestLlmReport:
 
     def test_validate_pf_claim(self):
         from nuri.llm.report import ReportContext, validate_output
-        ctx = ReportContext("g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s",
-                           known_numbers={"1.5"})
+
+        ctx = ReportContext("g", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s", known_numbers={"1.5"})
         text = "PF 9.9 완성도 시장 리스크 시그널 후보 전략 주의"
         result = validate_output(text, ctx)
         assert any("불일치" in w for w in result.warnings)
@@ -1360,11 +1759,13 @@ class TestLlmReport:
     def test_generate_llamacpp_no_path(self, monkeypatch):
         monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "")
         from nuri.llm.report import _generate_llamacpp
+
         assert _generate_llamacpp("test") == ""
 
     def test_generate_llamacpp_import_error(self, monkeypatch):
         monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "/fake/path.gguf")
         from nuri.llm.report import _generate_llamacpp
+
         # llama_cpp not installed -> ImportError path
         result = _generate_llamacpp("test prompt")
         assert result == ""
@@ -1377,6 +1778,7 @@ class TestLlmReport:
         mock_module.Llama = mock_llama
         monkeypatch.setitem(sys.modules, "llama_cpp", mock_module)
         from nuri.llm.report import _generate_llamacpp
+
         result = _generate_llamacpp("test prompt")
         assert result == ""
 
@@ -1385,38 +1787,52 @@ class TestLlmReport:
         mock_resp.json.return_value = {"response": "## 1. 데이터 완성도\nOK"}
         mock_resp.raise_for_status = MagicMock()
         import requests as _req_mod
+
         monkeypatch.setattr(_req_mod, "post", MagicMock(return_value=mock_resp))
         from nuri.llm.report import _generate_ollama
+
         result = _generate_ollama("test prompt")
         assert "완성도" in result
 
     def test_generate_ollama_thinking_mode(self, monkeypatch):
         """Cover Qwen3.5 thinking mode (response empty, use thinking)."""
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"response": "", "thinking": "## 1. 완성도 stuff"}
         mock_resp.raise_for_status = MagicMock()
         import requests as _req_mod
+
         monkeypatch.setattr(_req_mod, "post", MagicMock(return_value=mock_resp))
         from nuri.llm.report import _generate_ollama
+
         result = _generate_ollama("test")
         assert "완성도" in result
 
     def test_generate_ollama_connection_error(self, monkeypatch):
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         import requests as _req_mod
+
         monkeypatch.setattr(_req_mod, "post", MagicMock(side_effect=_req_mod.ConnectionError("fail")))
         from nuri.llm.report import _generate_ollama
+
         result = _generate_ollama("test")
-        assert "LLM 연결 실패" in result
+        # New: returns "" on failure; error surfaces at top-level generate_llm_report
+        assert result == ""
 
     def test_generate_ollama_other_error(self, monkeypatch):
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         import requests as _req_mod
+
         monkeypatch.setattr(_req_mod, "post", MagicMock(side_effect=RuntimeError("boom")))
         from nuri.llm.report import _generate_ollama
+
         result = _generate_ollama("test")
-        assert "LLM 오류" in result
+        # New: returns "" on any error; caller (generate_llm_report) emits help text
+        assert result == ""
 
     def test_generate_llm_report_gate_blocked(self, monkeypatch):
         from nuri.llm.report import ReportContext, generate_llm_report
+
         ctx = ReportContext("blocked", 0.1, "r", "m", "ri", "c", "co", "d", "co", "s")
         monkeypatch.setattr("nuri.llm.report.gather_context", lambda db_path=None: ctx)
         result = generate_llm_report()
@@ -1425,8 +1841,10 @@ class TestLlmReport:
 
     def test_generate_llm_report_success(self, monkeypatch):
         from nuri.llm.report import ReportContext, generate_llm_report
-        ctx = ReportContext("ok", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s",
-                           known_tickers={"AAPL"}, known_numbers={"50"})
+
+        ctx = ReportContext(
+            "ok", 0.8, "r", "m", "ri", "c", "co", "d", "co", "s", known_tickers={"AAPL"}, known_numbers={"50"}
+        )
         monkeypatch.setattr("nuri.llm.report.gather_context", lambda db_path=None: ctx)
         monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "")
         monkeypatch.setattr(
@@ -1440,15 +1858,19 @@ class TestLlmReport:
     def test_generate_llm_report_low_gate(self, monkeypatch):
         """Gate score < 0.7 adds completeness warning."""
         from nuri.llm.report import ReportContext, generate_llm_report
+
         ctx = ReportContext("partial", 0.5, "r", "m", "ri", "c", "co", "d", "co", "s")
         monkeypatch.setattr("nuri.llm.report.gather_context", lambda db_path=None: ctx)
         monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "")
-        monkeypatch.setattr("nuri.llm.report._generate_ollama", lambda p: "report 완성도 시장 리스크 시그널 후보 전략 주의")
+        monkeypatch.setattr(
+            "nuri.llm.report._generate_ollama", lambda p: "report 완성도 시장 리스크 시그널 후보 전략 주의"
+        )
         result = generate_llm_report()
         assert "완성도" in result["report"]
 
     def test_sync_wrapper(self, monkeypatch):
         from nuri.llm.report import generate_llm_report_sync
+
         monkeypatch.setattr(
             "nuri.llm.report.generate_llm_report",
             lambda db_path=None: {"report": "ok", "gate_blocked": False},
@@ -1468,11 +1890,18 @@ class TestLLMReport_R27:
     def test_report_context_post_init(self):
         """ReportContext __post_init__ sets defaults."""
         from nuri.llm.report import ReportContext
+
         ctx = ReportContext(
-            gate_summary="test", gate_score=0.5,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="test",
+            gate_score=0.5,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         assert ctx.known_tickers == set()
         assert ctx.known_numbers == set()
@@ -1480,13 +1909,20 @@ class TestLLMReport_R27:
     def test_format_prompt(self):
         """format_prompt assembles all sections."""
         from nuri.llm.report import ReportContext, format_prompt
+
         ctx = ReportContext(
-            gate_summary="Gate OK", gate_score=0.8,
-            regime_section="Bull", macro_section="Score 70",
-            risk_section="Low risk", candidates_section="3 buys",
-            conflicts_section="None", drift_section="Stable",
-            consensus_section="BUY", strategy_section="Aggressive",
-            external_section="TipRanks data", rebalance_section="No violations",
+            gate_summary="Gate OK",
+            gate_score=0.8,
+            regime_section="Bull",
+            macro_section="Score 70",
+            risk_section="Low risk",
+            candidates_section="3 buys",
+            conflicts_section="None",
+            drift_section="Stable",
+            consensus_section="BUY",
+            strategy_section="Aggressive",
+            external_section="TipRanks data",
+            rebalance_section="No violations",
         )
         prompt = format_prompt(ctx)
         assert "Gate OK" in prompt
@@ -1496,12 +1932,20 @@ class TestLLMReport_R27:
     def test_validate_output_clean(self):
         """Clean output passes validation."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers={"AAPL", "TSLA"}, known_numbers={"0.65", "2.5"},
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers={"AAPL", "TSLA"},
+            known_numbers={"0.65", "2.5"},
         )
         text = "## 1. 완성도\n시장 환경\n리스크\n시그널\n후보\n전략\n주의\nAAPL 승률 65%\nTSLA PF 2.5"
         result = validate_output(text, ctx)
@@ -1511,12 +1955,20 @@ class TestLLMReport_R27:
     def test_validate_output_hallucinated_ticker(self):
         """Hallucinated ticker is detected."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers={"AAPL"}, known_numbers=set(),
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers={"AAPL"},
+            known_numbers=set(),
         )
         text = "AAPL is good. ZZYZ is also interesting. 완성도 시장 리스크 시그널 후보 전략 주의"
         result = validate_output(text, ctx)
@@ -1525,12 +1977,20 @@ class TestLLMReport_R27:
     def test_validate_output_low_gate_score(self):
         """Low gate score adds warning."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.3,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers=set(), known_numbers=set(),
+            gate_summary="",
+            gate_score=0.3,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers=set(),
+            known_numbers=set(),
         )
         result = validate_output("완성도 시장 리스크 시그널 후보 전략 주의", ctx)
         assert any("완성도" in w for w in result.warnings)
@@ -1538,12 +1998,20 @@ class TestLLMReport_R27:
     def test_validate_output_missing_sections(self):
         """Missing sections add structure warning."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers=set(), known_numbers=set(),
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers=set(),
+            known_numbers=set(),
         )
         result = validate_output("Hello world", ctx)
         assert any("구조" in w for w in result.warnings)
@@ -1551,12 +2019,20 @@ class TestLLMReport_R27:
     def test_validate_output_fabricated_numbers(self):
         """Fabricated numbers detected."""
         from nuri.llm.report import ReportContext, validate_output
+
         ctx = ReportContext(
-            gate_summary="", gate_score=0.8,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
-            known_tickers=set(), known_numbers={"0.65"},
+            gate_summary="",
+            gate_score=0.8,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
+            known_tickers=set(),
+            known_numbers={"0.65"},
         )
         text = "승률 99% PF 8.8 완성도 시장 리스크 시그널 후보 전략 주의"
         result = validate_output(text, ctx)
@@ -1565,11 +2041,18 @@ class TestLLMReport_R27:
     def test_generate_llm_report_gate_blocked(self, monkeypatch):
         """generate_llm_report blocked by low gate score."""
         from nuri.llm.report import ReportContext, generate_llm_report
+
         ctx = ReportContext(
-            gate_summary="Low", gate_score=0.1,
-            regime_section="", macro_section="", risk_section="",
-            candidates_section="", conflicts_section="",
-            drift_section="", consensus_section="", strategy_section="",
+            gate_summary="Low",
+            gate_score=0.1,
+            regime_section="",
+            macro_section="",
+            risk_section="",
+            candidates_section="",
+            conflicts_section="",
+            drift_section="",
+            consensus_section="",
+            strategy_section="",
         )
         monkeypatch.setattr("nuri.llm.report.gather_context", lambda db_path=None: ctx)
         result = generate_llm_report()
@@ -1579,18 +2062,27 @@ class TestLLMReport_R27:
     def test_generate_llm_report_success(self, monkeypatch):
         """generate_llm_report with mocked LLM."""
         from nuri.llm.report import ReportContext, generate_llm_report
+
         ctx = ReportContext(
-            gate_summary="OK", gate_score=0.8,
-            regime_section="bull", macro_section="score 70",
-            risk_section="low", candidates_section="2 buys",
-            conflicts_section="none", drift_section="stable",
-            consensus_section="BUY", strategy_section="aggressive",
-            known_tickers={"AAPL"}, known_numbers={"70", "0.8"},
+            gate_summary="OK",
+            gate_score=0.8,
+            regime_section="bull",
+            macro_section="score 70",
+            risk_section="low",
+            candidates_section="2 buys",
+            conflicts_section="none",
+            drift_section="stable",
+            consensus_section="BUY",
+            strategy_section="aggressive",
+            known_tickers={"AAPL"},
+            known_numbers={"70", "0.8"},
         )
         monkeypatch.setattr("nuri.llm.report.gather_context", lambda db_path=None: ctx)
         monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "")
-        monkeypatch.setattr("nuri.llm.report._generate_ollama",
-                            lambda prompt: "## 1. 완성도 시장 리스크 시그널 후보 전략 주의 AAPL 승률 80%")
+        monkeypatch.setattr(
+            "nuri.llm.report._generate_ollama",
+            lambda prompt: "## 1. 완성도 시장 리스크 시그널 후보 전략 주의 AAPL 승률 80%",
+        )
         result = generate_llm_report()
         assert result["gate_blocked"] is False
         assert result["report"] is not None
@@ -1598,6 +2090,7 @@ class TestLLMReport_R27:
     def test_generate_llm_report_sync(self, monkeypatch):
         """generate_llm_report_sync delegates correctly."""
         from nuri.llm.report import generate_llm_report_sync
+
         monkeypatch.setattr("nuri.llm.report.generate_llm_report", lambda db_path=None: {"test": True})
         result = generate_llm_report_sync()
         assert result == {"test": True}
@@ -1605,17 +2098,20 @@ class TestLLMReport_R27:
     def test_generate_llamacpp_no_path(self):
         """_generate_llamacpp returns empty when no model path."""
         from nuri.llm.report import _generate_llamacpp
+
         result = _generate_llamacpp("test prompt")
         assert result == ""
 
     def test_generate_ollama_connection_error(self, monkeypatch):
-        """_generate_ollama handles connection error."""
+        """_generate_ollama returns '' on connection error (new architecture)."""
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "http://localhost:11434")
         import requests
 
         from nuri.llm.report import _generate_ollama
+
         monkeypatch.setattr(requests, "post", MagicMock(side_effect=requests.ConnectionError))
         result = _generate_ollama("test prompt")
-        assert "연결 실패" in result
+        assert result == ""
 
 
 # ═══════════════════════════════════════════════════════
@@ -1626,11 +2122,128 @@ class TestLLMReport_R27:
 class TestLLMReport_FinalPush:
     def test_import(self):
         import nuri.llm.report as report_mod
+
         assert hasattr(report_mod, "generate_report") or hasattr(report_mod, "generate_llm_report")
 
     @pytest.mark.slow
     def test_context_builder(self, db_path):
         """보고서 컨텍스트 빌드 함수 테스트."""
         from nuri.llm.report import ReportContext, gather_context
+
         ctx = gather_context(db_path=db_path)
         assert isinstance(ctx, ReportContext)
+
+
+# ═══════════════════════════════════════════════════════
+# _generate_openai + fallback chain (2026-04-14 STRATEGY §4.4.3 Tier 2)
+# ═══════════════════════════════════════════════════════
+
+
+class TestGenerateOpenAI:
+    """_generate_openai wraps openai_client.chat_text with Tier 2 gating."""
+
+    def test_returns_text_on_success(self, monkeypatch):
+        fake_client = MagicMock()
+        fake_client.chat_text.return_value = "## 1. 리포트 본문"
+        monkeypatch.setattr("nuri.llm.openai_client.get_client", lambda: fake_client)
+        from nuri.llm.report import _generate_openai
+
+        result = _generate_openai("sys", "user")
+        assert result == "## 1. 리포트 본문"
+        kwargs = fake_client.chat_text.call_args.kwargs
+        assert kwargs["data_tier"] == "tier2"
+
+    def test_disabled_returns_empty(self, monkeypatch):
+        from nuri.llm.openai_client import ExternalLLMDisabled
+
+        fake_client = MagicMock()
+        fake_client.chat_text.side_effect = ExternalLLMDisabled("opt-out")
+        monkeypatch.setattr("nuri.llm.openai_client.get_client", lambda: fake_client)
+        from nuri.llm.report import _generate_openai
+
+        assert _generate_openai("sys", "user") == ""
+
+    def test_zdr_not_approved_returns_empty(self, monkeypatch):
+        from nuri.llm.openai_client import ExternalLLMPolicyViolation
+
+        fake_client = MagicMock()
+        fake_client.chat_text.side_effect = ExternalLLMPolicyViolation("no ZDR")
+        monkeypatch.setattr("nuri.llm.openai_client.get_client", lambda: fake_client)
+        from nuri.llm.report import _generate_openai
+
+        assert _generate_openai("sys", "user") == ""
+
+    def test_network_failure_returns_empty(self, monkeypatch):
+        from nuri.llm.openai_client import ExternalLLMUnavailable
+
+        fake_client = MagicMock()
+        fake_client.chat_text.side_effect = ExternalLLMUnavailable("503")
+        monkeypatch.setattr("nuri.llm.openai_client.get_client", lambda: fake_client)
+        from nuri.llm.report import _generate_openai
+
+        assert _generate_openai("sys", "user") == ""
+
+
+class TestGenerateLLMReportFallbackChain:
+    """generate_llm_report: OpenAI → llama.cpp → Ollama → help-text."""
+
+    def _make_context(self, monkeypatch):
+        from nuri.llm.report import ReportContext
+
+        ctx = ReportContext(
+            gate_summary="OK",
+            gate_score=0.9,
+            regime_section="r",
+            macro_section="m",
+            risk_section="ri",
+            candidates_section="c",
+            conflicts_section="co",
+            drift_section="d",
+            consensus_section="cs",
+            strategy_section="s",
+        )
+        monkeypatch.setattr("nuri.llm.report.gather_context", lambda db_path=None: ctx)
+
+    def test_openai_success_stops_chain(self, monkeypatch):
+        self._make_context(monkeypatch)
+        llamacpp_mock = MagicMock(return_value="SHOULD NOT SEE")
+        ollama_mock = MagicMock(return_value="SHOULD NOT SEE")
+        monkeypatch.setattr(
+            "nuri.llm.report._generate_openai", lambda s, u: "## 1. 완성도 시장 리스크 시그널 후보 전략 주의 정상 응답"
+        )
+        monkeypatch.setattr("nuri.llm.report._generate_llamacpp", llamacpp_mock)
+        monkeypatch.setattr("nuri.llm.report._generate_ollama", ollama_mock)
+        from nuri.llm.report import generate_llm_report
+
+        result = generate_llm_report()
+        assert "정상 응답" in result["report"]
+        llamacpp_mock.assert_not_called()
+        ollama_mock.assert_not_called()
+
+    def test_openai_empty_falls_to_llamacpp(self, monkeypatch):
+        self._make_context(monkeypatch)
+        monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "/fake/model.gguf")
+        monkeypatch.setattr("nuri.llm.report._generate_openai", lambda s, u: "")
+        monkeypatch.setattr(
+            "nuri.llm.report._generate_llamacpp", lambda p: "## 1. 완성도 시장 리스크 시그널 후보 전략 주의 local"
+        )
+        monkeypatch.setattr("nuri.llm.report._generate_ollama", lambda p: "SHOULD NOT SEE")
+        from nuri.llm.report import generate_llm_report
+
+        result = generate_llm_report()
+        assert "local" in result["report"]
+
+    def test_all_fail_yields_help_text(self, monkeypatch):
+        """When every path returns empty, user sees concrete setup guidance."""
+        self._make_context(monkeypatch)
+        monkeypatch.setattr("nuri.llm.report.OLLAMA_HOST", "")
+        monkeypatch.setattr("nuri.llm.report.LLAMA_MODEL_PATH", "")
+        monkeypatch.setattr("nuri.llm.report._generate_openai", lambda s, u: "")
+        monkeypatch.setattr("nuri.llm.report._generate_llamacpp", lambda p: "")
+        monkeypatch.setattr("nuri.llm.report._generate_ollama", lambda p: "")
+        from nuri.llm.report import generate_llm_report
+
+        result = generate_llm_report()
+        assert "OPENAI_API_KEY" in result["report"]
+        assert "LLAMA_MODEL_PATH" in result["report"]
+        assert "OLLAMA_HOST" in result["report"]


### PR DESCRIPTION
## Summary
사용자 Option C 승인: Ollama 휴면 코드를 **OpenAI gpt-5.4-nano**로 대체. \`nuri/llm/report.py\`가 생성하는 일간 LLM 리포트는 보유 종목/손익/에이전트 판단 등 **Tier 2 데이터**를 포함하므로 §4.4.3 정책 개정이 선행.

향후 사용자가 로컬 LLM 인프라(Ollama/llama.cpp) 확정 시 로컬 전환 예정.

## STRATEGY.md 개정 (§2.5 + §4.4.3)
- Tier 2 → OpenAI \`gpt-5.4-nano\` 허용 (ZDR 필수)
- 4개 전제조건 명문화: ZDR, opt-out, no content logging, 로컬 전환 계획
- 비용: 일 1회 ~3K in + 2K out = 연 ~\$0.10

## Code changes
- \`openai_client.py\`: \`chat_text()\` + \`OPENAI_ZDR_APPROVED\` 게이트 + \`ExternalLLMPolicyViolation\` 신규
- \`report.py\`: OpenAI primary → llama.cpp → Ollama → help-text 폴백 체인
- 각 generator는 실패 시 \`\"\"\` 반환, 최종 help-text는 \`generate_llm_report\` 상단에서 조립
- \`ReportContext.known_tickers/numbers\` → \`field(default_factory=set)\` (pylance fix)
- \`.env.example\`: \`OPENAI_ZDR_APPROVED\` 가이드 + OLLAMA/LLAMA는 optional fallback

## Test plan (20 new tests)
- [x] \`tests/llm/test_openai_client.py\`: ZDR gate, tier1 거부, tier2 without/with ZDR, audit log endpoint 라벨링 (13건)
- [x] \`tests/llm/test_report.py\`: \`_generate_openai\` 성공/Disabled/Policy/Unavailable, fallback chain 3단 (7건)
- [x] 기존 Ollama 테스트 7건 수정 (new behavior: \"\" on error)
- [x] 전체 smoke: **2,858 tests pass**, ruff clean

## User action required
Tier 2 호출 전 사용자가 OpenAI ZDR 승인 요청 + \`OPENAI_ZDR_APPROVED=1\` 설정 필요. 미설정 시 wrapper가 \`ExternalLLMPolicyViolation\` raise → \`make report-llm\` 시도 시 OpenAI 스킵 → 로컬 폴백 없으면 help text 반환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)