### PR TITLE
chore(frontend): Tailwind canonical classes — 36 arbitrary sweep

### DIFF
--- a/frontend/src/app/evidence/page.tsx
+++ b/frontend/src/app/evidence/page.tsx
@@ -26,7 +26,7 @@ function Loading() {
       {[1, 2, 3].map((i) => (
         <div
           key={i}
-          className="animate-pulse bg-card rounded-xl border border-border h-[500px]"
+          className="animate-pulse bg-card rounded-xl border border-border h-125"
         />
       ))}
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -460,22 +460,22 @@ async function Dashboard({
               <div className="hidden sm:flex w-fit items-center gap-2 px-2 pb-1 text-[9px] text-zinc-600 uppercase">
                 <span className="w-10 2xl:w-16 shrink-0">{COL.ACCOUNT}</span>
                 <span className="w-20 shrink-0">{COL.TICKER}</span>
-                <span className="hidden md:flex w-[72px] text-right shrink-0 leading-tight justify-end">
+                <span className="hidden md:flex w-18 text-right shrink-0 leading-tight justify-end">
                   {COL.CURRENT}<span className="text-zinc-700">{COL.AVG}</span>
                 </span>
                 <span className="w-14 text-right shrink-0">{COL.PNL}</span>
                 <span className="w-12 text-right shrink-0">{COL.DAILY}</span>
-                <span className="w-[68px] text-center shrink-0">{COL.STATUS}</span>
-                <span className="hidden md:inline-block w-[68px] text-right shrink-0">{COL.STOP}</span>
-                <span className="hidden lg:inline-block w-[68px] text-right shrink-0">{COL.TP1}</span>
-                <span className="hidden lg:inline-block w-[68px] text-right shrink-0">{COL.TP2}</span>
+                <span className="w-17 text-center shrink-0">{COL.STATUS}</span>
+                <span className="hidden md:inline-block w-17 text-right shrink-0">{COL.STOP}</span>
+                <span className="hidden lg:inline-block w-17 text-right shrink-0">{COL.TP1}</span>
+                <span className="hidden lg:inline-block w-17 text-right shrink-0">{COL.TP2}</span>
                 {/* sparkline column label — xl: 80px / 2xl: 240px (둘 다 고정) */}
                 <span className="hidden xl:inline-block w-20 2xl:w-60 text-left shrink-0">
                   {COL.TREND}
                 </span>
                 {/* #218 (PR #219): 2xl+ 27" 전용 초광폭 컬럼. Sector 는 label 이라 text-left. */}
-                <span className="hidden 2xl:inline-block w-[96px] text-left shrink-0">{COL.SECTOR}</span>
-                <span className="hidden 2xl:inline-block w-[56px] text-right shrink-0">{COL.WEIGHT}</span>
+                <span className="hidden 2xl:inline-block w-24 text-left shrink-0">{COL.SECTOR}</span>
+                <span className="hidden 2xl:inline-block w-14 text-right shrink-0">{COL.WEIGHT}</span>
               </div>
               <div className="space-y-0.5">
                 {(holdingsExpanded

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -144,7 +144,7 @@ const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
   return (
     <div
       className={`
-        relative bg-card border rounded-xl px-5 py-4 min-w-[220px]
+        relative bg-card border rounded-xl px-5 py-4 min-w-55
         transition-all duration-200
         hover:bg-muted/80 hover:scale-[1.02]
         shadow-lg ${STATUS_GLOW[status]}
@@ -378,7 +378,7 @@ export default function PipelinePage() {
       </div>
 
       {/* React Flow 캔버스 */}
-      <div className="h-[320px] rounded-xl border border-border bg-background overflow-hidden">
+      <div className="h-80 rounded-xl border border-border bg-background overflow-hidden">
         <ReactFlow
           nodes={nodes}
           edges={EDGES}
@@ -431,7 +431,7 @@ export default function PipelinePage() {
               {PL.NO_EVENTS} &mdash; {PL.RUN_STEP_HINT}
             </p>
           ) : (
-            <div className="space-y-1.5 max-h-[400px] overflow-y-auto">
+            <div className="space-y-1.5 max-h-100 overflow-y-auto">
               {timeline.map((ev, i) => (
                 <div key={`${ev.timestamp}-${i}`} className="flex items-start gap-2 text-xs py-1.5 border-b border-border/30 last:border-0">
                   <span className="shrink-0 text-sm">{EVENT_ICONS[ev.event_type] || "\u2022"}</span>
@@ -475,7 +475,7 @@ export default function PipelinePage() {
               {PL.GATE_LOADING}
             </p>
           ) : (
-            <div className="space-y-1.5 max-h-[400px] overflow-y-auto">
+            <div className="space-y-1.5 max-h-100 overflow-y-auto">
               {allConditions.map((c) => (
                 <div key={c.id} className="flex items-start gap-2 text-xs py-1.5 border-b border-border/30 last:border-0">
                   <span className={`shrink-0 text-sm ${c.passed ? "text-emerald-400" : "text-red-400"}`}>

--- a/frontend/src/components/ui/composition-section.tsx
+++ b/frontend/src/components/ui/composition-section.tsx
@@ -172,7 +172,7 @@ export function CompositionSection({
             color dot · label · sector(meta) · $value · weight % · daily delta % */}
         {hasData ? (
           <div
-            className="flex-1 flex flex-col gap-1 self-stretch min-w-0 max-w-[640px]"
+            className="flex-1 flex flex-col gap-1 self-stretch min-w-0 max-w-160"
             data-testid="composition-legend"
           >
             {legend.map((row) => {
@@ -195,25 +195,25 @@ export function CompositionSection({
                     style={{ background: row.color }}
                   />
                   {/* primary label */}
-                  <span className="text-zinc-200 truncate min-w-0 flex-1 sm:flex-none sm:w-[120px]">
+                  <span className="text-zinc-200 truncate min-w-0 flex-1 sm:flex-none sm:w-30">
                     {row.label}
                   </span>
                   {/* meta (sector for ticker rows) */}
-                  <span className="hidden sm:inline-block text-zinc-600 truncate w-[110px] text-[10px]">
+                  <span className="hidden sm:inline-block text-zinc-600 truncate w-27.5 text-[10px]">
                     {row.meta ?? ""}
                   </span>
                   {/* USD value */}
-                  <span className="hidden md:inline-block text-zinc-500 tabular-nums w-[80px] text-right text-[10px]">
+                  <span className="hidden md:inline-block text-zinc-500 tabular-nums w-20 text-right text-[10px]">
                     {row.valueUsd != null
                       ? `$${row.valueUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
                       : ""}
                   </span>
                   {/* weight % */}
-                  <span className="text-zinc-200 font-semibold tabular-nums w-[52px] text-right">
+                  <span className="text-zinc-200 font-semibold tabular-nums w-13 text-right">
                     {row.weight.toFixed(1)}%
                   </span>
                   {/* daily delta */}
-                  <span className={`tabular-nums w-[58px] text-right text-[10px] ${deltaColor}`}>
+                  <span className={`tabular-nums w-14.5 text-right text-[10px] ${deltaColor}`}>
                     {hasDelta
                       ? `${deltaUp ? "+" : ""}${row.dailyDeltaPct!.toFixed(2)}%`
                       : "—"}
@@ -231,7 +231,7 @@ export function CompositionSection({
           Movers (top 3 / 3) · Concentration · (room for more later). */}
       <div className="flex flex-row gap-3 mt-1 flex-wrap" data-testid="composition-side-cards">
         {(summary.topMovers.winners.length > 0 || summary.topMovers.losers.length > 0) && (
-          <div className={`${sideCardClass} flex-1 min-w-[200px] max-w-[280px]`} data-testid="side-movers">
+          <div className={`${sideCardClass} flex-1 min-w-50 max-w-70`} data-testid="side-movers">
             <p className={sideCardLabelClass}>Movers (cumulative)</p>
             <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 mt-0.5">
               <div>
@@ -275,7 +275,7 @@ export function CompositionSection({
         )}
 
         {summary.concentration.topHolding && (
-          <div className={`${sideCardClass} flex-1 min-w-[200px] max-w-[280px]`} data-testid="side-concentration">
+          <div className={`${sideCardClass} flex-1 min-w-50 max-w-70`} data-testid="side-concentration">
             <p className={sideCardLabelClass}>{COMPOSITION.CONCENTRATION}</p>
             <div className="flex items-baseline gap-2 mt-0.5">
               <span

--- a/frontend/src/components/ui/equity-curve-chart.tsx
+++ b/frontend/src/components/ui/equity-curve-chart.tsx
@@ -62,7 +62,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
       </div>
 
       {/* Strategy vs SPY */}
-      <div className="w-full min-w-0 h-[200px]">
+      <div className="w-full min-w-0 h-50">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={200}>
           <ComposedChart data={chartData} syncId="equity" margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
@@ -111,7 +111,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
       </div>
 
       {/* Drawdown */}
-      <div className="w-full min-w-0 h-[80px]">
+      <div className="w-full min-w-0 h-20">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={80}>
           <ComposedChart data={chartData} syncId="equity" margin={{ top: 0, right: 5, bottom: 0, left: 0 }}>
             <XAxis dataKey="date" hide />

--- a/frontend/src/components/ui/holding-row.tsx
+++ b/frontend/src/components/ui/holding-row.tsx
@@ -347,7 +347,7 @@ export function HoldingRow({ holding: h, href }: HoldingRowProps) {
       </span>
       {/* 현재가 / 평단가 — md+ (768px+). leading-[1.3] 으로 두 줄 사이 여유 살림. */}
       <span
-        className="hidden md:flex flex-col items-end text-right tabular-nums shrink-0 w-[72px] leading-[1.3]"
+        className="hidden md:flex flex-col items-end text-right tabular-nums shrink-0 w-18 leading-[1.3]"
         aria-label={HOLDING_LABEL.CURRENT_AVG}
       >
         <span className="text-[10px] text-zinc-200">{formatPrice(h.latestPrice, h.currency)}</span>
@@ -368,27 +368,27 @@ export function HoldingRow({ holding: h, href }: HoldingRowProps) {
       </span>
       {/* status badge — 항상 */}
       <span
-        className={`inline-flex items-center justify-center text-[10px] font-medium rounded border px-1.5 py-0.5 w-[68px] shrink-0 ${status.className}`}
+        className={`inline-flex items-center justify-center text-[10px] font-medium rounded border px-1.5 py-0.5 w-17 shrink-0 ${status.className}`}
       >
         {status.text}
       </span>
       {/* stop loss — md+ */}
       <span
-        className="hidden md:inline-block w-[68px] text-right tabular-nums text-zinc-500 shrink-0"
+        className="hidden md:inline-block w-17 text-right tabular-nums text-zinc-500 shrink-0"
         aria-label={HOLDING_LABEL.STOP_LOSS}
       >
         {formatPrice(h.stopLoss, h.currency)}
       </span>
       {/* target_1 — lg+ */}
       <span
-        className="hidden lg:inline-block w-[68px] text-right tabular-nums shrink-0"
+        className="hidden lg:inline-block w-17 text-right tabular-nums shrink-0"
         aria-label={HOLDING_LABEL.TARGET_1}
       >
         {t1Cell}
       </span>
       {/* target_2 — lg+ */}
       <span
-        className="hidden lg:inline-block w-[68px] text-right tabular-nums shrink-0"
+        className="hidden lg:inline-block w-17 text-right tabular-nums shrink-0"
         aria-label={HOLDING_LABEL.TARGET_2}
       >
         {t2Cell}
@@ -419,7 +419,7 @@ export function HoldingRow({ holding: h, href }: HoldingRowProps) {
       </span>
       {/* #218: 섹터 — 2xl+ (1536px+) 27" 모니터용. Label 데이터라 text-left. */}
       <span
-        className="hidden 2xl:inline-block w-[96px] text-left text-[10px] text-zinc-500 truncate shrink-0"
+        className="hidden 2xl:inline-block w-24 text-left text-[10px] text-zinc-500 truncate shrink-0"
         aria-label={HOLDING_LABEL.SECTOR}
         data-testid="sector-cell"
         title={h.sector ?? undefined}
@@ -428,7 +428,7 @@ export function HoldingRow({ holding: h, href }: HoldingRowProps) {
       </span>
       {/* #218: 비중 (% of portfolio) — 2xl+ (1536px+) 27" 모니터용 */}
       <span
-        className="hidden 2xl:inline-block w-[56px] text-right tabular-nums text-[10px] text-zinc-400 shrink-0"
+        className="hidden 2xl:inline-block w-14 text-right tabular-nums text-[10px] text-zinc-400 shrink-0"
         aria-label={HOLDING_LABEL.POSITION_PCT}
         data-testid="position-pct-cell"
       >

--- a/frontend/src/components/ui/holdings-summary-panel.tsx
+++ b/frontend/src/components/ui/holdings-summary-panel.tsx
@@ -86,7 +86,7 @@ export function HoldingsSummaryPanel({
             {summary.byAccount.map((a) => (
               <div
                 key={a.account}
-                className="relative h-[16px] rounded-sm overflow-hidden bg-zinc-900/60"
+                className="relative h-4 rounded-sm overflow-hidden bg-zinc-900/60"
                 data-testid={`account-bar-${a.account}`}
               >
                 <div
@@ -121,7 +121,7 @@ export function HoldingsSummaryPanel({
             {summary.sectors.map((s) => (
               <div
                 key={s.name}
-                className="relative h-[16px] rounded-sm overflow-hidden bg-zinc-900/60"
+                className="relative h-4 rounded-sm overflow-hidden bg-zinc-900/60"
                 data-testid={`sector-bar-${s.name}`}
               >
                 <div

--- a/frontend/src/components/ui/market-context.tsx
+++ b/frontend/src/components/ui/market-context.tsx
@@ -43,7 +43,7 @@ function healthColor(value: number, thresholds: [number, number]): string {
 
 function HealthCard({ label, value, sub, href, color }: { label: string; value: string; sub: string; href: string; color: string }) {
   return (
-    <Link href={href} className="flex-1 min-w-[80px] rounded-lg bg-zinc-900/60 border border-zinc-800/50 p-2.5 hover:bg-zinc-800/60 transition-colors">
+    <Link href={href} className="flex-1 min-w-20 rounded-lg bg-zinc-900/60 border border-zinc-800/50 p-2.5 hover:bg-zinc-800/60 transition-colors">
       <p className="text-[10px] text-zinc-600 mb-0.5">{label}</p>
       <p className={`text-lg font-bold tabular-nums leading-tight ${color}`}>{value}</p>
       <p className="text-[10px] text-zinc-500 mt-0.5 truncate">{sub}</p>

--- a/frontend/src/components/ui/opportunity-explorer.tsx
+++ b/frontend/src/components/ui/opportunity-explorer.tsx
@@ -153,7 +153,7 @@ function OpportunityCard({ opp }: { opp: Opportunity }) {
           <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${style.bg} ${style.text}`}>
             {style.label}
           </span>
-          <span className="text-[10px] text-zinc-500 truncate max-w-[200px]">{opp.verdict}</span>
+          <span className="text-[10px] text-zinc-500 truncate max-w-50">{opp.verdict}</span>
         </div>
         <div className="flex items-center gap-2">
           {!analysis && (

--- a/frontend/src/components/ui/price-chart.tsx
+++ b/frontend/src/components/ui/price-chart.tsx
@@ -99,7 +99,7 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
       </div>
 
       {/* Price + Volume chart */}
-      <div className="w-full min-w-0 h-[280px]">
+      <div className="w-full min-w-0 h-70">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={280}>
           <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />


### PR DESCRIPTION
## Why (사용자 지적)

`tailwindcss-intellisense` suggestCanonicalClasses hint 36건 누적 — IDE 로그 오염.

## Transforms

| File | Count |
|---|---|
| composition-section.tsx | 10 |
| app/page.tsx | 7 |
| holding-row.tsx | 7 |
| pipeline/page.tsx | 4 |
| Others (7 files) | 8 |

Tailwind 4: `w-[72px]` → `w-18` (18 × 4px). Half-step 도 canonical 지원 (`w-27.5` = 110px).

## Kept (legitimate)

- `max-w-[40%]` — percent 의도 명시
- `h-[calc(100%-1px)]` — calc expression

## Local verify

- `vitest run`: **984 pass** (동일 className hash lookup 성공)
- `npm run build`: clean
- `npx tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)