### PR TITLE
test(universe) + docs: Phase 5 QA smoke + negative guardrails (P1 D — closes #272)

### DIFF
--- a/docs/SMOKE_RUN.md
+++ b/docs/SMOKE_RUN.md
@@ -1,0 +1,132 @@
+# SMOKE_RUN.md — Fresh Clone Setup Smoke Flow
+
+Nuri-Quant 첫 설치 / 재설치 / 신규 기여자 온보딩 용. **PR CI 가 확인하지 않는 end-to-end 시나리오**를 수동으로 검증하기 위한 절차. #272 Phase 5 (2026-04-15) 기준.
+
+> 📌 **언제 돌리나**: fresh clone, 환경 초기화 후, 중대 dependency 업그레이드 후, 분기별 헬스 체크. **PR 마다 X** — 네트워크 20-30분 소요, 비결정적 외부 API 영향 받음.
+
+---
+
+## 1. Prerequisites
+
+| 항목 | 필요 버전 | 설치 방법 |
+|------|----------|---------|
+| Python | 3.12 | `brew install python@3.12` |
+| uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| TA-Lib (C lib) | latest | `brew install ta-lib` |
+| Node.js | 22+ | `brew install node@22` |
+| Git | any | 이미 있을 것 |
+
+**예상 runtime (M2 Pro 기준)**:
+- `make setup`: 2-3분 (deps install + DB init)
+- `make universe-sync-us`: 10-20초 (Wikipedia scrape)
+- `make universe-sync-kr`: 10-30초 (FDR/KRX fetch, 네트워크 불안정 시 skip)
+- `make collect-universe`: **15-20분** (yfinance 746 tickers parallel + pykrx 203 sequential)
+- `make validate-universe`: 3-5초 (DB-only)
+
+**총 예상**: 20-25분 (네트워크 + API 상태 의존).
+
+---
+
+## 2. Fresh Clone Commands (정확한 순서)
+
+```bash
+# 0. Clone + branch
+git clone https://github.com/researcherhojin/nuri-quant.git
+cd nuri-quant
+git checkout main
+
+# 1. 환경 + DB 초기화
+make setup                       # venv + deps + DB schema + portfolio import
+cd frontend && npm ci && cd ..   # frontend deps
+
+# 2. Universe 동기화 (선택 — 기본 universe.yaml 이면 skip 가능)
+make universe-sync-us            # dry-run: Wikipedia S&P 500 diff 확인
+make universe-sync-kr            # dry-run: KOSPI 200 diff (FDR 필요 시 `uv pip install finance-datareader`)
+make universe-sync-apply         # 실제 universe.yaml 에 적용 (additions only)
+
+# 3. 데이터 수집
+make collect-universe            # US + KR prices/fundamentals/wallstreet/estimates (~15분)
+# 선택: 기술분석용 1y OHLCV 확보 (P1 A 이후 필수)
+make collect-universe-1y         # 1년치 가격 히스토리 backfill (~10-15분)
+
+# 4. 검증
+.venv/bin/python scripts/validate_universe.py             # 5-check coverage gate
+.venv/bin/python scripts/validate_universe.py --no-fetch  # CI 용 (네트워크 skip)
+make validate-portfolio                                   # portfolio.yaml 각 ticker DB 검증
+
+# 5. 서버 기동 (시각 확인)
+make start                       # API :8001 + Dashboard :3000
+# 브라우저에서 http://localhost:3000 열기
+```
+
+---
+
+## 3. Expected Success Signals
+
+각 스텝 완료 후 나와야 할 signal. 이게 안 나오면 **섹션 4 triage** 로 이동.
+
+| 스텝 | 성공 신호 | 실패 신호 |
+|------|----------|----------|
+| `make setup` | `Portfolio imported. 22 holdings across 4 accounts` | ModuleNotFoundError / sqlite 에러 |
+| `make universe-sync-us` | `fetched 500+ tickers from Wikipedia` + diff summary | Wikipedia 403 / HTTP error |
+| `make universe-sync-kr` | `fetched 200 tickers` 또는 `KR sync skipped (FDR missing)` | 비정상 traceback |
+| `make collect-universe` | `prices [universe]: 100%\|` tqdm 완료 + `수집 결과: ... 성공 / ... 실패` summary | silent hang > 5분 / ERROR 500줄 |
+| `make collect-universe-1y` | prices table median rows ≥ 200 (`SELECT COUNT(*) FROM prices WHERE ticker='SPY'`) | rows < 50 |
+| `validate_universe.py` | `Result: 5/5 PASS → exit 0` | `4/5 PASS` 또는 `exit 1` |
+
+**5/5 PASS 기준값** (2026-04-15 측정):
+- prices ≥ 95% (실측 99%)
+- fundamentals ≥ 80% (실측 99%)
+- analyst_ratings ≥ 70% (실측 97%)
+- insider_trades ≥ 50% (실측 97%)
+- superinvestors ≥ 80% (실측 97%)
+
+---
+
+## 4. Failure Triage
+
+| 증상 | 가능한 원인 | 해결 |
+|------|----------|------|
+| `FileNotFoundError: config/universe.yaml 가 없습니다` | `make setup` 스킵 | `git checkout main -- config/universe.yaml` |
+| `YAML 파싱 실패` | 수동 편집 오류 | `git checkout main -- config/universe.yaml` |
+| Wikipedia 403 / timeout | User-Agent blocked | 10분 기다린 후 재시도, 아니면 `--market kr` 만 실행 |
+| pykrx 정지 / 60 tickers 이후 hang | KR rate-limit | 정상. sequential + 0.1s sleep 이미 적용됨. 15-30분 기다리기 |
+| yfinance 대량 404 | ticker delisting 정상 | 최대 5-10% 실패 허용. summary 에 표시됨 |
+| `validate_universe.py` 4/5 PASS | 특정 테이블 coverage 미달 | 해당 collector 재실행 (`make wallstreet` 등) |
+| Dashboard 500 error | API 서버 미기동 | `make api` 독립 기동 + 로그 확인 |
+| `make collect-universe-1y` 중 OOM | parallel worker 과다 | 현재 10-thread 기본 — stock.py `max_workers=10` 조정 가능 |
+
+**디버그 시**: `data/reports/YYYY-MM-DD/` 의 최신 리포트 확인. `scripts/validate_universe.py --verbose` 상세 출력.
+
+---
+
+## 5. Cleanup / Reset (rerun 준비)
+
+```bash
+# Level 1: DB 만 리셋 (빠름)
+rm data/portfolio.db
+make setup                       # schema + portfolio 재import
+
+# Level 2: build 아티팩트 포함
+make clean-all                   # __pycache__ + build + token cache
+
+# Level 3: 완전 초기화 (deps 재설치 필요)
+make clean-deep                  # node_modules + uv cache 포함. interactive 확인
+# 이후: make setup && cd frontend && npm ci
+```
+
+**주의**: `config/portfolio.yaml` 은 gitignored (사용자 실 데이터). 삭제 전 백업.
+
+---
+
+## 참고 — Phase 5 QA Scope
+
+이 문서는 **manual smoke** 용. PR CI 에 포함된 negative tests:
+
+- `tests/collectors/test_universe_sync.py::TestPhase5NegativeGuardrails` — missing/malformed/empty `universe.yaml` graceful error
+- `tests/integration/test_universe_sync_real.py` — real network integration (marker `integration`, `make test-integration` 로만 실행)
+
+**out-of-scope** (별도 PR 후보):
+- API key 기반 collector 테스트 (현 path 는 모두 keyless)
+- 분기별 자동화 live smoke CI job
+- Dependency drift 감지

--- a/nuri/collectors/universe_sync.py
+++ b/nuri/collectors/universe_sync.py
@@ -96,9 +96,28 @@ def _fetch_kospi200() -> list[str]:
 
 
 def _load_universe() -> dict[str, Any]:
-    """current universe.yaml 로드."""
-    with UNIVERSE_PATH.open() as f:
-        return yaml.safe_load(f)
+    """current universe.yaml 로드.
+
+    Raises:
+        FileNotFoundError: universe.yaml 이 없으면 actionable error message 포함.
+        ValueError: yaml 파싱 실패 시 원인 + 해결 방법 안내.
+    """
+    if not UNIVERSE_PATH.exists():
+        raise FileNotFoundError(
+            f"{UNIVERSE_PATH} 가 없습니다. fresh clone 이면 `make setup` 실행, "
+            f"또는 `git checkout main -- {UNIVERSE_PATH}` 로 복구."
+        )
+    try:
+        with UNIVERSE_PATH.open() as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        raise ValueError(
+            f"{UNIVERSE_PATH} YAML 파싱 실패: {e}. 편집 중 문법 오류 확인 또는 "
+            f"`git checkout main -- {UNIVERSE_PATH}` 로 되돌리기."
+        ) from e
+    if data is None:
+        raise ValueError(f"{UNIVERSE_PATH} 가 비어있음. 최소 us + kr 섹션 필요.")
+    return data
 
 
 def _save_universe(u: dict[str, Any]) -> None:

--- a/tests/collectors/test_universe_sync.py
+++ b/tests/collectors/test_universe_sync.py
@@ -495,3 +495,56 @@ class TestNoNoisyOutput:
         # Only one KR warning should appear (no traceback explosion)
         kr_warnings = [r for r in caplog.records if "KR sync" in r.message or "KOSPI" in r.message]
         assert len(kr_warnings) <= 2  # one info ("fetching") + one warning ("skipped")
+
+
+class TestPhase5NegativeGuardrails:
+    """P1 D — Phase 5 QA negative cases (STRATEGY §7 Tier 2 #272 완결).
+
+    3 graceful-degradation contracts that must hold for fresh-clone /
+    corrupted-setup 상황. Codex-reviewed minimal set — API key 테스트는
+    collectors 가 keyless (wallstreet/estimates/stock* 모두 yfinance/FDR
+    기반) 이라서 의미 없어 제외.
+    """
+
+    def test_missing_universe_yaml_raises_actionable_error(self, tmp_path, monkeypatch):
+        """universe.yaml 이 없으면 FileNotFoundError 에 복구 명령 포함."""
+        import nuri.collectors.universe_sync as mod
+
+        # UNIVERSE_PATH 를 tmp_path 에 없는 경로로 치환
+        missing_path = tmp_path / "does_not_exist.yaml"
+        monkeypatch.setattr(mod, "UNIVERSE_PATH", missing_path)
+
+        with pytest.raises(FileNotFoundError) as exc:
+            mod._load_universe()
+
+        msg = str(exc.value)
+        assert "없습니다" in msg, "에러 메시지는 한국어로 상태 설명"
+        assert "make setup" in msg or "git checkout" in msg, "복구 명령 포함"
+
+    def test_malformed_universe_yaml_raises_actionable_error(self, tmp_path, monkeypatch):
+        """universe.yaml YAML 문법 오류면 ValueError 에 원인 + 해결 명령."""
+        import nuri.collectors.universe_sync as mod
+
+        bad_yaml = tmp_path / "universe.yaml"
+        bad_yaml.write_text("us:\n  - AAPL\n  bad_indent\nkr: [005930.KS]\n  extra:\n")
+        monkeypatch.setattr(mod, "UNIVERSE_PATH", bad_yaml)
+
+        with pytest.raises(ValueError) as exc:
+            mod._load_universe()
+
+        msg = str(exc.value)
+        assert "파싱 실패" in msg
+        assert "git checkout" in msg, "복구 명령 포함"
+
+    def test_empty_universe_yaml_raises_actionable_error(self, tmp_path, monkeypatch):
+        """universe.yaml 이 비어있으면 ValueError — 최소 섹션 필요 안내."""
+        import nuri.collectors.universe_sync as mod
+
+        empty = tmp_path / "universe.yaml"
+        empty.write_text("")
+        monkeypatch.setattr(mod, "UNIVERSE_PATH", empty)
+
+        with pytest.raises(ValueError) as exc:
+            mod._load_universe()
+
+        assert "비어있음" in str(exc.value)


### PR DESCRIPTION
## What

`#272 Phase 5` closes the universe coverage workstream. Three additions:

**1. Guardrail — `nuri/collectors/universe_sync.py::_load_universe()`**

Missing file → `FileNotFoundError` with recovery commands (`make setup` / `git checkout main -- config/universe.yaml`).
Malformed YAML → `ValueError` wrapping the parser error + same recovery path.
Empty file → `ValueError` ("universe.yaml 이 비어있음") instead of downstream KeyError.

**2. Negative tests — `TestPhase5NegativeGuardrails`**

3 unit-scope tests (monkeypatch `UNIVERSE_PATH`, no network). Each asserts error type + Korean status text + presence of recovery command.

**3. `docs/SMOKE_RUN.md`**

Manual fresh-clone onboarding doc. 5 sections: prerequisites + runtime budget (20-25 min on M2 Pro), exact command order, expected success signals with real 2026-04-15 coverage numbers (5/5 PASS — prices 99%, fundamentals 99%, analyst/insider/super 97%), failure triage table, cleanup levels.

## Codex-reviewed design decisions

`/codex consult` guided the scope:

- **Simulated in PR CI + manual live smoke in docs** — not a 30-min fresh-clone CI job. Core behaviors (degradation semantics, exit codes, operator guidance) are deterministic and cheap to test with tmp DB + monkeypatch. Real upstream-breakage detection already lives in `tests/integration/test_universe_sync_real.py`.
- **API-key test dropped** — current universe collectors (`stock`, `stock_kr`, `fundamental`, `wallstreet`, `estimates`) are all keyless; `wallstreet.py` header explicitly says "API 키 불필요", `estimates.py` is yfinance-only. Testing a contract the code doesn't have would be noise.
- **Partial-collection semantics** — already covered by `TestRunNoRetry` + `TestNoNoisyOutput` in the existing `test_universe_sync.py`. Not duplicated.
- **Broken-network retry/timeout** — already covered by stock_kr's sequential + 0.1s sleep pattern and `validate_universe.py`'s warn-and-continue on upstream fetch failure. Not duplicated.

## Scope

| File | Net lines |
|------|-----------|
| `docs/SMOKE_RUN.md` (new) | +132 |
| `nuri/collectors/universe_sync.py` | +25 / -3 |
| `tests/collectors/test_universe_sync.py` | +53 |

Total: +207 / -3 across 3 files. 1 commit. No API schema change, no migration, no UI change.

## Test plan

- [x] `pytest tests/collectors/test_universe_sync.py` → 33 passed (3 new + 30 existing)
- [x] `pytest tests/collectors/test_universe_sync.py::TestPhase5NegativeGuardrails` → 3 passed
- [x] `make lint` — clean
- [x] `scripts/check_privacy_leak.py` — clean
- [ ] Post-merge manual: once per quarter run `docs/SMOKE_RUN.md` flow on a fresh clone

## Closes

`#272 Phase 5`. Universe coverage workstream complete:
- Phase 2a-2c: universe sync + coverage gate
- Phase 3: 20 regression tests (#296)
- Phase 4: dashboard widget + /api/coverage (#297)
- Phase 5: this PR — negative guardrails + smoke doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)