### PR TITLE
ci: backend test shards 2 → 3 (~30% wall-clock cut)

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -236,9 +236,11 @@ jobs:
           "
 
   # ── Backend Tests (sharded matrix) ──
-  # Tests are split across 2 shards via pytest-shard, each running on its own
-  # 4-core runner. Wall time roughly halves vs the single-job design.
-  # Shard names are "Backend Tests Shard 1/2" — NOT a required check.
+  # Tests are split across 3 shards via pytest-shard, each running on its own
+  # 4-core runner. Wall time ~= max(shards) instead of sum, so 3 shards cuts
+  # ~30% off the 2-shard wall-clock at the cost of one extra runner minute
+  # (per-shard setup overhead: ~20s uv + TA-Lib cache restore).
+  # Shard names are "Backend Tests Shard 1/2/3" — NOT a required check.
   # The aggregator job below reports the single required check name "Backend Tests".
 
   backend-tests-shard:
@@ -249,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     steps:
       - name: Skip notice (no backend changes)
         if: needs.changes.outputs.backend != 'true' && github.event_name == 'pull_request'
@@ -311,17 +313,17 @@ jobs:
       # pytest-shard splits tests by hash(test_id) into N buckets. shard-id is
       # 0-indexed but the matrix exposes 1-indexed values for human readability.
       #
-      # PR runs: -m "not slow" — exclude ~12 slow tests (~135s saved per shard)
+      # PR runs: -m "not slow" — exclude 23 slow tests (~135s saved per shard)
       # main push: full suite including slow tests
 
       - name: Run tests with coverage (PR — fast)
         if: github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true'
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=2 --cov=nuri --cov-report=xml --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=3 --cov=nuri --cov-report=xml --cov-report=term
         timeout-minutes: 5
 
       - name: Run tests with coverage (main — full)
         if: github.event_name != 'pull_request'
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=2 --cov=nuri --cov-report=xml --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=3 --cov=nuri --cov-report=xml --cov-report=term
         timeout-minutes: 5
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary

Increases the backend test shard matrix from 2 to 3, cutting expected wall-clock from ~2m51s to ~1m54s on the bottleneck (backend tests dominate CI time).

## Baseline (observed)

Run [24443358335](https://github.com/researcherhojin/nuri-quant/actions/runs/24443358335) (#319 push to main, full suite including slow tests):

| Job | Duration |
|---|---|
| Backend Tests Shard 1 | **2m51s** |
| Backend Tests Shard 2 | **2m45s** |
| Frontend Tests | 1m23s |
| Frontend Build | 0m51s |
| Rest | < 20s each |
| **Wall-clock (max of parallel jobs)** | **3m03s** |

## Expected after this PR

- Per-shard runtime: ~2m51s × (2/3) ≈ **1m54s**
- New wall-clock: ~**2m05s** (bottleneck moves from backend shards to Frontend Tests at 1m23s)
- **Savings: ~55s (~30%) per CI run**

## Tradeoff (billing)

- +1 extra runner minute per push (1 additional shard × ~20s setup overhead + ~1m54s test run).
- Net test runtime same (~5m45s split 3 ways vs 2 ways).
- Setup cost (uv install + TA-Lib cache restore): ~20s × 3 = 60s instead of ~40s.
- Minor: more concurrent runners, but GitHub Actions free tier handles 20 concurrent jobs easily.

## Safety

- Required status check is `Backend Tests` (the **aggregator** job, `backend-tests-aggregator`), NOT per-shard names. Branch protection doesn't care how many shards feed in.
- `fail-fast: false` preserved → all 3 shards run to completion even if one fails (better signal).
- `pytest-shard` splits by `hash(test_id)` uniformly → 3 buckets will be evenly sized.

## Also fixed

Inline comment `~12 slow tests` → `23 slow tests` (matches PR #319 drift sync).

## Test plan

- [x] Diff verified — only shard count + comment changes
- [ ] This PR's own CI will validate the new 3-shard path (first test of new config)
- [ ] After merge: next push to main should show backend shards 1/2/3 each under 2m, wall-clock under 2m30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)