### PR TITLE
chore(makefile): update help target — resolve drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,17 +28,20 @@ help:
 	@echo "Nuri-Quant Makefile — 카테고리별 주요 명령"
 	@echo ""
 	@echo "  Setup:        make setup"
-	@echo "  Test/Lint:    make test, make lint, make lint-fix"
+	@echo "  Test/Lint:    make test, make test-fast, make lint, make lint-fix, make lint-sh"
 	@echo "  Verify:       make verify-help    (verify-quick → verify-all → verify-fast → verify, fastest first)"
 	@echo "  Data:         make collect, make collect-kis, make wallstreet, make filings"
+	@echo "  Universe:     make universe-sync[-us/-kr/-apply], make collect-universe[-1y], make validate-universe"
 	@echo "  Analysis:     make analyze, make consensus, make scan, make backtest"
 	@echo "  Pipeline:     make full-scan, make quick-scan"
 	@echo "  Trading:      make targets, make rebalance, make recommend, make certify, make remediate"
 	@echo "  Strategy:     make strategy, make backtest-ls, make optimize, make mean-reversion, make pairs"
 	@echo "  Reports:      make report, make report-llm, make evidence, make external"
 	@echo "  Server:       make api, make dashboard, make start"
-	@echo "  Deploy:       make pre-deploy, make deploy, make backup"
+	@echo "  Deploy:       make deploy-mini (★ MBP → Mac mini 1-cmd), make scheduler-reload-remote, make deploy, make backup"
+	@echo "  Dev sync:     make sync-start / sync-end / sync-status"
 	@echo "  Utility:      make ports, make ports-kill, make update-counts, make demo"
+	@echo "  Clean:        make clean, make clean-all, make clean-deep"
 
 verify-help:
 	@printf '\n'


### PR DESCRIPTION
## Summary

\`make help\` 가 최근 6 개 세션에서 추가된 target 을 반영 못 함. 개발자가 \`make help\` 로 workflow 탐색 시 존재 모르고 사용 안 하는 명령 존재.

## Drift 확인

| Target | 추가 PR | help 누락 여부 |
|---|---|---|
| \`deploy-mini\` | #337 | ❌ (가장 많이 쓰는 deploy 인데 없음) |
| \`scheduler-reload-remote\` | #336 | ❌ |
| \`sync-start\` / \`sync-end\` / \`sync-status\` | 이전 | ❌ (카테고리 자체 없음) |
| \`universe-sync*\`, \`collect-universe*\`, \`validate-universe\` | #272 | ❌ |
| \`lint-sh\` | #290 | ❌ |
| \`clean-all\` / \`clean-deep\` | 이전 | ❌ |

## Fix

\`help\` target 을 실측 Makefile target 과 일치시킴. \`★ MBP → Mac mini 1-cmd\` 마커로 \`deploy-mini\` 가 권장 workflow 임을 시각적으로 강조.

## Test plan

- [x] Local: \`make help\` 출력에 5 개 신규 카테고리 / target 전부 표시 확인
- [ ] CI green (Makefile-only)

## Flow metadata (§4.2)

- \`codex_plan: skipped\` — trivial help text drift fix
- \`codex_review: skipped\` — no behavior change, echo only
- Self-review: \`make help\` live 실행