### PR TITLE
fix(consensus): Learning Memory read path + write-boundary (Phase 2 A-1a)

### DIFF
--- a/nuri/trading/agents/consensus.py
+++ b/nuri/trading/agents/consensus.py
@@ -439,6 +439,11 @@ def save_to_recommendations(results: list[ConsensusResult], db_path=None) -> int
     today = today_kst()
     records = []
     for r in results:
+        # HOLD 는 Learning Memory 에 signal 없음 — outcome 이 "action 정확" 측정 불가.
+        # BUY/SELL 만 persist 해 가중치 학습 신호 품질 유지 (codex A-1 review).
+        if r.final_action not in ("BUY", "SELL"):
+            continue
+
         # 현재가 조회
         price_row = query(
             "SELECT close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",

--- a/nuri/trading/agents/consensus.py
+++ b/nuri/trading/agents/consensus.py
@@ -80,9 +80,9 @@ class ConsensusResult:
 def _compute_weights(db_path=None) -> dict[str, float]:
     """Learning Memory + recommendations 기반 동적 가중치 계산.
 
-    recommendations 테이블에서 에이전트별 적중률을 추적하여 가중치를 보정한다.
-    30일 이상 경과한 추천 중 outcome_30d가 있는 건으로 계산.
-    데이터 부족 시(< 10건) DEFAULT_WEIGHTS 반환.
+    recommendations.agent_verdicts (JSON list of verdict dicts) 를 primary source
+    로 읽어 에이전트별 적중률을 계산. 30일 이상 경과한 추천 중 outcome_30d 가
+    있는 건만 대상. 데이터 부족 시 (< min_records) DEFAULT_WEIGHTS 반환.
 
     TODO(#178): decisions 테이블 기반 compute_agent_accuracy()가 30건 이상
     완료되면, recommendations 대신 decisions 테이블을 primary source로 전환.
@@ -98,8 +98,10 @@ def _compute_weights(db_path=None) -> dict[str, float]:
 
     rows = query(
         """
-        SELECT signals, outcome_30d FROM recommendations
+        SELECT agent_verdicts, outcome_30d FROM recommendations
         WHERE outcome_30d IS NOT NULL
+          AND agent_verdicts IS NOT NULL
+          AND agent_verdicts != ''
           AND date >= date('now', ? || ' days')
         """,
         (f"-{lookback}",),
@@ -109,38 +111,51 @@ def _compute_weights(db_path=None) -> dict[str, float]:
     if len(rows) < min_records:
         return dict(DEFAULT_WEIGHTS)
 
-    # 에이전트별 적중률 계산
-    # signals 필드에 에이전트 verdict가 JSON으로 저장되어 있으면 파싱
     import json
 
     agent_hits: dict[str, list[bool]] = {name: [] for name in DEFAULT_WEIGHTS}
+    # Observability counters — silent fallback 방지 (codex A-1 review).
+    # 모든 row 가 skip 되면 min_records 문턱을 넘어도 가중치 변화 없이
+    # DEFAULT_WEIGHTS 로 귀결되는 silent failure. 카운터로 drill-down 가능.
+    rows_seen = len(rows)
+    rows_parsed = 0
+    rows_skipped_schema = 0
+    rows_skipped_json = 0
 
     for row in rows:
         try:
-            signals_str = row["signals"]
-            if not signals_str:
-                continue
-            # signals 필드가 에이전트 verdict JSON이 아닌 경우 스킵
-            data = json.loads(signals_str) if isinstance(signals_str, str) else None
-            if not isinstance(data, dict) or "verdicts" not in data:
+            verdicts_str = row["agent_verdicts"]
+            verdicts = json.loads(verdicts_str) if isinstance(verdicts_str, str) else None
+            if not isinstance(verdicts, list):
+                rows_skipped_schema += 1
                 continue
 
             # WHERE outcome_30d IS NOT NULL guards the read; `or 0` is defensive only.
             outcome = row["outcome_30d"] or 0
             is_positive = outcome > 0
+            rows_parsed += 1
 
-            for v in data["verdicts"]:
+            for v in verdicts:
+                if not isinstance(v, dict):
+                    continue
                 agent_name = v.get("agent_name", "")
                 action = v.get("action", "HOLD")
                 if agent_name in agent_hits:
-                    # BUY가 양수 수익이면 적중, SELL이 음수 수익이면 적중
+                    # BUY가 양수 수익이면 적중, SELL이 음수 수익이면 적중.
+                    # outcome_30d == 0 bias 는 의도적 pin (test_hit_rate_outcome_zero_is_buy_miss_sell_hit).
                     if action == "BUY":
                         agent_hits[agent_name].append(is_positive)
                     elif action == "SELL":
                         agent_hits[agent_name].append(not is_positive)
                     # HOLD는 적중 판정 제외
         except (json.JSONDecodeError, TypeError, KeyError):
+            rows_skipped_json += 1
             continue
+
+    logger.info(
+        "_compute_weights: rows_seen=%d rows_parsed=%d rows_skipped_schema=%d rows_skipped_json=%d",
+        rows_seen, rows_parsed, rows_skipped_schema, rows_skipped_json,
+    )
 
     # 적중률 기반 가중치 계산
     min_agent_records = _lm.get("min_agent_records", 5)

--- a/nuri/trading/agents/consensus.py
+++ b/nuri/trading/agents/consensus.py
@@ -108,9 +108,6 @@ def _compute_weights(db_path=None) -> dict[str, float]:
         db_path=db_path,
     )
 
-    if len(rows) < min_records:
-        return dict(DEFAULT_WEIGHTS)
-
     import json
 
     agent_hits: dict[str, list[bool]] = {name: [] for name in DEFAULT_WEIGHTS}
@@ -143,19 +140,39 @@ def _compute_weights(db_path=None) -> dict[str, float]:
                 if agent_name in agent_hits:
                     # BUY가 양수 수익이면 적중, SELL이 음수 수익이면 적중.
                     # outcome_30d == 0 bias 는 의도적 pin (test_hit_rate_outcome_zero_is_buy_miss_sell_hit).
+                    # HOLD agent verdict 는 hit 판정 제외 (분기 없음 → 자동 skip).
                     if action == "BUY":
                         agent_hits[agent_name].append(is_positive)
                     elif action == "SELL":
                         agent_hits[agent_name].append(not is_positive)
-                    # HOLD는 적중 판정 제외
         except (json.JSONDecodeError, TypeError, KeyError):
             rows_skipped_json += 1
             continue
 
-    logger.info(
-        "_compute_weights: rows_seen=%d rows_parsed=%d rows_skipped_schema=%d rows_skipped_json=%d",
-        rows_seen, rows_parsed, rows_skipped_schema, rows_skipped_json,
-    )
+    # min_records gate — parsed count 기반 (codex A-1 P1-2).
+    # 이전: len(rows) < min_records 로 raw SQL 수 검증 → malformed row 가 gate 통과 후
+    # 실제 학습 샘플이 문턱 미달로 가중치 shift. parsed 수로 gate 해야 샘플 신뢰성 보장.
+    if rows_parsed < min_records:
+        # fallback 발생 시 명시적 WARNING — normal path (early return) 과 구분.
+        if rows_seen > 0:
+            logger.warning(
+                "_compute_weights fallback to DEFAULT_WEIGHTS: rows_seen=%d rows_parsed=%d (< min_records=%d) skipped_schema=%d skipped_json=%d",
+                rows_seen, rows_parsed, min_records, rows_skipped_schema, rows_skipped_json,
+            )
+        return dict(DEFAULT_WEIGHTS)
+
+    # Normal path — DEBUG 레벨 (per-ticker 호출 hot path spam 방지).
+    # Anomaly (skip 발생) 시 INFO 로 올려 operator 눈에 띄게.
+    if rows_skipped_schema > 0 or rows_skipped_json > 0:
+        logger.info(
+            "_compute_weights anomaly: rows_seen=%d rows_parsed=%d rows_skipped_schema=%d rows_skipped_json=%d",
+            rows_seen, rows_parsed, rows_skipped_schema, rows_skipped_json,
+        )
+    else:
+        logger.debug(
+            "_compute_weights: rows_seen=%d rows_parsed=%d",
+            rows_seen, rows_parsed,
+        )
 
     # 적중률 기반 가중치 계산
     min_agent_records = _lm.get("min_agent_records", 5)
@@ -439,11 +456,10 @@ def save_to_recommendations(results: list[ConsensusResult], db_path=None) -> int
     today = today_kst()
     records = []
     for r in results:
-        # HOLD 는 Learning Memory 에 signal 없음 — outcome 이 "action 정확" 측정 불가.
-        # BUY/SELL 만 persist 해 가중치 학습 신호 품질 유지 (codex A-1 review).
-        if r.final_action not in ("BUY", "SELL"):
-            continue
-
+        # 모든 final_action (BUY/SELL/HOLD) persist — same-day 재실행 시 UPSERT 로 stale
+        # row 방지 (codex A-1 review P1-1). Learning Memory 는 개별 agent verdict 의
+        # action 으로 hit 판정하므로 rec.final_action=HOLD 라도 verdicts 배열 내 BUY/SELL
+        # 은 학습 대상. _compute_weights 의 action 분기가 HOLD 를 자동 skip.
         # 현재가 조회
         price_row = query(
             "SELECT close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",

--- a/nuri/trading/recommend/tracker.py
+++ b/nuri/trading/recommend/tracker.py
@@ -47,14 +47,19 @@ def save_recommendations(candidates=None, actions=None, verdicts=None, db_path=N
         db_path: DB 경로 (테스트용)
     """
     from nuri.core.timezone import today_kst
+    from nuri.trading.recommend.candidates import TIER_ACTIONABLE
 
     today = today_kst()
     records = []
 
-    # E-1 후보에서 regime_fit인 것만
+    # E-1 후보에서 regime_fit + actionable tier 인 것만.
+    # CLI 경로 (__main__) 는 이미 actionable 필터 후 호출하지만 다른 caller (테스트/
+    # 내부 script) 가 advisory/avoid 를 섞어 persist 하는 것을 방어 (codex A-1 review).
     if candidates:
         for c in candidates:
             if not c.regime_fit:
+                continue
+            if getattr(c, "tier", TIER_ACTIONABLE) != TIER_ACTIONABLE:
                 continue
             rec = {
                 "date": today,

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -1572,7 +1572,10 @@ class TestSaveToRecommendations:
         - save_to_recommendations 가 `INSERT OR REPLACE` → `ON CONFLICT DO UPDATE` 로 전환.
 
         Revert 시 이 테스트 fail: (date, ticker, action) 키였을 때 두 호출이 각각 다른
-        action 이면 2 행 생성. 이제는 1 행 + action=HOLD 로 update, id 동일.
+        action 이면 2 행 생성. 이제는 1 행 + action=SELL 로 update, id 동일.
+
+        Note (A-1a): BUY→HOLD 대신 BUY→SELL 로 전이. save_to_recommendations 이
+        HOLD 를 Learning Memory 노이즈 방지 위해 제외하도록 변경됨.
         """
         from nuri.core.db import query
         from nuri.trading.agents.consensus import save_to_recommendations
@@ -1580,11 +1583,11 @@ class TestSaveToRecommendations:
         save_to_recommendations([self._result(action="BUY", conf=70)], db_path=db_path)
         first_id = query("SELECT id FROM recommendations WHERE ticker='TEST'", db_path=db_path)[0]["id"]
 
-        save_to_recommendations([self._result(action="HOLD", conf=50)], db_path=db_path)
+        save_to_recommendations([self._result(action="SELL", conf=50)], db_path=db_path)
         rows = query("SELECT * FROM recommendations WHERE ticker='TEST' ORDER BY id", db_path=db_path)
 
         assert len(rows) == 1, "UPSERT 작동 — (date, ticker) 하나당 1 행만 유지"
-        assert rows[0]["action"] == "HOLD"
+        assert rows[0]["action"] == "SELL"
         assert rows[0]["confidence"] == 50.0
         assert rows[0]["id"] == first_id, "ON CONFLICT DO UPDATE 는 id 보존 — FK 안전"
 

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -1593,13 +1593,21 @@ class TestSaveToRecommendations:
 
 
 class TestComputeWeightsHitRates:
-    """`_compute_weights` hit_rates 적중률 경로 — lines 138-142 (BUY/SELL hit 분기)."""
+    """`_compute_weights` hit_rates 적중률 경로 — A-1a 이후 agent_verdicts 컬럼 기반.
+
+    이전 schema (`signals={verdicts:[...]}` dict) → `agent_verdicts` 컬럼 + list shape.
+    Read path 가 save path (tracker.py:70, consensus.py:450) 와 일치하도록 수정됨.
+    """
 
     def _seed_recommendations(self, db_path, n_records=15, outcome_sign=1):
-        """recommendations 테이블에 N 건의 verdict JSON 삽입. outcome_sign 으로 적중/오답 제어.
+        """recommendations 테이블에 N 건의 agent_verdicts JSON 삽입.
 
         outcome_sign=1 → 모두 양수 outcome (BUY 적중, SELL 오답).
         outcome_sign=-1 → 모두 음수 outcome (BUY 오답, SELL 적중).
+
+        Note: `agent_verdicts` 컬럼에 list-of-dict shape 으로 저장 — live prod schema
+        와 일치. 이전 버전은 `signals={verdicts:[...]}` dict-wrapped 였으나 read
+        path 가 읽지 못했음 (A-1a silent fallback 버그).
         """
         import json
 
@@ -1615,16 +1623,18 @@ class TestComputeWeightsHitRates:
                 ]
                 conn.execute(
                     """INSERT INTO recommendations
-                       (date, ticker, action, confidence, regime, signals, entry_price, outcome_30d)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         today_kst(),
                         f"T{i}",
                         "BUY",
                         50.0,
                         None,
-                        json.dumps({"verdicts": verdicts}),
+                        None,
                         100.0,
+                        json.dumps(verdicts),
                         0.05 * outcome_sign,
                     ),
                 )
@@ -1632,9 +1642,9 @@ class TestComputeWeightsHitRates:
     def test_hit_rate_outcome_sign_positive(self, db_path):
         """Positive outcome 15건 → technical(BUY) 가중치 ↑, fundamental(SELL) ↓.
 
-        STRATEGY §5.3.1 Gotcha-Test Pair: `consensus.py::_compute_weights` 의
-        SELECT 에 `outcome_30d` 포함 + `row["outcome_30d"]` 직접 읽기를 잠근다.
-        fix 되돌리면 (SELECT 축소 또는 `row.get()` 복구) 이 테스트 fail.
+        STRATEGY §5.3.1 Gotcha-Test Pair: A-1a 이후 read path 는 `agent_verdicts`
+        컬럼 + list shape. revert 시 (SELECT signals → SELECT agent_verdicts 되돌림
+        또는 list → dict 재변경) 이 테스트 fail.
         """
         from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
 
@@ -1673,7 +1683,7 @@ class TestComputeWeightsHitRates:
 
         이 비대칭은 arguable design: SELL 이 "loss avoidance" 의미라면 flat 은 회피 성공이
         아님. 하지만 현 구현을 의도적이라 가정하고 regression 으로 잠근다. 바꾸려면 별도
-        STRATEGY 개정 + 백테스트 필요 (scope 분리).
+        STRATEGY 개정 + 백테스트 필요 (scope 분리 — A-1b 후보).
         """
         import json
 
@@ -1689,18 +1699,11 @@ class TestComputeWeightsHitRates:
                 ]
                 conn.execute(
                     """INSERT INTO recommendations
-                       (date, ticker, action, confidence, regime, signals, entry_price, outcome_30d)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        today_kst(),
-                        f"Z{i}",
-                        "BUY",
-                        50.0,
-                        None,
-                        json.dumps({"verdicts": verdicts}),
-                        100.0,
-                        0.0,
-                    ),
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"Z{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(verdicts), 0.0),
                 )
 
         weights = _compute_weights(db_path=db_path)
@@ -1712,22 +1715,138 @@ class TestComputeWeightsHitRates:
         )
         assert abs(sum(weights.values()) - 1.0) < 0.001
 
-    def test_empty_signals_string_skipped(self, db_path):
-        """signals 필드가 빈 문자열이면 해당 row skip — crash 없이 DEFAULT_WEIGHTS 반환."""
+    def test_null_agent_verdicts_filtered_at_sql(self, db_path):
+        """agent_verdicts IS NULL/empty → SQL WHERE 절에서 이미 필터됨.
+
+        A-1a: read path SQL 은 `agent_verdicts IS NOT NULL AND agent_verdicts != ''`.
+        15 건 모두 NULL 이면 rows=0 → min_records gate (10) 미달 → DEFAULT_WEIGHTS.
+        """
         from nuri.core.db import get_db
         from nuri.core.timezone import today_kst
         from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
 
         with get_db(db_path) as conn:
-            # 15 건 모두 signals 빈 문자열
             for i in range(15):
                 conn.execute(
                     """INSERT INTO recommendations
-                       (date, ticker, action, confidence, regime, signals, entry_price, outcome_30d)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (today_kst(), f"X{i}", "BUY", 50.0, None, "", 100.0, 0.05),
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)""",
+                    (today_kst(), f"X{i}", "BUY", 50.0, None, None, 100.0, 0.05),
                 )
 
         weights = _compute_weights(db_path=db_path)
-        # 빈 signals → hit_rate 계산 불가 → DEFAULT_WEIGHTS
         assert weights == DEFAULT_WEIGHTS
+
+    def test_malformed_json_does_not_poison_other_rows(self, db_path):
+        """Malformed JSON row 는 skip — 유효 row 의 hit rate 계산은 살아남음.
+
+        A-1a codex review (P1-3): silent skip opacity 방지. malformed row 는
+        rows_skipped_json 카운터만 올리고 computation 은 유효 rows 로 진행.
+        """
+        import json
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        # 유효 12 건 (positive outcome, BUY hit) + malformed 3 건.
+        valid_verdicts = [
+            {"agent_name": "technical", "action": "BUY"},
+            {"agent_name": "fundamental", "action": "SELL"},
+        ]
+        with get_db(db_path) as conn:
+            for i in range(12):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"V{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(valid_verdicts), 0.05),
+                )
+            # Malformed — JSON parse error
+            for i in range(3):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"M{i}", "BUY", 50.0, None, None, 100.0,
+                     "{not valid json", 0.05),
+                )
+
+        weights = _compute_weights(db_path=db_path)
+        # 유효 12 건 > min_records (10) → 계산 진행. Malformed 3 건은 skip.
+        # technical 이 12회 BUY 적중 → 가중치 상승.
+        assert weights["technical"] > DEFAULT_WEIGHTS["technical"], (
+            "malformed rows skip 후에도 유효 12 건으로 hit rate 계산 진행"
+        )
+
+    def test_min_records_gate(self, db_path):
+        """rows < min_records (10) 면 DEFAULT_WEIGHTS 반환 — hit rate 계산 skip."""
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        # min_records 기본값 10 미만 — 9 건만 seed
+        self._seed_recommendations(db_path, n_records=9, outcome_sign=1)
+        weights = _compute_weights(db_path=db_path)
+
+        assert weights == DEFAULT_WEIGHTS, "< min_records gate 작동"
+
+    def test_list_non_dict_items_skipped_gracefully(self, db_path):
+        """agent_verdicts 가 list 지만 내부 item 이 dict 아니면 해당 item skip.
+
+        A-1a codex review: `if not isinstance(v, dict): continue` 방어 코드 regression.
+        """
+        import json
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        # list 이지만 일부 item 이 string — skip 되어야 함
+        mixed_verdicts = [
+            {"agent_name": "technical", "action": "BUY"},
+            "not a dict",  # skip 대상
+            {"agent_name": "fundamental", "action": "SELL"},
+            None,  # skip 대상
+        ]
+        with get_db(db_path) as conn:
+            for i in range(15):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"L{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(mixed_verdicts), 0.05),
+                )
+
+        weights = _compute_weights(db_path=db_path)
+        # dict items (technical/fundamental) 은 정상 처리, string/None 은 skip.
+        assert weights["technical"] > DEFAULT_WEIGHTS["technical"], (
+            "dict items 정상 처리 — non-dict items skip 안전"
+        )
+
+    def test_observability_counters_logged(self, db_path, caplog):
+        """rows_seen/rows_parsed/rows_skipped_schema/rows_skipped_json 로깅 검증.
+
+        A-1a codex review (P1-3): silent skip opacity 방지. silent fallback 감지
+        가능해야 함. fix revert (logger.info 제거) 시 이 테스트 fail.
+        """
+        import logging
+
+        from nuri.trading.agents.consensus import _compute_weights
+
+        self._seed_recommendations(db_path, n_records=15, outcome_sign=1)
+        with caplog.at_level(logging.INFO, logger="nuri.trading.agents.consensus"):
+            _compute_weights(db_path=db_path)
+
+        # 로그 메시지에 observability 카운터 포함 확인
+        log_texts = [r.message for r in caplog.records]
+        assert any("rows_seen=15" in m for m in log_texts), (
+            f"rows_seen=15 로그 기대. 실제: {log_texts}"
+        )
+        assert any("rows_parsed=15" in m for m in log_texts), (
+            "rows_parsed=15 로그 기대 (모두 valid)"
+        )

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -1572,10 +1572,10 @@ class TestSaveToRecommendations:
         - save_to_recommendations 가 `INSERT OR REPLACE` → `ON CONFLICT DO UPDATE` 로 전환.
 
         Revert 시 이 테스트 fail: (date, ticker, action) 키였을 때 두 호출이 각각 다른
-        action 이면 2 행 생성. 이제는 1 행 + action=SELL 로 update, id 동일.
+        action 이면 2 행 생성. 이제는 1 행 + action=HOLD 로 update, id 동일.
 
-        Note (A-1a): BUY→HOLD 대신 BUY→SELL 로 전이. save_to_recommendations 이
-        HOLD 를 Learning Memory 노이즈 방지 위해 제외하도록 변경됨.
+        A-1a P1-1 regression lock-in: HOLD 가 persist 되어야 stale BUY row 를 덮어
+        씀. HOLD skip 되면 UI 가 outdated BUY 표시 (codex A-1 review).
         """
         from nuri.core.db import query
         from nuri.trading.agents.consensus import save_to_recommendations
@@ -1583,11 +1583,11 @@ class TestSaveToRecommendations:
         save_to_recommendations([self._result(action="BUY", conf=70)], db_path=db_path)
         first_id = query("SELECT id FROM recommendations WHERE ticker='TEST'", db_path=db_path)[0]["id"]
 
-        save_to_recommendations([self._result(action="SELL", conf=50)], db_path=db_path)
+        save_to_recommendations([self._result(action="HOLD", conf=50)], db_path=db_path)
         rows = query("SELECT * FROM recommendations WHERE ticker='TEST' ORDER BY id", db_path=db_path)
 
         assert len(rows) == 1, "UPSERT 작동 — (date, ticker) 하나당 1 행만 유지"
-        assert rows[0]["action"] == "SELL"
+        assert rows[0]["action"] == "HOLD", "HOLD 가 BUY 를 덮어써야 UI stale 방지"
         assert rows[0]["confidence"] == 50.0
         assert rows[0]["id"] == first_id, "ON CONFLICT DO UPDATE 는 id 보존 — FK 안전"
 
@@ -1828,25 +1828,117 @@ class TestComputeWeightsHitRates:
             "dict items 정상 처리 — non-dict items skip 안전"
         )
 
-    def test_observability_counters_logged(self, db_path, caplog):
-        """rows_seen/rows_parsed/rows_skipped_schema/rows_skipped_json 로깅 검증.
+    def test_min_records_gate_on_parsed_count_not_raw(self, db_path):
+        """min_records gate 는 rows_parsed 기반 (codex A-1 P1-2 regression lock).
 
-        A-1a codex review (P1-3): silent skip opacity 방지. silent fallback 감지
-        가능해야 함. fix revert (logger.info 제거) 시 이 테스트 fail.
+        시나리오: 9 valid + 1 malformed = raw 10 rows. 이전 버그: len(rows) 가 10 이라
+        gate 통과 → 9 건으로 가중치 shift (sample 신뢰성 위반). Fix: rows_parsed 로 gate.
+        revert 시 이 테스트 fail (shift 가 발생 → != DEFAULT_WEIGHTS).
+        """
+        import json
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        valid_verdicts = [
+            {"agent_name": "technical", "action": "BUY"},
+            {"agent_name": "fundamental", "action": "SELL"},
+        ]
+        with get_db(db_path) as conn:
+            # 9 valid (min_records=10 미달)
+            for i in range(9):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"V{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(valid_verdicts), 0.05),
+                )
+            # 1 malformed — raw count 를 10 으로 올려 old gate 우회 공격
+            conn.execute(
+                """INSERT INTO recommendations
+                   (date, ticker, action, confidence, regime, signals, entry_price,
+                    agent_verdicts, outcome_30d)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (today_kst(), "M0", "BUY", 50.0, None, None, 100.0,
+                 "{bad json", 0.05),
+            )
+
+        weights = _compute_weights(db_path=db_path)
+        assert weights == DEFAULT_WEIGHTS, (
+            "rows_parsed=9 < min_records=10 → DEFAULT_WEIGHTS. "
+            "이전 버그: raw count=10 으로 gate 통과 → shift 발생."
+        )
+
+    def test_observability_normal_path_debug(self, db_path, caplog):
+        """Normal path (skip=0) 는 DEBUG 레벨 — per-ticker hot path spam 방지.
+
+        A-1a codex review (P2-3): analyze_portfolio 가 ticker 마다 _compute_weights
+        호출. 모든 row valid 면 DEBUG 레벨로 로그. revert (INFO 로 복구) 시 fail.
         """
         import logging
 
         from nuri.trading.agents.consensus import _compute_weights
 
         self._seed_recommendations(db_path, n_records=15, outcome_sign=1)
+
+        # INFO 레벨로 caplog 설정 — DEBUG 메시지는 안 잡힘. INFO 메시지 있으면 fail.
         with caplog.at_level(logging.INFO, logger="nuri.trading.agents.consensus"):
             _compute_weights(db_path=db_path)
 
-        # 로그 메시지에 observability 카운터 포함 확인
-        log_texts = [r.message for r in caplog.records]
-        assert any("rows_seen=15" in m for m in log_texts), (
-            f"rows_seen=15 로그 기대. 실제: {log_texts}"
+        info_msgs = [r.message for r in caplog.records
+                     if r.levelno >= logging.INFO and "_compute_weights" in r.message]
+        assert info_msgs == [], (
+            f"Normal path 는 DEBUG 레벨 — INFO 로그 없어야 함. 실제: {info_msgs}"
         )
-        assert any("rows_parsed=15" in m for m in log_texts), (
-            "rows_parsed=15 로그 기대 (모두 valid)"
+
+    def test_observability_anomaly_path_info(self, db_path, caplog):
+        """Skip 발생 시 INFO 레벨로 escalate — operator 감지 가능.
+
+        A-1a codex review (P2-3): normal 은 조용히, anomaly 는 요란하게.
+        """
+        import json
+        import logging
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import _compute_weights
+
+        valid_verdicts = [
+            {"agent_name": "technical", "action": "BUY"},
+            {"agent_name": "fundamental", "action": "SELL"},
+        ]
+        with get_db(db_path) as conn:
+            # min_records 통과 가능한 valid 12 + malformed 2 → INFO anomaly log
+            for i in range(12):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"V{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(valid_verdicts), 0.05),
+                )
+            for i in range(2):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"M{i}", "BUY", 50.0, None, None, 100.0,
+                     "{bad json", 0.05),
+                )
+
+        with caplog.at_level(logging.INFO, logger="nuri.trading.agents.consensus"):
+            _compute_weights(db_path=db_path)
+
+        info_msgs = [r.message for r in caplog.records
+                     if r.levelno == logging.INFO and "anomaly" in r.message]
+        assert len(info_msgs) >= 1, (
+            f"Skip 발생 시 INFO anomaly 로그 기대. 실제: {[r.message for r in caplog.records]}"
+        )
+        assert any("rows_skipped_json=2" in m for m in info_msgs), (
+            "rows_skipped_json=2 카운터 포함 기대"
         )


### PR DESCRIPTION
## Summary
- Learning Memory `_compute_weights()` 가 `recommendations.signals` 컬럼에서 `{verdicts: [...]}` dict shape 를 찾고 있었으나, save path (tracker.py, consensus.py) 는 `agent_verdicts` 컬럼에 list shape 로 저장. Read path schema mismatch 로 133/145 rows 의 학습 데이터가 dormant.
- Codex review 2 round: P1 blockers 3 개 fix (HOLD stale-row regression, pre-parse min_records gate, hot-path log spam). Final grade P1 A- / P2 B+ / ship ready.

## Before/after
- `recommendations.agent_verdicts`: 133/145 rows (이미 저장됨, 이전 read path 가 무시)
- `recommendations.outcome_30d`: 0/145 (oldest rec 9 일 전 — 30 일 경과 시 자동 활성화, ~2026-05-08)
- Live `_compute_weights()`: `min_records` gate 미달 → DEFAULT_WEIGHTS (정상). outcome 성숙 후 Learning Memory 가 autonomy 시작.

## 3 commits → squash

1. `db0a4fa` — read path: `agent_verdicts` 컬럼 + list shape + observability counters
2. `31955ba` — write-boundary: tracker actionable-only defensive filter
3. `b5d77ff` — test migration + 5 regression cases
4. `d012000` — codex P1 fixes: HOLD persist (UI stale 방지) + parsed-count gate + log level tiering

## Scope out (tracked as A-1b)
- `agent_accuracy_snapshots` periodic job
- `outcome_30d == 0` BUY miss / SELL hit bias (intentional policy pin)
- Gate semantics: rows_parsed → "rows with ≥1 usable BUY/SELL verdict" (remaining P2 per codex)

## Test plan
- [x] `make test-fast` — 914 trading tests pass
- [x] `make verify-quick` — pre-push green
- [x] Codex review — ship ready verdict
- [x] Live DB smoke: `_compute_weights()` 반환값 10-agent sum=1.0
- [ ] Post-merge Mac mini deploy (`make deploy-mini`)
- [ ] 2026-05-08± outcomes 성숙 후 `_compute_weights()` 실제 shift 검증

Closes part of #178 (Learning Memory restoration, A-1a scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)