### PR TITLE
docs(strategy): §7 Tier 1/2 재정렬 + 다음 세션 priority matrix (2026-04-14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Harness Principles
 
-See `docs/STRATEGY.md` §5.8 — six principles (모르면 읽는다 / 2번 실패하면 접근을 바꾼다 / 수정 후 실행한다 / 스코프를 지킨다 / 숫자를 grep한다 / 시스템이 차단한다). STRATEGY.md is the canonical source; do not duplicate the list here.
+See `docs/STRATEGY.md` §5.8 — seven principles (모르면 읽는다 / 2번 실패하면 접근을 바꾼다 / 사용자 워크플로로 검증한다 / 스코프를 지킨다 / 숫자를 grep한다 / 시스템이 차단한다 / 외부 API는 측정한다). STRATEGY.md is the canonical source; do not duplicate the list here.
+
+**Work status & changelog**: `docs/STRATEGY.md §7` manages Tier 1 (완료) / Tier 2 (next) backlog. Historical commits live in `git log` — do not re-document.
 
 ## Project
 
@@ -102,11 +104,12 @@ make rebalance        # 규칙 위반 감지 + 매도 수량 제시
 make evidence         # 5개 Plotly 증거 차트 생성 (data/reports/{date}/evidence/)
 make external         # 외부 데이터 요약 (TipRanks, Dataroma, ARK 등)
 make report            # Daily report (Discord/stdout)
-make report-llm       # Qwen3.5 LLM 리포트 생성 + 자동 저장
+make report-llm       # LLM 리포트 (OpenAI gpt-5.4-nano primary, §4.4.3 Tier 2 — OPENAI_ZDR_APPROVED=1 필수)
 
 # Lint + Test
 make lint             # ruff check
 make lint-fix         # ruff check --fix
+make lint-sh          # shellcheck scripts/*.sh (brew install shellcheck 필요)
 make test             # pytest tests/ -v --cov=nuri (full suite, ~50s local)
 make test-fast        # -m "not slow" — slow LLM tests 제외 (~24s, PR CI 기본)
 make test-slow        # slow tests only
@@ -169,7 +172,7 @@ nuri/
 │   ├── recommend/     # Candidates, rebalance, tracker, price_targets
 │   ├── swing/         # Market-wide scanner + rules
 │   └── execution/     # Broker interface (Alpaca paper + DryRun)
-├── api/               # FastAPI REST API (68 endpoints, routes/ incl. actions/opportunities/market-context)
+├── api/               # FastAPI REST API (69 endpoints, routes/ incl. actions/opportunities/market-context/coverage)
 ├── alerts/            # Discord daily report + bot, Telegram alerts
 └── llm/               # LLM report (Ollama) + OpenAI wrapper + event classifier
 ```
@@ -183,6 +186,7 @@ nuri/
 - **SIEGE 11-gate**: All recommendations must pass 11 conditions. See `nuri/trading/engine/CLAUDE.md`.
 - **20 signals, YAML registry**: `config/signals.yaml` drives `signal_backtest.py`. See `docs/ARCHITECTURE.md`.
 - **Regime classifier**: 6 base + 4 special regimes. See `docs/ARCHITECTURE.md`.
+- **External LLM gateway**: `nuri/llm/openai_client.py` is the ONLY external LLM entry point. Direct `import openai` forbidden. `chat_json` (Tier 0 JSON) / `chat_text` (Tier 2 narrative, ZDR-gated). Every call audit-logged to `external_llm_calls` (content never stored). Policy: `docs/STRATEGY.md §4.4.3`.
 
 ## Code Conventions
 
@@ -209,6 +213,9 @@ nuri/
 - **yfinance .KS fundamentals work**: Contrary to some code comments, `yfinance.Ticker("005930.KS").info` returns PE, ROE, margins, growth, debt for Korean individual stocks. ETFs return empty (expected). KIS API is NOT needed for fundamentals.
 - **pykrx API instability**: `get_market_fundamental`, `get_index_ohlcv`, `get_market_trading_value_by_date` — all broken (column name changes). KOSPI/KOSDAQ index collection uses yfinance `^KS11`/`^KQ11` fallback. Institutional flows currently unavailable.
 - **Macro event pipeline** (PR #249-#253): 15 categories (was 12), stale articles >7d filtered, confidence <0.3 excluded from event_score, recency weighting (today=1.0→3d=0.5), regime_hint requires 3+ events. Korean Market Agent reads `macro_events` table for `export_surge`/`demand_growth`.
+- **OpenAI Tier 2 ZDR gate** (PR #294): `make report-llm`이 조용히 실패하면 `OPENAI_ZDR_APPROVED=1` 미설정이 원인. OpenAI ZDR 승인 후 `.env`에 설정. `NURI_DISABLE_EXTERNAL_LLM=1`로 전면 opt-out 가능. 정책: §4.4.3.
+- **fastapi < 0.129 pinned** (PR #291, #277): `openbb-core 1.6.7`이 `fastapi<0.129`를 요구하므로 pin됨. Dependabot 0.129+ 제안은 자동 무시 (`dependabot.yml`). openbb 제약 풀릴 때까지 유지.
+- **`pd.DataFrame` in-place mutation + 공유 mock 참조** (PR #294/#295): `_standardize(df, ticker)` 같은 헬퍼가 `df.columns = ...` / `df["new"] = ...` 로 in-place mutation하고 테스트에서 `mock.return_value = df_fixture` (동일 객체)가 병렬 스레드에 공유되면 race → `pandas.errors.InvalidIndexError`. **방어**: 함수 진입 시 `df = df.copy()`.
 
 ## Harness File Map
 
@@ -228,6 +235,7 @@ This project uses layered context files. Root files load every session; director
 | `frontend/CLAUDE.md` | Next.js 16, design system, testing gotchas | When editing frontend/ |
 | `tests/CLAUDE.md` | Fixtures, mocks, testing gotchas | When editing tests/ |
 | `config/CLAUDE.md` | YAML structure, change procedures | When editing config/ |
+| `NEXT_SESSION.md` | Session handoff doc — 다음 세션 시작 시 먼저 읽음 | gitignored (personal) |
 
 User-scoped auto-memory lives outside the repo at `~/.claude/projects/-Users-ehbebe-workspace-nuri-quant/memory/` (`MEMORY.md` index + per-topic files). Auto-loaded each session for cross-conversation continuity; not committed.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ flowchart TD
   end
 
   subgraph Serve["Interface"]
-    API("FastAPI :8001\n68 endpoints + SSE")
+    API("FastAPI :8001\n69 endpoints + SSE")
     Dashboard("Next.js 16 :3000\n17 pages\nAction-First dashboard")
     Discord("Discord/Telegram\nalerts + daily report")
   end
@@ -159,7 +159,7 @@ flowchart TD
 | `nuri/trading/engine/` | Certify | SIEGE 11-gate (v2: asset-class-aware), conflict detection, learning memory |
 | `nuri/trading/recommend/` | Certify+Track | Candidates, price targets, rebalance advisor, outcome tracker (30/60/90d) |
 | `nuri/llm/` | Classify | Event classifier (OpenAI/regex), LLM report (Ollama, dormant), OpenAI wrapper |
-| `nuri/api/` | Serve | FastAPI REST + SSE on **:8001** (68 endpoints incl. `/actions`, `/opportunities`, `/market-context`). Swagger at `/docs` |
+| `nuri/api/` | Serve | FastAPI REST + SSE on **:8001** (69 endpoints incl. `/actions`, `/opportunities`, `/market-context`). Swagger at `/docs` |
 | `frontend/` | Serve | Next.js 16 + React 19 + Tailwind 4 + shadcn/ui on **:3000** (17 routes, Action-First dashboard, dark theme) |
 | `nuri/core/` | Foundation | db.py (sole SQLite), events.py (journal), freshness.py (SLA), timezone.py (KST), rules.py, signal_config.py |
 | `config/*.yaml` | Foundation | rules, agents, signals, universe, stock_types, portfolio (gitignored) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,15 +85,21 @@ cache invalidation (and, if necessary, coordinate a history rewrite).
 
 ## LLM and Model Safety
 
-- **Portfolio and narrative data must not be sent to remote LLM APIs.**
-  Ollama (local) handles all portfolio-related inference. See
-  `docs/STRATEGY.md` §4.4 for the full data classification (Tier 0/1/2).
-- **Public data (Tier 0) only** may be sent to external LLMs, gated
-  by the External LLM Egress Policy (`docs/STRATEGY.md` §4.4.3).
-  Currently: OpenAI `gpt-5.4-nano` for public RSS headline
-  classification only. All external calls go through
-  `nuri/llm/openai_client.py` (per-call audit log to
-  `external_llm_calls` table, content never logged).
+- **External LLM policy: whitelist per data tier** (updated 2026-04-14).
+  Full classification + rules: `docs/STRATEGY.md` §4.4.3.
+- **Tier 0 (public data)** — ALLOWED to external. Currently OpenAI
+  `gpt-5.4-nano` for RSS headline classification. No ZDR required.
+- **Tier 2 (portfolio/LLM daily report)** — ALLOWED to OpenAI
+  `gpt-5.4-nano` **only when `OPENAI_ZDR_APPROVED=1` env var is set**
+  (attestation that user obtained Zero Data Retention from OpenAI).
+  Without ZDR, `chat_text(data_tier="tier2")` raises
+  `ExternalLLMPolicyViolation` before any network call. Added in
+  PR #294 for prototype phase; local LLM transition planned.
+- **Tier 1 (user narrative/memos)** — NOT ALLOWED. Separate policy
+  revision + explicit user approval required to enable.
+- All external calls go through `nuri/llm/openai_client.py` (direct
+  `import openai` elsewhere is forbidden). Per-call audit row in
+  `external_llm_calls` table; content never logged.
 - `NURI_DISABLE_EXTERNAL_LLM=1` disables all external LLM calls
   (CI, offline, privacy mode).
 - Outputs from `nuri/llm/report.py` are validated for hallucinations:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,9 +74,9 @@ Trade execution API (`nuri/api/routes/trades.py`):
 
 `/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display.
 
-## API (68 endpoints)
+## API (69 endpoints)
 
-`nuri/api/routes/` — 68 REST endpoints on port **8001**. Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval).
+`nuri/api/routes/` — 69 REST endpoints on port **8001**. Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
 
 ### Action-First Dashboard APIs (PR #264-#266)
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -475,6 +475,25 @@ PM (spec) → Dev (impl) → Eval (test + smoke) → ship. Eval 단계 건너뛰
 
 **룰**: `gstack-codex` 등 외부 review tool 또는 사용자 review 단계 전에 ship 금지. 자동화된 integration test가 review 대체 가능.
 
+### 5.10 추천 파이프라인의 도구 사각지대 (JKHY 에피소드, 2026-04-14)
+
+**상황**: 세션 종료 직전 universe-wide BUY 추천 7종목 (TMUS/JKHY/V/MA/BX/ANET/NFLX) 제시. 사용자가 Investing.com 확인 → JKHY "적극 매도" (기술지표 종합). 시스템 추천과 정면 모순.
+
+**원인 (3층)**:
+
+1. **도구는 있으나 연결 안 됨** — `nuri/quant/chart_analysis.py` (BB/MACD/RSI/추세선) 구현 존재하지만, 추천 파이프라인 (`candidates.py`, `consensus.py`) 에서 호출하지 않음. "구현 = 사용"이 아님.
+2. **Fundamentals-only 추천** — 애널리스트 upgrade + ROE/PE 기반 Buy 신호만 사용. 가격 모멘텀/추세 완전 무시. 기본 시스템 design이 한 축에만 의존.
+3. **애널리스트 신호의 lag 속성 간과** — 애널리스트 target은 이미 오른 주식을 뒤늦게 upgrade하는 경향. 하락 중인 종목에 "upgrade + 30% upside"가 나오면 falling knife 신호일 수 있음. JKHY earnings surprise 4Q 연속 +0.0~0.2% = "soft beat" 성장 stall 신호도 놓침.
+
+**재발 방지 룰**:
+- 추천 내기 전 **반드시** 4개 축 통과: (a) fundamentals, (b) technicals, (c) earnings quality, (d) 시장 환경 (VIX/F&G/RSI)
+- "System has the tool" ≠ "Pipeline uses it". 통합 경로를 explicit 하게 테스트로 검증
+- 애널리스트 target upside + 현재가가 52주 고점/저점에서 어디 있는지 **반드시** 확인
+
+**방어 실행 (Tier 2 P1)**: `chart_analysis.py`를 `candidates.py`/`consensus.py`에 통합 + "fundamentals vs technicals divergence" 플래그 + earnings quality (soft beat) 자동 감지.
+
+**일반화된 교훈**: "Repo에 기능이 있다고 해서 실제 상품 경로에서 사용되고 있는 것은 아니다." 새 기능 추가 시 production path integration test 필수.
+
 ---
 
 ## 6. SIEGE 11-Gate 명세

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -514,21 +514,30 @@ PM (spec) → Dev (impl) → Eval (test + smoke) → ship. Eval 단계 건너뛰
 | 5b | ↳ Phase 2b BaseCollector `--source` | — | #278 | portfolio/universe/all 모드. 9 collectors tqdm + N/A coverage 진단 |
 | 5c | ↳ Phase 2c validate_universe + CI | — | #284, #286 | 7-check coverage gate, warning-only CI job |
 | 5d | ↳ KR/yfinance 성능 + UX fix | — | #281, #283, #285 | KR collect 33초, yfinance 10-thread parallel, sequential delay |
-| 6 | **Privacy scanner ticker+PnL pattern** | — | (TBD) | §4.4.1 ticker+PnL 사각지대 보완. `-34% (TEM)` / `PL +43%` 양 패턴 감지, `origin/main..HEAD` unpushed commit message 스캔 추가, `TICKER_FALSE_POSITIVES` 120개 (HWM/SL/MDD/VIX/BTC/ETH 등). PR #202 class 차단. |
+| 6 | **Privacy scanner ticker+PnL pattern** | — | #289 | §4.4.1 ticker+PnL 사각지대 보완. `-34% (TEM)` / `PL +43%` 양 패턴 감지, `origin/main..HEAD` unpushed commit message 스캔 추가, `TICKER_FALSE_POSITIVES` 120개. PR #202 class 차단. |
+| 7 | **Shell scripts 전수 shellcheck clean** | — | #290 | 16개 `.sh` (1,504 lines) → shellcheck 0 issues. `set -euo pipefail`, shebang 통일, 실제 버그 fix (trap SC2064, read -r, RSYNC_OPTS array), `make lint-sh` + CI job 추가 |
+| 8 | **OpenAI gpt-5.4-nano LLM 리포트 (§4.4.3 Tier 2)** | — | #294 | Ollama 휴면 → OpenAI primary. §4.4.3 정책 개정 (Tier 2 + ZDR 필수). `chat_text()` + `OPENAI_ZDR_APPROVED` 게이트. fallback chain (OpenAI → llama.cpp → Ollama). **부수 fix**: flaky `test_collect_full_flow` `df.copy()` (#295), security-scan 5m→10m timeout, codecov/patch 커버리지 테스트 3개 보강 |
+| 9 | **uv sync 충돌 해결 (fastapi <0.129 pin)** | [#277](https://github.com/researcherhojin/nuri-quant/issues/277) | #291 | openbb-core ↔ fastapi version conflict 해결. dependabot ignore 추가 |
+| 10 | **KR `n/a (US-only)` 표시 개선** | — | #288 | US_ONLY_TABLES frozenset + `check_universe_coverage.py` + `validate_universe.py` detail. 수집 실패 vs 소스 한계 시각 구분 |
+| 11 | **#272 Phase 3 (Eval): validate_universe + US_ONLY 회귀 테스트** | — | #296 | 20 tests: TestUsOnlyTables(4) + TestRunValidation/Print/Main/Fetch(11) + TestOutputFormat(5) |
+| 12 | **#272 Phase 4 (UX): Dashboard coverage widget + `/api/coverage`** | — | #297 | `CoverageStatus` widget (5/5 PASS 헤더 + 5-col 테이블 + 소스 한계 footer). 14 tests (backend 5 + frontend 9) |
 
 ### Tier 2 — 다음 1 달 (P1)
 
-전략적 가치 큼. Tier 1 끝나고 진행.
+**다음 세션 우선순위** — 구체적 작업 단위로 엄밀 정의 (2026-04-14 재평가).
 
-| # | 항목 | 이슈 | 카테고리 | 비고 |
-|---|------|------|---------|------|
-| 1 | 포트폴리오 온보딩 UI (YAML → Dashboard) | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 수동 yaml 편집 제거. 2026-04-14 portfolio.yaml 수동 수정 페인포인트 직접 경험 |
-| 2 | 백테스트 인터랙티브 equity curve | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 파라미터 sliders + 실시간 시뮬레이션 (이미 PR #269로 일부 완료, 추가 작업 가능) |
-| 3 | **Ollama LLM 휴면 코드 결정** | — | refactor | `nuri/llm/report.py` Ollama 의존 (현재 OLLAMA_HOST 미설정으로 비활성). OpenAI event_classifier는 active (737 calls 누적). Ollama 부분 유지 vs 제거 결정 필요. 2026-04-14 사용자 assignment: gpt-5.4 nano로 대체 검토 |
-| 4 | **OpenBB 호환성 fix** | [#274](https://github.com/researcherhojin/nuri-quant/issues/274) | bug(collectors) | openbb-core==1.6.7 ↔ openbb-news==1.6.1 충돌로 news/etf_flows 수집 불가. 점진적 upgrade 필요 (콜렉터별 smoke test 후 진행) |
-| 5 | **uv sync 충돌 해결** | [#277](https://github.com/researcherhojin/nuri-quant/issues/277) | bug(deps) | openbb-core ↔ fastapi version conflict로 `uv sync` / `uv add` 실패. fresh clone 시 영향 |
-| 6 | **#272 Phase 2c-3 — universe-check 필수 게이트화** | — | ops | `make collect-universe` 5/5 PASS 확인 후 branch protection에 universe-check를 required check로 토글 (사용자 manual) |
-| 7 | **wallstreet collect 성능 검증** | — | perf(collectors) | PR #285 parallel fetch 적용 후 실제 50min → 5min 효과 검증. universe collect 첫 머지 후 측정 |
+| 우선 | # | 항목 | 이슈 | 카테고리 | 예상 | Acceptance |
+|------|---|------|------|---------|------|------------|
+| 🟡 P1 | 1 | **#272 Phase 5 (QA): Negative + Smoke run** | — | test | 1 세션 (네트워크 필요) | 빈 DB/yaml 삭제 negative 3건 + fresh clone → `make setup` → `make universe-sync-us/kr` → `make collect` → `validate_universe` 실행 기록 → `docs/SMOKE_RUN.md` 작성 |
+| 🟡 P1 | 2 | **기술분석 통합 to 추천 파이프라인** | — | feat(recommend) | 1-2 세션 | JKHY 에피소드 (2026-04-14) 재발 방지. `nuri/quant/chart_analysis.py` (BB/MACD/RSI) 을 `candidates.py` / consensus에 자동 연동. "fundamentals Buy, technicals Sell" divergence 플래그 추가 |
+| 🟡 P1 | 3 | **가격 히스토리 확장 (5d → 1y+)** | — | ops | 0.5 세션 | `prices` 테이블 5일치만 있음 → 52주 레인지 / 추세선 계산 불가. 정기 `make collect --period 1y` 실행 체계 + scheduler 등록 |
+| 🟡 P1 | 4 | **Earnings quality 분석 통합** | — | feat(recommend) | 0.5 세션 | JKHY 에피소드 — surprise 0% 반복 = 성장 stall 신호 놓침. `earnings_surprises` 기반 "soft beat" 플래그 (surprise < 2% 지속 3Q) 추가 |
+| 🟢 P2 | 5 | **포트폴리오 온보딩 UI (YAML → Dashboard)** | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 2-3 세션 | 수동 yaml 편집 제거. 2026-04-14 portfolio.yaml 수동 수정 페인포인트 직접 경험 |
+| 🟢 P2 | 6 | **OpenBB 호환성 fix** | [#274](https://github.com/researcherhojin/nuri-quant/issues/274) | bug(collectors) | 1 세션 | openbb-core==1.6.7 ↔ openbb-news==1.6.1 충돌로 news/etf_flows 수집 불가. 점진적 upgrade 필요 (콜렉터별 smoke test 후 진행) |
+| 🟢 P2 | 7 | **백테스트 인터랙티브 equity curve** | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | feat(frontend) | 1 세션 | 파라미터 sliders + 실시간 시뮬레이션 (PR #269로 일부 완료, 마무리) |
+| 🟢 P2 | 8 | **#272 Phase 2c-3 — universe-check 필수 게이트화** | — | ops | 10분 | `make collect-universe` 5/5 PASS 상태 유지 중 → 사용자 수동으로 branch protection required check 토글 |
+| 🟢 P2 | 9 | **wallstreet collect 성능 검증** | — | perf(collectors) | 15분 | PR #285 parallel fetch 실제 50min → 15min 41초 (universe 746) 확인 완료 — **close 후보** |
+| ⚪ P3 | 10 | **flaky test 일반 stabilization** | — | test | 1 세션 | #295는 resolved. 다른 flaky 후보 (parallel sys.modules 오염 패턴) 전수 감사 |
 
 ### Tier 3 — 다음 분기 (P2)
 


### PR DESCRIPTION
## Summary
오늘 세션 (2026-04-14) 머지된 **8개 PR** 반영 + Tier 2 우선순위 **엄밀 재평가** + Acceptance Criteria 명시.

## Tier 1 추가 (완료, 2026-04-14)

| # | 항목 | PR |
|---|------|----|
| 6 | Privacy scanner ticker+PnL | #289 |
| 7 | Shell scripts shellcheck clean (16 files, 1504 lines) | #290 |
| 8 | OpenAI gpt-5.4-nano 리포트 (§4.4.3 Tier 2) | #294 |
| 9 | uv sync fastapi pin (#277 close) | #291 |
| 10 | KR n/a (US-only) 라벨 | #288 |
| 11 | Phase 3 Eval — 20 regression tests | #296 |
| 12 | Phase 4 UX — Dashboard coverage widget | #297 |

## Tier 2 Priority Matrix

### 🟡 P1 (다음 세션 즉시 착수 권고)

| # | 항목 | 예상 | Acceptance |
|---|------|------|------------|
| 1 | **Phase 5 (QA) Smoke + Negative** | 1 세션 | Fresh clone → make setup → universe-sync → collect → validate; docs/SMOKE_RUN.md |
| 2 | **기술분석 통합 to 추천 파이프라인** | 1-2 세션 | chart_analysis.py BB/MACD/RSI → candidates.py 연동 + divergence flag + 5 tests |
| 3 | 가격 히스토리 5d → 1y+ | 0.5 세션 | prices 테이블 1년치 + make collect-1y + 52w 레인지 계산 가능 |
| 4 | Earnings quality (soft beat) | 0.5 세션 | surprise < 2% 3Q+ 연속 → 성장 stall 플래그 |

### 🟢 P2 / ⚪ P3

포트폴리오 온보딩 UI (#25), OpenBB 호환성 (#274), 백테스트 sliders (#89), universe-check 필수화 (수동), flaky 감사 등.

## 왜 P1 #2 (기술분석 통합)가 중요한가

**JKHY 에피소드 (2026-04-14 23:00)**:
1. 시스템 추천: JKHY BUY (fundamentals + 최근 analyst upgrade)
2. Investing.com: "적극 매도" (기술지표 종합)
3. 원인: \`nuri/quant/chart_analysis.py\`는 존재하지만 추천 파이프라인에 **미통합**
4. 결과: 사용자 신뢰 손상 + 추천 철회

**시스템 구조적 결함**: 도구 있음 ≠ 파이프라인 활용. P1 #2로 차단.

## Test plan
- [x] STRATEGY.md markdown lint clean
- [x] Tier 1 PR 번호 검증 (#287-#297 전부 머지 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)