### PR TITLE
fix(scripts): pass shellcheck (follow-up to #355)

### DIFF
--- a/scripts/sync_doc_counts.sh
+++ b/scripts/sync_doc_counts.sh
@@ -5,6 +5,10 @@
 # Covers: collectors, endpoints, backend/frontend test files, e2e specs, pytest count.
 # Pair: scripts/verify_doc_counts.sh (read-only CI gate).
 # ═══════════════════════════════════════════════════════
+# All live_* functions are dispatched indirectly via $("$live_fn") in
+# update_claim — shellcheck 0.10 cannot trace dynamic dispatch, so disable
+# the false-positive "never invoked / unreachable" warnings file-wide.
+# shellcheck disable=SC2317,SC2329
 set -euo pipefail
 
 # shellcheck source=scripts/_common.sh
@@ -32,11 +36,11 @@ live_endpoints()    { grep -rhE '@router\.(get|post|put|delete|patch)' \
 
 live_test_files_be() { find tests -name "test_*.py" -type f | wc -l | tr -d ' '; }
 
-live_test_files_fe() { find frontend -name "*.test.ts" -o -name "*.test.tsx" 2>/dev/null \
-    | grep -v node_modules | wc -l | tr -d ' '; }
+live_test_files_fe() { find frontend \( -name "*.test.ts" -o -name "*.test.tsx" \) \
+    ! -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' '; }
 
-live_e2e_specs()    { find frontend/e2e -name "*.spec.ts" 2>/dev/null \
-    | grep -v node_modules | wc -l | tr -d ' '; }
+live_e2e_specs()    { find frontend/e2e -name "*.spec.ts" \
+    ! -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' '; }
 
 live_tests_be() {
     $PYTHON -m pytest tests/ --collect-only -q 2>/dev/null \

--- a/scripts/verify_doc_counts.sh
+++ b/scripts/verify_doc_counts.sh
@@ -14,20 +14,16 @@ source "$(dirname "$0")/_common.sh"
 live_collectors()   { find nuri/collectors -maxdepth 1 -name "*.py" \
     ! -name "__init__.py" ! -name "base.py" -type f | wc -l | tr -d ' '; }
 
-live_agents()       { find nuri/trading/agents -maxdepth 1 -name "*.py" \
-    ! -name "__init__.py" ! -name "base.py" \
-    ! -name "consensus.py" ! -name "learning_memory.py" -type f | wc -l | tr -d ' '; }
-
 live_endpoints()    { grep -rhE '@router\.(get|post|put|delete|patch)' \
     nuri/api/routes/ | wc -l | tr -d ' '; }
 
 live_test_files_be() { find tests -name "test_*.py" -type f | wc -l | tr -d ' '; }
 
-live_test_files_fe() { find frontend -name "*.test.ts" -o -name "*.test.tsx" 2>/dev/null \
-    | grep -v node_modules | wc -l | tr -d ' '; }
+live_test_files_fe() { find frontend \( -name "*.test.ts" -o -name "*.test.tsx" \) \
+    ! -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' '; }
 
-live_e2e_specs()    { find frontend/e2e -name "*.spec.ts" 2>/dev/null \
-    | grep -v node_modules | wc -l | tr -d ' '; }
+live_e2e_specs()    { find frontend/e2e -name "*.spec.ts" \
+    ! -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' '; }
 
 # Extract the target integer from a file.
 # Strategy: match the claim's context substring (must be unique in the file),
@@ -62,7 +58,6 @@ check_claim() {
 banner "Doc Count Verify"
 
 COLL=$(live_collectors)
-AGT=$(live_agents)
 EP=$(live_endpoints)
 TFBE=$(live_test_files_be)
 TFFE=$(live_test_files_fe)


### PR DESCRIPTION
## Why

PR #355 merged with a red Shell Lint check — I pasted `gh pr checks 355 | tail -20` during Review and the truncated output didn't include Shell Lint, so I claimed "all green" incorrectly. This PR cleans the outstanding shellcheck warnings so the CI light goes back to green on main.

## Changes

- **SC2317/SC2329** — `live_*` functions in `sync_doc_counts.sh` are dispatched via `$("$live_fn")` (dynamic), which shellcheck 0.10 cannot trace. File-level `# shellcheck disable=SC2317,SC2329` right after the shebang (inline directive only applies to the next command, so file-scope was required).
- **SC2126** — `find ... | grep -v node_modules | wc -l` → `find ... ! -path '*/node_modules/*'`. One fewer pipe, same semantics. Both scripts.
- **SC2034** — Removed unused `AGT=$(live_agents)` from `verify_doc_counts.sh`. It was pre-emptive for a future agent-count verify pattern; per STRATEGY §5.4 "요청받지 않은 개선 금지" I should not have added it. Can come back with a concrete pattern.

## Test plan

- [x] `shellcheck --source-path=SCRIPTDIR --external-sources scripts/*.sh` → exit 0
- [x] `bash scripts/sync_doc_counts.sh` → exit 0, no doc diff (counts preserved: collectors 25, endpoints 65, tests 2,993, fe files 60, e2e 6)
- [x] `bash scripts/verify_doc_counts.sh` → 11/11 pass
- [x] Live `live_test_files_fe` returns 60 and `live_e2e_specs` returns 6 under the new `! -path` form

## Reflection (for future sessions)

`| tail -20` on `gh pr checks` is unsafe when the PR has >20 checks. Switch to `--watch` or `--json statusCheckRollup -q '.statusCheckRollup[] | select(.conclusion=="FAILURE")'` for fail-only filtering. I am noting this in user memory as a process correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)