### PR TITLE
feat(candidates): scoring_detail discriminator + VIX sync (Phase 2 A-2b-pre)

### DIFF
--- a/nuri/trading/recommend/candidates.py
+++ b/nuri/trading/recommend/candidates.py
@@ -273,8 +273,13 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
                 regime_stats = regime_ctx.get("regime_stats", {}) if regime_ctx else {}
                 sig_in_regime = regime_stats.get(signal_id)
 
-                # scoring_detail 기록용
+                # scoring_detail 기록용. A-2b-pre: `source`/`schema_version` 으로
+                # consensus.py scoring_detail (schema: per-agent contributions) 와
+                # 구분 — A-2b API/frontend 가 같은 컬럼을 파싱할 때 key-sniffing
+                # 대신 discriminator 로 분기.
                 scoring = {
+                    "source": "candidate",
+                    "schema_version": 1,
                     "win_rate": round(win_rate, 4),
                     "profit_factor": round(pf, 2),
                     "regime": regime_ctx.get("regime", "") if regime_ctx else "",
@@ -395,16 +400,25 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
         logger.debug(f"Conflict detection 실패: {e}")
 
     # ── VIX Gate: 매수 후보 confidence 조정 ──
+    # A-2b-pre: scoring_detail["final_confidence"] 도 함께 업데이트해야 A-2b
+    # audit trail 이 stale 하지 않음 (codex A-2b-pre review Medium finding).
+    # `vix_penalty` 필드 기록해 어느 경로로 discount 됐는지 surface.
     if vix_gate["gate"] == "blocked":
         for c in candidates:
             if c.direction == "BUY":
                 c.confidence = 0  # VIX > 30: BUY 후보 전부 차단
                 c.notes = (c.notes + "; " if c.notes else "") + vix_gate["msg"]
+                if c.scoring_detail is not None:
+                    c.scoring_detail["vix_penalty"] = 0.0
+                    c.scoring_detail["final_confidence"] = 0.0
     elif vix_gate["gate"] == "caution":
         for c in candidates:
             if c.direction == "BUY":
                 c.confidence *= 0.5  # VIX 25~30: 절반 포지션
                 c.notes = (c.notes + "; " if c.notes else "") + vix_gate["msg"]
+                if c.scoring_detail is not None:
+                    c.scoring_detail["vix_penalty"] = 0.5
+                    c.scoring_detail["final_confidence"] = round(c.confidence, 2)
 
     # confidence 내림차순
     candidates.sort(key=lambda c: c.confidence, reverse=True)

--- a/nuri/trading/recommend/tracker.py
+++ b/nuri/trading/recommend/tracker.py
@@ -73,8 +73,10 @@ def save_recommendations(candidates=None, actions=None, verdicts=None, db_path=N
             # 에이전트 verdict 첨부
             if verdicts and c.ticker in verdicts:
                 rec["agent_verdicts"] = json.dumps(verdicts[c.ticker], ensure_ascii=False)
-            # scoring_detail 첨부
-            if hasattr(c, "scoring_detail") and c.scoring_detail:
+            # scoring_detail 첨부. A-2b-pre: `is not None` 로 guard 해 빈 dict `{}`
+            # 도 persist — consensus.py A-2a 수정과 동일 semantic (codex A-2a Round 2
+            # P3 연장선, falsy 실수 방지).
+            if hasattr(c, "scoring_detail") and c.scoring_detail is not None:
                 rec["scoring_detail"] = json.dumps(c.scoring_detail, ensure_ascii=False)
             records.append(rec)
 

--- a/tests/trading/recommend/test_candidates.py
+++ b/tests/trading/recommend/test_candidates.py
@@ -244,6 +244,92 @@ class TestScreenCandidates:
             assert c.scoring_detail["drift_multiplier"] == 0.3
 
 
+class TestScoringDetailDiscriminator:
+    """A-2b-pre — candidates scoring_detail 에 `source="candidate"`/`schema_version=1`
+    discriminator 가 박혀야 consensus scoring_detail (source="consensus") 와 구분됨.
+
+    STRATEGY §5.3.1 Gotcha-Test Pair — discriminator 를 실수로 제거하면 A-2b API
+    가 두 schema 를 key-sniffing 으로 분기하게 되어 brittle.
+    """
+
+    def test_candidate_scoring_detail_has_discriminator(self, rich_db):
+        """candidates 의 모든 scoring_detail 에 source + schema_version 포함."""
+        from unittest.mock import patch
+
+        from nuri.trading.recommend.candidates import screen_candidates
+
+        with patch("nuri.trading.recommend.candidates._load_scorecard", return_value=({}, None)):
+            with patch("nuri.trading.recommend.candidates._get_regime_context", return_value=None):
+                with patch("nuri.trading.recommend.candidates._get_drift_map", return_value={}):
+                    with patch("nuri.trading.engine.conflicts.detect_conflicts", return_value=[]):
+                        candidates = screen_candidates(lookback_days=500, db_path=rich_db)
+
+        assert candidates, "fixture 가 최소 1 개 candidate 생성"
+        for c in candidates:
+            assert c.scoring_detail is not None
+            assert c.scoring_detail.get("source") == "candidate", (
+                "A-2b-pre regression: candidates scoring_detail 에 source 가 없으면 "
+                "A-2b API 가 consensus 와 구분할 수 없음"
+            )
+            assert c.scoring_detail.get("schema_version") == 1
+
+    def test_vix_gate_syncs_scoring_detail_final_confidence(self, rich_db):
+        """A-2b-pre (codex Medium fix) — VIX gate 가 c.confidence 를 업데이트하면
+        scoring_detail["final_confidence"] 도 동기화. A-2b 가 audit source 로
+        scoring_detail 을 쓸 때 stale 방지.
+
+        STRATEGY §5.3.1 Gotcha-Test Pair: VIX gate 에서 scoring_detail 업데이트를
+        제거하면 test fail — candidate.confidence=0 (blocked) 인데 scoring_detail
+        에는 pre-VIX 값이 남아 있는 모순 상태 lock-in.
+        """
+        from unittest.mock import patch
+
+        from nuri.trading.recommend.candidates import screen_candidates
+
+        # VIX blocked — 모든 BUY 후보 confidence 0
+        vix_blocked = {"gate": "blocked", "msg": "VIX > 30", "vix": 35.0}
+        with patch("nuri.trading.recommend.candidates._load_scorecard", return_value=({}, None)):
+            with patch("nuri.trading.recommend.candidates._get_regime_context", return_value=None):
+                with patch("nuri.trading.recommend.candidates._get_drift_map", return_value={}):
+                    with patch("nuri.trading.engine.conflicts.detect_conflicts", return_value=[]):
+                        with patch("nuri.trading.recommend.candidates._check_vix_gate", return_value=vix_blocked):
+                            candidates = screen_candidates(lookback_days=500, db_path=rich_db)
+
+        buys = [c for c in candidates if c.direction == "BUY"]
+        assert buys, "fixture 가 BUY 후보 생성"
+        for c in buys:
+            assert c.confidence == 0, "VIX blocked 는 BUY confidence=0"
+            assert c.scoring_detail is not None
+            assert c.scoring_detail["final_confidence"] == 0.0, (
+                "scoring_detail['final_confidence'] 도 0 으로 동기화 — audit trail 일관성"
+            )
+            assert c.scoring_detail["vix_penalty"] == 0.0
+
+    def test_vix_caution_syncs_scoring_detail_final_confidence(self, rich_db):
+        """VIX caution (25~30) 경로도 scoring_detail 동기화 — codex Round 2 residual
+        gap. confidence × 0.5 discount 가 scoring_detail['final_confidence'] 에도
+        반영되는지 확인."""
+        from unittest.mock import patch
+
+        from nuri.trading.recommend.candidates import screen_candidates
+
+        vix_caution = {"gate": "caution", "msg": "VIX 25~30", "vix": 27.5}
+        with patch("nuri.trading.recommend.candidates._load_scorecard", return_value=({}, None)):
+            with patch("nuri.trading.recommend.candidates._get_regime_context", return_value=None):
+                with patch("nuri.trading.recommend.candidates._get_drift_map", return_value={}):
+                    with patch("nuri.trading.engine.conflicts.detect_conflicts", return_value=[]):
+                        with patch("nuri.trading.recommend.candidates._check_vix_gate", return_value=vix_caution):
+                            candidates = screen_candidates(lookback_days=500, db_path=rich_db)
+
+        buys = [c for c in candidates if c.direction == "BUY"]
+        assert buys, "fixture 가 BUY 후보 생성"
+        for c in buys:
+            assert c.scoring_detail is not None
+            assert c.scoring_detail["vix_penalty"] == 0.5
+            # scoring_detail["final_confidence"] == c.confidence (round 차이 허용)
+            assert abs(c.scoring_detail["final_confidence"] - c.confidence) < 0.1
+
+
 class TestLoadScorecard:
     """_load_scorecard with and without CSV files (from test_coverage_round18)."""
 

--- a/tests/trading/recommend/test_tracker.py
+++ b/tests/trading/recommend/test_tracker.py
@@ -1,6 +1,6 @@
 """Tests for tracker — split from test_trading_recommend_all.py."""
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -376,6 +376,42 @@ class TestTracker_R23:
 
         n = save_recommendations(candidates=[MockCandidate()], db_path=db_path)
         assert n == 1
+
+    def test_save_preserves_empty_scoring_detail_dict(self, db_path):
+        """A-2b-pre — 빈 dict `{}` 도 persist (falsy guard 제거).
+
+        STRATEGY §5.3.1 Gotcha-Test Pair: `if c.scoring_detail:` 로 revert 하면
+        empty dict 이 silently drop 되어 DB 에 NULL 로 저장 — downstream 이 "아직
+        scoring 없음" 과 "빈 compute 결과" 를 구분할 수 없음. consensus A-2a Round 2
+        P3 와 동일 semantic.
+        """
+        import json
+
+        from nuri.core.db import query
+        from nuri.trading.recommend.tracker import save_recommendations
+
+        @dataclass
+        class MockCandidate:
+            ticker: str = "EMPT"
+            direction: str = "BUY"
+            confidence: float = 50.0
+            signal_id: str = "test"
+            price: float = 100.0
+            regime_fit: bool = True
+            # 일부러 빈 dict — empty compute 결과 시뮬레이션
+            scoring_detail: dict = field(default_factory=dict)
+
+        n = save_recommendations(candidates=[MockCandidate()], db_path=db_path)
+        assert n == 1
+
+        row = query(
+            "SELECT scoring_detail FROM recommendations WHERE ticker='EMPT'",
+            db_path=db_path,
+        )[0]
+        assert row["scoring_detail"] is not None, (
+            "A-2b-pre regression: 빈 dict 이 NULL 로 drop 되면 안 됨"
+        )
+        assert json.loads(row["scoring_detail"]) == {}
 
     def test_print_tracking_report(self, db_path, capsys):
         """Print tracking report."""


### PR DESCRIPTION
## Summary

Codex A-2a Round 2 follow-up chore. Tags `candidates.py` scoring_detail with `source="candidate"` + `schema_version=1` so A-2b API can branch cleanly on the `source` key instead of key-sniffing between consensus (from PR #364) and candidate payloads. Also patches an audit-trail bug where VIX gate mutated `c.confidence` but left `scoring_detail["final_confidence"]` stale.

## Changes

- **`candidates.py`** — add `source`/`schema_version` to scoring dict. VIX `blocked`/`caution` branches now also update `scoring_detail["final_confidence"]` + record `vix_penalty` (0.0 for blocked, 0.5 for caution) to match the existing `conflict_penalty` path.
- **`tracker.py`** — `and c.scoring_detail` → `and c.scoring_detail is not None` so empty dict `{}` is preserved, mirroring A-2a Round 2 P3.

## Codex review

**Round 1** — Medium: VIX gate stale. `c.confidence` was updated but `scoring_detail["final_confidence"]` was not, so A-2b consuming scoring_detail as audit source would see divergent values for blocked/caution BUY candidates.

**Round 2** — No findings. Verdict: "VIX gate fix is consistent with the existing conflict_penalty path." Residual test gap (VIX caution untested) added per Round 2 suggestion.

## Regression locks (STRATEGY §5.3.1)

- `test_candidate_scoring_detail_has_discriminator` — fails if `source`/`schema_version` stripped.
- `test_vix_gate_syncs_scoring_detail_final_confidence` — fails if VIX blocked path skips scoring_detail update.
- `test_vix_caution_syncs_scoring_detail_final_confidence` — same for caution path.
- `test_save_preserves_empty_scoring_detail_dict` — fails if tracker reverts to falsy guard.

## Test plan

- [x] `make test-fast` — 2990/2990 pass (~24s)
- [x] `ruff check` — clean
- [ ] Live DB verify after next `make recommend` run shows `recommendations.scoring_detail` rows with `source="candidate"` (next session chore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)