### PR TITLE
docs: sync test count drift (2,934/2,944 → 2,947)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, ~339 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (2,934 backend + 913 frontend + 39 e2e)
+make test       # full suite (2,947 backend + 913 frontend + 39 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -170,7 +170,7 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,944 tests, 137 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 2,947 tests, 137 files |
 | Frontend tests | 목표 ≥ 90% | 913 tests, 60 files |
 | E2E | 핵심 flow 커버 | 39 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |


### PR DESCRIPTION
Trivial count sync after #312/#313 added tests. docs only.

- README.md L229: `2,934 backend` → `2,947`
- STRATEGY.md §4.1: `2,944 tests` → `2,947`

`pytest --collect-only` = 2,947/2,956 (9 deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)