### PR TITLE
fix(scripts): ci_local.sh --quick paths match current test tree

### DIFF
--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -32,8 +32,10 @@ case "$mode" in
         # Smoke test — collect only + critical paths
         echo -e "${YELLOW}Running: pytest --collect-only${NC}"
         $PYTHON -m pytest tests/ --collect-only -q 2>&1 | tail -3
-        echo -e "${YELLOW}Running: pytest tests/test_db.py tests/test_trading_engine_all.py::TestGate -q${NC}"
-        $PYTHON -m pytest tests/test_db.py tests/test_trading_engine_all.py::TestGate -q --tb=line
+        # Paths reflect current test tree — DB tests moved to tests/core/,
+        # trading engine tests split by subject (gate.py / conflicts.py / etc).
+        echo -e "${YELLOW}Running: pytest tests/core/test_db.py tests/trading/engine/test_gate.py -q${NC}"
+        $PYTHON -m pytest tests/core/test_db.py tests/trading/engine/test_gate.py -q --tb=line
         echo -e "${GREEN}✓ Quick smoke OK${NC}"
         ;;
 


### PR DESCRIPTION
## Why

`scripts/pre_push_check.sh` Section 3 (`bash scripts/ci_local.sh --quick`) has been silently failing because the smoke paths reference files that moved during the pytest reorganization:

| Old path | New path |
|---|---|
| `tests/test_db.py` | `tests/core/test_db.py` |
| `tests/test_trading_engine_all.py::TestGate` | `tests/trading/engine/test_gate.py` |

Surfaced while adding Section 2b/2c in #357 (pre-push mirrors of new CI gates).

## Fix

One-line path update in `scripts/ci_local.sh` `--quick` mode. No test changes.

## Test

```
$ bash scripts/ci_local.sh --quick
collected 41 items
tests/core/test_db.py ............................       [ 68%]
tests/trading/engine/test_gate.py .............          [100%]
41 passed in 0.53s

$ bash scripts/pre_push_check.sh --quick
━━━ 3. Tests (CI parity) ━━━
✓ Quick smoke OK
✓ Smoke tests pass
...
✓ ALL CHECKS PASSED — safe to push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)