### PR TITLE
feat(consensus): surface TechnicalAgent divergence (P1 A1 — JKHY §5.10)

### DIFF
--- a/nuri/trading/agents/consensus.py
+++ b/nuri/trading/agents/consensus.py
@@ -9,6 +9,7 @@
     python -m nuri.trading.agents.consensus
     python -m nuri.trading.agents.consensus --ticker TSLA
 """
+
 import argparse
 import logging
 from dataclasses import dataclass
@@ -32,16 +33,16 @@ logger = logging.getLogger(__name__)
 # 기본 가중치 (과거 데이터 없을 때)
 # 7→10 에이전트 확장: 기존 에이전트 비중 소폭 하향, 신규 3개 배분
 DEFAULT_WEIGHTS = {
-    "technical": 0.152,      # 16→15.2 (×0.95)
-    "fundamental": 0.114,    # 12→11.4
-    "macro": 0.114,          # 12→11.4
-    "risk": 0.19,            # 20→19 (거부권 유지)
-    "smart_money": 0.076,    # 8→7.6
-    "wallstreet": 0.105,     # 11→10.5
+    "technical": 0.152,  # 16→15.2 (×0.95)
+    "fundamental": 0.114,  # 12→11.4
+    "macro": 0.114,  # 12→11.4
+    "risk": 0.19,  # 20→19 (거부권 유지)
+    "smart_money": 0.076,  # 8→7.6
+    "wallstreet": 0.105,  # 11→10.5
     "korean_market": 0.076,  # 8→7.6 (.KS 종목에서만 실질 영향)
-    "options": 0.076,        # 8→7.6
-    "crypto": 0.047,         # 5→4.7
-    "retail": 0.05,          # 0→5% 활성화: WSB 역발상 시그널
+    "options": 0.076,  # 8→7.6
+    "crypto": 0.047,  # 5→4.7
+    "retail": 0.05,  # 0→5% 활성화: WSB 역발상 시그널
 }
 
 ALL_AGENTS = [
@@ -61,13 +62,16 @@ ALL_AGENTS = [
 @dataclass
 class ConsensusResult:
     """멀티 에이전트 합의 결과."""
+
     ticker: str
-    final_action: str       # "BUY", "SELL", "HOLD"
-    final_confidence: float # 0~100
-    agreement_rate: float   # 0~1 (동일 action 비율)
+    final_action: str  # "BUY", "SELL", "HOLD"
+    final_confidence: float  # 0~100
+    agreement_rate: float  # 0~1 (동일 action 비율)
     verdicts: list[AgentVerdict]
-    dissent: list[str]      # 반대 의견 에이전트 목록
-    reasoning: str          # 합의 근거 요약
+    dissent: list[str]  # 반대 의견 에이전트 목록
+    reasoning: str  # 합의 근거 요약
+    divergence_flag: bool = False  # TechnicalAgent 가 합의 BUY/SELL 에 정면 반대 (#5.10 JKHY 방지)
+    divergence_reason: str = ""  # flag 가 True 일 때 사용자에게 노출할 설명
 
 
 def _compute_weights(db_path=None) -> dict[str, float]:
@@ -105,6 +109,7 @@ def _compute_weights(db_path=None) -> dict[str, float]:
     # 에이전트별 적중률 계산
     # signals 필드에 에이전트 verdict가 JSON으로 저장되어 있으면 파싱
     import json
+
     agent_hits: dict[str, list[bool]] = {name: [] for name in DEFAULT_WEIGHTS}
 
     for row in rows:
@@ -187,9 +192,26 @@ def _build_consensus(ticker: str, verdicts: list[AgentVerdict], weights: dict) -
     agree_count = sum(1 for v in verdicts if v.action == final_action)
     agreement_rate = agree_count / len(verdicts) if verdicts else 0
     dissent = [
-        f"{v.agent_name}({v.action}, {v.confidence:.0f}): {v.reasoning}"
-        for v in verdicts if v.action != final_action
+        f"{v.agent_name}({v.action}, {v.confidence:.0f}): {v.reasoning}" for v in verdicts if v.action != final_action
     ]
+
+    # Divergence detection — STRATEGY §5.10 (JKHY, 2026-04-14) 재발 방지.
+    # 9개 fundamentals-ish 에이전트가 BUY 를 몰아주면 TechnicalAgent 의 SELL
+    # 반대가 묻힘. 합의 action 이 BUY/SELL 이고 technical 이 정확히 반대 action
+    # 이면 flag + reason 을 surface 해 사용자가 교차 검증하도록 한다.
+    # HOLD 는 "약한 반대" 로 간주해 flag 하지 않는다 (noise 억제).
+    divergence_flag = False
+    divergence_reason = ""
+    tech_v = next((v for v in verdicts if v.agent_name == "technical"), None)
+    if tech_v and final_action in ("BUY", "SELL"):
+        opposite = {"BUY": "SELL", "SELL": "BUY"}[final_action]
+        if tech_v.action == opposite:
+            divergence_flag = True
+            divergence_reason = (
+                f"기술지표 반대: TechnicalAgent 가 {tech_v.action} "
+                f"(conf {tech_v.confidence:.0f}) — 합의 {final_action} 과 충돌. "
+                f"근거: {tech_v.reasoning[:120]}"
+            )
 
     return ConsensusResult(
         ticker=ticker,
@@ -199,6 +221,8 @@ def _build_consensus(ticker: str, verdicts: list[AgentVerdict], weights: dict) -
         verdicts=verdicts,
         dissent=dissent,
         reasoning=reasoning,
+        divergence_flag=divergence_flag,
+        divergence_reason=divergence_reason,
     )
 
 
@@ -237,16 +261,12 @@ def analyze_ticker(ticker: str, db_path=None) -> ConsensusResult:
                 try:
                     verdicts.append(future.result())
                 except Exception as e:  # noqa: BLE001
-                    verdicts.append(
-                        AgentVerdict(agent.name, ticker, "HOLD", 0, f"에러: {e}")
-                    )
+                    verdicts.append(AgentVerdict(agent.name, ticker, "HOLD", 0, f"에러: {e}"))
         except concurrent.futures.TimeoutError:
             # 전체 batch timeout — 미완료 future는 폴백 verdict로
             for future, agent in futures.items():
                 if future not in completed:
-                    verdicts.append(
-                        AgentVerdict(agent.name, ticker, "HOLD", 0, "타임아웃")
-                    )
+                    verdicts.append(AgentVerdict(agent.name, ticker, "HOLD", 0, "타임아웃"))
     finally:
         # cancel_futures: 큐에 대기중인(아직 시작 안 한) future 취소
         # wait=False: 실행 중인 future가 끝날 때까지 기다리지 않음
@@ -310,7 +330,9 @@ def analyze_portfolio(db_path=None) -> list[ConsensusResult]:
     for ticker in tickers:
         result = analyze_ticker(ticker, db_path)
         results.append(result)
-        logger.info(f"{ticker}: {result.final_action} (conf={result.final_confidence:.0f}, agree={result.agreement_rate:.0%})")
+        logger.info(
+            f"{ticker}: {result.final_action} (conf={result.final_confidence:.0f}, agree={result.agreement_rate:.0%})"
+        )
     return results
 
 
@@ -409,8 +431,18 @@ def print_consensus(results: list[ConsensusResult], *, verbose: bool = False) ->
     print(f"  {'Ticker':<10} {'Action':<6} {'Conf':>5} {'Agree':>6} " + " ".join(f"{h:>5}" for h in header_agents))
     print(f"  {'-' * 110}")
 
-    agent_order = ["technical", "fundamental", "macro", "risk", "smart_money",
-                    "wallstreet", "korean_market", "options", "crypto", "retail"]
+    agent_order = [
+        "technical",
+        "fundamental",
+        "macro",
+        "risk",
+        "smart_money",
+        "wallstreet",
+        "korean_market",
+        "options",
+        "crypto",
+        "retail",
+    ]
 
     for r in sorted(results, key=lambda x: x.final_confidence, reverse=True):
         agent_map = {v.agent_name: v for v in r.verdicts}
@@ -423,8 +455,10 @@ def print_consensus(results: list[ConsensusResult], *, verbose: bool = False) ->
             else:
                 cols.append("--")
 
-        print(f"  {r.ticker:<10} {r.final_action:<6} {r.final_confidence:>4.0f} {r.agreement_rate:>5.0%} "
-              f"{' '.join(f'{c:>5}' for c in cols)}")
+        print(
+            f"  {r.ticker:<10} {r.final_action:<6} {r.final_confidence:>4.0f} {r.agreement_rate:>5.0%} "
+            f"{' '.join(f'{c:>5}' for c in cols)}"
+        )
 
     # 합의 supporters reasoning 출력 (verbose 모드 또는 단일 종목)
     show_supporters = verbose or len(results) == 1
@@ -433,7 +467,9 @@ def print_consensus(results: list[ConsensusResult], *, verbose: bool = False) ->
             supporters = [v for v in r.verdicts if v.action == r.final_action]
             if not supporters:
                 continue
-            print(f"\n  ▸ {r.ticker} {r.final_action} ({r.final_confidence:.0f}, agree={r.agreement_rate:.0%}) — supporters:")
+            print(
+                f"\n  ▸ {r.ticker} {r.final_action} ({r.final_confidence:.0f}, agree={r.agreement_rate:.0%}) — supporters:"
+            )
             for v in sorted(supporters, key=lambda x: x.confidence, reverse=True):
                 print(f"      {v.agent_name}({v.confidence:.0f}): {v.reasoning}")
 
@@ -448,6 +484,7 @@ def print_consensus(results: list[ConsensusResult], *, verbose: bool = False) ->
     # 가격 타겟 출력
     try:
         from nuri.trading.recommend.price_targets import calculate_targets, format_target_tree
+
         buy_hold = [r for r in results if r.final_action in ("BUY", "HOLD")]
         if buy_hold:
             print(f"\n{'=' * 85}")
@@ -464,6 +501,7 @@ def print_consensus(results: list[ConsensusResult], *, verbose: bool = False) ->
     # 외부 데이터 요약 출력
     try:
         from nuri.collectors.external import get_external
+
         tickers_with_data = set()
         for r in results:
             ext = get_external(r.ticker)
@@ -497,8 +535,9 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Nuri-Quant 멀티 에이전트 합의")
     parser.add_argument("--ticker", help="특정 종목만")
-    parser.add_argument("--verbose", "-v", action="store_true",
-                        help="합의 의견의 supporting verdicts reasoning 함께 출력")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="합의 의견의 supporting verdicts reasoning 함께 출력"
+    )
     args = parser.parse_args()
 
     if args.ticker:
@@ -510,6 +549,7 @@ if __name__ == "__main__":
             logger.info(f"recommendations 테이블에 {saved}건 저장")
         # Decision Intelligence: 의사결정 저널 기록
         from nuri.trading.engine.decisions import record_decisions
+
         dec_count = record_decisions([result])
         logger.info(f"decisions 테이블에 {dec_count}건 기록")
     else:
@@ -520,5 +560,6 @@ if __name__ == "__main__":
             logger.info(f"recommendations 테이블에 {saved}건 저장 (frontend /decision 활성화)")
         # Decision Intelligence: 의사결정 저널 기록
         from nuri.trading.engine.decisions import record_decisions
+
         dec_count = record_decisions(results)
         logger.info(f"decisions 테이블에 {dec_count}건 기록")

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -1,4 +1,5 @@
 """Tests for consensus agent — split from test_trading_agents_all.py."""
+
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -15,6 +16,7 @@ from tests.trading.agents._helpers import _seed_macro, _seed_portfolio, _seed_pr
 class TestConsensus:
     def test_consensus_returns_result(self, agent_data):
         from nuri.trading.agents.consensus import analyze_ticker
+
         r = analyze_ticker("TEST", db_path=agent_data)
         assert r.ticker == "TEST"
         assert r.final_action in ("BUY", "SELL", "HOLD")
@@ -28,19 +30,24 @@ class TestConsensus:
 
         with get_db(db_path) as conn:
             conn.execute(
-                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) "
-                "VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?, ?, ?, ?, ?)",
                 ("test", "VETO", 100, 100.0, "USD"),
             )
 
         dates = pd.bdate_range("2024-01-01", periods=250)
         close = np.concatenate([np.linspace(100, 120, 200), np.linspace(120, 60, 50)])
-        df = pd.DataFrame({
-            "ticker": "VETO", "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": close * 0.99, "high": close * 1.01,
-            "low": close * 0.98, "close": close,
-            "volume": [100000] * 250, "adj_close": close,
-        })
+        df = pd.DataFrame(
+            {
+                "ticker": "VETO",
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": close * 0.99,
+                "high": close * 1.01,
+                "low": close * 0.98,
+                "close": close,
+                "volume": [100000] * 250,
+                "adj_close": close,
+            }
+        )
         upsert_prices(df, db_path)
 
         r = analyze_ticker("VETO", db_path=db_path)
@@ -48,18 +55,21 @@ class TestConsensus:
 
     def test_no_data_returns_hold(self, db_path):
         from nuri.trading.agents.consensus import analyze_ticker
+
         r = analyze_ticker("NODATA", db_path=db_path)
         assert r.final_action == "HOLD"
 
     def test_dynamic_weights_fallback(self, db_path):
         """데이터 부족 시 DEFAULT_WEIGHTS 반환."""
         from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
         weights = _compute_weights(db_path=db_path)
         assert weights == DEFAULT_WEIGHTS
 
     def test_dynamic_weights_sum_to_one(self, db_path):
         """가중치 합은 항상 1.0."""
         from nuri.trading.agents.consensus import _compute_weights
+
         weights = _compute_weights(db_path=db_path)
         assert abs(sum(weights.values()) - 1.0) < 0.01
 
@@ -83,7 +93,7 @@ class TestDynamicWeights:
                     "INSERT INTO recommendations "
                     "(ticker, date, action, confidence, signals, outcome_30d) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    (f"T{i}", f"2025-01-{i+1:02d}", "BUY", 70, signals, 5.0 if i % 2 == 0 else -2.0),
+                    (f"T{i}", f"2025-01-{i + 1:02d}", "BUY", 70, signals, 5.0 if i % 2 == 0 else -2.0),
                 )
         weights = _compute_weights(db_path=db_path)
         assert abs(sum(weights.values()) - 1.0) < 0.01
@@ -99,7 +109,7 @@ class TestDynamicWeights:
                     "INSERT INTO recommendations "
                     "(ticker, date, action, confidence, signals, outcome_30d) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    (f"T{i}", f"2025-01-{i+1:02d}", "BUY", 70, "rsi_oversold", 5.0),
+                    (f"T{i}", f"2025-01-{i + 1:02d}", "BUY", 70, "rsi_oversold", 5.0),
                 )
         weights = _compute_weights(db_path=db_path)
         assert weights == DEFAULT_WEIGHTS
@@ -118,7 +128,7 @@ class TestDynamicWeights:
                     "INSERT INTO recommendations "
                     "(ticker, date, action, confidence, signals, outcome_30d) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    (f"T{i}", f"2025-01-{i+1:02d}", "SELL", 80, signals, -5.0),
+                    (f"T{i}", f"2025-01-{i + 1:02d}", "SELL", 80, signals, -5.0),
                 )
         weights = _compute_weights(db_path=db_path)
         assert weights["risk"] > 0.15
@@ -127,23 +137,181 @@ class TestDynamicWeights:
 class TestConsensusResult:
     def test_create(self):
         from nuri.trading.agents.consensus import ConsensusResult
+
         result = ConsensusResult(
-            ticker="AAPL", final_action="BUY", final_confidence=75.0,
-            agreement_rate=0.85, verdicts=[], dissent=[], reasoning="test",
+            ticker="AAPL",
+            final_action="BUY",
+            final_confidence=75.0,
+            agreement_rate=0.85,
+            verdicts=[],
+            dissent=[],
+            reasoning="test",
         )
         assert result.final_action == "BUY"
         assert result.agreement_rate == 0.85
+
+    def test_divergence_fields_default_false(self):
+        """신규 divergence 필드가 기본값(False, '') 이어야 한다 (회귀 가드)."""
+        from nuri.trading.agents.consensus import ConsensusResult
+
+        result = ConsensusResult(
+            ticker="AAPL",
+            final_action="HOLD",
+            final_confidence=50.0,
+            agreement_rate=0.5,
+            verdicts=[],
+            dissent=[],
+            reasoning="x",
+        )
+        assert result.divergence_flag is False
+        assert result.divergence_reason == ""
+
+
+class TestConsensusDivergence:
+    """#5.10 JKHY 방지 — TechnicalAgent 가 합의에 정면 반대하면 flag surface."""
+
+    @staticmethod
+    def _verdicts(spec: dict[str, str]) -> list:
+        """spec = {'technical': 'SELL', 'fundamental': 'BUY', ...} → AgentVerdict 리스트."""
+        from nuri.trading.agents.base import AgentVerdict
+
+        return [AgentVerdict(name, "TEST", action, 70, f"mock {name}") for name, action in spec.items()]
+
+    @staticmethod
+    def _even_weights(names) -> dict:
+        w = 1.0 / len(names)
+        return {n: w for n in names}
+
+    def test_buy_consensus_with_technical_sell_sets_flag(self):
+        """JKHY-class: 합의 BUY + technical SELL → divergence_flag=True."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        # 8 BUY + 1 SELL (technical) + 1 HOLD → BUY 우세, technical 반대
+        spec = {
+            "technical": "SELL",
+            "fundamental": "BUY",
+            "wallstreet": "BUY",
+            "smart_money": "BUY",
+            "macro": "BUY",
+            "korean_market": "BUY",
+            "options": "BUY",
+            "crypto": "BUY",
+            "retail": "BUY",
+            "risk": "HOLD",
+        }
+        verdicts = self._verdicts(spec)
+        weights = self._even_weights(spec.keys())
+        result = _build_consensus("TEST", verdicts, weights)
+        assert result.final_action == "BUY", f"sanity: expected BUY, got {result.final_action}"
+        assert result.divergence_flag is True
+        assert "TechnicalAgent" in result.divergence_reason
+        assert "SELL" in result.divergence_reason
+
+    def test_sell_consensus_with_technical_buy_sets_flag(self):
+        """역방향: 합의 SELL + technical BUY → flag=True."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        spec = {
+            "technical": "BUY",
+            "fundamental": "SELL",
+            "wallstreet": "SELL",
+            "smart_money": "SELL",
+            "macro": "SELL",
+            "korean_market": "SELL",
+            "options": "SELL",
+            "crypto": "SELL",
+            "retail": "SELL",
+            "risk": "HOLD",
+        }
+        verdicts = self._verdicts(spec)
+        weights = self._even_weights(spec.keys())
+        result = _build_consensus("TEST", verdicts, weights)
+        assert result.final_action == "SELL", f"sanity: expected SELL, got {result.final_action}"
+        assert result.divergence_flag is True
+        assert "BUY" in result.divergence_reason
+
+    def test_buy_consensus_with_technical_hold_no_flag(self):
+        """TechnicalAgent HOLD 는 "약한 반대" — flag 하지 않는다 (noise 억제)."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        spec = {
+            "technical": "HOLD",
+            "fundamental": "BUY",
+            "wallstreet": "BUY",
+            "smart_money": "BUY",
+            "macro": "BUY",
+            "korean_market": "BUY",
+            "options": "BUY",
+            "crypto": "BUY",
+            "retail": "BUY",
+            "risk": "HOLD",
+        }
+        verdicts = self._verdicts(spec)
+        weights = self._even_weights(spec.keys())
+        result = _build_consensus("TEST", verdicts, weights)
+        assert result.final_action == "BUY"
+        assert result.divergence_flag is False
+        assert result.divergence_reason == ""
+
+    def test_buy_consensus_with_technical_buy_no_flag(self):
+        """동조 — TechnicalAgent 가 합의와 같은 방향이면 flag 없음."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        spec = {
+            name: "BUY"
+            for name in [
+                "technical",
+                "fundamental",
+                "wallstreet",
+                "smart_money",
+                "macro",
+                "risk",
+                "korean_market",
+                "options",
+                "crypto",
+                "retail",
+            ]
+        }
+        verdicts = self._verdicts(spec)
+        weights = self._even_weights(spec.keys())
+        result = _build_consensus("TEST", verdicts, weights)
+        assert result.final_action == "BUY"
+        assert result.divergence_flag is False
+
+    def test_hold_consensus_with_technical_sell_no_flag(self):
+        """합의 HOLD 는 flag 대상 아님 — BUY/SELL 둘 다 아니니 대립 구도 성립 안 함."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        spec = {
+            "technical": "SELL",
+            "fundamental": "HOLD",
+            "wallstreet": "HOLD",
+            "smart_money": "HOLD",
+            "macro": "HOLD",
+            "risk": "HOLD",
+            "korean_market": "HOLD",
+            "options": "HOLD",
+            "crypto": "HOLD",
+            "retail": "HOLD",
+        }
+        verdicts = self._verdicts(spec)
+        weights = self._even_weights(spec.keys())
+        result = _build_consensus("TEST", verdicts, weights)
+        assert result.final_action == "HOLD"
+        assert result.divergence_flag is False
 
 
 class TestComputeWeights:
     def test_default_weights(self, db_path):
         """추천 데이터 부족 시 기본 가중치."""
         from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
         weights = _compute_weights(db_path=db_path)
         assert weights == DEFAULT_WEIGHTS
 
     def test_weights_sum_to_one(self, db_path):
         from nuri.trading.agents.consensus import _compute_weights
+
         weights = _compute_weights(db_path=db_path)
         assert abs(sum(weights.values()) - 1.0) < 0.01
 
@@ -151,16 +319,29 @@ class TestComputeWeights:
 class TestConsensusLogic:
     def test_all_agents_loaded(self):
         from nuri.trading.agents.consensus import ALL_AGENTS
+
         assert len(ALL_AGENTS) == 10
 
     def test_default_weights_keys(self):
         from nuri.trading.agents.consensus import DEFAULT_WEIGHTS
-        expected = {"technical", "fundamental", "macro", "risk", "smart_money",
-                    "wallstreet", "korean_market", "options", "crypto", "retail"}
+
+        expected = {
+            "technical",
+            "fundamental",
+            "macro",
+            "risk",
+            "smart_money",
+            "wallstreet",
+            "korean_market",
+            "options",
+            "crypto",
+            "retail",
+        }
         assert set(DEFAULT_WEIGHTS.keys()) == expected
 
     def test_risk_weight_highest(self):
         from nuri.trading.agents.consensus import DEFAULT_WEIGHTS
+
         assert DEFAULT_WEIGHTS["risk"] == max(DEFAULT_WEIGHTS.values())
 
 
@@ -194,6 +375,7 @@ class TestAnalyzeTicker:
         monkeypatch.setattr(cons_mod, "ALL_AGENTS", mock_agents)
 
         from nuri.trading.agents.consensus import analyze_ticker
+
         result = analyze_ticker("AAPL", db_path=db_path)
 
         assert result.ticker == "AAPL"
@@ -231,6 +413,7 @@ class TestAnalyzeTicker:
         monkeypatch.setattr(cons_mod, "ALL_AGENTS", mock_agents)
 
         from nuri.trading.agents.consensus import analyze_ticker
+
         result = analyze_ticker("DANGER", db_path=db_path)
         assert result.final_action == "SELL"
 
@@ -246,13 +429,25 @@ class TestAnalyzeTicker:
             def analyze(self, ticker, db_path=None):
                 return AgentVerdict(self.name, ticker, "SELL", 70, "mock")
 
-        mock_agents = [MockAgent(n) for n in [
-            "technical", "fundamental", "macro", "risk", "smart_money",
-            "wallstreet", "korean_market", "options", "crypto", "retail",
-        ]]
+        mock_agents = [
+            MockAgent(n)
+            for n in [
+                "technical",
+                "fundamental",
+                "macro",
+                "risk",
+                "smart_money",
+                "wallstreet",
+                "korean_market",
+                "options",
+                "crypto",
+                "retail",
+            ]
+        ]
         monkeypatch.setattr(cons_mod, "ALL_AGENTS", mock_agents)
 
         from nuri.trading.agents.consensus import analyze_ticker
+
         result = analyze_ticker("BEAR", db_path=db_path)
         assert result.final_action == "SELL"
         assert result.agreement_rate == 1.0
@@ -261,6 +456,7 @@ class TestAnalyzeTicker:
 class TestConsensusDeep:
     def test_analyze_ticker(self, rich_db):
         from nuri.trading.agents.consensus import analyze_ticker
+
         result = analyze_ticker("AAPL")
         assert hasattr(result, "final_action")
         assert hasattr(result, "final_confidence")
@@ -268,6 +464,7 @@ class TestConsensusDeep:
 
     def test_analyze_portfolio(self, rich_db):
         from nuri.trading.agents.consensus import analyze_portfolio
+
         results = analyze_portfolio()
         assert isinstance(results, list)
         assert len(results) > 0
@@ -276,6 +473,7 @@ class TestConsensusDeep:
 class TestConsensusInternals:
     def test_consensus_result_structure(self, rich_db):
         from nuri.trading.agents.consensus import analyze_ticker
+
         result = analyze_ticker("AAPL")
         assert hasattr(result, "verdicts")
         assert isinstance(result.verdicts, list)
@@ -283,6 +481,7 @@ class TestConsensusInternals:
 
     def test_consensus_all_tickers(self, rich_db):
         from nuri.trading.agents.consensus import analyze_portfolio
+
         results = analyze_portfolio(db_path=rich_db)
         tickers = [r.ticker for r in results]
         # rich_db seeds AAPL, MSFT, SPY, TSLA
@@ -292,8 +491,10 @@ class TestConsensusInternals:
 class TestConsensusSave:
     def test_save_to_db(self, rich_db):
         from nuri.trading.agents.consensus import analyze_ticker
+
         analyze_ticker("AAPL")
         from nuri.core.db import query
+
         recs = query("SELECT * FROM recommendations WHERE ticker='AAPL'")
         assert isinstance(recs, list)
 
@@ -304,24 +505,28 @@ class TestConsensus_R23:
     def test_compute_weights_no_data(self, db_path):
         """No recommendation data → default weights."""
         from nuri.trading.agents.consensus import _compute_weights
+
         weights = _compute_weights(db_path=db_path)
         assert abs(weights["technical"] - 0.16) < 0.01
 
     def test_compute_weights_with_data(self, db_path):
         """With enough data → adjusted weights."""
         from nuri.trading.agents.consensus import _compute_weights
+
         with get_db(db_path) as conn:
             for i in range(15):
-                verdicts = json.dumps({
-                    "verdicts": [
-                        {"agent_name": "technical", "action": "BUY"},
-                        {"agent_name": "fundamental", "action": "BUY"},
-                    ]
-                })
+                verdicts = json.dumps(
+                    {
+                        "verdicts": [
+                            {"agent_name": "technical", "action": "BUY"},
+                            {"agent_name": "fundamental", "action": "BUY"},
+                        ]
+                    }
+                )
                 conn.execute(
                     "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals, entry_price, outcome_30d) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (f"2026-01-{i+1:02d}", f"T{i}", "BUY", 70, "bull", verdicts, 100.0, 5.0 + i),
+                    (f"2026-01-{i + 1:02d}", f"T{i}", "BUY", 70, "bull", verdicts, 100.0, 5.0 + i),
                 )
         weights = _compute_weights(db_path=db_path)
         assert abs(sum(weights.values()) - 1.0) < 0.01
@@ -329,12 +534,13 @@ class TestConsensus_R23:
     def test_compute_weights_non_json_signals(self, db_path):
         """Signals field that isn't the expected JSON format."""
         from nuri.trading.agents.consensus import _compute_weights
+
         with get_db(db_path) as conn:
             for i in range(15):
                 conn.execute(
                     "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals, entry_price, outcome_30d) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (f"2026-02-{i+1:02d}", f"T{i}", "BUY", 70, "bull", '["rsi_oversold"]', 100.0, 3.0),
+                    (f"2026-02-{i + 1:02d}", f"T{i}", "BUY", 70, "bull", '["rsi_oversold"]', 100.0, 3.0),
                 )
         weights = _compute_weights(db_path=db_path)
         assert "technical" in weights
@@ -346,17 +552,20 @@ class TestConsensus_R23:
 
         class SlowAgent:
             name = "slow_agent"
+
             def analyze(self, ticker, db_path=None):
                 return AgentVerdict("slow_agent", ticker, "HOLD", 50, "slow result")
 
         class QuickAgent:
             name = "technical"
+
             def analyze(self, ticker, db_path=None):
                 return AgentVerdict("technical", ticker, "BUY", 70, "quick buy")
 
         monkeypatch.setattr("nuri.trading.agents.consensus.ALL_AGENTS", [QuickAgent(), SlowAgent()])
-        monkeypatch.setattr("nuri.trading.agents.consensus._compute_weights",
-                            lambda db_path=None: {"technical": 0.5, "slow_agent": 0.5})
+        monkeypatch.setattr(
+            "nuri.trading.agents.consensus._compute_weights", lambda db_path=None: {"technical": 0.5, "slow_agent": 0.5}
+        )
         result = analyze_ticker("AAPL", db_path=db_path)
         assert result.ticker == "AAPL"
         assert result.final_action in ("BUY", "SELL", "HOLD")
@@ -365,22 +574,29 @@ class TestConsensus_R23:
         """Print consensus with price targets."""
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
-        results = [ConsensusResult(
-            ticker="AAPL", final_action="BUY", final_confidence=75.0,
-            agreement_rate=0.8,
-            verdicts=[
-                AgentVerdict("technical", "AAPL", "BUY", 80, "buy signal"),
-                AgentVerdict("fundamental", "AAPL", "HOLD", 40, "neutral"),
-            ],
-            dissent=["fundamental(HOLD, 40): neutral"],
-            reasoning="technical: buy signal",
-        )]
-        monkeypatch.setattr("nuri.trading.recommend.price_targets.calculate_targets",
-                            lambda *a, **kw: {"ticker": "AAPL", "error": "no data"})
-        monkeypatch.setattr("nuri.trading.recommend.price_targets.format_target_tree",
-                            lambda t: "AAPL target tree")
-        monkeypatch.setattr("nuri.collectors.external.get_external",
-                            lambda *a: (_ for _ in ()).throw(ImportError("no module")))
+
+        results = [
+            ConsensusResult(
+                ticker="AAPL",
+                final_action="BUY",
+                final_confidence=75.0,
+                agreement_rate=0.8,
+                verdicts=[
+                    AgentVerdict("technical", "AAPL", "BUY", 80, "buy signal"),
+                    AgentVerdict("fundamental", "AAPL", "HOLD", 40, "neutral"),
+                ],
+                dissent=["fundamental(HOLD, 40): neutral"],
+                reasoning="technical: buy signal",
+            )
+        ]
+        monkeypatch.setattr(
+            "nuri.trading.recommend.price_targets.calculate_targets",
+            lambda *a, **kw: {"ticker": "AAPL", "error": "no data"},
+        )
+        monkeypatch.setattr("nuri.trading.recommend.price_targets.format_target_tree", lambda t: "AAPL target tree")
+        monkeypatch.setattr(
+            "nuri.collectors.external.get_external", lambda *a: (_ for _ in ()).throw(ImportError("no module"))
+        )
         print_consensus(results)
         captured = capsys.readouterr()
         assert "AAPL" in captured.out
@@ -389,6 +605,7 @@ class TestConsensus_R23:
     def test_print_consensus_empty(self, capsys):
         """Print with empty results."""
         from nuri.trading.agents.consensus import print_consensus
+
         print_consensus([])
         captured = capsys.readouterr()
         assert "합의 결과 없음" in captured.out
@@ -397,20 +614,30 @@ class TestConsensus_R23:
         """Print consensus with external data."""
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
-        results = [ConsensusResult(
-            ticker="AAPL", final_action="HOLD", final_confidence=50.0,
-            agreement_rate=0.6,
-            verdicts=[AgentVerdict("technical", "AAPL", "HOLD", 50, "neutral")],
-            dissent=[], reasoning="neutral",
-        )]
-        monkeypatch.setattr("nuri.trading.recommend.price_targets.calculate_targets",
-                            lambda *a, **kw: (_ for _ in ()).throw(Exception("fail")))
-        monkeypatch.setattr("nuri.collectors.external.get_external",
-                            lambda ticker: [
-                                {"data_type": "consensus", "value": "Strong Buy", "source": "tipranks", "numeric_value": None},
-                                {"data_type": "superinvestor_count", "value": "5", "source": "dataroma", "numeric_value": 5},
-                                {"data_type": "target_price", "value": "$200", "source": "tipranks", "numeric_value": 200},
-                            ])
+
+        results = [
+            ConsensusResult(
+                ticker="AAPL",
+                final_action="HOLD",
+                final_confidence=50.0,
+                agreement_rate=0.6,
+                verdicts=[AgentVerdict("technical", "AAPL", "HOLD", 50, "neutral")],
+                dissent=[],
+                reasoning="neutral",
+            )
+        ]
+        monkeypatch.setattr(
+            "nuri.trading.recommend.price_targets.calculate_targets",
+            lambda *a, **kw: (_ for _ in ()).throw(Exception("fail")),
+        )
+        monkeypatch.setattr(
+            "nuri.collectors.external.get_external",
+            lambda ticker: [
+                {"data_type": "consensus", "value": "Strong Buy", "source": "tipranks", "numeric_value": None},
+                {"data_type": "superinvestor_count", "value": "5", "source": "dataroma", "numeric_value": 5},
+                {"data_type": "target_price", "value": "$200", "source": "tipranks", "numeric_value": 200},
+            ],
+        )
         print_consensus(results)
         captured = capsys.readouterr()
         assert "External Data" in captured.out
@@ -422,13 +649,13 @@ class TestAdditionalEdgeCases_R23:
     def test_wallstreet_cached_ratings_upgrades(self, db_path):
         """WallStreet _check_cached with ratings data."""
         from nuri.trading.agents.wallstreet import WallStreetAgent
+
         agent = WallStreetAgent()
         with get_db(db_path) as conn:
             for i in range(5):
                 conn.execute(
-                    "INSERT INTO analyst_ratings (ticker, date, firm, action, target_price) "
-                    "VALUES (?, ?, ?, ?, ?)",
-                    ("TSLA", f"2026-03-{20+i}", f"Firm{i}", "upgrade", 300 + i * 10),
+                    "INSERT INTO analyst_ratings (ticker, date, firm, action, target_price) VALUES (?, ?, ?, ?, ?)",
+                    ("TSLA", f"2026-03-{20 + i}", f"Firm{i}", "upgrade", 300 + i * 10),
                 )
         result = agent._check_cached("TSLA", db_path)
         assert result is not None
@@ -437,6 +664,7 @@ class TestAdditionalEdgeCases_R23:
     def test_wallstreet_cached_earnings_positive(self, db_path):
         """WallStreet _check_cached with positive earnings surprise."""
         from nuri.trading.agents.wallstreet import WallStreetAgent
+
         agent = WallStreetAgent()
         with get_db(db_path) as conn:
             conn.execute(
@@ -450,6 +678,7 @@ class TestAdditionalEdgeCases_R23:
     def test_wallstreet_cached_earnings_negative(self, db_path):
         """WallStreet _check_cached with negative earnings surprise."""
         from nuri.trading.agents.wallstreet import WallStreetAgent
+
         agent = WallStreetAgent()
         with get_db(db_path) as conn:
             conn.execute(
@@ -463,13 +692,14 @@ class TestAdditionalEdgeCases_R23:
     def test_wallstreet_cached_insider_sells(self, db_path):
         """WallStreet _check_cached with heavy insider sells."""
         from nuri.trading.agents.wallstreet import WallStreetAgent
+
         agent = WallStreetAgent()
         with get_db(db_path) as conn:
             for i in range(8):
                 conn.execute(
                     "INSERT INTO insider_trades (ticker, date, insider_name, transaction_type, shares, value) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    ("TSLA", f"2026-03-{10+i}", f"Insider{i}", "sale", 1000, 100000),
+                    ("TSLA", f"2026-03-{10 + i}", f"Insider{i}", "sale", 1000, 100000),
                 )
         result = agent._check_cached("TSLA", db_path)
         assert result is not None
@@ -482,17 +712,20 @@ class TestAdditionalEdgeCases_R23:
 
         class RiskAgent:
             name = "risk"
+
             def analyze(self, ticker, db_path=None):
                 return AgentVerdict("risk", ticker, "SELL", 90, "veto: danger")
 
         class TechAgent:
             name = "technical"
+
             def analyze(self, ticker, db_path=None):
                 return AgentVerdict("technical", ticker, "BUY", 80, "buy signal")
 
         monkeypatch.setattr("nuri.trading.agents.consensus.ALL_AGENTS", [TechAgent(), RiskAgent()])
-        monkeypatch.setattr("nuri.trading.agents.consensus._compute_weights",
-                            lambda db_path=None: {"technical": 0.5, "risk": 0.5})
+        monkeypatch.setattr(
+            "nuri.trading.agents.consensus._compute_weights", lambda db_path=None: {"technical": 0.5, "risk": 0.5}
+        )
         result = analyze_ticker("AAPL", db_path=db_path)
         assert result.final_action == "SELL"
         assert "거부권" in result.reasoning
@@ -500,6 +733,7 @@ class TestAdditionalEdgeCases_R23:
     def test_wallstreet_insider_net_buy(self, db_path, monkeypatch):
         """Insider net buy signal."""
         from nuri.trading.agents.wallstreet import WallStreetAgent
+
         agent = WallStreetAgent()
         monkeypatch.setattr(agent, "_check_cached", lambda *a, **kw: None)
         ins_data = pd.DataFrame({"Text": ["Purchase of"] * 5 + ["Sale of"] * 1})
@@ -511,6 +745,7 @@ class TestAdditionalEdgeCases_R23:
             recommendations = None
 
         import yfinance
+
         monkeypatch.setattr(yfinance, "Ticker", lambda t: MockTicker())
         v = agent.analyze("TEST", db_path=db_path)
         assert "내부자 순매수" in v.reasoning
@@ -518,11 +753,18 @@ class TestAdditionalEdgeCases_R23:
     def test_wallstreet_consensus_bull(self, db_path, monkeypatch):
         """Consensus bullish."""
         from nuri.trading.agents.wallstreet import WallStreetAgent
+
         agent = WallStreetAgent()
         monkeypatch.setattr(agent, "_check_cached", lambda *a, **kw: None)
-        rec_data = pd.DataFrame({
-            "strongBuy": [8], "buy": [5], "hold": [2], "sell": [0], "strongSell": [0],
-        })
+        rec_data = pd.DataFrame(
+            {
+                "strongBuy": [8],
+                "buy": [5],
+                "hold": [2],
+                "sell": [0],
+                "strongSell": [0],
+            }
+        )
 
         class MockTicker:
             upgrades_downgrades = None
@@ -531,6 +773,7 @@ class TestAdditionalEdgeCases_R23:
             recommendations = rec_data
 
         import yfinance
+
         monkeypatch.setattr(yfinance, "Ticker", lambda t: MockTicker())
         v = agent.analyze("TEST", db_path=db_path)
         assert "매수" in v.reasoning
@@ -542,12 +785,14 @@ class TestConsensus_R27:
     def test_compute_weights_default(self, db_path):
         """Default weights when no recommendation data."""
         from nuri.trading.agents.consensus import _compute_weights
+
         weights = _compute_weights(db_path=db_path)
         assert abs(sum(weights.values()) - 1.0) < 0.01
 
     def test_compute_weights_with_data(self, db_path):
         """Weights adjusted with learning memory data."""
         from nuri.trading.agents.consensus import _compute_weights
+
         with get_db(db_path) as conn:
             for i in range(15):
                 verdicts_data = {
@@ -559,8 +804,16 @@ class TestConsensus_R27:
                 conn.execute(
                     "INSERT OR IGNORE INTO recommendations (date, ticker, action, confidence, regime, signals, "
                     "entry_price, outcome_30d) VALUES (?,?,?,?,?,?,?,?)",
-                    (f"2024-{(i%12)+1:02d}-{15+i}", f"AAPL{i}", "BUY", 70, "bull",
-                     json.dumps(verdicts_data), 150, 5.0 if i % 2 == 0 else -2.0),
+                    (
+                        f"2024-{(i % 12) + 1:02d}-{15 + i}",
+                        f"AAPL{i}",
+                        "BUY",
+                        70,
+                        "bull",
+                        json.dumps(verdicts_data),
+                        150,
+                        5.0 if i % 2 == 0 else -2.0,
+                    ),
                 )
         weights = _compute_weights(db_path=db_path)
         assert abs(sum(weights.values()) - 1.0) < 0.01
@@ -568,6 +821,7 @@ class TestConsensus_R27:
     def test_print_consensus_empty(self, capsys):
         """print_consensus with empty results."""
         from nuri.trading.agents.consensus import print_consensus
+
         print_consensus([])
         captured = capsys.readouterr()
         assert "합의 결과 없음" in captured.out
@@ -576,16 +830,22 @@ class TestConsensus_R27:
         """print_consensus with mock results."""
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
         verdicts = [
             AgentVerdict("technical", "AAPL", "BUY", 70, "RSI bullish"),
             AgentVerdict("risk", "AAPL", "HOLD", 50, "moderate risk"),
         ]
-        results = [ConsensusResult(
-            ticker="AAPL", final_action="BUY", final_confidence=65,
-            agreement_rate=0.7, verdicts=verdicts,
-            dissent=["risk(HOLD, 50): moderate risk"],
-            reasoning="technical: RSI bullish",
-        )]
+        results = [
+            ConsensusResult(
+                ticker="AAPL",
+                final_action="BUY",
+                final_confidence=65,
+                agreement_rate=0.7,
+                verdicts=verdicts,
+                dissent=["risk(HOLD, 50): moderate risk"],
+                reasoning="technical: RSI bullish",
+            )
+        ]
         print_consensus(results)
         captured = capsys.readouterr()
         assert "AAPL" in captured.out
@@ -594,6 +854,7 @@ class TestConsensus_R27:
 class TestPrintConsensus:
     def test_empty(self, capsys):
         from nuri.trading.agents.consensus import print_consensus
+
         print_consensus([])
         output = capsys.readouterr().out
         assert "없음" in output
@@ -601,6 +862,7 @@ class TestPrintConsensus:
     def test_with_results(self, capsys):
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
         verdicts = [
             AgentVerdict("technical", "AAPL", "BUY", 70, "RSI ok"),
             AgentVerdict("fundamental", "AAPL", "BUY", 65, "PE low"),
@@ -608,12 +870,17 @@ class TestPrintConsensus:
             AgentVerdict("risk", "AAPL", "HOLD", 50, "중립"),
             AgentVerdict("smart_money", "AAPL", "BUY", 55, "13F"),
         ]
-        results = [ConsensusResult(
-            ticker="AAPL", final_action="BUY", final_confidence=68.0,
-            agreement_rate=0.80, verdicts=verdicts,
-            dissent=["risk(HOLD, 50): 중립"],
-            reasoning="consensus",
-        )]
+        results = [
+            ConsensusResult(
+                ticker="AAPL",
+                final_action="BUY",
+                final_confidence=68.0,
+                agreement_rate=0.80,
+                verdicts=verdicts,
+                dissent=["risk(HOLD, 50): 중립"],
+                reasoning="consensus",
+            )
+        ]
         print_consensus(results)
         output = capsys.readouterr().out
         assert "AAPL" in output
@@ -622,6 +889,7 @@ class TestPrintConsensus:
 
     def test_analyze_portfolio_empty(self, db_path):
         from nuri.trading.agents.consensus import analyze_portfolio
+
         results = analyze_portfolio(db_path=db_path)
         assert results == []
 
@@ -630,9 +898,13 @@ class TestConsensusPrint:
     def test_print_consensus(self, capsys):
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult
+
         result = ConsensusResult(
-            ticker="AAPL", final_action="BUY", final_confidence=75.0,
-            agreement_rate=0.85, dissent=["risk"],
+            ticker="AAPL",
+            final_action="BUY",
+            final_confidence=75.0,
+            agreement_rate=0.85,
+            dissent=["risk"],
             verdicts=[
                 AgentVerdict("technical", "AAPL", "BUY", 70, "RSI 매수"),
                 AgentVerdict("risk", "AAPL", "SELL", 80, "과집중"),
@@ -648,6 +920,7 @@ class TestConsensusFull:
     def test_print_with_all_agents(self, capsys):
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
         verdicts = [
             AgentVerdict("technical", "AAPL", "BUY", 70, "RSI 과매도 반등"),
             AgentVerdict("fundamental", "AAPL", "BUY", 65, "PE 적정, ROE 높음"),
@@ -659,8 +932,11 @@ class TestConsensusFull:
         ]
         results = [
             ConsensusResult(
-                ticker="AAPL", final_action="BUY", final_confidence=68.0,
-                agreement_rate=0.57, verdicts=verdicts,
+                ticker="AAPL",
+                final_action="BUY",
+                final_confidence=68.0,
+                agreement_rate=0.57,
+                verdicts=verdicts,
                 dissent=[
                     "macro(HOLD, 45): 횡보 레짐",
                     "risk(HOLD, 40): 집중도 정상",
@@ -669,8 +945,11 @@ class TestConsensusFull:
                 reasoning="technical + fundamental + smart_money",
             ),
             ConsensusResult(
-                ticker="TSLA", final_action="SELL", final_confidence=72.0,
-                agreement_rate=0.71, verdicts=[
+                ticker="TSLA",
+                final_action="SELL",
+                final_confidence=72.0,
+                agreement_rate=0.71,
+                verdicts=[
                     AgentVerdict("technical", "TSLA", "SELL", 75, "데드크로스"),
                     AgentVerdict("fundamental", "TSLA", "SELL", 60, "PE 327"),
                     AgentVerdict("macro", "TSLA", "SELL", 55, "bear regime"),
@@ -697,13 +976,17 @@ class TestConsensusFull:
                 self.name = name
                 self._a = action
                 self._c = conf
+
             def analyze(self, ticker, db_path=None):
                 return AgentVerdict(self.name, ticker, self._a, self._c, "mock reason")
 
         agents = [
-            MockAgent("technical", "BUY", 70), MockAgent("fundamental", "BUY", 65),
-            MockAgent("macro", "HOLD", 50), MockAgent("risk", "HOLD", 45),
-            MockAgent("smart_money", "BUY", 55), MockAgent("wallstreet", "BUY", 60),
+            MockAgent("technical", "BUY", 70),
+            MockAgent("fundamental", "BUY", 65),
+            MockAgent("macro", "HOLD", 50),
+            MockAgent("risk", "HOLD", 45),
+            MockAgent("smart_money", "BUY", 55),
+            MockAgent("wallstreet", "BUY", 60),
             MockAgent("korean_market", "HOLD", 30),
         ]
         monkeypatch.setattr(cons_mod, "ALL_AGENTS", agents)
@@ -722,6 +1005,7 @@ class TestConsensusVerbose:
     def test_print_consensus_verbose_keyword_only(self, capsys):
         """verbose는 keyword-only — 위치 인자로 못 전달."""
         from nuri.trading.agents.consensus import print_consensus
+
         with pytest.raises(TypeError):
             print_consensus([], True)  # positional bool intentionally — verbose is keyword-only
 
@@ -729,6 +1013,7 @@ class TestConsensusVerbose:
         """여러 종목 + verbose=False → supporting reasoning 출력 안 함."""
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
         verdicts = [
             AgentVerdict("technical", "TSLA", "BUY", 100, "MACD>Signal; 추세강세(+84)"),
             AgentVerdict("risk", "TSLA", "BUY", 80, "수익 양호"),
@@ -742,6 +1027,7 @@ class TestConsensusVerbose:
     def test_print_consensus_verbose_shows_supporters(self, capsys):
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
         verdicts = [
             AgentVerdict("technical", "TSLA", "BUY", 100, "MACD>Signal; 추세강세(+84)"),
             AgentVerdict("risk", "TSLA", "BUY", 80, "수익 양호"),
@@ -758,6 +1044,7 @@ class TestConsensusVerbose:
         """단일 종목은 verbose=False여도 자동으로 supporting 출력."""
         from nuri.trading.agents.base import AgentVerdict
         from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
         verdicts = [
             AgentVerdict("technical", "TSLA", "BUY", 100, "test reasoning"),
         ]
@@ -812,7 +1099,8 @@ class TestConsensusTimeout_R130:
 
         monkeypatch.setattr(cons_mod, "ALL_AGENTS", [FastAgent(), HangingAgent()])
         monkeypatch.setattr(
-            cons_mod, "_compute_weights",
+            cons_mod,
+            "_compute_weights",
             lambda db_path=None: {"technical": 0.5, "hanging": 0.5},
         )
         self._patch_short_timeout(monkeypatch, 0.3)
@@ -859,7 +1147,8 @@ class TestConsensusTimeout_R130:
 
         monkeypatch.setattr(cons_mod, "ALL_AGENTS", [FastAgent(), HangingAgent()])
         monkeypatch.setattr(
-            cons_mod, "_compute_weights",
+            cons_mod,
+            "_compute_weights",
             lambda db_path=None: {"technical": 0.5, "hanging": 0.5},
         )
         self._patch_short_timeout(monkeypatch, 0.3)


### PR DESCRIPTION
## Problem

STRATEGY §5.10 (JKHY episode, 2026-04-14) — original hypothesis: *"`chart_analysis.py` exists but isn't wired into the recommendation pipeline."* Post-#300 backfill investigation showed the real failure mode is quieter:

- `TechnicalAgent` **already** imports and calls `analyze_chart(ticker)` (line 12, 78 of `nuri/trading/agents/technical.py`).
- For universe-only tickers with 3-5 DB rows (pre-#300), `analyze_chart` returned an empty `ChartAnalysis` (MIN_DATA_POINTS=30 unmet) and the chart contributions were silently skipped.
- Even after #300 backfilled 1y (252 rows) so the technical agent now produces a proper SELL, the other 9 fundamentals-ish agents (fundamental/wallstreet/smart_money/macro/etc.) can **outvote** it. The user sees "consensus BUY" without ever seeing the technical dissent.

P1 A1 surfaces the dissent so the user can cross-verify before acting.

## Change

`ConsensusResult` gets two new fields, defaulting to safe no-ops so every existing caller keeps working:

```python
divergence_flag: bool = False    # technical voted opposite of final action
divergence_reason: str = ""      # human-readable explanation for UI
```

`_build_consensus()` computes them after the existing dissent list. Rules:
- Flag only on direct BUY↔SELL opposition (consensus BUY + technical SELL, or inverse).
- Technical HOLD is treated as a *weak* disagreement and does **not** trip the flag — noise discipline so the warning keeps meaning.
- Consensus HOLD is never flagged (no BUY/SELL to oppose).

## Live verification (post-#300 backfill)

```
JKHY → action=BUY  conf=42.4  divergence_flag=True
       "TechnicalAgent 가 SELL (conf 100) — 합의 BUY 과 충돌.
        근거: SMA50<SMA200 (데드크로스); MACD<Signal; 추세약세(-63)"
V    → HOLD, no divergence
MA   → HOLD, no divergence
```

JKHY exactly reproduces the original episode. The divergence warning now surfaces instead of being swallowed.

## Tests

New `TestConsensusDivergence` class + `test_divergence_fields_default_false` (regression guard). 5 spec cases:

- BUY + technical SELL → flag=True (the JKHY class) ✅
- SELL + technical BUY → flag=True (inverse) ✅
- BUY + technical HOLD → flag=False (noise suppression) ✅
- BUY + technical BUY → flag=False (agreement) ✅
- HOLD + technical SELL → flag=False (no BUY/SELL to oppose) ✅

Full regression: 59/59 `test_consensus.py` passing.

## Scope discipline

- Backend only. 2 files (consensus.py + test_consensus.py). Net ~130 new lines; remaining diff is ruff format sweep on already-touched files.
- No API schema change, no frontend change, no migration, no config — all deferred to P1 A2.
- No change to voting, weights, veto, agreement_rate, or action determination. Flag is **additive** (pure observability).

## Deferred (P1 A2 — next PR)

- `/api/recommendations/*` schema: expose `divergence_flag` / `divergence_reason`.
- Dashboard recommendations list: badge + tooltip when flag is set.
- `/api/market-context` / actions widget: same rendering.
- Optional: propagate to `Candidate` dataclass in `candidates.py` for the screener path.

## Test plan

- [x] `pytest tests/trading/agents/test_consensus.py` → 59 passed
- [x] `pytest tests/trading/agents/test_consensus.py::TestConsensusDivergence` → 5 passed
- [x] `make lint` → clean
- [x] `scripts/check_privacy_leak.py` → clean
- [x] Live JKHY repro → `divergence_flag=True` with human-readable reason
- [ ] Post-merge: run `make consensus` / `make recommend` and confirm flag appears in logs for other tickers (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)