### PR TITLE
ci(stage 2a): fix CI infra blind spot + dead universe gate

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      universe: ${{ steps.filter.outputs.universe }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -51,9 +52,15 @@ jobs:
               - 'uv.lock'
               - 'Makefile'
               - 'config/**'
-              - '.github/workflows/main-ci-cd.yml'
+              - '.github/workflows/**'
+              - '.github/actions/**'
             frontend:
               - 'frontend/**'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            universe:
+              - 'config/universe.yaml'
+              - 'scripts/validate_universe.py'
               - '.github/workflows/main-ci-cd.yml'
 
   # ─── Frontend ───
@@ -203,7 +210,13 @@ jobs:
   universe-check:
     name: Universe Coverage Validation
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    # Previous condition was `needs.changes.outputs.python`, but `changes` never
+    # emitted a `python` output — the gate was dead (always skipped) since
+    # workflow inception. Fixed to use the new dedicated `universe` output
+    # (triggered by config/universe.yaml, scripts/validate_universe.py, or
+    # this workflow). Always runs on non-PR events to track coverage drift on
+    # main, matching the pattern used by other backend jobs.
+    if: needs.changes.outputs.universe == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true  # warning-only initially per spec §6 stage 1


### PR DESCRIPTION
## Summary

Stage 2a of the Codex-advised 4-step CI refactor. Prerequisite for the composite action work in Stage 2b (without this, a PR touching only \`.github/actions/**\` would silently fast-pass all backend tests).

## Fixes (both Codex-flagged as critical)

### 1. CI infra blind spot in \`changes\` filter

**Before**: \`backend\` / \`frontend\` filters only tracked \`.github/workflows/main-ci-cd.yml\` under CI paths.

**After**: Widened to \`.github/workflows/**\` and \`.github/actions/**\` so any CI infra change triggers the relevant test suites.

**Why**: Codex caught that the upcoming composite action extraction would create a blind spot — a PR modifying only \`.github/actions/setup-backend-env/\` would show \`backend=false\` and skip all backend tests. Fix must land first.

### 2. Dead universe-check gate

**Before**: \`if: needs.changes.outputs.python == 'true'\` — but \`changes\` job exposes only \`backend\` and \`frontend\` outputs. Never existed. Job has been \`0m00s skipped\` on every run since inception.

**After**:
- Added dedicated \`universe\` output to \`changes\` job (triggered by \`config/universe.yaml\`, \`scripts/validate_universe.py\`, or workflow edits)
- Condition: \`needs.changes.outputs.universe == 'true' || github.event_name != 'pull_request'\`
- Semantic: run on universe changes in PRs; always run on push to track main drift

**Why**: Dead gate pretended to validate but did nothing. Codex audit surface.

## Safety

- \`continue-on-error: true\` preserved — universe-check remains warning-only (spec §6 stage 1)
- Required status check unchanged (\`Backend Tests\` aggregator)
- No runner cost delta on PRs that don't touch universe files (filter short-circuit)

## Test plan

- [x] YAML syntax valid
- [x] Codex high-reasoning review on full plan (this is step 1-2 of 4)
- [ ] This PR's own CI: expect \`Universe Coverage Validation\` to ACTUALLY run for the first time (workflow itself modified → universe filter matches)
- [ ] Post-merge: next PR that doesn't touch universe.yaml should see universe-check skipped again (proves filter works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)