### PR TITLE
docs(agents): add 2-machine deploy commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,14 +44,18 @@ These are enforced by hooks, CI, and pre-push scripts. Violations are blocked me
 ## Key Commands
 
 ```bash
-make setup          # Python venv + deps + DB init
-make test           # Full backend test suite
-make test-fast      # Exclude slow LLM tests
-make lint           # ruff check
-make verify-quick   # ~10s pre-commit smoke test
-make verify-all     # Full verification (before push)
-make start          # API(:8001) + Dashboard(:3000)
+make setup                   # Python venv + deps + DB init
+make test                    # Full backend test suite
+make test-fast               # Exclude slow LLM tests
+make lint                    # ruff check
+make verify-quick            # ~10s pre-commit smoke test
+make verify-all              # ~30s pre-push (tests + backend + frontend + file integrity)
+make start                   # API(:8001) + Dashboard(:3000)
+make deploy-mini             # MBP → Mac mini 전체 동기화 (git pull + config + scheduler reload, ~30s)
+make scheduler-reload-remote # Mac mini scheduler 단독 reload (scheduler.py 변경 후)
 ```
+
+2-machine setup details: `CLAUDE.md` §Deploy. Both targets require `DEV2_HOST` env var.
 
 ## Architecture Reference
 


### PR DESCRIPTION
## Summary

Close drift gap between AGENTS.md and post-#336/#337 reality.

- Add `make deploy-mini` and `make scheduler-reload-remote` to Key Commands
- Fix `make verify-all` description ("Full verification (before push)" → "~30s pre-push (tests + backend + frontend + file integrity)") to match Makefile/CLAUDE.md
- Cross-reference CLAUDE.md §Deploy for full 6-step workflow

## Why

AGENTS.md is the universal agent instruction file (Cursor/Copilot/Codex/Gemini CLI read it). After PR #336/#337 shipped 2-machine deploy tooling, AGENTS.md Key Commands still only listed 7 general dev commands with no mention of `deploy-mini` or `scheduler-reload-remote`. Other AI coding agents had no pointer to the ops/deploy primitives that now live at the center of the workflow.

Also fixed `verify-all` description that was updated in CLAUDE.md (PR #333) but never back-ported to AGENTS.md — drift between the two "top-level rules" files.

## Out of scope

- NEXT_SESSION.md full refresh (gitignored personal file, edited separately)
- CLAUDE.md / README.md: audited, no drift found post-#337 merge
- Toss UX proposal (issue #335): unchanged, separate Tier 3 track

## Test plan

- [x] grep verified: no stale STRATEGY §5.9 / §5.10 / §7 Tier references in CLAUDE.md or README.md
- [x] `make deploy-mini` / `make scheduler-reload-remote` exist in Makefile (post-#336/#337)
- [ ] CI green (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)