### PR TITLE
chore(pre-push): mirror Shell Lint + Doc Count Drift Check locally

### DIFF
--- a/scripts/pre_push_check.sh
+++ b/scripts/pre_push_check.sh
@@ -44,6 +44,38 @@ else
     fail=1
 fi
 
+# ─── 2b. Shell Lint (shellcheck) ─────────────────────────────────
+# Local mirror of CI's `shell-lint` job. Added after PR #355 merged with a
+# red Shell Lint check because I did not run shellcheck locally — this
+# section prevents that class of recurrence (see memory
+# feedback_ci_check_reading.md).
+if command -v shellcheck > /dev/null 2>&1; then
+    echo -e "${YELLOW}━━━ 2b. Shell Lint (shellcheck) ━━━${NC}"
+    if shellcheck --source-path=SCRIPTDIR --external-sources scripts/*.sh; then
+        echo -e "${GREEN}✓ Shell lint clean${NC}\n"
+    else
+        echo -e "${RED}✗ Shellcheck failed — mirrors CI job 'Shell Lint'${NC}\n"
+        fail=1
+    fi
+else
+    echo -e "${YELLOW}━━━ 2b. Shell Lint ━━━${NC}"
+    echo -e "${YELLOW}⚠ shellcheck not installed — \`brew install shellcheck\`. CI will enforce.${NC}\n"
+fi
+
+# ─── 2c. Doc count drift ─────────────────────────────────
+# Local mirror of CI's `doc-counts-verify` job. Catches drift between docs and
+# live code (collectors/endpoints/test files/e2e specs) before push. Fast
+# (<1s, find + grep only).
+echo -e "${YELLOW}━━━ 2c. Doc Count Drift ━━━${NC}"
+if bash scripts/verify_doc_counts.sh > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Doc counts match live code${NC}\n"
+else
+    echo -e "${RED}✗ Doc drift detected — run \`make sync-doc-counts\` then amend commit${NC}"
+    bash scripts/verify_doc_counts.sh 2>&1 | grep -E "✗|DRIFT" | head -5
+    echo ""
+    fail=1
+fi
+
 # ─── 3. Tests (skipped in --skip-tests) ─────────────────────────────────
 if [ "$mode" != "--skip-tests" ]; then
     echo -e "${YELLOW}━━━ 3. Tests (CI parity) ━━━${NC}"


### PR DESCRIPTION
## Why

Follow-up to #355 / #356. Recurrence prevention (Layer A of the "C" plan the user approved — Layer B is the branch-protection promotion applied separately via `gh api`).

PR #355 merged with a red Shell Lint check because I did not run shellcheck locally. This PR adds a local fast-feedback mirror of the two CI jobs that landed in #355 so the same class of miss cannot recur.

## Changes

- **Section 2b — Shell Lint**: runs `shellcheck --source-path=SCRIPTDIR --external-sources scripts/*.sh` (identical to CI). Graceful skip with install hint when shellcheck is absent.
- **Section 2c — Doc Count Drift**: runs `bash scripts/verify_doc_counts.sh`. <1s, find + grep only. Points to `make sync-doc-counts` on failure.

## Test plan

- [x] `bash -n scripts/pre_push_check.sh` — syntax OK
- [x] `shellcheck scripts/pre_push_check.sh` — clean
- [x] `bash scripts/pre_push_check.sh --quick` — sections 2b and 2c both pass on current branch
- [x] Memory: feedback_ci_check_reading.md cross-linked

## Known orthogonal issue

`scripts/pre_push_check.sh` Section 3 (`ci_local.sh --quick`) fails with `tests/test_db.py` not found — the file was moved to `tests/core/test_db.py` at some point. Pre-existing, not caused by this PR; filing as a separate issue. Section 3 failing does not mask sections 2b/2c (the script collects all failures and reports at the end).

## Pairs with

- Branch protection: `Shell Lint` and `Doc Count Drift Check` will be promoted to `required_status_checks` via `gh api` immediately after this PR merges. That's the hard-veto layer (user can always skip pre-push locally with `--no-verify`; cannot skip the required check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)