### PR TITLE
test(collectors): fix macro_news RSS_FIXTURE time-bomb

### DIFF
--- a/tests/collectors/test_macro_news.py
+++ b/tests/collectors/test_macro_news.py
@@ -19,31 +19,42 @@ from nuri.core.db import query
 from nuri.core.timezone import kst_now
 
 
-def _recent_date_rfc822() -> str:
+def _recent_date_rfc822(hours_ago: int = 6) -> str:
     """테스트용 — stale 필터를 통과하는 최근 날짜 RFC 822 문자열."""
-    return format_datetime(kst_now() - timedelta(hours=6))
+    return format_datetime(kst_now() - timedelta(hours=hours_ago))
 
-# 최소 fixture — Reuters source 분리, source 없는 item, 빈 link 등 edge case 포함
-RSS_FIXTURE = (
-    b'<?xml version="1.0"?>'
-    b'<rss version="2.0"><channel>'
-    b'<item>'
-    b'<title>Iran agrees to ceasefire - Reuters</title>'
-    b'<link>https://news.google.com/articles/abc123</link>'
-    b'<pubDate>Wed, 09 Apr 2026 12:00:00 GMT</pubDate>'
-    b'<source url="https://www.reuters.com">Reuters</source>'
-    b'</item>'
-    b'<item>'
-    b'<title>Fed signals rate cut next meeting</title>'
-    b'<link>https://news.google.com/articles/def456</link>'
-    b'<pubDate>Wed, 09 Apr 2026 13:00:00 GMT</pubDate>'
-    b'</item>'
-    b'<item>'
-    b'<title>No URL</title>'
-    b'<link></link>'
-    b'</item>'
-    b'</channel></rss>'
-)
+
+def _build_rss_fixture() -> bytes:
+    """최소 fixture — Reuters source 분리, source 없는 item, 빈 link 등 edge case 포함.
+
+    pubDate 는 실행 시각 기준 -2h / -1h 로 동적 생성 — 7일 stale filter 통과 보장.
+    (이전 하드코딩 `Wed, 09 Apr 2026 ...` 는 7일 경과 후 테스트 fail 하는 time-bomb.)
+    """
+    d1 = _recent_date_rfc822(hours_ago=2).encode()
+    d2 = _recent_date_rfc822(hours_ago=1).encode()
+    return (
+        b'<?xml version="1.0"?>'
+        b'<rss version="2.0"><channel>'
+        b'<item>'
+        b'<title>Iran agrees to ceasefire - Reuters</title>'
+        b'<link>https://news.google.com/articles/abc123</link>'
+        b'<pubDate>' + d1 + b'</pubDate>'
+        b'<source url="https://www.reuters.com">Reuters</source>'
+        b'</item>'
+        b'<item>'
+        b'<title>Fed signals rate cut next meeting</title>'
+        b'<link>https://news.google.com/articles/def456</link>'
+        b'<pubDate>' + d2 + b'</pubDate>'
+        b'</item>'
+        b'<item>'
+        b'<title>No URL</title>'
+        b'<link></link>'
+        b'</item>'
+        b'</channel></rss>'
+    )
+
+
+RSS_FIXTURE = _build_rss_fixture()
 
 EMPTY_RSS = b'<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>'
 


### PR DESCRIPTION
## Summary

\`RSS_FIXTURE\` 의 pubDate 가 하드코딩 (\`Wed, 09 Apr 2026 12:00:00 GMT\` / \`13:00:00 GMT\`) 되어 있어 7일 경과 후 collector 의 stale filter 가 article 1 을 drop, article 2 만 남기며 \`TestCollect\` 의 2 건 테스트가 결정적으로 fail — 2026-04-16 현재 실제 CI 발생 (PR #339 block).

같은 파일 \`test_collect_filters_stale_articles\` 는 이미 \`_recent_date_rfc822\` helper 로 동적 시각 사용 중 — 일관성도 맞출 겸 같은 패턴으로 \`RSS_FIXTURE\` 생성도 동적 전환.

## Fix

\`_build_rss_fixture()\` 함수로 추출하여 매 테스트 실행 시 \`kst_now()\` 기준 -2h / -1h pubDate 생성. 7일 cutoff 과 무관하게 영구 pass.

## Verified

\`\`\`
tests/collectors/test_macro_news.py .................. 16/16 passed
\`\`\`

## Flow metadata (§4.2)

- \`codex_plan: skipped\` (trivial test fixture fix, scope = 1 파일)
- \`codex_review: skipped\` (test-only, no behavior change)
- Self-review: \`.venv/bin/python -m pytest tests/collectors/test_macro_news.py -v\` 로 live 실행 확인

## Test plan

- [x] Local: 16/16 green
- [ ] CI green
- [ ] Post-merge: PR #339 rebase + 재진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)