### PR TITLE
docs(claude): sync nuri/llm/ tree line with STRATEGY §4.4.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ nuri/
 │   └── execution/     # Broker interface (Alpaca paper + DryRun)
 ├── api/               # FastAPI REST API (68 endpoints, routes/ incl. actions/opportunities/market-context/coverage)
 ├── alerts/            # Discord daily report + bot, Telegram alerts
-└── llm/               # LLM report (Ollama) + OpenAI wrapper + event classifier
+└── llm/               # LLM report (OpenAI gpt-5.4-nano primary, §4.4.3 Tier 2; Ollama fallback) + openai_client gateway + event classifier
 ```
 
 ### Key Design Patterns


### PR DESCRIPTION
## Summary
- `CLAUDE.md` Architecture tree listed Ollama as primary for `nuri/llm/`, but STRATEGY §4.4.3 (2026-04-14) made OpenAI gpt-5.4-nano the Tier 2 primary with Ollama as fallback.
- Verified against `nuri/llm/report.py`: `_generate_openai` is called first (line 665), `_generate_ollama` only on fallback (line 671).
- Single-line edit; surfaces `openai_client` as the gateway (already canonical in line 226 Key Design Patterns bullet).

## Why now
- Codex consult (2026-04-28, session `019dd191-...`) ranked this as the highest-value of three CLAUDE.md improvement candidates — root harness metadata should not lie.
- Companion PR β (Gotchas hybrid compression) follows separately per PR discipline §7.2.

## Test plan
- [ ] `git diff main` shows exactly 1 line changed in `CLAUDE.md`
- [ ] No code/config touched — pure documentation accuracy fix