### PR TITLE
fix(ci): always run universe-check (required gate fix)

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -260,13 +260,11 @@ jobs:
   universe-check:
     name: Universe Coverage Validation
     needs: changes
-    # Previous condition was `needs.changes.outputs.python`, but `changes` never
-    # emitted a `python` output — the gate was dead (always skipped) since
-    # workflow inception. Fixed to use the new dedicated `universe` output
-    # (triggered by config/universe.yaml, scripts/validate_universe.py, or
-    # this workflow). Always runs on non-PR events to track coverage drift on
-    # main, matching the pattern used by other backend jobs.
-    if: needs.changes.outputs.universe == 'true' || github.event_name != 'pull_request'
+    # Always run — required gate (PR #343 promoted this to required_status_checks).
+    # Previous changes-conditional caused docs/gitignore-only PRs to report
+    # this check as "skipping", which blocks merge under the new required-check
+    # policy. The job is fast (~15s, no network), so always-on cost is trivial
+    # vs the merge-block cost.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary
Remove the `if:` condition from the Universe Coverage Validation job so it always runs.

## Why (root cause analysis)
PR #343 promoted Universe Coverage Validation to a `required_status_check`. The previous if-conditional was:

```yaml
if: needs.changes.outputs.universe == 'true' || github.event_name != 'pull_request'
```

For PRs that don't touch `config/universe.yaml`, `scripts/validate_universe.py`, or this workflow file, the `universe` output is false → job skipped → required check fails to report → **PR blocked from merge** under the new required-check policy.

PR #344 (.gitignore-only) reproduced this exact failure mode within minutes of #343 merging.

## Approach
Remove the `if:` condition. The job is fast (~15s, no network — yaml sanity check only) so always-on cost is trivial vs the merge-block cost.

## Same class of trap (CLAUDE.md gotcha extension)
The existing CLAUDE.md gotcha covers **name mismatch** between `required_status_checks` and workflow `name:`. This fix surfaces a sibling failure mode: **conditional skip** of a required check. Adding to the gotcha catalog in a separate docs-only follow-up.

## Test plan
- [x] Diff: `if:` line removed, `needs: changes` retained for sequencing
- [ ] PR CI: Universe Coverage Validation runs (not skipping) and passes
- [ ] After merge: PR #344 base update → universe-check runs → PR #344 unblocked

codex_plan: skipped (1 file, root-cause fix)
codex_review: required (CI workflow change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)