### PR TITLE
feat(scheduler): add daily consensus job at 07:05 KST

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -81,6 +81,13 @@ def _run_collector(name: str, **kwargs):
             from nuri.trading.engine.decisions import save_agent_accuracy_snapshot
             n = save_agent_accuracy_snapshot()
             logger.info(f"[agent_accuracy] {n}건 저장")
+        elif name == "consensus":
+            # 10-agent 합의 결과를 recommendations 에 저장 → Learning Memory 자동 학습 input.
+            # decision_outcomes 가 30 일 후 outcome_30d 채우면 _compute_weights 가 가중치 조정.
+            from nuri.trading.agents.consensus import analyze_portfolio, save_to_recommendations
+            results = analyze_portfolio()
+            saved = save_to_recommendations(results)
+            logger.info(f"[consensus] {len(results)}건 분석, {saved}건 저장")
     except Exception as e:
         logger.error(f"[{name}] 실행 실패: {e}", exc_info=True)
 
@@ -182,6 +189,12 @@ SCHEDULES = [
     # Decision outcome 추적 (매일 07:00 — 시장 개장 전)
     {"name": "decision_outcomes", "func": _run_collector, "args": ("decision_outcomes",),
      "cron": "0 7 * * *"},
+
+    # 10-agent consensus (매일 07:05 — technical 07:00 완료 후, daily_report 08:00 전).
+    # agent_verdicts 를 recommendations 테이블에 쌓아 Learning Memory 가 30 일 후 학습.
+    # Phase 2 A-1a (PR #361) 의 read path fix 를 활용하려면 input 이 꾸준히 쌓여야 함.
+    {"name": "consensus", "func": _run_collector, "args": ("consensus",),
+     "cron": "5 7 * * *"},
 
     # Agent accuracy 스냅샷 (주 1회 일요일 08:00)
     {"name": "agent_accuracy", "func": _run_collector, "args": ("agent_accuracy",),

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -627,6 +627,29 @@ class TestSchedulerDecisions:
             _run_collector("agent_accuracy")
         mock_fn.assert_called_once()
 
+    def test_run_collector_consensus(self):
+        """_run_collector dispatches to analyze_portfolio + save_to_recommendations.
+
+        Phase 2 A-1a 의 read path fix 가 의미 있으려면 input 이 꾸준히 쌓여야 함 —
+        이 job 이 매일 07:05 에 agent_verdicts 를 recommendations 테이블에 저장.
+        Revert (dispatch 제거) 시 이 테스트 fail.
+        """
+        from nuri.scheduler import _run_collector
+        with patch("nuri.trading.agents.consensus.analyze_portfolio", return_value=[]) as m_analyze, \
+             patch("nuri.trading.agents.consensus.save_to_recommendations", return_value=0) as m_save:
+            _run_collector("consensus")
+        m_analyze.assert_called_once()
+        m_save.assert_called_once()
+
+    def test_schedules_include_consensus_job(self):
+        """SCHEDULES 리스트에 consensus job entry 존재 — cron 스펙 lock-in."""
+        from nuri.scheduler import SCHEDULES
+        consensus_jobs = [j for j in SCHEDULES if j["name"] == "consensus"]
+        assert len(consensus_jobs) == 1, "consensus job 정확히 1 개 필요"
+        assert consensus_jobs[0]["args"] == ("consensus",)
+        # 07:05 — technical 07:00 완료 후, daily_report 08:00 전
+        assert consensus_jobs[0]["cron"] == "5 7 * * *"
+
 
 class TestSchedulerDbMaintenance_Db:
     def test_scheduler_db_maintenance_runs(self, db_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Phase 2 A-1a (PR #361) 가 Learning Memory read path 를 고쳤지만 **input 경로가 수동**이었음. `nuri/scheduler.py` 에 consensus 자동 실행이 없어 `agent_verdicts` 가 사용자가 `make consensus` 돌릴 때만 쌓임.
- 매일 07:05 KST (technical collector 07:00 완료 후, daily_report 08:00 전) 에 `analyze_portfolio + save_to_recommendations` 자동 실행 추가.

## Before/after

- Before: 133 rows over ~10 days (수동 실행 시). LM 학습 데이터 sparse.
- After: 매일 portfolio 크기 만큼 rows 추가. 30일 후 첫 `outcome_30d` 성숙 → Learning Memory 첫 가중치 shift.

## Test plan
- [x] `test_run_collector_consensus`: dispatch mock
- [x] `test_schedules_include_consensus_job`: SCHEDULES entry cron `5 7 * * *` lock-in
- [x] 76/76 scheduler tests pass
- [ ] Mac mini scheduler reload 후 내일 07:05 실행 확인

## 관련
- PR #361 (Phase 2 A-1a) 의 input 보완.
- Issue #178 (Learning Memory restoration) 의 운영 완성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)