### PR TITLE
fix(collectors+scripts): estimates CLI --source + siege_predictivity_audit --save 복구

### DIFF
--- a/nuri/collectors/estimates.py
+++ b/nuri/collectors/estimates.py
@@ -159,13 +159,24 @@ def _upsert_estimates(records: list[dict]) -> int:
 
 
 if __name__ == "__main__":
+    import argparse
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
+    parser = argparse.ArgumentParser(description="애널리스트 컨센서스 수집 (yfinance)")
+    parser.add_argument(
+        "--source",
+        choices=["portfolio", "universe", "all"],
+        default="portfolio",
+        help="티커 범위: portfolio(default, 보유종목만) / universe(config/universe.yaml 전체) / all(union)",
+    )
+    args = parser.parse_args()
+
     collector = EstimatesCollector()
-    count = collector.run()
+    count = collector.run(source=args.source)
 
     rows = query(
         """SELECT ticker, recommendation, target_mean, target_median,

--- a/scripts/siege_predictivity_audit.py
+++ b/scripts/siege_predictivity_audit.py
@@ -643,10 +643,12 @@ def main() -> int:
     parser.add_argument("--bootstrap-iter", type=int, default=5000, help="bootstrap iterations for CI")
     grp = parser.add_mutually_exclusive_group()
     grp.add_argument("--save", action="store_true", help="persist audit rows to certifications")
-    grp.add_argument("--dry-run", action="store_true", default=True, help="default — no DB write")
+    grp.add_argument("--dry-run", action="store_true",
+                     help="no DB write (default when --save not given)")
     args = parser.parse_args()
 
-    save = args.save and not args.dry_run
+    # 기본은 dry-run. --save 가 명시되면 실제 persist.
+    save = bool(args.save) and not bool(args.dry_run)
 
     LOG.info("═" * 60)
     LOG.info("  E4-0b SIEGE Historical Predictivity Audit")


### PR DESCRIPTION
## Summary

Issue #247 P0 완료 검증 중 실측에서 발견한 **2건 CLI 버그 fix**.

### 1. `nuri/collectors/estimates.py` — `--source` flag 미지원

`make collect-universe` 의 estimates 단계가 universe 543 tickers 대신 portfolio 8 tickers 만 수집. main 에 argparse 없이 `collector.run()` 호출 → default `source='portfolio'` 사용.

Fix: argparse 추가, `--source {portfolio, universe, all}` flag → `run(source=...)`.

### 2. `scripts/siege_predictivity_audit.py` — `--save` 무력화

mutually_exclusive_group 에서 `--dry-run default=True` 가 `--save` 와 동시 명시돼도 `args.dry_run=True` 유지 → `save = args.save and not args.dry_run` 항상 False.

Fix: `--dry-run` default 제거. `save = bool(args.save) and not bool(args.dry_run)`.

### 실측 결과 (post-fix)

- `estimates --source universe`: 543 tickers 시도 (log 확인) ✅
- `siege_predictivity_audit --save --months 60`: 48 audit:historical rows persisted ✅

## Related issues

- #247 closed (P0 완료) — 이 PR 이 검증 과정에서 발생한 fix
- #418 KIS Research (P1)
- #419 VKOSPI (P1)
- #420 estimates rate-limit (rate-limit 처리, 별도)

## Test plan

- [x] `make lint` clean
- [x] estimates 실행 log 확인 (543 tickers iteration)
- [x] siege_predictivity_audit 실행 log `save: True`
- [x] certifications 테이블 48 audit:historical rows 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)