### PR TITLE
fix(security): X-Frame-Options SAMEORIGIN + CSP frame-ancestors 'self'

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,186 backend tests across 144 files + 917 frontend vitest (60 files) + 38 Playwright E2E (7 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,186 backend tests across 144 files + 917 frontend vitest (60 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/frontend/e2e/evidence-iframe.spec.ts
+++ b/frontend/e2e/evidence-iframe.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * A2 fix lock — `/evidence` 페이지 iframe 이 X-Frame-Options SAMEORIGIN 정책 하에
+ * 정상 로드되는지 검증. 이전에는 `/(.*)` → `X-Frame-Options: DENY` + CSP
+ * `frame-ancestors 'none'` 이 same-origin iframe 도 차단 → 5 console 위반.
+ *
+ * 이 spec 은 regression lock — A2 fix 가 revert 되면 fail.
+ */
+import { test, expect } from "@playwright/test";
+
+test("evidence page loads iframes without X-Frame-Options violations", async ({ page }) => {
+  const frameViolations: string[] = [];
+  page.on("console", (msg) => {
+    const text = msg.text();
+    if (msg.type() === "error" && text.includes("X-Frame-Options")) {
+      frameViolations.push(text);
+    }
+  });
+
+  const resp = await page.goto("/evidence", { waitUntil: "domcontentloaded", timeout: 20000 });
+  expect(resp?.status()).toBe(200);
+
+  // iframe 내부 컨텐츠 로드 대기
+  await page.waitForTimeout(3000);
+
+  // iframe 개수 확인 (evidence 는 Plotly 차트 N개 embed)
+  const frameCount = await page.locator("iframe").count();
+  expect(frameCount).toBeGreaterThan(0);
+
+  // iframe 각각이 실제로 로드됐는지 (src + content-document)
+  const frames = page.frames();
+  // main frame + iframe들. main + at least one child.
+  expect(frames.length).toBeGreaterThan(1);
+
+  // X-Frame-Options 위반이 없어야
+  expect(frameViolations).toEqual([]);
+});
+
+test("X-Frame-Options header is SAMEORIGIN on both page and api routes", async ({ request }) => {
+  // Page
+  const pageResp = await request.get("/login");
+  expect(pageResp.headers()["x-frame-options"]).toBe("SAMEORIGIN");
+
+  // API via Next.js proxy (same origin to browser)
+  const apiResp = await request.get("/api/health");
+  expect(apiResp.headers()["x-frame-options"]).toBe("SAMEORIGIN");
+});
+
+test("CSP frame-ancestors is 'self' (not 'none')", async ({ request }) => {
+  const resp = await request.get("/login");
+  const csp = resp.headers()["content-security-policy"] || "";
+  expect(csp).toMatch(/frame-ancestors\s+'self'/);
+  expect(csp).not.toMatch(/frame-ancestors\s+'none'/);
+});

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -73,8 +73,13 @@ const nextConfig: NextConfig = {
             value: "nosniff",
           },
           {
+            // SAMEORIGIN: /evidence 페이지가 /api/evidence/{chart_id} 를 iframe 으로 embed
+            // (Plotly 차트 HTML). DENY 로 두면 same-origin embed 까지 차단되어 Playwright
+            // 검증에서 5 X-Frame-Options 위반이 보였음. SAMEORIGIN 은 same-origin iframe 만
+            // 허용 + cross-origin clickjacking 은 여전히 차단 — CSP `frame-ancestors 'self'`
+            // 와 일관.
             key: "X-Frame-Options",
-            value: "DENY",
+            value: "SAMEORIGIN",
           },
           {
             key: "X-XSS-Protection",
@@ -94,7 +99,10 @@ const nextConfig: NextConfig = {
               "font-src 'self' data:",
               `connect-src 'self' ${API_BACKEND} ws://localhost:3000 ws://${API_BACKEND.replace("http://", "")}`,
               `frame-src 'self' ${API_BACKEND}`,
-              "frame-ancestors 'none'",
+              // 'self' 허용: /evidence 페이지가 /api/evidence/{chart_id} 를 iframe 으로
+              // embed (Plotly HTML). 'none' 으로 두면 X-Frame-Options SAMEORIGIN 보다
+              // CSP 가 우선이라 여전히 blocked. cross-origin clickjacking 은 여전히 차단.
+              "frame-ancestors 'self'",
             ].join("; "),
           },
         ],

--- a/nuri/api/main.py
+++ b/nuri/api/main.py
@@ -87,10 +87,18 @@ app.add_middleware(
 # ─── 보안 헤더 미들웨어 ───
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
-    """보안 응답 헤더 추가."""
+    """보안 응답 헤더 추가.
+
+    X-Frame-Options: SAMEORIGIN — /evidence 페이지 (Next.js :3000) 가 Plotly
+    HTML evidence 를 `/api/evidence/{chart_id}` iframe 으로 embed. Next.js proxy
+    가 same-origin 으로 serve 하므로 SAMEORIGIN 정책이 허용. DENY 로 두면 chart
+    iframe 이 blocked (2026-04-20 Playwright audit 에서 5 violations 검출).
+    Cross-origin clickjacking 은 여전히 차단 — frontend/next.config.ts CSP
+    `frame-ancestors 'self'` 와 일관.
+    """
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     return response

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -30,7 +30,7 @@ class TestApiMain:
     def test_security_headers(self, client):
         resp = client.get("/api/health")
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"
-        assert resp.headers.get("X-Frame-Options") == "DENY"
+        assert resp.headers.get("X-Frame-Options") == "SAMEORIGIN"  # A2 fix: /evidence iframe
 
     def test_login_no_password_env(self, client, monkeypatch):
         monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
@@ -84,7 +84,7 @@ class TestAPIMain_R27:
         c = TestClient(app)
         response = c.get("/api/health")
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"  # A2 fix: /evidence iframe
 
     def test_auth_no_password_set(self, monkeypatch):
         """Auth endpoint when no DASHBOARD_PASSWORD set."""


### PR DESCRIPTION
## Summary (A2 from E4-0a audit)

`/evidence` 페이지가 Plotly HTML 차트를 iframe 으로 embed 하는데 기존 정책 3-layer 모두 `DENY` / `'none'` 으로 설정돼 same-origin iframe 까지 차단됨 → Playwright audit 에서 **5 X-Frame-Options console violations** 검출.

3 layer 동시 수정 (하나라도 DENY/'none' 이면 iframe 전체 blocked):
1. `frontend/next.config.ts` `X-Frame-Options: DENY → SAMEORIGIN`
2. `frontend/next.config.ts` CSP `frame-ancestors 'none' → 'self'` (CSP 가 XFO 보다 우선)
3. `nuri/api/main.py` security_headers middleware `DENY → SAMEORIGIN`

Cross-origin clickjacking 은 여전히 차단. `/evidence` 는 `/api/evidence/*` 과 same origin (Next.js proxy).

## Live verify (production build)

| Path | X-Frame-Options | frame-ancestors |
|---|---|---|
| `/evidence` (Next.js) | ✅ SAMEORIGIN | ✅ 'self' |
| `/api/evidence/regime` (via proxy) | ✅ SAMEORIGIN | — |
| `http://localhost:8001/api/evidence/regime` (direct) | ✅ SAMEORIGIN | — |

## Test plan

- [x] `make test-fast` — 3,158 passed. `tests/api/test_main.py` 두 assertion 을 SAMEORIGIN 으로 update
- [x] `make lint` clean
- [x] Playwright regression: `frontend/e2e/evidence-iframe.spec.ts` (3 tests) 모두 PASS
  - evidence page loads iframes without X-Frame-Options violations
  - X-Frame-Options SAMEORIGIN on page + api
  - CSP frame-ancestors 'self' not 'none'
- [x] Live dev verify: 프로덕션 빌드 + 서버로 헤더 직접 확인

## Related

- E4-0a PR #410 merged → post-merge audit 가 이 이슈 surface
- PR #412 (A1: freshness certification fix) — pending review
- A3~A6 issues tracked separately in NEXT_SESSION §2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)