### PR TITLE
refactor(analysis): remove unused Riskfolio portfolio init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ ENV/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.cache/
 .tox/
 .coverage
 .coverage.*

--- a/nuri/analysis/risk.py
+++ b/nuri/analysis/risk.py
@@ -11,7 +11,6 @@ import logging
 
 import numpy as np
 import pandas as pd
-import riskfolio as rp
 
 from nuri.core.db import query, query_df
 
@@ -66,10 +65,6 @@ def analyze_risk() -> dict:
     w = w_series[common]
     w = w / w.sum()
     port_returns = (returns[common] * w).sum(axis=1)
-
-    # Riskfolio 포트폴리오 객체
-    port = rp.Portfolio(returns=returns[common])
-    port.assets_stats(method_mu="hist", method_cov="hist")
 
     # 리스크프리 레이트
     rf_rows = query(


### PR DESCRIPTION
## Summary
- **`refactor(analysis)`**: `nuri/analysis/risk.py`의 `rp.Portfolio(returns) + assets_stats(...)` 호출은 `port` 객체를 downstream에서 참조하지 않는 dead code — 제거. `make analyze` 실행 시 "You must convert self.cov to a positive definite matrix" 경고 소거. VaR/CVaR/Sharpe/MDD 산출은 전혀 변하지 않음.
- **`chore(gitignore)`**: `$PWD/.cache`를 쓰는 도구(matplotlib MPLCONFIGDIR, yfinance 등)가 환경에 따라 남길 수 있는 로컬 캐시를 `.gitignore`에 추가 (`.pytest_cache/`, `.ruff_cache/`, `.mypy_cache/` 패턴 일치).

## Motivation
2026-04-16 `make full-scan` 한 사이클 관찰 중 발견된 두 가지 runtime hygiene 항목. STRATEGY §5.8 원칙 #3 ("사용자 워크플로로 검증한다") 실행의 부산물.

`nuri/analysis/rebalance.py`의 Riskfolio 사용은 `rp_optimization`/`optimization`을 실제 호출하므로 완전 독립 — 건드리지 않음.

## Test plan
- [x] `pytest tests/analysis/test_risk.py -v` — 9 passed
- [x] `make test-fast` — 2937 passed, 87% coverage, 26.5s
- [x] `ruff check nuri/ tests/` — clean
- [x] `check_privacy_leak.py --unpushed-commits` — clean (양 커밋)
- [ ] CI 통과 (PR 후 확인)

## Scope discipline
같은 세션에서 codex가 추가했던 cache paths (Makefile/scripts/_common.sh export XDG_CACHE_HOME) 및 technical.py concat→row refactor는 실존 문제가 없거나 (pandas 2.3.3에서 FutureWarning 재현 불가) 요청 외 스코프여서 STRATEGY §5.4에 따라 드롭. Group A (#89 interactive backtest) 변경은 `feat-issue-89-interactive-backtest` 브랜치 stash로 보존.