### PR TITLE
chore(gitignore): ignore personal trade plan files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,9 @@ ta-lib/
 ta-lib-*.tar.gz
 NEXT_SESSION.md
 SESSION_PROMPT.md
+# Personal trade plans (broker positions / prices — never commit)
+TRADE_PLAN.md
+TRADE_PLAN_*.md
 
 # Internal methodology (not for public repo)
 docs/SYSTEM.md


### PR DESCRIPTION
## Summary

Add `TRADE_PLAN.md` / `TRADE_PLAN_*.md` to `.gitignore` so personal trade plan files (broker positions, entry/stop/target prices) never reach the repo.

## Context

STRATEGY §4.4 Tier 2 — portfolio/broker/position data must never be committed. This extends the existing personal-only-files block that already ignores `NEXT_SESSION.md` and `SESSION_PROMPT.md`.

## Test plan

- [x] Privacy scan — pass
- [x] No logic changes, no runtime impact