### PR TITLE
fix(factors): read quality/value from fundamentals table (#349)

### DIFF
--- a/nuri/quant/factors/quality.py
+++ b/nuri/quant/factors/quality.py
@@ -1,4 +1,10 @@
-"""퀄리티 팩터 — ROE, 영업이익률 기반."""
+"""퀄리티 팩터 — ROE, 영업이익률 기반 (fundamentals 테이블 read).
+
+#349: 기존 구현은 `obb.equity.fundamental.ratios` 를 호출했으나 upstream #274 (`OBBject_EquityInfo`
+ImportError) 로 silent 실패 → 전 종목 `quality_score = 0.5` 상수. fundamental.py 가 이미 수집한
+`fundamentals` 테이블 (roe, operating_margin) 을 직접 읽도록 전환하여 아키텍처 일관성 회복
+(STRATEGY §2.3 / §3.1).
+"""
 import logging
 
 import pandas as pd
@@ -6,32 +12,45 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def compute_quality(tickers: list[str] | None = None) -> pd.DataFrame:
-    """종목별 퀄리티 스코어."""
-    from openbb import obb
+def compute_quality(tickers: list[str] | None = None, db_path=None) -> pd.DataFrame:
+    """종목별 퀄리티 스코어 — fundamentals 테이블 기반."""
+    from nuri.core.db import query
 
     if not tickers:
         from nuri.core.db import get_tickers
         tickers = [t for t in get_tickers() if not t.endswith(".KS")]
 
-    scores = {}
-    for ticker in tickers:
-        try:
-            result = obb.equity.fundamental.ratios(ticker, provider="yfinance", limit=1)
-            df = result.to_dataframe()
-            if df.empty:
-                continue
+    if not tickers:
+        return pd.DataFrame()
 
-            row = df.iloc[0]
-            roe = row.get("return_on_equity", row.get("roe"))
-            margin = row.get("operating_profit_margin", row.get("net_profit_margin"))
+    # ticker 별 최신 row 만 조회 (latest per ticker)
+    placeholders = ",".join("?" * len(tickers))
+    rows = query(
+        f"""
+        SELECT f.ticker, f.roe, f.operating_margin
+        FROM fundamentals f
+        INNER JOIN (
+            SELECT ticker, MAX(date) AS mx
+            FROM fundamentals
+            WHERE ticker IN ({placeholders})
+            GROUP BY ticker
+        ) latest ON f.ticker = latest.ticker AND f.date = latest.mx
+        """,
+        params=tuple(tickers),
+        db_path=db_path,
+    )
 
-            scores[ticker] = {
-                "roe": float(roe) if roe and roe == roe else None,
-                "operating_margin": float(margin) if margin and margin == margin else None,
-            }
-        except Exception as e:
-            logger.debug(f"{ticker}: 퀄리티 조회 실패 — {e}")
+    scores: dict[str, dict] = {}
+    for r in rows:
+        ticker = r["ticker"]
+        roe = r["roe"]
+        margin = r["operating_margin"]
+        if roe is None and margin is None:
+            continue
+        scores[ticker] = {
+            "roe": float(roe) if roe is not None else None,
+            "operating_margin": float(margin) if margin is not None else None,
+        }
 
     if not scores:
         return pd.DataFrame()

--- a/nuri/quant/factors/value.py
+++ b/nuri/quant/factors/value.py
@@ -1,4 +1,10 @@
-"""가치 팩터 — PER, PBR 기반 (OpenBB 펀더멘털 활용)."""
+"""가치 팩터 — PER, PBR 기반 (fundamentals 테이블 read).
+
+#349: 기존 구현은 `obb.equity.fundamental.ratios` 를 호출했으나 upstream #274 (`OBBject_EquityInfo`
+ImportError) 로 silent 실패 → 전 종목 `value_score = 0.5` 상수. fundamental.py 가 이미 수집한
+`fundamentals` 테이블 (pe_ratio, price_to_book) 을 직접 읽도록 전환하여 아키텍처 일관성 회복
+(STRATEGY §2.3 / §3.1).
+"""
 import logging
 
 import pandas as pd
@@ -6,39 +12,51 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def compute_value(tickers: list[str] | None = None) -> pd.DataFrame:
-    """종목별 가치 스코어 계산 (낮을수록 저평가)."""
-    from openbb import obb
+def compute_value(tickers: list[str] | None = None, db_path=None) -> pd.DataFrame:
+    """종목별 가치 스코어 — fundamentals 테이블 기반. 낮은 PE/PB 가 높은 가치 스코어."""
+    from nuri.core.db import query
 
     if not tickers:
         from nuri.core.db import get_tickers
         tickers = [t for t in get_tickers() if not t.endswith(".KS")]
 
-    scores = {}
-    for ticker in tickers:
-        try:
-            result = obb.equity.fundamental.ratios(ticker, provider="yfinance", limit=1)
-            df = result.to_dataframe()
-            if df.empty:
-                continue
+    if not tickers:
+        return pd.DataFrame()
 
-            row = df.iloc[0]
-            pe = row.get("pe_ratio", row.get("price_earnings_ratio"))
-            pb = row.get("pb_ratio", row.get("price_to_book_ratio"))
+    placeholders = ",".join("?" * len(tickers))
+    rows = query(
+        f"""
+        SELECT f.ticker, f.pe_ratio, f.price_to_book
+        FROM fundamentals f
+        INNER JOIN (
+            SELECT ticker, MAX(date) AS mx
+            FROM fundamentals
+            WHERE ticker IN ({placeholders})
+            GROUP BY ticker
+        ) latest ON f.ticker = latest.ticker AND f.date = latest.mx
+        """,
+        params=tuple(tickers),
+        db_path=db_path,
+    )
 
-            scores[ticker] = {
-                "pe_ratio": float(pe) if pe and pe == pe else None,
-                "pb_ratio": float(pb) if pb and pb == pb else None,
-            }
-        except Exception as e:
-            logger.debug(f"{ticker}: 펀더멘털 조회 실패 — {e}")
+    scores: dict[str, dict] = {}
+    for r in rows:
+        ticker = r["ticker"]
+        pe = r["pe_ratio"]
+        pb = r["price_to_book"]
+        if pe is None and pb is None:
+            continue
+        scores[ticker] = {
+            "pe_ratio": float(pe) if pe is not None else None,
+            "pb_ratio": float(pb) if pb is not None else None,
+        }
 
     if not scores:
         return pd.DataFrame()
 
     df = pd.DataFrame(scores).T
 
-    # 역수 정규화 (낮은 PE/PB = 높은 가치 스코어)
+    # 역수 정규화: 낮은 PE/PB = 높은 가치 스코어
     for col in ["pe_ratio", "pb_ratio"]:
         if col in df.columns:
             valid = df[col].dropna()

--- a/tests/quant/test_factors_quality.py
+++ b/tests/quant/test_factors_quality.py
@@ -40,3 +40,86 @@ class TestQuality:
         norm_cols = [c for c in df.columns if c.endswith("_norm")]
         df["quality_score"] = df[norm_cols].mean(axis=1)
         assert df.loc["AAPL", "quality_score"] > df.loc["MSFT", "quality_score"]
+
+
+class TestQualityDbRead:
+    """#349 regression lock-in — compute_quality 가 fundamentals 테이블 read 로 동작.
+
+    이전 구현은 `obb.equity.fundamental.ratios` 를 호출 → broken OpenBB 로 silent 0.5 상수.
+    아래 테스트는 seed 한 fundamentals 값 차이가 quality_score 에 반영되는지 검증한다.
+    revert 시 (API call 로 되돌리면) fundamentals seed 는 무시되어 score 가 상수화 → fail.
+    """
+
+    def _seed_fundamentals(self, db_path, rows: list[tuple]) -> None:
+        """rows: list of (ticker, date, roe, operating_margin)."""
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            for ticker, date, roe, margin in rows:
+                conn.execute(
+                    "INSERT OR REPLACE INTO fundamentals (ticker, date, roe, operating_margin)"
+                    " VALUES (?, ?, ?, ?)",
+                    (ticker, date, roe, margin),
+                )
+
+    def test_quality_score_non_constant_when_fundamentals_vary(self, db_path_mp):
+        """3 티커의 ROE/margin 이 다르면 quality_score 도 차별화되어야 한다."""
+        from nuri.quant.factors.quality import compute_quality
+
+        self._seed_fundamentals(
+            db_path_mp,
+            [
+                ("AAPL", "2026-04-15", 0.30, 0.35),
+                ("MSFT", "2026-04-15", 0.20, 0.25),
+                ("NVDA", "2026-04-15", 0.45, 0.50),
+            ],
+        )
+        df = compute_quality(tickers=["AAPL", "MSFT", "NVDA"])
+        assert not df.empty
+        assert "quality_score" in df.columns
+        # 핵심 회귀 방어: score 가 상수화되면 이 assert 가 깨진다
+        assert df["quality_score"].nunique() > 1, (
+            "quality_score 가 상수 (이전 0.5 버그 재발) — "
+            "fundamentals read 로 source 가 되었는지 확인"
+        )
+        # NVDA (최고 ROE + margin) > AAPL > MSFT 순서 검증
+        assert df.loc["NVDA", "quality_score"] > df.loc["AAPL", "quality_score"]
+        assert df.loc["AAPL", "quality_score"] > df.loc["MSFT", "quality_score"]
+
+    def test_quality_reads_latest_date_per_ticker(self, db_path_mp):
+        """동일 ticker 여러 날짜 → 가장 최신 row 만 사용."""
+        from nuri.quant.factors.quality import compute_quality
+
+        self._seed_fundamentals(
+            db_path_mp,
+            [
+                ("AAPL", "2026-04-10", 0.10, 0.10),  # old (should be ignored)
+                ("AAPL", "2026-04-15", 0.30, 0.35),  # latest
+                ("MSFT", "2026-04-15", 0.20, 0.25),
+            ],
+        )
+        df = compute_quality(tickers=["AAPL", "MSFT"])
+        # min-max 정규화 → AAPL roe=0.30 이 max → AAPL quality_score 가 더 큼.
+        # 만약 old row (0.10) 를 사용했다면 MSFT (0.20) 가 더 커진다.
+        assert df.loc["AAPL", "quality_score"] > df.loc["MSFT", "quality_score"]
+
+    def test_quality_source_has_no_openbb_import(self):
+        """아키텍처 회귀 방어: quality.py 가 OpenBB 를 다시 import 하지 않는지 확인.
+
+        §2.3 "Loose coupling via data" — factors 모듈은 DB query 만 사용. 단순 string
+        match 는 docstring 을 잡아 false positive 발생 — AST 로 실제 import 노드만 검사.
+        """
+        import ast
+        from pathlib import Path
+
+        tree = ast.parse(Path("nuri/quant/factors/quality.py").read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                assert "openbb" not in (node.module or "").lower(), (
+                    f"quality.py `from {node.module} import ...` 재도입됨 (§2.3 위배)"
+                )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert "openbb" not in alias.name.lower(), (
+                        f"quality.py `import {alias.name}` 재도입됨 (§2.3 위배)"
+                    )

--- a/tests/quant/test_factors_value.py
+++ b/tests/quant/test_factors_value.py
@@ -41,3 +41,84 @@ class TestValue:
         norm_cols = [c for c in df.columns if c.endswith("_norm")]
         df["value_score"] = df[norm_cols].mean(axis=1)
         assert df.loc["AAPL", "value_score"] > df.loc["MSFT", "value_score"]
+
+
+class TestValueDbRead:
+    """#349 regression lock-in — compute_value 가 fundamentals 테이블 read 로 동작.
+
+    이전 구현은 `obb.equity.fundamental.ratios` 를 호출 → broken OpenBB 로 silent 0.5 상수.
+    """
+
+    def _seed_fundamentals(self, db_path, rows: list[tuple]) -> None:
+        """rows: list of (ticker, date, pe_ratio, price_to_book)."""
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            for ticker, date, pe, pb in rows:
+                conn.execute(
+                    "INSERT OR REPLACE INTO fundamentals (ticker, date, pe_ratio, price_to_book)"
+                    " VALUES (?, ?, ?, ?)",
+                    (ticker, date, pe, pb),
+                )
+
+    def test_value_score_non_constant_when_fundamentals_vary(self, db_path_mp):
+        """3 티커의 PE/PB 가 다르면 value_score 도 차별화되어야 한다."""
+        from nuri.quant.factors.value import compute_value
+
+        self._seed_fundamentals(
+            db_path_mp,
+            [
+                ("AAPL", "2026-04-15", 15.0, 2.0),   # 저평가
+                ("MSFT", "2026-04-15", 30.0, 5.0),   # 중간
+                ("NVDA", "2026-04-15", 60.0, 10.0),  # 고평가
+            ],
+        )
+        df = compute_value(tickers=["AAPL", "MSFT", "NVDA"])
+        assert not df.empty
+        assert "value_score" in df.columns
+        # 핵심 회귀 방어: score 가 상수화되면 이 assert 가 깨진다
+        assert df["value_score"].nunique() > 1, (
+            "value_score 가 상수 (이전 0.5 버그 재발) — "
+            "fundamentals read 로 source 가 되었는지 확인"
+        )
+        # 낮은 PE/PB = 높은 가치 스코어 (역수 정규화)
+        assert df.loc["AAPL", "value_score"] > df.loc["MSFT", "value_score"]
+        assert df.loc["MSFT", "value_score"] > df.loc["NVDA", "value_score"]
+
+    def test_value_reads_latest_date_per_ticker(self, db_path_mp):
+        """동일 ticker 여러 날짜 → 가장 최신 row 만 사용."""
+        from nuri.quant.factors.value import compute_value
+
+        self._seed_fundamentals(
+            db_path_mp,
+            [
+                ("AAPL", "2026-04-10", 100.0, 20.0),  # old (should be ignored)
+                ("AAPL", "2026-04-15", 15.0, 2.0),    # latest — 저평가
+                ("MSFT", "2026-04-15", 30.0, 5.0),
+            ],
+        )
+        df = compute_value(tickers=["AAPL", "MSFT"])
+        # 최신 AAPL (PE 15) 가 MSFT (PE 30) 보다 저평가 → value_score 더 큼.
+        # 만약 old row (PE 100) 를 사용했다면 MSFT (PE 30) 가 더 커진다.
+        assert df.loc["AAPL", "value_score"] > df.loc["MSFT", "value_score"]
+
+    def test_value_source_has_no_openbb_import(self):
+        """아키텍처 회귀 방어: value.py 가 OpenBB 를 다시 import 하지 않는지 확인.
+
+        §2.3 "Loose coupling via data" — factors 모듈은 DB query 만 사용. 단순 string
+        match 는 docstring 을 잡아 false positive 발생 — AST 로 실제 import 노드만 검사.
+        """
+        import ast
+        from pathlib import Path
+
+        tree = ast.parse(Path("nuri/quant/factors/value.py").read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                assert "openbb" not in (node.module or "").lower(), (
+                    f"value.py `from {node.module} import ...` 재도입됨 (§2.3 위배)"
+                )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert "openbb" not in alias.name.lower(), (
+                        f"value.py `import {alias.name}` 재도입됨 (§2.3 위배)"
+                    )


### PR DESCRIPTION
## Summary

- `quant/factors/{quality,value}.py` now read from the `fundamentals` table instead of calling broken `obb.equity.fundamental.ratios`.
- Restores composite factor differentiation — every ticker used to get `quality_score = value_score = 0.5`.
- 6 regression tests + AST-based architecture guard.

## Motivation (live evidence)

Production DB 2026-04-17 KST:
```
factors: 1536 rows | all quality_score=0.5, all value_score=0.5
```

Root cause: `obb.equity.fundamental.ratios` → `ImportError: OBBject_EquityInfo` (same upstream bug as #274). Exception silently caught → empty DataFrame → composite.py defaults to 0.5 per ticker. Full investigation in #349.

## Post-fix live verification (6 portfolio tickers)

| Ticker | quality_score | value_score |
|---|---|---|
| NVDA | 0.83 | 0.34 |
| AAPL | 0.75 | 0.36 |
| MSFT | 0.45 | **0.93** |
| GOOGL | 0.33 | 0.71 |
| AMD  | 0.11 | 0.60 |
| TSLA | **0.00** | 0.15 |

Both scores now distinct across all 6 tickers (previously 0.5/0.5 constant).

## Test plan

- [x] `.venv/bin/python -m pytest tests/quant tests/analysis` — 517 passed
- [x] Live verification via `compute_quality()` + `compute_value()` on prod DB — 6 unique values each
- [x] `.venv/bin/python -m ruff check nuri/quant/factors/ tests/quant/` — clean
- [x] Existing tests still pass (`test_empty_when_no_data`, `test_normalization_logic`)

## Design notes

- No yfinance fallback — the DB is the source. `fundamental.py` already fetches via yfinance and upserts to `fundamentals`.
- SQL uses self-join for latest row per ticker (safe for small ticker lists; factors runs on ~380 tickers today).
- `db_path=None` param added for testability; no caller signature change (composite.py still calls `compute_quality()` without args).
- STRATEGY §2.3 / §3.1 compliance — phase-to-phase via DB, not re-fetching from upstream.

Closes #349
Related: #274 (sibling OpenBB fix, shipped as #347)

🤖 Generated with [Claude Code](https://claude.com/claude-code)