### PR TITLE
feat(collectors): make collect-universe-1y target (P1 B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ collect-universe:    ## Collect ALL universe data (US+KR prices, fundamentals, w
 	$(PYTHON) -m nuri.collectors.wallstreet --source universe
 	$(PYTHON) -m nuri.collectors.estimates --source universe
 
+collect-universe-1y: ## Backfill 1y OHLCV for full universe — prerequisite for P1 A tech analysis (BB/MACD/52w)
+	$(PYTHON) -m nuri.collectors.stock --source universe --period 1y
+	$(PYTHON) -m nuri.collectors.stock_kr --source universe --days 365
+
 test-integration: ## Integration tests — real external APIs (Wikipedia, FDR, yfinance). Network required.
 	$(PYTHON) -m pytest tests/integration/ -m integration -v --no-header
 

--- a/tests/collectors/test_stock.py
+++ b/tests/collectors/test_stock.py
@@ -173,3 +173,46 @@ class TestStockUniverseModeCoverage:
 
         info = [r for r in caplog.records if "source=universe" in r.message]
         assert len(info) >= 1
+
+
+class TestStockOneYearBackfill:
+    """#272 후속: `make collect-universe-1y` — P1 A (tech analysis) 선행 조건.
+
+    1y = 252 trading days (chart_analysis.LOOKBACK_52W 와 정확히 일치).
+    chart_analysis.analyze_chart lookback_days=365 default 과 맞춤.
+    """
+
+    def test_period_1y_maps_to_365_days_ago(self):
+        """_period_to_start_date('1y') → 365일 전 (±1일 허용, 월말 경계)."""
+        from datetime import datetime, timedelta
+
+        from nuri.collectors.stock import StockCollector
+        from nuri.core.timezone import kst_now
+
+        c = StockCollector()
+        start = c._period_to_start_date("1y")
+        parsed = datetime.strptime(start, "%Y-%m-%d")
+        now = kst_now().replace(tzinfo=None)
+        delta = (now - parsed).days
+        # mapping["1y"] = 365. ±2일 tolerance (timezone 경계 + 반올림).
+        assert 363 <= delta <= 367, f"1y should map to ~365 days, got {delta}"
+
+    def test_collect_1y_universe_logs_period(self, monkeypatch, db_with_portfolio, caplog):
+        """collect(period='1y', source='universe') — 1y 로그 + universe source 모두 기록."""
+        import logging
+
+        from nuri.collectors.stock import StockCollector
+
+        c = StockCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["SPY"])
+        monkeypatch.setattr(c, "_collect_ticker", lambda *a, **kw: None)
+
+        with caplog.at_level(logging.INFO):
+            c.collect(source="universe", period="1y")
+
+        # "수집 대상: ... (1y, source=universe)" 단일 메시지
+        hits = [r for r in caplog.records if "1y" in r.message and "source=universe" in r.message]
+        assert len(hits) >= 1, (
+            f"Expected log with both '1y' and 'source=universe'. "
+            f"Got: {[r.message for r in caplog.records if '수집' in r.message]}"
+        )


### PR DESCRIPTION
## Problem

`prices` table currently:
- Portfolio holdings: 5y OHLCV (from `make setup`)
- Universe (746 tickers): **3-5 days only** (75th percentile = 4 rows)

`chart_analysis.py` requires:
- `LOOKBACK_52W = 252` trading days for 52w high/low
- `POC_LOOKBACK = 120` for volume profile
- BB rolling 20, MACD ~26, RSI 14

Universe-wide tech analysis (P1 A) cannot run without 1y backfill. This PR adds the plumbing.

## Scope discipline (§5.4)

- Plumbing only — **does not execute the backfill**. User runs `make collect-universe-1y` post-merge (~10-15 min network).
- 1 commit, 2 files, +47 lines.
- No integration test — `conftest.mock_yfinance` autouse blocks real fetches; building a subprocess-based integration harness is scope creep. Real integration risk lives in the manual backfill (see Test plan).

## Spec deviations from PM phase

Original spec promised 1 integration test. Dropped after discovering conftest global mock would require either (a) override fixture or (b) subprocess spawn. Both are infra work orthogonal to this PR's 1-line Makefile change. The **downstream 52w SQL spot-check** (Test plan item 4) is the substitute — it catches the real risk: "can we actually compute 52w after running this?"

## Test plan

Before merge (automated):
- [x] `pytest tests/collectors/test_stock.py::TestStockOneYearBackfill` — 2 passed
- [x] `make lint` — clean
- [x] `scripts/check_privacy_leak.py` — clean
- [x] `make -n collect-universe-1y` — dry-run shows correct args (`--period 1y`, `--days 365`)

After merge (manual — user executes):
- [ ] `make collect-universe-1y` (network, ~10-15 min: US yfinance 10-thread + KR sequential)
- [ ] Verify universe coverage: 52w SQL spot-check for 3 tickers
      ```sql
      SELECT ticker, COUNT(*) as rows_,
             MAX(high) as high_52w, MIN(low) as low_52w
      FROM prices
      WHERE ticker IN ('SPY','AMD','JKHY')
        AND date >= DATE('now','-365 days')
      GROUP BY ticker;
      ```
      Expected: each ticker ≥200 rows, `high_52w` and `low_52w` non-null.
- [ ] Re-run `.venv/bin/python scripts/validate_universe.py --no-fetch` — 5/5 still PASS.

## Sizing notes

- 1y = 252 trading days = exactly `LOOKBACK_52W`. **Zero margin for holiday gaps.** If coverage misses arise, bump `--period 1y` → `2y` in a follow-up (Makefile-only, no code).
- DB growth estimate: ~420k rows (from current 28k). SQLite handles this trivially.
- Daily cron (`make collect-universe`) unchanged — still fetches 5d. `collect-universe-1y` is opt-in for backfill / weekly refresh.

## Why P1 B now

Blocks P1 A (JKHY episode follow-up, STRATEGY §5.10). Landing this first means P1 A can integrate `chart_analysis.analyze_chart(ticker)` without hitting "insufficient data" across the universe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)