### PR TITLE
ci: graduate shell-lint + upgrade ruff-action v3→v4

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@v6
         if: needs.changes.outputs.backend == 'true' || github.event_name != 'pull_request'
 
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4.0.0
         if: needs.changes.outputs.backend == 'true' || github.event_name != 'pull_request'
         with:
           args: "check nuri/ tests/ scripts/"
@@ -191,13 +191,16 @@ jobs:
         run: python3 scripts/check_privacy_leak.py
 
   # ── Shell script lint ──
-  # shellcheck로 scripts/*.sh 린트. warning-only (첫 도입 단계; required check
-  # 승격은 stable 후). Cost: ~10s, no deps (Ubuntu runner에 shellcheck 기본 포함).
+  # shellcheck로 scripts/*.sh 린트. Graduated from warning-only 2026-04-15 —
+  # passed cleanly across multiple consecutive runs (STRATEGY §7 Tier 1 #7
+  # shipped 16 files clean). Failures now block the job, but the check
+  # is still not in required_status_checks (branch protection update is a
+  # separate manual step when user chooses to enforce).
+  # Cost: ~10s, no deps (Ubuntu runner has shellcheck preinstalled).
   shell-lint:
     name: Shell Lint
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Run shellcheck


### PR DESCRIPTION
## Summary

Two small rigor improvements:

### 1. shell-lint graduated from warning-only

\`continue-on-error: true\` removed. The job has been consistently clean since STRATEGY §7 Tier 1 #7 shipped all 16 scripts as shellcheck-clean. No longer "first introduction" — failures now fail the job properly.

**Not yet in required_status_checks** — elevating to branch protection is a separate manual admin decision (branch protection is a repo-level setting, not a workflow change).

### 2. ruff-action v3 → v4

[\`astral-sh/ruff-action@v4\`](https://github.com/astral-sh/ruff-action/releases/tag/v4.0.0) (released 2026-04-12) bundles Node 24, resolving the Node 20 deprecation warning we've seen on every Backend Lint job:

> \`! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: astral-sh/ruff-action@v3.\`

No ruff behavior change expected (CLI invocation unchanged).

## Remaining Node 20 deprecation

The Security Scan job has a second Node 20 warning, but it's in a **transitive dependency** of Trivy's action (\`actions/cache@0400d5f644dc...\`), not something we can pin directly. Tracked upstream.

## Safety

- No required_status_checks impact
- No behavior change aside from shell-lint blocking on shellcheck failures
- ruff-action v4 is a drop-in replacement per the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)