### PR TITLE
fix(db): upsert_news returns actual insert count (#351)

### DIFF
--- a/nuri/core/db.py
+++ b/nuri/core/db.py
@@ -842,16 +842,21 @@ def insert_events(records: list[dict], db_path: Optional[Path] = None) -> int:
 
 
 def upsert_news(records: list[dict], db_path: Optional[Path] = None) -> int:
-    """뉴스 upsert (URL 기준 중복 제거)."""
+    """뉴스 upsert (URL 기준 중복 제거). 반환값은 실제 신규 삽입 건수 (dedup 후).
+
+    이전에는 `len(records)` 를 그대로 반환하여 URL UNIQUE 로 IGNORE 된 행도 카운트에
+    포함됐다 (#351). `cursor.rowcount` 는 INSERT OR IGNORE 에서 실제 inserted 수만
+    반환하므로 로그 "뉴스 N 건 수집" 이 DB 상태와 일치한다 (§2.4 Observability).
+    """
     if not records:
         return 0
     with get_db(db_path) as conn:
-        conn.executemany(
+        cur = conn.executemany(
             """INSERT OR IGNORE INTO news (ticker, date, title, url, source, sentiment)
                VALUES (:ticker, :date, :title, :url, :source, :sentiment)""",
             records,
         )
-        return len(records)
+        return cur.rowcount
 
 
 def upsert_macro_events(records: list[dict], db_path: Optional[Path] = None) -> int:

--- a/tests/core/test_db.py
+++ b/tests/core/test_db.py
@@ -325,3 +325,58 @@ class TestDbMaintenance:
         monkeypatch.setattr(db_mod, "DB_PATH", db_path)
         from nuri.scheduler import _run_db_maintenance
         _run_db_maintenance()  # 빈 DB에서도 에러 없이 실행
+
+
+class TestUpsertNewsDedupCount:
+    """#351 regression lock-in — upsert_news 가 실제 신규 삽입 수 반환.
+
+    이전 구현은 `len(records)` 를 반환하여 URL UNIQUE 로 IGNORE 된 row 도 카운트 포함
+    → 로그 "뉴스 N 건 수집" 과 DB 실제 상태 불일치 (§2.4 Observability 위배).
+    `cursor.rowcount` 는 INSERT OR IGNORE 에서 실제 inserted rows 만 반환.
+    """
+
+    def _make_record(self, url: str, title: str = "t") -> dict:
+        return {
+            "ticker": "AAPL",
+            "date": "2026-04-17",
+            "title": title,
+            "url": url,
+            "source": "test",
+            "sentiment": None,
+        }
+
+    def test_returns_actual_insert_count_on_url_dedup(self, db_path):
+        """중복 URL 포함 input → 반환값이 dedup 후 실제 insert 건수."""
+        from nuri.core.db import upsert_news
+
+        records = [
+            self._make_record("http://ex.com/1", "t1"),
+            self._make_record("http://ex.com/1", "t2"),  # dup URL (IGNORED)
+            self._make_record("http://ex.com/2", "t3"),
+        ]
+        ret = upsert_news(records, db_path=db_path)
+        actual = query("SELECT COUNT(*) AS c FROM news", db_path=db_path)[0]["c"]
+
+        assert ret == 2, f"expected actual insert count (2), got {ret}"
+        assert ret == actual, "return value must equal DB row count (§2.4)"
+
+    def test_second_call_with_same_urls_returns_zero(self, db_path):
+        """동일 URL 재전송 → 전부 IGNORE → 반환 0 (이전엔 len(records) 반환 버그)."""
+        from nuri.core.db import upsert_news
+
+        r1 = [self._make_record("http://ex.com/A", "first")]
+        assert upsert_news(r1, db_path=db_path) == 1
+
+        # 같은 URL 다시 전송
+        r2 = [self._make_record("http://ex.com/A", "second"), self._make_record("http://ex.com/B", "new")]
+        ret = upsert_news(r2, db_path=db_path)
+        assert ret == 1, f"only /B is new, expected 1, got {ret}"
+        # DB 에 총 2 건 (A 는 first 그대로, B 신규)
+        actual = query("SELECT COUNT(*) AS c FROM news", db_path=db_path)[0]["c"]
+        assert actual == 2
+
+    def test_empty_returns_zero(self, db_path):
+        """빈 input → 0 (기존 동작 유지 — len([]) == cursor.rowcount == 0)."""
+        from nuri.core.db import upsert_news
+
+        assert upsert_news([], db_path=db_path) == 0


### PR DESCRIPTION
## Summary

- `upsert_news()` returns `cursor.rowcount` instead of `len(records)` — matches DB truth after URL UNIQUE dedup.
- Scope guard: `_upsert_etf_flows` **not** touched (verified non-buggy under INSERT OR REPLACE semantics).
- 3 regression tests + inline reasoning.

## Live reproduction (pre-fix)

```
input: 3 records (2 unique URLs) | upsert_news returned: 3 | actual DB rows: 2
```

Log says "뉴스 3건 수집", DB has 2. STRATEGY §2.4 violation.

## Fix behavior

`INSERT OR IGNORE` + `executemany` → `cursor.rowcount` reports only actually-inserted rows (IGNORED rows excluded). Verified:
```
IGNORE: input=4, rowcount=3, actual=3  (1 dup URL excluded)
```

## Scope guard — `_upsert_etf_flows` excluded

Initially suspected as sibling of this bug. Verified **not** buggy under real usage:
- Uses `INSERT OR REPLACE` with PK (ticker, date)
- Normal input = one record per ETF per day → no internal dups
- `cursor.rowcount` counts insert AND replace operations → if caller resends same-day data, rowcount reflects "rows touched" (semantically accurate)
- Fix would only matter for pathological inputs with internal (ticker, date) dups in one call — unsupported use case

## Test plan

- [x] `.venv/bin/python -m pytest tests/core/test_db.py tests/analysis/test_sentiment.py tests/collectors/test_news.py` — 64 passed
- [x] `.venv/bin/python -m ruff check nuri/core/db.py tests/core/test_db.py` — clean
- [x] Live reproduce of bug + post-fix verification

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)