### PR TITLE
docs: fix test-path drift in specs + move P2 #8 to completed

### DIFF
--- a/docs/SPEC_universe_agent_coverage.md
+++ b/docs/SPEC_universe_agent_coverage.md
@@ -151,9 +151,9 @@ python scripts/validate_universe.py --no-fetch  # cached comparison only
 ### 3.4 Phase 3 — Tests
 
 **파일**:
-- `tests/test_universe_sync.py` — Wikipedia/KRX fetch mock + diff 정확성
-- `tests/test_validate_universe.py` — coverage threshold 검증
-- `tests/test_collector_universe_mode.py` — `_get_tickers(source='universe')` 동작
+- `tests/collectors/test_universe_sync.py` — Wikipedia/KRX fetch mock + diff 정확성
+- `tests/scripts/test_validate_universe.py` — coverage threshold 검증
+- `tests/collectors/test_base_universe_mode.py` — `_get_tickers(source='universe')` 동작
 
 **Coverage targets**: 신규 모듈 ≥ 90%
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -247,7 +247,7 @@ PR을 올리기 전 이 기준을 확인한다.
 2. `scripts/pre_push_check.sh` Section 4 — local pre-push gate. 로컬에서 실수 자동 차단.
 3. `.github/workflows/main-ci-cd.yml` `privacy-scan` job — CI gate, 모든 PR에서 항상 실행 (frontend-only PR도 예외 없음). 머지 차단.
 
-**새 broker name 추가 시**: `scripts/check_privacy_leak.py`의 `BROKER_NAMES_KO` / `BROKER_NAMES_EN` 튜플에 추가. 테스트는 `tests/test_check_privacy_leak.py`. 이 표도 같이 갱신.
+**새 broker name 추가 시**: `scripts/check_privacy_leak.py`의 `BROKER_NAMES_KO` / `BROKER_NAMES_EN` 튜플에 추가. 테스트는 `tests/scripts/test_check_privacy_leak.py`. 이 표도 같이 갱신.
 
 **Commit message 스캔 작동 방식 (PR #202 방지)**:
 - `scripts/pre_push_check.sh` Section 4b: `origin/main..HEAD` 범위의 모든 unpushed commit message를 `--unpushed-commits` 모드로 스캔 → push 차단

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -31,6 +31,7 @@
 | 15 | **B1 — recommendations UNIQUE + UPSERT** | — | #311 | `UNIQUE(date, ticker, action)` → `UNIQUE(date, ticker)`. Migration 20 (MAX(id) dedup). `INSERT OR REPLACE` → `ON CONFLICT DO UPDATE` (id 보존 — `trades.recommendation_id` FK 안전). 프로덕션 20 중복 그룹 정리. |
 | 16 | **#248 SIEGE v2 Phase 1 — asset-class gates** | [#248](https://github.com/researcherhojin/nuri-quant/issues/248) | #312 | Gate 5/7/8 per-asset-class (us/kr_equity/kr_index/commodity/bond). Cross-market spillover (KOSPI+SPY, USD/KRW+VIX). `config/rules.yaml siege_gates` spec. Codex challenge (3 결함 지적) → 재설계 → APPROVED. |
 | 17 | **#89 인터랙티브 백테스트 sliders + live equity curve** | [#89](https://github.com/researcherhojin/nuri-quant/issues/89) | #332 | `run_interactive_backtest()` — regime change arm, stop/tp threshold hit 시 disarm. `/swing/backtest/equity` 가 `sma`/`period`/`sl`/`tp` 쿼리 수락 + 5분 TTL cache. UI 4-param sliders + URL deep-link (`/strategy?sma=100&lb=3Y&sl=-10&tp=30`) + static/interactive toggle. Tier 2 P1 #7 완료. |
+| 18 | **wallstreet collect 성능 검증** | — | #285 | `make collect-universe` 에서 wallstreet 50min → 15min 41초 실측 확인 (universe 746). Tier 2 P2 #8 완료. |
 
 ## Tier 2 — 다음 1 달 (P1)
 
@@ -45,7 +46,6 @@
 | 🟢 P2 | 5 | **포트폴리오 온보딩 UI (YAML → Dashboard)** | [#25](https://github.com/researcherhojin/nuri-quant/issues/25) | feat(frontend) | 2-3 세션 | 수동 yaml 편집 제거. 2026-04-14 portfolio.yaml 수동 수정 페인포인트 직접 경험 |
 | 🟢 P2 | 6 | **OpenBB 호환성 fix** | [#274](https://github.com/researcherhojin/nuri-quant/issues/274) | bug(collectors) | 1 세션 | openbb-core==1.6.7 ↔ openbb-news==1.6.1 충돌로 news/etf_flows 수집 불가. 점진적 upgrade 필요 (콜렉터별 smoke test 후 진행) |
 | 🟢 P2 | 7 | **#272 Phase 2c-3 — universe-check 필수 게이트화** | — | ops | 10분 | `make collect-universe` 5/5 PASS 상태 유지 중 → 사용자 수동으로 branch protection required check 토글 |
-| 🟢 P2 | 8 | **wallstreet collect 성능 검증** | — | perf(collectors) | 15분 | PR #285 parallel fetch 실제 50min → 15min 41초 (universe 746) 확인 완료 — **close 후보** |
 | ⚪ P3 | 9 | **flaky test 일반 stabilization** | — | test | 1 세션 | #295는 resolved. 다른 flaky 후보 (parallel sys.modules 오염 패턴) 전수 감사 |
 
 ## Tier 3 — 다음 분기 (P2)


### PR DESCRIPTION
## Summary

Two small docs cleanups, bundled because they're both `docs/*` with no code impact.

### 1. Test-path drift in specs (4 refs)

An Explore agent audited every test-path reference in scripts, Makefile, CI workflows, and docs after PR #358 surfaced the pattern in `scripts/ci_local.sh --quick`. Found **4 more stale refs, all in docs** (live-verified that target paths exist):

| File:line | Old | New |
|---|---|---|
| `docs/STRATEGY.md:250` | `tests/test_check_privacy_leak.py` | `tests/scripts/test_check_privacy_leak.py` |
| `docs/SPEC_universe_agent_coverage.md:154` | `tests/test_universe_sync.py` | `tests/collectors/test_universe_sync.py` |
| `docs/SPEC_universe_agent_coverage.md:155` | `tests/test_validate_universe.py` | `tests/scripts/test_validate_universe.py` |
| `docs/SPEC_universe_agent_coverage.md:156` | `tests/test_collector_universe_mode.py` | `tests/collectors/test_base_universe_mode.py` |

Purely narrative drift — no CI job was affected. Scripts, Makefile, CI workflows, and `scripts/check_privacy_leak.py` all reference correct paths or use robust generic patterns (`pytest tests/`).

### 2. Tier 2 P2 #8 → Tier 1

`wallstreet collect 성능 검증` (PR #285 verified 50min → 15min 41초 on universe 746) moved from backlog to completed row 18.

## Follow-ups deferred (not in this PR)

- **Scheduler stale-code issue** — During live-verification (§2.1-bis from NEXT_SESSION.md), I found the `factors` table had `quality_score = value_score = 0.5` constants for today's 2026-04-17 row despite PR #350 being merged yesterday. Root cause: Mac mini scheduler daemon loaded Python imports at process start (pre-PR #350), so even though `make deploy-mini` autopull landed the new code on disk, the running process holds stale imports. **Local MBP DB recomputed inline (nunique now 11/12 as expected). Mac mini needs `make scheduler-reload-remote` out of band — that is a deploy action, not a code change, so it doesn't belong in this PR.**
- **Prevention: Registry YAML + dynamic discovery** — Agent's Part B recommends a `tests/REGISTRY.yaml` single source of truth + `scripts/load_registry.py` helper so `scripts/ci_local.sh --quick` queries the registry at runtime instead of hardcoding paths. ~50 LoC. Skipped to keep this PR docs-only; can be a follow-up chore PR.

## Test

- `make verify-doc-counts` — still 11/11 pass (no numeric count touched)
- `make test-fast` — unchanged, no code touched
- Manual grep: all 4 updated paths exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)