### PR TITLE
test(coverage): Phase 3 — validate_universe + US_ONLY_TABLES regression tests

### DIFF
--- a/tests/core/test_coverage.py
+++ b/tests/core/test_coverage.py
@@ -15,6 +15,7 @@ import yaml
 from nuri.core.coverage import (
     DATA_THRESHOLDS,
     UNIVERSE_THRESHOLD,
+    US_ONLY_TABLES,
     CoverageCheck,
     _load_universe,
     compute_all_data_coverage,
@@ -228,3 +229,77 @@ class TestConstants:
         assert DATA_THRESHOLDS["analyst_ratings"] == 0.70
         assert DATA_THRESHOLDS["insider_trades"] == 0.50
         assert DATA_THRESHOLDS["superinvestors"] == 0.80
+
+
+# ───────────────────────────────────────────────
+# US_ONLY_TABLES — #288 KR "n/a (US-only)" marker
+# ───────────────────────────────────────────────
+
+
+class TestUsOnlyTables:
+    """Tables whose data source doesn't cover KR (yfinance .KS / SEC EDGAR)."""
+
+    def test_expected_tables_are_us_only(self):
+        """Exact membership — guards against accidental additions/removals."""
+        assert US_ONLY_TABLES == frozenset(
+            {
+                "analyst_ratings",
+                "insider_trades",
+                "superinvestors",
+                "estimates",
+                "earnings_surprises",
+            }
+        )
+
+    def test_prices_and_fundamentals_not_us_only(self):
+        """KR price + fundamental data IS available via yfinance/pykrx."""
+        assert "prices" not in US_ONLY_TABLES
+        assert "fundamentals" not in US_ONLY_TABLES
+
+    def test_data_coverage_detail_notes_kr_unavailable(self, universe_yaml, tmp_path):
+        """compute_data_coverage appends KR-unavailable note to detail for US-only tables."""
+        from nuri.core.db import get_db, init_db
+
+        db = tmp_path / "test.db"
+        init_db(db)
+        with get_db(db) as conn:
+            for t in ["AAPL", "MSFT", "GOOGL", "NVDA"]:
+                conn.execute(
+                    "INSERT INTO analyst_ratings (ticker, date, firm, action, to_grade) VALUES (?, ?, ?, ?, ?)",
+                    (t, "2026-04-14", "Firm", "up", "Buy"),
+                )
+
+        universe = _load_universe(universe_yaml)
+        check = compute_data_coverage("analyst_ratings", 0.70, universe, db_path=db)
+        assert check.passed is True
+        assert "KR n/a" in check.detail or "소스 미지원" in check.detail
+
+    def test_data_coverage_non_us_only_table_omits_kr_note(self, universe_yaml, tmp_path):
+        """Non-US-only tables (prices) should NOT have the KR note."""
+        import pandas as pd
+
+        from nuri.core.db import init_db, upsert_prices
+
+        db = tmp_path / "test.db"
+        init_db(db)
+        df = pd.DataFrame(
+            [
+                {
+                    "ticker": t,
+                    "date": "2026-04-14",
+                    "open": 1,
+                    "high": 2,
+                    "low": 0.5,
+                    "close": 1.5,
+                    "volume": 1000,
+                    "adj_close": 1.5,
+                }
+                for t in ["AAPL", "MSFT", "GOOGL", "NVDA"]
+            ]
+        )
+        upsert_prices(df, db_path=db)
+
+        universe = _load_universe(universe_yaml)
+        check = compute_data_coverage("prices", 0.95, universe, db_path=db)
+        assert "KR n/a" not in check.detail
+        assert "소스 미지원" not in check.detail

--- a/tests/scripts/test_check_universe_coverage.py
+++ b/tests/scripts/test_check_universe_coverage.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/check_universe_coverage.py — #272 Phase 2c + #288 KR label.
+
+Smoke tests for the stdout output format. The script is a diagnostic
+quick-check (not a gate), so we verify:
+1. Runs without crashing on empty / populated DB
+2. US-only tables display "n/a (US-only)" per #288
+3. Non-US-only tables display real KR match percentage
+4. Footer includes the KR explanation note
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def universe_cwd(tmp_path, monkeypatch):
+    """Temp universe.yaml + cwd."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "universe.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "us_core": {"tickers": ["AAPL", "MSFT"]},
+                "kr_kospi200": {"tickers": ["005930.KS", "000660.KS"]},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def populated_db(tmp_path, monkeypatch):
+    import nuri.core.db as db_mod
+    from nuri.core.db import get_db, init_db
+
+    db = tmp_path / "test.db"
+    init_db(db)
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+    with get_db(db) as conn:
+        # prices: US + KR (not US_ONLY)
+        for t in ["AAPL", "MSFT", "005930.KS", "000660.KS"]:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) "
+                "VALUES (?, ?, 1, 2, 0.5, 1.5, 1000, 1.5)",
+                (t, "2026-04-14"),
+            )
+        # analyst_ratings: US only (US_ONLY_TABLES member)
+        for t in ["AAPL", "MSFT"]:
+            conn.execute(
+                "INSERT INTO analyst_ratings (ticker, date, firm, action, to_grade) VALUES (?, ?, 'Firm', 'up', 'Buy')",
+                (t, "2026-04-14"),
+            )
+    return db
+
+
+class TestOutputFormat:
+    def test_runs_on_empty_db(self, universe_cwd, tmp_path, monkeypatch, capsys):
+        """Empty DB: script should run to completion and print zero-counts."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+
+        db = tmp_path / "empty.db"
+        init_db(db)
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+        from scripts.check_universe_coverage import main
+
+        main()
+        out = capsys.readouterr().out
+        assert "Universe Coverage 확인" in out
+        assert "US=2" in out and "KR=2" in out
+
+    def _coverage_section_lines(self, out: str) -> list[str]:
+        """Extract only lines from the [2/2] Universe coverage section.
+
+        The script has two sections: [1/2] raw counts and [2/2] coverage %.
+        Tests for the #288 KR label apply to [2/2] only.
+        """
+        lines = out.splitlines()
+        try:
+            start = next(i for i, ln in enumerate(lines) if "[2/2]" in ln)
+        except StopIteration:
+            return []
+        return lines[start:]
+
+    def test_us_only_tables_show_na_label(self, universe_cwd, populated_db, capsys):
+        """#288: analyst_ratings KR column = 'n/a (US-only)' in coverage section."""
+        from scripts.check_universe_coverage import main
+
+        main()
+        out = capsys.readouterr().out
+        section = self._coverage_section_lines(out)
+
+        analyst_line = next((ln for ln in section if "analyst_ratings" in ln), None)
+        assert analyst_line is not None
+        assert "n/a (US-only)" in analyst_line
+        # Explicit: no KR percentage like "0/2 (0%)" for US-only tables
+        assert "0/2" not in analyst_line
+
+    def test_non_us_only_tables_show_real_kr_percentage(self, universe_cwd, populated_db, capsys):
+        """prices: KR column shows X/2 (Y%) in coverage section."""
+        from scripts.check_universe_coverage import main
+
+        main()
+        out = capsys.readouterr().out
+        section = self._coverage_section_lines(out)
+
+        prices_line = next((ln for ln in section if ln.strip().startswith("prices")), None)
+        assert prices_line is not None
+        assert "n/a (US-only)" not in prices_line
+        # Real KR match: 2/2 (100%)
+        assert "2/2" in prices_line
+
+    def test_footer_explains_us_only_label(self, universe_cwd, populated_db, capsys):
+        """Footer teaches the reader what 'n/a (US-only)' means — a docs invariant."""
+        from scripts.check_universe_coverage import main
+
+        main()
+        out = capsys.readouterr().out
+        assert "소스 한계" in out or "소스(yfinance .KS / SEC EDGAR)" in out
+
+    def test_missing_universe_yaml_does_not_crash(self, tmp_path, monkeypatch, capsys):
+        """Script prints error and returns instead of exception when yaml missing."""
+        monkeypatch.chdir(tmp_path)
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+
+        db = tmp_path / "x.db"
+        init_db(db)
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+        from scripts.check_universe_coverage import main
+
+        main()  # should not raise
+        out = capsys.readouterr().out
+        assert "config/universe.yaml 없음" in out

--- a/tests/scripts/test_validate_universe.py
+++ b/tests/scripts/test_validate_universe.py
@@ -1,0 +1,229 @@
+"""Tests for scripts/validate_universe.py — #272 Phase 2c CLI gate.
+
+Network-free: `fetch_upstream_universes` is always mocked. Tests verify:
+1. run_validation assembles checks correctly with/without fetch
+2. print_table formats without crashing
+3. main() returns correct exit codes (0 PASS, 1 FAIL)
+4. --format json and --no-fetch flags wire through
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from nuri.core.coverage import CoverageCheck
+
+
+@pytest.fixture
+def universe_cwd(tmp_path, monkeypatch):
+    """Temp universe.yaml + cwd for _load_universe to find it."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "universe.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "us_core": {"tickers": ["AAPL", "MSFT"]},
+                "us_sp500_extended": {"tickers": ["GOOGL"]},
+                "kr_kospi200": {"tickers": ["005930.KS"]},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def db_with_data(tmp_path, monkeypatch):
+    """DB with enough data to pass coverage thresholds."""
+    import pandas as pd
+
+    import nuri.core.db as db_mod
+    from nuri.core.db import get_db, init_db
+
+    db = tmp_path / "test.db"
+    init_db(db)
+    monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+    # Populate prices + fundamentals for AAPL/MSFT/GOOGL (3/3 = 100% US coverage)
+    with get_db(db) as conn:
+        for t in ["AAPL", "MSFT", "GOOGL"]:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) "
+                "VALUES (?, ?, 1, 2, 0.5, 1.5, 1000, 1.5)",
+                (t, "2026-04-14"),
+            )
+            conn.execute(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?, ?, 20)",
+                (t, "2026-04-14"),
+            )
+            conn.execute(
+                "INSERT INTO analyst_ratings (ticker, date, firm, action, to_grade) VALUES (?, ?, 'F', 'up', 'Buy')",
+                (t, "2026-04-14"),
+            )
+            conn.execute(
+                "INSERT INTO insider_trades (ticker, date, insider_name, transaction_type, shares) "
+                "VALUES (?, ?, 'x', 'P', 100)",
+                (t, "2026-04-14"),
+            )
+            conn.execute(
+                "INSERT INTO superinvestors (investor, filing_date, ticker, shares, market_value, portfolio_pct) "
+                "VALUES ('Buffett', '2026-02-17', ?, 100, 1000, 1.0)",
+                (t,),
+            )
+    return db
+
+
+# ═══════════════════════════════════════════════════════
+# run_validation
+# ═══════════════════════════════════════════════════════
+
+
+class TestRunValidation:
+    def test_no_fetch_skips_upstream_checks(self, universe_cwd, db_with_data):
+        """--no-fetch path: only data table checks, no universe.yaml vs upstream."""
+        from scripts.validate_universe import run_validation
+
+        checks, exit_code = run_validation(fetch=False)
+
+        # 5 data checks, no universe.* checks
+        names = [c.name for c in checks]
+        assert all(n.startswith("data.") for n in names)
+        assert len(checks) == 5
+        assert exit_code == 0
+
+    def test_all_checks_pass_with_complete_data(self, universe_cwd, db_with_data):
+        """With full DB, all 5 data checks should PASS."""
+        from scripts.validate_universe import run_validation
+
+        checks, exit_code = run_validation(fetch=False)
+        assert exit_code == 0
+        assert all(c.passed for c in checks)
+
+    def test_empty_db_yields_fail_exit_code(self, universe_cwd, tmp_path, monkeypatch):
+        """Empty DB → coverage 0% → FAIL on all thresholds."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+        from scripts.validate_universe import run_validation
+
+        db = tmp_path / "empty.db"
+        init_db(db)
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+        _, exit_code = run_validation(fetch=False)
+        assert exit_code == 1
+
+    def test_fetch_mode_includes_upstream_checks(self, universe_cwd, db_with_data):
+        """fetch=True should add universe.us_sp500 + universe.kr_kospi200 checks."""
+        from scripts.validate_universe import run_validation
+
+        with patch("scripts.validate_universe.fetch_upstream_universes") as mock_fetch:
+            # Return upstreams that fully match the fixture universe.yaml
+            mock_fetch.return_value = (
+                {"AAPL", "MSFT", "GOOGL"},  # us
+                {"005930.KS"},  # kr
+            )
+            checks, exit_code = run_validation(fetch=True)
+
+        names = [c.name for c in checks]
+        assert "universe.us_sp500" in names
+        assert "universe.kr_kospi200" in names
+        assert exit_code == 0
+
+
+# ═══════════════════════════════════════════════════════
+# print_table — smoke (no crash)
+# ═══════════════════════════════════════════════════════
+
+
+class TestPrintTable:
+    def test_print_table_pass_only(self, capsys):
+        from scripts.validate_universe import print_table
+
+        checks = [CoverageCheck("data.prices", 0.99, 0.95, "PASS", "537/543")]
+        print_table(checks)
+        out = capsys.readouterr().out
+        assert "✅ PASS" in out
+        assert "data.prices" in out
+        assert "exit 0" in out
+
+    def test_print_table_fail_with_detail(self, capsys):
+        from scripts.validate_universe import print_table
+
+        checks = [CoverageCheck("data.prices", 0.50, 0.95, "FAIL", "short data")]
+        print_table(checks)
+        out = capsys.readouterr().out
+        assert "🔴 FAIL" in out
+        assert "short data" in out
+        assert "exit 1" in out
+
+
+# ═══════════════════════════════════════════════════════
+# main() CLI
+# ═══════════════════════════════════════════════════════
+
+
+class TestMain:
+    def test_main_no_fetch_exit_zero(self, universe_cwd, db_with_data, monkeypatch):
+        from scripts.validate_universe import main
+
+        monkeypatch.setattr("sys.argv", ["validate_universe.py", "--no-fetch"])
+        assert main() == 0
+
+    def test_main_json_format_emits_valid_json(self, universe_cwd, db_with_data, monkeypatch, capsys):
+        from scripts.validate_universe import main
+
+        monkeypatch.setattr("sys.argv", ["validate_universe.py", "--no-fetch", "--format", "json"])
+        rc = main()
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert rc == 0
+        assert parsed["exit_code"] == 0
+        assert "checks" in parsed
+        assert len(parsed["checks"]) == 5
+
+    def test_main_table_format_prints_header(self, universe_cwd, db_with_data, monkeypatch, capsys):
+        from scripts.validate_universe import main
+
+        monkeypatch.setattr("sys.argv", ["validate_universe.py", "--no-fetch"])
+        main()
+        out = capsys.readouterr().out
+        assert "Universe + Agent Coverage Validation" in out
+
+
+# ═══════════════════════════════════════════════════════
+# fetch_upstream_universes — network-mocked
+# ═══════════════════════════════════════════════════════
+
+
+class TestFetchUpstream:
+    def test_both_sources_fail_returns_empty_sets(self, capsys):
+        from scripts.validate_universe import fetch_upstream_universes
+
+        with (
+            patch("nuri.collectors.universe_sync._fetch_sp500_from_wikipedia", side_effect=RuntimeError("wiki down")),
+            patch("nuri.collectors.universe_sync._fetch_kospi200", side_effect=RuntimeError("krx down")),
+        ):
+            us, kr = fetch_upstream_universes()
+
+        assert us == set()
+        assert kr == set()
+        err = capsys.readouterr().err
+        assert "S&P 500 fetch 실패" in err
+        assert "KOSPI 200 fetch 실패" in err
+
+    def test_partial_success_returns_one_empty(self):
+        """US succeeds, KR fails → US populated, KR empty."""
+        from scripts.validate_universe import fetch_upstream_universes
+
+        with (
+            patch("nuri.collectors.universe_sync._fetch_sp500_from_wikipedia", return_value=["AAPL", "MSFT"]),
+            patch("nuri.collectors.universe_sync._fetch_kospi200", side_effect=RuntimeError("krx 500")),
+        ):
+            us, kr = fetch_upstream_universes()
+
+        assert us == {"AAPL", "MSFT"}
+        assert kr == set()


### PR DESCRIPTION
## Summary
#272 Phase 3 (Eval): 20 신규 regression tests 추가.

Phase 2c (validate_universe.py) + #288 (KR "n/a (US-only)" label) 관련 코드의 회귀 방지.

## Coverage gaps closed

| 대상 | 이전 | 신규 |
|------|------|------|
| \`nuri/core/coverage.py\` \`US_ONLY_TABLES\` | 0 tests | **4** |
| \`scripts/validate_universe.py\` | 0 tests | **11** |
| \`scripts/check_universe_coverage.py\` | 0 tests | **5** |

## New tests

### \`TestUsOnlyTables\` (tests/core/test_coverage.py, +4)
- \`US_ONLY_TABLES\` frozenset 정확한 멤버 (analyst_ratings/insider_trades/superinvestors/estimates/earnings_surprises)
- prices/fundamentals 는 제외 (KR 커버)
- \`compute_data_coverage\` detail에 \"(KR n/a — 소스 미지원)\" 부착 확인
- 비-US_ONLY는 KR note 없음

### \`TestRunValidation\` + \`TestPrintTable\` + \`TestMain\` + \`TestFetchUpstream\` (tests/scripts/test_validate_universe.py, +11, NEW)
- run_validation: no-fetch 모드, 전체 PASS 케이스, 빈 DB FAIL
- fetch=True: universe.us_sp500 + kr_kospi200 체크 추가
- print_table PASS/FAIL 포맷
- main(): --no-fetch, --format json/table
- fetch_upstream_universes: 양쪽 실패 / 부분 성공

### \`TestOutputFormat\` (tests/scripts/test_check_universe_coverage.py, +5, NEW)
- 빈 DB 실행 가능
- US_ONLY 테이블의 "n/a (US-only)" 표시 (#288)
- 비-US_ONLY 테이블의 실제 KR %
- footer의 소스 한계 설명
- universe.yaml 없을 때 graceful fail

## Test plan
- [x] 39/39 pass locally (\`pytest tests/core/test_coverage.py tests/scripts/test_validate_universe.py tests/scripts/test_check_universe_coverage.py\`)
- [x] ruff clean
- [x] 전체 test suite 영향 없음 (network-free, tmp_path 격리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)