### PR TITLE
test(coverage): estimates + audit CLI 100% — refactor argparse → main()

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (3,239 backend + 917 frontend + 38 e2e)
+make test       # full suite (3,258 backend + 917 frontend + 38 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,239 backend tests across 146 files + 917 frontend vitest (64 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,258 backend tests across 146 files + 917 frontend vitest (64 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -279,7 +279,7 @@ PR을 올리기 전 이 기준을 확인한다.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,239 tests, 146 files |
+| Backend tests | 고정 minimum 없음 — Codecov 1% relative regression gate (목표 ≥ 95%) | 3,258 tests, 146 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 64 files |
 | E2E | 핵심 flow 커버 | 38 Playwright tests (6 spec) |
 | CI 통과 | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/estimates.py
+++ b/nuri/collectors/estimates.py
@@ -158,13 +158,9 @@ def _upsert_estimates(records: list[dict]) -> int:
         return len(records)
 
 
-if __name__ == "__main__":
+def _parse_args(argv: list[str] | None = None):
+    """argparse — unit-testable. argv=None 이면 sys.argv 사용."""
     import argparse
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
 
     parser = argparse.ArgumentParser(description="애널리스트 컨센서스 수집 (yfinance)")
     parser.add_argument(
@@ -173,8 +169,16 @@ if __name__ == "__main__":
         default="portfolio",
         help="티커 범위: portfolio(default, 보유종목만) / universe(config/universe.yaml 전체) / all(union)",
     )
-    args = parser.parse_args()
+    return parser.parse_args(argv)
 
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint — unit-testable via main(argv=[...])."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    args = _parse_args(argv)
     collector = EstimatesCollector()
     count = collector.run(source=args.source)
 
@@ -203,3 +207,8 @@ if __name__ == "__main__":
             rec = r["recommendation"] or "N/A"
             print(f"  {r['ticker']:<12} {rec:<12} {target_str:>10} {current_str:>10} {gap_str:>8} {analysts:>5}")
         print()
+    return count
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/siege_predictivity_audit.py
+++ b/scripts/siege_predictivity_audit.py
@@ -633,9 +633,8 @@ def _skip_breakdown(skipped: list[AuditSnapshot]) -> str:
 # ─── CLI ────────────────────────────────────────────────────────────────────
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-
+def _parse_args(argv: list[str] | None = None):
+    """argparse — unit-testable. argv=None 이면 sys.argv 사용."""
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
     parser.add_argument("--universe", default=DEFAULT_UNIVERSE, help="universe.yaml key")
     parser.add_argument("--months", type=int, default=DEFAULT_MONTHS, help="number of monthly snapshots")
@@ -645,10 +644,24 @@ def main() -> int:
     grp.add_argument("--save", action="store_true", help="persist audit rows to certifications")
     grp.add_argument("--dry-run", action="store_true",
                      help="no DB write (default when --save not given)")
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def resolve_save_flag(args) -> bool:
+    """mutually-exclusive group 에서 실제 save 여부 결정.
+
+    `--save` 명시되고 `--dry-run` 아닐 때만 True. (mutually_exclusive 가
+    default=True 와 상호작용 시 버그 방지용 — unit test 에서 직접 검증 가능)
+    """
+    return bool(args.save) and not bool(args.dry_run)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = _parse_args(argv)
 
     # 기본은 dry-run. --save 가 명시되면 실제 persist.
-    save = bool(args.save) and not bool(args.dry_run)
+    save = resolve_save_flag(args)
 
     LOG.info("═" * 60)
     LOG.info("  E4-0b SIEGE Historical Predictivity Audit")

--- a/tests/collectors/test_estimates.py
+++ b/tests/collectors/test_estimates.py
@@ -231,3 +231,96 @@ class TestEstimatesCollectorErrorHandling:
 
         assert _safe_int(30) == 30
         assert _safe_int(float("nan")) is None
+
+
+class TestEstimatesCli:
+    """`if __name__ == '__main__'` 블록 coverage — argparse 분기 + main() 직접 호출."""
+
+    def test_parse_args_default_portfolio(self):
+        from nuri.collectors.estimates import _parse_args
+
+        args = _parse_args([])
+        assert args.source == "portfolio"
+
+    def test_parse_args_universe(self):
+        from nuri.collectors.estimates import _parse_args
+
+        args = _parse_args(["--source", "universe"])
+        assert args.source == "universe"
+
+    def test_parse_args_all(self):
+        from nuri.collectors.estimates import _parse_args
+
+        args = _parse_args(["--source", "all"])
+        assert args.source == "all"
+
+    def test_parse_args_invalid_source_rejected(self):
+        import pytest as _pytest
+
+        from nuri.collectors.estimates import _parse_args
+
+        with _pytest.raises(SystemExit):
+            _parse_args(["--source", "invalid"])
+
+    def test_main_calls_run_with_source_and_returns_count(self, monkeypatch, tmp_path):
+        """main(['--source', 'universe']) → run(source='universe') 호출되고 count 반환."""
+        import nuri.collectors.estimates as mod
+
+        called = {}
+
+        class _FakeCollector:
+            def run(self, source="portfolio"):
+                called["source"] = source
+                return 7
+
+        monkeypatch.setattr(mod, "EstimatesCollector", _FakeCollector)
+        monkeypatch.setattr(mod, "query", lambda *a, **k: [])  # no rows → skip print block
+
+        out = mod.main(["--source", "universe"])
+        assert called == {"source": "universe"}
+        assert out == 7
+
+    def test_main_default_source_portfolio_when_no_args(self, monkeypatch):
+        import nuri.collectors.estimates as mod
+
+        called = {}
+
+        class _FakeCollector:
+            def run(self, source="portfolio"):
+                called["source"] = source
+                return 0
+
+        monkeypatch.setattr(mod, "EstimatesCollector", _FakeCollector)
+        monkeypatch.setattr(mod, "query", lambda *a, **k: [])
+
+        mod.main([])
+        assert called["source"] == "portfolio"
+
+    def test_main_print_block_when_rows_present(self, monkeypatch, capsys):
+        """rows 존재 시 print 블록도 실행 — format branches 커버."""
+        import nuri.collectors.estimates as mod
+
+        class _FakeCollector:
+            def run(self, source="portfolio"):
+                return 2
+
+        fake_rows = [
+            {
+                "ticker": "AAPL", "recommendation": "buy",
+                "target_mean": 250.0, "target_median": 245.0,
+                "current_price": 230.0, "num_analysts": 30,
+            },
+            {
+                "ticker": "X", "recommendation": None,
+                "target_mean": None, "target_median": None,
+                "current_price": None, "num_analysts": None,
+            },
+        ]
+        monkeypatch.setattr(mod, "EstimatesCollector", _FakeCollector)
+        monkeypatch.setattr(mod, "query", lambda *a, **k: fake_rows)
+
+        mod.main([])
+        out = capsys.readouterr().out
+        assert "AAPL" in out
+        assert "애널리스트 컨센서스" in out
+        assert "N/A" in out  # second row 의 None 분기

--- a/tests/scripts/test_siege_predictivity_audit.py
+++ b/tests/scripts/test_siege_predictivity_audit.py
@@ -424,3 +424,152 @@ class TestEndToEndTiny:
         # 최소 1개는 cert 생성
         valid = [s for s in snapshots if s.cert is not None]
         assert len(valid) >= 1, f"no valid cert generated; skipped: {[s.skipped_reason for s in snapshots]}"
+
+
+class TestCliArgparse:
+    """CLI `_parse_args` + `resolve_save_flag` — PR #421 coverage gap fix."""
+
+    def test_parse_args_defaults(self):
+        from scripts.siege_predictivity_audit import _parse_args
+
+        args = _parse_args([])
+        assert args.universe == "us_core"
+        assert args.months == 60
+        assert args.top_n == 10
+        assert args.bootstrap_iter == 5000
+        assert args.save is False
+        assert args.dry_run is False
+
+    def test_parse_args_save_flag(self):
+        from scripts.siege_predictivity_audit import _parse_args
+
+        args = _parse_args(["--save"])
+        assert args.save is True
+        assert args.dry_run is False
+
+    def test_parse_args_dry_run_flag(self):
+        from scripts.siege_predictivity_audit import _parse_args
+
+        args = _parse_args(["--dry-run"])
+        assert args.save is False
+        assert args.dry_run is True
+
+    def test_parse_args_save_and_dry_run_mutually_exclusive(self):
+        import pytest as _pytest
+
+        from scripts.siege_predictivity_audit import _parse_args
+
+        with _pytest.raises(SystemExit):
+            _parse_args(["--save", "--dry-run"])
+
+    def test_parse_args_override_months_top_n(self):
+        from scripts.siege_predictivity_audit import _parse_args
+
+        args = _parse_args(["--months", "12", "--top-n", "5", "--bootstrap-iter", "100"])
+        assert args.months == 12
+        assert args.top_n == 5
+        assert args.bootstrap_iter == 100
+
+    def test_resolve_save_flag_default_false(self):
+        """neither --save nor --dry-run → False (dry-run default semantics)."""
+        from scripts.siege_predictivity_audit import _parse_args, resolve_save_flag
+
+        assert resolve_save_flag(_parse_args([])) is False
+
+    def test_resolve_save_flag_save_only_true(self):
+        """`--save` 단독 → True."""
+        from scripts.siege_predictivity_audit import _parse_args, resolve_save_flag
+
+        assert resolve_save_flag(_parse_args(["--save"])) is True
+
+    def test_resolve_save_flag_dry_run_only_false(self):
+        """`--dry-run` 단독 → False."""
+        from scripts.siege_predictivity_audit import _parse_args, resolve_save_flag
+
+        assert resolve_save_flag(_parse_args(["--dry-run"])) is False
+
+
+class TestMainEntrypoint:
+    """main() 함수 직접 호출 — audit loop 는 mock, CLI wiring 만 검증."""
+
+    def test_main_default_no_save_returns_zero(self, monkeypatch, tmp_path):
+        import scripts.siege_predictivity_audit as mod
+
+        called = {}
+
+        def fake_run_audit(**kwargs):
+            called.update(kwargs)
+            return []
+
+        def fake_analyze(*a, **k):
+            return []
+
+        def fake_write(snapshots, metrics, output_path):
+            called["output_path"] = output_path
+
+        monkeypatch.setattr(mod, "run_audit", fake_run_audit)
+        monkeypatch.setattr(mod, "analyze_predictivity", fake_analyze)
+        monkeypatch.setattr(mod, "write_report", fake_write)
+        monkeypatch.setattr(mod, "today_kst", lambda: "2026-04-21")
+        monkeypatch.chdir(tmp_path)
+
+        exit_code = mod.main([])
+        assert exit_code == 0
+        assert called["save"] is False  # default dry-run
+        assert called["universe_key"] == "us_core"
+        assert called["months"] == 60
+        assert called["top_n"] == 10
+        # output_path 기본값: data/reports/{today}/e4_0b_siege_predictivity.md
+        assert str(called["output_path"]).endswith("e4_0b_siege_predictivity.md")
+
+    def test_main_save_flag_propagates(self, monkeypatch, tmp_path):
+        import scripts.siege_predictivity_audit as mod
+
+        called = {}
+        monkeypatch.setattr(mod, "run_audit", lambda **kw: (called.update(kw), [])[1])
+        monkeypatch.setattr(mod, "analyze_predictivity", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "write_report", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "today_kst", lambda: "2026-04-21")
+        monkeypatch.chdir(tmp_path)
+
+        mod.main(["--save", "--months", "2", "--top-n", "3"])
+        assert called["save"] is True
+        assert called["months"] == 2
+        assert called["top_n"] == 3
+
+    def test_main_console_summary_dry_run(self, monkeypatch, tmp_path, capsys):
+        import scripts.siege_predictivity_audit as mod
+
+        monkeypatch.setattr(mod, "run_audit", lambda **kw: [])
+        monkeypatch.setattr(mod, "analyze_predictivity", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "write_report", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "today_kst", lambda: "2026-04-21")
+        monkeypatch.chdir(tmp_path)
+
+        mod.main([])
+        out = capsys.readouterr().out
+        assert "dry-run" in out
+        assert "Audit complete" in out
+
+    def test_main_console_summary_save(self, monkeypatch, tmp_path, capsys):
+        import scripts.siege_predictivity_audit as mod
+        from scripts.siege_predictivity_audit import AuditSnapshot
+
+        fake_snap = AuditSnapshot(
+            snapshot_date="2024-01-31", tickers=["AAPL"],
+            cert={"certified": False, "score": 50, "total_conditions": 1,
+                  "passed": 0, "failed": 1, "warnings": 0, "timestamp": "x",
+                  "conditions": []},
+            regime="sideways_low_vol",
+            forward_nav={30: None, 60: None, 90: None},
+            forward_mae={30: None, 60: None, 90: None},
+        )
+        monkeypatch.setattr(mod, "run_audit", lambda **kw: [fake_snap])
+        monkeypatch.setattr(mod, "analyze_predictivity", lambda *a, **k: [])
+        monkeypatch.setattr(mod, "write_report", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "today_kst", lambda: "2026-04-21")
+        monkeypatch.chdir(tmp_path)
+
+        mod.main(["--save"])
+        out = capsys.readouterr().out
+        assert "audit:historical rows persisted" in out


### PR DESCRIPTION
## Why

PR #421 ship 시 codecov/patch 0.00% FAILURE. CLI 블록이 `if __name__ == '__main__'` 안에 있어 unit test 불가. 같은 세션 coverage-gap pattern 반복 (V2.1 #416, E4-0b #417, #421) — **memory feedback_coverage_discipline** 기록.

## Refactor + Tests

| 파일 | 변경 | 신규 test |
|---|---|---|
| `nuri/collectors/estimates.py` | argparse → `_parse_args(argv)` + `main(argv)` | 7 (default/universe/all/invalid + main 3 branches) |
| `scripts/siege_predictivity_audit.py` | argparse → `_parse_args` + `resolve_save_flag` + `main(argv)` | 12 (argparse 5 + resolve 3 + main 4) |

## Local coverage (commit 전 실측)

- `nuri/collectors/estimates.py`: **95%** (new lines 100%)
- `scripts/siege_predictivity_audit.py`: **91%** (new lines 100%)
- `make test-fast`: 3,216 → **3,235** pass
- `make lint`: clean

## 행동 교정

이번에는 **commit 전 로컬 coverage 측정** 후 push — 이전 3 PR 의 coverage-gap pattern 반복 안 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)