### PR TITLE
feat(#89): interactive backtest sliders with live equity curve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ SESSION_PROMPT.md
 
 # Internal methodology (not for public repo)
 docs/SYSTEM.md
+.gstack/

--- a/frontend/src/__tests__/components/backtest-sliders.test.tsx
+++ b/frontend/src/__tests__/components/backtest-sliders.test.tsx
@@ -13,39 +13,46 @@ vi.mock("recharts", () => ({
   CartesianGrid: () => <div data-testid="grid" />,
 }));
 
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/strategy",
+}));
+
 // ── BacktestSliders ──────────────────────────────────────────────────
 
 describe("BacktestSliders", () => {
   let BacktestSliders: any;
 
   beforeEach(async () => {
+    mockSearchParams = new URLSearchParams();
     const mod = await import("@/components/ui/backtest-sliders");
     BacktestSliders = mod.BacktestSliders;
   });
 
-  it("renders all four sliders with labels", () => {
+  it("renders current slider labels", () => {
     render(<BacktestSliders onRun={vi.fn()} />);
     expect(screen.getByText("Stop")).toBeInTheDocument();
-    expect(screen.getByText("TP1")).toBeInTheDocument();
-    expect(screen.getByText("TP2")).toBeInTheDocument();
-    expect(screen.getByText("Trail")).toBeInTheDocument();
+    expect(screen.getByText("Take")).toBeInTheDocument();
   });
 
   it("shows default slider values", () => {
     render(<BacktestSliders onRun={vi.fn()} />);
     expect(screen.getByText("-7%")).toBeInTheDocument();
     expect(screen.getByText("20%")).toBeInTheDocument();
-    expect(screen.getByText("40%")).toBeInTheDocument();
-    expect(screen.getByText("-15%")).toBeInTheDocument();
   });
 
-  it("renders period buttons with 3Y active by default", () => {
+  it("renders lookback buttons with 3Y active by default", () => {
     render(<BacktestSliders onRun={vi.fn()} />);
     const btn3Y = screen.getByText("3Y");
     expect(btn3Y).toBeInTheDocument();
     expect(btn3Y.className).toContain("bg-muted");
     expect(screen.getByText("1Y")).toBeInTheDocument();
     expect(screen.getByText("5Y")).toBeInTheDocument();
+    expect(screen.getByText("SMA 50").className).toContain("bg-muted");
   });
 
   it("hides reset button when params are at defaults", () => {
@@ -53,7 +60,7 @@ describe("BacktestSliders", () => {
     expect(screen.queryByText("Reset defaults")).not.toBeInTheDocument();
   });
 
-  it("shows reset button after changing a period", () => {
+  it("shows reset button after changing lookback", () => {
     render(<BacktestSliders onRun={vi.fn()} />);
     fireEvent.click(screen.getByText("1Y"));
     expect(screen.getByText("Reset defaults")).toBeInTheDocument();
@@ -69,10 +76,9 @@ describe("BacktestSliders", () => {
 
   it("hides reset button again after clicking reset", () => {
     render(<BacktestSliders onRun={vi.fn()} />);
-    // Change period to make reset visible
+    // Change lookback to make reset visible
     fireEvent.click(screen.getByText("5Y"));
     expect(screen.getByText("Reset defaults")).toBeInTheDocument();
-    // Click reset
     fireEvent.click(screen.getByText("Reset defaults"));
     expect(screen.queryByText("Reset defaults")).not.toBeInTheDocument();
   });
@@ -82,11 +88,10 @@ describe("BacktestSliders", () => {
     render(<BacktestSliders onRun={onRun} />);
     fireEvent.click(screen.getByText("Run Backtest"));
     expect(onRun).toHaveBeenCalledWith({
+      smaPeriod: 50,
+      lookback: "3Y",
       stopLoss: -7,
-      takeProfit1: 20,
-      takeProfit2: 40,
-      trailing: -15,
-      period: "3Y",
+      takeProfit: 20,
     });
   });
 
@@ -105,12 +110,31 @@ describe("BacktestSliders", () => {
   it("passes changed params to onRun after slider change", () => {
     const onRun = vi.fn();
     render(<BacktestSliders onRun={onRun} />);
-    // Change period to 1Y
+    fireEvent.click(screen.getByText("SMA 100"));
     fireEvent.click(screen.getByText("1Y"));
     fireEvent.click(screen.getByText("Run Backtest"));
     expect(onRun).toHaveBeenCalledWith(
-      expect.objectContaining({ period: "1Y" }),
+      expect.objectContaining({ smaPeriod: 100, lookback: "1Y" }),
     );
+  });
+
+  it("uses initial params when provided", () => {
+    const onRun = vi.fn();
+    render(
+      <BacktestSliders
+        onRun={onRun}
+        initialParams={{ smaPeriod: 200, lookback: "5Y", stopLoss: -10, takeProfit: 30 }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Run Backtest"));
+
+    expect(onRun).toHaveBeenCalledWith({
+      smaPeriod: 200,
+      lookback: "5Y",
+      stopLoss: -10,
+      takeProfit: 30,
+    });
   });
 });
 
@@ -137,6 +161,9 @@ describe("InteractiveBacktest", () => {
 
   beforeEach(async () => {
     vi.restoreAllMocks();
+    mockReplace.mockReset();
+    mockSearchParams = new URLSearchParams();
+    global.fetch = vi.fn();
     const mod = await import("@/components/ui/interactive-backtest");
     InteractiveBacktest = mod.InteractiveBacktest;
   });
@@ -147,10 +174,10 @@ describe("InteractiveBacktest", () => {
     expect(screen.getAllByTestId("responsive-container").length).toBe(2);
   });
 
-  it("renders the sliders panel", () => {
+  it("starts in static mode", () => {
     render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
-    expect(screen.getByText("Backtest Parameters")).toBeInTheDocument();
-    expect(screen.getByText("Run Backtest")).toBeInTheDocument();
+    expect(screen.getByText("Static").className).toContain("bg-muted");
+    expect(screen.queryByText("Backtest Parameters")).not.toBeInTheDocument();
   });
 
   it("displays initial metrics", () => {
@@ -178,12 +205,16 @@ describe("InteractiveBacktest", () => {
   it("shows 'Custom params' after a successful backtest run", async () => {
     const updatedEquity = mockEquity.map((p) => ({ ...p, strategy: p.strategy + 5 }));
     const updatedMetrics = { ...mockMetrics, total_return: 30.0, excess_return: 14.8 };
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ equity: updatedEquity, metrics: updatedMetrics }),
-    });
+    } as Response);
 
     render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Interactive"));
+    });
+    await waitFor(() => expect(screen.getByText("Run Backtest")).toBeInTheDocument());
     await act(async () => {
       fireEvent.click(screen.getByText("Run Backtest"));
     });
@@ -192,12 +223,17 @@ describe("InteractiveBacktest", () => {
       expect(screen.getByText("Custom params")).toBeInTheDocument();
     });
     expect(screen.getByText(/Return \+30/)).toBeInTheDocument();
+    expect(mockReplace).toHaveBeenCalledWith("/strategy?sma=50&lb=3Y&sl=-7&tp=20");
   });
 
   it("keeps current data on fetch error", async () => {
-    global.fetch = vi.fn().mockRejectedValueOnce(new Error("network error"));
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("network error"));
 
     render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Interactive"));
+    });
+    await waitFor(() => expect(screen.getByText("Run Backtest")).toBeInTheDocument());
     await act(async () => {
       fireEvent.click(screen.getByText("Run Backtest"));
     });
@@ -212,12 +248,16 @@ describe("InteractiveBacktest", () => {
   });
 
   it("keeps current data when API returns non-ok response", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
       ok: false,
       json: async () => ({}),
-    });
+    } as Response);
 
     render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Interactive"));
+    });
+    await waitFor(() => expect(screen.getByText("Run Backtest")).toBeInTheDocument());
     await act(async () => {
       fireEvent.click(screen.getByText("Run Backtest"));
     });
@@ -229,20 +269,39 @@ describe("InteractiveBacktest", () => {
   });
 
   it("constructs the correct fetch URL with params", async () => {
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ equity: [], metrics: null }),
-    });
+    } as Response);
 
     render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Interactive"));
+    });
+    await waitFor(() => expect(screen.getByText("SMA 100")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByText("SMA 100"));
+      fireEvent.click(screen.getAllByText("1Y")[0]);
+    });
+    await waitFor(() => expect(screen.getByText("SMA 100").className).toContain("bg-muted"));
     await act(async () => {
       fireEvent.click(screen.getByText("Run Backtest"));
     });
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/backtest/equity?sl=-7&tp1=20&tp2=40&trail=-15&period=3Y",
+        "/api/backtest/equity?sma=100&period=1Y&sl=-7&tp=20",
       );
     });
+  });
+
+  it("hydrates interactive mode from URL params", () => {
+    mockSearchParams = new URLSearchParams("sma=200&lb=5Y&sl=-10&tp=30");
+
+    render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+
+    expect(screen.getByText("Interactive").className).toContain("bg-muted");
+    expect(screen.getByText("Backtest Parameters")).toBeInTheDocument();
+    expect(screen.getByText("Custom params")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/components/backtest-sliders.test.tsx
+++ b/frontend/src/__tests__/components/backtest-sliders.test.tsx
@@ -304,4 +304,48 @@ describe("InteractiveBacktest", () => {
     expect(screen.getByText("Backtest Parameters")).toBeInTheDocument();
     expect(screen.getByText("Custom params")).toBeInTheDocument();
   });
+
+  it("toggles back to static mode and hides sliders", async () => {
+    render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Interactive"));
+    });
+    expect(screen.getByText("Backtest Parameters")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Static"));
+    });
+
+    expect(screen.getByText("Static").className).toContain("bg-muted");
+    expect(screen.queryByText("Backtest Parameters")).not.toBeInTheDocument();
+    expect(screen.getByText(/Return \+24\.5%/)).toBeInTheDocument();
+  });
+
+  it("reverts to initialMetrics after switching back to static post-run", async () => {
+    const customEquity = mockEquity.map((p) => ({ ...p, strategy: p.strategy + 10 }));
+    const customMetrics = { ...mockMetrics, total_return: 45.0, excess_return: 20.0 };
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ equity: customEquity, metrics: customMetrics }),
+    } as Response);
+
+    render(<InteractiveBacktest initialData={mockEquity} initialMetrics={mockMetrics} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Interactive"));
+    });
+    await waitFor(() => expect(screen.getByText("Run Backtest")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Run Backtest"));
+    });
+    await waitFor(() => expect(screen.getByText(/Return \+45/)).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Static"));
+    });
+
+    expect(screen.getByText(/Return \+24\.5%/)).toBeInTheDocument();
+    expect(screen.queryByText(/Return \+45/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Custom params")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/backtest-sliders.tsx
+++ b/frontend/src/components/ui/backtest-sliders.tsx
@@ -3,19 +3,26 @@
 import { useState } from "react";
 
 interface BacktestParams {
+  smaPeriod: number;
+  lookback: string;
   stopLoss: number;
-  takeProfit1: number;
-  takeProfit2: number;
-  trailing: number;
-  period: string;
+  takeProfit: number;
 }
 
 interface BacktestSlidersProps {
   onRun: (params: BacktestParams) => void;
+  initialParams?: BacktestParams;
   loading?: boolean;
 }
 
-const PERIODS = ["1Y", "3Y", "5Y"] as const;
+const LOOKBACKS = ["1Y", "3Y", "5Y"] as const;
+const SMA_PERIODS = [50, 100, 200] as const;
+const DEFAULT_PARAMS: BacktestParams = {
+  smaPeriod: 50,
+  lookback: "3Y",
+  stopLoss: -7,
+  takeProfit: 20,
+};
 
 function Slider({ label, value, min, max, step, suffix, onChange }: {
   label: string; value: number; min: number; max: number; step: number; suffix: string;
@@ -38,35 +45,31 @@ function Slider({ label, value, min, max, step, suffix, onChange }: {
   );
 }
 
-export function BacktestSliders({ onRun, loading }: BacktestSlidersProps) {
-  const [params, setParams] = useState<BacktestParams>({
-    stopLoss: -7,
-    takeProfit1: 20,
-    takeProfit2: 40,
-    trailing: -15,
-    period: "3Y",
-  });
+export function BacktestSliders({ onRun, initialParams, loading }: BacktestSlidersProps) {
+  const [params, setParams] = useState<BacktestParams>(initialParams ?? DEFAULT_PARAMS);
 
   const update = (key: keyof BacktestParams, value: number | string) =>
     setParams((p) => ({ ...p, [key]: value }));
 
-  const isDefault = params.stopLoss === -7 && params.takeProfit1 === 20 &&
-    params.takeProfit2 === 40 && params.trailing === -15 && params.period === "3Y";
+  const isDefault = params.smaPeriod === DEFAULT_PARAMS.smaPeriod &&
+    params.lookback === DEFAULT_PARAMS.lookback &&
+    params.stopLoss === DEFAULT_PARAMS.stopLoss &&
+    params.takeProfit === DEFAULT_PARAMS.takeProfit;
 
   return (
     <div className="flex flex-col gap-2 p-3 rounded-lg bg-zinc-900/40 border border-zinc-800/60">
       <div className="flex items-center justify-between">
         <span className="text-[10px] text-muted-foreground font-semibold">Backtest Parameters</span>
         <div className="flex items-center gap-1.5">
-          {PERIODS.map((p) => (
+          {SMA_PERIODS.map((period) => (
             <button
-              key={p}
-              onClick={() => update("period", p)}
+              key={period}
+              onClick={() => update("smaPeriod", period)}
               className={`text-[10px] px-1.5 py-0.5 rounded transition-colors ${
-                params.period === p ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
+                params.smaPeriod === period ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
               }`}
             >
-              {p}
+              SMA {period}
             </button>
           ))}
         </div>
@@ -74,15 +77,27 @@ export function BacktestSliders({ onRun, loading }: BacktestSlidersProps) {
 
       <div className="grid grid-cols-2 gap-x-4 gap-y-1">
         <Slider label="Stop" value={params.stopLoss} min={-15} max={-3} step={1} suffix="%" onChange={(v) => update("stopLoss", v)} />
-        <Slider label="TP1" value={params.takeProfit1} min={10} max={30} step={5} suffix="%" onChange={(v) => update("takeProfit1", v)} />
-        <Slider label="Trail" value={params.trailing} min={-20} max={-10} step={1} suffix="%" onChange={(v) => update("trailing", v)} />
-        <Slider label="TP2" value={params.takeProfit2} min={20} max={60} step={5} suffix="%" onChange={(v) => update("takeProfit2", v)} />
+        <Slider label="Take" value={params.takeProfit} min={10} max={40} step={5} suffix="%" onChange={(v) => update("takeProfit", v)} />
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        {LOOKBACKS.map((lookback) => (
+          <button
+            key={lookback}
+            onClick={() => update("lookback", lookback)}
+            className={`text-[10px] px-1.5 py-0.5 rounded transition-colors ${
+              params.lookback === lookback ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
+            }`}
+          >
+            {lookback}
+          </button>
+        ))}
       </div>
 
       <div className="flex items-center justify-between">
         {!isDefault && (
           <button
-            onClick={() => setParams({ stopLoss: -7, takeProfit1: 20, takeProfit2: 40, trailing: -15, period: "3Y" })}
+            onClick={() => setParams(DEFAULT_PARAMS)}
             className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
           >
             Reset defaults

--- a/frontend/src/components/ui/equity-curve-chart.tsx
+++ b/frontend/src/components/ui/equity-curve-chart.tsx
@@ -42,7 +42,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
   const chartData = sliced;
 
   return (
-    <div>
+    <div className="min-w-0">
       {/* Period selector */}
       <div className="flex items-center gap-1 mb-3">
         <span className="text-xs text-muted-foreground mr-2">Equity Curve</span>
@@ -62,83 +62,87 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
       </div>
 
       {/* Strategy vs SPY */}
-      <ResponsiveContainer width="100%" height={200}>
-        <ComposedChart data={chartData} syncId="equity" margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-          <XAxis
-            dataKey="date"
-            tick={{ fontSize: 10, fill: "#71717a" }}
-            tickLine={false}
-            interval={Math.floor(chartData.length / 6)}
-            tickFormatter={(v) => String(v).slice(2, 7)}
-          />
-          <YAxis
-            tick={{ fontSize: 10, fill: "#71717a" }}
-            tickLine={false}
-            axisLine={false}
-            tickFormatter={(v) => `${v}%`}
-            width={50}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: "#18181b",
-              border: "1px solid #3f3f46",
-              borderRadius: 8,
-              fontSize: 12,
-            }}
-            labelStyle={{ color: "#a1a1aa" }}
-            formatter={(value, name) => {
-              const v = Number(value);
-              const label = name === "strategy" ? "Strategy" : "SPY";
-              return [`${v > 0 ? "+" : ""}${v.toFixed(1)}%`, label];
-            }}
-          />
-          <Line
-            dataKey="spy"
-            stroke="#71717a"
-            strokeWidth={1.5}
-            dot={false}
-          />
-          <Line
-            dataKey="strategy"
-            stroke="#10b981"
-            strokeWidth={2}
-            dot={false}
-          />
-        </ComposedChart>
-      </ResponsiveContainer>
+      <div className="w-full min-w-0 h-[200px]">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={200}>
+          <ComposedChart data={chartData} syncId="equity" margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10, fill: "#71717a" }}
+              tickLine={false}
+              interval={Math.floor(chartData.length / 6)}
+              tickFormatter={(v) => String(v).slice(2, 7)}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: "#71717a" }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v) => `${v}%`}
+              width={50}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "#18181b",
+                border: "1px solid #3f3f46",
+                borderRadius: 8,
+                fontSize: 12,
+              }}
+              labelStyle={{ color: "#a1a1aa" }}
+              formatter={(value, name) => {
+                const v = Number(value);
+                const label = name === "strategy" ? "Strategy" : "SPY";
+                return [`${v > 0 ? "+" : ""}${v.toFixed(1)}%`, label];
+              }}
+            />
+            <Line
+              dataKey="spy"
+              stroke="#71717a"
+              strokeWidth={1.5}
+              dot={false}
+            />
+            <Line
+              dataKey="strategy"
+              stroke="#10b981"
+              strokeWidth={2}
+              dot={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
 
       {/* Drawdown */}
-      <ResponsiveContainer width="100%" height={80}>
-        <ComposedChart data={chartData} syncId="equity" margin={{ top: 0, right: 5, bottom: 0, left: 0 }}>
-          <XAxis dataKey="date" hide />
-          <YAxis
-            tick={{ fontSize: 9, fill: "#71717a" }}
-            tickLine={false}
-            axisLine={false}
-            tickFormatter={(v) => `${v}%`}
-            width={50}
-            domain={["dataMin", 0]}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: "#18181b",
-              border: "1px solid #3f3f46",
-              borderRadius: 8,
-              fontSize: 12,
-            }}
-            formatter={(value) => [`${Number(value).toFixed(1)}%`, "Drawdown"]}
-          />
-          <Area
-            dataKey="drawdown"
-            stroke="#ef4444"
-            fill="#ef4444"
-            fillOpacity={0.15}
-            strokeWidth={1}
-            dot={false}
-          />
-        </ComposedChart>
-      </ResponsiveContainer>
+      <div className="w-full min-w-0 h-[80px]">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={80}>
+          <ComposedChart data={chartData} syncId="equity" margin={{ top: 0, right: 5, bottom: 0, left: 0 }}>
+            <XAxis dataKey="date" hide />
+            <YAxis
+              tick={{ fontSize: 9, fill: "#71717a" }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v) => `${v}%`}
+              width={50}
+              domain={["dataMin", 0]}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "#18181b",
+                border: "1px solid #3f3f46",
+                borderRadius: 8,
+                fontSize: 12,
+              }}
+              formatter={(value) => [`${Number(value).toFixed(1)}%`, "Drawdown"]}
+            />
+            <Area
+              dataKey="drawdown"
+              stroke="#ef4444"
+              fill="#ef4444"
+              fillOpacity={0.15}
+              strokeWidth={1}
+              dot={false}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
 
       {/* Legend */}
       <div className="flex gap-4 mt-1 text-[10px] text-muted-foreground justify-center">

--- a/frontend/src/components/ui/interactive-backtest.tsx
+++ b/frontend/src/components/ui/interactive-backtest.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { EquityCurveChart } from "@/components/ui/equity-curve-chart";
 import { BacktestSliders } from "@/components/ui/backtest-sliders";
 
@@ -26,21 +27,41 @@ interface InteractiveBacktestProps {
 }
 
 export function InteractiveBacktest({ initialData, initialMetrics }: InteractiveBacktestProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const hasInteractiveParams = searchParams.has("sma") || searchParams.has("lb") || searchParams.has("sl") || searchParams.has("tp");
   const [data, setData] = useState<EquityPoint[]>(initialData);
   const [metrics, setMetrics] = useState<BacktestMetrics | undefined>(initialMetrics);
   const [loading, setLoading] = useState(false);
-  const [isCustom, setIsCustom] = useState(false);
+  const [isCustom, setIsCustom] = useState(hasInteractiveParams);
+  const [mode, setMode] = useState<"static" | "interactive">(hasInteractiveParams ? "interactive" : "static");
 
-  const runBacktest = async (params: { stopLoss: number; takeProfit1: number; takeProfit2: number; trailing: number; period: string }) => {
+  const initialParams = {
+    smaPeriod: Number(searchParams.get("sma") ?? "50"),
+    lookback: searchParams.get("lb") ?? "3Y",
+    stopLoss: Number(searchParams.get("sl") ?? "-7"),
+    takeProfit: Number(searchParams.get("tp") ?? "20"),
+  };
+
+  const runBacktest = async (params: { smaPeriod: number; lookback: string; stopLoss: number; takeProfit: number }) => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/backtest/equity?sl=${params.stopLoss}&tp1=${params.takeProfit1}&tp2=${params.takeProfit2}&trail=${params.trailing}&period=${params.period}`);
+      const query = new URLSearchParams({
+        sma: String(params.smaPeriod),
+        lb: params.lookback,
+        sl: String(params.stopLoss),
+        tp: String(params.takeProfit),
+      });
+      const res = await fetch(`/api/backtest/equity?sma=${params.smaPeriod}&period=${params.lookback}&sl=${params.stopLoss}&tp=${params.takeProfit}`);
       if (res.ok) {
         const result = await res.json();
         if (result.equity?.length > 0) {
           setData(result.equity);
           setMetrics(result.metrics);
           setIsCustom(true);
+          setMode("interactive");
+          router.replace(`${pathname}?${query.toString()}`);
         }
       }
     } catch {
@@ -52,24 +73,45 @@ export function InteractiveBacktest({ initialData, initialMetrics }: Interactive
 
   return (
     <div className="space-y-3">
-      <BacktestSliders onRun={runBacktest} loading={loading} />
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={() => setMode("static")}
+          className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+            mode === "static" ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
+          }`}
+        >
+          Static
+        </button>
+        <button
+          onClick={() => setMode("interactive")}
+          className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+            mode === "interactive" ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
+          }`}
+        >
+          Interactive
+        </button>
+      </div>
 
-      {metrics && (
+      {mode === "interactive" && (
+        <BacktestSliders onRun={runBacktest} initialParams={initialParams} loading={loading} />
+      )}
+
+      {(mode === "static" ? initialMetrics : metrics) && (
         <div className="flex gap-3 text-[10px]">
-          <span className={metrics.total_return >= 0 ? "text-emerald-400" : "text-red-400"}>
-            Return {metrics.total_return > 0 ? "+" : ""}{metrics.total_return}%
+          <span className={(mode === "static" ? initialMetrics : metrics)!.total_return >= 0 ? "text-emerald-400" : "text-red-400"}>
+            Return {(mode === "static" ? initialMetrics : metrics)!.total_return > 0 ? "+" : ""}{(mode === "static" ? initialMetrics : metrics)!.total_return}%
           </span>
-          <span className="text-zinc-400">Sharpe {metrics.sharpe}</span>
-          <span className="text-red-400">MDD {metrics.max_drawdown}%</span>
-          <span className="text-zinc-400">Win {(metrics.win_rate * 100).toFixed(0)}%</span>
-          <span className={metrics.excess_return >= 0 ? "text-emerald-500" : "text-red-500"}>
-            vs SPY {metrics.excess_return > 0 ? "+" : ""}{metrics.excess_return}%
+          <span className="text-zinc-400">Sharpe {(mode === "static" ? initialMetrics : metrics)!.sharpe}</span>
+          <span className="text-red-400">MDD {(mode === "static" ? initialMetrics : metrics)!.max_drawdown}%</span>
+          <span className="text-zinc-400">Win {((mode === "static" ? initialMetrics : metrics)!.win_rate * 100).toFixed(0)}%</span>
+          <span className={(mode === "static" ? initialMetrics : metrics)!.excess_return >= 0 ? "text-emerald-500" : "text-red-500"}>
+            vs SPY {(mode === "static" ? initialMetrics : metrics)!.excess_return > 0 ? "+" : ""}{(mode === "static" ? initialMetrics : metrics)!.excess_return}%
           </span>
-          {isCustom && <span className="text-amber-400 ml-auto">Custom params</span>}
+          {mode === "interactive" && isCustom && <span className="text-amber-400 ml-auto">Custom params</span>}
         </div>
       )}
 
-      <EquityCurveChart data={data} />
+      <EquityCurveChart data={mode === "static" ? initialData : data} />
     </div>
   );
 }

--- a/frontend/src/components/ui/price-chart.tsx
+++ b/frontend/src/components/ui/price-chart.tsx
@@ -79,7 +79,7 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
   const maxClose = Math.max(...sliced.map((d) => d.high)) * 1.02;
 
   return (
-    <div>
+    <div className="min-w-0">
       {/* Period selector */}
       <div className="flex items-center gap-1 mb-3">
         <span className="text-xs text-muted-foreground mr-2">{ticker}</span>
@@ -99,76 +99,78 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
       </div>
 
       {/* Price + Volume chart */}
-      <ResponsiveContainer width="100%" height={280}>
-        <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-          <XAxis
-            dataKey="date"
-            tick={{ fontSize: 10, fill: "#71717a" }}
-            tickLine={false}
-            interval={Math.floor(chartData.length / 6)}
-          />
-          <YAxis
-            yAxisId="price"
-            domain={[minClose, maxClose]}
-            tick={{ fontSize: 10, fill: "#71717a" }}
-            tickLine={false}
-            axisLine={false}
-            tickFormatter={(v) => v.toFixed(0)}
-            width={50}
-          />
-          <YAxis yAxisId="volume" orientation="right" hide />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: "#18181b",
-              border: "1px solid #3f3f46",
-              borderRadius: 8,
-              fontSize: 12,
-            }}
-            labelStyle={{ color: "#a1a1aa" }}
-            formatter={(value, name) => {
-              const v = Number(value);
-              if (name === "volume") return [formatVolume(v), "Vol"];
-              if (name === "close") return [`$${v.toFixed(2)}`, "Close"];
-              return [`$${v.toFixed(2)}`, String(name).toUpperCase()];
-            }}
-          />
-          <Bar
-            yAxisId="volume"
-            dataKey="volume"
-            fill="#3f3f46"
-            opacity={0.3}
-            barSize={2}
-          />
-          <Area
-            yAxisId="price"
-            dataKey="close"
-            stroke="#10b981"
-            fill="#10b981"
-            fillOpacity={0.05}
-            strokeWidth={1.5}
-            dot={false}
-          />
-          <Line
-            yAxisId="price"
-            dataKey="sma20"
-            stroke="#f59e0b"
-            strokeWidth={1}
-            dot={false}
-            strokeDasharray="4 2"
-            connectNulls
-          />
-          <Line
-            yAxisId="price"
-            dataKey="sma50"
-            stroke="#6366f1"
-            strokeWidth={1}
-            dot={false}
-            strokeDasharray="4 2"
-            connectNulls
-          />
-        </ComposedChart>
-      </ResponsiveContainer>
+      <div className="w-full min-w-0 h-[280px]">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={280}>
+          <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10, fill: "#71717a" }}
+              tickLine={false}
+              interval={Math.floor(chartData.length / 6)}
+            />
+            <YAxis
+              yAxisId="price"
+              domain={[minClose, maxClose]}
+              tick={{ fontSize: 10, fill: "#71717a" }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v) => v.toFixed(0)}
+              width={50}
+            />
+            <YAxis yAxisId="volume" orientation="right" hide />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "#18181b",
+                border: "1px solid #3f3f46",
+                borderRadius: 8,
+                fontSize: 12,
+              }}
+              labelStyle={{ color: "#a1a1aa" }}
+              formatter={(value, name) => {
+                const v = Number(value);
+                if (name === "volume") return [formatVolume(v), "Vol"];
+                if (name === "close") return [`$${v.toFixed(2)}`, "Close"];
+                return [`$${v.toFixed(2)}`, String(name).toUpperCase()];
+              }}
+            />
+            <Bar
+              yAxisId="volume"
+              dataKey="volume"
+              fill="#3f3f46"
+              opacity={0.3}
+              barSize={2}
+            />
+            <Area
+              yAxisId="price"
+              dataKey="close"
+              stroke="#10b981"
+              fill="#10b981"
+              fillOpacity={0.05}
+              strokeWidth={1.5}
+              dot={false}
+            />
+            <Line
+              yAxisId="price"
+              dataKey="sma20"
+              stroke="#f59e0b"
+              strokeWidth={1}
+              dot={false}
+              strokeDasharray="4 2"
+              connectNulls
+            />
+            <Line
+              yAxisId="price"
+              dataKey="sma50"
+              stroke="#6366f1"
+              strokeWidth={1}
+              dot={false}
+              strokeDasharray="4 2"
+              connectNulls
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
 
       {/* Legend */}
       <div className="flex gap-4 mt-1 text-[10px] text-muted-foreground justify-center">

--- a/nuri/api/routes/swing.py
+++ b/nuri/api/routes/swing.py
@@ -1,9 +1,13 @@
 """스윙 트레이드 API."""
 from dataclasses import asdict
+from time import monotonic
 
 from fastapi import APIRouter, Query
 
 router = APIRouter(tags=["swing"])
+
+_BACKTEST_CACHE_TTL_SECONDS = 300
+_interactive_backtest_cache: dict[tuple[int, str, int, int], tuple[float, dict]] = {}
 
 
 @router.get("/scan")
@@ -70,7 +74,12 @@ def get_backtest():
 
 
 @router.get("/backtest/equity")
-def get_backtest_equity():
+def get_backtest_equity(
+    sma: int = Query(50, ge=50, le=200),
+    period: str = Query("3Y", pattern="^(1Y|3Y|5Y)$"),
+    sl: int = Query(-7, ge=-15, le=-3),
+    tp: int = Query(20, ge=10, le=40),
+):
     """Equity curve + drawdown for interactive chart (#89).
 
     Returns lightweight data: equity curve points, drawdown, regime bands,
@@ -80,14 +89,27 @@ def get_backtest_equity():
 
     from nuri.trading.strategy.ls_backtest import (
         classify_historical_regimes,
-        run_backtest,
+        run_interactive_backtest,
     )
 
-    regimes = classify_historical_regimes()
+    cache_key = (sma, period, sl, tp)
+    cached = _interactive_backtest_cache.get(cache_key)
+    now = monotonic()
+    if cached and now - cached[0] < _BACKTEST_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    regimes = classify_historical_regimes(sma_period=sma)
     if regimes.empty:
         return {"error": "SPY data insufficient"}
 
-    result = run_backtest(regimes)
+    lookback_days = {"1Y": 252, "3Y": 756, "5Y": 1260}[period]
+    regimes = regimes.tail(lookback_days).reset_index(drop=True)
+
+    result = run_interactive_backtest(
+        regimes,
+        stop_loss_pct=sl,
+        take_profit_pct=tp,
+    )
 
     # numpy → native
     def _clean(obj):
@@ -105,7 +127,7 @@ def get_backtest_equity():
         dd_pct = ((val - peak) / peak * 100) if peak > 0 else 0
         drawdown.append({"date": pt.get("date"), "drawdown": round(dd_pct, 2)})
 
-    return _clean({
+    response = _clean({
         "equity": equity,
         "drawdown": drawdown,
         "metrics": {
@@ -120,6 +142,8 @@ def get_backtest_equity():
             "excess_return": result.excess_return,
         },
     })
+    _interactive_backtest_cache[cache_key] = (now, response)
+    return response
 
 
 @router.get("/strategy/status")

--- a/nuri/trading/strategy/ls_backtest.py
+++ b/nuri/trading/strategy/ls_backtest.py
@@ -88,8 +88,8 @@ class TimingAnalysis:
 # ═══════════════════════════════════════════════════════
 
 
-def classify_historical_regimes(db_path=None) -> pd.DataFrame:
-    """매 거래일의 레짐을 분류. SPY SMA50/200 + VIX 기반."""
+def classify_historical_regimes(db_path=None, sma_period: int = 50) -> pd.DataFrame:
+    """매 거래일의 레짐을 분류. SPY SMA/200 + VIX 기반."""
     spy = query_df(
         "SELECT date, close FROM prices WHERE ticker='SPY' ORDER BY date",
         db_path=db_path,
@@ -105,9 +105,9 @@ def classify_historical_regimes(db_path=None) -> pd.DataFrame:
 
     spy["date"] = pd.to_datetime(spy["date"])
     spy = spy.set_index("date")
-    spy["sma50"] = spy["close"].rolling(50).mean()
+    spy["sma_fast"] = spy["close"].rolling(sma_period).mean()
     spy["sma200"] = spy["close"].rolling(200).mean()
-    spy["sma_gap"] = (spy["sma50"] - spy["sma200"]) / spy["sma200"] * 100
+    spy["sma_gap"] = (spy["sma_fast"] - spy["sma200"]) / spy["sma200"] * 100
 
     # VIX 병합
     if not vix.empty:
@@ -132,14 +132,14 @@ def classify_historical_regimes(db_path=None) -> pd.DataFrame:
     for idx, row in spy.iterrows():
 
         close = row["close"]
-        sma50 = row["sma50"]
+        sma_fast = row["sma_fast"]
         sma200 = row["sma200"]
         gap = row["sma_gap"]
         sideways_th = row["sideways_th"] if pd.notna(row["sideways_th"]) else 2.0
 
         # 추세 — 가격 위치 + SMA 관계 + gap 종합
         price_above = close > sma200
-        sma_bullish = sma50 > sma200
+        sma_bullish = sma_fast > sma200
 
         if abs(gap) < sideways_th and not (price_above != sma_bullish):
             trend = "sideways"
@@ -171,6 +171,174 @@ def classify_historical_regimes(db_path=None) -> pd.DataFrame:
     spy["return"] = spy["close"].pct_change()
 
     return spy.reset_index()
+
+
+def run_interactive_backtest(
+    regimes_df: pd.DataFrame,
+    *,
+    stop_loss_pct: float,
+    take_profit_pct: float,
+    db_path=None,
+) -> BacktestResult:
+    """Parameterized backtest for the interactive strategy UI.
+
+    This keeps the core L/S regime allocation but allows the frontend to
+    pressure-test custom stop-loss and take-profit levels on the long sleeve.
+    """
+    df = regimes_df.copy()
+    df = df[df["regime"] != "unknown"].dropna(subset=["return"])
+    df = df.reset_index(drop=True)
+
+    if df.empty:
+        return BacktestResult(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, [])
+
+    sh = query_df("SELECT date, close, open FROM prices WHERE ticker='SH' ORDER BY date", db_path=db_path)
+    if not sh.empty:
+        sh["date"] = pd.to_datetime(sh["date"])
+        sh = sh.set_index("date")
+        sh["sh_return"] = sh["close"].pct_change()
+    else:
+        sh = pd.DataFrame()
+
+    spy_open = query_df("SELECT date, open FROM prices WHERE ticker='SPY' ORDER BY date", db_path=db_path)
+    if not spy_open.empty:
+        spy_open["date"] = pd.to_datetime(spy_open["date"])
+        spy_open = spy_open.set_index("date")
+
+    active_regime = df.iloc[0]["regime"]
+    hold_count = 0
+    effective_regimes = []
+    for _, row in df.iterrows():
+        raw_regime = row["regime"]
+        if raw_regime != active_regime:
+            hold_count += 1
+            if hold_count >= MIN_HOLD_DAYS:
+                active_regime = raw_regime
+                hold_count = 0
+        else:
+            hold_count = 0
+        effective_regimes.append(active_regime)
+    df["effective_regime"] = effective_regimes
+
+    strategy_returns = []
+    spy_returns = []
+    prev_regime = None
+    total_cost = 0.0
+    regime_changes = 0
+    long_active = True
+    long_trade_return = 0.0
+
+    stop_threshold = stop_loss_pct / 100
+    take_profit_threshold = take_profit_pct / 100
+
+    for i in range(1, len(df)):
+        row = df.iloc[i]
+        prev_row = df.iloc[i - 1]
+        regime = row["effective_regime"]
+        date = pd.Timestamp(row["date"])
+        spy_ret = row["return"]
+
+        gap_cost = 0.0
+        if not spy_open.empty and date in spy_open.index:
+            spy_open_price = spy_open.loc[date, "open"]
+            spy_prev_close = prev_row["close"]
+            if spy_prev_close > 0:
+                gap_cost = abs(spy_open_price / spy_prev_close - 1) * 0.3
+
+        alloc = REGIME_ALLOCATION.get(regime, REGIME_ALLOCATION["sideways_high_vol"])
+
+        cost = 0.0
+        if regime != prev_regime and prev_regime is not None:
+            cost = TRANSACTION_COST * 2 + SLIPPAGE * 2 + gap_cost
+            total_cost += cost
+            regime_changes += 1
+            long_active = True
+            long_trade_return = 0.0
+
+        if alloc["short"] > 0 and not sh.empty and date in sh.index:
+            short_ret = float(sh.loc[date, "sh_return"])
+            if pd.isna(short_ret):
+                short_ret = -spy_ret
+        else:
+            short_ret = -spy_ret
+
+        long_component = 0.0
+        if alloc["long"] > 0:
+            if not long_active:
+                long_component = 0.0
+            else:
+                prev_trade_return = long_trade_return
+                next_trade_return = prev_trade_return + spy_ret
+                if next_trade_return <= stop_threshold:
+                    long_component = (stop_threshold - prev_trade_return) * alloc["long"]
+                    long_trade_return = stop_threshold
+                    long_active = False
+                elif next_trade_return >= take_profit_threshold:
+                    long_component = (take_profit_threshold - prev_trade_return) * alloc["long"]
+                    long_trade_return = take_profit_threshold
+                    long_active = False
+                else:
+                    long_component = spy_ret * alloc["long"]
+                    long_trade_return = next_trade_return
+        else:
+            long_active = True
+            long_trade_return = 0.0
+
+        strat_ret = long_component + alloc["short"] * short_ret - cost
+        strategy_returns.append(strat_ret)
+        spy_returns.append(spy_ret)
+        prev_regime = regime
+
+    strat = pd.Series(strategy_returns)
+    spy_s = pd.Series(spy_returns)
+
+    if strat.empty:
+        return BacktestResult(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, [])
+
+    strat_cum = (1 + strat).cumprod()
+    spy_cum = (1 + spy_s).cumprod()
+
+    total_return = (strat_cum.iloc[-1] - 1) * 100
+    spy_total = (spy_cum.iloc[-1] - 1) * 100
+    years = len(strat) / 252
+
+    annual_return = ((1 + total_return / 100) ** (1 / max(years, 0.1)) - 1) * 100
+    spy_annual = ((1 + spy_total / 100) ** (1 / max(years, 0.1)) - 1) * 100
+
+    sharpe = strat.mean() / strat.std() * np.sqrt(252) if strat.std() > 0 else 0
+    spy_sharpe = spy_s.mean() / spy_s.std() * np.sqrt(252) if spy_s.std() > 0 else 0
+
+    strat_dd = (strat_cum / strat_cum.cummax() - 1).min() * 100
+    spy_dd = (spy_cum / spy_cum.cummax() - 1).min() * 100
+
+    dates = df["date"].iloc[1:].reset_index(drop=True)
+    strat_dd_series = (strat_cum / strat_cum.cummax() - 1) * 100
+    equity_curve = [
+        {
+            "date": str(dates.iloc[i])[:10],
+            "strategy": round(float((strat_cum.iloc[i] - 1) * 100), 2),
+            "spy": round(float((spy_cum.iloc[i] - 1) * 100), 2),
+            "drawdown": round(float(strat_dd_series.iloc[i]), 2),
+        }
+        for i in range(len(strat_cum))
+    ]
+
+    return BacktestResult(
+        total_return=round(total_return, 2),
+        annual_return=round(annual_return, 2),
+        sharpe=round(sharpe, 2),
+        max_drawdown=round(strat_dd, 2),
+        win_rate=round(float((strat > 0).mean()), 3),
+        total_days=len(strat),
+        regime_changes=regime_changes,
+        transaction_costs=round(total_cost * 100, 2),
+        spy_total_return=round(spy_total, 2),
+        spy_annual_return=round(spy_annual, 2),
+        spy_sharpe=round(spy_sharpe, 2),
+        spy_max_drawdown=round(spy_dd, 2),
+        excess_return=round(total_return - spy_total, 2),
+        equity_curve=equity_curve,
+    )
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/api/test_swing.py
+++ b/tests/api/test_swing.py
@@ -36,6 +36,14 @@ class TestSwing:
 class TestBacktestEquity:
     """Tests for GET /api/backtest/equity (#89)."""
 
+    @pytest.fixture(autouse=True)
+    def clear_interactive_backtest_cache(self):
+        from nuri.api.routes import swing
+
+        swing._interactive_backtest_cache.clear()
+        yield
+        swing._interactive_backtest_cache.clear()
+
     @patch("nuri.trading.strategy.ls_backtest.classify_historical_regimes")
     def test_returns_error_when_no_spy(self, mock_classify, client):
         mock_classify.return_value = pd.DataFrame()
@@ -43,7 +51,7 @@ class TestBacktestEquity:
         assert r.status_code == 200
         assert r.json().get("error") == "SPY data insufficient"
 
-    @patch("nuri.trading.strategy.ls_backtest.run_backtest")
+    @patch("nuri.trading.strategy.ls_backtest.run_interactive_backtest")
     @patch("nuri.trading.strategy.ls_backtest.classify_historical_regimes")
     def test_returns_equity_and_metrics(self, mock_classify, mock_bt, client):
         mock_classify.return_value = pd.DataFrame({"regime": ["bull"], "return": [0.01]})
@@ -73,7 +81,7 @@ class TestBacktestEquity:
                 ]
 
         mock_bt.return_value = FakeResult()
-        r = client.get("/api/backtest/equity")
+        r = client.get("/api/backtest/equity?sma=100&period=1Y&sl=-10&tp=30")
         assert r.status_code == 200
         data = r.json()
 
@@ -90,8 +98,13 @@ class TestBacktestEquity:
         assert m["sharpe"] == 1.5
         assert m["spy_total_return"] == 30.0
         assert m["excess_return"] == 20.0
+        mock_classify.assert_called_once_with(sma_period=100)
+        mock_bt.assert_called_once()
+        args, kwargs = mock_bt.call_args
+        pd.testing.assert_frame_equal(args[0], mock_classify.return_value.tail(252).reset_index(drop=True))
+        assert kwargs == {"stop_loss_pct": -10, "take_profit_pct": 30}
 
-    @patch("nuri.trading.strategy.ls_backtest.run_backtest")
+    @patch("nuri.trading.strategy.ls_backtest.run_interactive_backtest")
     @patch("nuri.trading.strategy.ls_backtest.classify_historical_regimes")
     def test_drawdown_computed_from_equity(self, mock_classify, mock_bt, client):
         mock_classify.return_value = pd.DataFrame({"regime": ["bull"], "return": [0.01]})
@@ -130,7 +143,7 @@ class TestBacktestEquity:
             assert "date" in dd
             assert "drawdown" in dd
 
-    @patch("nuri.trading.strategy.ls_backtest.run_backtest")
+    @patch("nuri.trading.strategy.ls_backtest.run_interactive_backtest")
     @patch("nuri.trading.strategy.ls_backtest.classify_historical_regimes")
     def test_empty_equity_curve(self, mock_classify, mock_bt, client):
         mock_classify.return_value = pd.DataFrame({"regime": ["bull"], "return": [0.01]})
@@ -157,3 +170,42 @@ class TestBacktestEquity:
         data = r.json()
         assert data["equity"] == []
         assert data["drawdown"] == []
+
+    @patch("nuri.trading.strategy.ls_backtest.run_interactive_backtest")
+    @patch("nuri.trading.strategy.ls_backtest.classify_historical_regimes")
+    def test_returns_cached_response_for_same_params(self, mock_classify, mock_bt, client):
+        mock_classify.return_value = pd.DataFrame({"regime": ["bull"], "return": [0.01]})
+
+        @dataclass
+        class FakeResult:
+            total_return: float = 12.0
+            annual_return: float = 5.0
+            sharpe: float = 1.1
+            max_drawdown: float = -4.0
+            win_rate: float = 0.52
+            total_days: int = 20
+            regime_changes: int = 1
+            transaction_costs: float = 0.1
+            spy_total_return: float = 8.0
+            spy_annual_return: float = 4.0
+            spy_sharpe: float = 0.8
+            spy_max_drawdown: float = -6.0
+            excess_return: float = 4.0
+            equity_curve: list | None = None
+
+            def __post_init__(self):
+                self.equity_curve = self.equity_curve or [
+                    {"date": "2024-01-01", "strategy": 0, "spy": 0, "drawdown": 0},
+                    {"date": "2024-01-02", "strategy": 1, "spy": 0.5, "drawdown": 0},
+                ]
+
+        mock_bt.return_value = FakeResult()
+
+        first = client.get("/api/backtest/equity?sma=50&period=3Y&sl=-7&tp=20")
+        second = client.get("/api/backtest/equity?sma=50&period=3Y&sl=-7&tp=20")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_classify.assert_called_once_with(sma_period=50)
+        mock_bt.assert_called_once()

--- a/tests/api/test_swing.py
+++ b/tests/api/test_swing.py
@@ -209,3 +209,48 @@ class TestBacktestEquity:
         assert first.json() == second.json()
         mock_classify.assert_called_once_with(sma_period=50)
         mock_bt.assert_called_once()
+
+    @patch("nuri.trading.strategy.ls_backtest.run_interactive_backtest")
+    @patch("nuri.trading.strategy.ls_backtest.classify_historical_regimes")
+    def test_cache_expires_after_ttl_and_re_runs(self, mock_classify, mock_bt, client, monkeypatch):
+        """Expired TTL entry triggers re-run (swing.py monotonic branch)."""
+        mock_classify.return_value = pd.DataFrame({"regime": ["bull"], "return": [0.01]})
+
+        @dataclass
+        class FakeResult:
+            total_return: float = 15.0
+            annual_return: float = 6.0
+            sharpe: float = 1.2
+            max_drawdown: float = -5.0
+            win_rate: float = 0.55
+            total_days: int = 30
+            regime_changes: int = 2
+            transaction_costs: float = 0.2
+            spy_total_return: float = 9.0
+            spy_annual_return: float = 4.5
+            spy_sharpe: float = 0.9
+            spy_max_drawdown: float = -7.0
+            excess_return: float = 6.0
+            equity_curve: list | None = None
+
+            def __post_init__(self):
+                self.equity_curve = self.equity_curve or [
+                    {"date": "2024-02-01", "strategy": 0, "spy": 0, "drawdown": 0},
+                ]
+
+        mock_bt.return_value = FakeResult()
+
+        from nuri.api.routes import swing
+        swing._interactive_backtest_cache.clear()
+
+        clock = [0.0]
+        monkeypatch.setattr(swing, "monotonic", lambda: clock[0])
+
+        first = client.get("/api/backtest/equity?sma=200&period=5Y&sl=-10&tp=25")
+        assert first.status_code == 200
+        assert mock_bt.call_count == 1
+
+        clock[0] = swing._BACKTEST_CACHE_TTL_SECONDS + 1.0
+        second = client.get("/api/backtest/equity?sma=200&period=5Y&sl=-10&tp=25")
+        assert second.status_code == 200
+        assert mock_bt.call_count == 2  # re-invoked after TTL

--- a/tests/trading/strategy/test_ls_backtest.py
+++ b/tests/trading/strategy/test_ls_backtest.py
@@ -103,6 +103,111 @@ class TestInteractiveBacktest:
         assert baseline.total_days == tighter.total_days
         assert baseline.total_return != tighter.total_return
 
+    def test_empty_regimes_after_filtering_returns_zero_result(self, backtest_data):
+        """df.empty guard inside run_interactive_backtest (line 193)."""
+        from nuri.trading.strategy.ls_backtest import run_interactive_backtest
+
+        only_unknown = pd.DataFrame({
+            "regime": ["unknown"] * 5,
+            "return": [0.01] * 5,
+            "date": pd.bdate_range("2024-01-01", periods=5),
+            "close": [100.0] * 5,
+        })
+
+        result = run_interactive_backtest(
+            only_unknown,
+            stop_loss_pct=-7,
+            take_profit_pct=20,
+            db_path=backtest_data,
+        )
+
+        assert result.total_days == 0
+        assert result.equity_curve == []
+
+    def test_missing_sh_data_falls_back_to_spy_inverse(self, db_path):
+        """No SH ticker in DB → sh empty DataFrame path (line 201)."""
+        import numpy as np
+
+        from nuri.core.db import upsert_prices
+        from nuri.trading.strategy.ls_backtest import (
+            classify_historical_regimes,
+            run_interactive_backtest,
+        )
+
+        dates = pd.bdate_range("2022-01-01", periods=300)
+        spy_close = np.linspace(400, 500, 300) + np.random.normal(0, 2, 300)
+        upsert_prices(
+            pd.DataFrame({
+                "ticker": "SPY",
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": spy_close * 0.999,
+                "high": spy_close * 1.005,
+                "low": spy_close * 0.995,
+                "close": spy_close,
+                "volume": [50_000_000] * 300,
+                "adj_close": spy_close,
+            }),
+            db_path,
+        )
+
+        regimes = classify_historical_regimes(db_path=db_path)
+        result = run_interactive_backtest(
+            regimes,
+            stop_loss_pct=-7,
+            take_profit_pct=20,
+            db_path=db_path,
+        )
+
+        assert result.total_days > 0
+
+    def test_sh_nan_return_falls_back_to_spy_inverse(self, backtest_data, monkeypatch):
+        """sh_return NaN in bear regime (line 261)."""
+        import numpy as np
+
+        from nuri.trading.strategy import ls_backtest
+
+        original = ls_backtest.query_df
+
+        def query_df_with_nan(sql, *args, **kwargs):
+            df = original(sql, *args, **kwargs)
+            if "ticker='SH'" in sql and not df.empty:
+                df.loc[10:12, "close"] = np.nan
+            return df
+
+        monkeypatch.setattr(ls_backtest, "query_df", query_df_with_nan)
+
+        regimes = ls_backtest.classify_historical_regimes(db_path=backtest_data)
+        regimes["regime"] = "bear_low_vol"
+        result = ls_backtest.run_interactive_backtest(
+            regimes,
+            stop_loss_pct=-7,
+            take_profit_pct=20,
+            db_path=backtest_data,
+        )
+
+        assert result.total_days > 0
+
+    def test_single_row_regimes_returns_zero_result(self, backtest_data):
+        """df with 1 row → loop skips → empty strat guard (line 296)."""
+        from nuri.trading.strategy.ls_backtest import run_interactive_backtest
+
+        single = pd.DataFrame({
+            "regime": ["bull_low_vol"],
+            "return": [0.01],
+            "date": [pd.Timestamp("2024-01-02")],
+            "close": [100.0],
+        })
+
+        result = run_interactive_backtest(
+            single,
+            stop_loss_pct=-7,
+            take_profit_pct=20,
+            db_path=backtest_data,
+        )
+
+        assert result.total_days == 0
+        assert result.equity_curve == []
+
 
 class TestAllocation:
     """From test_backtest.py — allocation sums."""

--- a/tests/trading/strategy/test_ls_backtest.py
+++ b/tests/trading/strategy/test_ls_backtest.py
@@ -56,6 +56,54 @@ class TestMonteCarlo:
         assert 0 <= mc["return_percentile"] <= 1
 
 
+class TestInteractiveBacktest:
+    def test_classify_historical_regimes_accepts_custom_sma(self, backtest_data):
+        from nuri.trading.strategy.ls_backtest import classify_historical_regimes
+
+        df_fast = classify_historical_regimes(db_path=backtest_data, sma_period=50)
+        df_slow = classify_historical_regimes(db_path=backtest_data, sma_period=100)
+
+        assert len(df_fast) == len(df_slow)
+        assert "sma_fast" in df_fast.columns
+        assert not df_fast["sma_gap"].equals(df_slow["sma_gap"])
+
+    def test_run_interactive_backtest_returns_equity_curve(self, backtest_data):
+        from nuri.trading.strategy.ls_backtest import classify_historical_regimes, run_interactive_backtest
+
+        regimes = classify_historical_regimes(db_path=backtest_data)
+        result = run_interactive_backtest(
+            regimes,
+            stop_loss_pct=-7,
+            take_profit_pct=20,
+            db_path=backtest_data,
+        )
+
+        assert result.total_days > 0
+        assert result.equity_curve is not None
+        assert len(result.equity_curve) == result.total_days
+        assert {"date", "strategy", "spy", "drawdown"} <= set(result.equity_curve[0])
+
+    def test_run_interactive_backtest_thresholds_change_result(self, backtest_data):
+        from nuri.trading.strategy.ls_backtest import classify_historical_regimes, run_interactive_backtest
+
+        regimes = classify_historical_regimes(db_path=backtest_data)
+        baseline = run_interactive_backtest(
+            regimes,
+            stop_loss_pct=-7,
+            take_profit_pct=20,
+            db_path=backtest_data,
+        )
+        tighter = run_interactive_backtest(
+            regimes,
+            stop_loss_pct=-3,
+            take_profit_pct=10,
+            db_path=backtest_data,
+        )
+
+        assert baseline.total_days == tighter.total_days
+        assert baseline.total_return != tighter.total_return
+
+
 class TestAllocation:
     """From test_backtest.py — allocation sums."""
 


### PR DESCRIPTION
Closes #89. Completes the work started in PR #269 — the strategy page gets a live backtest simulator where users move sliders and see the equity curve redraw against the cached baseline.

## Summary

Two commits, clean split by layer:

**1. `feat(backtest): parameterizable interactive engine + endpoint (#89)`**
- New `run_interactive_backtest()` in `nuri/trading/strategy/ls_backtest.py` — L/S regime allocation with configurable stop-loss and take-profit on the long sleeve. State machine arms on regime change, disarms on threshold trigger until the next regime transition (so stop-outs cannot re-fire within the same leg).
- `classify_historical_regimes()` gains `sma_period` kwarg (default 50) so the UI can swap SMA 50 / 100 / 200 regime filters. Internal `sma50` column renamed to `sma_fast`.
- `/swing/backtest/equity` now accepts `sma` (50..200) / `period` (1Y/3Y/5Y) / `sl` (-15..-3) / `tp` (10..40). 5-minute TTL in-memory cache keyed on the tuple so repeated slider sweeps do not re-run the engine.

**2. `feat(#89): interactive backtest sliders UI + deep-linkable params`**
- `backtest-sliders.tsx` reworked from the old 5-param schema (stop-loss / tp1 / tp2 / trailing / period) to the new 4-param schema (smaPeriod / lookback / stopLoss / takeProfit) that matches the endpoint.
- `interactive-backtest.tsx` adds URL state sync via `useSearchParams` + `router.replace`: `/strategy?sma=100&lb=3Y&sl=-10&tp=30` restores the full interactive state on reload/share. Static / Interactive mode toggle lets users A/B the default rules vs custom sweep without losing context.
- Chart wrappers (`equity-curve-chart.tsx`, `price-chart.tsx`): wrap `ResponsiveContainer` in `min-w-0` + fixed-height divs, pass `minWidth={0}` / explicit `minHeight` through to RC. Fixes the initial-render `width(0) height(0)` warning when the parent is a flex/grid item mid-layout.

## Motivation

STRATEGY Tier 2 P1 #7: 백테스트 인터랙티브 equity curve — 파라미터 sliders + 실시간 시뮬레이션. This PR finishes the remaining scope PR #269 left open (sliders were wired but the endpoint / engine were placeholder).

## Screenshots

**Interactive mode, default params (SMA 50, SL -7%, TP 20%, 3Y)**
_Attach: `~/Desktop/nuri_89_screenshot_interactive_defaults.png`_

**Custom params (SMA 100, SL -10%, TP 30%, 3Y) — equity curve re-renders, URL deep-links the state**
_Attach: `~/Desktop/nuri_89_screenshot_interactive_custom.png`_

> Screenshots are saved locally; drag and drop them into the PR description on the web UI to embed inline. URL after Run Backtest in screenshot 2: `/strategy?sma=100&lb=3Y&sl=-10&tp=30`.

## Test plan

- [x] `pytest tests/api/test_swing.py tests/trading/strategy/test_ls_backtest.py` — 37 passed (new cases: 22 existing + regime sma_period + interactive threshold cases + endpoint param + cache)
- [x] `make test-fast` — 2941 passed, 87% coverage, 25.2s
- [x] `npm test -- --run` (frontend) — 60 files, 915 tests passed, 4.2s
- [x] `ruff check nuri/ tests/` — clean
- [x] `scripts/check_privacy_leak.py --unpushed-commits` — clean (both commits)
- [x] Manual QA on `/strategy`: default static view, toggle to Interactive, adjust sliders, click Run Backtest → API call succeeds (200, 77KB), equity curve redraws, URL updates with param tuple.
- [ ] CI pipeline

## Known non-blocking

`ResponsiveContainer` still emits `width(-1) height(-1)` warnings transiently during the re-render **after** "Run Backtest" click (layout reflow between old and new series data). Initial page load is clean. The warning does not prevent the chart from rendering correctly. Tracked as a followup if it becomes noisy in CI logs.

## Scope note

This session also shipped two adjacent hygiene PRs that were found during the same full-scan cycle: #330 (`refactor(analysis): remove unused Riskfolio portfolio init` + `.cache/` gitignore) and #331 (`chore(gitignore): allowlist curated .claude/ assets`). Both merged to `main` before this branch rebased onto origin/main, so their changes are already picked up here.