### PR TITLE
docs(strategy): §2.7 next-session entry artifact Plan gate rule (codex handoff consult)

### DIFF
--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -135,6 +135,14 @@
 
 **Think/Plan 생략 패턴**: trivial chore (오타, 버전 번호, 주석 수정) 는 Think/Plan 을 inline 으로 압축 가능. 단 Build 이상부터는 반드시 모든 단계 준수. "trivial 로 시작했지만 커짐" 을 Build 중 발견하면 Think/Plan 으로 회귀.
 
+**Next-session entry artifact Plan gate** (2026-04-22 codex handoff consult): `NEXT_SESSION.md` / `SESSION_PROMPT.md` 같은 next-session entry artifact 는 docs-only 이고 gitignored 라도 **Reflect gate 산출물로 취급**. 이 문서의 수정 범위 분류:
+- **Inline 가능 (self-edit OK)**: typo, format, self-note, HEAD snapshot append.
+- **Plan consult 필수 (다음 primary PR 의 Plan consult 에 include 해 batch 검증)**: next primary 변경, 후보 우선순위 재정렬, 새 risk framing, live command 교체, acceptance criteria 변경.
+
+재-consult trigger: (a) next primary 가 바뀔 때, (b) 후보 우선순위 2+ 개 경쟁 상태, (c) handoff 실행 명령/HEAD/acceptance 가 stale 가능성, (d) 5 PR 누적 또는 48h burst ship 후 cadence reflection, (e) legal/TOS/production-risk 신규 도입. 매 세션 강제는 과잉.
+
+**Burst ship cadence 경계** (2026-04-22 실측, 48h 6 functional + 3 docs PR 사례): 재현 조건은 독립 scope + 명확한 queue + codex Plan consult 선행 이지만 **sustainable default 가 아님**. Side-effects 누적 — codex Round 2 skip 빈발 (quality regression), docs PR 의 scope-discipline 경계, reviewer fatigue, handoff doc drift. 48h 이상 burst 직후는 반드시 session handoff Plan consult (위 rule) + 다음 cycle 에 cadence 내림.
+
 ---
 
 ## 3. 핵심 아키텍처 결정 기록


### PR DESCRIPTION
## Summary

2026-04-22 codex handoff consult (prompt: session-handoff docs 엄밀성 검증) 권고 반영 — STRATEGY §2.7 Flow 섹션에 handoff docs 의 Plan gate rule 추가.

## Context

사용자가 질문: "NEXT_SESSION.md / SESSION_PROMPT.md 둘 다 엄밀하게 업데이트 되었나요? codex 와 consult 작업했나요?"

내 답: inline self-edit 만 수행, codex consult 미수행. 질문은 docs-only 이지만 next-session entry path production artifact 이므로 엄밀성 gap 을 드러냈다. Option A (지금 consult) 선택 → codex handoff consult 실행.

## Codex findings (archive: codex-reviews/PR-handoff-roundplan-20260421T193725Z.md)

1. `A` (gitignored 면제) 방어 불가 — STRATEGY §2.7 Reflect gate 에 이미 "다음 세션이 컨텍스트 없이 뛸 수 있는가" 명시.
2. `C` 배치형이 optimal — next primary 변경/후보 재정렬/acceptance 변경 diff 는 해당 primary PR Plan consult 에 묶어 검증.
3. `48h 6 PR` cadence 는 success narrative 가 아닌 경계 신호. sustainability / consult skip 누적 / docs PR scope discipline 재판단.

## Changes

`docs/STRATEGY.md §2.7` 말미에 2 paragraph 추가:

- **Next-session entry artifact Plan gate** — inline 가능 vs Plan consult 필수 경계 + re-consult trigger 5 개 명시
- **Burst ship cadence 경계** — 48h 실측 사례를 경계 신호로 기록, side-effects 명시, 48h burst 직후 session handoff consult 강제

## Test plan

- [x] Privacy scan clean
- [x] Doc counts 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)