### PR TITLE
docs(readme): simplify architecture — 5-step flow + ARCHITECTURE absorbs detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,28 @@ Every BUY/SELL recommendation runs through a **collect → analyze → consensus
 Every BUY/SELL decision travels a **5-step pipeline**. Phases talk only through SQLite + CSV (loose coupling, [STRATEGY §2.3](docs/STRATEGY.md#23-느슨한-결합-loose-coupling-via-data)) — rerun an upstream phase and downstream refreshes automatically.
 
 ```mermaid
-flowchart LR
-    A(["1 Collect<br/>25 collectors<br/>US · KR · macro · news"])
-    B(["2 Analyze<br/>signals · regime<br/>factors · events"])
-    C(["3 Consensus<br/>10 agents<br/>risk veto"])
-    D(["4 Certify<br/>SIEGE v2<br/>3D certification"])
-    E(["5 Track<br/>30 / 60 / 90-day<br/>outcome scoring"])
+flowchart TD
+    CFG[/"config/*.yaml<br/>rules · agents · signals · gates"/]
 
-    A --> B --> C --> D --> E
-    E -. feedback .-> C
+    subgraph Pipeline["Pipeline (5 phases · loose coupling via DB)"]
+        direction LR
+        A(["1 Collect<br/>25 collectors"])
+        B(["2 Analyze<br/>signals · regime · factors"])
+        C(["3 Consensus<br/>10 agents · risk veto"])
+        D(["4 Certify<br/>SIEGE v2 · 3D certification"])
+        E(["5 Track<br/>30 / 60 / 90-day outcomes"])
+
+        A -- "prices · fundamentals<br/>macro · news" --> B
+        B -- "signal_results · factors<br/>regime_transitions" --> C
+        C -- "recommendations<br/>per-agent verdicts" --> D
+        D -- "Certificate<br/>evidence trace" --> E
+        E -. "weight ±30% drift" .-> C
+    end
+
+    DB[("SQLite WAL · 32 tables<br/>pipeline_events · freshness SLA")]
+
+    CFG -. policies .-> Pipeline
+    Pipeline -. persist .-> DB
 ```
 
 Driven by `config/*.yaml` (rules · agents · signals · universe · SIEGE gates). Persisted in SQLite WAL — `nuri/core/db.py` is the only `sqlite3` importer. Per-phase detail, DB schema, and SIEGE v2 spec: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) + [docs/SIEGE_V2.md](docs/SIEGE_V2.md).

--- a/README.md
+++ b/README.md
@@ -14,71 +14,21 @@ Every BUY/SELL recommendation runs through a **collect → analyze → consensus
 
 ## Architecture
 
-The pipeline has **8 phases** organized into 5 conceptual stages. Phases never import each other — they communicate **only through DB tables and CSV files** (loose coupling, see [`docs/STRATEGY.md`](docs/STRATEGY.md#23-느슨한-결합-loose-coupling-via-data) §2.3). Re-running an upstream phase automatically refreshes downstream consumers.
-
-**At a glance**: `Collect → Analyze → Consensus → Certify → Track → Serve` — driven by `config/*.yaml`, persisted in SQLite, feedback loop from outcomes back to agent weights.
+Every BUY/SELL decision travels a **5-step pipeline**. Phases talk only through SQLite + CSV (loose coupling, [STRATEGY §2.3](docs/STRATEGY.md#23-느슨한-결합-loose-coupling-via-data)) — rerun an upstream phase and downstream refreshes automatically.
 
 ```mermaid
 flowchart LR
-    subgraph Collect["1 · Collect"]
-        direction TB
-        C1[US equities<br/>yfinance · OpenBB]
-        C2[KR equities<br/>pykrx · KIS]
-        C3[Macro + news<br/>FRED · RSS]
-        C4[External<br/>ARK · FINVIZ · Reddit]
-    end
+    A(["**1 Collect**<br/>25 collectors<br/>US · KR · macro · news"])
+    B(["**2 Analyze**<br/>signals · regime<br/>factors · events"])
+    C(["**3 Consensus**<br/>10 agents<br/>risk veto"])
+    D(["**4 Certify**<br/>SIEGE v2<br/>3D gate"])
+    E(["**5 Track**<br/>30 / 60 / 90-day<br/>outcome scoring"])
 
-    subgraph Foundation["Foundation"]
-        direction TB
-        DB[(SQLite WAL<br/>sole sqlite3 importer)]
-        CFG[config/*.yaml<br/>rules · agents · signals<br/>universe · siege_gates]
-        EVT[pipeline_events<br/>append-only · freshness SLA]
-    end
-
-    subgraph Analyze["2 · Analyze"]
-        direction TB
-        A1[Signals<br/>RSI · MACD · BB · volume]
-        A2[Regime — 6 base + 4 special]
-        A3[Macro + event score]
-        A4[Multi-factor<br/>momentum · value · quality]
-    end
-
-    subgraph Consensus["3 · Consensus"]
-        direction TB
-        AG[10 specialist agents<br/>Technical · Fundamental · Macro<br/>Smart Money · Wall Street · Korean<br/>Options · Crypto · Retail<br/>Risk — veto power]
-        VO[Weighted vote · drift ± 30%<br/>learning memory feedback]
-    end
-
-    subgraph Certify["4 · SIEGE v2"]
-        direction TB
-        B1[Base: position · sector · stop-loss<br/>leverage · conflict · drift · macro]
-        B2[Per-asset-class: freshness · volatility · external<br/>us_equity · kr_equity · kr_index · commodity · bond]
-        B3[CERTIFIED / REJECTED + evidence trace]
-    end
-
-    subgraph Track["5 · Track"]
-        direction TB
-        T1[Outcome tracker<br/>30 / 60 / 90-day scoring]
-        T2[Learning memory<br/>agent weight adjustment]
-    end
-
-    subgraph Serve["Serve"]
-        direction TB
-        S1[FastAPI :8001 REST + SSE]
-        S2[Next.js 16 :3000 dashboard]
-        S3[Discord · Telegram alerts]
-    end
-
-    Collect --> DB
-    CFG -.-> Analyze
-    CFG -.-> Consensus
-    CFG -.-> Certify
-    DB --> Analyze --> Consensus --> Certify --> Track
-    Track -.->|weight feedback| Consensus
-    DB --> Serve
-    Certify --> Serve
-    EVT -.-> Serve
+    A --> B --> C --> D --> E
+    E -. weight feedback .-> C
 ```
+
+Driven by `config/*.yaml` (rules · agents · signals · universe · SIEGE gates). Persisted in SQLite WAL — `nuri/core/db.py` is the only `sqlite3` importer. Per-phase detail, DB schema, and SIEGE v2 spec: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) + [docs/SIEGE_V2.md](docs/SIEGE_V2.md).
 
 ### Key architectural decisions
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Every BUY/SELL decision travels a **5-step pipeline**. Phases talk only through 
 
 ```mermaid
 flowchart LR
-    A(["**1 Collect**<br/>25 collectors<br/>US · KR · macro · news"])
-    B(["**2 Analyze**<br/>signals · regime<br/>factors · events"])
-    C(["**3 Consensus**<br/>10 agents<br/>risk veto"])
-    D(["**4 Certify**<br/>SIEGE v2<br/>3D gate"])
-    E(["**5 Track**<br/>30 / 60 / 90-day<br/>outcome scoring"])
+    A(["1 Collect<br/>25 collectors<br/>US · KR · macro · news"])
+    B(["2 Analyze<br/>signals · regime<br/>factors · events"])
+    C(["3 Consensus<br/>10 agents<br/>risk veto"])
+    D(["4 Certify<br/>SIEGE v2<br/>3D certification"])
+    E(["5 Track<br/>30 / 60 / 90-day<br/>outcome scoring"])
 
     A --> B --> C --> D --> E
-    E -. weight feedback .-> C
+    E -. feedback .-> C
 ```
 
 Driven by `config/*.yaml` (rules · agents · signals · universe · SIEGE gates). Persisted in SQLite WAL — `nuri/core/db.py` is the only `sqlite3` importer. Per-phase detail, DB schema, and SIEGE v2 spec: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) + [docs/SIEGE_V2.md](docs/SIEGE_V2.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,32 @@
 
 Detailed reference for Nuri-Quant internals. This file is NOT auto-loaded — agents read it when working on cross-cutting concerns.
 
+## Pipeline Phases (5-step)
+
+README shows the high-level flow. Per-phase detail below — the source of truth for what each step actually consumes and emits.
+
+| # | Phase | Inputs | Outputs | Key modules |
+|---|-------|--------|---------|-------------|
+| 1 | **Collect** | External APIs (yfinance · OpenBB · pykrx · KIS · FRED · Wikipedia · GoogleNews RSS · FINVIZ · ARK · Reddit) | `prices` · `fundamentals` · `macro` · `superinvestors` · `estimates` · `analyst_ratings` · `insider_trades` · `news` · `events` tables | `nuri/collectors/` (25 collectors, BaseCollector pattern) |
+| 2 | **Analyze** | Phase 1 tables | `signal_results.csv` + `signal_scorecard.csv` (daily reports) + `regime_transitions` + `factors` tables | `nuri/quant/regime/` · `nuri/quant/validation/` · `nuri/quant/factors/` · `nuri/llm/event_classifier.py` |
+| 3 | **Consensus** | Phase 2 outputs + `portfolio` + `macro_events` | `recommendations` table rows with per-agent verdicts + weighted final action | `nuri/trading/agents/` (10 specialists + consensus engine) |
+| 4 | **Certify** | Phase 3 recommendations + `config/rules.yaml siege_gates` | `Certificate` → CERTIFIED / REJECTED + evidence trace written via `pipeline_events` | `nuri/trading/engine/certification.py` |
+| 5 | **Track** | Phase 3 `recommendations.action` + actual prices after N days | `outcome_30d` / `outcome_60d` / `outcome_90d` + `agent_accuracy_snapshots` (feeds Learning Memory back to Phase 3 weights) | `nuri/trading/recommend/tracker.py` + `nuri/trading/engine/learning_memory.py` |
+
+**Collect sources (detail)**: US equities via yfinance/OpenBB · KR equities via pykrx + KIS Open API · macro + calendar via FRED/yfinance · news via GoogleNews RSS · external signals via ARK (cathiesark.com) · FINVIZ · Reddit (WallStreetBets). KIS details: [docs/KIS_INTEGRATION.md](KIS_INTEGRATION.md).
+
+**Analyze layers**:
+- Signals — 20 definitions from `config/signals.yaml` (price / macro / data-dependent / chart-pattern — see "Signal System" below)
+- Regime — 6 base × 2 vol + 4 special (euphoria, stagflation, recovery, sector_rotation) — see "Regime Classifier" below
+- Factors — momentum, value, quality, composite (from DB only — no external API, per `STRATEGY §3.1`)
+- Events — 15 macro event categories, OpenAI gpt-5.4-nano classifier (regex fallback). `export_surge`, `demand_growth`, `currency_shift` feed Korean Market Agent
+
+**Consensus layer**: 10 agents (Technical, Fundamental, Macro, Smart Money, Wall Street, Korean Market, Options, Crypto, Retail, Risk). Weighted vote — drift ±30% from learning memory feedback loop. Risk agent has veto power (SELL + confidence ≥ 80 overrides). See `nuri/trading/agents/CLAUDE.md`.
+
+**Certify dimensions** (SIEGE v2): Account (strategy profile: core / active / swing / long_term / pension) × Asset Class (us_equity / kr_equity / kr_index / commodity / bond) × Execution Market (KRX / NYSE). Base gates (position · sector · stop-loss · leverage · conflict · drift · macro) + per-asset-class gates (freshness · volatility · external data). 1 error-grade fail → REJECTED. Canonical: [docs/SIEGE_V2.md](SIEGE_V2.md).
+
+**Serve layer (not a pipeline phase — read-only projection)**: FastAPI REST + SSE on `:8001`, Next.js 16 dashboard on `:3000`, Discord + Telegram alerts. All read from DB; never run analysis inline (5s projection rule).
+
 ## DB as the Sole Integration Point
 
 `nuri/core/db.py` is the **only** module that imports `sqlite3`. DB file: `data/portfolio.db` (WAL mode). All upsert functions accept optional `db_path` — tests inject `tmp_path` for isolation. Schema versioning via `schema_version` table + `_MIGRATIONS` list.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,29 +4,17 @@ Detailed reference for Nuri-Quant internals. This file is NOT auto-loaded — ag
 
 ## Pipeline Phases (5-step)
 
-README shows the high-level flow. Per-phase detail below — the source of truth for what each step actually consumes and emits.
+README shows the high-level flow. Per-phase orientation table — each row points at the canonical detail section below (or peer doc).
 
-| # | Phase | Inputs | Outputs | Key modules |
-|---|-------|--------|---------|-------------|
-| 1 | **Collect** | External APIs (yfinance · OpenBB · pykrx · KIS · FRED · Wikipedia · GoogleNews RSS · FINVIZ · ARK · Reddit) | `prices` · `fundamentals` · `macro` · `superinvestors` · `estimates` · `analyst_ratings` · `insider_trades` · `news` · `events` tables | `nuri/collectors/` (25 collectors, BaseCollector pattern) |
-| 2 | **Analyze** | Phase 1 tables | `signal_results.csv` + `signal_scorecard.csv` (daily reports) + `regime_transitions` + `factors` tables | `nuri/quant/regime/` · `nuri/quant/validation/` · `nuri/quant/factors/` · `nuri/llm/event_classifier.py` |
-| 3 | **Consensus** | Phase 2 outputs + `portfolio` + `macro_events` | `recommendations` table rows with per-agent verdicts + weighted final action | `nuri/trading/agents/` (10 specialists + consensus engine) |
-| 4 | **Certify** | Phase 3 recommendations + `config/rules.yaml siege_gates` | `Certificate` → CERTIFIED / REJECTED + evidence trace written via `pipeline_events` | `nuri/trading/engine/certification.py` |
-| 5 | **Track** | Phase 3 `recommendations.action` + actual prices after N days | `outcome_30d` / `outcome_60d` / `outcome_90d` + `agent_accuracy_snapshots` (feeds Learning Memory back to Phase 3 weights) | `nuri/trading/recommend/tracker.py` + `nuri/trading/engine/learning_memory.py` |
+| # | Phase | Inputs | Outputs | Key modules | Detail |
+|---|-------|--------|---------|-------------|--------|
+| 1 | **Collect** | External APIs (yfinance · OpenBB · pykrx · KIS · FRED · Wikipedia · GoogleNews RSS · FINVIZ · ARK · Reddit) | `prices` · `fundamentals` · `macro` · `superinvestors` · `estimates` · `analyst_ratings` · `insider_trades` · `news` · `events` tables | `nuri/collectors/` (25 collectors, BaseCollector pattern) | [KIS_INTEGRATION.md](KIS_INTEGRATION.md) · `nuri/collectors/CLAUDE.md` |
+| 2 | **Analyze** | Phase 1 tables | `signal_results.csv` + `signal_scorecard.csv` + `regime_transitions` + `factors` tables | `nuri/quant/regime/` · `nuri/quant/validation/` · `nuri/quant/factors/` · `nuri/llm/event_classifier.py` | "Signal System" + "Regime Classifier" below |
+| 3 | **Consensus** | Phase 2 outputs + `portfolio` + `macro_events` | `recommendations` table rows with per-agent verdicts + weighted final action | `nuri/trading/agents/` (10 specialists + consensus engine, risk veto) | `nuri/trading/agents/CLAUDE.md` |
+| 4 | **Certify** | Phase 3 recommendations + `config/rules.yaml siege_gates` | `Certificate` → CERTIFIED / REJECTED + evidence trace via `pipeline_events` | `nuri/trading/engine/certification.py` | "SIEGE Engine" below + [SIEGE_V2.md](SIEGE_V2.md) |
+| 5 | **Track** | Phase 3 `recommendations.action` + actual prices after N days | `outcome_30d` / `outcome_60d` / `outcome_90d` + `agent_accuracy_snapshots` (feeds Learning Memory back to Phase 3 weights) | `nuri/trading/recommend/tracker.py` + `nuri/trading/engine/learning_memory.py` | "C→D→E Data Flow" below |
 
-**Collect sources (detail)**: US equities via yfinance/OpenBB · KR equities via pykrx + KIS Open API · macro + calendar via FRED/yfinance · news via GoogleNews RSS · external signals via ARK (cathiesark.com) · FINVIZ · Reddit (WallStreetBets). KIS details: [docs/KIS_INTEGRATION.md](KIS_INTEGRATION.md).
-
-**Analyze layers**:
-- Signals — 20 definitions from `config/signals.yaml` (price / macro / data-dependent / chart-pattern — see "Signal System" below)
-- Regime — 6 base × 2 vol + 4 special (euphoria, stagflation, recovery, sector_rotation) — see "Regime Classifier" below
-- Factors — momentum, value, quality, composite (from DB only — no external API, per `STRATEGY §3.1`)
-- Events — 15 macro event categories, OpenAI gpt-5.4-nano classifier (regex fallback). `export_surge`, `demand_growth`, `currency_shift` feed Korean Market Agent
-
-**Consensus layer**: 10 agents (Technical, Fundamental, Macro, Smart Money, Wall Street, Korean Market, Options, Crypto, Retail, Risk). Weighted vote — drift ±30% from learning memory feedback loop. Risk agent has veto power (SELL + confidence ≥ 80 overrides). See `nuri/trading/agents/CLAUDE.md`.
-
-**Certify dimensions** (SIEGE v2): Account (strategy profile: core / active / swing / long_term / pension) × Asset Class (us_equity / kr_equity / kr_index / commodity / bond) × Execution Market (KRX / NYSE). Base gates (position · sector · stop-loss · leverage · conflict · drift · macro) + per-asset-class gates (freshness · volatility · external data). 1 error-grade fail → REJECTED. Canonical: [docs/SIEGE_V2.md](SIEGE_V2.md).
-
-**Serve layer (not a pipeline phase — read-only projection)**: FastAPI REST + SSE on `:8001`, Next.js 16 dashboard on `:3000`, Discord + Telegram alerts. All read from DB; never run analysis inline (5s projection rule).
+The **Serve** layer (FastAPI `:8001` + Next.js `:3000` + Discord/Telegram) is a read-only projection from the DB — not a pipeline phase. See "API (65 endpoints)" and "Dashboard API" sections below.
 
 ## DB as the Sole Integration Point
 
@@ -77,7 +65,7 @@ Special regimes (priority order, override base `regime` field): euphoria, stagfl
 
 `nuri/trading/engine/` — Gated Execution + Conflict Detection + Learning Memory. Confidence scoring in `candidates.py` combines regime win rate, profit factor, learning memory drift, conflict penalties, and regime fit.
 
-Full certification architecture + 3D gate specification: **[`docs/SIEGE_V2.md`](SIEGE_V2.md)** (canonical). Confidence scoring formula: [`docs/STRATEGY.md` §3.3](STRATEGY.md). Gate policy: [`docs/STRATEGY.md` §6](STRATEGY.md).
+Full certification architecture + 3-dimensional certification specification: **[`docs/SIEGE_V2.md`](SIEGE_V2.md)** (canonical). Confidence scoring formula: [`docs/STRATEGY.md` §3.3](STRATEGY.md). Gate policy: [`docs/STRATEGY.md` §6](STRATEGY.md).
 
 ## Pipeline Observability
 


### PR DESCRIPTION
## Problem

User feedback on GitHub README view: the 7-subgraph mermaid renders illegibly at default zoom — too many tiny text blocks, can't scan. PR #385 already removed the dark theme; the structural density remained.

## Change

**README.md** — replace 7-subgraph flowchart (23 nodes) with **5 pill-shape nodes** + weight feedback:

```mermaid
flowchart LR
    A(["**1 Collect**<br/>25 collectors<br/>US · KR · macro · news"])
    B(["**2 Analyze**<br/>signals · regime<br/>factors · events"])
    C(["**3 Consensus**<br/>10 agents<br/>risk veto"])
    D(["**4 Certify**<br/>SIEGE v2<br/>3D gate"])
    E(["**5 Track**<br/>30 / 60 / 90-day<br/>outcome scoring"])

    A --> B --> C --> D --> E
    E -. weight feedback .-> C
```

Plus a single prose line: config-driven, SQLite-persisted, cross-ref to `docs/ARCHITECTURE.md` + `docs/SIEGE_V2.md`.

**docs/ARCHITECTURE.md** — prepend new **"Pipeline Phases (5-step)"** section (~26 lines): per-phase table with Inputs / Outputs / Key modules. Absorbs every concrete fact dropped from README:
- Collect sources (yfinance/OpenBB/pykrx/KIS/FRED/RSS/ARK/FINVIZ/Reddit)
- Analyze layers (signals/regime/factors/events, all detail)
- Consensus 10 agents + risk veto
- SIEGE v2 3D dimensions (Account × Asset Class × Execution Market)
- Track learning memory feedback loop
- Serve layer explicitly flagged as projection-only

## Verification

- `make verify-doc-counts` passes
- `git diff --stat`: README -50 net lines, ARCHITECTURE.md +26 lines
- Key decisions bullet list + Code layout table unchanged — they already carried the rigor

## Not in scope

- SIEGE_V2.md terminology pass (separate PR)
- SIEGE aggressive/conservative framework (deferred — needs codex + backtest)
- README mermaid binary asset alternatives (evaluated, rejected — maintenance cost)

Codex Round 1 adversarial review in progress (`codex-reviews/docs-readme-redesign-round1-*.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)