### PR TITLE
chore(post-248): doc drift + Pylance cleanup (H6/H7/H8/D1)

### DIFF
--- a/docs/SIEGE_V2.md
+++ b/docs/SIEGE_V2.md
@@ -197,10 +197,19 @@ def certify(db_path=None) -> Certificate:
 
 ## 7. 구현 Phase
 
-| Phase | 내용 | 선행 |
-|-------|------|------|
-| **1** | Gate 정책 YAML 외부화 + certification.py 리팩토링 | — |
-| **2** | Gate evidence 필드 + claim trace (OAE 패턴) | Phase 1 |
-| **3** | Safety lattice 5단계 (CERTIFIED → GUARDED → REVIEW_REQUIRED → BLOCKED → REJECTED) | Phase 2 |
-| **4** | safeslice 통계적 신뢰 구간 (drift_multiplier → Wilson CI + witness cliff) | Phase 3 |
-| **5** | Recursive improvement (failure memory + reuse signal) | Phase 4 |
+| Phase | 내용 | 선행 | 상태 |
+|-------|------|------|------|
+| **1** | Gate 정책 YAML 외부화 + certification.py 리팩토링 | — | ✅ **완료** (PR #312, issue #248) |
+| **2** | Gate evidence 필드 + claim trace (OAE 패턴) | Phase 1 | 미착수 |
+| **3** | Safety lattice 5단계 (CERTIFIED → GUARDED → REVIEW_REQUIRED → BLOCKED → REJECTED) | Phase 2 | 미착수 |
+| **4** | safeslice 통계적 신뢰 구간 (drift_multiplier → Wilson CI + witness cliff) | Phase 3 | 미착수 |
+| **5** | Recursive improvement (failure memory + reuse signal) | Phase 4 | 미착수 |
+
+**Phase 1 deliverables (#312)**:
+- `config/rules.yaml` `siege_gates` section (asset_class_rules + per-class policies)
+- `nuri/trading/engine/certification.py`: `_classify_asset_class`, `_group_holdings_by_asset_class`, per-class gate 5/7/8
+- Cross-market spillover (primary + secondary 지표 구조)
+- Legacy fallback (빈 portfolio / 설정 부재)
+- Tests: `TestAssetClassification` (4) + `TestAssetClassGates` (7)
+
+**Phase 1 scope out** (후속 PR 후보): Gate #11 macro event asset-class matrix (§6 표).

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -170,8 +170,8 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,763 tests, 130 files |
-| Frontend tests | 목표 ≥ 90% | 876 tests, 58 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,944 tests, 137 files |
+| Frontend tests | 목표 ≥ 90% | 913 tests, 60 files |
 | E2E | 핵심 flow 커버 | 39 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 의존 | 금지 | conftest.py에서 yfinance/외부 API mock |
@@ -573,7 +573,7 @@ PM (spec) → Dev (impl) → Eval (test + smoke) → ship. Eval 단계 건너뛰
 
 이 섹션은 **앞으로 할 일**만 기록한다. 완료된 항목은 git log + closed PR + closed issue가 진실 source. 새 작업을 시작하기 전에 이 순서를 확인하고, 새 발견은 GitHub 이슈로 등록한 뒤 이 표에 추가한다.
 
-### Tier 1 — 완료 (2026-04-13 ~ 04-14)
+### Tier 1 — 완료 (2026-04-13 ~ 04-15)
 
 | # | 항목 | 이슈 | PR | 비고 |
 |---|------|------|----|------|
@@ -593,6 +593,10 @@ PM (spec) → Dev (impl) → Eval (test + smoke) → ship. Eval 단계 건너뛰
 | 10 | **KR `n/a (US-only)` 표시 개선** | — | #288 | US_ONLY_TABLES frozenset + `check_universe_coverage.py` + `validate_universe.py` detail. 수집 실패 vs 소스 한계 시각 구분 |
 | 11 | **#272 Phase 3 (Eval): validate_universe + US_ONLY 회귀 테스트** | — | #296 | 20 tests: TestUsOnlyTables(4) + TestRunValidation/Print/Main/Fetch(11) + TestOutputFormat(5) |
 | 12 | **#272 Phase 4 (UX): Dashboard coverage widget + `/api/coverage`** | — | #297 | `CoverageStatus` widget (5/5 PASS 헤더 + 5-col 테이블 + 소스 한계 footer). 14 tests (backend 5 + frontend 9) |
+| 13 | **README drift sync** | — | #309 | collectors 24→26, LLM 우선순위 (OpenAI primary), test counts 2,763→2,934. Codex APPROVED. |
+| 14 | **B2 — Learning Memory outcome read 역방향** | — | #310 | `_compute_weights` SELECT 에 `outcome_30d` 누락 + `sqlite3.Row.get()` 없음. 두 층 버그로 수개월간 weight 역방향. Fix + 3 regression (revert-proof). #308 lock-in 해제. |
+| 15 | **B1 — recommendations UNIQUE + UPSERT** | — | #311 | `UNIQUE(date, ticker, action)` → `UNIQUE(date, ticker)`. Migration 20 (MAX(id) dedup). `INSERT OR REPLACE` → `ON CONFLICT DO UPDATE` (id 보존 — `trades.recommendation_id` FK 안전). 프로덕션 20 중복 그룹 정리. |
+| 16 | **#248 SIEGE v2 Phase 1 — asset-class gates** | [#248](https://github.com/researcherhojin/nuri-quant/issues/248) | #312 | Gate 5/7/8 per-asset-class (us/kr_equity/kr_index/commodity/bond). Cross-market spillover (KOSPI+SPY, USD/KRW+VIX). `config/rules.yaml siege_gates` spec. Codex challenge (3 결함 지적) → 재설계 → APPROVED. |
 
 ### Tier 2 — 다음 1 달 (P1)
 

--- a/nuri/api/routes/targets.py
+++ b/nuri/api/routes/targets.py
@@ -1,4 +1,5 @@
 """가격 타겟 + 리밸런스 어드바이저 + SIEGE 인증 + Remediation API."""
+
 from fastapi import APIRouter
 
 router = APIRouter(tags=["targets"])
@@ -12,6 +13,7 @@ def get_portfolio_targets():
         check_take_profit_signals,
         check_trailing_stop_signals,
     )
+
     targets = calculate_portfolio_targets()
 
     # 익절/트레일링 도달 종목 태깅
@@ -37,6 +39,7 @@ def get_portfolio_targets():
 def get_ticker_targets(ticker: str):
     """단일 종목 가격 타겟."""
     from nuri.trading.recommend.price_targets import calculate_targets
+
     target = calculate_targets(ticker.upper())
     return target
 
@@ -45,14 +48,19 @@ def get_ticker_targets(ticker: str):
 def get_rebalance_advisor():
     """규칙 위반 감지 + 매도 수량 + 회수 금액."""
     from nuri.analysis.rebalance_advisor import generate_advisor_report
+
     return generate_advisor_report()
 
 
 _certify_cache: dict = {"data": None, "ts": 0}
 
+
 @router.get("/certify")
 def get_certification():
-    """SIEGE 11-condition 인증 상태 (5분 캐시)."""
+    """SIEGE 인증 상태 (5분 캐시).
+
+    v2 (#248): 11 base gate check × per-asset-class expansion 으로 total_conditions 가변.
+    """
     import time
     from dataclasses import asdict
 
@@ -61,6 +69,7 @@ def get_certification():
         return _certify_cache["data"]
 
     from nuri.trading.engine.certification import certify
+
     cert = certify()
     result = {
         "certified": cert.certified,
@@ -83,6 +92,7 @@ def get_remediation():
     from dataclasses import asdict
 
     from nuri.trading.engine.remediation import generate_remediation
+
     plan = generate_remediation()
     return {
         "certified": plan.certified,

--- a/nuri/trading/engine/CLAUDE.md
+++ b/nuri/trading/engine/CLAUDE.md
@@ -25,21 +25,31 @@ Phase 4 (safeslice 패턴): `drift_multiplier`를 통계적 신뢰 구간(Wilson
 
 ## SIEGE 11-Gate Specification
 
-All recommendations must pass. 1 error-grade failure = REJECTED.
+All recommendations must pass. 1 error-grade failure = REJECTED. `Certificate.certified` = error severity 0건 기준.
+
+**v2 expansion (#248, PR #312)**: Gate 5/7/8 은 portfolio 를 `asset_class` 로 group
+한 뒤 per-class 정책 (`config/rules.yaml` `siege_gates`) 적용. 따라서 실행 시 실제
+`total_conditions` 는 portfolio 구성에 따라 **11 ~ 30+ 가변**. 예: US + KR + ETF
+혼합 포트폴리오면 us_equity/kr_equity/kr_index/commodity/bond 5 class × 3 gate =
+15 + 비asset 8 = 23 condition 발행. secondary spillover 지표 (예: KR 보유 시 VIX
+spillover) 는 추가 warning.
 
 | # | Condition | Grade | Threshold | v2 변경 |
 |---|-----------|-------|-----------|---------|
-| 1 | position_limit | error | Per-account strategy | v2: 계좌별 + 전체 이중 체크 |
-| 2 | sector_limit | error | Per-account strategy | v2: 계좌별 전략 기준 |
+| 1 | position_limit | error | Per-account strategy | 계좌별 + 전체 이중 체크 |
+| 2 | sector_limit | error | Per-account strategy | 계좌별 전략 기준 |
 | 3 | stop_loss_growth | error | Per-account strategy | 기존 유지 |
 | 4 | stop_loss_value | error | Per-account strategy | 기존 유지 |
-| 5 | data_fresh | warning | Per-asset-class ticker | v2: SPY or KOSPI or GC=F |
+| 5 | data_fresh | warning | **Per-asset-class** primary + secondary | ✅ 구현 (#312): us=SPY / kr_equity=KOSPI+[SPY spillover] / kr_index=KOSPI+[SPY] / commodity=GC=F / bond=TLT |
 | 6 | leverage_ban | error | No TSLL/TQQQ etc. | 기존 유지 |
-| 7 | vix_gate | warning | Per-asset-class indicator | v2: VIX or USD/KRW or gold vol |
-| 8 | external_data | warning | Per-asset-class threshold | v2: 자산별 기준 분리 |
+| 7 | volatility_gate (구 vix_gate) | warning | **Per-asset-class** primary + secondary | ✅ 구현 (#312): us=VIX / kr_equity=USD/KRW_3d+[VIX] / kr_index=KOSPI_3d+[USD/KRW] / commodity=gold_3d |
+| 8 | external_data | warning | **Per-asset-class** threshold + ticker filter | ✅ 구현 (#312): us ≥ 10/3, kr_equity ≥ 5/2 (ticker IN 쿼리로 실제 카운트) |
 | 9 | conflict_free | warning | No BUY/SELL conflict | 기존 유지 |
 | 10 | drift_safe | warning | No critical drift | 기존 유지 |
-| 11 | macro_event_alignment | warning | \|event_score\| >= 10 alert | 기존 유지 |
+| 11 | macro_event_alignment | warning | \|event_score\| >= 10 alert | 기존 유지 (asset-class matrix 는 별도 PR 예정) |
+
+**Legacy fallback**: empty portfolio 또는 `siege_gates` 설정 부재 시 Gate 5/7/8 은
+구 SPY/VIX 단일 체크로 안전하게 돌아감.
 
 ## Execution Priority
 

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -5,23 +5,28 @@ SIEGE Certification Engine — 추천 결과의 형식 검증.
 추천이 rules.yaml의 모든 규칙을 만족하는지 기계적으로 검증하고,
 위반 시 인증서를 거부한다.
 
-검증 항목 (11-condition):
-1. position_limit     — 종목 비중 <= 15%
+검증 항목 (11 base gate checks → v2 asset-class expansion 으로 실행 시
+total_conditions 가변):
+
+1. position_limit     — 종목 비중 <= 15% (계좌별 전략 적용)
 2. sector_limit       — 섹터 비중 <= 35%
-3. cash_reserve       — 현금 비중 >= 20%
-4. stop_loss_growth   — 성장주 손절 -7% 이내
-5. stop_loss_value    — 가치주 손절 -10% 이내
+3. stop_loss_growth   — 성장주 손절 -7% 이내
+4. stop_loss_value    — 가치주 손절 -10% 이내
+5. data_fresh         — [v2] per-class freshness (us=SPY, kr=KOSPI+SPY, ...)
 6. leverage_ban       — 레버리지 ETF 비보유
-7. vix_gate           — VIX > 30 시 매수 없음
-8. buy_checklist      — TipRanks + 슈퍼투자자 + PE + 매출
+7. volatility_gate    — [v2] per-class 변동성 (us=VIX, kr=USD/KRW+VIX, ...)
+                       (구 vix_gate)
+8. external_data      — [v2] per-class 외부 데이터 카운트 (ticker 필터)
 9. conflict_free      — BUY/SELL 동시 시그널 없음 (또는 관망)
 10. drift_safe        — critical drift 시그널 기반 매수 없음
 11. macro_event_alignment — |event_score| >= 10 시 경고
 
 v2 (#248): Gate 5/7/8 은 portfolio 를 asset_class 로 group 한 뒤 per-class 정책
-(config/rules.yaml siege_gates) 적용. KR 종목 보유 시 KOSPI freshness + USD/KRW
-volatility + 완화된 external threshold 로 평가됨. US spillover 는 secondary
-지표로 warning emit.
+(config/rules.yaml siege_gates) 적용. 예: KR 종목 보유 시 KOSPI freshness +
+USD/KRW volatility + 완화된 external threshold 로 평가되고 US spillover 는
+secondary 지표로 warning emit. 따라서 실제 `Certificate.total_conditions` 는
+portfolio 의 asset_class 조합에 따라 11~30+ 범위. `certified` 판정은 기존과
+동일하게 error severity 0건 기준.
 
 사용법:
     python -m nuri.trading.engine.certification
@@ -543,8 +548,8 @@ def _check_rules_loaded(db_path=None) -> CertCondition:
     )
 
 
-# 11개 조건 목록. asset-class 분리 gate (5/7/8) 는 list[CertCondition] 반환,
-# 나머지는 CertCondition 단건. certify() 에서 자동 flatten.
+# 11개 base gate checks. asset-class 분리 gate (5/7/8) 는 list[CertCondition] 반환
+# (per-class expansion → 실행 시 total_conditions 가변), 나머지는 단건. certify() 에서 flatten.
 ALL_CERT_CHECKS = [
     _check_position_limits,  # 1. 종목 비중
     _check_sector_limits,  # 2. 섹터 비중
@@ -561,10 +566,11 @@ ALL_CERT_CHECKS = [
 
 
 def certify(db_path=None) -> Certificate:
-    """SIEGE 인증서 발급. 11개 조건 검증 후 pass/fail 판정.
+    """SIEGE 인증서 발급. 11 base gate check 실행 후 pass/fail 판정.
 
     v2 (#248): gate 5/7/8 은 portfolio asset_class 별로 multiple CertCondition
-    을 반환. certify() 가 flatten 하여 total_conditions 에 반영.
+    을 반환. certify() 가 flatten 하여 total_conditions 에 반영 (portfolio
+    구성에 따라 11 ~ 30+ 범위). `certified` 는 error severity 0건 기준 (기존 유지).
     """
     conditions: list[CertCondition] = []
     for check in ALL_CERT_CHECKS:

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -313,7 +313,7 @@ class TestConsensusDivergenceMechanicalPenalty:
     """
 
     @staticmethod
-    def _verdict(name, action, confidence=70):
+    def _verdict(name, action, confidence: float = 70.0):
         from nuri.trading.agents.base import AgentVerdict
 
         return AgentVerdict(name, "TEST", action, confidence, f"mock {name}")
@@ -1171,7 +1171,7 @@ class TestConsensusVerbose:
         from nuri.trading.agents.consensus import print_consensus
 
         with pytest.raises(TypeError):
-            print_consensus([], True)  # positional bool intentionally — verbose is keyword-only
+            print_consensus([], True)  # pyright: ignore[reportCallIssue]  # positional bool intentional — verbose is keyword-only
 
     def test_print_consensus_no_verbose_for_multi(self, capsys):
         """여러 종목 + verbose=False → supporting reasoning 출력 안 함."""
@@ -1352,7 +1352,7 @@ class TestPenaltyTelemetryEvent:
     """
 
     @staticmethod
-    def _verdict(name, action, confidence=70):
+    def _verdict(name, action, confidence: float = 70.0):
         from nuri.trading.agents.base import AgentVerdict
 
         return AgentVerdict(name, "JKHY", action, confidence, f"mock {name}")


### PR DESCRIPTION
## Summary

#312 (SIEGE v2 Phase 1, #248) 머지 후 누적된 문서/주석 drift + pre-existing Pylance 3 에러 묶음 정리. **코드 동작 변화 없음** — docstring / comment / type annotation / markdown only.

## 범위 (6 파일)

| 카테고리 | 파일 | 변경 |
|---------|------|------|
| H6 — 11-gate 설명 (v2 per-class) | \`nuri/trading/engine/certification.py\` | module docstring + gate list comment + certify() docstring |
| H6 — 11-gate 설명 | \`nuri/trading/engine/CLAUDE.md\` | SIEGE 11-Gate table ✅ 표시 + 11~30+ range + legacy fallback |
| H7 — Phase 상태 | \`docs/SIEGE_V2.md\` | §7 Phase table '상태' 컬럼 + Phase 1 완료 + deliverables |
| H8 — Pylance | \`tests/trading/agents/test_consensus.py\` | \`_verdict(confidence: float = 70.0)\` × 2 + \`# pyright: ignore[reportCallIssue]\` |
| D1 — STRATEGY drift | \`docs/STRATEGY.md\` | §7 Tier 1 4 row 추가 (#309~#312) + §4.1 test count |
| API docstring (codex-suggested) | \`nuri/api/routes/targets.py\` | /certify docstring v2 설명 |

## Pylance 에러 3건 (pre-existing)

- **L316/L1355**: \`_verdict(..., confidence=70)\` — \`AgentVerdict.confidence: float\` 과 mismatch → 타입 annotation 추가 (\`confidence: float = 70.0\`)
- **L1174**: \`print_consensus([], True)\` — 의도적 keyword-only negative test → \`# pyright: ignore[reportCallIssue]\` (codex review: \`call-arg\` 는 mypy-style, pyright 에서는 \`reportCallIssue\`)

## Codex consult / review

- **Consult** (scope): verdict **modify scope** — 초안 4 파일 → 6 파일로 확장 (certification.py docstring + api/routes/targets.py + STRATEGY §4.1 drift 추가)
- **Review** (final): verdict **changes required** (1건: pyright code name) → 수정 → **APPROVED**

## Test plan

- [x] \`pytest tests/trading/agents/ tests/trading/engine/ tests/api/test_actions.py\` — 215/215 passed
- [x] \`make lint\` clean
- [x] Privacy scan clean
- [x] Codex APPROVED after 1 fix

## Scope out (의도적 잔존)

- \`test_certification.py::TestCertify\` 의 \`cert.total_conditions == 11\` 하드코딩: 현재 fixture (us_equity only or empty fallback) 에서는 정확히 11 발행이라 문제 없음. 추가 방어 assertion 은 scope creep 으로 별도 이관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)