### PR TITLE
feat(siege): E3-3c regime-adaptive position cap — Stage 2 PASS wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (3,122 backend + 917 frontend + 38 e2e)
+make test       # full suite (3,147 backend + 917 frontend + 38 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -234,3 +234,40 @@ siege_gates:
       volatility_secondary: []
       external_min_records: 3
       external_min_sources: 1
+
+  # E3-3c (PR TBD) — regime-adaptive position cap multipliers.
+  # STRATEGY §3.6 Stage 2 PASS verdict (#402, paired counterfactual N=254,
+  # 60d 95% CI [+0.0153, +0.1588]% → 60d mean ~+0.5%/year annualized) 가
+  # justify. Codex Round 1 권장 scope: per_position_max **only** —
+  # max_sector_exposure 는 portfolio simulator (E3-4) 후로 deferral
+  # (single-position model 로 검증 불가).
+  #
+  # Mechanics: _check_position_limits 가 현재 regime 조회 → multiplier 적용
+  # → effective_max = base_max × multiplier (account 별). 절대 cap 으로
+  # overflow 방지. Hard veto (VIX>30 신규 매수 차단) 는 별도 volatility_gate
+  # 에 그대로 — override 불가 (§2.6 Hard veto = policy-level).
+  #
+  # Neutral regime (sideways_*, sector_rotation, bear_low_vol) 는 미정의 =
+  # 1.0 default. classify_regime 실패 (data gap) → 1.0 fallback.
+  regime_overrides:
+    # Aggressive — Stage 2 paired counterfactual 에서 favorable forward outcome
+    bull_low_vol:
+      per_position_max_multiplier: 1.20
+    recovery:
+      per_position_max_multiplier: 1.20
+    # Conservative — high-vol, late-cycle, stagflation 에서 size-down
+    bear_high_vol:
+      per_position_max_multiplier: 0.80
+    bull_high_vol:
+      per_position_max_multiplier: 0.80
+    stagflation:
+      per_position_max_multiplier: 0.80
+    euphoria:
+      per_position_max_multiplier: 0.80
+    # Neutral regime 은 미정의 = 1.0 default (sideways_*, sector_rotation,
+    # bear_low_vol)
+
+  # Safety cap: multiplier × base_max 이 이 % 초과 시 cap 으로 clip.
+  # pension(40%) × 1.20 = 48% — under 50, OK. 만약 future strategy 가
+  # base_max 50%+ 가 되면 이 cap 도 함께 재검토.
+  regime_override_absolute_cap_pct: 50.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,122 backend tests across 142 files + 917 frontend vitest (60 files) + 38 Playwright E2E (6 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,147 backend tests across 143 files + 917 frontend vitest (60 files) + 38 Playwright E2E (6 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -257,7 +257,7 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,122 tests, 142 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,147 tests, 143 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 60 files |
 | E2E | 핵심 flow 커버 | 38 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -80,8 +80,50 @@ class Certificate:
             self.timestamp = kst_now().isoformat()
 
 
+def _current_regime() -> str | None:
+    """현재 regime label. classify 실패 시 None (caller 가 1.0 multiplier fallback)."""
+    try:
+        from nuri.core.timezone import today_kst
+        from nuri.quant.regime.classifier import classify_regime
+        state = classify_regime(date=today_kst())
+        return state.regime if state else None
+    except Exception as e:
+        logger.warning(f"_current_regime 조회 실패 — neutral fallback: {e}")
+        return None
+
+
+def _get_position_multiplier(regime: str | None) -> float:
+    """siege_gates.regime_overrides[regime].per_position_max_multiplier.
+
+    Neutral regime (등록 안 됨) 또는 None regime → 1.0 (no adjustment).
+    Config 부재 → 1.0 (graceful fallback).
+    """
+    if regime is None:
+        return 1.0
+    overrides = RULES.get("siege_gates", {}).get("regime_overrides", {})
+    spec = overrides.get(regime, {})
+    return float(spec.get("per_position_max_multiplier", 1.0))
+
+
+def _apply_position_multiplier(base_pct: float, regime: str | None) -> float:
+    """base_pct (계좌 strategy 의 max_single_position, 0~1 단위) × regime multiplier.
+
+    Absolute cap (config: regime_override_absolute_cap_pct, 0~100 단위) 로 overflow
+    방지. base_pct 자체가 cap 보다 크면 base_pct 를 그대로 반환 (cap 은 multiplier 가
+    base 를 inflate 시켰을 때만 발동 — 보수적으로 strategy 자체 한도는 침해하지 않음).
+    """
+    multiplier = _get_position_multiplier(regime)
+    raised = base_pct * multiplier
+    cap_pct = float(RULES.get("siege_gates", {}).get("regime_override_absolute_cap_pct", 100.0))
+    cap_fraction = cap_pct / 100.0
+    # multiplier 가 raise 한 경우만 cap (multiplier <= 1.0 → original 보존)
+    if multiplier > 1.0 and raised > cap_fraction:
+        return cap_fraction
+    return raised
+
+
 def _check_position_limits(db_path=None) -> CertCondition:
-    """1. 단일 종목 비중 — 계좌별 전략 프로파일 적용."""
+    """1. 단일 종목 비중 — 계좌별 전략 프로파일 + regime override 적용 (E3-3c)."""
     try:
         from nuri.analysis.portfolio import analyze_portfolio
         from nuri.core.rules import get_account_strategy
@@ -90,23 +132,30 @@ def _check_position_limits(db_path=None) -> CertCondition:
         if df.empty:
             return CertCondition("position_limit", "종목 비중 한도", True, "포트폴리오 비어있음")
 
+        regime = _current_regime()
+        multiplier = _get_position_multiplier(regime)
+
         # 종목별 합산 비중 + 해당 종목이 속한 계좌들의 가장 관대한 한도
         agg = df.groupby("ticker")["weight_pct"].sum()
         ticker_accounts = df.groupby("ticker")["account"].apply(list).to_dict()
         violations = {}
         for ticker, weight in agg.items():
             accounts = ticker_accounts.get(ticker, [])
-            max_pos = max(
+            base_max = max(
                 (get_account_strategy(a).get("max_single_position", MAX_SINGLE_POSITION) for a in accounts),
                 default=MAX_SINGLE_POSITION,
             )
-            if weight / 100 > max_pos:
-                violations[ticker] = (weight, max_pos)
+            effective_max = _apply_position_multiplier(base_max, regime)
+            if weight / 100 > effective_max:
+                violations[ticker] = (weight, effective_max)
 
+        regime_tag = f" (regime={regime}, ×{multiplier:.2f})" if multiplier != 1.0 else ""
         if not violations:
-            return CertCondition("position_limit", "종목 비중 한도", True, f"최대 비중: {agg.max():.1f}%")
+            return CertCondition("position_limit", "종목 비중 한도", True,
+                                 f"최대 비중: {agg.max():.1f}%{regime_tag}")
         tickers = ", ".join(f"{t}({w:.1f}%>{limit * 100:.0f}%)" for t, (w, limit) in violations.items())
-        return CertCondition("position_limit", "종목 비중 한도", False, f"위반: {tickers}", "error")
+        return CertCondition("position_limit", "종목 비중 한도", False,
+                             f"위반: {tickers}{regime_tag}", "error")
     except Exception as e:
         return CertCondition("position_limit", "종목 비중 한도", False, f"검증 실패: {e}")
 

--- a/tests/trading/engine/test_certification_regime_overrides.py
+++ b/tests/trading/engine/test_certification_regime_overrides.py
@@ -1,0 +1,249 @@
+"""E3-3c regime-adaptive position cap — siege_gates.regime_overrides tests.
+
+Stage 2 (#402) PASS verdict justifies regime-adaptive sizing on per_position_max.
+This test suite locks the override semantics:
+
+- Multiplier loader (config → dict)
+- Apply per-account / per-regime
+- Neutral / None / missing-config fallback to 1.0
+- Absolute cap protection
+- _check_position_limits integration (pass + fail under override)
+- Hard veto preserved (volatility_gate orthogonal to position_limit)
+
+Reference: STRATEGY §3.6 + #402 codex Round 1 verdict ("ship narrowly for
+per_position_max only, sector cap stays out").
+"""
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+
+class TestGetPositionMultiplier:
+    """siege_gates.regime_overrides[regime].per_position_max_multiplier lookup."""
+
+    def test_aggressive_regimes_return_1_2(self):
+        from nuri.trading.engine.certification import _get_position_multiplier
+        assert _get_position_multiplier("bull_low_vol") == 1.2
+        assert _get_position_multiplier("recovery") == 1.2
+
+    def test_conservative_regimes_return_0_8(self):
+        from nuri.trading.engine.certification import _get_position_multiplier
+        assert _get_position_multiplier("bear_high_vol") == 0.8
+        assert _get_position_multiplier("bull_high_vol") == 0.8
+        assert _get_position_multiplier("stagflation") == 0.8
+        assert _get_position_multiplier("euphoria") == 0.8
+
+    def test_neutral_regimes_default_to_1_0(self):
+        """Neutral regime 은 YAML 에 미등록 → 1.0."""
+        from nuri.trading.engine.certification import _get_position_multiplier
+        for regime in ["sideways_low_vol", "sideways_high_vol", "bear_low_vol",
+                       "sector_rotation"]:
+            assert _get_position_multiplier(regime) == 1.0, f"{regime} should be 1.0"
+
+    def test_none_regime_returns_1_0(self):
+        """classify_regime 실패 → 1.0 fallback."""
+        from nuri.trading.engine.certification import _get_position_multiplier
+        assert _get_position_multiplier(None) == 1.0
+
+    def test_unknown_regime_returns_1_0(self):
+        """존재하지 않는 regime label → 1.0 fallback."""
+        from nuri.trading.engine.certification import _get_position_multiplier
+        assert _get_position_multiplier("nonexistent_regime") == 1.0
+
+
+class TestApplyPositionMultiplier:
+    """base × multiplier with absolute cap clip."""
+
+    def test_aggressive_raises_position_pct(self):
+        """active 25% × 1.2 = 30%."""
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        assert _apply_position_multiplier(0.25, "bull_low_vol") == pytest.approx(0.30)
+
+    def test_conservative_lowers_position_pct(self):
+        """core 15% × 0.8 = 12%."""
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        assert _apply_position_multiplier(0.15, "bear_high_vol") == pytest.approx(0.12)
+
+    def test_neutral_unchanged(self):
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        assert _apply_position_multiplier(0.15, "sideways_low_vol") == 0.15
+
+    def test_pension_aggressive_within_cap(self):
+        """pension 40% × 1.2 = 48%, cap=50% → 48% (no clip)."""
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        assert _apply_position_multiplier(0.40, "bull_low_vol") == pytest.approx(0.48)
+
+    def test_aggressive_clipped_at_absolute_cap(self):
+        """Force base 0.45 × 1.2 = 0.54 → clipped to 0.50."""
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        result = _apply_position_multiplier(0.45, "bull_low_vol")
+        assert result == pytest.approx(0.50)
+
+    def test_conservative_does_not_use_cap(self):
+        """0.8× lowers, never inflates → cap path 안 탐 (base 보존, lower)."""
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        # active 25% × 0.8 = 20% (cap 50% irrelevant)
+        assert _apply_position_multiplier(0.25, "bear_high_vol") == pytest.approx(0.20)
+
+    def test_base_above_cap_neutral_returns_base(self):
+        """Strategy 자체가 cap 보다 크면 multiplier=1.0 path 에서 base 보존 — 침해하지 않음."""
+        from nuri.trading.engine.certification import _apply_position_multiplier
+        # 60% base × 1.0 = 60% (cap 적용 안 함, neutral path)
+        assert _apply_position_multiplier(0.60, "sideways_low_vol") == 0.60
+
+
+class TestGetMultiplierGracefulFallback:
+    """Config 부재 / 손상 시 graceful 1.0 fallback."""
+
+    def test_missing_regime_overrides_key_falls_back_to_1(self):
+        """siege_gates.regime_overrides 자체 부재 → 1.0."""
+        from nuri.trading.engine import certification as cert_mod
+        with patch.object(cert_mod, "RULES", {"siege_gates": {}}):
+            assert cert_mod._get_position_multiplier("bull_low_vol") == 1.0
+
+    def test_missing_siege_gates_key_falls_back_to_1(self):
+        from nuri.trading.engine import certification as cert_mod
+        with patch.object(cert_mod, "RULES", {}):
+            assert cert_mod._get_position_multiplier("recovery") == 1.0
+
+    def test_missing_multiplier_field_falls_back_to_1(self):
+        """regime entry 는 있지만 per_position_max_multiplier 누락 → 1.0."""
+        from nuri.trading.engine import certification as cert_mod
+        with patch.object(cert_mod, "RULES", {
+            "siege_gates": {"regime_overrides": {"bull_low_vol": {}}}
+        }):
+            assert cert_mod._get_position_multiplier("bull_low_vol") == 1.0
+
+
+class TestCurrentRegime:
+    """_current_regime() 의 graceful fallback (None) — classify 실패 시."""
+
+    def test_returns_regime_string_on_success(self):
+        from nuri.trading.engine import certification as cert_mod
+        # MockRegimeState
+        class MockState:
+            regime = "bull_low_vol"
+        with patch("nuri.quant.regime.classifier.classify_regime", return_value=MockState()):
+            assert cert_mod._current_regime() == "bull_low_vol"
+
+    def test_returns_none_when_classify_returns_none(self):
+        from nuri.trading.engine import certification as cert_mod
+        with patch("nuri.quant.regime.classifier.classify_regime", return_value=None):
+            assert cert_mod._current_regime() is None
+
+    def test_returns_none_on_exception(self):
+        """Data gap 등으로 classify 가 throw 해도 None 반환 (graceful)."""
+        from nuri.trading.engine import certification as cert_mod
+        with patch("nuri.quant.regime.classifier.classify_regime",
+                   side_effect=RuntimeError("DB gap")):
+            assert cert_mod._current_regime() is None
+
+
+class TestCheckPositionLimitsWithOverride:
+    """_check_position_limits 가 regime override 를 적용하는 통합 path."""
+
+    def _seed_portfolio(self, db_path, holdings):
+        """holdings: list of dict {ticker, account, qty, avg_price}."""
+        from nuri.core.db import upsert_portfolio
+        rows = [
+            {"ticker": h["ticker"], "account": h["account"], "qty": h["qty"],
+             "avg_price": h["avg_price"], "currency": "USD",
+             "name": h["ticker"], "sector": "Tech"}
+            for h in holdings
+        ]
+        upsert_portfolio(rows, db_path=db_path)
+
+    def test_pass_under_aggressive_regime_when_baseline_would_fail(self, monkeypatch, tmp_path):
+        """regime=bull_low_vol 18% cap → 16% holding PASS (baseline 15% 였으면 FAIL)."""
+        from nuri.trading.engine import certification as cert_mod
+
+        # Mock analyze_portfolio: single AAPL at 16% under core (15% baseline).
+        df = pd.DataFrame([{"ticker": "AAPL", "weight_pct": 16.0,
+                            "account": "core_account", "sector": "Tech"}])
+
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df), \
+             patch.object(cert_mod, "_current_regime", return_value="bull_low_vol"):
+            result = cert_mod._check_position_limits()
+        assert result.passed is True, f"expected PASS under bull_low_vol×1.2, got: {result.detail}"
+        assert "regime=bull_low_vol" in result.detail
+
+    def test_fail_under_conservative_regime_when_baseline_would_pass(self, monkeypatch):
+        """regime=bear_high_vol 12% cap → 13% holding FAIL (baseline 15% 였으면 PASS)."""
+        from nuri.trading.engine import certification as cert_mod
+
+        df = pd.DataFrame([{"ticker": "AAPL", "weight_pct": 13.0,
+                            "account": "core_account", "sector": "Tech"}])
+
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df), \
+             patch.object(cert_mod, "_current_regime", return_value="bear_high_vol"):
+            result = cert_mod._check_position_limits()
+        assert result.passed is False, f"expected FAIL under bear_high_vol×0.8, got: {result.detail}"
+        assert "regime=bear_high_vol" in result.detail
+
+    def test_neutral_regime_baseline_behavior(self, monkeypatch):
+        """regime=sideways_low_vol → multiplier 1.0 → baseline behavior preserved.
+
+        15% holding under core (15% baseline) → exactly at limit, NOT > 0.15 → PASS.
+        Regime tag 표시 안 됨 (multiplier == 1.0 → no `(regime=...)` suffix)."""
+        from nuri.trading.engine import certification as cert_mod
+
+        df = pd.DataFrame([{"ticker": "AAPL", "weight_pct": 15.0,
+                            "account": "core_account", "sector": "Tech"}])
+
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df), \
+             patch.object(cert_mod, "_current_regime", return_value="sideways_low_vol"):
+            result = cert_mod._check_position_limits()
+        assert result.passed is True
+        assert "regime=" not in result.detail  # neutral → no tag
+
+    def test_none_regime_baseline_behavior(self):
+        """classify failed (regime=None) → multiplier 1.0 → baseline behavior."""
+        from nuri.trading.engine import certification as cert_mod
+
+        df = pd.DataFrame([{"ticker": "AAPL", "weight_pct": 16.0,
+                            "account": "core_account", "sector": "Tech"}])
+
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df), \
+             patch.object(cert_mod, "_current_regime", return_value=None):
+            result = cert_mod._check_position_limits()
+        # 16% > 15% (core baseline) → FAIL
+        assert result.passed is False
+        assert "regime=" not in result.detail
+
+    def test_empty_portfolio_returns_pass(self):
+        from nuri.trading.engine import certification as cert_mod
+        with patch("nuri.analysis.portfolio.analyze_portfolio",
+                   return_value=pd.DataFrame()), \
+             patch.object(cert_mod, "_current_regime", return_value="bull_low_vol"):
+            result = cert_mod._check_position_limits()
+        assert result.passed is True
+        assert "비어있음" in result.detail
+
+
+class TestHardVetoPreserved:
+    """Hard veto (VIX>30 신규 매수 차단) 는 volatility_gate 에 그대로 — position_limit
+    은 직교. 이 test 는 두 path 가 분리됨을 lock-in."""
+
+    def test_position_override_does_not_touch_volatility_gate(self):
+        """regime_override 가 _check_volatility_for_class 의 threshold 변경 안 함."""
+        from nuri.core.rules import RULES
+        gates = RULES.get("siege_gates", {})
+        # us_equity volatility threshold = 30 (Hard veto VIX>30)
+        us = gates.get("asset_classes", {}).get("us_equity", {})
+        assert us.get("volatility_primary_threshold") == 30, \
+            "Hard veto VIX>30 threshold must be untouched by regime_override"
+
+    def test_regime_overrides_only_specifies_per_position_max(self):
+        """E3-3c scope: per_position_max_multiplier ONLY.
+        sector / stop_loss / leverage_ban override 는 미정의 (codex narrow scope)."""
+        from nuri.core.rules import RULES
+        overrides = RULES.get("siege_gates", {}).get("regime_overrides", {})
+        for regime, spec in overrides.items():
+            keys = set(spec.keys())
+            allowed = {"per_position_max_multiplier"}
+            extra = keys - allowed
+            assert not extra, (
+                f"{regime} has out-of-scope override keys: {extra}. "
+                "E3-3c is narrow — sector/stop_loss/leverage_ban are E3-4 follow-up."
+            )


### PR DESCRIPTION
## Summary

E3-3c implements STRATEGY §3.6 Stage 2 PASS verdict (#402) as runtime config + code path. **Codex Round 1 (#402) verdict strictly followed**: ship narrowly for `per_position_max` ONLY, sector cap stays out until portfolio simulator (E3-4).

## What changed

**`config/rules.yaml`** — `siege_gates.regime_overrides` schema:
- Aggressive **1.20×**: `bull_low_vol`, `recovery`
- Conservative **0.80×**: `bear_high_vol`, `bull_high_vol`, `stagflation`, `euphoria`
- Neutral (omitted, default 1.0): sideways_*, sector_rotation, bear_low_vol
- `regime_override_absolute_cap_pct: 50.0` overflow safety

**`nuri/trading/engine/certification.py`** — 3 new helpers + modified gate:
- `_current_regime()` — graceful None on classify exception
- `_get_position_multiplier(regime)` — YAML lookup with 1.0 fallback
- `_apply_position_multiplier(base, regime)` — multiplier + cap clip ONLY when raising
- `_check_position_limits` — applies multiplier per-ticker

**Hard veto preserved (orthogonal)**: VIX>30 매수 차단 stays in `volatility_gate` — explicitly tested unchanged.

## Live verify

Current regime = `sideways_high_vol` (neutral, mult=1.0):
- position_limit: BAC(19.7%) + TSLA(20.5%) FAIL — **same as pre-E3-3c (no regression in neutral regime)**

## Test coverage

25 regression tests in 5 classes (codex spec ≥15):

| Class | Tests | Coverage |
|---|---|---|
| TestGetPositionMultiplier | 5 | aggressive/conservative/neutral/None/unknown |
| TestApplyPositionMultiplier | 7 | raise/lower/cap/edge cases (active 25%×1.2=30, pension 40%×1.2=48 within cap, base 0.45×1.2 clipped to 0.50) |
| TestGetMultiplierGracefulFallback | 3 | missing config key paths |
| TestCurrentRegime | 3 | success/None-state/exception |
| TestCheckPositionLimitsWithOverride | 5 | pass-aggressive, fail-conservative, neutral-baseline, None-baseline, empty |
| TestHardVetoPreserved | 2 | VIX threshold lock + override scope restriction (per_position_max ONLY) |

## Known limitations (NOT in this PR)

- **Transition handling**: regime flip A→C with over-limit position → instant FAIL, no grace period. Future PR if usability problem emerges.
- **max_sector_exposure regime override**: needs multi-position portfolio simulator (E3-4). Stage 2 single-position model cannot validate sector cap effect.
- **Per-asset-class differentiated multipliers**: out of scope (same reason).

## Test plan

- [x] `make lint` clean
- [x] `make test-fast` 3,099 → **3,124 pass** (+25 new)
- [x] `make sync-doc-counts` 5 location updates (3,122 → 3,147)
- [x] Live `_check_position_limits()` on actual portfolio — neutral regime preserves baseline behavior

## E3 series status

| Sub-task | Status |
|---|---|
| E3-0 acceptance restate (#393) | ✅ |
| E3-1 Stage 0 audit (#395) | ✅ |
| E3-2 Stage 1 plausibility (#398) | ✅ |
| E3-3a backfill (#400) | ✅ |
| E3-3b Stage 2 PASS (#402) | ✅ |
| **E3-3c regime override wiring** (this PR) | **THIS** |
| E3-4 portfolio simulator + sector cap override | future (only if user wants additional uplift) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)