### PR TITLE
ci: backend test slow-split + codecov flag alignment

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -235,13 +235,27 @@ jobs:
           print('✅ Universe sanity check PASS')
           "
 
-  # ── Backend Tests (sharded matrix) ──
-  # Tests are split across 3 shards via pytest-shard, each running on its own
-  # 4-core runner. Wall time ~= max(shards) instead of sum, so 3 shards cuts
-  # ~30% off the 2-shard wall-clock at the cost of one extra runner minute
-  # (per-shard setup overhead: ~20s uv + TA-Lib cache restore).
-  # Shard names are "Backend Tests Shard 1/2/3" — NOT a required check.
-  # The aggregator job below reports the single required check name "Backend Tests".
+  # ── Backend Tests — fast/slow split + fast shards ──
+  #
+  # Architecture (post PR #320 revert + STRATEGY §5.8 #2 "2번 실패하면 접근을
+  # 바꾼다"):
+  #   1. backend-tests-shard  — fast tests only (-m "not slow"), 2-shard matrix.
+  #      Runs on both PR and push. Always excludes slow.
+  #   2. backend-tests-slow   — 23 slow tests, unsharded, single job.
+  #      Runs ONLY on push to main (PR still skips slow, matching pre-split
+  #      behavior).
+  #   3. backend-tests        — aggregator. Reports the "Backend Tests"
+  #      required check. needs: [changes, backend-tests-shard, backend-tests-slow].
+  #
+  # Rationale: #320 tried increasing shards 2→3, but hash-based pytest-shard
+  # concentrated slow tests in one bucket (shard 3 = 2m48s, unchanged
+  # wall-clock). Splitting by marker isolates the heavy tests from fast ones,
+  # so wall-clock becomes max(fast_shard, slow_job) instead of max(shard
+  # containing slow). Coverage uploaded from both with distinct flags so
+  # Codecov merges correctly.
+  #
+  # Shard names are "Backend Tests Shard 1/2" — NOT required checks.
+  # Only the aggregator name "Backend Tests" is protected.
 
   backend-tests-shard:
     name: Backend Tests Shard ${{ matrix.shard }}
@@ -251,7 +265,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2]
     steps:
       - name: Skip notice (no backend changes)
         if: needs.changes.outputs.backend != 'true' && github.event_name == 'pull_request'
@@ -310,20 +324,14 @@ jobs:
         if: (needs.changes.outputs.backend == 'true' || github.event_name != 'pull_request') && steps.cache-venv.outputs.cache-hit != 'true'
         run: uv sync --frozen --extra dev
 
-      # pytest-shard splits tests by hash(test_id) into N buckets. shard-id is
-      # 0-indexed but the matrix exposes 1-indexed values for human readability.
-      #
-      # PR runs: -m "not slow" — exclude 23 slow tests (~135s saved per shard)
-      # main push: full suite including slow tests
+      # pytest-shard splits non-slow tests by hash(test_id) into 2 buckets.
+      # shard-id is 0-indexed but the matrix exposes 1-indexed values.
+      # Slow tests (23, LLM/scheduler) are ALWAYS excluded here and run
+      # separately in backend-tests-slow on push only.
 
-      - name: Run tests with coverage (PR — fast)
-        if: github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true'
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=3 --cov=nuri --cov-report=xml --cov-report=term
-        timeout-minutes: 5
-
-      - name: Run tests with coverage (main — full)
-        if: github.event_name != 'pull_request'
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=3 --cov=nuri --cov-report=xml --cov-report=term
+      - name: Run fast tests with coverage
+        if: needs.changes.outputs.backend == 'true' || github.event_name != 'pull_request'
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=2 --cov=nuri --cov-report=xml --cov-report=term
         timeout-minutes: 5
 
       - name: Upload coverage to Codecov
@@ -332,30 +340,125 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          flags: backend
+          flags: backend-fast
+          disable_search: true
+          fail_ci_if_error: false
+
+  # ── Backend Tests (slow) — isolated, push-only ──
+  # Runs the 23 @pytest.mark.slow tests (mostly LLM/scheduler) in a single
+  # unsharded job. Push-only: PRs deliberately skip slow tests, matching
+  # pre-split behavior (see STRATEGY §4.1 — slow excluded from PR CI).
+  # Coverage uploaded with flag `backend-slow` so Codecov merges with the
+  # fast shards' flag `backend-fast` for full-suite coverage on main.
+
+  backend-tests-slow:
+    name: Backend Tests (slow)
+    needs: changes
+    # Push-only (strict). workflow_dispatch and schedule won't run slow.
+    # PR deliberately skips slow (matches pre-split behavior, STRATEGY §4.1).
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: false
+
+      - name: Cache TA-Lib
+        id: cache-talib-slow
+        uses: actions/cache@v5
+        with:
+          path: /tmp/talib-installed
+          key: talib-0.4.0-${{ runner.os }}-v5
+
+      - name: Build TA-Lib from source
+        if: steps.cache-talib-slow.outputs.cache-hit != 'true'
+        run: |
+          wget -q http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+          tar -xzf ta-lib-0.4.0-src.tar.gz
+          cd ta-lib && ./configure --prefix=/usr && make && sudo make install
+          mkdir -p /tmp/talib-installed
+          sudo cp /usr/lib/libta_lib* /tmp/talib-installed/
+          sudo cp -r /usr/include/ta-lib /tmp/talib-installed/
+
+      - name: Restore TA-Lib from cache
+        if: steps.cache-talib-slow.outputs.cache-hit == 'true'
+        run: |
+          sudo cp /tmp/talib-installed/libta_lib* /usr/lib/
+          sudo mkdir -p /usr/include/ta-lib
+          sudo cp /tmp/talib-installed/ta-lib/* /usr/include/ta-lib/ 2>/dev/null || true
+          sudo ln -sf /usr/lib/libta_lib.so.0.0.0 /usr/lib/libta_lib.so.0 2>/dev/null || true
+
+      - name: Configure TA-Lib
+        run: sudo ldconfig 2>/dev/null
+
+      - name: Cache venv
+        id: cache-venv-slow
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('uv.lock') }}
+
+      - name: Install deps
+        if: steps.cache-venv-slow.outputs.cache-hit != 'true'
+        run: uv sync --frozen --extra dev
+
+      - name: Run slow tests with coverage
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --cov=nuri --cov-report=xml --cov-report=term
+        timeout-minutes: 5
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: backend-slow
           disable_search: true
           fail_ci_if_error: false
 
   # ── Backend Tests aggregator ──
-  # Single check name "Backend Tests" reported to branch protection. Always runs
-  # (even if shards are skipped) so the required check always reports.
+  # Single check name "Backend Tests" reported to branch protection. Always
+  # runs (if: always()) so the required check always reports.
+  #
+  # needs both fast shards and slow job. On PR, slow is skipped by design —
+  # treated as OK (result=skipped). Only failure/cancelled propagates.
+  #
+  # ⚠ Keep name EXACTLY "Backend Tests" — that is the protected check.
+  # ⚠ Do not rename child jobs to collide with this name.
 
   backend-tests:
     name: Backend Tests
-    needs: [changes, backend-tests-shard]
+    needs: [changes, backend-tests-shard, backend-tests-slow]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: Aggregate shard results
+      - name: Aggregate shard + slow results
         run: |
-          result="${{ needs.backend-tests-shard.result }}"
-          echo "Shards overall result: $result"
-          if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-            echo "::error::One or more backend test shards failed"
+          changes="${{ needs.changes.result }}"
+          fast="${{ needs.backend-tests-shard.result }}"
+          slow="${{ needs.backend-tests-slow.result }}"
+          echo "changes=$changes fast=$fast slow=$slow"
+          # changes must actually succeed — if it failed, downstream jobs will
+          # be skipped and we'd false-green (Codex #2 Task A).
+          if [[ "$changes" != "success" ]]; then
+            echo "::error::changes job did not succeed (result=$changes) — cannot verify downstream"
             exit 1
           fi
-          echo "✓ All backend test shards passed (or skipped)"
+          if [[ "$fast" == "failure" || "$fast" == "cancelled" ]]; then
+            echo "::error::backend-tests-shard (fast) failed or cancelled"
+            exit 1
+          fi
+          if [[ "$slow" == "failure" || "$slow" == "cancelled" ]]; then
+            echo "::error::backend-tests-slow failed or cancelled"
+            exit 1
+          fi
+          echo "✓ backend tests passed (or skipped) — fast=$fast slow=$slow"
 
   # ─── Security ───
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,11 +4,14 @@
 # Codecov가 PR마다 backend/frontend 커버리지를 별도 배지로 표시
 # 정책: 자동 임계값 + 1% 허용범위 (작은 변동 무시)
 
-# 2 backend shards + 1 frontend = 3 uploads per commit.
-# Wait for all before computing coverage to avoid partial-report artifacts.
+# Uploads per event (after slow-split):
+#   - PR:   2 backend-fast shards + 1 frontend                    = 3 uploads
+#   - push: 2 backend-fast shards + 1 backend-slow + 1 frontend   = 4 uploads
+# `after_n_builds` removed — a static value would either hang PRs (waiting
+# for a 4th upload that never comes) or report partial push coverage. Codecov
+# now processes uploads as they arrive; status settles on the final state.
 codecov:
-  notify:
-    after_n_builds: 3
+  notify: {}
 
 coverage:
   status:
@@ -22,11 +25,18 @@ coverage:
         threshold: 5%        # 리팩토링(문자열 교체 등)에서 미커버 기존 라인 허용
 
 # Backend = Python (nuri/), Frontend = TypeScript (frontend/src/)
+# backend-fast / backend-slow: workflow 의 slow-split 대응. 두 flag 모두
+# nuri/ 를 대상으로 하고, component_management 에서 'backend' component 로
+# 합쳐진다 (flag_regexes: backend.*).
 flags:
-  backend:
+  backend-fast:
     paths:
       - nuri/
     carryforward: true       # 미수정 파일 직전 커버리지 유지
+  backend-slow:
+    paths:
+      - nuri/
+    carryforward: true
   frontend:
     paths:
       - frontend/src/
@@ -54,7 +64,7 @@ component_management:
     - component_id: backend
       name: Backend (Python)
       flag_regexes:
-        - backend
+        - backend.*          # backend-fast + backend-slow 모두 매치
     - component_id: frontend
       name: Frontend (Next.js)
       flag_regexes:


### PR DESCRIPTION
## Summary

Replaces the failed 3-shard approach (PR #320) with a **marker-based split**:
- Fast tests (2 shards, `-m 'not slow'`) + Slow tests (single job, push-only, `-m 'slow'`) + aggregator.
- Coverage uploaded from both with distinct flags (`backend-fast` / `backend-slow`), codecov.yml updated to match.

## Why #320 failed

| | 2-shard baseline | 3-shard (#320) |
|---|---|---|
| Shard 1 | 2m51s | 1m53s |
| Shard 2 | 2m45s | 2m01s |
| Shard 3 | — | **2m48s** ← new bottleneck |
| Wall-clock | 3m03s | **3m05s** (worse!) |

`pytest-shard` splits by `hash(test_id)`. Heavy `@pytest.mark.slow` tests concentrated in shard 3 → adding shards doesn't help. Root cause: wrong axis of partitioning.

## New design (this PR)

```
backend-tests-shard (fast, matrix [1,2], -m "not slow")   ← ~50s each
backend-tests-slow  (push-only, unsharded, -m "slow")      ← ~60-90s
frontend-tests                                              ← ~1m24s
                         ↓
backend-tests (aggregator, needs all 3)
```

**Expected main-push wall-clock**: `max(fast_shard ~50s, slow ~1m30s, frontend ~1m24s)` ≈ **~1m30s** (vs 3m03s baseline = ~50% cut).

**PR wall-clock unchanged**: slow job skipped on PR (by design, matches pre-split behavior per STRATEGY §4.1).

## Codex consult results

Ran `codex exec --reasoning high` on the initial draft before push. Codex caught **3 critical issues**:

| # | Issue | Fix applied |
|---|---|---|
| 1 | `codecov.yml` still defined flags `backend`/`frontend` with `after_n_builds: 3`. Workflow uploads `backend-fast`/`backend-slow`, and main-push now produces 4 uploads (not 3). Would cause Codecov to hang PRs or report partial coverage. | Removed `after_n_builds`, added new flags, `component_management` uses regex `backend.*` to aggregate. |
| 2 | Aggregator script checked `fast`/`slow` results but not `changes`. If `changes` fails, downstream jobs skip → aggregator false-greens. | Added explicit `changes.result != 'success'` check. |
| 3 | Slow-job guard `if: github.event_name != 'pull_request'` would also run on `workflow_dispatch` and `schedule`, not matching stated "push-only". | Tightened to `== 'push'`. |

Plus 4 separate audit findings for `.github/` config files (CODEOWNERS, dependabot, labeler, PR template) — deferred to separate PRs per scope discipline.

## Safety

- Required status check `Backend Tests` (aggregator name) — **unchanged**. Branch protection intact.
- Aggregator `if: always()` preserved → required check always reports.
- `fail-fast: false` on shard matrix preserved.

## Test plan

- [x] `yaml.safe_load` both files — valid
- [x] Codex independent review — 3 issues found + fixed
- [ ] This PR's own CI validates the new structure (first live test)
- [ ] After merge: next push-to-main measured — expect ~1m30s wall-clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)