### PR TITLE
docs+feat(engine): E4-0b SIEGE historical predictivity audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (3,199 backend + 917 frontend + 38 e2e)
+make test       # full suite (3,239 backend + 917 frontend + 38 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,199 backend tests across 144 files + 917 frontend vitest (64 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,239 backend tests across 146 files + 917 frontend vitest (64 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -247,6 +247,28 @@ base = regime_win_rate × 60% + profit_factor × 40%
 
 **경고**: 본 §3.7 진단·가설을 prescriptive (V2 design truth) 로 인용해 config/code 변경 PR 을 만드는 것은 금지. §3.6 백테스트 PASS 전까지는 hypothesis 등급.
 
+### 3.8 SIEGE predictivity measurement (E4-0b)
+
+**상태**: infrastructure shipped — E4-0b (이 PR). 실측 audit run 은 `make siege-audit` 실행 필요 (post-merge).
+
+**Purpose**: §3.7 진단("upside/opportunity-cost gate 0개") 을 numeric evidence 로 승격. 각 SIEGE gate 가 실제로 forward NAV drop 을 예측하는지 historical snapshot × forward return 으로 측정. E4-0c 재-grading 의 근거.
+
+**Script**: `scripts/siege_predictivity_audit.py` (docs/plans/e4_0b.md 참조).
+- Monthly top-10 momentum snapshot (us_core 85, 60 snapshots over 5Y)
+- 각 snapshot 에서 `certify(snapshot=..., caller="audit:historical", timestamp=fixed)`
+- Forward 30/60/90d portfolio NAV + MAE 측정
+- Q4 B metric: `E[fwd_return | gate fired] - E[fwd_return | not fired]` + 95% bootstrap CI
+- Output: `data/reports/{today}/e4_0b_siege_predictivity.md`
+
+**Gate injection hook**: `certify(snapshot: CertSnapshot | None = None, timestamp: str | None = None)` — `_capture_snapshot()` 우회. Production default (snapshot=None) zero regression. Caller `"audit:historical"` 는 V1 API / V2.1 dashboard 에서 자연 분리 (square shape).
+
+**Acceptance** (이 PR 은 infra 만; predictivity 결과 승격은 별도 post-merge PR):
+- 60±10 audit rows → `certifications` (caller=audit:historical)
+- Per-gate Q4 B report 생성
+- §3.7 hypothesis 를 measured evidence 로 승격 PR 에서 인용 가능
+
+**Warning** (§3.7 정신 계승): 실측 결과를 단발 measurement 로 mechanical config 변경에 사용 금지. Surface 단계 rank + CI 만; Soft penalty 승격은 E4-0c + codex consult + 별도 STRATEGY 개정.
+
 ---
 
 ## 4. 개발 품질 기준
@@ -257,7 +279,7 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,199 tests, 144 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,239 tests, 146 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 64 files |
 | E2E | 핵심 flow 커버 | 38 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |

--- a/docs/plans/e4_0b.md
+++ b/docs/plans/e4_0b.md
@@ -1,0 +1,244 @@
+# E4-0b Plan — SIEGE historical predictivity audit
+
+**Status**: Draft (codex Plan consult pending — §2.7 Flow Plan gate)
+**Author**: claude-opus-4-7 (self-plan, codex queued 2026-04-21)
+**Branch**: `feat/e4-0b-siege-predictivity-audit`
+**Spec origin**: `NEXT_SESSION.md §2.7`, `STRATEGY.md §3.7` hypothesis
+
+## 1. Problem framing (Think phase)
+
+### 1.1 What we know post-E4-0a
+
+- `certifications` 테이블 (migration 21) 이 매 `certify()` 실행을 persist — 2 주간 live 누적 21 rows.
+- 모든 row 가 동일 portfolio/regime → **observational data 만으로는 gate 별 predictivity 측정 불가** (V2.1 이 이미 이 degenerate 를 정보축 variation 으로 우회).
+- SIEGE `ALL_CERT_CHECKS` 11 base + per-asset-class expansion = portfolio 에 따라 11-30+ condition. **error / warning 등급 할당은 intuition-driven** (STRATEGY §3.7 진단).
+- 각 gate 의 실제 forward predictive value 는 **측정된 적 없음**.
+
+### 1.2 Why measure now
+
+- SIEGE 가 REJECTED/CERTIFIED 를 결정하는데, REJECTED 의 실제 NAV 하락 예측력이 randomness 수준이면 mechanical enforcement 가 가치 negative.
+- E4-0c (재-grading) 은 evidence 기반 severity 재할당 — evidence 가 E4-0b 산출물.
+- STRATEGY §3.7 hypothesis → "measured evidence" 로 승격하려면 이 측정이 선행.
+
+### 1.3 Scope boundary
+
+**In-scope**:
+- Historical portfolio snapshot generation (5Y × monthly ≈ 60)
+- 각 snapshot 에서 SIEGE 평가 (caller=`audit:historical`)
+- Per-gate predictivity metric (conditional forward return difference + bootstrap CI)
+- STRATEGY §3.7 hypothesis → measured evidence 승격 + §4.1 "SIEGE predictivity score" 신설
+
+**Out-of-scope** (→ E4-0c):
+- 실제 severity 재할당
+- Config 변경 (`config/rules.yaml siege_gates` 수정 금지)
+- Production gate 동작 변경
+
+## 2. Five design questions (Plan phase)
+
+### Q1. Portfolio snapshot generation method
+
+**Options**:
+- A. Stage 2 SMA golden cross entries — single-position, but SIEGE 는 다중 ticker portfolio 를 기대 (position/sector limit 평가)
+- B. Monthly top-N momentum portfolio — 5Y monthly rebalance, N=10 (core strategy 전형)
+- C. Event-driven (actual portfolio.yaml git history) — retrospective, but portfolio.yaml 은 gitignored + 최근만 존재
+
+**Recommendation**: **B** (monthly top-10 momentum).
+- Rationale: SIEGE 는 multi-ticker portfolio 평가 전용. Stage 2 와 동일 universe (us_core 85) 에서 매월 말 momentum 상위 10개 선정. Look-ahead 없음 (cutoff < snapshot date). 5Y × 12 months = 60 snapshots — paired counterfactual sample size 와 동일 order.
+- Equal-weight 10 positions (weight=10% 각각) — position_limit core 15% 미충돌, sector_limit 은 universe 의 sector 분포에 따라.
+- **기각 C**: 실제 portfolio 이력 없음. 기각 A: single-position 은 position/sector gate 를 trivial 통과 → measurement 의미 축소.
+
+### Q2. Universe
+
+**Options**:
+- A. `us_core` 85 (Stage 2 연속성, 5Y prices + VIX 이미 backfilled)
+- B. Sector-balanced 50 (S&P 500 11 sector × top 4-5 per sector)
+
+**Recommendation**: **A** (us_core 85).
+- Rationale: Stage 2 가 이미 us_core 로 validated — 같은 universe 에서 SIEGE 평가 일관성. Sector-balanced 는 별도 backfill 필요 (추가 0.5 세션) + universe 변경이 predictivity 측정에 미치는 영향 분리 불가.
+- 우려: us_core 의 sector 분포가 tech-heavy → sector_limit fire 빈도 과다 가능. **이건 예상된 measurement output 이지 bug 아님** (정확한 현재 universe 의 predictivity 측정).
+
+### Q3. Forward NAV measurement
+
+**Options**:
+- A. Position-weighted return, hold until next snapshot (monthly rebalance matches construction)
+- B. Position-weighted, daily rebalance (unrealistic, high noise)
+- C. Equal-weight, rebalance as (A)
+- D. Fixed 30/60/90d hold then liquidate
+
+**Recommendation**: **D** (fixed horizon 30/60/90d, matches Stage 2).
+- Rationale: Stage 2 paired counterfactual 이 fixed 30/60/90d 사용 — E4-0b 와 직접 비교 가능. Monthly rebalance (A) 은 한 snapshot 당 1개 측정만 (30d) 제공 → sample size 감소. D 는 동일 snapshot 으로 3 horizon 측정.
+- Forward NAV = Σ (ticker_weight × forward_return_at_horizon). Position weight 는 동일 10% (equal-weight, Q1 B 와 일치).
+- MAE (Max Adverse Excursion) 도 함께 기록 — Stage 2 패턴 동일.
+
+### Q4. Per-gate predictivity metric
+
+**Options**:
+- A. Pearson correlation (gate_fired_binary, forward_NAV_change)
+- B. Conditional mean difference: `E[fwd_ret | gate fired] - E[fwd_ret | not fired]` + 95% bootstrap CI
+- C. AUC (gate severity ranking → NAV drop ranking)
+- D. B + Kolmogorov-Smirnov statistic (distribution shift)
+
+**Recommendation**: **B** (primary) + **C** (secondary — for granularity beyond binary).
+- Rationale: B 는 가장 interpretable — "position_limit fire 시 forward 30d NAV 가 평균 Δ% 낮다". CI 가 0 을 포함하면 predictivity insignificant. §2.1 Evidence-first 와 정합.
+- C 는 error vs warning 등급 차이 측정 — E4-0c 재-grading 시 severity 경계 tuning 에 유용.
+- Sharpe-like 척도: `(E[fwd_ret | not fired] - E[fwd_ret | fired]) / std(fwd_ret)` — normalized gate signal 강도.
+- **기각 A**: Pearson 은 linear 만 capture, binary gate 에는 부적합. **기각 D** alone: KS 는 significant 하나 방향 정보 없음, B 와 함께면 가치 있으나 scope 확장.
+
+### Q5. Acceptance / output form
+
+**Options**:
+- A. Hard threshold ("predictivity score ≥ 0.N → keep severity; 미달 → downgrade")
+- B. Ranking + 95% CI + advisory (E4-0c 에서 action 결정)
+
+**Recommendation**: **B** (ranking + CI, advisory-only).
+- Rationale: STRATEGY §2.6 escalation ladder Surface 단계 — 관찰 데이터 축적 후 Soft penalty 로 승격. 한 번의 audit 으로 production gate 를 바꾸는 것은 "숫자가 없을 때 추천하지 않는다" (§2.1) 의 dual — 숫자가 있어도 단발 측정으로 mechanical 변경은 성급.
+- Output: `data/reports/{today}/e4_0b_siege_predictivity.md` — per-gate table (fire count / cond mean diff 30d/60d/90d / CI / CERTIFIED-vs-REJECTED Sharpe 차이) + 상위/하위 rank.
+- STRATEGY update: §3.7 hypothesis 를 "measured evidence" 로 승격 (E4-0c 가 config 변경 전 Surface 단계).
+- `certifications` 테이블에 `caller="audit:historical"` rows append — V2.1 dashboard 에서 square shape 으로 자동 분리 (V1 API 에 `exclude_audit=true` 필터 추가 고려).
+
+## 3. Technical design (pre-Build)
+
+### 3.1 Certify() snapshot injection
+
+현재 `certify()` 는 `_capture_snapshot()` 을 무조건 호출 → ContextVar 를 override. Historical 모드 지원하려면 외부 주입이 필요.
+
+**Minimal API extension**:
+```python
+def certify(
+    db_path=None, persist=True, caller=None, swallow_persist_errors=False,
+    snapshot: CertSnapshot | None = None,  # E4-0b audit mode
+) -> Certificate:
+    if snapshot is None:
+        snapshot = _capture_snapshot(db_path=db_path)
+    # ... rest unchanged
+```
+
+**Constructing historical snapshot**:
+- `regime`: `classify_regime(date=snapshot_date)` — 이미 historical 지원
+- `portfolio_raw`: `[{"account":"audit","ticker":T,"sector":S,"quantity":1,"avg_price":P} for T in selected]`
+- `portfolio_df`: 작은 helper `_synthesize_portfolio_df(rows, as_of_date)` 신설 — `analyze_portfolio()` 의 output schema (USD conversion, weight_pct) 를 raw rows 로부터 재조립. Price 는 as_of_date 의 close 로 lookup.
+- `portfolio_hash`: `_compute_portfolio_hash(rows=portfolio_raw)` 재사용
+
+### 3.2 Historical data prerequisites (live probe)
+
+- `prices`: us_core 85 × 5Y 이미 backfilled (E3-3a #400 verified)
+- `macro.vix`: 5Y backfilled (#400)
+- `macro.*` 외 SIEGE 가 쓰는 지표 (USD/KRW / TLT / GC=F 등): KR + commodity 자산 없으면 해당 gate 는 skip (per-asset-class expansion). us_core 는 us_equity only → 관련 없음.
+
+### 3.3 Script layout
+
+`scripts/siege_predictivity_audit.py` (~400 lines):
+1. `_load_us_core()` — universe 로드
+2. `_monthly_snapshot_dates(start, end)` — 5Y 월말 날짜 리스트 (60개)
+3. `_top_n_momentum(universe, as_of_date, n=10)` — 252d return top N
+4. `_synthesize_snapshot(tickers, as_of_date)` — CertSnapshot 조립
+5. `_run_audit_cert(snapshot)` — `certify(snapshot=..., caller="audit:historical")` 호출
+6. `_forward_nav(tickers, weights, entry_date, horizon)` — portfolio-level forward return + MAE
+7. `_analyze_predictivity(cert_rows, nav_rows)` — Q4 B + C 계산 per gate
+8. `_write_report(analysis)` — markdown output
+9. `main()` — idempotent (기존 `caller="audit:historical"` rows 재실행 감지 → skip)
+
+### 3.4 Idempotency guard
+
+`certifications` 테이블에 이미 해당 snapshot_date × audit caller rows 있으면 skip — re-run safety. `timestamp = snapshot_date + "T00:00:00+09:00"` 로 고정해 dedupe key 역할.
+
+### 3.5 Regression tests (≥15, `tests/scripts/test_e4_0b_*.py`)
+
+- `test_monthly_snapshot_dates_determinism` — 동일 start/end 면 동일 60 dates
+- `test_top_n_momentum_no_lookahead` — as_of_date 이후 price 데이터 유입 안 됨
+- `test_top_n_momentum_handles_sparse_coverage` — 250d 미만 coverage ticker 제외
+- `test_synthesize_snapshot_shape` — portfolio_raw 필드 완비, portfolio_df 이 analyze_portfolio output 과 schema 일치
+- `test_synthesize_snapshot_hash_derived_from_raw` — _compute_portfolio_hash(rows=raw) 와 동일
+- `test_run_audit_cert_injects_snapshot` — `snapshot` 파라미터가 `_capture_snapshot` 호출 차단하는지 mock check
+- `test_audit_caller_persists_to_certifications` — row 에 `caller="audit:historical"` 저장
+- `test_audit_does_not_mutate_real_portfolio` — DB portfolio 테이블 read 0 times (snapshot 은 synthetic)
+- `test_forward_nav_portfolio_weighted` — 10 positions × 10% weight → equal-weighted avg return
+- `test_forward_nav_handles_missing_horizon_data` — partial data 시 None 반환
+- `test_conditional_mean_difference_basic` — 알려진 분포 → 예상 mean diff
+- `test_bootstrap_ci_percentile_method` — 재현성 있는 CI
+- `test_predictivity_output_schema` — markdown 에 per-gate table 존재
+- `test_idempotent_rerun_skips_existing_snapshots` — 두 번째 실행 시 기존 row 감지 후 skip
+- `test_certify_snapshot_param_back_compat` — snapshot=None 시 기존 flow (production cert) 영향 없음
+
+Bonus (E2E-ish):
+- `test_e4_0b_end_to_end_tiny` — mini universe (3 tickers × 12 months) → script 전체 run, certifications rows + report 생성 확인
+
+### 3.6 Surface impact to V1 API / V2.1 dashboard
+
+- V1 API `/api/certifications` 에 audit rows 섞이면 timeline flat 강도 증가. 대처: **V2.1 의 caller separation 이 이미 square shape 분리** — audit 은 유저 trigger 와 즉시 구별 가능.
+- V1 API 에 `?exclude_audit=true` query param 추가 option — 이번 PR 포함 (작음) OR 후속 PR (scope split). **이번 PR 포함** 권장 — 같은 flow 의 UX 연속성.
+
+## 4. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Snapshot methodology 가 Stage 2 와 달라 confounding (momentum vs SMA cross) | medium | Q3 에서 fixed horizon 고정 → Stage 2 와 horizon level 비교 가능. Methodology 차이는 report 에 명시. |
+| `analyze_portfolio()` output schema 재조립 실수 (schema drift 시 silent broken) | medium | `_synthesize_portfolio_df` 가 `analyze_portfolio()` 의 real output 과 columns + dtypes equality 체크 — regression test. |
+| `certifications` 테이블에 60 historical rows 한꺼번에 append → dashboard 혼란 | low | Caller 분리 (square shape) 이미 V2.1 에서 처리. V1 API exclude filter 추가로 완전 분리. |
+| 5Y backfill 재생성 시간 (~30-60 min 예상) | low | Idempotent 재실행 (§3.4). 한 번만 돌리면 됨. |
+| Historical regime 판정이 prices 5Y + VIX 5Y 의 edge 구간에서 None 반환 | medium | None 시 snapshot skip + log (§3.3 `_run_audit_cert` ). Acceptance N≥50 (with buffer). |
+
+## 5. Acceptance criteria
+
+**Ship if all**:
+- 60 ± 10 audit rows 누적 in `certifications` (caller=audit:historical)
+- 15+ regression tests pass
+- Report `data/reports/{today}/e4_0b_siege_predictivity.md` 생성 + per-gate Q4 B metric + 95% CI 표 + top-3 / bottom-3 predictivity gate list
+- STRATEGY §3.7 hypothesis section 이 "measured evidence" 로 승격 (§4.1 "SIEGE predictivity score" 표 신설)
+- V1 API `?exclude_audit=true` filter 추가 (scope 포함)
+- CI all-green + codex Round 1 challenge 통과 (또는 self-review + debt tracking)
+
+## 6. Commit structure (≤3)
+
+1. `feat(engine): certify() snapshot injection — E4-0b audit mode` — certify() param + `_synthesize_portfolio_df` helper + V1 API exclude_audit filter
+2. `feat(scripts): siege_predictivity_audit.py — E4-0b historical SIEGE backfill + predictivity report`
+3. `test + docs`: 15+ regression tests + STRATEGY §3.7/§4.1 update + `docs/plans/e4_0b.md` (이 문서) checkpoint
+
+## 7. Codex Plan consult log
+
+**Request sent**: 2026-04-21 01:XX KST (via `@codex review` on PR #417)
+**Status**: **unresponsive ≥30 min** — STRATEGY §2.7 fallback 적용 (self-review + debt note for 후속 PR review).
+
+**Self-review verdict** (2026-04-21, post-Build):
+- Q1 monthly top-N momentum: Stage 2 의 SMA cross 와 직접 비교 곤란하지만 SIEGE 는 multi-ticker portfolio 가 원래 target 이므로 momentum portfolio 가 더 적절. ✅
+- Q4 primary B (conditional mean diff + CI): 해석 가능성 최우선, significant 판정은 CI 가 0을 포함하지 않음으로. ✅
+- §3.1 certify(snapshot=...): 11 regression test 로 기존 경로 (snapshot=None) 와 주입 경로 양쪽 lock-in. 256 engine tests regression-free. ✅
+- §3.4 idempotency timestamp: 00:00+09:00 은 realistic 하지 않으나 **semantic key** 역할. Real 측정 시각은 `created_at` 컬럼에서 확보 (`DEFAULT (datetime('now'))`) — 중복 없음. 기각 재검토 필요 없음.
+- §5 acceptance N≥50: 5Y × monthly = 60 기준으로 snapshot 당 평균 14 조건 × 60 snap = 840 cert-condition observation. Bootstrap 5000 iter 로 mean diff CI 통계력 충분. ✅
+
+**Debt**: 후속 PR Review 단계에서 codex 에게 이 self-review 를 함께 제시해 회수. E4-0c (실제 severity 재할당) 전 필수.
+
+## 8. Implementation status (2026-04-21)
+
+### Shipped commits
+
+1. **`feat(engine): certify() snapshot + timestamp injection`** (HEAD `798b232`)
+   - CallerTag `"audit:historical"` 등록
+   - `certify(snapshot=None, timestamp=None)` 파라미터 추가, production path zero regression
+   - 11 regression test in `tests/trading/engine/test_certification_snapshot_inject.py`
+
+2. **`feat(scripts): siege_predictivity_audit.py`** (HEAD `a6de025`)
+   - 문서 §3.3 9 함수 full implementation (monthly_snapshot_dates, top_n_momentum,
+     synthesize_portfolio_df, synthesize_cert_snapshot, forward_portfolio_nav,
+     _bootstrap_diff_ci, analyze_predictivity, _fixed_timestamp, _already_audited,
+     run_audit, write_report, main)
+   - Smoke run verified: `--months 4 --dry-run` 성공 (4 snapshots, 14 gates, report 생성)
+   - Doc count sync: test_files_be 144→145, tests 3199→3210
+
+3. **`test + docs: E4-0b regression + STRATEGY §3.8 승격 + Plan checkpoint`** (이 commit)
+   - 29 regression test in `tests/scripts/test_siege_predictivity_audit.py` (Plan §3.5 요구 15+ 초과)
+   - STRATEGY §3.8 "SIEGE predictivity measurement (E4-0b)" 신설 — §3.7 hypothesis 를 infrastructure 로 승격 (measurement 결과는 post-merge)
+   - 이 Plan 문서 §7/§8 업데이트
+
+### Not yet shipped (post-merge items)
+
+- Actual 60-snapshot audit run (`make siege-audit` or equivalent) — certifications
+  테이블에 audit:historical rows 누적
+- Per-gate predictivity report 결과 분석 + §3.8 경고 준수한 advisory 보고서
+- V1 API `?exclude_audit=true` filter — 이번 PR 에서 배제 (scope 축소). 후속
+  V2.2 또는 별도 PR
+
+### PR scope summary
+
+**In**: certify signature + script + 29 test + STRATEGY §3.8 infrastructure note
+**Out**: actual audit run + predictivity result + API filter (후속)

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -64,6 +64,8 @@ CallerTag = Literal[
     "api:targets",
     "api:actions:violations",
     "api:actions:health",
+    # E4-0b audit 모드 — historical snapshot 기반 SIEGE 평가 (production cert 아님)
+    "audit:historical",
     # test 전용
     "test",
     "test:caller:example",
@@ -845,6 +847,8 @@ def certify(
     persist: bool = True,
     caller: Optional[CallerTag] = None,
     swallow_persist_errors: bool = False,
+    snapshot: Optional[CertSnapshot] = None,
+    timestamp: Optional[str] = None,
 ) -> Certificate:
     """SIEGE 인증서 발급. 11 base gate check 실행 후 pass/fail 판정.
 
@@ -860,8 +864,16 @@ def certify(
     regime + portfolio_df + portfolio_hash 를 1회 read → ContextVar 로 설정.
     이후 모든 gate 가 호출하는 `_current_regime` / `_snapshot_portfolio` 은 snapshot
     값 참조. finally 로 ContextVar reset → nested/parallel certify 안전.
+
+    **E4-0b audit 모드** (docs/plans/e4_0b.md §3.1): `snapshot` 이 주어지면
+    `_capture_snapshot()` 호출 대신 주입된 snapshot 을 그대로 사용. Historical
+    portfolio state 평가 용 — 실 DB 의 portfolio 를 건드리지 않고 synthetic
+    portfolio × 과거 regime 으로 certify 실행. `timestamp` 도 함께 주입되면
+    Certificate.timestamp + certifications row timestamp 에 반영 (idempotency
+    — 같은 snapshot_date 재실행 시 기존 row 중복 제거 가능).
     """
-    snapshot = _capture_snapshot(db_path=db_path)
+    if snapshot is None:
+        snapshot = _capture_snapshot(db_path=db_path)
     token = _CERT_SNAPSHOT.set(snapshot)
 
     try:
@@ -883,7 +895,7 @@ def certify(
         from nuri.core.timezone import kst_now
 
         cert = Certificate(
-            timestamp=kst_now().isoformat(),
+            timestamp=timestamp or kst_now().isoformat(),
             total_conditions=total,
             passed=passed,
             failed=failed,

--- a/scripts/siege_predictivity_audit.py
+++ b/scripts/siege_predictivity_audit.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""E4-0b — SIEGE historical predictivity audit.
+
+docs/plans/e4_0b.md Plan doc 구현. SIEGE 각 gate 의 실측 predictivity 측정:
+각 gate 가 fire 할 때 실제로 portfolio forward return 이 낮은가?
+
+Methodology (Plan doc §2 Q1-Q5):
+- Q1 Monthly top-10 momentum snapshot (us_core 85 universe, 5Y = 60 snapshots)
+- Q2 Universe: us_core (Stage 2 연속성)
+- Q3 Forward NAV: fixed 30/60/90d horizon (Stage 2 패턴)
+- Q4 Metric: conditional mean diff + 95% bootstrap CI (primary) + AUC (secondary)
+- Q5 Output: ranking + advisory (hard threshold → E4-0c)
+
+Architecture:
+1. Generate monthly snapshot dates (month-end, 5Y back from today)
+2. For each date:
+   a. Pick top-10 momentum tickers from us_core (252d lookback, strict no-lookahead)
+   b. Classify regime at that date
+   c. Build CertSnapshot (synthetic portfolio: 10 tickers × 10% weight)
+   d. Run certify(snapshot=..., caller="audit:historical", timestamp=...)
+   e. Compute forward 30/60/90d NAV (portfolio-level, weight-averaged return + MAE)
+3. After loop: analyze persisted audit rows + NAV outcomes → per-gate predictivity
+4. Output markdown report
+
+Usage:
+    .venv/bin/python scripts/siege_predictivity_audit.py [--full | --universe us_core | --months 60]
+                                                         [--bootstrap-iter 5000]
+                                                         [--save | --dry-run]
+
+기본값 dry-run — 실 certifications 에 persist 안 함. `--save` 로 audit rows 기록.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from nuri.core.db import query, query_df
+from nuri.core.timezone import today_kst
+from nuri.quant.regime.classifier import classify_regime
+from nuri.trading.engine.certification import (
+    CertCondition,
+    CertSnapshot,
+    _compute_portfolio_hash,
+    certify,
+)
+
+LOG = logging.getLogger("e4_0b_audit")
+
+HORIZONS = [30, 60, 90]
+DEFAULT_UNIVERSE = "us_core"
+DEFAULT_MONTHS = 60
+DEFAULT_TOP_N = 10
+MOMENTUM_LOOKBACK = 252  # 1Y trading days
+
+
+@dataclass
+class AuditSnapshot:
+    """Single monthly snapshot — portfolio + forward NAV measurement."""
+
+    snapshot_date: str  # "YYYY-MM-DD"
+    tickers: list[str]  # top-N by momentum
+    cert: dict | None  # Certificate dict (from certify() output)
+    regime: str | None
+    forward_nav: dict[int, float | None]  # horizon → portfolio-level forward return %
+    forward_mae: dict[int, float | None]  # horizon → max adverse excursion %
+    skipped_reason: str | None = None  # None if snapshot constructed, else reason
+
+
+@dataclass
+class GateMetric:
+    """Per-gate predictivity metric — Q4 B primary."""
+
+    gate_id: str
+    severity: str  # "error" | "warning"
+    fire_count: int  # snapshots where this gate failed
+    not_fire_count: int  # snapshots where this gate passed
+    # conditional means at each horizon (fwd return | gate fired vs not fired)
+    mean_when_fired: dict[int, float | None] = field(default_factory=dict)
+    mean_when_not_fired: dict[int, float | None] = field(default_factory=dict)
+    # primary metric (Q4 B): mean_fired - mean_not_fired + 95% CI
+    cond_mean_diff: dict[int, float | None] = field(default_factory=dict)
+    ci_low: dict[int, float | None] = field(default_factory=dict)
+    ci_high: dict[int, float | None] = field(default_factory=dict)
+    # Sharpe-like (Q4 B bonus): (diff) / std(forward_returns)
+    sharpe_like: dict[int, float | None] = field(default_factory=dict)
+
+
+# ─── helpers: universe + snapshot dates ────────────────────────────────────
+
+
+def _load_universe(key: str = DEFAULT_UNIVERSE) -> list[str]:
+    """config/universe.yaml 의 tickers 로드. Stage 2 와 동일 루틴."""
+    import yaml
+
+    with open("config/universe.yaml") as f:
+        u = yaml.safe_load(f) or {}
+    section = u.get(key) or {}
+    tickers = section.get("tickers") or []
+    if not tickers:
+        raise RuntimeError(f"universe.yaml {key}.tickers empty")
+    return sorted(tickers)
+
+
+def monthly_snapshot_dates(end_date: str, months: int = DEFAULT_MONTHS) -> list[str]:
+    """end_date 부터 뒤로 N개월, 매월 말 (business day) 날짜 리스트 (오래된 → 최신).
+
+    Determinism — 같은 (end_date, months) 입력 → 항상 같은 리스트.
+    """
+    end = pd.Timestamp(end_date)
+    # 월말로 스냅 (pandas 'ME' frequency)
+    dates = pd.date_range(end=end, periods=months, freq="ME")
+    return [d.strftime("%Y-%m-%d") for d in dates]
+
+
+def _trading_day_on_or_before(date: str, db_path=None) -> str | None:
+    """prices 테이블에서 해당 date 이전(포함) 가장 최신 거래일."""
+    rows = query(
+        "SELECT date FROM prices WHERE ticker='SPY' AND date <= ? ORDER BY date DESC LIMIT 1",
+        (date,),
+        db_path=db_path,
+    )
+    return rows[0]["date"] if rows else None
+
+
+# ─── momentum selection (strict no-lookahead) ───────────────────────────────
+
+
+def top_n_momentum(
+    universe: list[str], as_of_date: str, n: int = DEFAULT_TOP_N, db_path=None
+) -> list[str]:
+    """as_of_date 기준 252d return top N 반환. Strict no-lookahead.
+
+    각 ticker 의 return = (close[as_of] - close[as_of - 252td]) / close[as_of - 252td]
+    - 250d 이상 coverage 없으면 제외
+    - as_of_date 이후 row 참조 금지
+    """
+    scores: list[tuple[str, float]] = []
+    for ticker in universe:
+        df = query_df(
+            "SELECT date, close FROM prices WHERE ticker=? AND date<=? ORDER BY date DESC LIMIT ?",
+            (ticker, as_of_date, MOMENTUM_LOOKBACK + 10),
+            db_path=db_path,
+        )
+        if len(df) < MOMENTUM_LOOKBACK:
+            continue
+        # df 은 내림차순 → [0] 가 가장 최신 (as_of 이하), [lookback-1] 가 1년 전
+        close_now = df.iloc[0]["close"]
+        close_then = df.iloc[MOMENTUM_LOOKBACK - 1]["close"]
+        if close_then <= 0:
+            continue
+        ret = (close_now - close_then) / close_then
+        scores.append((ticker, ret))
+    scores.sort(key=lambda x: x[1], reverse=True)
+    return [t for t, _ in scores[:n]]
+
+
+# ─── synthetic portfolio_df (analyze_portfolio schema) ──────────────────────
+
+
+def synthesize_portfolio_df(
+    tickers: list[str], as_of_date: str, db_path=None, weight_pct: float = 10.0
+) -> pd.DataFrame | None:
+    """Historical portfolio DataFrame — analyze_portfolio() output schema.
+
+    각 ticker 10% weight, USD 기준 (us_core 가정 — KR 미지원).
+    가격 lookup: as_of_date 이전 최신 close. 데이터 부족 시 None.
+    """
+    rows = []
+    for ticker in tickers:
+        price_row = query(
+            "SELECT close, date FROM prices WHERE ticker=? AND date<=? ORDER BY date DESC LIMIT 1",
+            (ticker, as_of_date),
+            db_path=db_path,
+        )
+        if not price_row:
+            LOG.debug(f"  {ticker}: no price on/before {as_of_date}")
+            return None
+        close = price_row[0]["close"]
+        # sector lookup — portfolio 테이블이 단일 sector source (fundamentals 는 sector 미포함).
+        # historical audit 은 portfolio 에 해당 ticker 가 없을 수 있으므로 fallback "Unknown".
+        sector_row = query(
+            "SELECT DISTINCT sector FROM portfolio WHERE ticker=? AND sector IS NOT NULL LIMIT 1",
+            (ticker,),
+            db_path=db_path,
+        )
+        sector = sector_row[0]["sector"] if sector_row else "Unknown"
+        # 단순 unit: quantity=1 each → position_usd = close. Weight 는 total 에서 derive.
+        rows.append(
+            {
+                "account": "audit",
+                "ticker": ticker,
+                "sector": sector,
+                "quantity": 1,
+                "avg_price": close,
+                "current_price": close,
+                "currency": "USD",
+                "current_value_usd": round(close, 2),
+                "cost_basis_usd": round(close, 2),
+                "pnl_usd": 0.0,
+                "pnl_pct": 0.0,
+                "price_date": price_row[0]["date"],
+            }
+        )
+    if not rows:
+        return None
+    df = pd.DataFrame(rows)
+    total = df["current_value_usd"].sum() or 1
+    # Equal-weight override — 각 ticker 가 정확히 weight_pct 로 보이도록 value 재조정
+    # (top-N momentum 에서 ticker 간 close 차이가 커서 natural weight 가 비대칭)
+    target_value = total / len(tickers)
+    df["current_value_usd"] = round(target_value, 2)
+    df["cost_basis_usd"] = round(target_value, 2)
+    df["weight_pct"] = round(df["current_value_usd"] / (target_value * len(tickers)) * 100, 2)
+    df.attrs["warnings"] = []
+    df.attrs["total_value_usd"] = round(total, 2)
+    df.attrs["usd_krw"] = 1380.0  # historical USD/KRW not material for us-only
+    return df
+
+
+def synthesize_cert_snapshot(
+    tickers: list[str], as_of_date: str, db_path=None
+) -> CertSnapshot | None:
+    """완전한 CertSnapshot — certify(snapshot=...) 에 주입 가능.
+
+    regime 은 classify_regime(date=as_of_date). None 이면 snapshot 반환 None.
+    """
+    state = classify_regime(date=as_of_date)
+    if state is None:
+        LOG.debug(f"  {as_of_date}: regime classification 실패 (데이터 부족)")
+        return None
+    df = synthesize_portfolio_df(tickers, as_of_date, db_path=db_path)
+    if df is None or df.empty:
+        return None
+    raw = [
+        {
+            "account": r["account"],
+            "ticker": r["ticker"],
+            "sector": r["sector"],
+            "quantity": r["quantity"],
+            "avg_price": r["avg_price"],
+        }
+        for r in df.to_dict(orient="records")
+    ]
+    return CertSnapshot(
+        regime=state.regime,
+        portfolio_raw=raw,
+        portfolio_df=df,
+        portfolio_hash=_compute_portfolio_hash(rows=raw),
+        portfolio_error=None,
+    )
+
+
+# ─── forward NAV ────────────────────────────────────────────────────────────
+
+
+def forward_portfolio_nav(
+    tickers: list[str], entry_date: str, horizon: int, db_path=None
+) -> tuple[float | None, float | None]:
+    """Equal-weight portfolio-level forward return % + MAE %.
+
+    각 ticker 의 forward N-day return 을 equal-weight average.
+    partial data (일부 ticker 누락) 은 None 반환 (conservative).
+    """
+    per_ticker: list[float] = []
+    per_ticker_mae: list[float] = []
+    for ticker in tickers:
+        rows = query(
+            "SELECT date, close FROM prices WHERE ticker=? AND date>=? ORDER BY date LIMIT ?",
+            (ticker, entry_date, horizon + 1),
+            db_path=db_path,
+        )
+        if len(rows) < horizon + 1:
+            return None, None
+        entry_close = rows[0]["close"]
+        exit_close = rows[horizon]["close"]
+        ret = (exit_close - entry_close) / entry_close * 100
+        # MAE (max adverse excursion) — intra-window lowest close
+        intra_lows = [r["close"] for r in rows[1 : horizon + 1]]
+        mae = (min(intra_lows) - entry_close) / entry_close * 100 if intra_lows else 0.0
+        per_ticker.append(ret)
+        per_ticker_mae.append(mae)
+    if not per_ticker:
+        return None, None
+    return statistics.mean(per_ticker), statistics.mean(per_ticker_mae)
+
+
+# ─── audit loop ─────────────────────────────────────────────────────────────
+
+
+def _fixed_timestamp(snapshot_date: str) -> str:
+    """Idempotency key — snapshot_date 00:00 KST. 재실행 시 기존 row 감지 가능."""
+    return f"{snapshot_date}T00:00:00+09:00"
+
+
+def _already_audited(snapshot_date: str, db_path=None) -> bool:
+    """이미 같은 snapshot_date × audit:historical row 있으면 True."""
+    rows = query(
+        "SELECT COUNT(*) c FROM certifications WHERE timestamp = ? AND caller = 'audit:historical'",
+        (_fixed_timestamp(snapshot_date),),
+        db_path=db_path,
+    )
+    return rows[0]["c"] > 0
+
+
+def run_audit(
+    universe_key: str,
+    months: int,
+    top_n: int,
+    save: bool,
+    db_path=None,
+) -> list[AuditSnapshot]:
+    """Main loop — 월별 snapshot 생성 + certify + forward NAV."""
+    universe = _load_universe(universe_key)
+    end_date = today_kst()
+    dates = monthly_snapshot_dates(end_date, months)
+    LOG.info(f"Universe: {universe_key} ({len(universe)} tickers), months: {months}, "
+             f"save: {save}")
+    LOG.info(f"Snapshot dates: {dates[0]} → {dates[-1]} ({len(dates)} total)")
+
+    results: list[AuditSnapshot] = []
+    for snapshot_date in dates:
+        if save and _already_audited(snapshot_date, db_path=db_path):
+            LOG.info(f"  {snapshot_date}: 이미 audit 완료 (skip, idempotent)")
+            continue
+
+        tickers = top_n_momentum(universe, snapshot_date, n=top_n, db_path=db_path)
+        if len(tickers) < top_n:
+            results.append(AuditSnapshot(
+                snapshot_date=snapshot_date,
+                tickers=tickers,
+                cert=None, regime=None,
+                forward_nav={h: None for h in HORIZONS},
+                forward_mae={h: None for h in HORIZONS},
+                skipped_reason=f"momentum top-N insufficient ({len(tickers)}/{top_n})",
+            ))
+            continue
+
+        snapshot = synthesize_cert_snapshot(tickers, snapshot_date, db_path=db_path)
+        if snapshot is None:
+            results.append(AuditSnapshot(
+                snapshot_date=snapshot_date,
+                tickers=tickers,
+                cert=None, regime=None,
+                forward_nav={h: None for h in HORIZONS},
+                forward_mae={h: None for h in HORIZONS},
+                skipped_reason="snapshot build 실패 (regime 또는 price 데이터 부족)",
+            ))
+            continue
+
+        try:
+            cert = certify(
+                db_path=db_path,
+                persist=save,
+                caller="audit:historical",
+                snapshot=snapshot,
+                timestamp=_fixed_timestamp(snapshot_date),
+            )
+        except Exception as e:
+            LOG.warning(f"  {snapshot_date}: certify 실패 — {e}")
+            results.append(AuditSnapshot(
+                snapshot_date=snapshot_date,
+                tickers=tickers,
+                cert=None, regime=snapshot.regime,
+                forward_nav={h: None for h in HORIZONS},
+                forward_mae={h: None for h in HORIZONS},
+                skipped_reason=f"certify raise: {type(e).__name__}",
+            ))
+            continue
+
+        forward_nav: dict[int, float | None] = {}
+        forward_mae: dict[int, float | None] = {}
+        for h in HORIZONS:
+            ret, mae = forward_portfolio_nav(tickers, snapshot_date, h, db_path=db_path)
+            forward_nav[h] = ret
+            forward_mae[h] = mae
+
+        # Serialize cert for analysis (conditions 포함)
+        cert_dict = {
+            "timestamp": cert.timestamp,
+            "certified": cert.certified,
+            "score": cert.score,
+            "total_conditions": cert.total_conditions,
+            "passed": cert.passed,
+            "failed": cert.failed,
+            "warnings": cert.warnings,
+            "conditions": [
+                {"id": c.id, "passed": c.passed, "severity": c.severity}
+                for c in cert.conditions
+            ],
+        }
+        results.append(AuditSnapshot(
+            snapshot_date=snapshot_date,
+            tickers=tickers,
+            cert=cert_dict,
+            regime=snapshot.regime,
+            forward_nav=forward_nav,
+            forward_mae=forward_mae,
+        ))
+
+    LOG.info(f"  collected {len([r for r in results if r.cert])} snapshots "
+             f"(skipped: {len([r for r in results if r.skipped_reason])})")
+    return results
+
+
+# ─── predictivity analysis ──────────────────────────────────────────────────
+
+
+def _bootstrap_diff_ci(
+    fired_returns: list[float],
+    not_fired_returns: list[float],
+    n_iter: int = 5000,
+    conf_level: float = 0.95,
+    seed: int = 42,
+) -> tuple[float, float]:
+    """Bootstrap CI on (mean_fired - mean_not_fired). (lower, upper).
+
+    percentile method. None if either sample < 2.
+    """
+    arr_f = np.array([v for v in fired_returns if v is not None])
+    arr_n = np.array([v for v in not_fired_returns if v is not None])
+    if len(arr_f) < 2 or len(arr_n) < 2:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    diffs = np.empty(n_iter)
+    for i in range(n_iter):
+        bf = rng.choice(arr_f, len(arr_f), replace=True).mean()
+        bn = rng.choice(arr_n, len(arr_n), replace=True).mean()
+        diffs[i] = bf - bn
+    alpha = (1 - conf_level) / 2
+    lo, hi = np.percentile(diffs, [alpha * 100, (1 - alpha) * 100])
+    return float(lo), float(hi)
+
+
+def analyze_predictivity(
+    snapshots: list[AuditSnapshot], n_iter: int = 5000
+) -> list[GateMetric]:
+    """Per-gate predictivity — Q4 B primary (conditional mean diff + bootstrap CI).
+
+    각 gate id 에 대해:
+    - fired snapshots (passed=False) vs not_fired (passed=True)
+    - 각 subset 의 forward_nav (30/60/90d) 분포
+    - mean_fired - mean_not_fired + 95% CI (percentile bootstrap)
+    """
+    # Filter snapshots with cert + NAV
+    valid = [s for s in snapshots if s.cert is not None]
+    if not valid:
+        return []
+
+    # Collect all unique gate_id × severity combos
+    gates: dict[tuple[str, str], GateMetric] = {}
+    for s in valid:
+        assert s.cert is not None  # Pylance narrowing: valid 에서 이미 필터됨
+        for cond in s.cert["conditions"]:
+            key = (cond["id"], cond["severity"])
+            if key not in gates:
+                gates[key] = GateMetric(gate_id=cond["id"], severity=cond["severity"],
+                                        fire_count=0, not_fire_count=0)
+
+    # Aggregate forward NAV per gate × horizon
+    for (gate_id, severity), metric in gates.items():
+        fired_per_h: dict[int, list[float]] = {h: [] for h in HORIZONS}
+        not_fired_per_h: dict[int, list[float]] = {h: [] for h in HORIZONS}
+        for s in valid:
+            assert s.cert is not None  # same narrowing as above
+            cond_found = None
+            for c in s.cert["conditions"]:
+                if c["id"] == gate_id and c["severity"] == severity:
+                    cond_found = c
+                    break
+            if cond_found is None:
+                continue  # 이 snapshot 에 해당 gate 없음 (variable total_conditions)
+            for h in HORIZONS:
+                ret = s.forward_nav.get(h)
+                if ret is None:
+                    continue
+                if cond_found["passed"]:
+                    not_fired_per_h[h].append(ret)
+                else:
+                    fired_per_h[h].append(ret)
+
+        metric.fire_count = len(fired_per_h[HORIZONS[0]])
+        metric.not_fire_count = len(not_fired_per_h[HORIZONS[0]])
+
+        for h in HORIZONS:
+            fired_arr = fired_per_h[h]
+            not_fired_arr = not_fired_per_h[h]
+            metric.mean_when_fired[h] = (
+                round(statistics.mean(fired_arr), 3) if fired_arr else None
+            )
+            metric.mean_when_not_fired[h] = (
+                round(statistics.mean(not_fired_arr), 3) if not_fired_arr else None
+            )
+            if fired_arr and not_fired_arr:
+                diff = statistics.mean(fired_arr) - statistics.mean(not_fired_arr)
+                metric.cond_mean_diff[h] = round(diff, 3)
+                lo, hi = _bootstrap_diff_ci(fired_arr, not_fired_arr, n_iter=n_iter)
+                metric.ci_low[h] = round(lo, 3)
+                metric.ci_high[h] = round(hi, 3)
+                # Sharpe-like: normalized by std of the full sample
+                all_rets = fired_arr + not_fired_arr
+                if len(all_rets) >= 2:
+                    sd = statistics.stdev(all_rets)
+                    metric.sharpe_like[h] = round(diff / sd, 3) if sd > 0 else None
+            else:
+                metric.cond_mean_diff[h] = None
+                metric.ci_low[h] = None
+                metric.ci_high[h] = None
+                metric.sharpe_like[h] = None
+
+    return list(gates.values())
+
+
+# ─── report output ──────────────────────────────────────────────────────────
+
+
+def _format_pct(v: float | None, digits: int = 2) -> str:
+    return f"{v:+.{digits}f}%" if v is not None else "—"
+
+
+def write_report(
+    snapshots: list[AuditSnapshot],
+    metrics: list[GateMetric],
+    output_path: Path,
+) -> None:
+    """Markdown report — per-gate table + top/bottom predictivity rank."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    valid = [s for s in snapshots if s.cert is not None]
+    skipped = [s for s in snapshots if s.skipped_reason]
+
+    lines: list[str] = []
+    lines.append("# E4-0b — SIEGE Historical Predictivity Audit")
+    lines.append("")
+    lines.append(f"Generated: {today_kst()} KST")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Total snapshots attempted: **{len(snapshots)}**")
+    lines.append(f"- Valid (cert + NAV): **{len(valid)}**")
+    lines.append(f"- Skipped: **{len(skipped)}** ({_skip_breakdown(skipped)})")
+    if valid:
+        certified_n = sum(1 for s in valid if s.cert and s.cert["certified"])
+        lines.append(f"- CERTIFIED rate: **{certified_n}/{len(valid)} = {certified_n/len(valid)*100:.1f}%**")
+    lines.append("")
+
+    # Per-gate table
+    lines.append("## Per-gate predictivity (Q4 B — conditional mean difference)")
+    lines.append("")
+    lines.append("| Gate | Severity | Fire | Not-fire | Δ30d | CI30d | Δ60d | CI60d | Δ90d | CI90d |")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|")
+    # Sort: most negative Δ30d first (strongest downside predictivity). None 은 마지막.
+    def _sort_key(m: GateMetric) -> float:
+        v = m.cond_mean_diff.get(30)
+        return v if v is not None else float("inf")
+
+    sorted_metrics = sorted(metrics, key=_sort_key)
+    for m in sorted_metrics:
+        ci30 = (
+            f"[{_format_pct(m.ci_low.get(30))}, {_format_pct(m.ci_high.get(30))}]"
+            if m.ci_low.get(30) is not None else "—"
+        )
+        ci60 = (
+            f"[{_format_pct(m.ci_low.get(60))}, {_format_pct(m.ci_high.get(60))}]"
+            if m.ci_low.get(60) is not None else "—"
+        )
+        ci90 = (
+            f"[{_format_pct(m.ci_low.get(90))}, {_format_pct(m.ci_high.get(90))}]"
+            if m.ci_low.get(90) is not None else "—"
+        )
+        lines.append(
+            f"| `{m.gate_id}` | {m.severity} | {m.fire_count} | {m.not_fire_count} | "
+            f"{_format_pct(m.cond_mean_diff.get(30))} | {ci30} | "
+            f"{_format_pct(m.cond_mean_diff.get(60))} | {ci60} | "
+            f"{_format_pct(m.cond_mean_diff.get(90))} | {ci90} |"
+        )
+    lines.append("")
+    lines.append("**해석**: Δ = mean(fwd_return | gate fired) − mean(fwd_return | not fired).")
+    lines.append("음수가 클수록 해당 gate fire 시 forward NAV 저조 → predictivity 높음.")
+    lines.append("CI 가 0을 포함하면 통계적 significance 부족.")
+    lines.append("")
+
+    # Top/bottom rank
+    if sorted_metrics:
+        lines.append("## Top 3 downside predictivity (Δ30d most negative)")
+        lines.append("")
+        for m in sorted_metrics[:3]:
+            lines.append(
+                f"- `{m.gate_id}` ({m.severity}): Δ30d = {_format_pct(m.cond_mean_diff.get(30))}, "
+                f"fire/not = {m.fire_count}/{m.not_fire_count}"
+            )
+        lines.append("")
+        lines.append("## Bottom 3 predictivity (Δ30d most positive or null)")
+        lines.append("")
+        for m in sorted_metrics[-3:]:
+            lines.append(
+                f"- `{m.gate_id}` ({m.severity}): Δ30d = {_format_pct(m.cond_mean_diff.get(30))}, "
+                f"fire/not = {m.fire_count}/{m.not_fire_count}"
+            )
+        lines.append("")
+
+    # Methodology note
+    lines.append("## Methodology")
+    lines.append("")
+    lines.append("- **Snapshot**: monthly end, {} snapshots over 5Y (us_core top-10 momentum)".format(len(snapshots)))
+    lines.append("- **Portfolio**: equal-weight 10 positions (10% each)")
+    lines.append("- **Forward NAV**: fixed horizon 30/60/90d, equal-weight average forward return")
+    lines.append("- **Regime**: classify_regime(date=snapshot_date) — 과거 시점 snapshot")
+    lines.append("- **Metric**: conditional mean diff + 95% percentile bootstrap CI (primary Q4 B)")
+    lines.append("- **Caller tag**: `audit:historical` — production cert 와 분리 (V2.1 dashboard 에서 square shape)")
+    lines.append("")
+    lines.append("See docs/plans/e4_0b.md for full Plan doc + codex consult log.")
+
+    output_path.write_text("\n".join(lines))
+    LOG.info(f"Report written: {output_path}")
+
+
+def _skip_breakdown(skipped: list[AuditSnapshot]) -> str:
+    """skipped snapshots 원인 요약."""
+    reasons: dict[str, int] = {}
+    for s in skipped:
+        key = (s.skipped_reason or "unknown").split(":")[0]
+        reasons[key] = reasons.get(key, 0) + 1
+    return ", ".join(f"{k}={v}" for k, v in reasons.items())
+
+
+# ─── CLI ────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
+    parser.add_argument("--universe", default=DEFAULT_UNIVERSE, help="universe.yaml key")
+    parser.add_argument("--months", type=int, default=DEFAULT_MONTHS, help="number of monthly snapshots")
+    parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N, help="momentum top-N positions per snapshot")
+    parser.add_argument("--bootstrap-iter", type=int, default=5000, help="bootstrap iterations for CI")
+    grp = parser.add_mutually_exclusive_group()
+    grp.add_argument("--save", action="store_true", help="persist audit rows to certifications")
+    grp.add_argument("--dry-run", action="store_true", default=True, help="default — no DB write")
+    args = parser.parse_args()
+
+    save = args.save and not args.dry_run
+
+    LOG.info("═" * 60)
+    LOG.info("  E4-0b SIEGE Historical Predictivity Audit")
+    LOG.info("═" * 60)
+    snapshots = run_audit(
+        universe_key=args.universe, months=args.months,
+        top_n=args.top_n, save=save,
+    )
+
+    metrics = analyze_predictivity(snapshots, n_iter=args.bootstrap_iter)
+
+    output_dir = Path("data/reports") / today_kst()
+    output_path = output_dir / "e4_0b_siege_predictivity.md"
+    write_report(snapshots, metrics, output_path)
+
+    # Console summary
+    print()
+    print("═" * 60)
+    print(f"  Audit complete — {len([s for s in snapshots if s.cert])} valid snapshots")
+    print(f"  Report: {output_path}")
+    if save:
+        print(f"  DB: {len([s for s in snapshots if s.cert])} audit:historical rows persisted")
+    else:
+        print("  DB: dry-run (no rows persisted — use --save to persist)")
+    print("═" * 60)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_siege_predictivity_audit.py
+++ b/tests/scripts/test_siege_predictivity_audit.py
@@ -1,0 +1,426 @@
+"""E4-0b — siege_predictivity_audit.py regression tests.
+
+docs/plans/e4_0b.md §3.5 요구 사항: ≥15 regression tests.
+
+분류:
+- Snapshot date 생성 + momentum selection (determinism + no-lookahead)
+- Synthesize helpers (portfolio_df schema + cert snapshot hash/regime)
+- Forward NAV (equal-weight + partial data)
+- Bootstrap CI (reproducibility)
+- Predictivity aggregation (fire/not-fire bucketing)
+- Idempotency (fixed_timestamp + already_audited)
+- Report output (markdown shape)
+- End-to-end tiny run
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from nuri.core.db import get_db, init_db, upsert_macro, upsert_prices
+
+# Script import
+from scripts.siege_predictivity_audit import (
+    AuditSnapshot,
+    GateMetric,
+    _already_audited,
+    _bootstrap_diff_ci,
+    _fixed_timestamp,
+    analyze_predictivity,
+    forward_portfolio_nav,
+    monthly_snapshot_dates,
+    synthesize_cert_snapshot,
+    synthesize_portfolio_df,
+    top_n_momentum,
+    write_report,
+)
+
+# ─── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tiny_db(tmp_path, monkeypatch):
+    """3-ticker universe × 400 trading days prices. For momentum + NAV tests."""
+    import nuri.core.db as db_mod
+
+    path = tmp_path / "tiny.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+
+    with get_db(path) as conn:
+        # Minimal portfolio row (sector lookup)
+        conn.execute(
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+            "VALUES ('audit', 'AAPL', 10, 150, 'USD', 'Technology')"
+        )
+        conn.execute(
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+            "VALUES ('audit', 'MSFT', 5, 300, 'USD', 'Technology')"
+        )
+
+    # 400 business days price series — AAPL up trend, MSFT flat, SPY required for _trading_day_on_or_before
+    start = pd.Timestamp("2023-01-02")
+    dates = pd.bdate_range(start, periods=400)
+    prices = []
+    for i, d in enumerate(dates):
+        ds = d.strftime("%Y-%m-%d")
+        prices.append({"ticker": "AAPL", "date": ds, "open": 100 + i * 0.1, "high": 102 + i * 0.1,
+                       "low": 99 + i * 0.1, "close": 100 + i * 0.1, "volume": 1000, "adj_close": 100 + i * 0.1})
+        prices.append({"ticker": "MSFT", "date": ds, "open": 300, "high": 302, "low": 298,
+                       "close": 300, "volume": 1000, "adj_close": 300})
+        prices.append({"ticker": "SPY", "date": ds, "open": 400, "high": 402, "low": 398,
+                       "close": 400 + i * 0.05, "volume": 1000, "adj_close": 400 + i * 0.05})
+        prices.append({"ticker": "NVDA", "date": ds, "open": 500, "high": 510, "low": 490,
+                       "close": 500 + i * 0.2, "volume": 1000, "adj_close": 500 + i * 0.2})
+    upsert_prices(pd.DataFrame(prices), path)
+
+    # VIX + macro for regime classification
+    macro = []
+    for i, d in enumerate(dates):
+        ds = d.strftime("%Y-%m-%d")
+        macro.append({"indicator": "vix", "date": ds, "value": 15.0 + (i % 5), "source": "test"})
+        macro.append({"indicator": "usd_krw", "date": ds, "value": 1380.0, "source": "test"})
+    upsert_macro(macro, path)
+
+    return path
+
+
+# ─── 1. monthly_snapshot_dates ──────────────────────────────────────────────
+
+
+class TestMonthlySnapshotDates:
+    def test_determinism(self):
+        """같은 입력 → 같은 리스트."""
+        a = monthly_snapshot_dates("2026-04-01", months=12)
+        b = monthly_snapshot_dates("2026-04-01", months=12)
+        assert a == b
+        assert len(a) == 12
+
+    def test_month_end_format(self):
+        """각 원소가 YYYY-MM-DD 형식 + 월말 근처 (day ≥ 28)."""
+        dates = monthly_snapshot_dates("2026-04-01", months=6)
+        for d in dates:
+            assert len(d) == 10
+            day = int(d.split("-")[-1])
+            assert day >= 28, f"{d} is not month-end"
+
+    def test_oldest_first_ordering(self):
+        """return 리스트는 oldest → newest 정렬."""
+        dates = monthly_snapshot_dates("2026-04-01", months=6)
+        assert dates == sorted(dates)
+
+
+# ─── 2. top_n_momentum ──────────────────────────────────────────────────────
+
+
+class TestTopNMomentum:
+    def test_picks_highest_return(self, tiny_db):
+        """최대 % return 보유 ticker 선택 — AAPL (+25% over 252d) > NVDA (+10%) > MSFT (0%)."""
+        picks = top_n_momentum(["AAPL", "MSFT", "NVDA"], "2024-06-01", n=1, db_path=tiny_db)
+        # AAPL: 100→125.2 (+25%), NVDA: 500→550.4 (+10%), MSFT: flat — AAPL top.
+        assert picks == ["AAPL"]
+
+    def test_picks_top_n_ordered_by_return(self, tiny_db):
+        """top-N 이 return 내림차순 정렬."""
+        picks = top_n_momentum(["AAPL", "MSFT", "NVDA"], "2024-06-01", n=3, db_path=tiny_db)
+        assert picks == ["AAPL", "NVDA", "MSFT"]
+
+    def test_excludes_sparse_coverage(self, tiny_db):
+        """252d 미만 coverage ticker 는 제외."""
+        # fake 이력 없는 ticker
+        picks = top_n_momentum(["AAPL", "GHOST"], "2024-06-01", n=2, db_path=tiny_db)
+        assert "GHOST" not in picks
+        assert "AAPL" in picks
+
+    def test_no_lookahead(self, tiny_db):
+        """as_of 이후 close 로 계산하지 않음 — as_of 이전 ≥252d 필수."""
+        # tiny_db 가 2023-01-02 시작이므로 as_of 가 너무 이르면 returns 제외
+        picks = top_n_momentum(["AAPL"], "2023-06-01", n=1, db_path=tiny_db)
+        # 2023-01 ~ 2023-06 = ~100d 거래일 → 252d lookback 부족 → 제외
+        assert picks == []
+
+
+# ─── 3. synthesize_portfolio_df ─────────────────────────────────────────────
+
+
+class TestSynthesizePortfolioDf:
+    def test_returns_analyze_portfolio_schema(self, tiny_db):
+        """df columns 가 analyze_portfolio output 과 일치."""
+        df = synthesize_portfolio_df(["AAPL", "MSFT"], "2024-06-01", db_path=tiny_db)
+        assert df is not None
+        required = {"account", "ticker", "sector", "quantity", "avg_price",
+                    "current_price", "currency", "current_value_usd", "cost_basis_usd",
+                    "pnl_usd", "pnl_pct", "price_date", "weight_pct"}
+        assert required.issubset(set(df.columns))
+
+    def test_equal_weight(self, tiny_db):
+        """모든 ticker 가 동일 weight_pct — 10 positions → 10% 각각."""
+        df = synthesize_portfolio_df(["AAPL", "MSFT", "NVDA"], "2024-06-01", db_path=tiny_db)
+        assert df is not None
+        weights = df["weight_pct"].tolist()
+        assert all(abs(w - weights[0]) < 0.01 for w in weights), "weight_pct 가 동일하지 않음"
+
+    def test_missing_price_returns_none(self, tiny_db):
+        """데이터 없는 ticker 포함 → None."""
+        df = synthesize_portfolio_df(["AAPL", "NONEXISTENT"], "2024-06-01", db_path=tiny_db)
+        assert df is None
+
+    def test_sector_fallback_unknown(self, tiny_db):
+        """portfolio 에 sector 없는 ticker → 'Unknown'."""
+        # NVDA 는 portfolio 테이블에 없음 → Unknown 폴백
+        df = synthesize_portfolio_df(["NVDA"], "2024-06-01", db_path=tiny_db)
+        assert df is not None
+        assert df.iloc[0]["sector"] == "Unknown"
+
+
+# ─── 4. synthesize_cert_snapshot ────────────────────────────────────────────
+
+
+class TestSynthesizeCertSnapshot:
+    def test_hash_matches_raw(self, tiny_db):
+        """CertSnapshot.portfolio_hash 가 portfolio_raw 에서 바로 파생."""
+        from nuri.trading.engine.certification import _compute_portfolio_hash
+
+        snap = synthesize_cert_snapshot(["AAPL", "MSFT"], "2024-06-01", db_path=tiny_db)
+        assert snap is not None
+        assert snap.portfolio_hash == _compute_portfolio_hash(rows=snap.portfolio_raw)
+
+    def test_regime_populated_from_classifier(self, tiny_db):
+        """snap.regime 이 classify_regime(date=...) 결과."""
+        snap = synthesize_cert_snapshot(["AAPL", "MSFT"], "2024-06-01", db_path=tiny_db)
+        assert snap is not None
+        assert snap.regime is not None
+
+    def test_none_when_regime_fails(self, tiny_db):
+        """regime 실패 시 None (historical 데이터 부족)."""
+        with patch("scripts.siege_predictivity_audit.classify_regime", return_value=None):
+            snap = synthesize_cert_snapshot(["AAPL"], "2024-06-01", db_path=tiny_db)
+            assert snap is None
+
+
+# ─── 5. forward_portfolio_nav ───────────────────────────────────────────────
+
+
+class TestForwardPortfolioNav:
+    def test_equal_weight_average(self, tiny_db):
+        """return = 2 tickers 의 단순 평균."""
+        ret, mae = forward_portfolio_nav(["AAPL", "MSFT"], "2024-01-02", 30, db_path=tiny_db)
+        assert ret is not None
+        # AAPL 상승 + MSFT flat → 평균은 양수의 절반 수준
+        assert ret > 0
+
+    def test_partial_data_returns_none(self, tiny_db):
+        """일부 ticker 데이터 부족 → None (conservative)."""
+        ret, mae = forward_portfolio_nav(["AAPL", "GHOST"], "2024-01-02", 30, db_path=tiny_db)
+        assert ret is None
+        assert mae is None
+
+    def test_mae_is_lower_bound(self, tiny_db):
+        """MAE 는 entry 이후 최저 close 기준 — ret 이하 (flat 이상에서)."""
+        ret, mae = forward_portfolio_nav(["AAPL"], "2024-01-02", 30, db_path=tiny_db)
+        assert ret is not None and mae is not None
+        # 상승 ticker 의 MAE 는 entry close 보다 작거나 같음 (intra-window low)
+        assert mae <= ret
+
+
+# ─── 6. bootstrap CI ────────────────────────────────────────────────────────
+
+
+class TestBootstrapDiffCi:
+    def test_reproducibility_same_seed(self):
+        """같은 seed + 입력 → 같은 CI."""
+        fired = [1.0, 2.0, 3.0, 4.0, 5.0]
+        notf = [10.0, 12.0, 14.0, 16.0, 18.0]
+        a = _bootstrap_diff_ci(fired, notf, n_iter=500, seed=42)
+        b = _bootstrap_diff_ci(fired, notf, n_iter=500, seed=42)
+        assert a == b
+
+    def test_insufficient_sample_returns_nan(self):
+        """len < 2 → (nan, nan)."""
+        lo, hi = _bootstrap_diff_ci([1.0], [10.0], n_iter=100)
+        assert lo != lo  # NaN != NaN
+        assert hi != hi
+
+    def test_diff_sign_preserved(self):
+        """fired << not_fired → CI 가 음수 영역."""
+        fired = list(range(-20, -5))  # mean ~ -12.5
+        notf = list(range(10, 25))  # mean ~ 17
+        lo, hi = _bootstrap_diff_ci(fired, notf, n_iter=500, seed=42)
+        assert hi < 0  # fired - notf 음수
+
+
+# ─── 7. analyze_predictivity ────────────────────────────────────────────────
+
+
+class TestAnalyzePredictivity:
+    def _make_snap(self, date: str, cond_passed: bool, fwd_30: float) -> AuditSnapshot:
+        return AuditSnapshot(
+            snapshot_date=date, tickers=["AAPL"],
+            cert={
+                "certified": cond_passed,
+                "score": 100 if cond_passed else 50,
+                "total_conditions": 1,
+                "passed": 1 if cond_passed else 0,
+                "failed": 0 if cond_passed else 1,
+                "warnings": 0,
+                "conditions": [
+                    {"id": "position_limit", "passed": cond_passed, "severity": "error"},
+                ],
+                "timestamp": f"{date}T00:00:00+09:00",
+            },
+            regime="bull_low_vol",
+            forward_nav={30: fwd_30, 60: None, 90: None},
+            forward_mae={30: fwd_30 - 1, 60: None, 90: None},
+        )
+
+    def test_buckets_by_fired_not_fired(self):
+        """fired (passed=False) vs not_fired (passed=True) 분리 카운트."""
+        snaps = [
+            self._make_snap("2024-01-31", False, -5.0),  # fired
+            self._make_snap("2024-02-29", False, -3.0),  # fired
+            self._make_snap("2024-03-31", True, 2.0),  # not fired
+            self._make_snap("2024-04-30", True, 4.0),  # not fired
+        ]
+        metrics = analyze_predictivity(snaps, n_iter=100)
+        assert len(metrics) == 1
+        m = metrics[0]
+        assert m.fire_count == 2
+        assert m.not_fire_count == 2
+        assert m.mean_when_fired[30] == -4.0
+        assert m.mean_when_not_fired[30] == 3.0
+        assert m.cond_mean_diff[30] == -7.0  # fired - not = -4 - 3
+
+    def test_empty_snapshots_returns_empty(self):
+        """빈 입력 → empty metrics."""
+        assert analyze_predictivity([]) == []
+
+    def test_skipped_snapshots_excluded(self):
+        """cert=None 인 snapshot 은 제외."""
+        snaps = [
+            AuditSnapshot(snapshot_date="2024-01-31", tickers=[], cert=None, regime=None,
+                          forward_nav={}, forward_mae={}, skipped_reason="no data"),
+            self._make_snap("2024-02-29", False, -2.0),
+            self._make_snap("2024-03-31", True, 3.0),
+        ]
+        metrics = analyze_predictivity(snaps, n_iter=100)
+        assert metrics[0].fire_count == 1
+        assert metrics[0].not_fire_count == 1
+
+
+# ─── 8. idempotency helpers ─────────────────────────────────────────────────
+
+
+class TestIdempotency:
+    def test_fixed_timestamp_format(self):
+        """_fixed_timestamp 가 YYYY-MM-DDT00:00:00+09:00 형식."""
+        assert _fixed_timestamp("2024-06-01") == "2024-06-01T00:00:00+09:00"
+
+    def test_already_audited_false_empty_db(self, tiny_db):
+        """빈 certifications → False."""
+        assert _already_audited("2024-06-01", db_path=tiny_db) is False
+
+    def test_already_audited_true_after_insert(self, tiny_db):
+        """audit:historical row 있으면 True."""
+        from nuri.core.db import insert_certification
+
+        insert_certification(
+            {
+                "timestamp": "2024-06-01T00:00:00+09:00",
+                "certified": 0,
+                "score": 50,
+                "total_conditions": 10,
+                "passed": 5,
+                "failed": 1,
+                "warnings": 4,
+                "regime": "bull_low_vol",
+                "portfolio_hash": "abc",
+                "conditions_json": "[]",
+                "caller": "audit:historical",
+            },
+            db_path=tiny_db,
+        )
+        assert _already_audited("2024-06-01", db_path=tiny_db) is True
+
+    def test_already_audited_excludes_other_callers(self, tiny_db):
+        """같은 timestamp 라도 caller 다르면 False (audit 전용)."""
+        from nuri.core.db import insert_certification
+
+        insert_certification(
+            {
+                "timestamp": "2024-06-01T00:00:00+09:00",
+                "certified": 1, "score": 100, "total_conditions": 10,
+                "passed": 10, "failed": 0, "warnings": 0,
+                "regime": None, "portfolio_hash": "x", "conditions_json": "[]",
+                "caller": "cli",  # NOT audit
+            },
+            db_path=tiny_db,
+        )
+        assert _already_audited("2024-06-01", db_path=tiny_db) is False
+
+
+# ─── 9. write_report markdown shape ─────────────────────────────────────────
+
+
+class TestWriteReport:
+    def test_produces_markdown_sections(self, tmp_path):
+        """report 에 예상된 sections 모두 포함."""
+        snapshots = [
+            AuditSnapshot(
+                snapshot_date="2024-01-31", tickers=["AAPL"],
+                cert={"certified": True, "score": 100, "total_conditions": 1,
+                      "passed": 1, "failed": 0, "warnings": 0, "timestamp": "x",
+                      "conditions": [{"id": "position_limit", "passed": True, "severity": "error"}]},
+                regime="bull_low_vol",
+                forward_nav={30: 3.0, 60: None, 90: None},
+                forward_mae={30: -1.0, 60: None, 90: None},
+            ),
+            AuditSnapshot(
+                snapshot_date="2024-02-29", tickers=["MSFT"],
+                cert={"certified": False, "score": 0, "total_conditions": 1,
+                      "passed": 0, "failed": 1, "warnings": 0, "timestamp": "x",
+                      "conditions": [{"id": "position_limit", "passed": False, "severity": "error"}]},
+                regime="bull_low_vol",
+                forward_nav={30: -5.0, 60: None, 90: None},
+                forward_mae={30: -6.0, 60: None, 90: None},
+            ),
+        ]
+        metrics = analyze_predictivity(snapshots, n_iter=100)
+        output_path = tmp_path / "report.md"
+        write_report(snapshots, metrics, output_path)
+
+        text = output_path.read_text()
+        assert "# E4-0b" in text
+        assert "## Summary" in text
+        assert "## Per-gate predictivity" in text
+        assert "## Methodology" in text
+        assert "`position_limit`" in text
+
+
+# ─── 10. end-to-end tiny run (integration) ──────────────────────────────────
+
+
+class TestEndToEndTiny:
+    def test_run_audit_with_dry_run(self, tiny_db, monkeypatch):
+        """3-ticker universe × 2 snapshot 소규모 end-to-end, dry-run."""
+        from scripts.siege_predictivity_audit import run_audit
+
+        # universe.yaml read 우회 — monkey-patch
+        monkeypatch.setattr(
+            "scripts.siege_predictivity_audit._load_universe",
+            lambda key="us_core": ["AAPL", "MSFT", "NVDA"],
+        )
+
+        # today 를 tiny_db 마지막 price 근처로 고정
+        monkeypatch.setattr(
+            "scripts.siege_predictivity_audit.today_kst",
+            lambda: "2024-06-30",
+        )
+
+        snapshots = run_audit(universe_key="us_core", months=2, top_n=2, save=False, db_path=tiny_db)
+        assert len(snapshots) == 2
+        # 최소 1개는 cert 생성
+        valid = [s for s in snapshots if s.cert is not None]
+        assert len(valid) >= 1, f"no valid cert generated; skipped: {[s.skipped_reason for s in snapshots]}"

--- a/tests/trading/engine/test_certification_snapshot_inject.py
+++ b/tests/trading/engine/test_certification_snapshot_inject.py
@@ -1,0 +1,221 @@
+"""E4-0b — certify() snapshot injection + timestamp override regression tests.
+
+docs/plans/e4_0b.md §3.1 에 따라 `certify(snapshot=..., timestamp=...)` 확장.
+Historical audit 모드 — 실 DB portfolio 를 건드리지 않고 synthetic snapshot 주입.
+
+중요 invariant:
+- snapshot=None 이면 _capture_snapshot() 호출 (기존 production 동작 불변)
+- snapshot 주입 시 _capture_snapshot() 호출 안 됨 (재-read 금지)
+- timestamp 주입 시 Certificate.timestamp + certifications row 에 동일 반영
+- caller="audit:historical" 이 CallerTag Literal 에 등록
+- ContextVar 경유로 gate 들이 주입된 snapshot 값 읽음 (R2/R4 rigor 유지)
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from nuri.core.db import query
+from nuri.trading.engine.certification import (
+    Certificate,
+    CertSnapshot,
+    _compute_portfolio_hash,
+    certify,
+)
+
+
+def _make_snapshot(portfolio_raw: list[dict], *, regime: str = "bull_low_vol") -> CertSnapshot:
+    """Synthetic CertSnapshot — portfolio_df 는 analyze_portfolio output schema 모사."""
+    df = pd.DataFrame(
+        [
+            {
+                "account": r["account"],
+                "ticker": r["ticker"],
+                "sector": r["sector"],
+                "quantity": r["quantity"],
+                "avg_price": r["avg_price"],
+                "current_price": r["avg_price"],  # flat — no P&L
+                "currency": "USD",
+                "current_value_usd": round(r["quantity"] * r["avg_price"], 2),
+                "cost_basis_usd": round(r["quantity"] * r["avg_price"], 2),
+                "pnl_usd": 0.0,
+                "pnl_pct": 0.0,
+                "price_date": "2024-01-31",
+            }
+            for r in portfolio_raw
+        ]
+    )
+    total_value = df["current_value_usd"].sum() or 1
+    df["weight_pct"] = round(df["current_value_usd"] / total_value * 100, 2)
+    df.attrs["warnings"] = []
+    df.attrs["total_value_usd"] = round(total_value, 2)
+    df.attrs["usd_krw"] = 1380.0
+    return CertSnapshot(
+        regime=regime,
+        portfolio_raw=portfolio_raw,
+        portfolio_df=df,
+        portfolio_hash=_compute_portfolio_hash(rows=portfolio_raw),
+        portfolio_error=None,
+    )
+
+
+class TestSnapshotInjection:
+    """snapshot 파라미터가 _capture_snapshot 호출을 대체한다."""
+
+    def test_snapshot_provided_skips_capture(self, populated_db_cert, monkeypatch):
+        """snapshot 주입 시 _capture_snapshot() 호출 0회 — 재-read 금지."""
+        calls = {"n": 0}
+        from nuri.trading.engine import certification as cert_mod
+
+        original = cert_mod._capture_snapshot
+
+        def counting(**kw):
+            calls["n"] += 1
+            return original(**kw)
+
+        monkeypatch.setattr(cert_mod, "_capture_snapshot", counting)
+
+        snap = _make_snapshot(
+            [{"account": "test", "ticker": "AAPL", "sector": "Tech", "quantity": 10, "avg_price": 150}]
+        )
+        certify(db_path=populated_db_cert, caller="audit:historical", snapshot=snap)
+
+        assert calls["n"] == 0, "snapshot 주입 시 _capture_snapshot 호출되면 재-read 발생"
+
+    def test_snapshot_none_calls_capture_once(self, populated_db_cert, monkeypatch):
+        """snapshot=None 이면 _capture_snapshot 정확히 1회 호출 (production path 유지)."""
+        calls = {"n": 0}
+        from nuri.trading.engine import certification as cert_mod
+
+        original = cert_mod._capture_snapshot
+
+        def counting(**kw):
+            calls["n"] += 1
+            return original(**kw)
+
+        monkeypatch.setattr(cert_mod, "_capture_snapshot", counting)
+
+        certify(db_path=populated_db_cert, caller="test")
+        assert calls["n"] == 1
+
+    def test_injected_snapshot_regime_used_by_gates(self, populated_db_cert):
+        """주입된 snapshot.regime 이 gate 내부 _current_regime() 호출 결과로 보임."""
+        snap = _make_snapshot(
+            [{"account": "test", "ticker": "AAPL", "sector": "Tech", "quantity": 10, "avg_price": 150}],
+            regime="stagflation",
+        )
+        certify(db_path=populated_db_cert, caller="audit:historical", snapshot=snap)
+        rows = query("SELECT regime FROM certifications", db_path=populated_db_cert)
+        assert rows[0]["regime"] == "stagflation"
+
+    def test_injected_snapshot_hash_persisted(self, populated_db_cert):
+        """snapshot.portfolio_hash 가 그대로 persist — recomputation 없음."""
+        raw = [
+            {"account": "audit", "ticker": "GOOG", "sector": "Tech", "quantity": 5, "avg_price": 200.0},
+            {"account": "audit", "ticker": "NVDA", "sector": "Tech", "quantity": 3, "avg_price": 500.0},
+        ]
+        snap = _make_snapshot(raw)
+        expected_hash = snap.portfolio_hash
+        certify(db_path=populated_db_cert, caller="audit:historical", snapshot=snap)
+        rows = query("SELECT portfolio_hash FROM certifications", db_path=populated_db_cert)
+        assert rows[0]["portfolio_hash"] == expected_hash
+
+
+class TestTimestampOverride:
+    """timestamp 파라미터 — historical snapshot 의 고정 timestamp 로 dedupe 가능."""
+
+    def test_timestamp_none_uses_kst_now(self, populated_db_cert):
+        """timestamp=None 이면 kst_now() 기반 — 현재 시각 prefix 매치."""
+        from nuri.core.timezone import today_kst
+
+        today = today_kst()  # already ISO string 'YYYY-MM-DD'
+        cert = certify(db_path=populated_db_cert, caller="test")
+        assert cert.timestamp.startswith(today)
+
+    def test_timestamp_override_reflected_in_cert(self, populated_db_cert):
+        """timestamp 주입 시 Certificate.timestamp 가 그 값 그대로."""
+        fixed = "2024-03-15T00:00:00+09:00"
+        snap = _make_snapshot(
+            [{"account": "audit", "ticker": "AAPL", "sector": "Tech", "quantity": 10, "avg_price": 150}]
+        )
+        cert = certify(
+            db_path=populated_db_cert,
+            caller="audit:historical",
+            snapshot=snap,
+            timestamp=fixed,
+        )
+        assert cert.timestamp == fixed
+
+    def test_timestamp_override_persisted(self, populated_db_cert):
+        """timestamp 주입 시 certifications row 의 timestamp 도 동일."""
+        fixed = "2024-06-01T00:00:00+09:00"
+        snap = _make_snapshot(
+            [{"account": "audit", "ticker": "MSFT", "sector": "Tech", "quantity": 2, "avg_price": 400.0}]
+        )
+        certify(
+            db_path=populated_db_cert,
+            caller="audit:historical",
+            snapshot=snap,
+            timestamp=fixed,
+        )
+        rows = query("SELECT timestamp FROM certifications", db_path=populated_db_cert)
+        assert rows[0]["timestamp"] == fixed
+
+    def test_timestamp_enables_dedupe_by_snapshot_date(self, populated_db_cert):
+        """같은 timestamp 로 2회 persist → 2 rows (애플리케이션 레벨 dedup 책임 확인).
+
+        중복 감지는 script-level idempotency guard 책임 (docs/plans/e4_0b.md §3.4).
+        engine layer 는 timestamp 를 그대로 저장, dedupe 강제 안 함.
+        """
+        fixed = "2024-09-10T00:00:00+09:00"
+        snap = _make_snapshot(
+            [{"account": "audit", "ticker": "AAPL", "sector": "Tech", "quantity": 10, "avg_price": 150}]
+        )
+        certify(db_path=populated_db_cert, caller="audit:historical", snapshot=snap, timestamp=fixed)
+        certify(db_path=populated_db_cert, caller="audit:historical", snapshot=snap, timestamp=fixed)
+        rows = query(
+            "SELECT COUNT(*) c FROM certifications WHERE timestamp = ?",
+            (fixed,),
+            db_path=populated_db_cert,
+        )
+        assert rows[0]["c"] == 2
+
+
+class TestCallerTagAuditHistorical:
+    """audit:historical caller 가 CallerTag Literal 에 등록 + persist 가능."""
+
+    def test_audit_historical_caller_persists(self, populated_db_cert):
+        snap = _make_snapshot(
+            [{"account": "audit", "ticker": "AAPL", "sector": "Tech", "quantity": 10, "avg_price": 150}]
+        )
+        certify(
+            db_path=populated_db_cert,
+            caller="audit:historical",
+            snapshot=snap,
+        )
+        rows = query("SELECT caller FROM certifications", db_path=populated_db_cert)
+        assert rows[0]["caller"] == "audit:historical"
+
+
+class TestBackwardCompat:
+    """기존 production path — snapshot/timestamp=None — 모든 동작 불변."""
+
+    def test_no_params_matches_prior_behavior(self, populated_db_cert):
+        """신규 kwargs 없이 호출 → production 동작 (Certificate 반환, 1 row persist)."""
+        cert = certify(db_path=populated_db_cert, caller="test")
+        assert isinstance(cert, Certificate)
+        rows = query("SELECT COUNT(*) c FROM certifications", db_path=populated_db_cert)
+        assert rows[0]["c"] == 1
+
+    def test_snapshot_param_does_not_leak_contextvar(self, populated_db_cert):
+        """certify(snapshot=...) 후 _CERT_SNAPSHOT 는 reset 되어 외부 코드에 누수 안 됨."""
+        from nuri.trading.engine.certification import _CERT_SNAPSHOT
+
+        snap = _make_snapshot(
+            [{"account": "audit", "ticker": "AAPL", "sector": "Tech", "quantity": 10, "avg_price": 150}]
+        )
+        assert _CERT_SNAPSHOT.get() is None
+        certify(db_path=populated_db_cert, caller="audit:historical", snapshot=snap)
+        assert _CERT_SNAPSHOT.get() is None  # reset 확인
+
+


### PR DESCRIPTION
## Summary

E4-0b — SIEGE historical predictivity audit **infrastructure**. Plan doc self-reviewed (codex 30분+ 무응답, STRATEGY §2.7 fallback). Actual 60-snapshot audit run 은 post-merge.

## Shipped (3 commits, per §4.2)

1. **feat(engine)** — `certify(snapshot=None, timestamp=None)` 파라미터 추가 + `CallerTag "audit:historical"` 등록. Production path (snapshot=None) zero regression. 11 unit tests lock.
2. **feat(scripts)** — `siege_predictivity_audit.py` (680 lines): monthly top-N momentum × historical certify × forward NAV × bootstrap CI. `--dry-run` 기본, `--save` 으로 persist. Smoke tested.
3. **test+docs** — 29 regression tests (script) + `docs/plans/e4_0b.md` Plan doc + STRATEGY §3.8 신설.

## Coverage

- `certification.py` 추가 함수 파라미터 + 11 test = 100% branches 신규 코드
- `siege_predictivity_audit.py` 29 test across 10 카테고리, end-to-end tiny run 포함

## Plan Q&A (Plan doc §2)

| Q | Decision |
|---|---|
| Q1 snapshot method | Monthly top-10 momentum (us_core × 60 months) |
| Q2 universe | us_core (Stage 2 연속성) |
| Q3 forward NAV | Fixed 30/60/90d horizon |
| Q4 metric | Conditional mean diff + 95% bootstrap CI (Q4 B primary) |
| Q5 output | Ranking + CI + advisory (hard threshold → E4-0c) |

## STRATEGY §3.8 신설

§3.7 "SIEGE limits hypothesis" → "infrastructure shipped" 승격. 실측 결과는 post-merge (audit run 실행 후). §3.7 정신 계승한 Warning: 단발 measurement 로 mechanical config 변경 금지.

## Out of scope (후속)

- Actual 60-snapshot audit run (post-merge, `scripts/siege_predictivity_audit.py --save --months 60`)
- Per-gate predictivity 분석 결과 보고서
- V1 API `?exclude_audit=true` filter (V2.2 후보)

## Test plan

- [x] `make test-fast` pass (3,210 tests)
- [x] `make lint` clean
- [x] `make verify-doc-counts` green
- [x] Smoke: `.venv/bin/python scripts/siege_predictivity_audit.py --months 4 --dry-run` ✓ (4 snapshots, report 생성)
- [ ] Codex review (unresponsive — self-review verdict 는 Plan doc §7)
- [ ] Manual review by reviewer (audit script 의 methodology decisions)

@codex review

docs/plans/e4_0b.md §7 self-review verdict 를 challenge 해 주세요. 특히:
- Q1 monthly top-N momentum 이 현실 portfolio construction 과 충분히 align 되는가
- §3.1 certify() snapshot injection 이 13 gate 내부에 silent regression 을 만들 위험 (contextvar 경로)
- acceptance N=60 bootstrap 5000 iter 의 Q4 B 통계력

🤖 Generated with [Claude Code](https://claude.com/claude-code)