### PR TITLE
feat(ui): #272 Phase 4 — Dashboard coverage widget + /api/coverage

### DIFF
--- a/frontend/src/__tests__/components/coverage-status.test.tsx
+++ b/frontend/src/__tests__/components/coverage-status.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CoverageStatus, type CoverageData } from "@/components/ui/coverage-status";
+
+function makeData(overrides: Partial<CoverageData> = {}): CoverageData {
+  return {
+    pass: 5,
+    fail: 0,
+    exit_code: 0,
+    checks: [
+      { name: "data.prices", actual: 0.99, threshold: 0.95, status: "PASS",
+        detail: "537/543 US tickers", us_only: false },
+      { name: "data.fundamentals", actual: 0.99, threshold: 0.80, status: "PASS",
+        detail: "537/543 US tickers", us_only: false },
+      { name: "data.analyst_ratings", actual: 0.97, threshold: 0.70, status: "PASS",
+        detail: "528/543 US tickers (KR n/a — 소스 미지원)", us_only: true },
+      { name: "data.insider_trades", actual: 0.97, threshold: 0.50, status: "PASS",
+        detail: "526/543 US tickers (KR n/a — 소스 미지원)", us_only: true },
+      { name: "data.superinvestors", actual: 0.97, threshold: 0.80, status: "PASS",
+        detail: "524/543 US tickers (KR n/a — 소스 미지원)", us_only: true },
+    ],
+    ...overrides,
+  };
+}
+
+describe("CoverageStatus", () => {
+  it("renders 5/5 PASS header when all checks pass", () => {
+    render(<CoverageStatus data={makeData()} />);
+    expect(screen.getByText(/5\/5 PASS/)).toBeInTheDocument();
+  });
+
+  it("renders FAIL header when any check fails", () => {
+    const data = makeData({ pass: 3, fail: 2, exit_code: 1 });
+    data.checks[0] = { ...data.checks[0], status: "FAIL" };
+    data.checks[1] = { ...data.checks[1], status: "FAIL" };
+    render(<CoverageStatus data={data} />);
+    expect(screen.getByText(/3\/5 PASS/)).toBeInTheDocument();
+  });
+
+  it("renders table with all 5 checks and strips 'data.' prefix", () => {
+    render(<CoverageStatus data={makeData()} />);
+    expect(screen.getByText("prices")).toBeInTheDocument();
+    expect(screen.getByText("fundamentals")).toBeInTheDocument();
+    expect(screen.getByText("analyst_ratings")).toBeInTheDocument();
+    expect(screen.getByText("insider_trades")).toBeInTheDocument();
+    expect(screen.getByText("superinvestors")).toBeInTheDocument();
+  });
+
+  it("shows 'n/a (US-only)' label in KR column for US_ONLY_TABLES (#288)", () => {
+    render(<CoverageStatus data={makeData()} />);
+    const naLabels = screen.getAllByText("n/a (US-only)");
+    // 3 US_ONLY tables (analyst_ratings, insider_trades, superinvestors)
+    expect(naLabels).toHaveLength(3);
+  });
+
+  it("shows real KR match count for non-US-only tables", () => {
+    const data = makeData();
+    // Mutate detail for prices to include explicit "537/543"
+    data.checks[0] = { ...data.checks[0], detail: "537/543 US tickers" };
+    render(<CoverageStatus data={data} />);
+    // 537/543 appears in the KR column (non-US-only extracts it from detail)
+    expect(screen.getAllByText("537/543").length).toBeGreaterThan(0);
+  });
+
+  it("includes footer note explaining 'n/a (US-only)' semantics", () => {
+    render(<CoverageStatus data={makeData()} />);
+    expect(screen.getByText(/소스가 KR 종목 미지원/)).toBeInTheDocument();
+  });
+
+  it("omits footer note when no US_ONLY tables present", () => {
+    const data = makeData();
+    data.checks = data.checks.map((c) => ({ ...c, us_only: false }));
+    render(<CoverageStatus data={data} />);
+    expect(screen.queryByText(/소스가 KR 종목 미지원/)).not.toBeInTheDocument();
+  });
+
+  it("renders error state when data.error is set", () => {
+    const data: CoverageData = {
+      pass: 0, fail: 0, exit_code: 1, checks: [],
+      error: "coverage computation failed",
+    };
+    render(<CoverageStatus data={data} />);
+    expect(screen.getByText(/Coverage 확인 실패/)).toBeInTheDocument();
+    expect(screen.getByText(/coverage computation failed/)).toBeInTheDocument();
+  });
+
+  it("displays percentage formatting for actual and threshold columns", () => {
+    render(<CoverageStatus data={makeData()} />);
+    // prices: 99% actual, ≥95% threshold
+    expect(screen.getAllByText("99%").length).toBeGreaterThan(0);
+    expect(screen.getByText("≥95%")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import { fetchAPI } from "@/lib/api";
 
 import { StatusBadge } from "@/components/ui/status-badge";
 import { FreshnessBar, type FreshnessItem } from "@/components/ui/freshness-bar";
+import { CoverageStatus } from "@/components/ui/coverage-status";
 import { HoldingRow, buildEnrichedHoldings, type RawAction, type RawTarget, type RawAdvisorAction, type RawEvent } from "@/components/ui/holding-row";
 import { CollapsibleStrip } from "@/components/ui/collapsible-strip";
 import { HeroStats } from "@/components/ui/hero-stats";
@@ -130,7 +131,7 @@ async function Dashboard({
   const compositionTab = parseCompositionTab(params.comp);
   const holdingsExpanded = params.holdings === "expanded";
 
-  const [d, freshness, pipelineStatus, portfolio, siege, advisor, targets, actionsData, opportunitiesData, marketCtx] = await Promise.all([
+  const [d, freshness, pipelineStatus, portfolio, siege, advisor, targets, actionsData, opportunitiesData, marketCtx, coverage] = await Promise.all([
     fetchAPI<DashboardData>("/api/dashboard"),
     fetchAPI<FreshnessData>("/api/freshness").catch((): FreshnessData => ({ items: [], details: [], overall: "FAIL", pass: 0, warn: 0, fail: 0 })),
     fetchAPI<PipelineStatusData>("/api/pipeline/status").catch((): PipelineStatusData => ({ steps: [] })),
@@ -144,6 +145,7 @@ async function Dashboard({
     fetchAPI<any>("/api/actions").catch(() => ({ urgent: [], check: [], hold: [] })),
     fetchAPI<any>("/api/opportunities").catch(() => ({ opportunities: [] })),
     fetchAPI<any>("/api/market-context").catch(() => ({ macro_events: [], system_health: {} })),
+    fetchAPI<import("@/components/ui/coverage-status").CoverageData>("/api/coverage").catch(() => null),
   ]);
 
   const holdingCount = portfolio?.count ?? portfolio?.holdings?.length ?? 0;
@@ -501,6 +503,13 @@ async function Dashboard({
             </Link>
           </div>
           <OpportunityExplorer opportunities={(opportunitiesData?.opportunities ?? []).slice(0, 3)} />
+        </div>
+      )}
+
+      {/* ═══ Data Coverage (#272 Phase 4) ═══ */}
+      {coverage && !coverage.error && coverage.checks?.length > 0 && (
+        <div className="pt-2">
+          <CoverageStatus data={coverage} />
         </div>
       )}
 

--- a/frontend/src/components/ui/coverage-status.tsx
+++ b/frontend/src/components/ui/coverage-status.tsx
@@ -1,0 +1,107 @@
+/**
+ * CoverageStatus — Universe + Agent 데이터 coverage 표시 위젯 (#272 Phase 4).
+ *
+ * Backend `/api/coverage` 응답을 테이블로 렌더. US-only 테이블의 KR 컬럼은
+ * `n/a (US-only)` 로 표시 (#288 컨벤션).
+ *
+ * PASS=emerald, FAIL=red. 모든 체크 PASS 시 헤더 "5/5 PASS" 녹색.
+ */
+
+export interface CoverageCheck {
+  name: string;
+  actual: number;
+  threshold: number;
+  status: "PASS" | "FAIL";
+  detail: string;
+  us_only: boolean;
+}
+
+export interface CoverageData {
+  pass: number;
+  fail: number;
+  exit_code: 0 | 1;
+  checks: CoverageCheck[];
+  error?: string;
+}
+
+function displayName(name: string): string {
+  // "data.analyst_ratings" → "analyst_ratings"
+  return name.replace(/^data\./, "");
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function krColumnText(c: CoverageCheck): string {
+  if (c.us_only) return "n/a (US-only)";
+  // For non-US-only, the detail already includes the ticker count;
+  // extract just the first "X/Y" fragment if present, else show detail.
+  const match = c.detail.match(/(\d+\/\d+)/);
+  return match ? match[1] : c.detail;
+}
+
+export function CoverageStatus({ data }: { data: CoverageData }) {
+  if (data.error) {
+    return (
+      <div className="rounded-md border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-400">
+        Coverage 확인 실패: {data.error}
+      </div>
+    );
+  }
+
+  const allPass = data.fail === 0;
+  const total = data.checks.length;
+  const headerColor = allPass ? "text-emerald-400" : "text-red-400";
+  const headerIcon = allPass ? "\u2705" : "\u274C";
+
+  return (
+    <div className="rounded-md border border-border bg-card/40 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Data Coverage
+        </span>
+        <span className={`text-sm font-medium ${headerColor}`}>
+          {headerIcon} {data.pass}/{total} PASS
+        </span>
+      </div>
+
+      <table className="w-full text-[12px]">
+        <thead className="text-left text-muted-foreground/70">
+          <tr className="border-b border-border/50">
+            <th className="py-1 font-normal">Table</th>
+            <th className="py-1 text-right font-normal">US</th>
+            <th className="py-1 text-right font-normal">KR</th>
+            <th className="py-1 text-right font-normal">Threshold</th>
+            <th className="py-1 text-right font-normal">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.checks.map((c) => {
+            const statusStyle = c.status === "PASS" ? "text-emerald-400" : "text-red-400";
+            const krStyle = c.us_only ? "text-muted-foreground/60 italic" : "text-foreground";
+            return (
+              <tr key={c.name} className="border-b border-border/30 last:border-0">
+                <td className="py-1 font-mono">{displayName(c.name)}</td>
+                <td className="py-1 text-right font-mono">{formatPercent(c.actual)}</td>
+                <td className={`py-1 text-right font-mono ${krStyle}`}>{krColumnText(c)}</td>
+                <td className="py-1 text-right font-mono text-muted-foreground/70">
+                  &ge;{formatPercent(c.threshold)}
+                </td>
+                <td className={`py-1 text-right font-medium ${statusStyle}`}>
+                  {c.status}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {data.checks.some((c) => c.us_only) && (
+        <p className="mt-2 text-[10px] text-muted-foreground/60">
+          KR &quot;n/a (US-only)&quot;: yfinance .KS / SEC EDGAR 소스가 KR 종목 미지원 (수집 실패 아님).
+        </p>
+      )}
+    </div>
+  );
+}

--- a/nuri/api/main.py
+++ b/nuri/api/main.py
@@ -10,6 +10,7 @@ Nuri-Quant FastAPI — Phase A~E 분석 결과를 JSON API로 제공.
     API_KEY=xxx → 간단한 API 키 인증
     API_SECRET_KEY=xxx → JWT 서명 키
 """
+
 import logging
 import os
 
@@ -27,6 +28,7 @@ from slowapi.util import get_remote_address
 from nuri.api.routes import (
     actions,
     agents,
+    coverage,
     dashboard,
     decisions,
     engine,
@@ -81,6 +83,7 @@ app.add_middleware(
     allow_credentials=True,
 )
 
+
 # ─── 보안 헤더 미들웨어 ───
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
@@ -99,6 +102,7 @@ app.include_router(portfolio.router, prefix="/api")
 app.include_router(regime.router, prefix="/api")
 app.include_router(signals.router, prefix="/api")
 app.include_router(rebalance.router, prefix="/api")
+app.include_router(coverage.router, prefix="/api")
 app.include_router(engine.router, prefix="/api")
 app.include_router(pipeline.router, prefix="/api")
 app.include_router(agents.router, prefix="/api")
@@ -139,6 +143,7 @@ async def login(request: Request):
 def root():
     """API root → redirect to docs."""
     from fastapi.responses import RedirectResponse
+
     return RedirectResponse(url="/docs")
 
 
@@ -151,5 +156,6 @@ if __name__ == "__main__":
     import os
 
     import uvicorn
+
     port = int(os.getenv("API_PORT", "8001"))
     uvicorn.run("nuri.api.main:app", host="0.0.0.0", port=port, reload=True)

--- a/nuri/api/routes/coverage.py
+++ b/nuri/api/routes/coverage.py
@@ -1,0 +1,58 @@
+"""Universe + Agent coverage API (#272 Phase 4).
+
+Frontend의 Dashboard widget이 5/5 PASS 현황을 시각적으로 표시할 수 있도록
+`nuri.core.coverage`의 순수 함수 결과를 JSON 으로 노출.
+
+KR "n/a (US-only)" 구분은 `US_ONLY_TABLES` 멤버십으로 결정 (#288 참고).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["coverage"])
+
+
+@router.get("/coverage")
+def get_coverage() -> dict:
+    """Universe + Agent 데이터 coverage 현황.
+
+    Returns:
+        {
+            "pass": int, "fail": int, "exit_code": 0|1,
+            "checks": [
+                {
+                    "name": "data.prices",
+                    "actual": 0.99, "threshold": 0.95,
+                    "status": "PASS"|"FAIL",
+                    "detail": "537/543 US tickers (KR n/a — 소스 미지원)",
+                    "us_only": true|false,
+                },
+                ...
+            ],
+        }
+    """
+    try:
+        from nuri.core.coverage import (
+            US_ONLY_TABLES,
+            compute_all_data_coverage,
+            summary,
+        )
+
+        checks = compute_all_data_coverage()
+        payload = summary(checks)
+
+        # Annotate each check with `us_only` flag so the frontend can render
+        # the "n/a (US-only)" KR label without re-implementing the heuristic.
+        for c in payload["checks"]:
+            table_name = c["name"].replace("data.", "", 1)
+            c["us_only"] = table_name in US_ONLY_TABLES
+
+        return payload
+    except Exception:
+        # Avoid leaking stack traces in HTTP responses (CodeQL py/stack-trace-exposure).
+        logger.exception("coverage computation failed")
+        return {"error": "coverage computation failed"}

--- a/tests/api/test_coverage.py
+++ b/tests/api/test_coverage.py
@@ -1,0 +1,114 @@
+"""Tests for nuri.api.routes.coverage — #272 Phase 4 UX backend.
+
+Exposes `compute_all_data_coverage()` results via REST so the Dashboard
+widget can render PASS/FAIL status + KR "n/a (US-only)" labels.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+
+class TestCoverageEndpoint:
+    def test_returns_200_and_shape(self, client, tmp_path, monkeypatch):
+        """GET /api/coverage returns {pass, fail, exit_code, checks[]}."""
+        # Write temp universe.yaml so compute_all_data_coverage has something
+        cfg = tmp_path / "config"
+        cfg.mkdir(exist_ok=True)
+        (cfg / "universe.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "us_core": {"tickers": ["AAPL", "MSFT"]},
+                    "kr_kospi200": {"tickers": ["005930.KS"]},
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+
+        r = client.get("/api/coverage")
+        assert r.status_code == 200
+        data = r.json()
+        assert set(data.keys()) >= {"pass", "fail", "exit_code", "checks"}
+        assert isinstance(data["checks"], list)
+        assert len(data["checks"]) == 5  # 5 data tables per Spec §2.2
+
+    def test_each_check_has_us_only_flag(self, client, tmp_path, monkeypatch):
+        """Each check exposes `us_only: bool` so frontend renders KR label."""
+        cfg = tmp_path / "config"
+        cfg.mkdir(exist_ok=True)
+        (cfg / "universe.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "us_core": {"tickers": ["AAPL"]},
+                    "kr_kospi200": {"tickers": ["005930.KS"]},
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+
+        data = client.get("/api/coverage").json()
+        for c in data["checks"]:
+            assert "us_only" in c
+            assert isinstance(c["us_only"], bool)
+            # name format "data.<table>"
+            assert c["name"].startswith("data.")
+
+    def test_us_only_flag_matches_table_set(self, client, tmp_path, monkeypatch):
+        """analyst_ratings/insider_trades/superinvestors/estimates/earnings_surprises
+        → us_only=True; prices/fundamentals → False."""
+        cfg = tmp_path / "config"
+        cfg.mkdir(exist_ok=True)
+        (cfg / "universe.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "us_core": {"tickers": ["AAPL"]},
+                    "kr_kospi200": {"tickers": ["005930.KS"]},
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+
+        data = client.get("/api/coverage").json()
+        flags = {c["name"]: c["us_only"] for c in data["checks"]}
+
+        assert flags["data.prices"] is False
+        assert flags["data.fundamentals"] is False
+        assert flags["data.analyst_ratings"] is True
+        assert flags["data.insider_trades"] is True
+        assert flags["data.superinvestors"] is True
+
+    def test_check_fields_include_status_and_detail(self, client, tmp_path, monkeypatch):
+        """Each check has actual/threshold/status/detail for UI rendering."""
+        cfg = tmp_path / "config"
+        cfg.mkdir(exist_ok=True)
+        (cfg / "universe.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "us_core": {"tickers": ["AAPL"]},
+                    "kr_kospi200": {"tickers": ["005930.KS"]},
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+
+        data = client.get("/api/coverage").json()
+        c0 = data["checks"][0]
+        assert set(c0.keys()) >= {"name", "actual", "threshold", "status", "detail", "us_only"}
+        assert c0["status"] in ("PASS", "FAIL")
+        assert 0.0 <= c0["actual"] <= 1.0
+        assert 0.0 < c0["threshold"] <= 1.0
+
+    def test_error_path_returns_json(self, client, tmp_path, monkeypatch):
+        """Missing universe.yaml → still 200 with error key, never 500.
+
+        The endpoint catches exceptions and returns a JSON body (CodeQL
+        py/stack-trace-exposure invariant)."""
+        # No universe.yaml in cwd
+        monkeypatch.chdir(tmp_path)
+
+        r = client.get("/api/coverage")
+        assert r.status_code == 200
+        # Either computed with empty universe (FAIL all) OR error JSON —
+        # either way it's a valid dict, no 500
+        data = r.json()
+        assert isinstance(data, dict)


### PR DESCRIPTION
## Summary
#272 Phase 4 (UX): Dashboard에 Universe+Agent coverage 현황 표시.

## Backend (+96 lines)
- \`nuri/api/routes/coverage.py\` 신규 — \`GET /api/coverage\`
- \`compute_all_data_coverage()\` 결과를 JSON 으로 노출 + \`us_only\` flag 주입
- Exception 경로는 JSON error 반환 (CodeQL py/stack-trace-exposure)

## Frontend (+130 lines)
- \`CoverageStatus\` widget — 5/5 PASS 헤더 + 5-column 테이블
- US_ONLY 테이블의 KR 컬럼 "n/a (US-only)" italic muted (#288 컨벤션)
- 비-US_ONLY는 detail에서 X/Y 매치 카운트 추출
- 하단 설명 footer ("소스 한계 — 수집 실패 아님")
- Dashboard page.tsx 통합 (footer 위 렌더)

## Tests (+14)
- \`tests/api/test_coverage.py\`: 5 (shape, us_only flag, table mapping, field contract, error path)
- \`frontend/src/__tests__/components/coverage-status.test.tsx\`: 9 (PASS header, FAIL header, 5 rows, US-only 3 labels, 실제 KR match, footer conditional, error state, % format)

## Test plan
- [x] \`pytest tests/api/test_coverage.py\` → 5/5 PASS
- [x] \`npx vitest run coverage-status\` → 9/9 PASS
- [x] \`npx vitest run dashboard\` → 41/41 PASS (no regression)
- [x] \`npx tsc --noEmit\` clean
- [x] \`ruff check\` clean
- [x] Live smoke: \`GET /api/coverage\` returns correct 5-check payload

## Visual
Dashboard footer 위 새 위젯:
\`\`\`
  DATA COVERAGE                                    ✅ 5/5 PASS
  Table            US      KR              Threshold   Status
  prices           99%     537/543         ≥95%        PASS
  fundamentals     99%     537/543         ≥80%        PASS
  analyst_ratings  97%     n/a (US-only)   ≥70%        PASS
  insider_trades   97%     n/a (US-only)   ≥50%        PASS
  superinvestors   97%     n/a (US-only)   ≥80%        PASS

  KR "n/a (US-only)": yfinance .KS / SEC EDGAR 소스가 KR 종목 미지원 (수집 실패 아님).
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)