### PR TITLE
chore(github): clean up stale refs + privacy checkbox (Codex audit)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,8 +17,9 @@
 # ─── Security-sensitive ─────────────────────────────────
 /config/rules.yaml         @researcherhojin
 /scripts/gate_check.py     @researcherhojin
+/scripts/check_privacy_leak.py  @researcherhojin
 /nuri/api/main.py          @researcherhojin
-/nuri/api/routes/auth*.py  @researcherhojin
+/nuri/api/auth.py          @researcherhojin
 /.env.example              @researcherhojin
 
 # ─── DB schema (migrations append-only — careful) ───────
@@ -31,6 +32,6 @@
 
 # ─── Documentation ──────────────────────────────────────
 /docs/STRATEGY.md          @researcherhojin
-/docs/ROADMAP.md           @researcherhojin
 /CLAUDE.md                 @researcherhojin
 /README.md                 @researcherhojin
+/AGENTS.md                 @researcherhojin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,7 @@ updates:
           - "@vitest/*"
           - "@testing-library/*"
           - "@playwright/*"
+          - "playwright"         # standalone package (defensive — @playwright/test pulls it in)
         update-types:
           - "minor"
           - "patch"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,13 +39,13 @@ llm:
           - "nuri/llm/**"
 
 evidence:
+  # 2026-04-15 Codex audit: previous 5 paths were ALL stale (non-existent files).
+  # Replaced with the actual evidence-related modules.
   - changed-files:
       - any-glob-to-any-file:
-          - "nuri/core/evidence.py"
-          - "nuri/core/data_quality.py"
-          - "nuri/trading/recommend/institutional_check.py"
-          - "nuri/trading/recommend/momentum_filter.py"
-          - "frontend/src/app/decision/**"
+          - "nuri/analysis/evidence_charts.py"
+          - "frontend/src/app/evidence/**"
+          - "frontend/src/__tests__/pages/evidence.test.tsx"
 
 kis:
   - changed-files:
@@ -92,9 +92,14 @@ config:
           - ".env.example"
 
 security:
+  # 2026-04-15 Codex audit: `nuri/api/middleware*.py` never existed — the
+  # label misrouted or matched nothing. Replaced with the actual security-
+  # sensitive modules (auth, privacy scanner, SIEGE gate, policy files).
   - changed-files:
       - any-glob-to-any-file:
           - ".gitignore"
           - "config/rules.yaml"
-          - "nuri/api/middleware*.py"
+          - "nuri/api/auth.py"
           - "scripts/gate_check.py"
+          - "scripts/check_privacy_leak.py"
+          - "SECURITY.md"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,10 +37,14 @@ the previous session (drift bugs, atomicity, scope creep).
 - [ ] Config in `config/*.yaml` (no hardcoded values)
 - [ ] Numbers updated if changed (README, CLAUDE.md, STRATEGY.md)
 
+## Privacy (STRATEGY.md §4.4.1 — enforced by `scripts/check_privacy_leak.py`)
+
+- [ ] No broker names, account holdings, avg price, quantity, or ticker + PnL
+      in diff, tests, commit messages, or PR body
+- [ ] Scanner clean: `.venv/bin/python scripts/check_privacy_leak.py --unpushed-commits`
+
 ## Risk
 
 <!-- What could go wrong? What's the rollback path? -->
 
 - Rollback:
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

4 file cleanups for \`.github/\` configs flagged by Codex audit earlier. All stale refs verified non-existent before removal. No behavior change.

## Changes

### \`labeler.yml\`
- **\`evidence\` label**: ALL 5 paths were dead. Replaced with real evidence modules (\`nuri/analysis/evidence_charts.py\`, \`frontend/src/app/evidence/**\`, \`frontend/src/__tests__/pages/evidence.test.tsx\`).
- **\`security\` label**: \`nuri/api/middleware*.py\` never existed. Replaced with real security files (\`nuri/api/auth.py\`, \`scripts/check_privacy_leak.py\`, \`SECURITY.md\`).

### \`CODEOWNERS\`
- Removed \`/docs/ROADMAP.md\` (file doesn't exist)
- Fixed \`/nuri/api/routes/auth*.py\` → \`/nuri/api/auth.py\` (actual path)
- Added \`/scripts/check_privacy_leak.py\` (STRATEGY §4.4.1 enforcer, was unowned)
- Added \`/AGENTS.md\` (new sibling file missed by doc section)

### \`dependabot.yml\`
- Defensive: added \`playwright\` standalone to \`frontend-test\` group. \`@playwright/test\` pulls it in transitively today; if ever added as direct dep it would split out of the group.

### \`pull_request_template.md\`
- Removed trailing \`🤖 Generated with Claude Code\` footer — template is a repo artifact, not a Claude output.
- Added **Privacy** section with STRATEGY §4.4.1 checkbox + scanner command. PR #202 previously leaked broker + ticker + PnL in commit messages; template reminder reduces recurrence risk.

## Verification

- [x] All stale refs confirmed non-existent (\`ls\` check before removal)
- [x] Actual replacement refs confirmed exist
- [x] YAML syntax valid (labeler + dependabot)
- [x] No behavior change — only ref hygiene + template improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)