### PR TITLE
fix(consensus): tighten rows_parsed gate to usable verdicts (Phase 2 A-1b)

### DIFF
--- a/nuri/trading/agents/consensus.py
+++ b/nuri/trading/agents/consensus.py
@@ -119,9 +119,13 @@ def _compute_weights(db_path=None) -> dict[str, float]:
     # 모든 row 가 skip 되면 min_records 문턱을 넘어도 가중치 변화 없이
     # DEFAULT_WEIGHTS 로 귀결되는 silent failure. 카운터로 drill-down 가능.
     rows_seen = len(rows)
-    rows_parsed = 0
+    rows_parsed = 0  # A-1b: BUY/SELL verdict 가 최소 1개 있는 row 만 counted.
     rows_skipped_schema = 0
     rows_skipped_json = 0
+    # A-1b: JSON 은 유효하지만 등록된 agent (DEFAULT_WEIGHTS) 에서 usable BUY/SELL
+    # verdict 하나도 없는 row — 즉 "학습 샘플 아님". 대부분 HOLD-only 지만, 미등록
+    # agent verdict 만 있는 row, 이상한 action 값 row 도 여기 합산됨 (codex Round 1).
+    rows_skipped_no_usable = 0
 
     for row in rows:
         try:
@@ -134,8 +138,13 @@ def _compute_weights(db_path=None) -> dict[str, float]:
             # WHERE outcome_30d IS NOT NULL guards the read; `or 0` is defensive only.
             outcome = row["outcome_30d"] or 0
             is_positive = outcome > 0
-            rows_parsed += 1
 
+            # A-1b (codex A-1a Round 2 residual P2): rows_parsed 를 "valid JSON" 이
+            # 아니라 "actual learning sample" 로 tighten. 모든 verdict 가 HOLD 면
+            # agent_hits 에 기여하지 않음 → sample 로 카운트되지 않는 게 정확.
+            # 이전: 10 개 row 모두 HOLD-only 여도 `rows_parsed=10 >= min_records=10`
+            # 통과하지만 hit_rates dict 가 empty 로 귀결되는 silent fallback.
+            row_has_usable_verdict = False
             for v in verdicts:
                 if not isinstance(v, dict):
                     continue
@@ -147,8 +156,15 @@ def _compute_weights(db_path=None) -> dict[str, float]:
                     # HOLD agent verdict 는 hit 판정 제외 (분기 없음 → 자동 skip).
                     if action == "BUY":
                         agent_hits[agent_name].append(is_positive)
+                        row_has_usable_verdict = True
                     elif action == "SELL":
                         agent_hits[agent_name].append(not is_positive)
+                        row_has_usable_verdict = True
+
+            if row_has_usable_verdict:
+                rows_parsed += 1
+            else:
+                rows_skipped_no_usable += 1
         except (json.JSONDecodeError, TypeError, KeyError):
             rows_skipped_json += 1
             continue
@@ -156,21 +172,22 @@ def _compute_weights(db_path=None) -> dict[str, float]:
     # min_records gate — parsed count 기반 (codex A-1 P1-2).
     # 이전: len(rows) < min_records 로 raw SQL 수 검증 → malformed row 가 gate 통과 후
     # 실제 학습 샘플이 문턱 미달로 가중치 shift. parsed 수로 gate 해야 샘플 신뢰성 보장.
+    # A-1b: rows_parsed 는 이제 "≥1 BUY/SELL verdict" row 만 포함.
     if rows_parsed < min_records:
         # fallback 발생 시 명시적 WARNING — normal path (early return) 과 구분.
         if rows_seen > 0:
             logger.warning(
-                "_compute_weights fallback to DEFAULT_WEIGHTS: rows_seen=%d rows_parsed=%d (< min_records=%d) skipped_schema=%d skipped_json=%d",
-                rows_seen, rows_parsed, min_records, rows_skipped_schema, rows_skipped_json,
+                "_compute_weights fallback to DEFAULT_WEIGHTS: rows_seen=%d rows_parsed=%d (< min_records=%d) skipped_schema=%d skipped_json=%d skipped_no_usable=%d",
+                rows_seen, rows_parsed, min_records, rows_skipped_schema, rows_skipped_json, rows_skipped_no_usable,
             )
         return dict(DEFAULT_WEIGHTS)
 
     # Normal path — DEBUG 레벨 (per-ticker 호출 hot path spam 방지).
     # Anomaly (skip 발생) 시 INFO 로 올려 operator 눈에 띄게.
-    if rows_skipped_schema > 0 or rows_skipped_json > 0:
+    if rows_skipped_schema > 0 or rows_skipped_json > 0 or rows_skipped_no_usable > 0:
         logger.info(
-            "_compute_weights anomaly: rows_seen=%d rows_parsed=%d rows_skipped_schema=%d rows_skipped_json=%d",
-            rows_seen, rows_parsed, rows_skipped_schema, rows_skipped_json,
+            "_compute_weights anomaly: rows_seen=%d rows_parsed=%d rows_skipped_schema=%d rows_skipped_json=%d rows_skipped_no_usable=%d",
+            rows_seen, rows_parsed, rows_skipped_schema, rows_skipped_json, rows_skipped_no_usable,
         )
     else:
         logger.debug(

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -2101,6 +2101,138 @@ class TestComputeWeightsHitRates:
             "이전 버그: raw count=10 으로 gate 통과 → shift 발생."
         )
 
+    def test_hold_only_rows_excluded_from_parsed_count(self, db_path):
+        """A-1b — HOLD-only row 는 rows_parsed 에 counted 되지 않음.
+
+        STRATEGY §5.3.1 Gotcha-Test Pair (codex A-1a Round 2 residual P2):
+        모든 verdict 가 HOLD 인 row 는 agent_hits 에 기여하지 않는데, 이전에는
+        rows_parsed += 1 로 카운트 → 10 개 HOLD-only row 가 gate 통과해 silent
+        fallback. Fix 후 rows_parsed=0 → DEFAULT_WEIGHTS 조기 반환.
+
+        Revert 시 이 테스트 fail (10 rows × HOLD-only 면 DEFAULT_WEIGHTS 로 귀결되는
+        normal path 가 gate 통과 실패 path 로 전환 — log level WARNING vs DEBUG 로 구분).
+        """
+        import json
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        hold_only_verdicts = [
+            {"agent_name": "technical", "action": "HOLD"},
+            {"agent_name": "fundamental", "action": "HOLD"},
+            {"agent_name": "risk", "action": "HOLD"},
+        ]
+        with get_db(db_path) as conn:
+            # 15 rows 모두 HOLD-only (min_records=10 보다 많지만 학습 샘플 0)
+            for i in range(15):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"H{i}", "HOLD", 50.0, None, None, 100.0,
+                     json.dumps(hold_only_verdicts), 0.05),
+                )
+
+        weights = _compute_weights(db_path=db_path)
+        assert weights == DEFAULT_WEIGHTS, (
+            "HOLD-only rows 15 개 → rows_parsed=0 → DEFAULT_WEIGHTS. "
+            "이전 버그: rows_parsed=15 >= min_records=10 으로 pass 했지만 "
+            "agent_hits 가 비어 있어 hit_rates 계산 무의미."
+        )
+
+    def test_mixed_usable_and_hold_only_rows_counts_only_usable(self, db_path, caplog):
+        """A-1b — mixed: 일부 BUY/SELL row + 일부 HOLD-only row. parsed 는 usable 만."""
+        import json
+        import logging
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        usable = [{"agent_name": "technical", "action": "BUY"}]
+        hold_only = [{"agent_name": "technical", "action": "HOLD"}]
+        with get_db(db_path) as conn:
+            # 6 usable + 9 HOLD-only = 15 total. 6 < min_records=10 → fallback 기대.
+            for i in range(6):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"U{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(usable), 0.05),
+                )
+            for i in range(9):
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"H{i}", "HOLD", 50.0, None, None, 100.0,
+                     json.dumps(hold_only), 0.05),
+                )
+
+        with caplog.at_level(logging.WARNING, logger="nuri.trading.agents.consensus"):
+            weights = _compute_weights(db_path=db_path)
+
+        assert weights == DEFAULT_WEIGHTS
+        # WARNING log 에 skipped_no_usable=9 가 찍혀 observability 확인.
+        fallback_logs = [r for r in caplog.records if "fallback" in r.getMessage()]
+        assert fallback_logs, "rows_parsed < min_records 시 WARNING emit"
+        assert "skipped_no_usable=9" in fallback_logs[0].getMessage(), (
+            "HOLD-only skip counter 가 log 에 surface — operator 가 원인 식별 가능"
+        )
+
+    def test_usable_plus_hold_only_gate_passes_but_logs_info_anomaly(self, db_path, caplog):
+        """A-1b — 10 usable + 1 HOLD-only: gate 통과하지만 INFO anomaly 로 log.
+
+        codex A-1b Round 1 residual: fallback path (WARNING) 는 잠겼지만 "gate
+        통과하는 정상 경로에서 HOLD-only row 가 observability 에 노출되는가" 를
+        별도로 lock-in. INFO 레벨 (hot path 에서 다빈도 호출 고려).
+        """
+        import json
+        import logging
+
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import DEFAULT_WEIGHTS, _compute_weights
+
+        usable = [
+            {"agent_name": "technical", "action": "BUY"},
+            {"agent_name": "fundamental", "action": "SELL"},
+        ]
+        hold_only = [{"agent_name": "technical", "action": "HOLD"}]
+        with get_db(db_path) as conn:
+            for i in range(10):  # 10 usable → gate 통과
+                conn.execute(
+                    """INSERT INTO recommendations
+                       (date, ticker, action, confidence, regime, signals, entry_price,
+                        agent_verdicts, outcome_30d)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (today_kst(), f"U{i}", "BUY", 50.0, None, None, 100.0,
+                     json.dumps(usable), 0.05),
+                )
+            conn.execute(  # 1 HOLD-only → skipped, anomaly INFO
+                """INSERT INTO recommendations
+                   (date, ticker, action, confidence, regime, signals, entry_price,
+                    agent_verdicts, outcome_30d)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (today_kst(), "H0", "HOLD", 50.0, None, None, 100.0,
+                 json.dumps(hold_only), 0.05),
+            )
+
+        with caplog.at_level(logging.INFO, logger="nuri.trading.agents.consensus"):
+            weights = _compute_weights(db_path=db_path)
+
+        # Gate 통과 — weights 는 기본값에서 shift (technical BUY 가 양수 outcome 으로 hit)
+        assert weights != dict(DEFAULT_WEIGHTS), "10 usable → weight shift 발생"
+        # INFO anomaly log 에 skipped_no_usable=1 포함
+        anomaly_logs = [r for r in caplog.records if "anomaly" in r.getMessage()]
+        assert anomaly_logs, "HOLD-only skip 있으면 INFO anomaly emit"
+        assert "skipped_no_usable=1" in anomaly_logs[0].getMessage()
+
     def test_observability_normal_path_debug(self, db_path, caplog):
         """Normal path (skip=0) 는 DEBUG 레벨 — per-ticker hot path spam 방지.
 


### PR DESCRIPTION
## Summary

Close the codex A-1a Round 2 residual P2: `_compute_weights` previously counted any row with a valid JSON list toward `rows_parsed`, including HOLD-only rows that cannot actually feed `agent_hits`. Ten HOLD-only rows could pass `min_records` and yield an empty `hit_rates` — a silent fallback that looked like a gate pass in logs.

## Fix

Count `rows_parsed` only when the row contains at least one `BUY`/`SELL` verdict for an agent registered in `DEFAULT_WEIGHTS`. Otherwise increment `rows_skipped_no_usable` (renamed from `hold_only` per codex Round 1 — the bucket is broader: also catches unregistered agents and unexpected action values).

WARNING fallback and INFO anomaly paths both surface `skipped_no_usable` so operators can distinguish "no real samples yet" from "malformed data".

## Regression locks (STRATEGY §5.3.1)

- `test_hold_only_rows_excluded_from_parsed_count` — 15 HOLD-only rows keep DEFAULT_WEIGHTS.
- `test_mixed_usable_and_hold_only_rows_counts_only_usable` — WARNING fallback surfaces `skipped_no_usable=9`.
- `test_usable_plus_hold_only_gate_passes_but_logs_info_anomaly` — gate passes, weights shift, INFO anomaly emits `skipped_no_usable=1` (codex Round 1 gap).

## Codex review (2 rounds)

- Round 1: no blocking. 2 LOWs (semantic rename + gate-pass observability test). Both addressed.
- Round 2: 1 LOW stale test comment. Fixed.

## NEXT_SESSION drift found

A-1b spec mentioned "add `agent_accuracy_snapshots` periodic job" — **already exists** in scheduler.py:200 (weekly Sunday 08:00). Spec was stale. Real gap was only the parsed-count tighten.

## Test plan

- [x] `make test-fast` — 3001/3001 pass
- [x] `ruff check` — clean
- [ ] Live verify after Mac mini reconnect + 30 days of LM data (next window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)