### PR TITLE
chore(gitignore): use data/*.db glob for SQLite files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,9 +132,12 @@ test-results/
 *.cover
 
 # ─── Data & runtime artifacts ──────────────────────────────────
-data/portfolio.db
-data/portfolio.db-wal
-data/portfolio.db-shm
+# SQLite DB files in data/ — glob form so future DB names (e.g. nuri.db,
+# nuri.db-wal) are caught automatically. Only matches direct children;
+# tests/fixtures/*.db remain trackable.
+data/*.db
+data/*.db-wal
+data/*.db-shm
 data/backups/
 data/exports/
 data/reports/


### PR DESCRIPTION
## Summary
- Replace specific `data/portfolio.db{,-wal,-shm}` gitignore entries with `data/*.db`, `data/*.db-wal`, `data/*.db-shm` globs
- Remove 0-byte `data/nuri.db` artifact (manually deleted from working tree)

## Why
Surfaced via session inspection — `git status --short` showed `?? data/` despite the production DB (`portfolio.db`, 26MB) being gitignored. Root cause: a 0-byte `data/nuri.db` file existed (likely created by SQLite when an earlier code path probed a non-default DB name). The current default DB path is `data/portfolio.db` per `nuri/core/db.py:15`, so the 0-byte file was harmless — but the gitignore being filename-specific was the structural risk.

## Scope boundary
- Glob only matches direct children of `data/`. `tests/fixtures/*.db` (test fixtures) remain trackable. Verified via `git check-ignore`.
- Pure config polish — no application logic, no new behavior.

## Test plan
- [x] `git check-ignore -v data/portfolio.db` → matches new glob
- [x] `git check-ignore -v data/nuri.db` → matches new glob (future-proof)
- [x] `git check-ignore -v tests/fixtures/sample.db` → no match (correct, fixtures stay trackable)
- [ ] CI passes (no test impact expected)

codex_plan: skipped (1 file, scope clear)
codex_review: skipped (no logic change, equivalent to config polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)