### PR TITLE
ops: add make scheduler-reload-remote for Mac mini

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ make sync-status      # 양쪽 git HEAD + NEXT_SESSION timestamp 비교 (read-on
 scripts/sync_dev.sh push      # 저수준 — make sync-end 가 wrap. NEXT_SESSION.md 미포함 (별도 scp)
 scripts/sync_dev.sh pull      # 저수준 — make sync-start 가 wrap (--with-reports / --no-claude)
 bash scripts/auto_deploy.sh   # Mac mini receiver: fetch + ff-only merge + 변경 분석 (manual test; canonical run is launchd com.nuri-quant.autopull every 5min)
+make scheduler-reload-remote  # Mac mini scheduler launchd reload (nuri/scheduler.py 변경 후 필수 — DEV2_HOST 환경변수 필요)
 
 # Decision tracking
 make track-decisions  # Decision outcome tracking + snapshot

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PYTHON = .venv/bin/python
         targets rebalance evidence external \
         api dashboard start \
         full-scan quick-scan \
-        deploy pre-deploy backup ports ports-kill update-counts demo
+        deploy pre-deploy backup scheduler-reload-remote ports ports-kill update-counts demo
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -394,6 +394,17 @@ sync-end:
 
 sync-status:
 	bash scripts/dev_sync.sh status
+
+scheduler-reload-remote: ## Reload scheduler on Mac mini (nuri/scheduler.py 변경 반영)
+	@test -n "$$DEV2_HOST" || { echo "❌ DEV2_HOST 미설정. ~/.zshrc 에 export DEV2_HOST=ehbebe@Ehbebeui-Macmini.local 추가 필요"; exit 1; }
+	@echo "→ Mac mini scheduler reload..."
+	@ssh "$$DEV2_HOST" '\
+		launchctl unload ~/Library/LaunchAgents/com.nuri-quant.scheduler.plist 2>/dev/null; \
+		sleep 2; \
+		launchctl load ~/Library/LaunchAgents/com.nuri-quant.scheduler.plist && \
+		echo "✅ scheduler reloaded" && \
+		launchctl list | grep nuri-quant && \
+		tail -5 ~/workspace/nuri-quant/data/logs/scheduler.log'
 
 ports:
 	bash scripts/ports.sh


### PR DESCRIPTION
## Summary

- Add `make scheduler-reload-remote` Makefile target for reloading the scheduler launchd process on Mac mini after `nuri/scheduler.py` changes
- CLAUDE.md Commands section updated with the new target

## Why

PR #334 added weekly 1y backfill jobs to `SCHEDULES`. Mac mini's `autopull` launchd pulls code every 5 min, but the scheduler process holds the old `SCHEDULES` in memory until restarted. Without manual `launchctl unload/load`, new jobs never register. `auto_deploy.sh:107-110` has kickstart logic but is commented out.

## Usage

```bash
make scheduler-reload-remote
# Requires: DEV2_HOST env var in ~/.zshrc
# Sequence: SSH → launchctl unload → sleep 2 → load → verify + tail log
```

## Test plan

- [x] `make -n scheduler-reload-remote` dry-run shows correct SSH + launchctl sequence
- [x] Without `DEV2_HOST` set: exits with "❌ DEV2_HOST 미설정" (guard clause)
- [ ] CI green (Makefile-only change, no Python)
- [ ] Post-merge: `make scheduler-reload-remote` from MBP with Mac mini online → log shows "Scheduler started"

🤖 Generated with [Claude Code](https://claude.com/claude-code)