### PR TITLE
chore(security): bump python-multipart 0.0.26 + hono 4.12.14

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7024,9 +7024,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,5 +43,8 @@
     "tailwindcss": "^4",
     "typescript": "^6",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "hono": ">=4.12.14"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,19 @@ Issues = "https://github.com/researcherhojin/nuri-quant/issues"
 
 
 # ═══════════════════════════════════════════════════════════════
+# uv override — openbb 상위 제약을 우회하여 보안 패치 강제
+# ═══════════════════════════════════════════════════════════════
+[tool.uv]
+override-dependencies = [
+    # GHSA-mj87-hwqh-73pj (DoS via multipart preamble/epilogue) —
+    # openbb-core 1.6.7 이 python-multipart>=0.0.22,<0.0.23 로 하드 핀했지만
+    # 0.0.22 → 0.0.26 은 패치 수준 API 차이 없음 (실측: test suite green).
+    # openbb 가 pin 을 완화하면 이 override 제거 가능.
+    "python-multipart>=0.0.26",
+]
+
+
+# ═══════════════════════════════════════════════════════════════
 # Build (hatchling — egg-info 생성 X, setuptools보다 깔끔)
 # ═══════════════════════════════════════════════════════════════
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+overrides = [{ name = "python-multipart", specifier = ">=0.0.26" }]
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -3397,11 +3400,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Dependabot 보안 alert 2 건 해결.

## Alerts resolved

| Alert | Package | Before → After | Advisory |
|---|---|---|---|
| #17 | python-multipart | 0.0.22 → **0.0.26** | [GHSA-mj87-hwqh-73pj](https://github.com/advisories/GHSA-mj87-hwqh-73pj) / CVE-2026-40347 (DoS via multipart preamble/epilogue) |
| #18 | hono | 4.12.12 → **4.12.14** | [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) (Improper JSX attribute — HTML injection) |

## Implementation

### Python (python-multipart)

\`openbb-core 1.6.7\` 이 \`python-multipart>=0.0.22,<0.0.23\` 으로 하드 핀. 직접 dep 선언은 resolver 충돌.

→ \`[tool.uv]\` 의 \`override-dependencies\` 로 upstream 제약 우회:

\`\`\`toml
[tool.uv]
override-dependencies = [
    "python-multipart>=0.0.26",
]
\`\`\`

0.0.22 → 0.0.26 은 patch 범위이고 openbb 가 실제 사용하는 API 변경 없음. Runtime verification: \`make test-fast\` 2952/2952 pass, \`pytest tests/api/\` 411/411 pass.

### Frontend (hono)

\`shadcn 4.2.0\` transitive. \`frontend/package.json\` 에 \`overrides\` 추가:

\`\`\`json
"overrides": {
  "hono": ">=4.12.14"
}
\`\`\`

## Verified

- [x] \`uv lock\` 성공, python-multipart 0.0.26 resolved
- [x] \`npm install\` 성공, hono 4.12.14 resolved
- [x] \`make test-fast\` 2952/2952 green (regression 0)
- [x] \`pytest tests/api/\` 411/411 green (multipart 사용 경로 직접 검증)
- [ ] CI green
- [ ] Post-merge: Dependabot alerts #17 / #18 자동 close 확인

## Flow metadata (§4.2)

- \`codex_plan: skipped\` — trivial security patch, upstream advisories 명시된 정해진 버전으로 bump
- \`codex_review: skipped\` — dependency-only, no behavior change
- Self-review: uv sync + npm install + full test suite live 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)