### PR TITLE
docs(config): expand config/CLAUDE.md + sync collector count drift

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,30 +1,85 @@
 # config/ — YAML Configuration
 
-All rules, thresholds, and metadata live here. **Never hardcode** these values in Python code.
+**Canonical source of truth** for investment rules, agent thresholds, signal metadata, and account strategy profiles. Python code **never hardcodes** these values — always read from the corresponding loader in `nuri/core/`. (§2.2 mechanical execution.)
 
-## Change Procedure
+## File inventory
 
-1. Edit the YAML file
-2. Verify with backtest if it's a trading rule (`config/rules.yaml`)
-3. Run `make test` to confirm nothing breaks
-4. Commit the YAML change (separate from code changes when possible)
+| File | Lines | Purpose | Loader |
+|------|-------|---------|--------|
+| `rules.yaml` | ~230 | Investment rules (stop-loss, take-profit, position limits, VIX gate, account_strategies, siege_gates) | `nuri/core/rules.py` |
+| `agents.yaml` | ~235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
+| `signals.yaml` | ~190 | 20 signal definitions (type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
+| `alerts.yaml` | ~25 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
+| `stock_types.yaml` | ~50 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |
+| `universe.yaml` | ~755 | S&P 500 + KOSPI 200 + manual ETFs. Auto-maintained by `make universe-sync` (Wikipedia + KRX/FDR); manual entries preserved | `nuri/collectors/universe_sync.py` |
+| `portfolio.example.yaml` | ~40 | Example template showing account + holdings shape | `scripts/import_portfolio.py` (via `cp` to `portfolio.yaml`) |
+| `portfolio.yaml` | user | Real portfolio — **gitignored** (account labels, holdings, avg price). Shape matches `portfolio.example.yaml` | `scripts/import_portfolio.py` |
+| `kis/` | — | KIS Open API credentials directory — **gitignored** (`kis_devlp.yaml`, token cache). `.gitkeep` only is tracked. Legacy `~/KIS/` also supported for backward compat | `nuri/collectors/kis_*.py` |
 
-## Files
+## Change procedure
 
-| File | Purpose | Loaded by |
-|------|---------|-----------|
-| `rules.yaml` | Investment rules (stop-loss, take-profit, position limits, execution_priority) | `nuri/core/rules.py` |
-| `agents.yaml` | Agent weights, thresholds (RSI, PE, confidence caps), normalization scales | `nuri/core/agent_config.py` |
-| `signals.yaml` | Signal metadata (thresholds, categories, hold_days, buy/sell type) | `nuri/core/signal_config.py` |
-| `alerts.yaml` | Alert thresholds (price swing 3%, F&G bounds 20/80), report timing | Direct YAML load |
-| `portfolio.yaml` | Accounts + holdings (gitignored for real data, committed for test/demo) | `scripts/import_portfolio.py` |
-| `stock_types.yaml` | Growth/value override per ticker → controls stop-loss/take-profit thresholds | Direct YAML load |
+1. Edit the YAML file.
+2. If it's a trading rule (`rules.yaml` / `signals.yaml`): run the relevant backtest to verify intended effect.
+3. `make test` — confirm no loader breakage or test fixture drift.
+4. Commit the YAML change **separately** from code changes when possible — makes diffs easier to review and bisect.
+5. If you're also changing a Python-exposed constant (e.g. `STOCK_STOP_LOSS`), update the loader in `nuri/core/` AND the callers. Don't silently leave YAML and code out of sync.
 
-## Account Strategy Profiles (in rules.yaml)
+## Account strategy profiles (authoritative in `rules.yaml`)
 
-Each `portfolio.yaml` account selects a strategy via `strategy:` field:
-- `core` (-7% stop, 15% max position) — default
-- `active` (-10% stop, 25% max, trailing_stop_arm at +15%)
-- `swing` (-15% stop, 30% max)
-- `long_term` (-20% stop, 25% max)
-- `pension` (-30% stop, 40% max)
+| Strategy | stop_loss | max_single_position | max_sector_exposure | Extra |
+|----------|-----------|---------------------|---------------------|-------|
+| `core` | -7% | 15% | 35% | Default |
+| `active` | -10% | 25% | 45% | `trailing_stop_arm: 15` (auto-arm trailing stop at +15%) |
+| `swing` | -15% | 30% | 50% | — |
+| `long_term` | -20% | 25% | 50% | — |
+| `pension` | -30% | 40% | 60% | — |
+
+Each `portfolio.yaml` account chooses via `strategy:` field. Default = `core`. Cross-referenced in `docs/STRATEGY.md §3.5`.
+
+## Schema landmarks
+
+### `agents.yaml` — per-agent confidence shape
+
+Every agent (except `korean_market` which uses absolute scores) has a `confidence:` sub-block with a repeating shape:
+
+```yaml
+<agent_name>:
+  # agent-specific scoring thresholds (pe_undervalued, rsi_oversold, etc.)
+  score_buy: N
+  score_sell: -N
+  confidence:
+    cap: NN                  # upper bound for both BUY and SELL (some agents split: buy_cap / sell_cap)
+    buy_base: NN             # BUY confidence baseline
+    buy_multiplier: NN       # × score → BUY confidence
+    sell_base: NN            # SELL confidence baseline
+    sell_multiplier: NN
+    hold_base: NN
+    hold_multiplier: NN
+    no_data: NN              # fallback when data absent
+```
+
+The duplication across 10 agents is **intentional** — each agent's confidence curve is tuned independently, so the shape is shared but the values diverge. Do not DRY this into a shared default without a PR that also updates `agent_config.py` loader and all agent classes.
+
+### `rules.yaml` — global vs. account-scoped stop_loss
+
+`stop_loss.per_stock: -7` (global, loaded as `STOCK_STOP_LOSS`) currently duplicates `account_strategies.core.stop_loss: -7`. If you change one, change both. A future chore PR may collapse these into a single source (derive `STOCK_STOP_LOSS` from `account_strategies.core.stop_loss`).
+
+### `signals.yaml` — detector ↔ metadata split
+
+The YAML only carries **metadata** (type, hold_days, params). The actual signal detector lives in `nuri/quant/validation/signal_backtest.py` as a function. Disabling a signal:
+
+```yaml
+rsi_oversold:
+  enabled: false   # detector still exists but config_loader filters it out
+```
+
+### `rules.yaml` — `siege_gates.asset_class_rules` ordering
+
+Matching is first-match-wins from top to bottom. `default: true` is the fallback and must stay last. When adding a new asset class, insert before `default` and make sure the per-class policy exists under `asset_classes:`.
+
+## Gitignored files
+
+- `portfolio.yaml` — real holdings (privacy, §4.4.1 scanner catches broker name leaks in commits)
+- `kis/*` except `.gitkeep` — KIS credentials
+
+Both directories must keep their tracked sentinel (`portfolio.example.yaml` for shape reference, `kis/.gitkeep` for directory preservation) so fresh clones don't lose the path.

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -16,8 +16,15 @@ position_limits:
 
 # ─── 손절 규칙 ──────────────────────────────────────────
 # 원칙: 손실은 짧게 자르기. 감정 배제, 기계적 실행.
+#
+# 주의: `per_stock: -7` 은 `account_strategies.core.stop_loss: -7` 와 동일한 값이
+# 서로 다른 경로로 로드됨. `STOCK_STOP_LOSS` (global) 는 legacy fallback 이고,
+# `get_stop_loss_for_account(account)` 가 실제 per-account threshold resolver.
+# 두 값이 divert 하면 core 계좌의 global fallback path 가 잘못된 threshold 를
+# 집어올 수 있음 → 변경 시 둘 다 업데이트 필수. 향후 PR 에서 single source 로
+# 통합 예정 (derive `STOCK_STOP_LOSS` from core strategy).
 stop_loss:
-  per_stock: -7                 # 종목별 손절선 (%) — O'Neil: -7~8%
+  per_stock: -7                 # 종목별 손절선 (%) — O'Neil: -7~8%. core 전략 default 와 동기화.
   per_stock_value: -10          # 가치주 손절선 (%) — 변동성 감안 완화
   portfolio: -10                # 포트폴리오 전체 손절선 (%)
 


### PR DESCRIPTION
Small doc tightening following `/init` + config audit.

## Changes
- `config/CLAUDE.md`: full file inventory (universe.yaml, kis/ added), schema landmarks (agents.yaml confidence block shape, rules.yaml global vs per-account stop_loss duality, signals.yaml metadata↔detector split, siege_gates.asset_class_rules ordering).
- `config/rules.yaml`: inline comment flagging `stop_loss.per_stock` ↔ `account_strategies.core.stop_loss` duplication risk.
- `CLAUDE.md` + `README.md`: 25 → 27 collectors (drift from A-6 Tier 1 catch).

## Not included
- Per-agent confidence DRY refactor (intentional divergence, documented as-is).
- `STOCK_STOP_LOSS` derive-from-core-strategy refactor — requires code + callers update, filed as follow-up.

No semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)