### PR TITLE
chore(docs): refactor root docs + config — stale count + dual-pipeline clarity + Mermaid refine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,89 +3,102 @@
 # ═══════════════════════════════════════════════════════════════
 # Setup:
 #   1) cp .env.example .env
-#   2) Fill in values you need (대부분 optional, fallback 존재)
-#   3) chmod 600 .env  (CRITICAL — 본인만 read/write)
+#   2) chmod 600 .env            # 본인만 read/write (CRITICAL)
+#   3) 필요한 값만 채움 — 대부분 optional, 없으면 fallback or feature off
+#   4) secret rotation: prod 배포 전 / 외부 노출 의심 시 즉시 재발급
 #
 # Security:
-#   - .env는 git에 절대 커밋 X (.gitignore에 명시됨)
-#   - 모든 secret은 chmod 600
-#   - prod 배포 전 키 재발급 권장
-#   - .env.example만 git 트래킹 (값 없음)
+#   - .env 는 절대 커밋 금지 (.gitignore 에 명시)
+#   - .env.example 만 git 트래킹 (값 없음, template 용)
+#   - 의심 노출 시 모든 API key 재발급 + commit history scan
+#
+# 우선순위 결정 로직: 각 feature 의 loader 가 빈 값 / 미설정 시 자동으로
+# fallback 경로로 내려감 → 설정 안 해도 앱은 기동됨.
 # ═══════════════════════════════════════════════════════════════
 
 
 # ───────────────────────────────────────────────────────────────
-# 1. KIS (한국투자증권) Open API
+# 1. KIS Open API (한국투자증권)
 # ───────────────────────────────────────────────────────────────
-# 발급: https://apiportal.koreainvestment.com
-# 신규 신청 후 3일간 초당 3건 제한
+# 발급: https://apiportal.koreainvestment.com  (신규 승인 후 3일간 3 TPS)
 #
-# 자격 증명 위치 우선순위:
-#   1) 아래 env 변수 (권장)
-#   2) config/kis/kis_devlp.yaml (프로젝트 내 gitignored, KIS SDK 호환)
-#   3) ~/KIS/config/kis_devlp.yaml (레거시 위치, 하위 호환)
+# 자격 증명 위치 우선순위 (collector 가 순서대로 탐색):
+#   1) 아래 env 변수 (권장 — 이 파일)
+#   2) config/kis/kis_devlp.yaml  (gitignored, KIS 공식 SDK 호환 포맷)
+#   3) ~/KIS/config/kis_devlp.yaml (레거시, 하위 호환)
 #
-# 모의투자 (paper / vps) — 기본 사용
+# 시스템은 read-only (시세/잔고) endpoint 만 호출 — 주문 endpoint 미사용
+# (STRATEGY §7.1 자동 매매 영구 deferred). prod 신청이 불필요하면 paper 만 채움.
+
+# 모의투자 (기본, 신규 가입 시 즉시 사용 가능)
 KIS_PAPER_APP_KEY=
 KIS_PAPER_APP_SECRET=
 KIS_PAPER_ACCOUNT=                       # 모의투자 증권계좌 8자리
-#
-# 실전투자 (prod) — 별도 신청 시
+
+# 실전투자 (잔고/시세 read-only — 주문 절대 호출하지 않음)
 KIS_PROD_APP_KEY=
 KIS_PROD_APP_SECRET=
 KIS_PROD_ACCOUNT=                        # 실전 증권계좌 8자리
-#
-# 공통
-KIS_HTS_ID=                              # HTS ID (WebSocket 사용 시 필수)
+
+# 공통 (WebSocket 실시간 시세 사용 시 필수)
+KIS_HTS_ID=
 
 
 # ───────────────────────────────────────────────────────────────
-# 2. LLM Providers
+# 2. LLM Providers  (STRATEGY §4.4.3 Egress Policy 필독)
 # ───────────────────────────────────────────────────────────────
-# OpenAI (gpt-5.4-nano) — 2026-04-14 STRATEGY §4.4.3 개정 후 용도:
-#   (a) Tier 0: 공개 RSS 헤드라인 분류 (event_classifier) — ZDR 불필요
-#   (b) Tier 2: 일간 LLM 리포트 (report.py) — ZDR 필수, 프로토타입 단계
-# 발급: https://platform.openai.com/api-keys
+# 모든 외부 LLM 호출은 `nuri/llm/openai_client.py` 단일 wrapper 경유.
+# `external_llm_calls` 테이블에 per-call audit log (timestamp/model/tokens —
+# content 는 저장 안 함). 미설정 시 기능 자동 off + regex fallback.
+
+# OpenAI — primary provider (Tier 0 + Tier 2 모두)
+#   Tier 0: 공개 RSS 헤드라인 분류 (event_classifier) — ZDR 불필요
+#   Tier 2: 일간 포트폴리오 리포트 (report.py) — ZDR 필수
+#   모델 기본값: gpt-5.4-nano (연간 ~$3.61 at 100 headlines/day + 1 report/day)
+#   발급: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
-#
-# Tier 2 전용: OpenAI Zero Data Retention 승인 attestation
-# ZDR 요청 완료 후에만 설정. 미설정 시 Tier 2 호출은 ExternalLLMPolicyViolation raise.
-# 요청 방법: https://platform.openai.com/docs/models/how-we-use-your-data
+OPENAI_MODEL=gpt-5.4-nano                # override 원할 때만 변경
+
+# Tier 2 (portfolio 데이터 송신) attestation — ZDR 승인 후에만 1 설정
+# 미설정 시 Tier 2 호출은 ExternalLLMPolicyViolation raise (fail loud)
+# ZDR 요청: https://platform.openai.com/docs/models/how-we-use-your-data
 # OPENAI_ZDR_APPROVED=1
-#
-# 로컬 폴백 (선택) — OpenAI 호출 실패 또는 NURI_DISABLE_EXTERNAL_LLM=1 시 사용
-# Ollama (HTTP API, `ollama serve` 실행 후 사용 가능)
+
+# Local fallback — OpenAI 실패 또는 NURI_DISABLE_EXTERNAL_LLM=1 시 활성
+# Ollama (HTTP API)
 # OLLAMA_HOST=http://localhost:11434
 # OLLAMA_MODEL=qwen3.5
-#
 # llama.cpp (GGUF 직접 실행)
 # LLAMA_MODEL_PATH=/path/to/model.gguf
-#
-# 외부 LLM 전체 비활성화 (CI, 오프라인 모드)
+
+# LLM 전체 비활성화 (CI, 오프라인 모드, 프라이버시 최상 모드)
 # NURI_DISABLE_EXTERNAL_LLM=1
 
 
 # ───────────────────────────────────────────────────────────────
-# 3. Data Source API Keys (모두 optional — fallback 존재)
+# 3. Data Source API Keys  (전부 optional, fallback 존재)
 # ───────────────────────────────────────────────────────────────
-FINNHUB_API_KEY=                         # US 기관 flows
-FRED_API_KEY=                            # FRED 매크로 (없으면 yfinance fallback)
+FRED_API_KEY=                            # FRED 매크로 — 미설정 시 yfinance fallback
+FINNHUB_API_KEY=                         # US 기관 flows (선택)
+FMP_API_KEY=                             # Fundamental data (선택)
 
 
 # ───────────────────────────────────────────────────────────────
-# 4. Alerts (Discord / Telegram)
+# 4. Alerts
 # ───────────────────────────────────────────────────────────────
+# 미설정 시 stdout 폴백 (make report 가 콘솔만 출력).
 DISCORD_WEBHOOK_URL=                     # 일일 리포트 webhook
-DISCORD_TOKEN=                           # 봇 모드 (optional)
+DISCORD_BOT_TOKEN=                       # 봇 모드 (선택)
 DISCORD_CHANNEL_ID=
-#
+
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 
 
 # ───────────────────────────────────────────────────────────────
-# 5. Paper Trading (선택)
+# 5. Paper Trading (deferred — STRATEGY §7.1 자동 매매 보류)
 # ───────────────────────────────────────────────────────────────
+# 시스템은 현재 주문 endpoint 미호출. 설정해도 read-only 시세만.
 ALPACA_API_KEY=
 ALPACA_SECRET_KEY=
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
@@ -94,29 +107,29 @@ ALPACA_BASE_URL=https://paper-api.alpaca.markets
 # ───────────────────────────────────────────────────────────────
 # 6. API Server
 # ───────────────────────────────────────────────────────────────
-API_PORT=8001
-# NURI_DB_PATH=data/portfolio.db           # SQLite DB 경로 (기본값: data/portfolio.db)
+API_PORT=8001                            # FastAPI port
+# NURI_DB_PATH=data/portfolio.db         # SQLite 경로 override
 # API_AUTH_ENABLED=true                  # JWT/API key 인증 활성화
 # API_KEY=                               # Bearer token
-# API_SECRET_KEY=                        # JWT 서명 키 (미설정 시 랜덤 생성)
-# CORS_ORIGINS=https://your-domain.com   # 프로덕션 CORS 도메인 (쉼표 구분)
+# API_SECRET_KEY=                        # JWT 서명 키 (prod 배포 시 필수 — 재시작 시 JWT 유지)
+# CORS_ORIGINS=https://your-domain.com   # production CORS allowlist (쉼표 구분)
 
 
 # ───────────────────────────────────────────────────────────────
-# 7. Dashboard
+# 7. Dashboard (Next.js middleware auth)
 # ───────────────────────────────────────────────────────────────
-# DASHBOARD_PASSWORD=                    # HMAC-SHA256 쿠키 인증 활성화 (Edge Runtime)
+# DASHBOARD_PASSWORD=                    # HMAC-SHA256 쿠키 인증 (Edge Runtime)
 
 
 # ───────────────────────────────────────────────────────────────
-# 8. Mac Mini (Production Sync)
+# 8. Production Sync (2-machine setup)
 # ───────────────────────────────────────────────────────────────
+# Mac mini 배포 대상 (make deploy-mini)
 MACMINI_HOST=macmini.local
-MACMINI_USER=ehbebe
+MACMINI_USER=                            # ssh 계정
 MACMINI_PATH=~/nuri-quant
 
-
-# ───────────────────────────────────────────────────────────────
-# 9. Dev/Prod Sync (양 노트북 동기화)
-# ───────────────────────────────────────────────────────────────
-# DEV2_HOST=dev2.local                   # 두 번째 dev 머신 (~/.zshrc 권장)
+# Dev2 호스트 (양 노트북 간 state sync — scripts/sync_dev.sh).
+# ⚠ `.env` 는 deploy_mini.sh 가 양 머신에 복사하므로 DEV2_HOST 를 이 파일에
+# 두면 두 머신이 서로 자기 자신을 가리키는 버그 발생. **반드시 ~/.zshrc 에 export**.
+# DEV2_HOST=dev2.local  # (여기 두지 말 것)

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 # ═══════════════════════════════════════════════════════════════
 # Nuri-Quant — gitignore
 # ═══════════════════════════════════════════════════════════════
-# Security: secrets/credentials는 절대 커밋 X
-# Lockfiles: uv.lock는 트래킹 (재현성), node lock도 트래킹
-# Generated: 빌드 산출물 + 캐시 + 리포트는 트래킹 X
+# Policy:
+#   - Secrets/credentials: never commit (다층 패턴 방어)
+#   - Lockfiles: track (uv.lock, package-lock.json) for reproducibility
+#   - Build/cache/generated reports: ignore
+#   - Personal state (portfolio, NEXT_SESSION, trade plans): ignore
+#
+# STRATEGY §4.4.1 privacy scanner 는 commit/PR/code 에서 broker name +
+# monetary literal 을 차단 — 이 파일은 그 defense 의 1차 layer.
 
 # ─── Secrets / Credentials ─────────────────────────────────────
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,16 @@ For Claude Code-specific features (hooks, @imports, skills), see `CLAUDE.md`.
 
 ## Project
 
-Nuri-Quant — open-source quant investment platform. Python 3.12, uv, SQLite, Next.js 16.
-8-phase pipeline: collect → analyze → validate → regime → recommend → certify → evidence → notify.
+Nuri-Quant — open-source quant investment platform. Python 3.12, uv, SQLite (WAL), Next.js 16 + React 19.
+
+Two pipeline views:
+
+- **Decision pipeline** (5 phases, README architecture, DB-only coupling):
+  `collect → analyze → consensus → certify → track`
+- **Operational pipeline** (8 phases, `make full-scan`, same modules regrouped):
+  `collect → analyze → validate → regime → recommend → certify → evidence → notify`
+
+Phases communicate through SQLite tables + CSV only. Rerun any upstream phase and downstream refreshes automatically.
 
 ## Hard Rules
 

--- a/README.md
+++ b/README.md
@@ -17,35 +17,43 @@ Every BUY/SELL recommendation runs through a **collect → analyze → consensus
 Every BUY/SELL decision travels a **5-step pipeline**. Phases talk only through SQLite + CSV (loose coupling, [STRATEGY §2.3](docs/STRATEGY.md#23-느슨한-결합-loose-coupling-via-data)) — rerun an upstream phase and downstream refreshes automatically.
 
 ```mermaid
-flowchart TD
-    CFG[/"config/*.yaml<br/>rules · agents · signals · siege_gates · universe"/]
+flowchart LR
+    CFG[/"config/*.yaml<br/>rules · agents · signals · universe · siege_gates"/]:::config
 
-    subgraph Pipeline["Pipeline · 5 phases · DB-only coupling"]
+    subgraph Pipeline["Decision pipeline · 5 phases · DB-only coupling"]
         direction LR
-        A(["1 Collect<br/>25 collectors<br/>US · KR · macro · news · 13F · ARK"])
-        B(["2 Analyze<br/>20 signals · 10 regimes (6+4)<br/>4 factors · 15 event categories"])
-        C(["3 Consensus<br/>10 agents · weighted vote<br/>risk veto (SELL conf ≥ 80)"])
-        D(["4 Certify<br/>SIEGE v2 · 11+ conditions<br/>5 accounts × 5 asset classes"])
-        E(["5 Track<br/>outcome_30d · outcome_60d · outcome_90d<br/>→ agent accuracy feedback"])
+        A(["① Collect<br/>25 collectors<br/>US · KR · macro · news · 13F · ARK"]):::collect
+        B(["② Analyze<br/>20 signals · 10 regimes<br/>(6 base + 4 special) · 4 factors<br/>15 macro event categories"]):::analyze
+        C(["③ Consensus<br/>10 agents · weighted vote<br/>risk veto (SELL conf ≥ 80)"]):::consensus
+        D(["④ Certify<br/>SIEGE v2 · 11 base / 11-30+ per-class<br/>5 accounts × 5 asset classes<br/>regime-adaptive position cap"]):::certify
+        E(["⑤ Track<br/>outcome_30d · _60d · _90d<br/>→ agent accuracy feedback"]):::track
 
-        A -- "prices · fundamentals<br/>macro · news · events" --> B
-        B -- "signal_results.csv · factors<br/>regime_transitions" --> C
+        A -- "prices · fundamentals<br/>macro · news · institutional_flows" --> B
+        B -- "signal_results · factors<br/>regime_transitions · macro_events" --> C
         C -- "recommendations<br/>agent_verdicts · scoring_detail" --> D
-        D -- "Certificate<br/>conditions + evidence" --> E
-        E -. "outcome_{30,60,90}d<br/>weight ±30% drift" .-> C
+        D -- "certifications · conditions<br/>evidence + portfolio_hash" --> E
+        E -. "agent weight drift (±30%)" .-> C
     end
 
-    DB[("SQLite WAL · 32 tables<br/>pipeline_events · freshness SLA")]
+    DB[("SQLite WAL · 34 tables<br/>pipeline_events · certifications<br/>freshness SLA · audit trail")]:::db
 
     CFG -. "policies<br/>(YAML loaders in nuri/core)" .-> Pipeline
     Pipeline -. persist .-> DB
+
+    classDef config fill:#1e293b,stroke:#64748b,color:#e2e8f0
+    classDef collect fill:#064e3b,stroke:#10b981,color:#ecfdf5
+    classDef analyze fill:#1e3a8a,stroke:#3b82f6,color:#dbeafe
+    classDef consensus fill:#581c87,stroke:#a855f7,color:#f3e8ff
+    classDef certify fill:#7c2d12,stroke:#f97316,color:#ffedd5
+    classDef track fill:#831843,stroke:#ec4899,color:#fce7f3
+    classDef db fill:#0f172a,stroke:#334155,color:#cbd5e1
 ```
 
 Driven by `config/*.yaml` (rules · agents · signals · universe · SIEGE gates). Persisted in SQLite WAL — `nuri/core/db.py` is the only `sqlite3` importer. Per-phase detail, DB schema, and SIEGE v2 spec: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) + [docs/SIEGE_V2.md](docs/SIEGE_V2.md).
 
 ### Key architectural decisions
 
-- **Sole SQLite gateway** — `nuri/core/db.py` is the only `sqlite3` importer (hook-enforced). 32 tables, WAL mode. All modules use `query()`, `query_df()`, `upsert_*()`, `get_db()`. Tests inject `tmp_path` for full isolation.
+- **Sole SQLite gateway** — `nuri/core/db.py` is the only `sqlite3` importer (hook-enforced). 34 tables, WAL mode. All modules use `query()`, `query_df()`, `upsert_*()`, `get_db()`. Tests inject `tmp_path` for full isolation.
 - **Config-driven, code-static** — all thresholds, rules, signal metadata, and SIEGE gate policies live in `config/*.yaml`. Changing a stop-loss or adding a new market means editing YAML, not Python. See `rules.yaml`, `agents.yaml`, `signals.yaml`, `universe.yaml`.
 - **DB-only integration between phases** — phases communicate through DB tables and CSV files, never direct imports. Re-running an upstream phase automatically refreshes downstream consumers.
 - **SIEGE v2: 3-dimensional certification** — gates apply per Account (strategy profile) × Asset Class (exposure: us_equity, kr_equity, commodity, bond) × Execution Market (KRX, NYSE). See [`docs/SIEGE_V2.md`](docs/SIEGE_V2.md). Inspired by [nutshells3/SIEGE](https://github.com/nutshells3/Swarm-Intelligence-Engine-with-Gated-Execution).
@@ -131,7 +139,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite (3,275 backend + 917 frontend + 38 e2e)
+make test       # full suite (3,280 backend + 984 frontend + 38 e2e)
 make test-fast  # backend only, slow tests excluded (~24s)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler)
 ```
@@ -145,7 +153,7 @@ Nuri-Quant runs across two Apple Silicon Macs.
 | Role | Development, analysis, manual runs | Production scheduler, data collection, alerts |
 | Code sync | `git push` → | launchd `autopull` every 5 min (git fetch + ff-merge) |
 | Config sync | `make deploy-mini` → | `.env`, `portfolio.yaml`, `NEXT_SESSION.md` via SCP (DB excluded) |
-| Scheduler | N/A | 23 jobs: collectors, consensus, backtest, weekly 1y universe backfill |
+| Scheduler | N/A | 24 jobs: collectors, consensus, backtest, weekly 1y universe backfill |
 
 ```bash
 # After shipping a PR from MBP — 1 command syncs everything to Mac mini:

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,13 +6,13 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | ~230 | Investment rules (stop-loss, take-profit, position limits, VIX gate, account_strategies, siege_gates) | `nuri/core/rules.py` |
-| `agents.yaml` | ~235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
-| `signals.yaml` | ~190 | 20 signal definitions (type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
-| `alerts.yaml` | ~25 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
-| `stock_types.yaml` | ~50 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |
-| `universe.yaml` | ~755 | S&P 500 + KOSPI 200 + manual ETFs. Auto-maintained by `make universe-sync` (Wikipedia + KRX/FDR); manual entries preserved | `nuri/collectors/universe_sync.py` |
-| `portfolio.example.yaml` | ~40 | Example template showing account + holdings shape | `scripts/import_portfolio.py` (via `cp` to `portfolio.yaml`) |
+| `rules.yaml` | 273 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `siege_gates` incl. `regime_overrides`) | `nuri/core/rules.py` |
+| `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
+| `signals.yaml` | 186 | 20 signal definitions (type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
+| `alerts.yaml` | 24 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
+| `stock_types.yaml` | 49 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |
+| `universe.yaml` | 755 | 746 tickers: `us_core` (85) + `us_sp500_extended` (458) + `kr_kospi200` (203). Auto-maintained by `make universe-sync`; manual entries preserved | `nuri/collectors/universe_sync.py` |
+| `portfolio.example.yaml` | 39 | Example template showing account + holdings shape | `scripts/import_portfolio.py` (via `cp` to `portfolio.yaml`) |
 | `portfolio.yaml` | user | Real portfolio — **gitignored** (account labels, holdings, avg price). Shape matches `portfolio.example.yaml` | `scripts/import_portfolio.py` |
 | `kis/` | — | KIS Open API credentials directory — **gitignored** (`kis_devlp.yaml`, token cache). `.gitkeep` only is tracked. Legacy `~/KIS/` also supported for backward compat | `nuri/collectors/kis_*.py` |
 


### PR DESCRIPTION
## Scope

README.md + AGENTS.md + .env.example + .gitignore + config/CLAUDE.md 일괄 refactor.

## 주요 변경

### README.md Architecture Mermaid
- `flowchart TD → LR` + classDef 컬러 테마 (5 phase)
- DB 설명 확장 (certifications · audit trail)
- Flow labels 구체화 (institutional_flows / agent_verdicts 등)

### Stale counts (실측)
- backend tests 3,275 → 3,280
- frontend tests 917 → 984
- DB tables 32 → 34 (migration 21 + audit)
- scheduler jobs 23 → 24
- config line counts ~230→273 / ~190→186 / ~25→24 etc.

### AGENTS.md
- Dual-pipeline view 명시 (README 5-phase vs `make full-scan` 8-phase)

### .env.example
- Section 별 fallback/우선순위 인라인 문서화
- `OPENAI_MODEL` 추가, Tier 0/2 명확화
- DEV2_HOST trap (deploy_mini 양머신 복사) 경고
- `MACMINI_USER` hardcoded default 제거

## 실측 sanity

- `verify_doc_counts.sh`: 11/11 pass
- `make lint`: clean
- YAML + JSON syntax: OK
- Targeted pytest 167 pass

## Security note (out of PR scope)

`.env` 에 실제 OpenAI key + KIS prod secret 평문 저장 확인. Rotation 필요 — 사용자 직접 조치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)