### PR TITLE
feat(frontend): surface consensus scoring_detail on /consensus (Phase 2 A-2c)

### DIFF
--- a/frontend/src/__tests__/components/consensus-table.test.tsx
+++ b/frontend/src/__tests__/components/consensus-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ConsensusTable } from "@/components/ui/consensus-table";
 
@@ -220,5 +220,112 @@ describe("ConsensusTable", () => {
     render(<ConsensusTable data={withEmptyReason} vix={null} />);
     const badge = screen.getByTestId("divergence-badge");
     expect(badge).toHaveAttribute("title", "기술지표 반대");
+  });
+
+  // A-2c — scoring_detail (PR #368 API expose) 기반 UI 회귀 잠금.
+  // Gotcha-Test Pair (STRATEGY §5.3.1): action-source 배지 / basis 라벨 / 기여도 강조를
+  // 실수로 제거하면 아래 테스트가 fail.
+  describe("scoring_detail surfacing (A-2c)", () => {
+    const makeScoring = (overrides = {}) => ({
+      source: "consensus",
+      schema_version: 1,
+      weights: { technical: 0.4, fundamental: 0.3, risk: 0.2, macro: 0.1 },
+      action_scores: { BUY: 0.55, SELL: 0.0, HOLD: 0.15 },
+      contributions: [
+        { agent_name: "technical", action: "BUY", confidence: 75, weight: 0.4, weighted: 0.3, counted_for_basis_action: true },
+        { agent_name: "fundamental", action: "HOLD", confidence: 50, weight: 0.3, weighted: 0.15, counted_for_basis_action: false },
+        { agent_name: "risk", action: "BUY", confidence: 60, weight: 0.2, weighted: 0.12, counted_for_basis_action: true },
+        { agent_name: "macro", action: "BUY", confidence: 70, weight: 0.1, weighted: 0.07, counted_for_basis_action: true },
+      ],
+      final_action: "BUY",
+      final_confidence: 72.5,
+      final_action_source: "weighted_sum" as const,
+      basis_action: "BUY",
+      agreement_rate: 0.75,
+      risk_veto_fired: false,
+      divergence_flag: false,
+      penalty_applied: false,
+      pre_penalty_action: "",
+      ...overrides,
+    });
+
+    it("does not render action-source badge when weighted_sum", () => {
+      const d = [{ ...mockData[0], scoring_detail: makeScoring() }];
+      render(<ConsensusTable data={d} />);
+      expect(screen.queryByTestId("action-source-badge")).not.toBeInTheDocument();
+    });
+
+    it("renders risk_veto action-source badge with tooltip", () => {
+      const d = [{
+        ...mockData[0],
+        scoring_detail: makeScoring({ final_action_source: "risk_veto", risk_veto_fired: true }),
+      }];
+      render(<ConsensusTable data={d} />);
+      const badge = screen.getByTestId("action-source-badge");
+      expect(badge.textContent).toContain("🛑");
+      expect(badge.getAttribute("title")).toContain("거부권");
+    });
+
+    it("renders divergence_penalty badge + basis label when penalty_applied", () => {
+      const d = [{
+        ...mockData[0],
+        final_action: "HOLD",
+        scoring_detail: makeScoring({
+          final_action: "HOLD",
+          final_action_source: "divergence_penalty",
+          basis_action: "BUY",
+          penalty_applied: true,
+          pre_penalty_action: "BUY",
+        }),
+      }];
+      render(<ConsensusTable data={d} />);
+      expect(screen.getByTestId("action-source-badge").textContent).toContain("⚠️");
+      const basis = screen.getByTestId("penalty-basis-label");
+      // "BUY → HOLD" downgrade 표시 — 사용자가 원 방향 추정 가능
+      expect(basis.textContent).toContain("BUY");
+      expect(basis.textContent).toContain("HOLD");
+    });
+
+    it("renders weighted contribution % for agents that voted for basis_action", () => {
+      const d = [{ ...mockData[0], scoring_detail: makeScoring() }];
+      render(<ConsensusTable data={d} />);
+      fireEvent.click(screen.getByText("TSLA"));
+      // technical counted_for_basis_action=true, weighted 0.3 / action_scores.BUY=0.55 ≈ 55%
+      // (basis_action 분모 기반 — codex Round 1 LOW 1 fix)
+      const pct = screen.getByTestId("contrib-pct-technical");
+      const num = parseInt(pct.textContent!.replace("%", ""), 10);
+      expect(num).toBeGreaterThan(40);
+      expect(num).toBeLessThan(60);
+    });
+
+    it("omits contribution % for agents whose action differs from basis_action", () => {
+      // fundamental = HOLD (counted_for_basis_action=false when basis=BUY) → % 가 의미 없어 미렌더
+      const d = [{ ...mockData[0], scoring_detail: makeScoring() }];
+      render(<ConsensusTable data={d} />);
+      fireEvent.click(screen.getByText("TSLA"));
+      expect(screen.queryByTestId("contrib-pct-fundamental")).not.toBeInTheDocument();
+    });
+
+    it("highlights counted_for_basis_action agents with emerald ring", () => {
+      const d = [{ ...mockData[0], scoring_detail: makeScoring() }];
+      render(<ConsensusTable data={d} />);
+      fireEvent.click(screen.getByText("TSLA"));
+      const tech = screen.getByTestId("agent-card-technical");
+      expect(tech.className).toContain("emerald");
+      const fund = screen.getByTestId("agent-card-fundamental");
+      expect(fund.className).not.toContain("emerald-500");
+    });
+
+    it("falls back gracefully when scoring_detail is null (backward compat)", () => {
+      const d = [{ ...mockData[0], scoring_detail: null }];
+      render(<ConsensusTable data={d} />);
+      // Expanded row 는 여전히 reasoning 표시 (기존 경로)
+      fireEvent.click(screen.getByText("TSLA"));
+      expect(screen.getByText("RSI oversold bounce")).toBeInTheDocument();
+      // contribution % cell 은 없음
+      expect(screen.queryByTestId("contrib-pct-technical")).not.toBeInTheDocument();
+      // action-source 배지도 없음
+      expect(screen.queryByTestId("action-source-badge")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/__tests__/components/consensus-table.test.tsx
+++ b/frontend/src/__tests__/components/consensus-table.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { ConsensusTable } from "@/components/ui/consensus-table";
+import { ConsensusTable, type ScoringDetail } from "@/components/ui/consensus-table";
 
 const mockData = [
   {
@@ -226,7 +226,8 @@ describe("ConsensusTable", () => {
   // Gotcha-Test Pair (STRATEGY §5.3.1): action-source 배지 / basis 라벨 / 기여도 강조를
   // 실수로 제거하면 아래 테스트가 fail.
   describe("scoring_detail surfacing (A-2c)", () => {
-    const makeScoring = (overrides = {}) => ({
+    // ScoringDetail 을 명시 반환 타입으로 — overrides 가 widen 해도 contract 유지.
+    const makeScoring = (overrides: Partial<ScoringDetail> = {}): ScoringDetail => ({
       source: "consensus",
       schema_version: 1,
       weights: { technical: 0.4, fundamental: 0.3, risk: 0.2, macro: 0.1 },
@@ -239,7 +240,7 @@ describe("ConsensusTable", () => {
       ],
       final_action: "BUY",
       final_confidence: 72.5,
-      final_action_source: "weighted_sum" as const,
+      final_action_source: "weighted_sum",
       basis_action: "BUY",
       agreement_rate: 0.75,
       risk_veto_fired: false,

--- a/frontend/src/components/ui/consensus-table.tsx
+++ b/frontend/src/components/ui/consensus-table.tsx
@@ -15,7 +15,41 @@ interface AgentVerdict {
   action: string;
   confidence: number;
   reasoning: string;
-  data_points: Record<string, any>;
+  data_points: Record<string, unknown>;
+}
+
+// A-2c (PR #368): backend scoring_detail contract. Populated by `_build_consensus`
+// (consensus.py) when source="consensus"; source="candidate" 도 같은 컬럼을 공유하나
+// 이 테이블은 consensus rows 전용.
+// Literal union 으로 backend enum 잠금 (codex A-2c review LOW 2 — contract drift 방어).
+type Action = "BUY" | "SELL" | "HOLD";
+type ScoringSource = "consensus" | "candidate";
+type FinalActionSource = "weighted_sum" | "risk_veto" | "divergence_penalty";
+
+interface ScoringContribution {
+  agent_name: string;
+  action: Action;
+  confidence: number;
+  weight: number;
+  weighted: number; // weight × (confidence/100) — action_scores[action] 에 누적된 값
+  counted_for_basis_action: boolean;
+}
+
+interface ScoringDetail {
+  source: ScoringSource;
+  schema_version: number;
+  weights: Record<string, number>;
+  action_scores: Record<Action, number>;
+  contributions: ScoringContribution[];
+  final_action: Action;
+  final_confidence: number;
+  final_action_source: FinalActionSource;
+  basis_action: Action;
+  agreement_rate: number;
+  risk_veto_fired: boolean;
+  divergence_flag: boolean;
+  penalty_applied: boolean;
+  pre_penalty_action: Action | "";
 }
 
 interface ConsensusRow {
@@ -28,6 +62,7 @@ interface ConsensusRow {
   reasoning: string;
   divergence_flag?: boolean;
   divergence_reason?: string;
+  scoring_detail?: ScoringDetail | null;
 }
 
 const AGENT_ORDER = [
@@ -57,6 +92,14 @@ function agentCell(verdict: AgentVerdict | undefined) {
     </span>
   );
 }
+
+// A-2c: `final_action_source` 를 한국어 tooltip + 이모지 아이콘으로 시각화.
+// satisfies 로 backend literal union 과 key exhaustiveness 연결 (codex review LOW 2).
+const SOURCE_META = {
+  weighted_sum: { icon: "🗳️", tip: "가중 합의" },
+  risk_veto: { icon: "🛑", tip: "리스크 에이전트 거부권 (Risk SELL conf ≥ 80)" },
+  divergence_penalty: { icon: "⚠️", tip: "기술지표 반대로 HOLD 강등" },
+} satisfies Record<FinalActionSource, { icon: string; tip: string }>;
 
 export function ConsensusTable({ data, vix }: { data: ConsensusRow[]; vix?: number | null }) {
   const [expanded, setExpanded] = useState<string | null>(null);
@@ -107,6 +150,25 @@ export function ConsensusTable({ data, vix }: { data: ConsensusRow[]; vix?: numb
                         ⚠
                       </span>
                     )}
+                    {/* A-2c: final_action_source 가 weighted_sum 이 아니면 아이콘으로 override 원인 surface.
+                        basis_action ≠ final_action 인 penalty 케이스에는 "pre_penalty → final" 미니 텍스트. */}
+                    {row.scoring_detail && row.scoring_detail.final_action_source !== "weighted_sum" && (
+                      <span
+                        className="text-[10px] ml-1 cursor-help"
+                        title={SOURCE_META[row.scoring_detail.final_action_source]?.tip || row.scoring_detail.final_action_source}
+                        data-testid="action-source-badge"
+                      >
+                        {SOURCE_META[row.scoring_detail.final_action_source]?.icon || "·"}
+                      </span>
+                    )}
+                    {row.scoring_detail?.penalty_applied && row.scoring_detail.basis_action !== row.final_action && (
+                      <div
+                        className="text-[9px] text-amber-400/80 mt-0.5 leading-tight"
+                        data-testid="penalty-basis-label"
+                      >
+                        {row.scoring_detail.pre_penalty_action} → {row.final_action}
+                      </div>
+                    )}
                   </td>
                   <td className="py-1.5 px-2 text-right">{row.final_confidence.toFixed(1)}</td>
                   <td className="py-1.5 px-2 text-right hidden sm:table-cell">
@@ -123,22 +185,64 @@ export function ConsensusTable({ data, vix }: { data: ConsensusRow[]; vix?: numb
                 {isExpanded && (
                   <tr className="bg-muted/10">
                     <td colSpan={4 + AGENT_ORDER.length} className="px-3 py-3">
-                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                        {AGENT_ORDER.map((a) => {
-                          const v = agentMap[a.key];
-                          if (!v) return null;
-                          return (
-                            <div key={a.key} className="bg-muted/30 rounded-md p-2 border border-border/30">
-                              <div className="flex items-center gap-2 mb-1">
-                                <span className="text-[10px] font-medium text-muted-foreground">{a.label}</span>
-                                <StatusBadge status={v.action} size="sm" />
-                                <span className="text-[10px] text-muted-foreground ml-auto">{v.confidence.toFixed(0)}%</span>
-                              </div>
-                              <p className="text-[10px] text-muted-foreground/80 leading-tight">{v.reasoning}</p>
-                            </div>
-                          );
-                        })}
-                      </div>
+                      {/* A-2c: contributions 에서 agent 별 weighted 값을 lookup.
+                          분모는 basis_action bucket 의 action_scores 합 — "basis 방향 결정에 얼마나
+                          기여했는가" 가 UI 의도 (codex review LOW 1 — 전체 총합 분모는 semantic drift).
+                          basis_action 과 반대쪽 agent 의 `%` 는 null 로 렌더 (basis 기여 아니므로 무의미). */}
+                      {(() => {
+                        const sd = row.scoring_detail;
+                        const contribMap = Object.fromEntries(
+                          (sd?.contributions ?? []).map((c) => [c.agent_name, c])
+                        );
+                        const basisDenom = sd?.action_scores[sd.basis_action] ?? 0;
+                        return (
+                          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                            {AGENT_ORDER.map((a) => {
+                              const v = agentMap[a.key];
+                              if (!v) return null;
+                              const contrib = contribMap[a.key];
+                              // basis 방향에 기여한 에이전트만 % 계산 (의미 있는 causal share).
+                              const pctOfBasis = contrib?.counted_for_basis_action && basisDenom > 0
+                                ? (contrib.weighted / basisDenom) * 100
+                                : null;
+                              return (
+                                <div
+                                  key={a.key}
+                                  className={`bg-muted/30 rounded-md p-2 border ${
+                                    contrib?.counted_for_basis_action
+                                      ? "border-emerald-500/40"
+                                      : "border-border/30"
+                                  }`}
+                                  data-testid={`agent-card-${a.key}`}
+                                >
+                                  <div className="flex items-center gap-2 mb-1">
+                                    <span className="text-[10px] font-medium text-muted-foreground">{a.label}</span>
+                                    <StatusBadge status={v.action} size="sm" />
+                                    <span className="text-[10px] text-muted-foreground ml-auto">{v.confidence.toFixed(0)}%</span>
+                                  </div>
+                                  {contrib && (
+                                    <div className="flex items-center gap-1 mb-1 text-[9px] text-muted-foreground/80">
+                                      <span title={`weighted = ${contrib.weight} × ${contrib.confidence}/100 = ${contrib.weighted}`}>
+                                        w={contrib.weight.toFixed(3)} · c={contrib.weighted.toFixed(3)}
+                                      </span>
+                                      {pctOfBasis !== null && (
+                                        <span
+                                          className="ml-auto font-mono"
+                                          data-testid={`contrib-pct-${a.key}`}
+                                          title={`${sd?.basis_action} 방향 결정 기여도 (action_scores[${sd?.basis_action}] 대비)`}
+                                        >
+                                          {pctOfBasis.toFixed(0)}%
+                                        </span>
+                                      )}
+                                    </div>
+                                  )}
+                                  <p className="text-[10px] text-muted-foreground/80 leading-tight">{v.reasoning}</p>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        );
+                      })()}
                       {/* 에이전트 reasoning trace — 실시간 스트리밍 */}
                       <div className="mt-3 pt-3 border-t border-border/20">
                         <AgentTrace ticker={row.ticker} />

--- a/frontend/src/components/ui/consensus-table.tsx
+++ b/frontend/src/components/ui/consensus-table.tsx
@@ -22,11 +22,12 @@ interface AgentVerdict {
 // (consensus.py) when source="consensus"; source="candidate" 도 같은 컬럼을 공유하나
 // 이 테이블은 consensus rows 전용.
 // Literal union 으로 backend enum 잠금 (codex A-2c review LOW 2 — contract drift 방어).
-type Action = "BUY" | "SELL" | "HOLD";
-type ScoringSource = "consensus" | "candidate";
-type FinalActionSource = "weighted_sum" | "risk_veto" | "divergence_penalty";
+// export — 회귀 테스트가 같은 literal shape 로 fixture 를 생성할 수 있게.
+export type Action = "BUY" | "SELL" | "HOLD";
+export type ScoringSource = "consensus" | "candidate";
+export type FinalActionSource = "weighted_sum" | "risk_veto" | "divergence_penalty";
 
-interface ScoringContribution {
+export interface ScoringContribution {
   agent_name: string;
   action: Action;
   confidence: number;
@@ -35,7 +36,7 @@ interface ScoringContribution {
   counted_for_basis_action: boolean;
 }
 
-interface ScoringDetail {
+export interface ScoringDetail {
   source: ScoringSource;
   schema_version: number;
   weights: Record<string, number>;


### PR DESCRIPTION
## Summary

Closes the A-2 loop (#364 persist → #366 discriminator → #368 API → **this PR UI**). ConsensusTable now consumes `scoring_detail` from `/api/consensus` so users can see *why* a given action won — per-agent weighted contribution, final action source, and penalty context.

## UI additions

- **Action column**: emoji badge for non-`weighted_sum` sources (`🛑` risk_veto with 거부권 tooltip, `⚠️` divergence_penalty with HOLD 강등 tooltip). `weighted_sum` hidden to reduce noise.
- **Penalty label**: `"BUY → HOLD"` mini-text when `penalty_applied && basis_action !== final_action` (the divergence downgrade case).
- **Expanded row**: each agent card shows `weight` · `weighted` (= weight × confidence/100) and `%` of `action_scores[basis_action]` — but **only for agents counted toward basis** (non-basis agents omit the `%` since it would be meaningless). Emerald border highlights agents whose vote fed basis_action.
- **Graceful null fallback**: legacy rows without scoring_detail keep the prior reasoning-only view.

## Contract drift defense

- TS literal unions for `Action`, `ScoringSource`, `FinalActionSource`.
- `SOURCE_META satisfies Record<FinalActionSource, { icon; tip }>` for exhaustiveness.
- `ScoringDetail.action_scores` is `Record<Action, number>` so backend enum changes surface as compile errors.

## Codex review (2 rounds)

**Round 1 LOW 1 (causal share)**: denominator was total weighted mass — `%` was "share of total vote mass", not "share of the decision". Switched to `action_scores[basis_action]` so the `%` is "% of the basis_action bucket you caused" (the actual audit question). Non-basis agents now omit the `%`.

**Round 1 LOW 2 (contract drift)**: literal unions + satisfies added.

**Round 2 LOW**: tooltip wording `weight × confidence/100 = weighted` used the weighted value on both sides — fixed to reference the actual confidence value.

**Round 2 final**: no further findings.

## Regression locks (STRATEGY §5.3.1)

`TestConsensusTable.scoring_detail_surfacing` (7 tests):
- weighted_sum hides badge
- risk_veto renders 🛑 with 거부권 tooltip
- divergence_penalty renders ⚠️ + "BUY → HOLD" basis label
- contribution % renders for basis-aligned agents (40-60% for fixture)
- non-basis agent omits %
- emerald border only for counted_for_basis_action=true
- null scoring_detail falls back to reasoning-only view

## Live verification

- `/api/consensus` returned all 21 tickers with `source="consensus"`, `schema_version=1`
- `next start` prod HTML contained the full scoring_detail hydration payload
- All 21 current rows have `final_action_source="weighted_sum"` → badge/penalty UI correctly hidden in prod today. Unit tests cover the veto + penalty cases.

## Scope (intentionally narrow)

- `/dashboard` ActionItems card and `/actions` page do **not** consume scoring_detail yet. Deferred to a follow-up — they receive the field from backend already (#368) but UI wiring is a separate decision (card layout is tight).

## Test plan

- [x] `npm run test` — 924/924 pass
- [x] `npm run build` — green
- [x] `npx eslint <touched>` — clean
- [x] Live `/api/consensus` 21 tickers shape check
- [x] `next start` HTML hydration payload grep
- [ ] Interactive browser QA (expand row, click through) — deferred; dev server hung on first compile. Unit tests + SSR HTML verify equivalent coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)