### PR TITLE
feat(consensus): divergence_flag mechanical penalty (P1 A3 — closes JKHY loop)

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -220,6 +220,13 @@ consensus:
   # 가 한 번만 느려도 전체 ticker가 죽던 #130 버그의 근본 수정.
   # timeout 도달 시 미완료 에이전트는 HOLD/0/타임아웃 verdict로 폴백.
   agent_timeout_sec: 60
+  # Divergence mechanical penalty — STRATEGY §5.10 JKHY 재발 방지.
+  # TechnicalAgent 가 합의 BUY/SELL 과 정면 반대 방향이면서 confidence 가
+  # threshold 이상이면 final_action 을 HOLD 로 downgrade. 단순 surface 에서
+  # 실질 guardrail 로 전환 (P1 A1/A2 가 informational only 였던 것 보완).
+  # Risk veto 는 이 penalty 보다 우선한다 (precedence).
+  # disable 하려면 divergence_technical_threshold 를 101 이상으로.
+  divergence_technical_threshold: 80
   learning_memory:
     lookback_days: 180
     min_records: 10

--- a/nuri/trading/agents/consensus.py
+++ b/nuri/trading/agents/consensus.py
@@ -178,10 +178,12 @@ def _build_consensus(ticker: str, verdicts: list[AgentVerdict], weights: dict) -
     # 리스크 에이전트 거부권
     veto_threshold = AGENT_CONFIG.get("consensus", {}).get("risk_veto_threshold", 80)
     risk_v = next((v for v in verdicts if v.agent_name == "risk"), None)
+    risk_veto_fired = False
     if risk_v and risk_v.action == "SELL" and risk_v.confidence >= veto_threshold:
         final_action = "SELL"
         final_confidence = risk_v.confidence
         reasoning = f"리스크 에이전트 거부권 발동: {risk_v.reasoning}"
+        risk_veto_fired = True
     else:
         final_action = max(action_scores, key=lambda k: action_scores[k])
         total_weight = sum(action_scores.values())
@@ -189,17 +191,10 @@ def _build_consensus(ticker: str, verdicts: list[AgentVerdict], weights: dict) -
         supporters = [v for v in verdicts if v.action == final_action]
         reasoning = " | ".join(f"{v.agent_name}: {v.reasoning}" for v in supporters)
 
-    agree_count = sum(1 for v in verdicts if v.action == final_action)
-    agreement_rate = agree_count / len(verdicts) if verdicts else 0
-    dissent = [
-        f"{v.agent_name}({v.action}, {v.confidence:.0f}): {v.reasoning}" for v in verdicts if v.action != final_action
-    ]
-
     # Divergence detection — STRATEGY §5.10 (JKHY, 2026-04-14) 재발 방지.
     # 9개 fundamentals-ish 에이전트가 BUY 를 몰아주면 TechnicalAgent 의 SELL
     # 반대가 묻힘. 합의 action 이 BUY/SELL 이고 technical 이 정확히 반대 action
-    # 이면 flag + reason 을 surface 해 사용자가 교차 검증하도록 한다.
-    # HOLD 는 "약한 반대" 로 간주해 flag 하지 않는다 (noise 억제).
+    # 이면 flag + reason 을 surface. HOLD 는 "약한 반대" 로 간주해 flag 하지 않음.
     divergence_flag = False
     divergence_reason = ""
     tech_v = next((v for v in verdicts if v.agent_name == "technical"), None)
@@ -212,6 +207,32 @@ def _build_consensus(ticker: str, verdicts: list[AgentVerdict], weights: dict) -
                 f"(conf {tech_v.confidence:.0f}) — 합의 {final_action} 과 충돌. "
                 f"근거: {tech_v.reasoning[:120]}"
             )
+
+    # Divergence mechanical penalty — flag 가 informational 인 P1 A1/A2 한계 보완.
+    # tech confidence 가 threshold 이상일 때만 final_action 을 HOLD 로 downgrade.
+    # 원래 계산된 final_confidence 는 **그대로 유지** (downstream 이 신뢰도 정보
+    # 로 사용할 수 있게). reasoning 에 penalty 근거 prepend. Risk veto 가 이미
+    # 발동했다면 precedence 에 따라 penalty skip.
+    divergence_threshold = AGENT_CONFIG.get("consensus", {}).get("divergence_technical_threshold", 80)
+    if divergence_flag and not risk_veto_fired and tech_v and tech_v.confidence >= divergence_threshold:
+        final_action = "HOLD"
+        reasoning = f"기술지표 반대로 downgrade (tech {tech_v.action} conf {tech_v.confidence:.0f} ≥ {divergence_threshold}) | {reasoning}"
+
+    # agreement_rate / dissent 는 **penalty 이전** 의 원 verdict 분포 기준으로
+    # 계산 — 사용자가 "10 중 몇 개가 HOLD 동의" 가 아니라 "원래 BUY/SELL 쪽은
+    # 몇 개 였는지" 를 볼 수 있어야 penalty 맥락을 이해할 수 있다.
+    pre_penalty_action = (
+        final_action
+        if not (divergence_flag and not risk_veto_fired and tech_v and tech_v.confidence >= divergence_threshold)
+        else ("BUY" if tech_v and tech_v.action == "SELL" else "SELL")
+    )
+    agree_count = sum(1 for v in verdicts if v.action == pre_penalty_action)
+    agreement_rate = agree_count / len(verdicts) if verdicts else 0
+    dissent = [
+        f"{v.agent_name}({v.action}, {v.confidence:.0f}): {v.reasoning}"
+        for v in verdicts
+        if v.action != pre_penalty_action
+    ]
 
     return ConsensusResult(
         ticker=ticker,

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -301,6 +301,150 @@ class TestConsensusDivergence:
         assert result.divergence_flag is False
 
 
+class TestConsensusDivergenceMechanicalPenalty:
+    """P1 A3 — divergence_flag 가 informational 에서 실 action downgrade 로 전환.
+
+    Codex-reviewed design:
+    - tech confidence ≥ threshold (default 80) 일 때만 발동
+    - BUY/SELL → HOLD downgrade (risk veto 와 달리 full flip 아님)
+    - Symmetric: BUY vs SELL 같이 처리
+    - Risk veto 우선 — 그 경우 penalty skip
+    - final_confidence 는 **보존** (원 계산값). agreement_rate/dissent 도 원 final_action 기준.
+    """
+
+    @staticmethod
+    def _verdict(name, action, confidence=70):
+        from nuri.trading.agents.base import AgentVerdict
+
+        return AgentVerdict(name, "TEST", action, confidence, f"mock {name}")
+
+    def _scenario_buy_consensus_with_tech_sell(self, tech_conf: float):
+        """BUY 8 + HOLD 1 + tech=SELL — 합의 BUY 여야 자연스러움."""
+        verdicts = [
+            self._verdict("technical", "SELL", tech_conf),
+            self._verdict("fundamental", "BUY", 70),
+            self._verdict("wallstreet", "BUY", 70),
+            self._verdict("smart_money", "BUY", 70),
+            self._verdict("macro", "BUY", 70),
+            self._verdict("korean_market", "BUY", 70),
+            self._verdict("options", "BUY", 70),
+            self._verdict("crypto", "BUY", 70),
+            self._verdict("retail", "BUY", 70),
+            self._verdict("risk", "HOLD", 40),
+        ]
+        weights = {v.agent_name: 0.1 for v in verdicts}
+        return verdicts, weights
+
+    def test_buy_consensus_with_technical_sell_80_downgrades_to_hold(self):
+        """JKHY-class: BUY 합의 + tech SELL conf=80 → final_action=HOLD."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        verdicts, weights = self._scenario_buy_consensus_with_tech_sell(tech_conf=80)
+        result = _build_consensus("TEST", verdicts, weights)
+
+        assert result.final_action == "HOLD", f"Expected HOLD (penalty), got {result.final_action}"
+        assert result.divergence_flag is True
+        assert "downgrade" in result.reasoning, "reasoning should flag penalty"
+
+    def test_sell_consensus_with_technical_buy_80_downgrades_to_hold(self):
+        """역방향 대칭: SELL 합의 + tech BUY conf=80 → HOLD."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        verdicts = [
+            self._verdict("technical", "BUY", 80),
+            self._verdict("fundamental", "SELL", 70),
+            self._verdict("wallstreet", "SELL", 70),
+            self._verdict("smart_money", "SELL", 70),
+            self._verdict("macro", "SELL", 70),
+            self._verdict("korean_market", "SELL", 70),
+            self._verdict("options", "SELL", 70),
+            self._verdict("crypto", "SELL", 70),
+            self._verdict("retail", "SELL", 70),
+            self._verdict("risk", "HOLD", 40),
+        ]
+        weights = {v.agent_name: 0.1 for v in verdicts}
+        result = _build_consensus("TEST", verdicts, weights)
+
+        assert result.final_action == "HOLD"
+        assert result.divergence_flag is True
+
+    def test_technical_confidence_79_does_not_trigger_penalty(self):
+        """경계 조건: tech conf 79 < threshold 80 → action 유지, flag 만 설정."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        verdicts, weights = self._scenario_buy_consensus_with_tech_sell(tech_conf=79)
+        result = _build_consensus("TEST", verdicts, weights)
+
+        assert result.final_action == "BUY", f"79 < 80 — penalty 발동 안 해야 함, got {result.final_action}"
+        assert result.divergence_flag is True, "flag 는 여전히 set"
+
+    def test_risk_veto_wins_over_divergence_penalty(self):
+        """Precedence: risk SELL conf=90 거부권 발동 → final SELL 유지 (HOLD downgrade 아님).
+
+        Risk veto 는 포트폴리오 안전 규칙. tech=BUY 가 반대한다고 HOLD 로
+        희석되면 거부권 의미 상실. risk 거부권이 divergence penalty 보다 우선.
+        """
+        from nuri.trading.agents.consensus import _build_consensus
+
+        verdicts = [
+            self._verdict("technical", "BUY", 90),  # tech 반대 + 고confidence
+            self._verdict("fundamental", "BUY", 60),
+            self._verdict("wallstreet", "BUY", 60),
+            self._verdict("risk", "SELL", 90),  # risk 거부권 발동
+            self._verdict("smart_money", "HOLD", 40),
+            self._verdict("macro", "HOLD", 40),
+            self._verdict("korean_market", "HOLD", 40),
+            self._verdict("options", "HOLD", 40),
+            self._verdict("crypto", "HOLD", 40),
+            self._verdict("retail", "HOLD", 40),
+        ]
+        weights = {v.agent_name: 0.1 for v in verdicts}
+        result = _build_consensus("TEST", verdicts, weights)
+
+        # Risk veto 승. SELL 그대로. HOLD 로 downgrade 되면 안 됨.
+        assert result.final_action == "SELL"
+        assert "거부권" in result.reasoning
+
+    def test_divergence_flag_still_surfaces_after_penalty(self):
+        """Penalty 가 발동해도 flag + reason 은 사용자에게 여전히 노출."""
+        from nuri.trading.agents.consensus import _build_consensus
+
+        verdicts, weights = self._scenario_buy_consensus_with_tech_sell(tech_conf=85)
+        result = _build_consensus("TEST", verdicts, weights)
+
+        assert result.final_action == "HOLD"  # penalty fired
+        assert result.divergence_flag is True
+        assert result.divergence_reason != ""
+        assert "SELL" in result.divergence_reason
+
+    def test_final_confidence_preserved_after_penalty(self):
+        """Penalty 가 action 만 바꾸고 final_confidence 는 원 계산값 유지.
+
+        근거: downstream (dashboard, SIEGE) 이 confidence 를 신뢰도 정보로 사용.
+        Penalty 발동 시 "HOLD with 원 confidence 50" 이 "원래는 BUY 70% 였지만
+        tech 반대로 HOLD" 라는 의미를 유지. 0 으로 리셋하면 정보 손실.
+        """
+        from nuri.trading.agents.consensus import _build_consensus
+
+        verdicts, weights = self._scenario_buy_consensus_with_tech_sell(tech_conf=90)
+        # tech conf 79 는 penalty 발동 안 함 → 같은 weights/actions 로 원 final_confidence 확보
+        ref_verdicts, _ = self._scenario_buy_consensus_with_tech_sell(tech_conf=79)
+        ref_result = _build_consensus("TEST", ref_verdicts, weights)
+        # action_scores 에서 weight × (conf/100) 가 들어가므로 79 vs 90 이 결과에 영향.
+        # 동일 conf 로 확보하려면 79 → penalty 전 최대 79 의 BUY/SELL 분포로 비교
+        # 대신 중요한 assertion 은 final_confidence 가 0 으로 리셋 안 되었다는 것.
+        result = _build_consensus("TEST", verdicts, weights)
+
+        assert result.final_action == "HOLD"
+        assert result.final_confidence > 0, "penalty 가 confidence 를 0 으로 리셋하면 안 됨"
+        assert result.final_confidence != 0.0, "preserved original computed confidence"
+        # sanity: ref 는 penalty 발동 안 했으니 같은 크기 수준이어야
+        assert abs(result.final_confidence - ref_result.final_confidence) < 5, (
+            f"penalty 이후 confidence 크게 달라짐: ref={ref_result.final_confidence}, "
+            f"after penalty={result.final_confidence}"
+        )
+
+
 class TestComputeWeights:
     def test_default_weights(self, db_path):
         """추천 데이터 부족 시 기본 가중치."""


### PR DESCRIPTION
## Why

P1 A1/A2 surfaced the TechnicalAgent dissent as a ⚠ badge but did not change the final action. `/codex challenge` called this directly: *"divergence_flag is informational only, not mechanical protection. BUY stays BUY."* For the JKHY class (strong fundamentals, bearish technicals), the user still saw a BUY headline and could still act on it. Cosmetic.

## What changed

`_build_consensus()` now downgrades `final_action` BUY/SELL → HOLD when the technical agent votes the opposite direction with confidence ≥ threshold.

## Design (codex-reviewed)

- **Option D, threshold 80, symmetric.** Gate on `technical.confidence ≥ 80`. Re-uses the "80 = strong enough for mechanical action" threshold already used for `risk_veto_threshold`. Config-driven: new `consensus.divergence_technical_threshold` in `config/agents.yaml`.
- **Downgrade to HOLD, not flip to SELL.** Technical is one vote, not a dedicated safety veto; flipping would overweight it.
- **Symmetric.** `BUY + tech=SELL` and `SELL + tech=BUY` both downgrade.
- **Risk veto precedence.** When the risk agent fires (SELL + conf ≥ 80), the penalty is skipped so portfolio safety still wins over technical dissent.
- **`final_confidence` preserved.** The originally computed value is kept so downstream (`/api/consensus`, SIEGE gates, dashboard) can still reason about "was originally 70% BUY but HOLD due to technical". Zeroing would lose that context.
- **`agreement_rate` / `dissent` computed against the pre-penalty action** — the user should see that the *original* consensus was 8 BUY / 1 SELL, not "everyone HOLD".

## Live verification (post-merge of P1 B backfill)

```
JKHY → action: BUY → HOLD
       confidence: 42.4 (preserved)
       divergence_flag: True
       reasoning: "기술지표 반대로 downgrade (tech SELL conf 100 ≥ 80) | fundamental: PE 21.8 ... | wallstreet: 등급↑ ..."
```

Other portfolio tickers (NVDA, AMD, GOOGL, TSLA, AMZN, VOO, V, MA) — no penalty fired. JKHY is the only case where technical opposes consensus at conf ≥ 80. Zero false positives.

## Tests

New `TestConsensusDivergenceMechanicalPenalty` (6 cases):

- [x] BUY consensus + tech SELL 80 → final_action HOLD
- [x] SELL consensus + tech BUY 80 → final_action HOLD (symmetric)
- [x] tech confidence 79 → no penalty, action preserved, flag still true (boundary)
- [x] Risk veto SELL 90 + tech BUY 90 → final SELL (precedence)
- [x] After penalty: divergence_flag + divergence_reason still surface
- [x] After penalty: final_confidence preserved, not zeroed

Full regression: **67/67** consensus + agents API tests pass.

## Scope

- `config/agents.yaml`: +7 lines (new key + comment)
- `nuri/trading/agents/consensus.py`: +25 lines (penalty logic, pre-penalty action capture for agreement_rate/dissent)
- `tests/trading/agents/test_consensus.py`: +144 lines (new test class)
- 1 commit, no API schema change, no UI change, no migration

## Closes JKHY loop

- **P1 B (#300)**: universe 1y backfill → technical agent can see full chart
- **P1 A1 (#301)**: backend detects BUY↔tech SELL dissent
- **P1 A2 (#302, open)**: frontend surfaces ⚠ badge + tooltip
- **P1 A3 (this PR)**: mechanical action — BUY downgraded to HOLD

Badge + downgrade together. User sees both the warning AND the system's response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)