### PR TITLE
chore(gitignore): allowlist curated .claude/ assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,13 @@ frontend/test-results/
 .pydevproject
 
 # ─── Claude Code / AI assistants ───────────────────────────────
-.claude/
+# Default-ignore .claude/ to keep personal state (settings.local.json,
+# hooks drafts, notes) out of git. Explicitly allowlist the curated
+# project-scoped assets so any Claude Code user working on this repo
+# picks them up automatically.
+.claude/*
+!.claude/settings.json
+!.claude/skills/
 
 # ─── OS ────────────────────────────────────────────────────────
 .DS_Store


### PR DESCRIPTION
## Summary
기존 `.claude/` 통째 ignore 규칙을 **`*` + allowlist** 패턴으로 교체. 의도가 규칙 자체에 명시돼 미래 기여자가 `.claude/settings.json` 이나 `.claude/skills/*/README.md` 가 **왜** 추적되는지 git blame 없이 바로 이해할 수 있음.

## Before
```gitignore
.claude/
```
→ 규칙은 전체 ignore인데 실제로는 이미 추적 중인 파일 4개 (`settings.json` + skills 3개) 가 git tracked. "왜 tracked 인가"가 커밋 히스토리에만 존재하는 상태 (`2c0ae8d`).

## After
```gitignore
.claude/*
!.claude/settings.json
!.claude/skills/
```
→ allowlist 로 의도를 code level 에서 자체 문서화.

## Verification
`git check-ignore -v` 매트릭스 (전부 예상대로):

| 경로 | 결과 | 이유 |
|------|------|------|
| `.claude/settings.json` | NOT ignored | allowlist |
| `.claude/skills/nuri-deploy/README.md` | NOT ignored | skills/ allowlist |
| `.claude/skills/nuri-verify/README.md` | NOT ignored | 동 |
| `.claude/skills/nuri-review/README.md` | NOT ignored | 동 |
| `.claude/settings.local.json` | ignored | `.claude/*` |
| `.claude/hooks/future_hook.sh` (가상) | ignored | `.claude/*` |
| `.claude/my_personal_notes.md` (가상) | ignored | `.claude/*` |
| `.claude/local_override.json` (가상) | ignored | `.claude/*` |

## Impact
- `git ls-files .claude/` 결과 before/after 동일 (추적 파일 셋 불변)
- 새 기여자가 `.claude/my_local_hack.md` 같은 개인 파일 실수로 커밋 시도해도 여전히 ignore 됨
- 새 프로젝트 skill (예: `.claude/skills/nuri-new/README.md`) 추가 시 자동 allowlist 범위 — 별도 negate 불필요

## Test plan
- [x] `git check-ignore` 8 case 매트릭스 검증
- [x] `git ls-files .claude/` 결과 일치 확인
- [ ] CI 통과