### PR TITLE
feat(engine): SIEGE v2 Phase 1 — asset-class gates for KR/commodity/bond (#248)

### DIFF
--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -143,3 +143,87 @@ buy_checklist:
   max_pe_ratio: 100                         # PE 100 이상 = 투기 경고
   min_revenue_growth: 0                     # 매출 > $0 (프리레비뉴 기업 금지)
   require_factor_top50pct: true             # 멀티팩터 상위 50% 이내
+
+# ─── SIEGE Gate 정책 (v2: Asset Class 차원) ────────────────
+# 근거: docs/SIEGE_V2.md §4. Issue #248.
+# Gate #5 (data_fresh), #7 (volatility / 구 vix_gate), #8 (external_data) 는
+# 포트폴리오를 asset_class 별로 group 한 뒤 각 group 에 해당 정책을 적용한다.
+# primary 실패는 현 severity 유지, secondary 는 warning only (cross-market
+# spillover 인지용). primary 를 error 로 올리려면 STRATEGY 개정 + 백테스트.
+#
+# Cross-market 의도: KR 종목 보유자에게 SPY/VIX 도 영향 (상관 > 0.5).
+# secondary 지표는 "US spillover / KR spillover" 를 명시적으로 경고로 노출.
+siege_gates:
+  # 포트폴리오 holdings 를 asset_class 로 분류. 위에서부터 순서대로 matching —
+  # 더 구체적인 rule 우선. default 는 마지막.
+  asset_class_rules:
+    - match: {sector_prefix: "ETF/USIndex"}
+      asset_class: us_equity
+    - match: {sector_prefix: "ETF/USTech"}
+      asset_class: us_equity
+    - match: {sector_prefix: "ETF/Commodity"}
+      asset_class: commodity
+    - match: {sector_prefix: "ETF/Bond"}
+      asset_class: bond
+    - match: {sector_prefix: "ETF/KRIndex"}
+      asset_class: kr_index
+    - match: {ticker_suffix: ".KS"}
+      asset_class: kr_equity
+    - match: {ticker_suffix: ".KQ"}
+      asset_class: kr_equity
+    - match: {sector: "ETF"}
+      asset_class: us_equity
+    - match: {default: true}
+      asset_class: us_equity
+
+  # Asset class 별 gate 정책. 현 PR: kr_equity + us_equity primary path.
+  # 기타 class (commodity/bond/kr_index) 는 정책만 선언 — 데이터 없으면 graceful skip.
+  asset_classes:
+    us_equity:
+      freshness_primary: SPY
+      freshness_secondary: []              # US leader — cross-ref 없음
+      freshness_max_hours: 72
+      volatility_primary: vix
+      volatility_primary_threshold: 30     # VIX > 30 → 매수 warning
+      volatility_secondary: []
+      external_min_records: 10
+      external_min_sources: 3
+    kr_equity:
+      freshness_primary: KOSPI
+      freshness_secondary: [SPY]           # US spillover (KR 은 follower)
+      freshness_max_hours: 72
+      volatility_primary: usd_krw_3d_change
+      volatility_primary_threshold: 3.0    # USD/KRW 3d 변동 > 3% → 매수 warning
+      volatility_secondary: [vix]          # US 변동성 전이
+      volatility_secondary_threshold: 30
+      external_min_records: 5              # KR 외부 소스 부족 — 완화
+      external_min_sources: 2
+    kr_index:
+      # KOSPI ETF 계열 (예: 292160.KS). 지수 ETF 는 국지 변동성 + US 교차.
+      freshness_primary: KOSPI
+      freshness_secondary: [SPY]
+      freshness_max_hours: 72
+      volatility_primary: kospi_3d_change
+      volatility_primary_threshold: 5.0
+      volatility_secondary: [usd_krw_3d_change]
+      volatility_secondary_threshold: 3.0
+      external_min_records: 3
+      external_min_sources: 1
+    commodity:
+      freshness_primary: "GC=F"            # gold futures
+      freshness_secondary: []
+      freshness_max_hours: 72
+      volatility_primary: gold_3d_change
+      volatility_primary_threshold: 5.0
+      volatility_secondary: []
+      external_min_records: 3
+      external_min_sources: 1
+    bond:
+      freshness_primary: TLT
+      freshness_secondary: []
+      freshness_max_hours: 120             # 채권 데이터 주말/이벤트 갭 허용
+      volatility_primary: yield_3d_change
+      volatility_primary_threshold: 0.3
+      volatility_secondary: []
+      external_min_records: 3
+      external_min_sources: 1

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -18,9 +18,15 @@ SIEGE Certification Engine — 추천 결과의 형식 검증.
 10. drift_safe        — critical drift 시그널 기반 매수 없음
 11. macro_event_alignment — |event_score| >= 10 시 경고
 
+v2 (#248): Gate 5/7/8 은 portfolio 를 asset_class 로 group 한 뒤 per-class 정책
+(config/rules.yaml siege_gates) 적용. KR 종목 보유 시 KOSPI freshness + USD/KRW
+volatility + 완화된 external threshold 로 평가됨. US spillover 는 secondary
+지표로 warning emit.
+
 사용법:
     python -m nuri.trading.engine.certification
 """
+
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -30,6 +36,7 @@ from nuri.core.rules import (
     LEVERAGE_ETFS,
     MAX_SECTOR_EXPOSURE,
     MAX_SINGLE_POSITION,
+    RULES,
     STOCK_STOP_LOSS,
     VIX_BLOCK_ABOVE,
 )
@@ -40,6 +47,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CertCondition:
     """인증 조건 결과."""
+
     id: str
     description: str
     passed: bool
@@ -50,14 +58,15 @@ class CertCondition:
 @dataclass
 class Certificate:
     """SIEGE 인증서."""
+
     timestamp: str
     total_conditions: int
     passed: int
     failed: int
     warnings: int
-    certified: bool          # 모든 error 조건 통과
+    certified: bool  # 모든 error 조건 통과
     conditions: list[CertCondition]
-    score: float             # 0~100
+    score: float  # 0~100
 
     def __post_init__(self):
         if not self.timestamp:
@@ -71,6 +80,7 @@ def _check_position_limits(db_path=None) -> CertCondition:
     try:
         from nuri.analysis.portfolio import analyze_portfolio
         from nuri.core.rules import get_account_strategy
+
         df = analyze_portfolio()
         if df.empty:
             return CertCondition("position_limit", "종목 비중 한도", True, "포트폴리오 비어있음")
@@ -89,11 +99,9 @@ def _check_position_limits(db_path=None) -> CertCondition:
                 violations[ticker] = (weight, max_pos)
 
         if not violations:
-            return CertCondition("position_limit", "종목 비중 한도", True,
-                                f"최대 비중: {agg.max():.1f}%")
-        tickers = ", ".join(f"{t}({w:.1f}%>{limit*100:.0f}%)" for t, (w, limit) in violations.items())
-        return CertCondition("position_limit", "종목 비중 한도", False,
-                            f"위반: {tickers}", "error")
+            return CertCondition("position_limit", "종목 비중 한도", True, f"최대 비중: {agg.max():.1f}%")
+        tickers = ", ".join(f"{t}({w:.1f}%>{limit * 100:.0f}%)" for t, (w, limit) in violations.items())
+        return CertCondition("position_limit", "종목 비중 한도", False, f"위반: {tickers}", "error")
     except Exception as e:
         return CertCondition("position_limit", "종목 비중 한도", False, f"검증 실패: {e}")
 
@@ -102,6 +110,7 @@ def _check_sector_limits(db_path=None) -> CertCondition:
     """2. 섹터 비중 <= 35%."""
     try:
         from nuri.analysis.portfolio import analyze_portfolio
+
         df = analyze_portfolio()
         if df.empty:
             return CertCondition("sector_limit", "섹터 비중 <= 35%", True, "포트폴리오 비어있음")
@@ -109,42 +118,170 @@ def _check_sector_limits(db_path=None) -> CertCondition:
         sector_agg = df.groupby("sector")["weight_pct"].sum()
         violations = sector_agg[sector_agg / 100 > MAX_SECTOR_EXPOSURE]
         if violations.empty:
-            return CertCondition("sector_limit", "섹터 비중 <= 35%", True,
-                                f"최대 섹터: {sector_agg.max():.1f}%")
+            return CertCondition("sector_limit", "섹터 비중 <= 35%", True, f"최대 섹터: {sector_agg.max():.1f}%")
         sectors = ", ".join(f"{s}({v:.1f}%)" for s, v in violations.items())
-        return CertCondition("sector_limit", "섹터 비중 <= 35%", False,
-                            f"위반: {sectors}", "error")
+        return CertCondition("sector_limit", "섹터 비중 <= 35%", False, f"위반: {sectors}", "error")
     except Exception:
         return CertCondition("sector_limit", "섹터 비중 <= 35%", True, "검증 스킵")
 
 
 def _check_leverage_ban(db_path=None) -> CertCondition:
     """6. 레버리지 ETF 비보유."""
-    rows = query("SELECT ticker FROM portfolio WHERE ticker IN ({})".format(
-        ",".join(f"'{t}'" for t in LEVERAGE_ETFS)
-    ), db_path=db_path)
+    rows = query(
+        "SELECT ticker FROM portfolio WHERE ticker IN ({})".format(",".join(f"'{t}'" for t in LEVERAGE_ETFS)),
+        db_path=db_path,
+    )
     held = [r["ticker"] for r in rows]
     if not held:
         return CertCondition("leverage_ban", "레버리지 ETF 비보유", True, "위반 없음")
-    return CertCondition("leverage_ban", "레버리지 ETF 비보유", False,
-                        f"보유 중: {', '.join(held)}", "error")
+    return CertCondition("leverage_ban", "레버리지 ETF 비보유", False, f"보유 중: {', '.join(held)}", "error")
 
 
-def _check_vix_gate(db_path=None) -> CertCondition:
-    """7. VIX > 30 시 매수 시그널 없음."""
-    vix_rows = query(
-        "SELECT value FROM macro WHERE indicator='vix' ORDER BY date DESC LIMIT 1",
+def _classify_asset_class(ticker: str, sector: str, rules: list[dict]) -> str:
+    """Portfolio holding 을 asset_class 로 분류.
+
+    config/rules.yaml siege_gates.asset_class_rules 순서대로 matching — 더 구체적인
+    rule 이 위에 있어야 함. match key: sector_prefix / ticker_suffix / sector / default.
+    """
+    sector = sector or ""
+    for rule in rules:
+        m = rule.get("match", {})
+        if m.get("default"):
+            return rule["asset_class"]
+        if "sector_prefix" in m and sector.startswith(m["sector_prefix"]):
+            return rule["asset_class"]
+        if "ticker_suffix" in m and ticker.endswith(m["ticker_suffix"]):
+            return rule["asset_class"]
+        if "sector" in m and sector == m["sector"]:
+            return rule["asset_class"]
+    return "us_equity"  # safety net — YAML 에 default rule 없을 때
+
+
+def _group_holdings_by_asset_class(db_path=None) -> dict[str, list[dict]]:
+    """portfolio 를 asset_class 로 group. 빈 portfolio 면 {}.
+
+    Returns: {asset_class: [{ticker, sector}, ...]}
+    """
+    gate_config = RULES.get("siege_gates", {})
+    rules = gate_config.get("asset_class_rules", [])
+    if not rules:
+        return {}
+
+    rows = query(
+        "SELECT DISTINCT ticker, sector FROM portfolio WHERE ticker != '' ",
         db_path=db_path,
     )
-    if not vix_rows:
-        return CertCondition("vix_gate", f"VIX > {VIX_BLOCK_ABOVE} 매수 차단", True, "VIX 데이터 없음")
+    groups: dict[str, list[dict]] = {}
+    for row in rows:
+        cls = _classify_asset_class(row["ticker"], row["sector"] or "", rules)
+        groups.setdefault(cls, []).append({"ticker": row["ticker"], "sector": row["sector"]})
+    return groups
 
-    vix = float(vix_rows[0]["value"])
-    if vix <= VIX_BLOCK_ABOVE:
-        return CertCondition("vix_gate", f"VIX > {VIX_BLOCK_ABOVE} 매수 차단", True,
-                            f"VIX {vix:.1f} (정상)")
-    return CertCondition("vix_gate", f"VIX > {VIX_BLOCK_ABOVE} 매수 차단", False,
-                        f"VIX {vix:.1f} — 신규 매수 금지 구간", "warning")
+
+def _read_indicator(name: str, db_path=None) -> float | None:
+    """macro 테이블에서 최신 지표 값. 없으면 None."""
+    rows = query(
+        "SELECT value FROM macro WHERE indicator=? ORDER BY date DESC LIMIT 1",
+        (name,),
+        db_path=db_path,
+    )
+    if not rows or rows[0]["value"] is None:
+        return None
+    return float(rows[0]["value"])
+
+
+def _compute_3d_change(indicator: str, db_path=None) -> float | None:
+    """indicator 의 최근 4개 값에서 3일 pct change 계산. 데이터 부족 시 None."""
+    rows = query(
+        "SELECT value FROM macro WHERE indicator=? ORDER BY date DESC LIMIT 4",
+        (indicator,),
+        db_path=db_path,
+    )
+    if len(rows) < 4 or rows[0]["value"] is None or rows[-1]["value"] is None:
+        return None
+    latest = float(rows[0]["value"])
+    past = float(rows[-1]["value"])
+    if past == 0:
+        return None
+    return abs((latest - past) / past * 100)
+
+
+def _get_indicator_value(name: str, db_path=None) -> float | None:
+    """volatility indicator 값 조회. computed 지표 (*_3d_change) 는 자동 계산."""
+    if name.endswith("_3d_change"):
+        base = name.replace("_3d_change", "")
+        return _compute_3d_change(base, db_path=db_path)
+    return _read_indicator(name, db_path=db_path)
+
+
+def _check_volatility_for_class(asset_class: str, policy: dict, db_path=None) -> list[CertCondition]:
+    """Asset class 별 변동성 gate. primary + secondary 각각 condition 발행.
+
+    Returns: [primary_condition, *secondary_conditions]. 데이터 없으면 PASS.
+    """
+    out: list[CertCondition] = []
+    prim_name = policy.get("volatility_primary")
+    prim_thr = policy.get("volatility_primary_threshold", 30)
+    if prim_name:
+        val = _get_indicator_value(prim_name, db_path=db_path)
+        cid = f"volatility_gate_{asset_class}"
+        desc = f"[{asset_class}] {prim_name} <= {prim_thr}"
+        if val is None:
+            out.append(CertCondition(cid, desc, True, f"{prim_name} 데이터 없음 — 스킵"))
+        elif val <= prim_thr:
+            out.append(CertCondition(cid, desc, True, f"{prim_name} {val:.2f} (정상)"))
+        else:
+            out.append(CertCondition(cid, desc, False, f"{prim_name} {val:.2f} > {prim_thr} — 매수 주의", "warning"))
+
+    # secondary — cross-market spillover (warning only)
+    sec_list = policy.get("volatility_secondary", []) or []
+    sec_thr = policy.get("volatility_secondary_threshold", prim_thr)
+    for sec_name in sec_list:
+        val = _get_indicator_value(sec_name, db_path=db_path)
+        cid = f"volatility_gate_{asset_class}_{sec_name}"
+        desc = f"[{asset_class}] {sec_name} spillover"
+        if val is None:
+            continue  # secondary 데이터 없으면 silent skip
+        if val <= sec_thr:
+            out.append(CertCondition(cid, desc, True, f"{sec_name} {val:.2f} (정상)"))
+        else:
+            out.append(CertCondition(cid, desc, False, f"{sec_name} {val:.2f} > {sec_thr} — 교차 시장 경고", "warning"))
+    return out
+
+
+def _check_volatility_gates(db_path=None) -> list[CertCondition]:
+    """Gate #7 (구 vix_gate) — 자산 클래스 별 변동성.
+
+    Legacy compatibility: portfolio 가 비어있거나 siege_gates 설정 없으면 구
+    VIX 전용 로직으로 fallback.
+    """
+    gate_config = RULES.get("siege_gates", {})
+    asset_classes = gate_config.get("asset_classes", {})
+    groups = _group_holdings_by_asset_class(db_path=db_path)
+
+    # Legacy fallback — 설정이 없거나 portfolio 비어있으면 기존 VIX 단일 체크
+    if not asset_classes or not groups:
+        val = _read_indicator("vix", db_path=db_path)
+        if val is None:
+            return [CertCondition("vix_gate", f"VIX > {VIX_BLOCK_ABOVE} 매수 차단", True, "VIX 데이터 없음")]
+        ok = val <= VIX_BLOCK_ABOVE
+        return [
+            CertCondition(
+                "vix_gate",
+                f"VIX > {VIX_BLOCK_ABOVE} 매수 차단",
+                ok,
+                f"VIX {val:.1f} {'(정상)' if ok else '— 신규 매수 금지 구간'}",
+                "error" if ok else "warning",
+            )
+        ]
+
+    out: list[CertCondition] = []
+    for cls in sorted(groups.keys()):
+        policy = asset_classes.get(cls)
+        if not policy:
+            continue  # YAML 에 클래스 정의 없으면 gate 스킵
+        out.extend(_check_volatility_for_class(cls, policy, db_path=db_path))
+    return out
 
 
 def _check_stop_loss_compliance(db_path=None) -> CertCondition:
@@ -152,6 +289,7 @@ def _check_stop_loss_compliance(db_path=None) -> CertCondition:
     try:
         from nuri.analysis.portfolio import analyze_portfolio
         from nuri.core.rules import get_account_strategy
+
         df = analyze_portfolio()
         if df.empty:
             return CertCondition("stop_loss", "손절선 준수", True, "포트폴리오 비어있음")
@@ -166,11 +304,9 @@ def _check_stop_loss_compliance(db_path=None) -> CertCondition:
                 violation_rows.append(row)
 
         if not violation_rows:
-            return CertCondition("stop_loss", "손절선 준수", True,
-                                f"최대 손실: {df['pnl_pct'].min():.1f}%")
+            return CertCondition("stop_loss", "손절선 준수", True, f"최대 손실: {df['pnl_pct'].min():.1f}%")
         tickers = ", ".join(f"{r['ticker']}({r['pnl_pct']:.1f}%)" for r in violation_rows[:5])
-        return CertCondition("stop_loss", "손절선 준수", False,
-                            f"위반 {len(violation_rows)}건: {tickers}", "error")
+        return CertCondition("stop_loss", "손절선 준수", False, f"위반 {len(violation_rows)}건: {tickers}", "error")
     except Exception:
         return CertCondition("stop_loss", "손절선 준수", True, "검증 스킵")
 
@@ -179,14 +315,13 @@ def _check_conflicts(db_path=None) -> CertCondition:
     """9. BUY/SELL 동시 시그널 해소."""
     try:
         from nuri.trading.engine.conflicts import detect_conflicts
+
         conflicts = detect_conflicts(db_path=db_path)
         high = [c for c in conflicts if c.severity == "high"]
         if not high:
-            return CertCondition("conflict_free", "방향 충돌 해소", True,
-                                f"충돌 {len(conflicts)}건 (high 0건)")
+            return CertCondition("conflict_free", "방향 충돌 해소", True, f"충돌 {len(conflicts)}건 (high 0건)")
         tickers = ", ".join(c.ticker for c in high[:5])
-        return CertCondition("conflict_free", "방향 충돌 해소", False,
-                            f"high 충돌 {len(high)}건: {tickers}", "warning")
+        return CertCondition("conflict_free", "방향 충돌 해소", False, f"high 충돌 {len(high)}건: {tickers}", "warning")
     except Exception:
         return CertCondition("conflict_free", "방향 충돌 해소", True, "검증 스킵")
 
@@ -195,70 +330,199 @@ def _check_drift_safety(db_path=None) -> CertCondition:
     """10. Critical drift 시그널 기반 매수 없음."""
     try:
         from nuri.trading.engine.memory import detect_drift
+
         drifts = detect_drift(db_path=db_path)
         critical = [d for d in drifts if d.status == "critical"]
         if not critical:
             return CertCondition("drift_safe", "시그널 drift 안전", True, "critical 없음")
         names = ", ".join(d.signal_id for d in critical)
-        return CertCondition("drift_safe", "시그널 drift 안전", False,
-                            f"critical {len(critical)}개: {names}", "warning")
+        return CertCondition(
+            "drift_safe", "시그널 drift 안전", False, f"critical {len(critical)}개: {names}", "warning"
+        )
     except Exception:
         return CertCondition("drift_safe", "시그널 drift 안전", True, "검증 스킵")
 
 
-def _check_external_data(db_path=None) -> CertCondition:
-    """8. 외부 데이터 수집 여부 (매수 체크리스트)."""
-    try:
-        from nuri.collectors.external import get_external_summary
-        summary = get_external_summary(db_path)
-        total = summary["total_records"]
-        sources = len(summary["sources"])
-        if total >= 10 and sources >= 3:
-            return CertCondition("external_data", "외부 데이터 충분", True,
-                                f"{total}건, {sources}개 소스")
-        return CertCondition("external_data", "외부 데이터 충분", False,
-                            f"{total}건, {sources}개 소스 (10건+, 3소스+ 필요)", "warning")
-    except Exception:
-        return CertCondition("external_data", "외부 데이터 충분", False, "external_analysis 테이블 없음", "warning")
-
-
-def _check_data_freshness(db_path=None) -> CertCondition:
-    """5. 데이터 신선도 (SPY 72h 이내)."""
-    rows = query("SELECT MAX(date) as latest FROM prices WHERE ticker='SPY'", db_path=db_path)
+def _ticker_age_hours(ticker: str, db_path=None) -> float | None:
+    """ticker 의 최신 price date 까지 age(시간). 데이터 없으면 None."""
+    rows = query("SELECT MAX(date) as latest FROM prices WHERE ticker=?", (ticker,), db_path=db_path)
     if not rows or not rows[0]["latest"]:
-        return CertCondition("data_fresh", "데이터 신선도 (72h)", False, "SPY 데이터 없음")
+        return None
     from nuri.core.timezone import kst_now
 
     latest = datetime.strptime(rows[0]["latest"], "%Y-%m-%d")
-    # KST 기준으로 신선도 비교 (naive datetime 통일)
-    age_hours = (kst_now().replace(tzinfo=None) - latest).total_seconds() / 3600
-    if age_hours <= 72:
-        return CertCondition("data_fresh", "데이터 신선도 (72h)", True,
-                            f"SPY {age_hours:.0f}시간 전")
-    return CertCondition("data_fresh", "데이터 신선도 (72h)", False,
-                        f"SPY {age_hours:.0f}시간 전 (72h 초과)", "warning")
+    return (kst_now().replace(tzinfo=None) - latest).total_seconds() / 3600
+
+
+def _check_freshness_for_class(asset_class: str, policy: dict, db_path=None) -> list[CertCondition]:
+    """Asset class 별 freshness gate. primary + secondary 개별 condition."""
+    out: list[CertCondition] = []
+    max_hours = policy.get("freshness_max_hours", 72)
+    prim = policy.get("freshness_primary")
+    if prim:
+        age = _ticker_age_hours(prim, db_path=db_path)
+        cid = f"data_fresh_{asset_class}"
+        desc = f"[{asset_class}] {prim} <= {max_hours}h"
+        if age is None:
+            out.append(CertCondition(cid, desc, False, f"{prim} 데이터 없음", "warning"))
+        elif age <= max_hours:
+            out.append(CertCondition(cid, desc, True, f"{prim} {age:.0f}시간 전"))
+        else:
+            out.append(CertCondition(cid, desc, False, f"{prim} {age:.0f}시간 전 ({max_hours}h 초과)", "warning"))
+
+    # secondary — cross-market reference
+    for sec in policy.get("freshness_secondary") or []:
+        age = _ticker_age_hours(sec, db_path=db_path)
+        cid = f"data_fresh_{asset_class}_{sec}"
+        desc = f"[{asset_class}] {sec} spillover freshness"
+        if age is None:
+            continue  # secondary 없으면 silent
+        if age <= max_hours:
+            out.append(CertCondition(cid, desc, True, f"{sec} {age:.0f}시간 전"))
+        else:
+            out.append(CertCondition(cid, desc, False, f"{sec} {age:.0f}시간 전 — 교차 시장 stale", "warning"))
+    return out
+
+
+def _check_data_freshness(db_path=None) -> list[CertCondition]:
+    """5. 데이터 신선도 — asset class 별 (v2). Legacy fallback: SPY 단일."""
+    gate_config = RULES.get("siege_gates", {})
+    asset_classes = gate_config.get("asset_classes", {})
+    groups = _group_holdings_by_asset_class(db_path=db_path)
+
+    if not asset_classes or not groups:
+        # Legacy — SPY 전용 체크
+        age = _ticker_age_hours("SPY", db_path=db_path)
+        if age is None:
+            return [CertCondition("data_fresh", "데이터 신선도 (72h)", False, "SPY 데이터 없음", "warning")]
+        ok = age <= 72
+        return [
+            CertCondition(
+                "data_fresh",
+                "데이터 신선도 (72h)",
+                ok,
+                f"SPY {age:.0f}시간 전" + ("" if ok else " (72h 초과)"),
+                "error" if ok else "warning",
+            )
+        ]
+
+    out: list[CertCondition] = []
+    for cls in sorted(groups.keys()):
+        policy = asset_classes.get(cls)
+        if not policy:
+            continue
+        out.extend(_check_freshness_for_class(cls, policy, db_path=db_path))
+    return out
+
+
+def _count_external_for_class(asset_class: str, tickers: list[str], db_path=None) -> tuple[int, int]:
+    """Asset class 에 속한 ticker 들의 external_analysis 집계. (records, sources).
+
+    kr_equity 등 자국 ticker 는 ticker column 으로 필터.
+    US ETF 는 ticker 기준. records 는 해당 ticker 쌓인 모든 행.
+    """
+    if not tickers:
+        # ticker 없으면 전체 조회로 fallback (미국 default class 등)
+        rows = query(
+            "SELECT COUNT(*) AS n, COUNT(DISTINCT source) AS s FROM external_analysis",
+            db_path=db_path,
+        )
+        return (int(rows[0]["n"]) if rows else 0, int(rows[0]["s"]) if rows else 0)
+    placeholders = ",".join("?" * len(tickers))
+    rows = query(
+        f"SELECT COUNT(*) AS n, COUNT(DISTINCT source) AS s FROM external_analysis WHERE ticker IN ({placeholders})",
+        tuple(tickers),
+        db_path=db_path,
+    )
+    return (int(rows[0]["n"]) if rows else 0, int(rows[0]["s"]) if rows else 0)
+
+
+def _check_external_for_class(asset_class: str, tickers: list[str], policy: dict, db_path=None) -> CertCondition:
+    """Asset class 별 external data gate."""
+    min_rec = policy.get("external_min_records", 10)
+    min_src = policy.get("external_min_sources", 3)
+    cid = f"external_data_{asset_class}"
+    desc = f"[{asset_class}] external >= {min_rec}건 / {min_src}소스"
+    try:
+        records, sources = _count_external_for_class(asset_class, tickers, db_path=db_path)
+    except Exception:
+        return CertCondition(cid, desc, False, "external_analysis 조회 실패", "warning")
+
+    if records >= min_rec and sources >= min_src:
+        return CertCondition(cid, desc, True, f"{records}건, {sources}개 소스")
+    return CertCondition(
+        cid, desc, False, f"{records}건, {sources}개 소스 (기준: {min_rec}+건/{min_src}+소스)", "warning"
+    )
+
+
+def _check_external_data(db_path=None) -> list[CertCondition]:
+    """8. 외부 데이터 — asset class 별 (v2). Legacy fallback: 전체 10/3."""
+    gate_config = RULES.get("siege_gates", {})
+    asset_classes = gate_config.get("asset_classes", {})
+    groups = _group_holdings_by_asset_class(db_path=db_path)
+
+    if not asset_classes or not groups:
+        # Legacy — get_external_summary 기반
+        try:
+            from nuri.collectors.external import get_external_summary
+
+            summary = get_external_summary(db_path)
+            total = summary["total_records"]
+            sources = len(summary["sources"])
+            ok = total >= 10 and sources >= 3
+            return [
+                CertCondition(
+                    "external_data",
+                    "외부 데이터 충분",
+                    ok,
+                    f"{total}건, {sources}개 소스" + ("" if ok else " (10건+, 3소스+ 필요)"),
+                    "warning" if not ok else "error",
+                )
+            ]
+        except Exception:
+            return [
+                CertCondition("external_data", "외부 데이터 충분", False, "external_analysis 테이블 없음", "warning")
+            ]
+
+    out: list[CertCondition] = []
+    for cls in sorted(groups.keys()):
+        policy = asset_classes.get(cls)
+        if not policy:
+            continue
+        tickers = [h["ticker"] for h in groups[cls]]
+        out.append(_check_external_for_class(cls, tickers, policy, db_path=db_path))
+    return out
 
 
 def _check_macro_event_alignment(db_path=None) -> CertCondition:
     """11. 매크로 이벤트 정합성 — event_score 기반 경고."""
     try:
         from nuri.quant.regime.event_score import compute_event_score
+
         es = compute_event_score(db_path=db_path)
         score = es.score
         dominant = es.dominant_category or "none"
 
         if abs(score) >= 15:
             return CertCondition(
-                "macro_event_alignment", "매크로 이벤트 정합성", False,
-                f"강한 매크로 이벤트 감지 (score={score:+.1f}): {dominant}", "warning",
+                "macro_event_alignment",
+                "매크로 이벤트 정합성",
+                False,
+                f"강한 매크로 이벤트 감지 (score={score:+.1f}): {dominant}",
+                "warning",
             )
         if abs(score) >= 10:
             return CertCondition(
-                "macro_event_alignment", "매크로 이벤트 정합성", False,
-                f"매크로 이벤트 주의 (score={score:+.1f}): {dominant}", "warning",
+                "macro_event_alignment",
+                "매크로 이벤트 정합성",
+                False,
+                f"매크로 이벤트 주의 (score={score:+.1f}): {dominant}",
+                "warning",
             )
         return CertCondition(
-            "macro_event_alignment", "매크로 이벤트 정합성", True,
+            "macro_event_alignment",
+            "매크로 이벤트 정합성",
+            True,
             f"event_score={score:+.1f} (정상)",
         )
     except Exception:
@@ -269,33 +533,46 @@ def _check_macro_event_alignment(db_path=None) -> CertCondition:
 def _check_rules_loaded(db_path=None) -> CertCondition:
     """규칙 파일 로드 확인."""
     from nuri.core.rules import RULES
+
     keys = len(RULES)
     has_take_profit = "take_profit" in RULES
     has_entry = "entry_rules" in RULES
     ok = keys >= 5 and has_take_profit and has_entry
-    return CertCondition("rules_loaded", "rules.yaml 완전 로드", ok,
-                        f"{keys}개 섹션 (take_profit={has_take_profit}, entry={has_entry})")
+    return CertCondition(
+        "rules_loaded", "rules.yaml 완전 로드", ok, f"{keys}개 섹션 (take_profit={has_take_profit}, entry={has_entry})"
+    )
 
 
-# 11개 조건 목록
+# 11개 조건 목록. asset-class 분리 gate (5/7/8) 는 list[CertCondition] 반환,
+# 나머지는 CertCondition 단건. certify() 에서 자동 flatten.
 ALL_CERT_CHECKS = [
-    _check_position_limits,          # 1. 종목 비중
-    _check_sector_limits,            # 2. 섹터 비중
-    _check_stop_loss_compliance,     # 3-4. 손절선
-    _check_data_freshness,           # 5. 데이터 신선도
-    _check_leverage_ban,             # 6. 레버리지 금지
-    _check_vix_gate,                 # 7. VIX 게이트
-    _check_external_data,            # 8. 외부 데이터
-    _check_conflicts,                # 9. 충돌 해소
-    _check_drift_safety,             # 10. drift 안전
-    _check_macro_event_alignment,    # 11. 매크로 이벤트 정합성
-    _check_rules_loaded,             # 규칙 로드
+    _check_position_limits,  # 1. 종목 비중
+    _check_sector_limits,  # 2. 섹터 비중
+    _check_stop_loss_compliance,  # 3-4. 손절선
+    _check_data_freshness,  # 5. 데이터 신선도 (per-class list)
+    _check_leverage_ban,  # 6. 레버리지 금지
+    _check_volatility_gates,  # 7. 변동성 게이트 (per-class list, 구 vix_gate)
+    _check_external_data,  # 8. 외부 데이터 (per-class list)
+    _check_conflicts,  # 9. 충돌 해소
+    _check_drift_safety,  # 10. drift 안전
+    _check_macro_event_alignment,  # 11. 매크로 이벤트 정합성
+    _check_rules_loaded,  # 규칙 로드
 ]
 
 
 def certify(db_path=None) -> Certificate:
-    """SIEGE 인증서 발급. 11개 조건 검증 후 pass/fail 판정."""
-    conditions = [check(db_path=db_path) for check in ALL_CERT_CHECKS]
+    """SIEGE 인증서 발급. 11개 조건 검증 후 pass/fail 판정.
+
+    v2 (#248): gate 5/7/8 은 portfolio asset_class 별로 multiple CertCondition
+    을 반환. certify() 가 flatten 하여 total_conditions 에 반영.
+    """
+    conditions: list[CertCondition] = []
+    for check in ALL_CERT_CHECKS:
+        result = check(db_path=db_path)
+        if isinstance(result, list):
+            conditions.extend(result)
+        else:
+            conditions.append(result)
 
     total = len(conditions)
     passed = sum(1 for c in conditions if c.passed)
@@ -325,8 +602,7 @@ def print_certificate(cert: Certificate) -> None:
     print(f"  SIEGE Certificate — {status} ({cert.score:.0f}%)")
     print(f"  {cert.timestamp}")
     print(f"{'═' * 60}")
-    print(f"  Passed: {cert.passed}/{cert.total_conditions} | "
-          f"Failed: {cert.failed} | Warnings: {cert.warnings}")
+    print(f"  Passed: {cert.passed}/{cert.total_conditions} | Failed: {cert.failed} | Warnings: {cert.warnings}")
     print(f"{'─' * 60}")
 
     for c in cert.conditions:

--- a/tests/trading/engine/conftest.py
+++ b/tests/trading/engine/conftest.py
@@ -2,6 +2,7 @@
 
 Extracted from tests/test_trading_engine_all.py (refactor #157).
 """
+
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -22,6 +23,7 @@ def db_path(tmp_path):
 def db_path_monkeypatched(tmp_path, monkeypatch):
     """DB with monkeypatched DB_PATH for modules that use the global."""
     import nuri.core.db as db_mod
+
     path = tmp_path / "test.db"
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
@@ -32,33 +34,41 @@ def db_path_monkeypatched(tmp_path, monkeypatch):
 def populated_db(db_path, monkeypatch):
     """Gate/certification test data: portfolio + 300-day SPY + VIX."""
     import nuri.core.db as db_mod
+
     monkeypatch.setattr(db_mod, "DB_PATH", db_path)
 
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?, ?, ?, ?, ?, ?)",
             ("test", "TEST", 100, 50.0, "USD", "Technology"),
         )
 
     dates = pd.bdate_range("2024-01-01", periods=300)
     close = np.linspace(100, 150, 300) + np.random.normal(0, 1, 300)
-    df = pd.DataFrame({
-        "ticker": "SPY", "date": [d.strftime("%Y-%m-%d") for d in dates],
-        "open": close * 0.99, "high": close * 1.01,
-        "low": close * 0.98, "close": close,
-        "volume": [50000000] * 300, "adj_close": close,
-    })
+    df = pd.DataFrame(
+        {
+            "ticker": "SPY",
+            "date": [d.strftime("%Y-%m-%d") for d in dates],
+            "open": close * 0.99,
+            "high": close * 1.01,
+            "low": close * 0.98,
+            "close": close,
+            "volume": [50000000] * 300,
+            "adj_close": close,
+        }
+    )
     upsert_prices(df, db_path)
 
     df2 = df.copy()
     df2["ticker"] = "TEST"
     upsert_prices(df2, db_path)
 
-    upsert_macro([{"indicator": "vix", "date": dates[-1].strftime("%Y-%m-%d"),
-                    "value": 18.0, "source": "test"}], db_path)
-    upsert_macro([{"indicator": "fear_greed", "date": dates[-1].strftime("%Y-%m-%d"),
-                    "value": 50.0, "source": "test"}], db_path)
+    upsert_macro(
+        [{"indicator": "vix", "date": dates[-1].strftime("%Y-%m-%d"), "value": 18.0, "source": "test"}], db_path
+    )
+    upsert_macro(
+        [{"indicator": "fear_greed", "date": dates[-1].strftime("%Y-%m-%d"), "value": 50.0, "source": "test"}], db_path
+    )
 
     return db_path
 
@@ -67,34 +77,65 @@ def populated_db(db_path, monkeypatch):
 def populated_db_cert(tmp_path, monkeypatch):
     """Certification-specific populated DB (from test_certification.py)."""
     import nuri.core.db as db_mod
+
     path = tmp_path / "test.db"
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
     with get_db(path) as conn:
         conn.execute(
-            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?, ?, ?, ?, ?, ?)",
             ("test", "AAPL", 10, 150.0, "USD", "Technology"),
         )
         conn.execute(
-            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?, ?, ?, ?, ?, ?)",
             ("test", "MSFT", 5, 300.0, "USD", "Technology"),
         )
 
     today = datetime.now().strftime("%Y-%m-%d")
-    prices = pd.DataFrame([
-        {"ticker": "SPY", "date": today, "open": 500, "high": 510, "low": 495, "close": 505, "volume": 50000000, "adj_close": 505},
-        {"ticker": "AAPL", "date": today, "open": 155, "high": 158, "low": 153, "close": 156, "volume": 10000000, "adj_close": 156},
-        {"ticker": "MSFT", "date": today, "open": 310, "high": 315, "low": 308, "close": 312, "volume": 5000000, "adj_close": 312},
-    ])
+    prices = pd.DataFrame(
+        [
+            {
+                "ticker": "SPY",
+                "date": today,
+                "open": 500,
+                "high": 510,
+                "low": 495,
+                "close": 505,
+                "volume": 50000000,
+                "adj_close": 505,
+            },
+            {
+                "ticker": "AAPL",
+                "date": today,
+                "open": 155,
+                "high": 158,
+                "low": 153,
+                "close": 156,
+                "volume": 10000000,
+                "adj_close": 156,
+            },
+            {
+                "ticker": "MSFT",
+                "date": today,
+                "open": 310,
+                "high": 315,
+                "low": 308,
+                "close": 312,
+                "volume": 5000000,
+                "adj_close": 312,
+            },
+        ]
+    )
     upsert_prices(prices, path)
 
-    upsert_macro([
-        {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
-        {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
-    ], path)
+    upsert_macro(
+        [
+            {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
+            {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
+        ],
+        path,
+    )
 
     return path
 
@@ -108,11 +149,35 @@ def rich_db(tmp_path, monkeypatch):
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10, "avg_price": 170, "currency": "USD", "sector": "Technology"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5, "avg_price": 120, "currency": "USD", "sector": "Semiconductor"},
-        {"account": "test", "ticker": "TSLA", "quantity": 8, "avg_price": 250, "currency": "USD", "sector": "SectorA"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 170,
+                "currency": "USD",
+                "sector": "Technology",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 120,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+            {
+                "account": "test",
+                "ticker": "TSLA",
+                "quantity": 8,
+                "avg_price": 250,
+                "currency": "USD",
+                "sector": "SectorA",
+            },
+        ],
+        path,
+    )
 
     dates = pd.bdate_range("2024-06-01", periods=300, freq="B")
     rows = []
@@ -120,11 +185,18 @@ def rich_db(tmp_path, monkeypatch):
         base = {"SPY": 450, "AAPL": 170, "NVDA": 120, "TSLA": 200, "VOO": 440}[t]
         for i, d in enumerate(dates):
             p = base + i * 0.2 + np.sin(i / 20) * 5
-            rows.append({
-                "ticker": t, "date": d.strftime("%Y-%m-%d"),
-                "open": p, "high": p + 3, "low": p - 2,
-                "close": p + 1, "volume": 50_000_000, "adj_close": p + 1,
-            })
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 3,
+                    "low": p - 2,
+                    "close": p + 1,
+                    "volume": 50_000_000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
 
     macro = []
@@ -156,4 +228,40 @@ def _seed_macro_r23(db_path, indicator="vix", value=20.0, days=1):
             conn.execute(
                 "INSERT OR REPLACE INTO macro (indicator, date, value, source) VALUES (?, ?, ?, ?)",
                 (indicator, date_str, value, "test"),
+            )
+
+
+def _seed_kr_portfolio(db_path, holdings=None):
+    """KR 종목이 포함된 portfolio fixture (#248 asset-class gate 테스트용).
+
+    holdings 기본값: 삼성전자(005930.KS) + KR ETF 5종 (US/Tech/Commodity/Bond/KRIndex).
+    이 조합이 실제 사용자 포트폴리오와 동일 — asset_class_rules 전체 경로 검증.
+    """
+    defaults = [
+        ("005930.KS", "Semiconductor", 50.0),
+        ("000660.KS", "Semiconductor", 50.0),
+        ("448300.KS", "ETF/USIndex", 50.0),
+        ("132030.KS", "ETF/Commodity", 50.0),
+        ("447660.KS", "ETF/Bond", 50.0),
+        ("292160.KS", "ETF/KRIndex", 50.0),
+        ("AAPL", "Technology", 150.0),
+    ]
+    with get_db(db_path) as conn:
+        for ticker, sector, price in holdings or defaults:
+            conn.execute(
+                "INSERT OR REPLACE INTO portfolio (ticker, sector, avg_price, quantity, account) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (ticker, sector, price, 10, "test_account"),
+            )
+
+
+def _seed_usd_krw_series(db_path, values=None):
+    """usd_krw 4일치 시계열 삽입 — _compute_3d_change 작동 검증용."""
+    values = values or [1300.0, 1305.0, 1310.0, 1330.0]  # 4개 필요 (LIMIT 4)
+    with get_db(db_path) as conn:
+        for i, v in enumerate(values):
+            date_str = (datetime.now() - timedelta(days=i)).strftime("%Y-%m-%d")
+            conn.execute(
+                "INSERT OR REPLACE INTO macro (indicator, date, value, source) VALUES (?, ?, ?, ?)",
+                ("usd_krw", date_str, v, "test"),
             )

--- a/tests/trading/engine/test_certification.py
+++ b/tests/trading/engine/test_certification.py
@@ -3,6 +3,7 @@
 Extracted from tests/test_trading_engine_all.py (refactor #157).
 Source: test_certification.py, test_coverage_round23.py, test_coverage_round27.py.
 """
+
 from dataclasses import dataclass
 from datetime import datetime
 from unittest.mock import MagicMock
@@ -10,7 +11,12 @@ from unittest.mock import MagicMock
 import pandas as pd
 
 from nuri.core.db import get_db, upsert_macro, upsert_prices
-from tests.trading.engine.conftest import _seed_macro_r23, _seed_prices_r23
+from tests.trading.engine.conftest import (
+    _seed_kr_portfolio,
+    _seed_macro_r23,
+    _seed_prices_r23,
+    _seed_usd_krw_series,
+)
 
 
 class TestCertCondition:
@@ -18,6 +24,7 @@ class TestCertCondition:
 
     def test_create(self):
         from nuri.trading.engine.certification import CertCondition
+
         cond = CertCondition("test_id", "test desc", True, "detail")
         assert cond.id == "test_id"
         assert cond.passed is True
@@ -25,6 +32,7 @@ class TestCertCondition:
 
     def test_warning_severity(self):
         from nuri.trading.engine.certification import CertCondition
+
         cond = CertCondition("test", "desc", False, "warn", "warning")
         assert cond.severity == "warning"
 
@@ -34,9 +42,16 @@ class TestCertificate:
 
     def test_create(self):
         from nuri.trading.engine.certification import Certificate
+
         cert = Certificate(
-            timestamp="", total_conditions=10, passed=8, failed=1, warnings=1,
-            certified=False, conditions=[], score=80.0,
+            timestamp="",
+            total_conditions=10,
+            passed=8,
+            failed=1,
+            warnings=1,
+            certified=False,
+            conditions=[],
+            score=80.0,
         )
         assert cert.certified is False
         assert cert.score == 80.0
@@ -44,9 +59,16 @@ class TestCertificate:
 
     def test_certified_when_no_failures(self):
         from nuri.trading.engine.certification import Certificate
+
         cert = Certificate(
-            timestamp="2026-03-28", total_conditions=10, passed=10, failed=0, warnings=0,
-            certified=True, conditions=[], score=100.0,
+            timestamp="2026-03-28",
+            total_conditions=10,
+            passed=10,
+            failed=0,
+            warnings=0,
+            certified=True,
+            conditions=[],
+            score=100.0,
         )
         assert cert.certified is True
 
@@ -56,6 +78,7 @@ class TestLeverageBan:
 
     def test_no_leverage(self, db_path):
         from nuri.trading.engine.certification import _check_leverage_ban
+
         result = _check_leverage_ban(db_path=db_path)
         assert result.passed is True
         assert result.id == "leverage_ban"
@@ -68,6 +91,7 @@ class TestLeverageBan:
                 ("test", "TSLL", 100, 15.0, "USD", "SectorB"),
             )
         from nuri.trading.engine.certification import _check_leverage_ban
+
         result = _check_leverage_ban(db_path=db_path)
         assert result.passed is False
         assert "TSLL" in result.detail
@@ -77,8 +101,9 @@ class TestVixGate:
     """From test_certification.py."""
 
     def test_normal_vix(self, populated_db_cert):
-        from nuri.trading.engine.certification import _check_vix_gate
-        result = _check_vix_gate(db_path=populated_db_cert)
+        from nuri.trading.engine.certification import _check_volatility_gates
+
+        result = _check_volatility_gates(db_path=populated_db_cert)[0]
         assert result.passed is True
         assert "18.0" in result.detail
 
@@ -86,14 +111,16 @@ class TestVixGate:
         today = datetime.now().strftime("%Y-%m-%d")
         upsert_macro([{"indicator": "vix", "date": today, "value": 35.0, "source": "test"}], db_path)
 
-        from nuri.trading.engine.certification import _check_vix_gate
-        result = _check_vix_gate(db_path=db_path)
+        from nuri.trading.engine.certification import _check_volatility_gates
+
+        result = _check_volatility_gates(db_path=db_path)[0]
         assert result.passed is False
         assert result.severity == "warning"
 
     def test_no_vix_data(self, db_path):
-        from nuri.trading.engine.certification import _check_vix_gate
-        result = _check_vix_gate(db_path=db_path)
+        from nuri.trading.engine.certification import _check_volatility_gates
+
+        result = _check_volatility_gates(db_path=db_path)[0]
         assert result.passed is True
         assert "없음" in result.detail
 
@@ -103,22 +130,36 @@ class TestDataFreshness:
 
     def test_fresh_data(self, populated_db_cert):
         from nuri.trading.engine.certification import _check_data_freshness
-        result = _check_data_freshness(db_path=populated_db_cert)
+
+        result = _check_data_freshness(db_path=populated_db_cert)[0]
         assert result.passed is True
 
     def test_no_spy_data(self, db_path):
         from nuri.trading.engine.certification import _check_data_freshness
-        result = _check_data_freshness(db_path=db_path)
+
+        result = _check_data_freshness(db_path=db_path)[0]
         assert result.passed is False
         assert "SPY 데이터 없음" in result.detail
 
     def test_stale_data(self, db_path):
-        prices = pd.DataFrame([
-            {"ticker": "SPY", "date": "2020-01-01", "open": 300, "high": 305, "low": 295, "close": 302, "volume": 50000000, "adj_close": 302},
-        ])
+        prices = pd.DataFrame(
+            [
+                {
+                    "ticker": "SPY",
+                    "date": "2020-01-01",
+                    "open": 300,
+                    "high": 305,
+                    "low": 295,
+                    "close": 302,
+                    "volume": 50000000,
+                    "adj_close": 302,
+                },
+            ]
+        )
         upsert_prices(prices, db_path)
         from nuri.trading.engine.certification import _check_data_freshness
-        result = _check_data_freshness(db_path=db_path)
+
+        result = _check_data_freshness(db_path=db_path)[0]
         assert result.passed is False
         assert "72h 초과" in result.detail
 
@@ -128,6 +169,7 @@ class TestRulesLoaded:
 
     def test_rules_present(self):
         from nuri.trading.engine.certification import _check_rules_loaded
+
         result = _check_rules_loaded()
         assert result.id == "rules_loaded"
         assert result.passed is True
@@ -138,14 +180,17 @@ class TestCheckConflicts:
 
     def test_no_conflicts(self, db_path):
         from nuri.trading.engine.certification import _check_conflicts
+
         result = _check_conflicts(db_path=db_path)
         assert result.passed is True
 
     def test_exception_returns_pass(self, db_path, monkeypatch):
         def mock_detect(*args, **kwargs):
             raise RuntimeError("test")
+
         monkeypatch.setattr("nuri.trading.engine.certification._check_conflicts.__module__", "test")
         from nuri.trading.engine.certification import _check_conflicts
+
         result = _check_conflicts(db_path=db_path)
         assert result.passed is True
 
@@ -155,6 +200,7 @@ class TestCheckDriftSafety:
 
     def test_no_drift(self, db_path):
         from nuri.trading.engine.certification import _check_drift_safety
+
         result = _check_drift_safety(db_path=db_path)
         assert result.passed is True
         assert "critical 없음" in result.detail
@@ -165,7 +211,8 @@ class TestCheckExternalData:
 
     def test_no_external_table(self, db_path):
         from nuri.trading.engine.certification import _check_external_data
-        result = _check_external_data(db_path=db_path)
+
+        result = _check_external_data(db_path=db_path)[0]
         assert result.severity == "warning"
 
 
@@ -174,6 +221,7 @@ class TestStopLossCompliance:
 
     def test_empty_db_returns_pass(self, db_path_monkeypatched):
         from nuri.trading.engine.certification import _check_stop_loss_compliance
+
         result = _check_stop_loss_compliance(db_path=db_path_monkeypatched)
         assert result.passed is True
 
@@ -183,6 +231,7 @@ class TestPositionLimits:
 
     def test_exception_returns_pass(self, db_path):
         from nuri.trading.engine.certification import _check_position_limits
+
         result = _check_position_limits(db_path=db_path)
         assert isinstance(result.passed, bool)
 
@@ -192,6 +241,7 @@ class TestSectorLimits:
 
     def test_no_data(self, db_path_monkeypatched):
         from nuri.trading.engine.certification import _check_sector_limits
+
         result = _check_sector_limits(db_path=db_path_monkeypatched)
         assert result.passed is True
 
@@ -202,6 +252,7 @@ class TestMacroEventAlignment:
     def test_pass_no_events(self, db_path):
         """이벤트 없으면 graceful pass."""
         from nuri.trading.engine.certification import _check_macro_event_alignment
+
         result = _check_macro_event_alignment(db_path=db_path)
         assert result.passed is True
         assert result.id == "macro_event_alignment"
@@ -210,14 +261,20 @@ class TestMacroEventAlignment:
     def test_pass_low_score(self, db_path, monkeypatch):
         """event_score < 10 이면 pass."""
         from nuri.quant.regime.event_score import EventScore
+
         monkeypatch.setattr(
             "nuri.quant.regime.event_score.compute_event_score",
             lambda **kw: EventScore(
-                date="2026-04-10", score=5.0, event_count=2,
-                category_breakdown={}, dominant_category="fed_dovish", regime_hint=None,
+                date="2026-04-10",
+                score=5.0,
+                event_count=2,
+                category_breakdown={},
+                dominant_category="fed_dovish",
+                regime_hint=None,
             ),
         )
         from nuri.trading.engine.certification import _check_macro_event_alignment
+
         result = _check_macro_event_alignment(db_path=db_path)
         assert result.passed is True
         assert "+5.0" in result.detail
@@ -225,14 +282,20 @@ class TestMacroEventAlignment:
     def test_warn_score_10(self, db_path, monkeypatch):
         """|event_score| >= 10 이면 warning."""
         from nuri.quant.regime.event_score import EventScore
+
         monkeypatch.setattr(
             "nuri.quant.regime.event_score.compute_event_score",
             lambda **kw: EventScore(
-                date="2026-04-10", score=-12.0, event_count=5,
-                category_breakdown={}, dominant_category="trade_war", regime_hint=None,
+                date="2026-04-10",
+                score=-12.0,
+                event_count=5,
+                category_breakdown={},
+                dominant_category="trade_war",
+                regime_hint=None,
             ),
         )
         from nuri.trading.engine.certification import _check_macro_event_alignment
+
         result = _check_macro_event_alignment(db_path=db_path)
         assert result.passed is False
         assert result.severity == "warning"
@@ -242,14 +305,20 @@ class TestMacroEventAlignment:
     def test_warn_score_15(self, db_path, monkeypatch):
         """|event_score| >= 15 이면 강한 경고."""
         from nuri.quant.regime.event_score import EventScore
+
         monkeypatch.setattr(
             "nuri.quant.regime.event_score.compute_event_score",
             lambda **kw: EventScore(
-                date="2026-04-10", score=18.0, event_count=10,
-                category_breakdown={}, dominant_category="geopolitical_escalation", regime_hint=None,
+                date="2026-04-10",
+                score=18.0,
+                event_count=10,
+                category_breakdown={},
+                dominant_category="geopolitical_escalation",
+                regime_hint=None,
             ),
         )
         from nuri.trading.engine.certification import _check_macro_event_alignment
+
         result = _check_macro_event_alignment(db_path=db_path)
         assert result.passed is False
         assert result.severity == "warning"
@@ -259,14 +328,20 @@ class TestMacroEventAlignment:
     def test_warn_negative_score_15(self, db_path, monkeypatch):
         """음수 event_score -15 이하도 경고."""
         from nuri.quant.regime.event_score import EventScore
+
         monkeypatch.setattr(
             "nuri.quant.regime.event_score.compute_event_score",
             lambda **kw: EventScore(
-                date="2026-04-10", score=-17.5, event_count=8,
-                category_breakdown={}, dominant_category="geopolitical_escalation", regime_hint=None,
+                date="2026-04-10",
+                score=-17.5,
+                event_count=8,
+                category_breakdown={},
+                dominant_category="geopolitical_escalation",
+                regime_hint=None,
             ),
         )
         from nuri.trading.engine.certification import _check_macro_event_alignment
+
         result = _check_macro_event_alignment(db_path=db_path)
         assert result.passed is False
         assert "강한" in result.detail
@@ -278,6 +353,7 @@ class TestMacroEventAlignment:
             lambda **kw: (_ for _ in ()).throw(RuntimeError("test")),
         )
         from nuri.trading.engine.certification import _check_macro_event_alignment
+
         result = _check_macro_event_alignment(db_path=db_path)
         assert result.passed is True
         assert "스킵" in result.detail
@@ -288,6 +364,7 @@ class TestCertify:
 
     def test_returns_certificate(self, populated_db_cert):
         from nuri.trading.engine.certification import certify
+
         cert = certify(db_path=populated_db_cert)
         assert cert.total_conditions == 11
         assert 0 <= cert.score <= 100
@@ -295,16 +372,19 @@ class TestCertify:
 
     def test_empty_db_still_runs(self, db_path):
         from nuri.trading.engine.certification import certify
+
         cert = certify(db_path=db_path)
         assert cert.total_conditions == 11
 
     def test_all_checks_list(self):
         from nuri.trading.engine.certification import ALL_CERT_CHECKS
+
         assert len(ALL_CERT_CHECKS) == 11
 
     def test_certify_includes_macro_event_gate(self, db_path):
         """certify() 결과에 macro_event_alignment gate이 포함되어야 함."""
         from nuri.trading.engine.certification import certify
+
         cert = certify(db_path=db_path)
         gate_ids = [c.id for c in cert.conditions]
         assert "macro_event_alignment" in gate_ids
@@ -315,6 +395,7 @@ class TestPrintCertificate:
 
     def test_print_certified(self, capsys):
         from nuri.trading.engine.certification import CertCondition, Certificate, print_certificate
+
         conds = [CertCondition(f"c{i}", f"desc{i}", True, "ok") for i in range(10)]
         cert = Certificate("2026-03-28", 10, 10, 0, 0, True, conds, 100.0)
         print_certificate(cert)
@@ -324,6 +405,7 @@ class TestPrintCertificate:
 
     def test_print_rejected(self, capsys):
         from nuri.trading.engine.certification import CertCondition, Certificate, print_certificate
+
         conds = [CertCondition("c1", "desc1", False, "fail", "error")]
         cert = Certificate("2026-03-28", 1, 0, 1, 0, False, conds, 0.0)
         print_certificate(cert)
@@ -332,6 +414,7 @@ class TestPrintCertificate:
 
     def test_print_warning(self, capsys):
         from nuri.trading.engine.certification import CertCondition, Certificate, print_certificate
+
         conds = [
             CertCondition("c1", "pass", True, "ok"),
             CertCondition("c2", "warn", False, "warn detail", "warning"),
@@ -348,11 +431,13 @@ class TestCertification_R23:
     def test_check_position_limits_pass(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_position_limits
 
-        mock_df = pd.DataFrame({
-            "ticker": ["AAPL", "MSFT"],
-            "weight_pct": [10.0, 8.0],
-            "account": ["test", "test"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL", "MSFT"],
+                "weight_pct": [10.0, 8.0],
+                "account": ["test", "test"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
         cond = _check_position_limits(db_path)
         assert cond.passed is True
@@ -361,11 +446,13 @@ class TestCertification_R23:
     def test_check_position_limits_violation(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_position_limits
 
-        mock_df = pd.DataFrame({
-            "ticker": ["AAPL", "AAPL"],
-            "weight_pct": [50.0, 30.0],
-            "account": ["test", "test"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL", "AAPL"],
+                "weight_pct": [50.0, 30.0],
+                "account": ["test", "test"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
         cond = _check_position_limits(db_path)
         assert cond.passed is False
@@ -374,7 +461,9 @@ class TestCertification_R23:
     def test_check_position_limits_exception(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_position_limits
 
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError("fail")))
+        monkeypatch.setattr(
+            "nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError("fail"))
+        )
         cond = _check_position_limits(db_path)
         assert cond.passed is False
         assert "검증 실패" in cond.detail
@@ -382,11 +471,13 @@ class TestCertification_R23:
     def test_check_sector_limits_pass(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_sector_limits
 
-        mock_df = pd.DataFrame({
-            "ticker": ["AAPL", "JNJ"],
-            "sector": ["Tech", "Health"],
-            "weight_pct": [20.0, 15.0],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL", "JNJ"],
+                "sector": ["Tech", "Health"],
+                "weight_pct": [20.0, 15.0],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
         cond = _check_sector_limits(db_path)
         assert cond.passed is True
@@ -394,7 +485,9 @@ class TestCertification_R23:
     def test_check_sector_limits_exception(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_sector_limits
 
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError("fail")))
+        monkeypatch.setattr(
+            "nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError("fail"))
+        )
         cond = _check_sector_limits(db_path)
         assert cond.passed is True
         assert "스킵" in cond.detail
@@ -402,10 +495,12 @@ class TestCertification_R23:
     def test_check_stop_loss_violations(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_stop_loss_compliance
 
-        mock_df = pd.DataFrame({
-            "ticker": ["AAPL", "MSFT"],
-            "pnl_pct": [-25.0, 5.0],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL", "MSFT"],
+                "pnl_pct": [-25.0, 5.0],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
         cond = _check_stop_loss_compliance(db_path)
         assert cond.passed is False
@@ -435,7 +530,9 @@ class TestCertification_R23:
     def test_check_conflicts_exception(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_conflicts
 
-        monkeypatch.setattr("nuri.trading.engine.conflicts.detect_conflicts", lambda **kw: (_ for _ in ()).throw(RuntimeError()))
+        monkeypatch.setattr(
+            "nuri.trading.engine.conflicts.detect_conflicts", lambda **kw: (_ for _ in ()).throw(RuntimeError())
+        )
         cond = _check_conflicts(db_path)
         assert cond.passed is True
         assert "스킵" in cond.detail
@@ -456,34 +553,42 @@ class TestCertification_R23:
     def test_check_drift_exception(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_drift_safety
 
-        monkeypatch.setattr("nuri.trading.engine.memory.detect_drift", lambda **kw: (_ for _ in ()).throw(RuntimeError()))
+        monkeypatch.setattr(
+            "nuri.trading.engine.memory.detect_drift", lambda **kw: (_ for _ in ()).throw(RuntimeError())
+        )
         cond = _check_drift_safety(db_path)
         assert cond.passed is True
 
     def test_check_external_data_insufficient(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_external_data
 
-        monkeypatch.setattr("nuri.collectors.external.get_external_summary",
-                            lambda *a: {"total_records": 3, "sources": ["tipranks"]})
-        cond = _check_external_data(db_path)
+        monkeypatch.setattr(
+            "nuri.collectors.external.get_external_summary", lambda *a: {"total_records": 3, "sources": ["tipranks"]}
+        )
+        cond = _check_external_data(db_path)[0]
         assert cond.passed is False
         assert "3건" in cond.detail
 
     def test_check_external_data_exception(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_external_data
 
-        monkeypatch.setattr("nuri.collectors.external.get_external_summary",
-                            lambda *a: (_ for _ in ()).throw(RuntimeError()))
-        cond = _check_external_data(db_path)
+        monkeypatch.setattr(
+            "nuri.collectors.external.get_external_summary", lambda *a: (_ for _ in ()).throw(RuntimeError())
+        )
+        cond = _check_external_data(db_path)[0]
         assert cond.passed is False
         assert "테이블 없음" in cond.detail
 
     def test_certify_full(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import CertCondition, certify
 
-        monkeypatch.setattr("nuri.trading.engine.certification.ALL_CERT_CHECKS",
-                            [lambda **kw: CertCondition("c1", "desc", True, "ok"),
-                             lambda **kw: CertCondition("c2", "desc", False, "fail", "warning")])
+        monkeypatch.setattr(
+            "nuri.trading.engine.certification.ALL_CERT_CHECKS",
+            [
+                lambda **kw: CertCondition("c1", "desc", True, "ok"),
+                lambda **kw: CertCondition("c2", "desc", False, "fail", "warning"),
+            ],
+        )
         cert = certify(db_path)
         assert cert.certified is True
         assert cert.warnings == 1
@@ -526,10 +631,10 @@ class TestCertification_R23:
 
     def test_certification_vix_gate_high(self, db_path):
         """From TestAdditionalEdgeCases."""
-        from nuri.trading.engine.certification import _check_vix_gate
+        from nuri.trading.engine.certification import _check_volatility_gates
 
         _seed_macro_r23(db_path, "vix", 35.0)
-        cond = _check_vix_gate(db_path)
+        cond = _check_volatility_gates(db_path)[0]
         assert cond.passed is False
         assert "금지" in cond.detail
 
@@ -538,7 +643,7 @@ class TestCertification_R23:
         from nuri.trading.engine.certification import _check_data_freshness
 
         _seed_prices_r23(db_path, "SPY", 500.0)
-        cond = _check_data_freshness(db_path)
+        cond = _check_data_freshness(db_path)[0]
         assert cond.passed is True
 
     def test_certification_data_stale(self, db_path):
@@ -550,7 +655,7 @@ class TestCertification_R23:
                 "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
                 ("SPY", "2025-01-01", 450.0),
             )
-        cond = _check_data_freshness(db_path)
+        cond = _check_data_freshness(db_path)[0]
         assert cond.passed is False
 
 
@@ -559,58 +664,72 @@ class TestCertification_R27:
 
     def test_check_leverage_ban_clean(self, db_path):
         from nuri.trading.engine.certification import _check_leverage_ban
+
         result = _check_leverage_ban(db_path=db_path)
         assert result.passed is True
 
     def test_check_leverage_ban_violation(self, db_path):
         from nuri.trading.engine.certification import _check_leverage_ban
+
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO portfolio (account, ticker, quantity, avg_price) VALUES (?,?,?,?)",
-                         ("test", "TQQQ", 10, 50.0))
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price) VALUES (?,?,?,?)",
+                ("test", "TQQQ", 10, 50.0),
+            )
         result = _check_leverage_ban(db_path=db_path)
         assert result.passed is False
 
     def test_check_vix_gate_no_data(self, db_path):
-        from nuri.trading.engine.certification import _check_vix_gate
-        result = _check_vix_gate(db_path=db_path)
+        from nuri.trading.engine.certification import _check_volatility_gates
+
+        result = _check_volatility_gates(db_path=db_path)[0]
         assert result.passed is True
 
     def test_check_vix_gate_high(self, db_path):
-        from nuri.trading.engine.certification import _check_vix_gate
+        from nuri.trading.engine.certification import _check_volatility_gates
+
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO macro (indicator, date, value) VALUES (?,?,?)",
-                         ("vix", "2025-03-28", 35.0))
-        result = _check_vix_gate(db_path=db_path)
+            conn.execute("INSERT INTO macro (indicator, date, value) VALUES (?,?,?)", ("vix", "2025-03-28", 35.0))
+        result = _check_volatility_gates(db_path=db_path)[0]
         assert result.passed is False
 
     def test_check_data_freshness_no_data(self, db_path):
         from nuri.trading.engine.certification import _check_data_freshness
-        result = _check_data_freshness(db_path=db_path)
+
+        result = _check_data_freshness(db_path=db_path)[0]
         assert result.passed is False
 
     def test_check_data_freshness_fresh(self, db_path):
         from nuri.core.timezone import kst_now
         from nuri.trading.engine.certification import _check_data_freshness
+
         today = kst_now().strftime("%Y-%m-%d")
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO prices (ticker, date, close) VALUES (?,?,?)",
-                         ("SPY", today, 500.0))
-        result = _check_data_freshness(db_path=db_path)
+            conn.execute("INSERT INTO prices (ticker, date, close) VALUES (?,?,?)", ("SPY", today, 500.0))
+        result = _check_data_freshness(db_path=db_path)[0]
         assert result.passed is True
 
     def test_check_rules_loaded(self, db_path):
         from nuri.trading.engine.certification import _check_rules_loaded
+
         result = _check_rules_loaded(db_path=db_path)
         assert result.passed is True
 
     def test_certify_and_print(self, db_path, capsys, monkeypatch):
         from nuri.trading.engine.certification import certify, print_certificate
-        monkeypatch.setattr("nuri.trading.engine.certification._check_position_limits",
-                            lambda db_path=None: MagicMock(passed=True, severity="error", id="pos", description="test", detail="ok"))
-        monkeypatch.setattr("nuri.trading.engine.certification._check_sector_limits",
-                            lambda db_path=None: MagicMock(passed=True, severity="error", id="sec", description="test", detail="ok"))
-        monkeypatch.setattr("nuri.trading.engine.certification._check_stop_loss_compliance",
-                            lambda db_path=None: MagicMock(passed=True, severity="error", id="sl", description="test", detail="ok"))
+
+        monkeypatch.setattr(
+            "nuri.trading.engine.certification._check_position_limits",
+            lambda db_path=None: MagicMock(passed=True, severity="error", id="pos", description="test", detail="ok"),
+        )
+        monkeypatch.setattr(
+            "nuri.trading.engine.certification._check_sector_limits",
+            lambda db_path=None: MagicMock(passed=True, severity="error", id="sec", description="test", detail="ok"),
+        )
+        monkeypatch.setattr(
+            "nuri.trading.engine.certification._check_stop_loss_compliance",
+            lambda db_path=None: MagicMock(passed=True, severity="error", id="sl", description="test", detail="ok"),
+        )
         cert = certify(db_path=db_path)
         assert cert.total_conditions > 0
         assert isinstance(cert.score, float)
@@ -620,8 +739,10 @@ class TestCertification_R27:
 
     def test_certificate_post_init_empty_timestamp(self):
         from nuri.trading.engine.certification import Certificate
-        cert = Certificate(timestamp="", total_conditions=0, passed=0, failed=0,
-                           warnings=0, certified=True, conditions=[], score=100.0)
+
+        cert = Certificate(
+            timestamp="", total_conditions=0, passed=0, failed=0, warnings=0, certified=True, conditions=[], score=100.0
+        )
         assert cert.timestamp != ""
 
 
@@ -632,15 +753,18 @@ class TestAccountStrategyIntegration:
         """swing 계좌의 -10% 손실은 위반이 아님 (한도 -15%)."""
         from nuri.trading.engine.certification import _check_stop_loss_compliance
 
-        mock_df = pd.DataFrame({
-            "ticker": ["TEM"],
-            "pnl_pct": [-10.0],
-            "account": ["sub_account"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["TEM"],
+                "pnl_pct": [-10.0],
+                "account": ["sub_account"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
         # swing 전략: stop_loss -15%
-        monkeypatch.setattr("nuri.core.rules.get_account_strategy",
-                            lambda a: {"stop_loss": -15, "max_single_position": 0.30})
+        monkeypatch.setattr(
+            "nuri.core.rules.get_account_strategy", lambda a: {"stop_loss": -15, "max_single_position": 0.30}
+        )
 
         cond = _check_stop_loss_compliance(db_path)
         assert cond.passed is True
@@ -649,14 +773,17 @@ class TestAccountStrategyIntegration:
         """swing 계좌의 -16% 손실은 위반 (한도 -15% 초과)."""
         from nuri.trading.engine.certification import _check_stop_loss_compliance
 
-        mock_df = pd.DataFrame({
-            "ticker": ["TSLA"],
-            "pnl_pct": [-16.0],
-            "account": ["sub_account"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["TSLA"],
+                "pnl_pct": [-16.0],
+                "account": ["sub_account"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
-        monkeypatch.setattr("nuri.core.rules.get_account_strategy",
-                            lambda a: {"stop_loss": -15, "max_single_position": 0.30})
+        monkeypatch.setattr(
+            "nuri.core.rules.get_account_strategy", lambda a: {"stop_loss": -15, "max_single_position": 0.30}
+        )
 
         cond = _check_stop_loss_compliance(db_path)
         assert cond.passed is False
@@ -666,14 +793,17 @@ class TestAccountStrategyIntegration:
         """core 계좌의 -8% 손실은 위반 (한도 -7%)."""
         from nuri.trading.engine.certification import _check_stop_loss_compliance
 
-        mock_df = pd.DataFrame({
-            "ticker": ["MSFT"],
-            "pnl_pct": [-8.0],
-            "account": ["main_account"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["MSFT"],
+                "pnl_pct": [-8.0],
+                "account": ["main_account"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
-        monkeypatch.setattr("nuri.core.rules.get_account_strategy",
-                            lambda a: {"stop_loss": -7, "max_single_position": 0.15})
+        monkeypatch.setattr(
+            "nuri.core.rules.get_account_strategy", lambda a: {"stop_loss": -7, "max_single_position": 0.15}
+        )
 
         cond = _check_stop_loss_compliance(db_path)
         assert cond.passed is False
@@ -682,15 +812,22 @@ class TestAccountStrategyIntegration:
         """swing 계좌의 25% 비중은 위반이 아님 (한도 30%)."""
         from nuri.trading.engine.certification import _check_position_limits
 
-        mock_df = pd.DataFrame({
-            "ticker": ["TSLA", "TSLA"],
-            "weight_pct": [15.0, 10.0],
-            "account": ["main", "sub"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["TSLA", "TSLA"],
+                "weight_pct": [15.0, 10.0],
+                "account": ["main", "sub"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
-        monkeypatch.setattr("nuri.core.rules.get_account_strategy",
-                            lambda a: {"stop_loss": -15, "max_single_position": 0.30} if a == "sub"
-                            else {"stop_loss": -7, "max_single_position": 0.15})
+        monkeypatch.setattr(
+            "nuri.core.rules.get_account_strategy",
+            lambda a: (
+                {"stop_loss": -15, "max_single_position": 0.30}
+                if a == "sub"
+                else {"stop_loss": -7, "max_single_position": 0.15}
+            ),
+        )
 
         cond = _check_position_limits(db_path)
         assert cond.passed is True
@@ -699,16 +836,235 @@ class TestAccountStrategyIntegration:
         """swing 허용해도 35% 비중은 위반 (한도 30%)."""
         from nuri.trading.engine.certification import _check_position_limits
 
-        mock_df = pd.DataFrame({
-            "ticker": ["TSLA", "TSLA"],
-            "weight_pct": [20.0, 15.0],
-            "account": ["main", "sub"],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "ticker": ["TSLA", "TSLA"],
+                "weight_pct": [20.0, 15.0],
+                "account": ["main", "sub"],
+            }
+        )
         monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
-        monkeypatch.setattr("nuri.core.rules.get_account_strategy",
-                            lambda a: {"stop_loss": -15, "max_single_position": 0.30} if a == "sub"
-                            else {"stop_loss": -7, "max_single_position": 0.15})
+        monkeypatch.setattr(
+            "nuri.core.rules.get_account_strategy",
+            lambda a: (
+                {"stop_loss": -15, "max_single_position": 0.30}
+                if a == "sub"
+                else {"stop_loss": -7, "max_single_position": 0.15}
+            ),
+        )
 
         cond = _check_position_limits(db_path)
         assert cond.passed is False
         assert "TSLA" in cond.detail
+
+
+class TestAssetClassification:
+    """#248 — _classify_asset_class: sector_prefix + ticker_suffix 우선순위."""
+
+    def test_sector_prefix_beats_suffix(self, db_path):
+        """KR ETF (448300.KS, sector=ETF/USIndex) 는 ticker 가 .KS 여도 us_equity."""
+        from nuri.core.rules import RULES
+        from nuri.trading.engine.certification import _classify_asset_class
+
+        rules = RULES["siege_gates"]["asset_class_rules"]
+        assert _classify_asset_class("448300.KS", "ETF/USIndex", rules) == "us_equity"
+        assert _classify_asset_class("132030.KS", "ETF/Commodity", rules) == "commodity"
+        assert _classify_asset_class("447660.KS", "ETF/Bond", rules) == "bond"
+        assert _classify_asset_class("292160.KS", "ETF/KRIndex", rules) == "kr_index"
+        assert _classify_asset_class("381170.KS", "ETF/USTech", rules) == "us_equity"
+
+    def test_ks_suffix_without_sector_prefix(self, db_path):
+        """일반 KR 종목 (005930.KS, sector=Semiconductor) 는 kr_equity."""
+        from nuri.core.rules import RULES
+        from nuri.trading.engine.certification import _classify_asset_class
+
+        rules = RULES["siege_gates"]["asset_class_rules"]
+        assert _classify_asset_class("005930.KS", "Semiconductor", rules) == "kr_equity"
+        assert _classify_asset_class("000660.KS", "Semiconductor", rules) == "kr_equity"
+
+    def test_kq_suffix(self, db_path):
+        from nuri.core.rules import RULES
+        from nuri.trading.engine.certification import _classify_asset_class
+
+        rules = RULES["siege_gates"]["asset_class_rules"]
+        assert _classify_asset_class("068760.KQ", "Biotech", rules) == "kr_equity"
+
+    def test_us_default(self, db_path):
+        from nuri.core.rules import RULES
+        from nuri.trading.engine.certification import _classify_asset_class
+
+        rules = RULES["siege_gates"]["asset_class_rules"]
+        assert _classify_asset_class("AAPL", "Technology", rules) == "us_equity"
+        assert _classify_asset_class("UNKNOWN", "", rules) == "us_equity"
+
+
+class TestAssetClassGates:
+    """#248 — asset-class 그룹 별 gate 5/7/8 verification.
+
+    Issue #248 검증 조건:
+    - 삼성전자 보유 portfolio 가 Gate #8 (external_data) 를 KR 완화 기준 (5건/2소스) 로 평가
+    - KR 종목 변동성은 usd_krw 기반; US VIX spillover 는 warning only
+    - Freshness: KR 은 KOSPI primary + SPY secondary
+    """
+
+    def test_kr_portfolio_produces_kr_equity_gates(self, db_path):
+        """KR 종목 보유 시 kr_equity asset_class 에 대한 gate 3종 (freshness/volatility/external) 발행."""
+        from nuri.trading.engine.certification import (
+            _check_data_freshness,
+            _check_external_data,
+            _check_volatility_gates,
+        )
+
+        _seed_kr_portfolio(db_path)
+        upsert_prices(
+            pd.DataFrame(
+                [
+                    {
+                        "ticker": "KOSPI",
+                        "date": datetime.now().strftime("%Y-%m-%d"),
+                        "open": 2500,
+                        "high": 2520,
+                        "low": 2480,
+                        "close": 2510,
+                        "volume": 0,
+                        "adj_close": 2510,
+                    },
+                    {
+                        "ticker": "SPY",
+                        "date": datetime.now().strftime("%Y-%m-%d"),
+                        "open": 500,
+                        "high": 505,
+                        "low": 498,
+                        "close": 502,
+                        "volume": 0,
+                        "adj_close": 502,
+                    },
+                ]
+            ),
+            db_path,
+        )
+        _seed_usd_krw_series(db_path)
+        _seed_macro_r23(db_path, "vix", 20.0)
+
+        fresh = _check_data_freshness(db_path=db_path)
+        vol = _check_volatility_gates(db_path=db_path)
+        ext = _check_external_data(db_path=db_path)
+
+        # freshness: kr_equity primary (KOSPI) + secondary (SPY) → 최소 2개
+        assert any(c.id.startswith("data_fresh_kr_equity") for c in fresh)
+        # volatility: kr_equity primary (usd_krw) + secondary (vix)
+        assert any(c.id == "volatility_gate_kr_equity" for c in vol)
+        assert any(c.id.startswith("volatility_gate_kr_equity_vix") for c in vol)
+        # external: kr_equity 그룹용 별도 condition
+        assert any(c.id == "external_data_kr_equity" for c in ext)
+
+    def test_kr_external_threshold_lower_than_us(self, db_path):
+        """kr_equity external threshold (5건/2소스) 는 us_equity (10건/3소스) 보다 완화."""
+        from nuri.trading.engine.certification import _check_external_data
+
+        _seed_kr_portfolio(db_path)
+        # 6 rows for KR ticker (2 sources) → kr pass (5+/2+), us fail (<10)
+        with get_db(db_path) as conn:
+            for i in range(6):
+                conn.execute(
+                    "INSERT INTO external_analysis (date, source, ticker, data_type, value) VALUES (?, ?, ?, ?, ?)",
+                    (f"2026-04-{10 + i:02d}", "tipranks" if i < 3 else "dataroma", "005930.KS", "consensus", "buy"),
+                )
+
+        ext = _check_external_data(db_path=db_path)
+        kr_cond = next(c for c in ext if c.id == "external_data_kr_equity")
+        # 6건 ≥ 5, 2소스 ≥ 2 — PASS
+        assert kr_cond.passed is True, f"KR 완화 기준 통과 기대: {kr_cond.detail}"
+
+    def test_usd_krw_volatility_primary_fires_when_high(self, db_path):
+        """USD/KRW 3일 변동 > 3% → kr_equity volatility primary warning."""
+        from nuri.trading.engine.certification import _check_volatility_gates
+
+        _seed_kr_portfolio(db_path)
+        # 3일간 5% 상승: 1300 → 1365
+        _seed_usd_krw_series(db_path, values=[1365.0, 1355.0, 1330.0, 1300.0])
+        _seed_macro_r23(db_path, "vix", 20.0)
+
+        vol = _check_volatility_gates(db_path=db_path)
+        kr_primary = next(c for c in vol if c.id == "volatility_gate_kr_equity")
+        assert kr_primary.passed is False
+        assert kr_primary.severity == "warning"
+        assert "usd_krw_3d_change" in kr_primary.detail
+
+    def test_vix_spillover_warns_kr_portfolio(self, db_path):
+        """KR 단독 portfolio + VIX 35 → kr_equity vix secondary 에서 warning."""
+        from nuri.trading.engine.certification import _check_volatility_gates
+
+        # KR 만 보유 (portfolio 에 US 없음)
+        _seed_kr_portfolio(db_path, holdings=[("005930.KS", "Semiconductor", 50.0)])
+        _seed_usd_krw_series(db_path)  # usd_krw 정상
+        _seed_macro_r23(db_path, "vix", 35.0)  # VIX 위험 구간
+
+        vol = _check_volatility_gates(db_path=db_path)
+        # kr_equity primary (usd_krw) 는 정상
+        prim = next(c for c in vol if c.id == "volatility_gate_kr_equity")
+        assert prim.passed is True
+        # secondary vix spillover 는 warning
+        sec = next(c for c in vol if c.id.endswith("_vix"))
+        assert sec.passed is False
+        assert sec.severity == "warning"
+
+    def test_empty_portfolio_legacy_fallback(self, db_path):
+        """Portfolio 비어있으면 구 동작 (SPY/VIX 단일 체크) 로 fallback."""
+        from nuri.trading.engine.certification import (
+            _check_data_freshness,
+            _check_external_data,
+            _check_volatility_gates,
+        )
+
+        # portfolio 아예 seed 안 함. SPY/VIX 도 없음.
+        fresh = _check_data_freshness(db_path=db_path)
+        vol = _check_volatility_gates(db_path=db_path)
+        ext = _check_external_data(db_path=db_path)
+
+        # legacy fallback 은 단일 condition 반환
+        assert len(fresh) == 1
+        assert fresh[0].id == "data_fresh"
+        assert len(vol) == 1
+        assert vol[0].id == "vix_gate"
+        assert len(ext) == 1
+        assert ext[0].id == "external_data"
+
+    def test_missing_siege_gates_config_legacy_fallback(self, db_path, monkeypatch):
+        """siege_gates 설정이 RULES 에 없어도 — 이전 버전 rules.yaml 로 KR 종목 보유 시 —
+        기존 SPY/VIX 단일 체크 로 안전하게 fallback. Codex review non-blocking 커버리지."""
+        from nuri.trading.engine import certification as cert_mod
+
+        _seed_kr_portfolio(db_path)  # KR 포트폴리오는 존재
+        _seed_macro_r23(db_path, "vix", 20.0)
+        # siege_gates 키를 제거한 RULES 로 교체
+        rules_without_gates = {k: v for k, v in cert_mod.RULES.items() if k != "siege_gates"}
+        monkeypatch.setattr(cert_mod, "RULES", rules_without_gates)
+
+        fresh = cert_mod._check_data_freshness(db_path=db_path)
+        vol = cert_mod._check_volatility_gates(db_path=db_path)
+        ext = cert_mod._check_external_data(db_path=db_path)
+
+        # config 없으면 portfolio 무관하게 legacy 단일 condition 유지
+        assert len(fresh) == 1 and fresh[0].id == "data_fresh"
+        assert len(vol) == 1 and vol[0].id == "vix_gate"
+        assert len(ext) == 1 and ext[0].id == "external_data"
+
+    def test_us_only_portfolio_only_us_equity_group(self, db_path):
+        """US 종목만 보유 → kr_equity gate 미발행 (그룹 없음)."""
+        from nuri.trading.engine.certification import (
+            _check_data_freshness,
+            _check_volatility_gates,
+        )
+
+        _seed_kr_portfolio(db_path, holdings=[("AAPL", "Technology", 150.0)])
+        _seed_macro_r23(db_path, "vix", 20.0)
+
+        fresh = _check_data_freshness(db_path=db_path)
+        vol = _check_volatility_gates(db_path=db_path)
+
+        # US 만 있으므로 kr_equity gate 없어야 함
+        assert not any("kr_equity" in c.id for c in fresh)
+        assert not any("kr_equity" in c.id for c in vol)
+        # us_equity 는 있어야 함
+        assert any(c.id == "volatility_gate_us_equity" for c in vol)


### PR DESCRIPTION
## Summary

Fixes #248 — SIEGE 11-gate 중 Gate #5 (data_fresh) / #7 (vix_gate) / #8 (external_data) 가 US 하드코딩 기준으로 .KS 종목에서 오작동. SIEGE_V2.md Phase 1 spec 에 따라 asset-class 차원 추가.

## Root cause (codex challenge)

1. \`certify()\` 가 portfolio 전체를 1회 판정 — asset-class grouping 없음
2. \`.KS → kr_equity\` 단순 매핑은 KR 상장 US ETF (448300.KS ETF/USIndex 등) 오분류
3. \`external_data\` threshold 만 낮추면 repo 전체 총합이 통과하는 fake green

## Fix

### 1. \`config/rules.yaml\` siege_gates section

- \`asset_class_rules\` 9개 (sector_prefix 우선 → ticker_suffix → default 순)
- \`asset_classes\`: us_equity / kr_equity / kr_index / commodity / bond 별 정책
  - \`freshness_primary\` / \`freshness_secondary\` (cross-market)
  - \`volatility_primary\` / \`volatility_secondary\`
  - \`external_min_records\` / \`external_min_sources\` (KR 완화: 5건/2소스)

### 2. \`certification.py\` 리팩터

- \`_classify_asset_class(ticker, sector, rules)\` — sector_prefix 우선
- \`_group_holdings_by_asset_class(db_path)\` — portfolio → {class: [tickers]}
- Gate 5/7/8 → \`list[CertCondition]\` 반환 (class 별 multiple conditions)
- \`_count_external_for_class\` 가 \`WHERE ticker IN (...)\` 로 per-class 실제 카운트
- \`_compute_3d_change\` 로 \`usd_krw_3d_change\` 등 computed 지표 지원
- Legacy fallback: empty portfolio / 설정 부재 시 구 SPY/VIX 단일 체크

### 3. Cross-market spillover (user 요청)

- \`kr_equity.freshness_secondary: [SPY]\`, \`volatility_secondary: [vix]\`
- secondary 는 warning only → 교차 시장 경고 (KOSPI-SPY 상관 > 0.5 반영)

## Tests

**New (11)**:
- \`TestAssetClassification\` (4): sector_prefix 우선 + .KS/.KQ + default
- \`TestAssetClassGates\` (7): KR gate 발행, 완화 threshold, usd_krw primary, VIX spillover, legacy fallback (2종), US-only group

**Migrated (16)**: 기존 vix_gate/data_fresh/external_data 테스트가 list 반환에 맞춰 \`[0]\` 언랩.

## Verification (issue #248 criteria)

- 삼성전자 등 KR 보유 시 \`external_data_kr_equity\` 가 완화 기준으로 PASS 가능 확인 (\`test_kr_external_threshold_lower_than_us\`)
- VIX 35 + KR portfolio → \`usd_krw\` primary 정상, \`vix\` secondary warning (\`test_vix_spillover_warns_kr_portfolio\`)
- 실제 DB 로 certify() 실행: 27 conditions (was 11), 5개 asset class 모두 감지

## Design decisions

- **Palantir/OPA framing 제거** (codex challenge 수용): 불필요한 marketing naming 삭제
- **Plain policy loading + grouping** 만 채택
- **Severity unchanged**: primary/secondary 모두 warning. \`certified\` 판정 (error 0건 기준) 변화 없음

## Scope out (별도 PR)

- Gate #11 macro event asset-class matrix (SIEGE_V2 §6)
- Safety lattice 5-stage (Phase 3), safeslice Wilson CI (Phase 4)

## Codex reviews

- **Challenge** (pre-implementation): 3 결함 지적 → design 수정
- **Review** (post-implementation): **APPROVED**. Non-blocking: missing-config fallback 커버리지 요청 → \`test_missing_siege_gates_config_legacy_fallback\` 추가

## Test plan

- [x] 새 tests 11/11 PASS
- [x] 기존 engine tests 66/66 PASS
- [x] \`make test-fast\` 2,932/2,932 PASS (coverage 87%)
- [x] \`make lint\` clean
- [x] Privacy scan clean
- [x] Codex APPROVED (challenge + review 2회)

🤖 Generated with [Claude Code](https://claude.com/claude-code)