### PR TITLE
chore(scripts): session-level dev_sync workflow (start/end/status)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,15 @@ deploy:
 backup:
 	bash scripts/backup.sh
 
+sync-start:
+	bash scripts/dev_sync.sh start
+
+sync-end:
+	bash scripts/dev_sync.sh end
+
+sync-status:
+	bash scripts/dev_sync.sh status
+
 ports:
 	bash scripts/ports.sh
 

--- a/scripts/dev_sync.sh
+++ b/scripts/dev_sync.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Nuri-Quant: dev↔dev 세션 동기화 헬퍼
+#
+# scripts/sync_dev.sh 위에 얇은 세션 워크플로 layer:
+#   start   = 작업 시작 — 다른 머신 → 이 머신 (pull) + NEXT_SESSION.md
+#   end     = 작업 종료 — 이 머신 → 다른 머신 (push) + NEXT_SESSION.md
+#   status  = 양쪽 git HEAD + NEXT_SESSION.md 타임스탬프 비교 (read-only)
+#
+# 사용법 (Makefile 타겟 권장):
+#   make sync-start   |  bash scripts/dev_sync.sh start
+#   make sync-end     |  bash scripts/dev_sync.sh end
+#   make sync-status  |  bash scripts/dev_sync.sh status
+#
+# DEV2_HOST 는 ~/.zshrc 에 머신마다 다른 값으로 export 되어 있어야 함
+# (.env 에 두면 sync 시 cross-pollute 되므로 금지 — sync_dev.sh 헤더 참조).
+#
+# shellcheck disable=SC2029
+# ^ ssh "…${REMOTE_PATH}…" client-side expansion intentional.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+ACTION="${1:-}"
+shift || true
+
+REMOTE_HOST="${DEV2_HOST:-}"
+REMOTE_PATH="${DEV2_PATH:-~/workspace/nuri-quant}"
+
+if [[ -z "${REMOTE_HOST}" ]]; then
+    echo "❌ DEV2_HOST 미설정. ~/.zshrc 에 다음 한 줄 추가:"
+    echo "   export DEV2_HOST=<other-mac>.local"
+    exit 1
+fi
+
+usage() {
+    cat <<EOF
+사용법: bash scripts/dev_sync.sh {start|end|status} [options]
+
+  start   다른 머신 → 이 머신 (작업 시작 시)
+  end     이 머신 → 다른 머신 (작업 종료 시)
+  status  양쪽 git HEAD + NEXT_SESSION.md 타임스탬프 비교
+
+추가 옵션은 sync_dev.sh 그대로 통과 (--with-reports / --no-claude).
+EOF
+}
+
+case "${ACTION}" in
+    start)
+        echo "=== sync start: pulling from ${REMOTE_HOST} ==="
+        bash "${SCRIPT_DIR}/sync_dev.sh" pull "$@"
+        if scp -q "${REMOTE_HOST}:${REMOTE_PATH}/NEXT_SESSION.md" ./NEXT_SESSION.md 2>/dev/null; then
+            echo "✓ NEXT_SESSION.md synced"
+        else
+            echo "⚠ NEXT_SESSION.md skipped (not on remote)"
+        fi
+        echo "=== sync start done ==="
+        ;;
+    end)
+        echo "=== sync end: pushing to ${REMOTE_HOST} ==="
+        bash "${SCRIPT_DIR}/sync_dev.sh" push "$@"
+        if [[ -f NEXT_SESSION.md ]]; then
+            scp -q NEXT_SESSION.md "${REMOTE_HOST}:${REMOTE_PATH}/NEXT_SESSION.md" \
+                && echo "✓ NEXT_SESSION.md synced"
+        fi
+        echo "=== sync end done ==="
+        ;;
+    status)
+        echo "─── local ($(hostname -s)) ───"
+        git log -1 --oneline 2>/dev/null || echo "(no git)"
+        grep -E "^마지막 업데이트" NEXT_SESSION.md 2>/dev/null | head -1 \
+            || echo "(no NEXT_SESSION.md timestamp)"
+        echo "─── remote (${REMOTE_HOST}) ───"
+        ssh -o BatchMode=yes -o ConnectTimeout=5 "${REMOTE_HOST}" \
+            "cd ${REMOTE_PATH} 2>/dev/null && git log -1 --oneline && (grep -E '^마지막 업데이트' NEXT_SESSION.md 2>/dev/null | head -1)" \
+            || echo "(remote unreachable)"
+        ;;
+    ""|-h|--help|help)
+        usage
+        ;;
+    *)
+        echo "❌ unknown action: ${ACTION}"
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- `scripts/dev_sync.sh` — thin layer over existing `scripts/sync_dev.sh` exposing session-level subcommands (`start` / `end` / `status`)
- `Makefile` — `sync-start` / `sync-end` / `sync-status` targets following existing `deploy` / `backup` convention
- Bundles `NEXT_SESSION.md` handoff (gitignored — `sync_dev.sh` doesn't cover it, so handled via `scp` here)

## Why

MacBook (portable dev) ↔ Mac mini (24/7 receiver) workflow needs explicit session entry/exit sync. Without this layer each session starts with 3 manual commands (`cd` + `sync_dev.sh pull` + `scp NEXT_SESSION.md`); same on exit. Project-local Makefile keeps the convention discoverable via `make help` and survives across machines via git (vs user-level `~/.zshrc` functions which would clutter the global shell config and don't generalize across other projects).

## Architecture (3-layer separation)

| Layer | Location | Why there |
|---|---|---|
| Logic (portable) | `scripts/dev_sync.sh` | git-tracked → auto-deployed to Mac mini via launchd autopull |
| UX (project-local) | `Makefile sync-start/end/status` | follows existing target convention |
| Identity (machine-local) | `~/.zshrc DEV2_HOST` | machine-specific; **never** in `.env` because `sync_dev.sh` syncs `.env` itself → cross-pollution |

## Test plan

- [x] `make sync-status` live: both machines report identical git HEAD (`7b26e73`) + NEXT_SESSION timestamp
- [x] `bash scripts/dev_sync.sh start` exits cleanly when `DEV2_HOST` set
- [x] `bash scripts/dev_sync.sh` (no arg) prints usage
- [x] Unknown action exits 1 with usage hint
- [ ] CI shellcheck passes (local `shellcheck` not installed — verified style matches sibling `scripts/sync_dev.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)