### PR TITLE
fix(collectors): yfinance fallback for news + etf_flows (#274)

### DIFF
--- a/nuri/collectors/etf_flows.py
+++ b/nuri/collectors/etf_flows.py
@@ -1,7 +1,9 @@
 """
 ETF 자금흐름 수집기 — 섹터 ETF AUM/거래량 추적.
 
-OpenBB etf.info (yfinance) → total_assets, volume_avg, nav_price.
+OpenBB etf.info primary + yfinance `Ticker.info` fallback → total_assets, volume_avg,
+nav_price. OpenBB 상류 bug (#274, upstream #7379/#7460) 동안 yfinance 로 자동 수집.
+
 AUM 변화를 주기적으로 수집하여 섹터 자금흐름(rotation)을 추정한다.
 
 사용법:
@@ -51,13 +53,9 @@ class EtfFlowsCollector(BaseCollector):
         super().__init__("etf_flows")
 
     def collect(self, **kwargs) -> list[dict]:
-        """OpenBB etf.info로 ETF 정보 수집.
-
-        Note: 2026-04 기준 OpenBB OBBject_EtfCountries import 깨짐 (#274). 모든 fetch 실패.
-        """
+        """ETF 정보 수집. OpenBB etf.info primary + yfinance `Ticker.info` fallback."""
         import warnings
 
-        from openbb import obb
         from tqdm import tqdm
 
         warnings.filterwarnings("ignore")
@@ -73,41 +71,82 @@ class EtfFlowsCollector(BaseCollector):
         iterator = tqdm(etfs_list, desc="  etf_flows", unit="etf", disable=len(etfs_list) < 10)
 
         for ticker, label in iterator:
-            try:
-                r = obb.etf.info(ticker, provider="yfinance")
-                df = r.to_df()
-                if df.empty:
-                    continue
-
-                row = df.iloc[0]
-                results.append(
-                    {
-                        "ticker": ticker,
-                        "date": today,
-                        "name": str(row.get("name", label))[:100],
-                        "total_assets": float(row["total_assets"]) if pd.notna(row.get("total_assets")) else None,
-                        "volume_avg": float(row["volume_avg"]) if pd.notna(row.get("volume_avg")) else None,
-                        "nav_price": float(row["nav_price"]) if pd.notna(row.get("nav_price")) else None,
-                    }
-                )
-                if len(etfs_list) < 10:
-                    self.logger.info(f"  {ticker} ({label}): AUM=${row.get('total_assets', 0) / 1e9:.1f}B")
-
-            except Exception as e:
+            rec = self._fetch_etf(ticker, label, today)
+            if rec is None:
                 failed.append(ticker)
-                self.logger.debug(f"{ticker}: 수집 실패 — {e}")
                 continue
+            results.append(rec)
+            if len(etfs_list) < 10 and rec.get("total_assets"):
+                self.logger.info(f"  {ticker} ({label}): AUM=${rec['total_assets'] / 1e9:.1f}B")
 
         sample = ", ".join(failed[:5]) + (f" 외 {len(failed) - 5}개" if len(failed) > 5 else "")
         self.logger.info(
-            "📊 ETF flows: ✅ %d 성공 / ❌ %d 실패 (총 %d) — failed: %s%s",
+            "📊 ETF flows: ✅ %d 성공 / ❌ %d 실패 (총 %d) — failed: %s",
             len(results),
             len(failed),
             len(etfs_list),
             sample or "없음",
-            "  [⚠️ OpenBB #274 깨짐 — 모두 실패 정상]" if len(failed) == len(etfs_list) else "",
         )
         return results
+
+    def _fetch_etf(self, ticker: str, label: str, today: str) -> dict | None:
+        """단일 ETF 정보. OpenBB → yfinance 직접 폴백."""
+        # 1차: OpenBB
+        try:
+            from openbb import obb
+
+            r = obb.etf.info(ticker, provider="yfinance")
+            df = r.to_df()
+            if not df.empty:
+                row = df.iloc[0]
+                return {
+                    "ticker": ticker,
+                    "date": today,
+                    "name": str(row.get("name", label))[:100],
+                    "total_assets": float(row["total_assets"]) if pd.notna(row.get("total_assets")) else None,
+                    "volume_avg": float(row["volume_avg"]) if pd.notna(row.get("volume_avg")) else None,
+                    "nav_price": float(row["nav_price"]) if pd.notna(row.get("nav_price")) else None,
+                }
+        except Exception as e:
+            self.logger.debug(f"{ticker}: OpenBB etf.info 실패 — {e}")
+
+        # 2차: yfinance 직접 호출 (OpenBB 장애 시 폴백)
+        try:
+            import yfinance as yf
+
+            info = yf.Ticker(ticker).info or {}
+            if not info:
+                return None
+
+            name = info.get("longName") or info.get("shortName") or label
+            total_assets = info.get("totalAssets")
+
+            # total_assets 가 없는 row 는 failed 처리: analyze_sector_rotation 이
+            # `aum_current - aum_prev` 를 수행하는데 한쪽이 None 이면 TypeError → 분석 전체 실패.
+            if not pd.notna(total_assets):
+                return None
+
+            # yfinance .info 의 missing 필드는 float('nan') 으로 자주 반환되어 Python `or`
+            # 가 truthy 로 취급한다 (nan 은 0 이 아님). secondary 필드로 fallback 하려면
+            # pd.notna 로 명시적 NaN/None 체크 후 선택해야 한다.
+            av_primary = info.get("averageVolume")
+            volume_avg = av_primary if pd.notna(av_primary) else info.get("averageVolume10days")
+
+            nav_primary = info.get("navPrice")
+            nav_price = nav_primary if pd.notna(nav_primary) else info.get("regularMarketPrice")
+
+            # NaN → None 정규화: volume_avg / nav_price 는 downstream 에서 None 허용.
+            return {
+                "ticker": ticker,
+                "date": today,
+                "name": str(name)[:100],
+                "total_assets": float(total_assets),
+                "volume_avg": float(volume_avg) if pd.notna(volume_avg) else None,
+                "nav_price": float(nav_price) if pd.notna(nav_price) else None,
+            }
+        except Exception as e:
+            self.logger.debug(f"{ticker}: yfinance etf info 폴백 실패 — {e}")
+            return None
 
     def save(self, data: Any) -> int:
         """etf_flows 테이블에 upsert."""

--- a/nuri/collectors/news.py
+++ b/nuri/collectors/news.py
@@ -1,5 +1,9 @@
 """
-뉴스 수집기 — OpenBB Platform 기반 종목별 뉴스 수집.
+뉴스 수집기 — OpenBB Platform primary + yfinance direct fallback.
+
+OpenBB 상류 bug (#274, upstream OpenBB-finance/OpenBB #7379/#7460) 로 news.company import
+가 깨진 상태 — yfinance `Ticker.news` 로 자동 fallback 하여 수집 지속. upstream release
+이 수정되면 OpenBB 경로가 자연 복원됨 (stock.py 와 동일 패턴).
 
 사용법:
     python -m nuri.collectors.news
@@ -12,18 +16,13 @@ from nuri.core.db import upsert_news
 
 
 class NewsCollector(BaseCollector):
-    """OpenBB로 종목별 뉴스 수집."""
+    """OpenBB primary + yfinance fallback 으로 종목별 뉴스 수집."""
 
     def __init__(self):
         super().__init__("news")
 
     def collect(self, source: str = "portfolio", **kwargs) -> list[dict]:
-        """뉴스 수집. source='universe' 시 universe.yaml 전체.
-
-        Note: 2026-04 기준 OpenBB OBBject_CompanyNews import 깨짐 (#274). 모든 fetch 실패.
-        구조는 유지하되 실제 작동은 #274 fix 후 가능.
-        """
-        from openbb import obb
+        """뉴스 수집. source='universe' 시 universe.yaml 전체."""
         from tqdm import tqdm
 
         tickers = self._get_tickers(market="us", source=source)
@@ -37,55 +36,159 @@ class NewsCollector(BaseCollector):
         iterator = tqdm(tickers, desc=f"  news [{source}]", unit="tk", disable=len(tickers) < 20)
 
         for ticker in iterator:
-            try:
-                result = obb.news.company(symbol=ticker, provider="yfinance", limit=10)
-                df = result.to_dataframe()
-                if df.empty:
-                    continue
-
-                for _, row in df.iterrows():
-                    url = row.get("url", "")
-                    if not url:
-                        continue
-
-                    # 날짜: index 또는 컬럼
-                    if hasattr(row.name, "strftime"):
-                        date = row.name.strftime("%Y-%m-%d")
-                    elif "date" in row.index:
-                        date = str(row["date"])[:10]
-                    else:
-                        from nuri.core.timezone import today_kst
-
-                        date = today_kst()
-
-                    records.append(
-                        {
-                            "ticker": ticker,
-                            "date": date,
-                            "title": str(row.get("title", ""))[:500],
-                            "url": str(url)[:1000],
-                            "source": str(row.get("source", ""))[:100],
-                            "sentiment": None,
-                        }
-                    )
-
-            except Exception as e:
+            items = self._fetch_ticker_news(ticker)
+            if not items:
                 failed.append(ticker)
-                self.logger.debug(f"{ticker}: 뉴스 수집 실패 — {e}")
+                continue
+            records.extend(items)
 
         if len(tickers) >= 20:
             sample = ", ".join(failed[:5]) + (f" 외 {len(failed) - 5}개" if len(failed) > 5 else "")
             self.logger.info(
-                "📊 뉴스: %d 건 수집 / ❌ %d 종목 실패 (총 %d) — failed: %s%s",
+                "📊 뉴스: %d 건 수집 / ❌ %d 종목 실패 (총 %d) — failed: %s",
                 len(records),
                 len(failed),
                 len(tickers),
                 sample or "없음",
-                "  [⚠️ OpenBB #274 깨짐 — 대부분 실패 정상]" if len(failed) > len(tickers) * 0.5 else "",
             )
         else:
             self.logger.info(f"뉴스 {len(records)}건 수집")
         return records
+
+    def _fetch_ticker_news(self, ticker: str) -> list[dict]:
+        """단일 종목 뉴스. OpenBB → yfinance 직접 폴백."""
+        # 1차: OpenBB
+        try:
+            from openbb import obb
+
+            result = obb.news.company(symbol=ticker, provider="yfinance", limit=10)
+            df = result.to_dataframe()
+            if not df.empty:
+                return self._parse_openbb_news(df, ticker)
+        except Exception as e:
+            self.logger.debug(f"{ticker}: OpenBB news 실패 — {e}")
+
+        # 2차: yfinance 직접 호출 (OpenBB 장애 시 폴백)
+        try:
+            import yfinance as yf
+
+            raw = yf.Ticker(ticker).news or []
+            return self._parse_yfinance_news(raw, ticker)
+        except Exception as e:
+            self.logger.debug(f"{ticker}: yfinance news 폴백 실패 — {e}")
+            return []
+
+    def _parse_openbb_news(self, df, ticker: str) -> list[dict]:
+        """OpenBB DataFrame → news record list."""
+        from nuri.core.timezone import today_kst
+
+        records: list[dict] = []
+        for _, row in df.iterrows():
+            url = row.get("url", "")
+            if not url:
+                continue
+
+            # 날짜: index 또는 컬럼
+            if hasattr(row.name, "strftime"):
+                date = row.name.strftime("%Y-%m-%d")
+            elif "date" in row.index:
+                date = str(row["date"])[:10]
+            else:
+                date = today_kst()
+
+            records.append(
+                {
+                    "ticker": ticker,
+                    "date": date,
+                    "title": str(row.get("title", ""))[:500],
+                    "url": str(url)[:1000],
+                    "source": str(row.get("source", ""))[:100],
+                    "sentiment": None,
+                }
+            )
+        return records
+
+    def _parse_yfinance_news(self, raw: list, ticker: str) -> list[dict]:
+        """yfinance Ticker.news → news record list.
+
+        yfinance 는 두 payload format 을 혼재 사용:
+        - 구형 (flat): {"title", "link", "publisher", "providerPublishTime": epoch}
+        - 신형 (nested): {"id", "content": {"title", "canonicalUrl": {"url"}, "provider": {"displayName"}, "pubDate": ISO}}
+        버전/제공자에 따라 달라지므로 둘 다 처리한다.
+
+        날짜는 모두 KST 기준으로 정규화 (프로젝트 표준: `today_kst()` — §4.3).
+        """
+        from datetime import datetime
+
+        from nuri.core.timezone import KST, today_kst
+
+        records: list[dict] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+
+            content = item.get("content")
+            if isinstance(content, dict):
+                # 신형 nested
+                title = content.get("title") or ""
+                url_obj = content.get("canonicalUrl") or content.get("clickThroughUrl") or {}
+                url = url_obj.get("url", "") if isinstance(url_obj, dict) else ""
+                provider_obj = content.get("provider") or {}
+                source = provider_obj.get("displayName", "") if isinstance(provider_obj, dict) else ""
+
+                pub_date = content.get("pubDate") or content.get("displayTime") or ""
+                date = self._iso_utc_to_kst_date(pub_date) or today_kst()
+            else:
+                # 구형 flat
+                title = item.get("title") or ""
+                url = item.get("link") or ""
+                source = item.get("publisher") or ""
+
+                epoch = item.get("providerPublishTime")
+                if isinstance(epoch, (int, float)) and epoch > 0:
+                    # epoch 는 UTC 기준 → KST 전환 후 날짜 추출
+                    date = datetime.fromtimestamp(int(epoch), tz=KST).strftime("%Y-%m-%d")
+                else:
+                    date = today_kst()
+
+            if not title or not url:
+                continue
+
+            records.append(
+                {
+                    "ticker": ticker,
+                    "date": date,
+                    "title": str(title)[:500],
+                    "url": str(url)[:1000],
+                    "source": str(source)[:100],
+                    "sentiment": None,
+                }
+            )
+        return records
+
+    @staticmethod
+    def _iso_utc_to_kst_date(pub_date: str) -> str | None:
+        """ISO 8601 UTC ("2026-04-17T14:42:20Z") → KST "YYYY-MM-DD".
+
+        실패 시 None 반환 — 호출자가 `today_kst()` fallback.
+        """
+        if not isinstance(pub_date, str) or len(pub_date) < 10:
+            return None
+        try:
+            from datetime import datetime
+
+            from nuri.core.timezone import KST
+
+            # Python fromisoformat 은 "Z" suffix 를 3.11+ 부터 인식, 안전을 위해 명시 치환
+            iso = pub_date.rstrip("Z")
+            dt = datetime.fromisoformat(iso)
+            if dt.tzinfo is None:
+                from datetime import timezone as _tz
+
+                dt = dt.replace(tzinfo=_tz.utc)
+            return dt.astimezone(KST).strftime("%Y-%m-%d")
+        except (ValueError, TypeError):
+            return None
 
     def save(self, data: list[dict]) -> int:
         """뉴스를 DB에 저장 (URL 중복 자동 제거)."""

--- a/tests/collectors/test_etf_flows.py
+++ b/tests/collectors/test_etf_flows.py
@@ -230,6 +230,124 @@ class TestEtfFlowsNanValues:
         assert results[0]["total_assets"] is None
 
 
+class TestEtfFlowsYfinanceFallback:
+    """yfinance Ticker.info 폴백 경로 (#274) regression lock-in.
+
+    - total_assets 누락 시 failed 처리 (analyze_sector_rotation TypeError 방지)
+    - NaN primary + usable secondary → pd.notna 기반 secondary 선택
+    """
+
+    def _patch_openbb_fail(self, monkeypatch):
+        """OpenBB primary 를 무조건 실패시켜 yfinance fallback 유도."""
+        import sys
+
+        mock_obb = MagicMock()
+        mock_obb.etf.info.side_effect = ImportError("OBBject_EtfCountries not found")
+        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+
+    def test_yfinance_fallback_full_fields(self, monkeypatch):
+        """yfinance .info 에 모든 필드 정상 — 변환 후 dict 반환."""
+        import sys
+
+        from nuri.collectors.etf_flows import EtfFlowsCollector
+
+        self._patch_openbb_fail(monkeypatch)
+
+        info = {
+            "longName": "SPDR S&P 500 ETF Trust",
+            "totalAssets": 650_000_000_000,
+            "averageVolume": 80_000_000,
+            "navPrice": 700.12,
+        }
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.info = info
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        rec = EtfFlowsCollector()._fetch_etf("SPY", "S&P 500", "2026-04-17")
+        assert rec is not None
+        assert rec["ticker"] == "SPY"
+        assert rec["name"] == "SPDR S&P 500 ETF Trust"
+        assert rec["total_assets"] == 650_000_000_000
+        assert rec["volume_avg"] == 80_000_000
+        assert rec["nav_price"] == 700.12
+
+    def test_yfinance_fallback_rejects_missing_total_assets(self, monkeypatch):
+        """totalAssets 없으면 None 반환 (failed 처리).
+
+        downstream analyze_sector_rotation() 이 `aum_current - aum_prev` 를 수행 →
+        partial None 이 섞이면 TypeError → 분석 전체 crash.
+        """
+        import sys
+
+        from nuri.collectors.etf_flows import EtfFlowsCollector
+
+        self._patch_openbb_fail(monkeypatch)
+
+        # 1) totalAssets 자체 누락
+        info_missing = {"longName": "X", "averageVolume": 100, "navPrice": 50}
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.info = info_missing
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+        assert EtfFlowsCollector()._fetch_etf("XX", "X", "2026-04-17") is None
+
+        # 2) totalAssets 가 NaN
+        info_nan = {"longName": "Y", "totalAssets": float("nan"), "averageVolume": 100, "navPrice": 50}
+        mock_yf.Ticker.return_value.info = info_nan
+        assert EtfFlowsCollector()._fetch_etf("YY", "Y", "2026-04-17") is None
+
+    def test_yfinance_fallback_secondary_when_primary_is_nan(self, monkeypatch):
+        """averageVolume 이 NaN 이면 averageVolume10days 로 fallback.
+
+        `a or b` 는 NaN 을 truthy 로 취급 → pd.notna 기반 명시적 선택 필요.
+        """
+        import sys
+
+        from nuri.collectors.etf_flows import EtfFlowsCollector
+
+        self._patch_openbb_fail(monkeypatch)
+
+        info = {
+            "longName": "Partial ETF",
+            "totalAssets": 100_000_000,
+            "averageVolume": float("nan"),        # primary NaN
+            "averageVolume10days": 5_000_000,     # secondary usable
+            "navPrice": float("nan"),             # primary NaN
+            "regularMarketPrice": 55.0,           # secondary usable
+        }
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.info = info
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        rec = EtfFlowsCollector()._fetch_etf("PP", "Partial", "2026-04-17")
+        assert rec is not None
+        assert rec["volume_avg"] == 5_000_000, "secondary averageVolume10days must be picked when primary is NaN"
+        assert rec["nav_price"] == 55.0, "secondary regularMarketPrice must be picked when navPrice is NaN"
+
+    def test_yfinance_fallback_all_secondary_missing(self, monkeypatch):
+        """primary NaN + secondary 도 missing → volume_avg/nav_price 는 None (total_assets 있으면 row 유지)."""
+        import sys
+
+        from nuri.collectors.etf_flows import EtfFlowsCollector
+
+        self._patch_openbb_fail(monkeypatch)
+
+        info = {
+            "totalAssets": 1_000_000,
+            "averageVolume": float("nan"),
+            "navPrice": float("nan"),
+            # no secondary
+        }
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.info = info
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        rec = EtfFlowsCollector()._fetch_etf("QQ", "Q", "2026-04-17")
+        assert rec is not None
+        assert rec["total_assets"] == 1_000_000
+        assert rec["volume_avg"] is None
+        assert rec["nav_price"] is None
+
+
 # ##############################################################################
 # Source: test_uncovered.py
 # ##############################################################################

--- a/tests/collectors/test_news.py
+++ b/tests/collectors/test_news.py
@@ -217,9 +217,15 @@ class TestYfinanceFallback:
         assert fn("2026-04-16T15:00:00+00:00") == "2026-04-17"
         # naive (no tz) — UTC 로 간주
         assert fn("2026-04-16T15:00:00") == "2026-04-17"
-        # 잘못된 입력
+        # 잘못된 입력 — early return (len<10) 경로
         assert fn("invalid") is None
         assert fn("") is None
         assert fn(None) is None
         # 짧은 ISO date-only
         assert fn("2026-04-17") == "2026-04-17"
+        # len >= 10 이지만 fromisoformat 가 raise 하는 경우 — except 경로 검증
+        # early return ("invalid"/"") 만 테스트하면 try/except 의 defense 가
+        # 한 번도 exercised 되지 않아 §5.5 Test Illusion (문서상 방어 != 실제 방어).
+        assert fn("2026-04-16T99:99:99Z") is None  # invalid hour → ValueError
+        assert fn("2026-13-40T12:00:00Z") is None  # invalid month → ValueError
+        assert fn("not-valid-iso-string-2026") is None  # 완전 malformed → ValueError

--- a/tests/collectors/test_news.py
+++ b/tests/collectors/test_news.py
@@ -72,3 +72,154 @@ class TestNewsCollector_Uncovered:
         from nuri.collectors.news import NewsCollector
 
         assert NewsCollector().save([]) == 0
+
+
+class TestYfinanceFallback:
+    """yfinance 직접 폴백 경로 (#274). Flat vs nested payload + KST 변환 regression lock-in."""
+
+    def test_fallback_parses_nested_payload(self, monkeypatch, db_with_portfolio):
+        """신형 yfinance: {id, content: {...}} 구조 파싱."""
+        import sys
+
+        from nuri.collectors.news import NewsCollector
+
+        # OpenBB primary 강제 실패시킴 → fallback 유도
+        mock_obb = MagicMock()
+        mock_obb.news.company.side_effect = ImportError("OBBject_CompanyNews not found")
+        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+
+        nested = [
+            {
+                "id": "abc123",
+                "content": {
+                    "title": "AAPL beats earnings",
+                    "canonicalUrl": {"url": "https://example.com/nested/1"},
+                    "provider": {"displayName": "Yahoo Finance"},
+                    "pubDate": "2026-04-16T15:30:00Z",  # UTC → KST 2026-04-17
+                },
+            }
+        ]
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.news = nested
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        results = NewsCollector().collect()
+        assert len(results) >= 1
+        first = next(r for r in results if r["url"] == "https://example.com/nested/1")
+        assert first["title"] == "AAPL beats earnings"
+        assert first["source"] == "Yahoo Finance"
+        assert first["date"] == "2026-04-17"  # UTC 15:30 → KST 00:30 다음날
+
+    def test_fallback_parses_flat_payload(self, monkeypatch, db_with_portfolio):
+        """구형 yfinance: {title, link, publisher, providerPublishTime: epoch} 구조 파싱."""
+        import sys
+        from datetime import datetime, timezone
+
+        from nuri.collectors.news import NewsCollector
+        from nuri.core.timezone import KST
+
+        mock_obb = MagicMock()
+        mock_obb.news.company.side_effect = ImportError("OBBject_CompanyNews not found")
+        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+
+        # UTC 2026-04-16 14:00:00 → KST 2026-04-16 23:00 (같은 날)
+        epoch_same_day = int(datetime(2026, 4, 16, 14, 0, 0, tzinfo=timezone.utc).timestamp())
+        # UTC 2026-04-16 15:30:00 → KST 2026-04-17 00:30 (다음 날)
+        epoch_next_day = int(datetime(2026, 4, 16, 15, 30, 0, tzinfo=timezone.utc).timestamp())
+
+        flat = [
+            {"title": "Flat same-day", "link": "https://ex.com/flat/1", "publisher": "WSJ", "providerPublishTime": epoch_same_day},
+            {"title": "Flat next-day", "link": "https://ex.com/flat/2", "publisher": "WSJ", "providerPublishTime": epoch_next_day},
+        ]
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.news = flat
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        results = NewsCollector().collect()
+        by_url = {r["url"]: r for r in results}
+
+        assert "https://ex.com/flat/1" in by_url
+        assert by_url["https://ex.com/flat/1"]["date"] == "2026-04-16"
+        assert by_url["https://ex.com/flat/1"]["source"] == "WSJ"
+        assert by_url["https://ex.com/flat/2"]["date"] == "2026-04-17"
+
+        # 변환 결과가 프로젝트 KST helper 와 동치임을 확인
+        expected = datetime.fromtimestamp(epoch_next_day, tz=KST).strftime("%Y-%m-%d")
+        assert by_url["https://ex.com/flat/2"]["date"] == expected
+
+    def test_fallback_handles_mixed_and_malformed_items(self, monkeypatch, db_with_portfolio):
+        """빈 content / 누락 필드 / 잘못된 타입 혼재 — 크래시 없이 skip."""
+        import sys
+
+        from nuri.collectors.news import NewsCollector
+
+        mock_obb = MagicMock()
+        mock_obb.news.company.side_effect = ImportError("broken")
+        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+
+        mixed = [
+            # nested 정상
+            {"content": {"title": "Good", "canonicalUrl": {"url": "https://ok.com/1"}, "pubDate": "2026-04-15T00:00:00Z", "provider": {"displayName": "X"}}},
+            # nested 에 title 없음
+            {"content": {"canonicalUrl": {"url": "https://skip.com/1"}, "pubDate": "2026-04-15T00:00:00Z"}},
+            # nested 에 url 없음
+            {"content": {"title": "No url", "pubDate": "2026-04-15T00:00:00Z"}},
+            # flat 에 url 없음
+            {"title": "Flat no url", "publisher": "Y"},
+            # None 아이템
+            None,
+            # 잘못된 타입
+            "string item",
+            # flat 정상
+            {"title": "Good flat", "link": "https://ok.com/2", "publisher": "Z", "providerPublishTime": 1745000000},
+        ]
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value.news = mixed
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        results = NewsCollector().collect()
+        urls = {r["url"] for r in results}
+        assert "https://ok.com/1" in urls
+        assert "https://ok.com/2" in urls
+        # malformed skipped
+        assert "https://skip.com/1" not in urls
+
+    def test_fallback_returns_empty_when_yfinance_raises(self, monkeypatch, db_with_portfolio):
+        """yfinance 자체가 exception — fallback 은 per-ticker [] 반환 (silent degrade)."""
+        import sys
+
+        from nuri.collectors.news import NewsCollector
+
+        mock_obb = MagicMock()
+        mock_obb.news.company.side_effect = ImportError("broken")
+        monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.side_effect = RuntimeError("network fail")
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        results = NewsCollector().collect()
+        assert results == []
+
+    def test_iso_utc_to_kst_date_boundaries(self):
+        """UTC→KST date 변환 경계값. KST=UTC+9 이므로 15:00 UTC 가 자정 경계."""
+        from nuri.collectors.news import NewsCollector
+
+        fn = NewsCollector._iso_utc_to_kst_date
+        # UTC 14:59 → KST 23:59 (같은 날)
+        assert fn("2026-04-16T14:59:59Z") == "2026-04-16"
+        # UTC 15:00 → KST 00:00 (다음 날)
+        assert fn("2026-04-16T15:00:00Z") == "2026-04-17"
+        # +00:00 suffix
+        assert fn("2026-04-16T15:00:00+00:00") == "2026-04-17"
+        # naive (no tz) — UTC 로 간주
+        assert fn("2026-04-16T15:00:00") == "2026-04-17"
+        # 잘못된 입력
+        assert fn("invalid") is None
+        assert fn("") is None
+        assert fn(None) is None
+        # 짧은 ISO date-only
+        assert fn("2026-04-17") == "2026-04-17"


### PR DESCRIPTION
## Summary

- Ports `stock.py` OpenBB→yfinance fallback pattern to `news.py` and `etf_flows.py`, unblocking collection while upstream fix ships.
- Handles yfinance's two news payload shapes (nested `{content:…}`, flat `{title,link,publisher,…}`) + KST-normalized dates.
- Uses `pd.notna(...)` for NaN-aware field selection in `Ticker.info`; rejects ETF rows missing `total_assets` so `analyze_sector_rotation()` can't hit `None - float` TypeError.

## Root cause (`/Users/ehbebe/workspace/nuri-quant/CLAUDE.md` gotcha candidate)

`openbb 4.7.1` stubs do `from openbb_core.app.provider_interface import OBBject_CompanyNews, …` — but those names are generated dynamically at runtime (`create_model(f"OBBject_{name}", …)`), never registered as module attributes. Every `obb.*` endpoint raises `ImportError`.

Verified: upstream bug reported (`OpenBB-finance/OpenBB#7379`), fix PRs merged to `develop` (`#7381`, `#7460`), but **no new `openbb-core` release** yet (`1.6.7` remains latest). Local downgrade unviable — checked `1.4.0`–`1.6.7` + meta `4.7.0`, all broken or regenerate broken stubs on first import.

## Live verification

| Collector | Baseline | Post-fix |
|---|---|---|
| `news.py` (portfolio) | 0 items | **120** |
| `etf_flows.py` (16 ETFs) | 0/16 | **16/16** |
| `stock.py` (AAPL 5d) | 48 rows | 48 (no regression) |
| `fundamental.py` | 15 rows | 15 (no regression) |
| `estimates.py` | 11 rows | 11 (no regression) |

## Test plan

- [x] `.venv/bin/ruff check` — pass
- [x] `.venv/bin/python -m pytest tests/collectors/test_news.py tests/collectors/test_etf_flows.py` — 29/29 pass
- [x] `.venv/bin/python -m pytest tests/ -m "not slow"` — 2951 pass (1 pre-existing flaky `test_search_korean_name`, same result on main; out of scope)
- [x] Live smoke — 120 news items / 16 ETF rows / upstream collectors unregressed
- [x] codex review: 3 rounds, all P1/P2 addressed, final review PASS

## When upstream ships the fix

No code change needed. `OpenBB` path resumes as primary; `yfinance` fallback goes dormant — mirrors `stock.py`.

Closes #274