### PR TITLE
docs: sync drift from codex round 1 audit — 10 numeric + 3 structural

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ flowchart LR
 
 ### Key architectural decisions
 
-- **Sole SQLite gateway** — `nuri/core/db.py` is the only `sqlite3` importer (hook-enforced). 33 tables, WAL mode. All modules use `query()`, `query_df()`, `upsert_*()`, `get_db()`. Tests inject `tmp_path` for full isolation.
+- **Sole SQLite gateway** — `nuri/core/db.py` is the only `sqlite3` importer (hook-enforced). 32 tables, WAL mode. All modules use `query()`, `query_df()`, `upsert_*()`, `get_db()`. Tests inject `tmp_path` for full isolation.
 - **Config-driven, code-static** — all thresholds, rules, signal metadata, and SIEGE gate policies live in `config/*.yaml`. Changing a stop-loss or adding a new market means editing YAML, not Python. See `rules.yaml`, `agents.yaml`, `signals.yaml`, `universe.yaml`.
 - **DB-only integration between phases** — phases communicate through DB tables and CSV files, never direct imports. Re-running an upstream phase automatically refreshes downstream consumers.
 - **SIEGE v2: 3-dimensional certification** — gates apply per Account (strategy profile) × Asset Class (exposure: us_equity, kr_equity, commodity, bond) × Execution Market (KRX, NYSE). See [`docs/SIEGE_V2.md`](docs/SIEGE_V2.md). Inspired by [nutshells3/SIEGE](https://github.com/nutshells3/Swarm-Intelligence-Engine-with-Gated-Execution).
@@ -167,7 +167,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (3,081 backend + 917 frontend + 39 e2e)
+make test       # full suite (3,074 backend + 917 frontend + 38 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 
 ## Scheduler
 
-`nuri/scheduler.py` — 21 cron jobs in `SCHEDULES` list. All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects.
+`nuri/scheduler.py` — 24 cron jobs in `SCHEDULES` list. All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects.
 
 ## Environment Variables
 
@@ -110,7 +110,7 @@ Configured in `.env` (see `.env.example`):
 
 ## DB Schema (SQLite, WAL mode)
 
-33 tables total (20 migrations). Key tables:
+32 tables total (20 migrations). Key tables:
 
 | Table | Purpose |
 |-------|---------|
@@ -180,9 +180,9 @@ data/
 
 ## Testing
 
-3,081 backend tests across 139 files + 917 frontend vitest (60 files) + 39 Playwright E2E (6 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,074 backend tests across 139 files + 917 frontend vitest (60 files) + 38 Playwright E2E (6 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
-**Slow marker**: 23 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
+**Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 
 ```python
 @pytest.fixture

--- a/docs/DX_GUIDE.md
+++ b/docs/DX_GUIDE.md
@@ -19,7 +19,7 @@ previous session:
 | Test isolation flake | `pytest -n auto` (CI-parity flags) | 1+ CI roundtrips |
 | Atomicity violation | `check_atomic.sh` (multi-commit branches) | reset + re-stage cycle |
 
-## The 5 scripts
+## The 4 scripts + 1 PR template
 
 ### 1. `scripts/ci_local.sh` — exact CI parity
 

--- a/docs/KIS_INTEGRATION.md
+++ b/docs/KIS_INTEGRATION.md
@@ -140,7 +140,7 @@ def _yfinance_fallback(tickers):
     return recovered
 ```
 
-**효과**: KIS 22/23 → yfinance fallback +2 → **총 23/23 (100%)**
+**효과**: KIS 21/23 → yfinance fallback +2 → **총 23/23 (100%)**
 
 ## Token 관리
 
@@ -150,10 +150,11 @@ KIS는 토큰 발급 시 1분당 1회 제한. 연속 호출 시 거부됨.
 
 ### 디스크 캐시
 
-| 경로 | 형식 | TTL |
-|---|---|---|
-| `config/kis/cache/token_prod.json` | `{access_token, issued_at, expires_in}` | 23h (실제 24h, 마진 1h) |
-| `config/kis/cache/token_paper.json` | 동일 | 동일 |
+| 경로 | 형식 | TTL | 선택 조건 |
+|---|---|---|---|
+| `config/kis/cache/token_prod.json` | `{access_token, issued_at, expires_in}` | 23h (실제 24h, 마진 1h) | project-local `config/kis/kis_devlp.yaml` 또는 `.env` 사용 시 (기본) |
+| `config/kis/cache/token_paper.json` | 동일 | 동일 | 동일 |
+| `~/KIS/cache/token_*.json` | 동일 | 동일 | legacy — `~/KIS/config/kis_devlp.yaml` 만 존재할 때 (SDK 공존 케이스) |
 
 ### Cooldown 응답 감지
 
@@ -188,7 +189,7 @@ KIS는 미국 종목을 거래소별로 분리:
 | 테스트 | 결과 |
 |---|---|
 | **23개 보유 종목 수집** | 100% (KIS 21 + yfinance fallback 2) |
-| **단위 테스트** | 26 PASS (`tests/collectors/test_kis_realtime.py`) |
+| **단위 테스트** | 31 PASS (`tests/collectors/test_kis_realtime.py`) |
 | **검증 함수** | `_is_rate_limit`, `_is_token_cooldown`, `load_credentials`, `inquire_price_kr/us` |
 
 ## 알려진 한계

--- a/docs/SMOKE_RUN.md
+++ b/docs/SMOKE_RUN.md
@@ -67,7 +67,7 @@ make start                       # API :8001 + Dashboard :3000
 
 | 스텝 | 성공 신호 | 실패 신호 |
 |------|----------|----------|
-| `make setup` | `Portfolio imported. 22 holdings across 4 accounts` | ModuleNotFoundError / sqlite 에러 |
+| `make setup` | `=== Sync complete: -N +M ===` (`scripts/import_portfolio.py` 종료 메시지) | ModuleNotFoundError / sqlite 에러 |
 | `make universe-sync-us` | `fetched 500+ tickers from Wikipedia` + diff summary | Wikipedia 403 / HTTP error |
 | `make universe-sync-kr` | `fetched 200 tickers` 또는 `KR sync skipped (FDR missing)` | 비정상 traceback |
 | `make collect-universe` | `prices [universe]: 100%\|` tqdm 완료 + `수집 결과: ... 성공 / ... 실패` summary | silent hang > 5분 / ERROR 500줄 |
@@ -96,7 +96,7 @@ make start                       # API :8001 + Dashboard :3000
 | Dashboard 500 error | API 서버 미기동 | `make api` 독립 기동 + 로그 확인 |
 | `make collect-universe-1y` 중 OOM | parallel worker 과다 | 현재 10-thread 기본 — stock.py `max_workers=10` 조정 가능 |
 
-**디버그 시**: `data/reports/YYYY-MM-DD/` 의 최신 리포트 확인. `scripts/validate_universe.py --verbose` 상세 출력.
+**디버그 시**: `data/reports/YYYY-MM-DD/` 의 최신 리포트 확인. `scripts/validate_universe.py --format=markdown` 상세 테이블 출력 (지원 플래그는 `--no-fetch`, `--format`).
 
 ---
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -207,9 +207,9 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,081 tests, 139 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,074 tests, 139 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 60 files |
-| E2E | 핵심 flow 커버 | 39 Playwright tests (6 spec) |
+| E2E | 핵심 flow 커버 | 38 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 의존 | 금지 | conftest.py에서 yfinance/외부 API mock |
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,7 +23,7 @@ All tests run **network-free**. Override per-test if needed, but never remove gl
 
 ## Slow Marker
 
-23 LLM/heavy tests marked `@pytest.mark.slow`. PR CI excludes via `-m "not slow"`.
+11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI excludes via `-m "not slow"`.
 - `make test-fast` — excludes slow (~24s)
 - `make test-slow` — slow only
 - `make test` — full suite (~50s)


### PR DESCRIPTION
## Summary

Codex Round 1 docs audit (`codex-reviews/docs-audit-round1-*.md`) surfaced stale numeric claims + naming issues across 7 files. Each finding verified locally before fixing.

## Drift fixes (10 numeric)

| File | Before | After | Source |
|------|--------|-------|--------|
| ARCHITECTURE.md | 33 tables | 32 | `grep -c "CREATE TABLE" nuri/core/db.py` |
| ARCHITECTURE.md | 21 cron jobs | 24 | `grep -c '\"cron\":' nuri/scheduler.py` |
| ARCHITECTURE.md | 23 slow | 11 | `grep -r "pytest.mark.slow" tests \| wc -l` |
| ARCHITECTURE.md | 3,081 backend | 3,074 | `pytest --collect-only -q` |
| ARCHITECTURE.md | 39 Playwright | 38 | `grep -rhE "^\s*test\(" frontend/e2e/` |
| STRATEGY.md | 3,081 backend | 3,074 | same |
| STRATEGY.md | 39 Playwright | 38 | same |
| README.md | 33 tables | 32 | same |
| README.md | 3,081 + 39 | 3,074 + 38 | same |
| tests/CLAUDE.md | 23 slow | 11 | same |
| KIS_INTEGRATION.md | KIS 22/23 | 21/23 | matches line 190 arithmetic |
| KIS_INTEGRATION.md | 26 PASS | 31 | `grep -E "^\s+def test_" tests/collectors/test_kis_realtime.py` |

## Structural fixes (3)

- **DX_GUIDE.md** — "The 5 scripts" section actually has 4 scripts + 1 PR template. Renamed for accuracy.
- **KIS_INTEGRATION.md** — Token cache table only listed `config/kis/cache/`, but `load_credentials()` also falls back to `~/KIS/cache`. Added 3rd row with selection rule.
- **SMOKE_RUN.md** — (a) `Portfolio imported. 22 holdings across 4 accounts` string does not exist anywhere in repo. Replaced with the actual `scripts/import_portfolio.py` final message `=== Sync complete: -N +M ===`. (b) `scripts/validate_universe.py --verbose` flag does not exist (only `--no-fetch` / `--format`). Replaced with `--format=markdown`.

## Verification

`make verify-doc-counts` passes. No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)