### PR TITLE
feat(api): expose scoring_detail + agent_verdicts (Phase 2 A-2b)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -139,7 +139,18 @@
     "NOPX",
     "SCDT",
     "SCDN",
-    "executemany"
+    "executemany",
+    "devlp",
+    "FINNHUB",
+    "finnhub",
+    "HMAC",
+    "MACMINI",
+    "macmini",
+    "TSMC",
+    "longshort",
+    "longterm",
+    "hojin",
+    "kakao"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/.cspell.json
+++ b/.cspell.json
@@ -150,7 +150,9 @@
     "longshort",
     "longterm",
     "hojin",
-    "kakao"
+    "kakao",
+    "TQQQ",
+    "MRVL"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -99,6 +99,11 @@ def _build_actions() -> dict:
             "target_1": target.get("target_1"),
             "target_2": target.get("target_2"),
             "reasons": [],
+            # A-2b: `_get_recommendations` 가 parse 해둔 JSON 을 그대로 노출.
+            # Frontend (A-2c) 가 actions card 에서 10-agent breakdown + basis/penalty
+            # 표시. codex A-2b Round 1 HIGH — `_build_actions` 이 drop 하던 bug fix.
+            "scoring_detail": rec.get("scoring_detail"),
+            "agent_verdicts": rec.get("agent_verdicts"),
         }
 
         # ── 🔴 즉시 실행 조건 ──
@@ -297,9 +302,13 @@ def get_market_context():
 
 
 def _get_recommendations() -> list[dict]:
-    """최신 consensus 결과 조회."""
+    """최신 consensus 결과 조회.
+
+    A-2b: `scoring_detail` + `agent_verdicts` 컬럼도 노출 — frontend (A-2c) 가
+    10-agent contribution breakdown 시각화 + basis_action/penalty 표시에 사용.
+    """
     rows = query("""
-        SELECT ticker, action, confidence, signals
+        SELECT ticker, action, confidence, signals, scoring_detail, agent_verdicts
         FROM recommendations
         WHERE date = (SELECT MAX(date) FROM recommendations)
         ORDER BY confidence DESC
@@ -313,11 +322,26 @@ def _get_recommendations() -> list[dict]:
                 agreement = data.get("agreement_rate")
             except (json.JSONDecodeError, TypeError):
                 pass
+        # Parse 실패 → None. source=consensus/candidate 로 frontend 분기 (PR #364/#366).
+        scoring_detail = None
+        if r.get("scoring_detail"):
+            try:
+                scoring_detail = json.loads(r["scoring_detail"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        agent_verdicts = None
+        if r.get("agent_verdicts"):
+            try:
+                agent_verdicts = json.loads(r["agent_verdicts"])
+            except (json.JSONDecodeError, TypeError):
+                pass
         results.append({
             "ticker": r["ticker"],
             "action": r["action"],
             "confidence": round(r["confidence"] * 100) if r["confidence"] and r["confidence"] <= 1 else round(r["confidence"] or 0),
             "agreement": round(agreement * 100) if agreement is not None and agreement <= 1 else agreement,
+            "scoring_detail": scoring_detail,
+            "agent_verdicts": agent_verdicts,
         })
     return results
 

--- a/nuri/api/routes/agents.py
+++ b/nuri/api/routes/agents.py
@@ -43,6 +43,9 @@ def get_consensus():
     except Exception:
         pass
 
+    # A-2b: scoring_detail 은 _build_consensus (PR #364) 에서 채워짐.
+    # `source="consensus"`/`schema_version=1`/`contributions`/`basis_action`/
+    # `final_action_source` 필드 포함. frontend A-2c 가 이 dict 를 consume.
     data = {
         "regime": regime_info,
         "results": [
@@ -56,6 +59,7 @@ def get_consensus():
                 "reasoning": r.reasoning,
                 "divergence_flag": r.divergence_flag,
                 "divergence_reason": r.divergence_reason,
+                "scoring_detail": r.scoring_detail,
             }
             for r in results
         ],
@@ -82,6 +86,7 @@ def get_consensus_ticker(ticker: str):
         "reasoning": r.reasoning,
         "divergence_flag": r.divergence_flag,
         "divergence_reason": r.divergence_reason,
+        "scoring_detail": r.scoring_detail,
     }
 
 

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -178,6 +178,21 @@ def _extract_reason(signals_raw: str | None) -> tuple[str, float | None]:
         return signals_raw[:60], None
 
 
+def _parse_json_field(raw: str | None) -> dict | list | None:
+    """A-2b: `scoring_detail` / `agent_verdicts` 컬럼 JSON 파싱.
+
+    Parse 실패 또는 NULL → None 반환 (frontend 가 null-check 로 graceful degrade).
+    dict (scoring_detail) 또는 list (agent_verdicts) 둘 다 수용.
+    """
+    if not raw:
+        return None
+    import json
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
 def _get_ticker_account_map() -> dict[str, str]:
     """ticker → account 매핑 (첫 번째 계좌 기준)."""
     from nuri.core.db import query
@@ -219,7 +234,8 @@ def _get_account_labels() -> dict[str, str]:
                 labels[acc] = custom_label.strip()
                 continue
             # (2) strategy-based default with duplicate-count suffix
-            strategy_name = info.get("strategy", "core")
+            # Pylance type narrow — info.get()는 Any, 명시적 str coerce 로 dict.get 시그니처 만족.
+            strategy_name = str(info.get("strategy") or "core")
             base_label = _STRATEGY_LABELS.get(strategy_name, strategy_name.title())
             count = seen.get(base_label, 0)
             seen[base_label] = count + 1
@@ -235,7 +251,8 @@ def _get_latest_actions() -> list[dict]:
     from nuri.core.ticker_names import get_ticker_name
     try:
         rows = query("""
-            SELECT ticker, action, confidence, regime, signals, date
+            SELECT ticker, action, confidence, regime, signals, date,
+                   scoring_detail, agent_verdicts
             FROM recommendations
             WHERE date = (SELECT MAX(date) FROM recommendations)
             ORDER BY confidence DESC
@@ -253,6 +270,10 @@ def _get_latest_actions() -> list[dict]:
             reason, agreement_rate = _extract_reason(row.get("signals"))
             raw_account = ticker_account.get(row["ticker"], "")
             account_label = account_labels.get(raw_account, raw_account)
+            # A-2b: scoring_detail + agent_verdicts JSON 파싱. source=consensus/candidate
+            # 로 discriminate (PR #364/#366 스키마). Parse 실패는 None 로 graceful degrade.
+            scoring_detail = _parse_json_field(row.get("scoring_detail"))
+            agent_verdicts = _parse_json_field(row.get("agent_verdicts"))
 
             if action == "BUY" and confidence >= 50:
                 actions.append({
@@ -263,6 +284,8 @@ def _get_latest_actions() -> list[dict]:
                     "reason": reason,
                     "agreement": round(agreement_rate * 100) if agreement_rate is not None else None,
                     "account": account_label,
+                    "scoring_detail": scoring_detail,
+                    "agent_verdicts": agent_verdicts,
                 })
             elif action == "SELL" and confidence >= 70:
                 actions.append({
@@ -273,6 +296,8 @@ def _get_latest_actions() -> list[dict]:
                     "reason": reason,
                     "agreement": round(agreement_rate * 100) if agreement_rate is not None else None,
                     "account": account_label,
+                    "scoring_detail": scoring_detail,
+                    "agent_verdicts": agent_verdicts,
                 })
 
         # 상위 5개만

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -732,7 +732,8 @@ class TestBuildActionsScoringDetail:
              patch("nuri.api.routes.actions._get_targets_status", return_value={}), \
              patch("nuri.api.routes.actions._get_portfolio_map", return_value={
                  "TSLA": {"account": "Main", "pnl_pct": 5, "position_pct": 10}
-             }):
+             }), \
+             patch("nuri.api.routes.actions._get_short_interest", return_value=None):
             result = _build_actions()
 
         # urgent/check/hold 중 어디든 TSLA item 찾기

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -621,3 +621,126 @@ class TestBuildOpportunitiesLogic:
     def test_sorted_by_score(self):
         result = self._run([self._scan("LOW", score=10), self._scan("HIGH", score=70)])
         assert result[0]["ticker"] == "HIGH"
+
+
+class TestGetRecommendationsScoringDetail:
+    """A-2b — /actions `_get_recommendations` 가 scoring_detail + agent_verdicts
+    pass-through. Frontend (A-2c) actions page 가 10-agent breakdown 표시에 사용.
+    """
+
+    @patch("nuri.api.routes.actions.query")
+    def test_passes_scoring_detail_and_agent_verdicts(self, mock_query):
+        """scoring_detail + agent_verdicts JSON → response dict 파싱 포함."""
+        scoring = {
+            "source": "consensus",
+            "schema_version": 1,
+            "basis_action": "BUY",
+            "final_action_source": "weighted_sum",
+        }
+        verdicts = [{"agent_name": "technical", "action": "BUY", "confidence": 80}]
+        mock_query.return_value = [
+            {
+                "ticker": "TSLA",
+                "action": "BUY",
+                "confidence": 0.75,
+                "signals": '{"agreement_rate": 0.8}',
+                "scoring_detail": json.dumps(scoring),
+                "agent_verdicts": json.dumps(verdicts),
+            }
+        ]
+        from nuri.api.routes.actions import _get_recommendations
+        result = _get_recommendations()
+        assert len(result) == 1
+        assert "scoring_detail" in result[0], (
+            "A-2b regression: /actions response 에 scoring_detail 누락"
+        )
+        assert result[0]["scoring_detail"]["source"] == "consensus"
+        assert result[0]["scoring_detail"]["basis_action"] == "BUY"
+        assert result[0]["agent_verdicts"] == verdicts
+
+    @patch("nuri.api.routes.actions.query")
+    def test_handles_null_scoring_detail(self, mock_query):
+        """NULL scoring_detail/agent_verdicts → None pass-through (legacy row)."""
+        mock_query.return_value = [
+            {
+                "ticker": "OLD",
+                "action": "HOLD",
+                "confidence": 0.5,
+                "signals": None,
+                "scoring_detail": None,
+                "agent_verdicts": None,
+            }
+        ]
+        from nuri.api.routes.actions import _get_recommendations
+        result = _get_recommendations()
+        assert result[0]["scoring_detail"] is None
+        assert result[0]["agent_verdicts"] is None
+
+    @patch("nuri.api.routes.actions.query")
+    def test_handles_malformed_json(self, mock_query):
+        """malformed JSON → None graceful degrade (crash 방지)."""
+        mock_query.return_value = [
+            {
+                "ticker": "BAD",
+                "action": "BUY",
+                "confidence": 0.6,
+                "signals": "{}",
+                "scoring_detail": "not-json{{{",
+                "agent_verdicts": "also-bad",
+            }
+        ]
+        from nuri.api.routes.actions import _get_recommendations
+        result = _get_recommendations()
+        assert result[0]["scoring_detail"] is None
+        assert result[0]["agent_verdicts"] is None
+
+
+class TestBuildActionsScoringDetail:
+    """A-2b — `_build_actions` 이 `_get_recommendations` 결과의 scoring_detail /
+    agent_verdicts 를 최종 item 에 포함 (codex A-2b Round 1 HIGH — drop bug 방지).
+
+    STRATEGY §5.3.1 Gotcha-Test Pair — `_build_actions` 이 `rec.get()` 안 하면
+    endpoint response 가 두 필드 누락해 A-2c UI 가 consume 불가.
+    """
+
+    def test_build_actions_exposes_scoring_detail_per_item(self):
+        """Urgent/check/hold 어느 bucket 에 들어가든 item 에 scoring_detail 포함."""
+        from unittest.mock import patch
+
+        from nuri.api.routes.actions import _build_actions
+
+        scoring = {
+            "source": "consensus",
+            "schema_version": 1,
+            "basis_action": "BUY",
+            "final_action_source": "weighted_sum",
+        }
+        verdicts = [{"agent_name": "technical", "action": "BUY", "confidence": 80}]
+        recs = [
+            {
+                "ticker": "TSLA",
+                "action": "BUY",
+                "confidence": 70,
+                "agreement": 80,
+                "scoring_detail": scoring,
+                "agent_verdicts": verdicts,
+            }
+        ]
+
+        with patch("nuri.api.routes.actions._get_recommendations", return_value=recs), \
+             patch("nuri.api.routes.actions._get_siege_violations", return_value=[]), \
+             patch("nuri.api.routes.actions._get_targets_status", return_value={}), \
+             patch("nuri.api.routes.actions._get_portfolio_map", return_value={
+                 "TSLA": {"account": "Main", "pnl_pct": 5, "position_pct": 10}
+             }):
+            result = _build_actions()
+
+        # urgent/check/hold 중 어디든 TSLA item 찾기
+        all_items = result.get("urgent", []) + result.get("check", []) + result.get("hold", [])
+        tsla = next((i for i in all_items if i["ticker"] == "TSLA"), None)
+        assert tsla is not None, "TSLA item 이 생성돼야 함"
+        assert "scoring_detail" in tsla, (
+            "A-2b Round 1 HIGH regression: _build_actions 이 scoring_detail 을 drop"
+        )
+        assert tsla["scoring_detail"] == scoring
+        assert tsla["agent_verdicts"] == verdicts

--- a/tests/api/test_consensus.py
+++ b/tests/api/test_consensus.py
@@ -25,3 +25,104 @@ class TestConsensusAPI:
     def test_consensus_ticker(self, client):
         r = client.get("/api/consensus/AAPL")
         assert r.status_code == 200
+
+
+class TestConsensusScoringDetailExpose:
+    """A-2b — /consensus endpoints 가 scoring_detail 을 노출. A-2c frontend 가
+    10-agent contribution breakdown 을 시각화하려면 이 필드가 필수.
+
+    STRATEGY §5.3.1 Gotcha-Test Pair — endpoint response 에서 scoring_detail 를
+    실수로 제거하면 이 test fail. PR #364 로 backend persist 완성 상태를 API 가
+    pass-through 하는지 lock-in.
+    """
+
+    def test_consensus_portfolio_includes_scoring_detail(self, client):
+        """GET /api/consensus — 각 result 에 scoring_detail 포함 (None 허용)."""
+        from unittest.mock import MagicMock, patch
+
+        from nuri.trading.agents.base import AgentVerdict
+        from nuri.trading.agents.consensus import ConsensusResult
+
+        mock_result = ConsensusResult(
+            ticker="TSLA",
+            final_action="BUY",
+            final_confidence=70.0,
+            agreement_rate=0.8,
+            verdicts=[AgentVerdict("technical", "TSLA", "BUY", 70, "r")],
+            dissent=[],
+            reasoning="t",
+            scoring_detail={
+                "source": "consensus",
+                "schema_version": 1,
+                "final_action": "BUY",
+                "basis_action": "BUY",
+                "final_action_source": "weighted_sum",
+                "contributions": [],
+                "weights": {},
+                "action_scores": {"BUY": 0.7, "SELL": 0.0, "HOLD": 0.3},
+                "agreement_rate": 0.8,
+                "risk_veto_fired": False,
+                "divergence_flag": False,
+                "penalty_applied": False,
+                "pre_penalty_action": "",
+            },
+        )
+        # 캐시 무효화 + analyze_portfolio mock
+        with patch("nuri.api.routes.agents._cache", {"data": None, "ts": 0}):
+            with patch("nuri.api.routes.agents.analyze_portfolio" if False else "nuri.trading.agents.consensus.analyze_portfolio", return_value=[mock_result]):
+                with patch("nuri.quant.regime.classifier.classify_regime", return_value=MagicMock(regime="bull", trend="up", details={})):
+                    r = client.get("/api/consensus")
+        assert r.status_code == 200
+        data = r.json()
+        assert "results" in data
+        assert len(data["results"]) >= 1
+        first = data["results"][0]
+        assert "scoring_detail" in first, (
+            "A-2b regression: /consensus response 에 scoring_detail 누락 — "
+            "A-2c frontend 가 agent breakdown 을 consume 할 수 없음"
+        )
+        sd = first["scoring_detail"]
+        assert sd is not None
+        # Discriminator + basis_action + final_action_source pass-through
+        assert sd["source"] == "consensus"
+        assert sd["schema_version"] == 1
+        assert sd["basis_action"] == "BUY"
+        assert sd["final_action_source"] == "weighted_sum"
+
+    def test_consensus_ticker_includes_scoring_detail(self, client):
+        """GET /api/consensus/{ticker} — scoring_detail 포함."""
+        from unittest.mock import patch
+
+        from nuri.trading.agents.base import AgentVerdict
+        from nuri.trading.agents.consensus import ConsensusResult
+
+        mock_result = ConsensusResult(
+            ticker="NVDA",
+            final_action="HOLD",
+            final_confidence=50.0,
+            agreement_rate=0.5,
+            verdicts=[AgentVerdict("technical", "NVDA", "HOLD", 50, "r")],
+            dissent=[],
+            reasoning="t",
+            scoring_detail={
+                "source": "consensus",
+                "schema_version": 1,
+                "final_action": "HOLD",
+                "basis_action": "HOLD",
+                "final_action_source": "weighted_sum",
+                "contributions": [],
+                "weights": {},
+                "action_scores": {"BUY": 0.3, "SELL": 0.2, "HOLD": 0.5},
+                "agreement_rate": 0.5,
+                "risk_veto_fired": False,
+                "divergence_flag": False,
+                "penalty_applied": False,
+                "pre_penalty_action": "",
+            },
+        )
+        with patch("nuri.trading.agents.consensus.analyze_ticker", return_value=mock_result):
+            r = client.get("/api/consensus/NVDA")
+        assert r.status_code == 200
+        data = r.json()
+        assert "scoring_detail" in data
+        assert data["scoring_detail"]["source"] == "consensus"

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -1102,3 +1102,77 @@ class TestLatestActionsAccountField:
         buys = [a for a in result if a["action"] == "BUY"]
         assert len(buys) >= 1
         assert buys[0]["account"] == ""
+
+
+class TestLatestActionsScoringDetail:
+    """A-2b — /dashboard `_get_latest_actions` 가 scoring_detail + agent_verdicts
+    컬럼을 pass-through. Frontend (A-2c) 가 actions card 에서 agent breakdown
+    및 basis_action 을 시각화할 때 필수.
+    """
+
+    def test_latest_actions_passes_scoring_detail(self, db_path, monkeypatch):
+        """recommendations row 의 scoring_detail JSON 이 response dict 에 파싱돼 포함."""
+        import json as _json
+
+        import nuri.api.routes.dashboard as dash_mod
+        import nuri.core.db as db_mod
+        monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+
+        scoring = {
+            "source": "consensus",
+            "schema_version": 1,
+            "basis_action": "BUY",
+            "final_action_source": "weighted_sum",
+            "contributions": [{"agent_name": "technical", "counted_for_basis_action": True}],
+        }
+        verdicts = [{"agent_name": "technical", "action": "BUY", "confidence": 75}]
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals, scoring_detail, agent_verdicts) VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    "2026-04-18",
+                    "TSLA",
+                    "BUY",
+                    0.85,
+                    "bull_low_vol",
+                    '{"reasoning": "test", "agreement_rate": 0.8}',
+                    _json.dumps(scoring),
+                    _json.dumps(verdicts),
+                ),
+            )
+
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {})
+        monkeypatch.setattr(dash_mod, "_get_ticker_account_map", lambda: {})
+        result = dash_mod._get_latest_actions()
+
+        buys = [a for a in result if a["action"] == "BUY"]
+        assert buys, "BUY row 가 최소 1 개 반환"
+        first = buys[0]
+        assert "scoring_detail" in first, (
+            "A-2b regression: dashboard action dict 에 scoring_detail 누락 — "
+            "frontend 가 agent breakdown 조회 불가"
+        )
+        assert first["scoring_detail"] is not None
+        assert first["scoring_detail"]["source"] == "consensus"
+        assert first["scoring_detail"]["basis_action"] == "BUY"
+        assert first["agent_verdicts"] == verdicts
+
+    def test_latest_actions_handles_null_scoring_detail(self, db_path, monkeypatch):
+        """scoring_detail NULL (legacy row) → response 에 None 으로 graceful."""
+        import nuri.api.routes.dashboard as dash_mod
+        import nuri.core.db as db_mod
+        monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals) VALUES (?,?,?,?,?,?)",
+                ("2026-04-18", "NVDA", "BUY", 0.6, "bull", "{}"),
+            )
+
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {})
+        monkeypatch.setattr(dash_mod, "_get_ticker_account_map", lambda: {})
+        result = dash_mod._get_latest_actions()
+        buys = [a for a in result if a["action"] == "BUY"]
+        assert buys
+        assert buys[0]["scoring_detail"] is None
+        assert buys[0]["agent_verdicts"] is None


### PR DESCRIPTION
## Summary

Closes the loop started by A-2a (#364) + A-2b-pre (#366). Those PRs populated `recommendations.scoring_detail` and `recommendations.agent_verdicts` but the API never exposed them — `/dashboard`, `/actions`, and `/consensus` all served the consensus action without the breakdown. This PR threads both fields through all three routes so A-2c (frontend UI) can consume.

## Changes

- **`agents.py`** — `/consensus` + `/consensus/{ticker}` response dict gains `scoring_detail` (pass-through of `ConsensusResult.scoring_detail`).
- **`dashboard.py`** — `_get_latest_actions` SELECT adds `scoring_detail, agent_verdicts`. New `_parse_json_field` helper for NULL/malformed JSON graceful degrade. Both BUY + SELL item dicts get the fields. Also fixes pre-existing Pylance type error (severity 8) in `_get_account_labels` (user-requested cleanup).
- **`actions.py`** — `_get_recommendations` SELECT + parse. `_build_actions` threads the fields into the item dict **before** urgent/check/hold bucket branching (codex Round 1 HIGH fix).
- **`.cspell.json`** — whitelist domain terms (`finnhub`, `HMAC`, `macmini`, `TSMC`, `longshort`, `longterm`, `kakao`, `hojin`, `devlp`).

## Codex review (2 rounds)

**Round 1 HIGH**: `_get_recommendations()` exposed the fields but `_build_actions()` was dropping them when constructing urgent/check/hold items. `/actions` response therefore remained unchanged — A-2c couldn't consume from that route. Fix: thread both fields into the item dict before bucket branching.

**Round 2**: No findings. All three routes verified against their DB read paths.

Residual note (non-blocking, deferred to A-6): DRY the JSON parse helper between actions.py and dashboard.py; add Pydantic response models.

## Regression locks (STRATEGY §5.3.1)

- `TestConsensusScoringDetailExpose` (2): `/consensus` + `/consensus/{ticker}` carry `source`/`schema_version`/`basis_action`/`final_action_source`.
- `TestLatestActionsScoringDetail` (2): dashboard parses JSON + NULL row graceful.
- `TestGetRecommendationsScoringDetail` (3): actions parses JSON + NULL + malformed → None.
- `TestBuildActionsScoringDetail` (1): `_build_actions` threads fields into final item (codex Round 1 HIGH lock-in).

## Test plan

- [x] `make test-fast` — 2998/2998 pass (~25s)
- [x] `ruff check` — clean
- [ ] Live API verify after next `make full-scan` run: `curl localhost:8001/api/consensus | jq '.results[0].scoring_detail'` returns populated dict (next session chore, not blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)