### PR TITLE
feat(api): V1 SIEGE certifications history API (E4-0a observation loop)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ nuri/
 │   ├── recommend/     # Candidates, rebalance, tracker, price_targets
 │   ├── swing/         # Market-wide scanner + rules
 │   └── execution/     # Broker interface (Alpaca paper + DryRun)
-├── api/               # FastAPI REST API (65 endpoints, routes/ incl. actions/opportunities/market-context/coverage)
+├── api/               # FastAPI REST API (68 endpoints, routes/ incl. actions/opportunities/market-context/coverage)
 ├── alerts/            # Discord daily report + bot, Telegram alerts
 └── llm/               # LLM report (Ollama) + OpenAI wrapper + event classifier
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (3,186 backend + 917 frontend + 38 e2e)
+make test       # full suite (3,197 backend + 917 frontend + 38 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,9 +90,9 @@ Trade execution API (`nuri/api/routes/trades.py`):
 
 `/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display.
 
-## API (65 endpoints)
+## API (68 endpoints)
 
-`nuri/api/routes/` — 65 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 18 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
+`nuri/api/routes/` — 68 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 18 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
 
 ### Action-First Dashboard APIs (PR #264-#266)
 
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,186 backend tests across 144 files + 917 frontend vitest (60 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,197 backend tests across 144 files + 917 frontend vitest (60 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -257,7 +257,7 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,186 tests, 144 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,197 tests, 144 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 60 files |
 | E2E | 핵심 flow 커버 | 38 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/engine.py
+++ b/nuri/api/routes/engine.py
@@ -1,9 +1,12 @@
-"""SIEGE-inspired engine API: gate, conflicts, memory."""
+"""SIEGE-inspired engine API: gate, conflicts, memory, certifications."""
+import json
 from dataclasses import asdict
+from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from nuri.api.auth import require_write_auth
+from nuri.core.db import query
 
 router = APIRouter(tags=["engine"])
 
@@ -56,3 +59,155 @@ def post_memory_snapshot(user=Depends(require_write_auth)):
     from nuri.trading.engine.memory import save_snapshot
     n = save_snapshot()
     return {"saved": n}
+
+
+# ─── V1: SIEGE certifications history API (E4-0a instrumentation 소비) ───
+# E4-0a (PR #410) 가 매 certify() 실행을 certifications 테이블에 persist.
+# 이 endpoint 는 dashboard V2 timeline chart + CLI siege_history.py 와 같은
+# observation loop 를 API 로 노출. Read-only, auth 불필요 (dashboard public read).
+
+
+def _format_cert_row(row: dict) -> dict:
+    """certifications row → API response shape. conditions_json 은 parsed list 로."""
+    try:
+        conditions = json.loads(row.get("conditions_json") or "[]")
+    except json.JSONDecodeError:
+        conditions = []
+    return {
+        "id": row["id"],
+        "timestamp": row["timestamp"],
+        "certified": bool(row["certified"]),
+        "score": row["score"],
+        "total_conditions": row["total_conditions"],
+        "passed": row["passed"],
+        "failed": row["failed"],
+        "warnings": row["warnings"],
+        "regime": row["regime"],
+        "portfolio_hash": row["portfolio_hash"],
+        "caller": row["caller"],
+        "created_at": row["created_at"],
+        "conditions": conditions,
+    }
+
+
+@router.get("/certifications")
+def get_certifications_history(
+    limit: int = Query(30, ge=1, le=500),
+    caller: Optional[str] = Query(None, description="caller 필터 (예: cli, api:actions:health)"),
+    regime: Optional[str] = Query(None, description="regime 필터"),
+    since: Optional[str] = Query(None, description="ISO timestamp 이후만 (YYYY-MM-DDTHH:MM:SS)"),
+):
+    """SIEGE 인증 실행 history (E4-0a 이후 persist 된 모든 row).
+
+    - 최신순 정렬 (id DESC)
+    - 필터: `caller`, `regime`, `since` (optional)
+    - `limit` 1-500 (default 30 — dashboard timeline 용)
+    - Response 에 `conditions_json` 을 parsed `conditions` 리스트로 제공 (JSON double-encode 방지)
+    """
+    where: list[str] = []
+    params: list = []
+    if caller:
+        where.append("caller = ?")
+        params.append(caller)
+    if regime:
+        where.append("regime = ?")
+        params.append(regime)
+    if since:
+        where.append("timestamp >= ?")
+        params.append(since)
+
+    sql = "SELECT id, timestamp, certified, score, total_conditions, passed, failed, warnings, regime, portfolio_hash, caller, created_at, conditions_json FROM certifications"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY id DESC LIMIT ?"
+    params.append(limit)
+
+    rows = query(sql, params)
+
+    # Summary: 각 caller / regime 분포 + 최근 hash 변경 count (portfolio transition 감지)
+    total_query = "SELECT COUNT(*) AS c FROM certifications"
+    total_rows = query(total_query)
+    total = total_rows[0]["c"] if total_rows else 0
+
+    return {
+        "items": [_format_cert_row(r) for r in rows],
+        "count": len(rows),
+        "total_in_db": total,
+        "filters": {"caller": caller, "regime": regime, "since": since, "limit": limit},
+    }
+
+
+@router.get("/certifications/summary")
+def get_certifications_summary(days: int = Query(30, ge=1, le=365)):
+    """최근 N일간 집계 — dashboard overview 카드 용.
+
+    Returns:
+        - `certified_rate`: PASS 비율
+        - `avg_score`: 평균 score
+        - `by_caller`: caller 별 run count
+        - `by_regime`: regime 별 run count
+        - `latest`: 가장 최근 cert 1건 요약
+    """
+    from nuri.core.timezone import kst_now
+
+    cutoff = (kst_now().replace(tzinfo=None) -
+              __import__("datetime").timedelta(days=days)).isoformat()
+
+    rows = query(
+        """SELECT certified, score, regime, caller, timestamp FROM certifications
+           WHERE timestamp >= ? ORDER BY id DESC""",
+        (cutoff,),
+    )
+
+    if not rows:
+        return {
+            "days": days,
+            "count": 0,
+            "certified_rate": None,
+            "avg_score": None,
+            "by_caller": {},
+            "by_regime": {},
+            "latest": None,
+        }
+
+    certified_n = sum(1 for r in rows if r["certified"])
+    total = len(rows)
+
+    by_caller: dict = {}
+    for r in rows:
+        k = r["caller"] or "(none)"
+        by_caller[k] = by_caller.get(k, 0) + 1
+
+    by_regime: dict = {}
+    for r in rows:
+        k = r["regime"] or "(none)"
+        by_regime[k] = by_regime.get(k, 0) + 1
+
+    latest = rows[0]
+    return {
+        "days": days,
+        "count": total,
+        "certified_rate": round(certified_n / total * 100, 1),
+        "avg_score": round(sum(r["score"] for r in rows) / total, 1),
+        "by_caller": by_caller,
+        "by_regime": by_regime,
+        "latest": {
+            "timestamp": latest["timestamp"],
+            "certified": bool(latest["certified"]),
+            "score": latest["score"],
+            "regime": latest["regime"],
+            "caller": latest["caller"],
+        },
+    }
+
+
+@router.get("/certifications/{cert_id}")
+def get_certification(cert_id: int):
+    """단일 certification detail — timeline 클릭 시 modal 렌더용."""
+    rows = query(
+        "SELECT id, timestamp, certified, score, total_conditions, passed, failed, warnings, regime, portfolio_hash, caller, created_at, conditions_json FROM certifications WHERE id = ?",
+        (cert_id,),
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"certification id={cert_id} 없음")
+    return _format_cert_row(rows[0])

--- a/tests/api/test_engine.py
+++ b/tests/api/test_engine.py
@@ -48,3 +48,154 @@ class TestEngine:
         r = client.post("/api/memory/snapshot")
         assert r.status_code == 200
         assert "saved" in r.json()
+
+
+class TestCertificationsAPI:
+    """V1 — E4-0a certifications 테이블을 읽어오는 API.
+
+    Dashboard V2 timeline + CLI siege_history.py 와 같은 observation loop 기반.
+    Read-only, auth 불필요.
+    """
+
+    def _insert_cert(self, **overrides):
+        """certifications 테이블에 row 삽입 helper — client fixture 의 DB_PATH 사용."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import get_db
+
+        base = {
+            "timestamp": "2026-04-20T10:00:00+09:00",
+            "certified": 1,
+            "score": 85.0,
+            "total_conditions": 15,
+            "passed": 13,
+            "failed": 0,
+            "warnings": 2,
+            "regime": "sideways_low_vol",
+            "portfolio_hash": "abc123",
+            "caller": "cli",
+            "conditions_json": '[{"id":"position_limit","passed":true,"severity":"error"}]',
+        }
+        base.update(overrides)
+        with get_db(db_mod.DB_PATH) as conn:
+            cols = ", ".join(base.keys())
+            placeholders = ", ".join(["?"] * len(base))
+            conn.execute(f"INSERT INTO certifications ({cols}) VALUES ({placeholders})", list(base.values()))
+
+    def test_list_empty(self, client):
+        """빈 DB → items=[] + total_in_db=0."""
+        r = client.get("/api/certifications")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["items"] == []
+        assert data["count"] == 0
+        assert data["total_in_db"] == 0
+
+    def test_list_returns_recent_rows_desc(self, client):
+        """여러 row 삽입 → 최신순 (id DESC) 정렬."""
+        for i in range(3):
+            self._insert_cert(timestamp=f"2026-04-20T10:0{i}:00+09:00")
+
+        r = client.get("/api/certifications")
+        data = r.json()
+        assert data["count"] == 3
+        assert data["total_in_db"] == 3
+        # id DESC → 최근 timestamp 가 먼저
+        assert data["items"][0]["timestamp"] == "2026-04-20T10:02:00+09:00"
+        assert data["items"][-1]["timestamp"] == "2026-04-20T10:00:00+09:00"
+
+    def test_list_filter_by_caller(self, client):
+        """caller 필터 — cli 만 반환."""
+        self._insert_cert(caller="cli", timestamp="2026-04-20T10:00:00+09:00")
+        self._insert_cert(caller="api:actions:health", timestamp="2026-04-20T10:01:00+09:00")
+        self._insert_cert(caller="cli", timestamp="2026-04-20T10:02:00+09:00")
+
+        r = client.get("/api/certifications?caller=cli")
+        data = r.json()
+        assert data["count"] == 2
+        assert all(item["caller"] == "cli" for item in data["items"])
+
+    def test_list_filter_by_regime(self, client):
+        """regime 필터."""
+        self._insert_cert(regime="bull_low_vol", timestamp="2026-04-20T10:00:00+09:00")
+        self._insert_cert(regime="bear_high_vol", timestamp="2026-04-20T10:01:00+09:00")
+
+        r = client.get("/api/certifications?regime=bull_low_vol")
+        data = r.json()
+        assert data["count"] == 1
+        assert data["items"][0]["regime"] == "bull_low_vol"
+
+    def test_list_limit_validation(self, client):
+        """limit 범위 — 1 ≤ limit ≤ 500. 벗어나면 422 validation."""
+        r = client.get("/api/certifications?limit=0")
+        assert r.status_code == 422
+        r = client.get("/api/certifications?limit=501")
+        assert r.status_code == 422
+
+    def test_list_conditions_parsed_as_list(self, client):
+        """conditions_json 이 parsed list 로 노출됨 (string 아닌 list)."""
+        self._insert_cert(
+            conditions_json='[{"id":"a","passed":true,"severity":"error"},{"id":"b","passed":false,"severity":"warning"}]',
+        )
+        r = client.get("/api/certifications")
+        data = r.json()
+        item = data["items"][0]
+        assert isinstance(item["conditions"], list)
+        assert len(item["conditions"]) == 2
+        assert item["conditions"][0]["id"] == "a"
+
+    def test_summary_empty(self, client):
+        """빈 DB summary → null values."""
+        r = client.get("/api/certifications/summary")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] == 0
+        assert data["certified_rate"] is None
+        assert data["avg_score"] is None
+        assert data["latest"] is None
+
+    def test_summary_certified_rate(self, client):
+        """certified_rate 계산 — 2 PASS / 4 total = 50%."""
+        from nuri.core.timezone import kst_now
+
+        now_iso = kst_now().isoformat()
+        self._insert_cert(certified=1, score=90.0, timestamp=now_iso)
+        self._insert_cert(certified=1, score=85.0, timestamp=now_iso)
+        self._insert_cert(certified=0, score=50.0, timestamp=now_iso)
+        self._insert_cert(certified=0, score=45.0, timestamp=now_iso)
+
+        r = client.get("/api/certifications/summary")
+        data = r.json()
+        assert data["count"] == 4
+        assert data["certified_rate"] == 50.0
+        assert data["avg_score"] == 67.5
+        assert data["latest"] is not None
+
+    def test_summary_by_caller_distribution(self, client):
+        """by_caller dict — caller 별 count."""
+        from nuri.core.timezone import kst_now
+
+        now_iso = kst_now().isoformat()
+        self._insert_cert(caller="cli", timestamp=now_iso)
+        self._insert_cert(caller="cli", timestamp=now_iso)
+        self._insert_cert(caller="api:actions:health", timestamp=now_iso)
+
+        r = client.get("/api/certifications/summary")
+        data = r.json()
+        assert data["by_caller"] == {"cli": 2, "api:actions:health": 1}
+
+    def test_detail_by_id(self, client):
+        """GET /certifications/{id} — 단일 row detail."""
+        self._insert_cert(score=77.7)
+        # row id 는 1부터 시작 (tmp_path fixture 에서 fresh DB)
+        r = client.get("/api/certifications/1")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["id"] == 1
+        assert data["score"] == 77.7
+        assert isinstance(data["conditions"], list)
+
+    def test_detail_404(self, client):
+        """존재하지 않는 id → 404."""
+        r = client.get("/api/certifications/99999")
+        assert r.status_code == 404
+        assert "없음" in r.json()["detail"]


### PR DESCRIPTION
## Summary

E4-0a (PR #410) 가 `certifications` 테이블에 매 `certify()` 실행을 persist 했지만 조회 경로는 CLI `make certify-history` 하나였음. V1 은 같은 데이터를 API 로 노출 → dashboard V2 timeline chart / 외부 모니터링이 consume 가능.

## 3 new endpoints (nuri/api/routes/engine.py)

| Endpoint | 용도 |
|---|---|
| `GET /api/certifications?limit=&caller=&regime=&since=` | 목록 조회 (items+count+total_in_db+filters). id DESC. conditions JSON 이 parsed list 로 exposed (JSON double-encode 방지) |
| `GET /api/certifications/summary?days=N` | 기간 집계 — `certified_rate`, `avg_score`, `by_caller`, `by_regime`, `latest`. Dashboard overview card 용 |
| `GET /api/certifications/{id}` | 단일 row detail (timeline modal 렌더). 404 on missing |

**Auth**: read-only, public (E4-0a row 민감정보 없음 — portfolio_hash 는 one-way sha256).

## Live verify (MBP production API)

```
GET /api/certifications              → items=17 total_in_db=17
GET /api/certifications?caller=cli   → items=2
GET /api/certifications/summary      → count=17 rate=0.0% avg=52.9
GET /api/certifications/1            → id=1 conditions=17
GET /api/certifications/999999       → 404 expected
```

## Test plan

- [x] 11 regression tests in `TestCertificationsAPI`:
  - `test_list_empty`, `test_list_returns_recent_rows_desc`
  - `test_list_filter_by_{caller,regime}`, `test_list_limit_validation` (422)
  - `test_list_conditions_parsed_as_list` (shape invariant)
  - `test_summary_empty`, `test_summary_certified_rate`, `test_summary_by_caller_distribution`
  - `test_detail_by_id`, `test_detail_404`
- [x] `make test-fast` 3,174 passed. Lint clean. Doc counts synced.

## Out-of-scope (V2 별도 PR)

- `/engine` 페이지의 SIEGE timeline chart (이 V1 API 를 consume)
- Hash change markers, regime transition shading
- Click-to-modal detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)