### PR TITLE
fix(signals): skip SHADOW market_wide signals silently — close #455

### DIFF
--- a/nuri/quant/validation/signal_backtest.py
+++ b/nuri/quant/validation/signal_backtest.py
@@ -376,12 +376,19 @@ def _build_signal_definitions() -> dict[str, dict]:
     """config/signals.yaml + detector 레지스트리에서 SIGNAL_DEFINITIONS 빌드.
 
     YAML 메타데이터 (description/hold_days/enabled) + Python detector 결합.
-    enabled=false 시그널은 제외.
+    `enabled=false` 시그널은 제외. `scope: market_wide` 시그널 (SHADOW crash
+    precursors, PR C #436) 은 per-ticker 백테스트 엔진에 들어가지 않음 — 별도
+    `nuri/quant/validation/market_signals.py::DETECTORS` 에 등록되어 daily brief
+    및 SHADOW surface 에서만 사용. silent skip (warning 발생 안 함).
     """
     cfg = SIGNAL_CONFIG.get("signals", {})
     result: dict[str, dict] = {}
     for sid, meta in cfg.items():
         if not meta.get("enabled", True):
+            continue
+        if meta.get("scope") == "market_wide":
+            # SHADOW market-wide signals — market_signals.DETECTORS 가 처리.
+            # per-ticker backtest 와 등록 경로 분리 (PR C codex Plan consult).
             continue
         if sid not in _ENTRY_DETECTORS:
             logger.warning("signals.yaml에 정의된 %s에 대응하는 detector 함수 없음", sid)

--- a/tests/quant/test_validation_signal.py
+++ b/tests/quant/test_validation_signal.py
@@ -307,7 +307,48 @@ class TestSignalDefinitions:
         from nuri.quant.validation.signal_backtest import SIGNAL_DEFINITIONS
         # 15 base + 5 chart pattern signals (macd_bullish_turn, macd_bearish_turn,
         # bb_squeeze_breakout, near_52w_low_bounce, volume_profile_resistance)
+        # SHADOW market_wide signals (yield_curve_inversion, hy_oas_widening) excluded —
+        # registered in market_signals.DETECTORS instead.
         assert len(SIGNAL_DEFINITIONS) == 20
+
+    def test_shadow_market_wide_signals_excluded_from_per_ticker_registry(self):
+        """SHADOW market_wide signals 는 per-ticker SIGNAL_DEFINITIONS 에 안 들어감.
+
+        PR C #436 등록한 `yield_curve_inversion` / `hy_oas_widening` 은 `scope:
+        market_wide` — `_build_signal_definitions()` 가 silent skip 해야 함.
+        regression: skip 룰 제거 시 두 signal 이 SIGNAL_DEFINITIONS 에 들어가서
+        per-ticker backtest 가 detector 없는 entry 호출로 실패하거나, warning 이
+        매번 fire (issue #455 재발).
+        """
+        from nuri.quant.validation.signal_backtest import SIGNAL_DEFINITIONS
+        assert "yield_curve_inversion" not in SIGNAL_DEFINITIONS
+        assert "hy_oas_widening" not in SIGNAL_DEFINITIONS
+
+    def test_shadow_signals_have_market_wide_registry(self):
+        """SHADOW signals 는 market_signals.DETECTORS 에 등록돼 있어야 daily brief
+        SHADOW 섹션이 작동. signal_backtest 에서 빠진 게 silent loss 가 아니라
+        교차 등록 invariant 임을 lock.
+        """
+        from nuri.quant.validation.market_signals import DETECTORS
+        assert "yield_curve_inversion" in DETECTORS
+        assert "hy_oas_widening" in DETECTORS
+
+    def test_shadow_signals_skip_emits_no_warning(self, caplog):
+        """`_build_signal_definitions()` re-call 시 SHADOW signal 에 대해 warning 없음.
+
+        Issue #455 trigger: 매 import 마다 `signals.yaml에 정의된 X에 대응하는
+        detector 함수 없음` 2회 fire. fix 후 0회.
+        """
+        import logging
+
+        from nuri.quant.validation.signal_backtest import _build_signal_definitions
+        with caplog.at_level(logging.WARNING, logger="nuri.quant.validation.signal_backtest"):
+            _build_signal_definitions()
+        shadow_warnings = [
+            r for r in caplog.records
+            if "yield_curve_inversion" in r.getMessage() or "hy_oas_widening" in r.getMessage()
+        ]
+        assert not shadow_warnings, f"SHADOW signals should skip silently, got: {[r.getMessage() for r in shadow_warnings]}"
 
     def test_chart_pattern_signals_in_definitions(self):
         from nuri.quant.validation.signal_backtest import (


### PR DESCRIPTION
## Summary
Fix #455 — `_build_signal_definitions()` warned 'detector 함수 없음' for `yield_curve_inversion` / `hy_oas_widening` on every module load, but those are SHADOW signals (PR C #436) with `scope: market_wide` registered in `market_signals.DETECTORS`, NOT in per-ticker `_ENTRY_DETECTORS` by design.

Cross-registry false positive — silenced via early `continue` when `meta.scope == 'market_wide'`.

## Why this isn't a "missing detector"
- `yield_curve_inversion` + `hy_oas_widening` already implemented in `nuri/quant/validation/market_signals.py::DETECTORS` (since PR C #436)
- They're per-day **market-wide** state (1 reading), not per-ticker entry signals (per-bar OHLC scan)
- `signal_backtest.py` is the per-ticker engine — these don't belong there
- `market_signals.py` handles them via `detect_all()` / `fired_shadow_signals()` for daily brief SHADOW surface
- Old code: warned (false positive). New code: silent skip with comment explaining the architectural separation.

## Verification
```bash
# Before: 2 warnings on import
WARNING signals.yaml에 정의된 yield_curve_inversion에 대응하는 detector 함수 없음
WARNING signals.yaml에 정의된 hy_oas_widening에 대응하는 detector 함수 없음

# After: 0 warnings
$ .venv/bin/python -c "from nuri.quant.validation import signal_backtest"
(no output)
```

## Invariants preserved
- `SIGNAL_DEFINITIONS` still has 20 per-ticker signals (no change)
- `market_signals.DETECTORS` still has both SHADOW signals (PR C #436 invariant)
- `is_actionable()` and `list_shadow_signals()` (PR C helpers) unchanged

## Test plan
- [x] `tests/quant/test_validation_signal.py::TestSignalDefinitions::test_shadow_market_wide_signals_excluded_from_per_ticker_registry` — locks SIGNAL_DEFINITIONS exclusion
- [x] `::test_shadow_signals_have_market_wide_registry` — locks market_signals.DETECTORS inclusion (cross-registry invariant)
- [x] `::test_shadow_signals_skip_emits_no_warning` — caplog assertion that fix removes warning
- [x] All 82 tests in `test_validation_signal.py` pass
- [x] `make lint` — All checks passed
- [x] Live verification: `import signal_backtest` emits 0 warnings (was 2)

Closes #455.