### PR TITLE
fix(collectors): add --source freshness for SIEGE freshness tickers (SPY/TLT/GC=F)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ verify:          ## ~5min pre-release (verify.py full, includes backtest)
 # ═══════════════════════════════════════════════════════════════
 collect:
 	$(PYTHON) -m nuri.collectors.stock
+	$(PYTHON) -m nuri.collectors.stock --source freshness   # #453 — SIEGE freshness pass (SPY/TLT/GC=F)
 	$(PYTHON) -m nuri.collectors.stock_kr
 	$(PYTHON) -m nuri.collectors.macro
 	$(PYTHON) -m nuri.collectors.technical

--- a/nuri/collectors/stock.py
+++ b/nuri/collectors/stock.py
@@ -23,6 +23,32 @@ from nuri.core.db import upsert_prices
 # OpenBB 프로바이더 우선순위 (무료)
 PROVIDERS = ["yfinance"]
 
+# SIEGE freshness extraction — yfinance 가 직접 fetch 못하는 macro/index 식별자.
+# config/rules.yaml siege_gates.asset_classes.*.freshness_primary 가 source of truth 이지만
+# KOSPI 같은 macro indicator name 은 stock.py 의 yfinance 경로에서 빈 결과 → 사전 제외.
+# KOSPI 는 macro 테이블 (issue #454 dual-source lookup 범위) — 본 collector 미담당.
+_NON_YFINANCE_FRESHNESS_TICKERS: frozenset[str] = frozenset({"KOSPI"})
+
+
+def _load_freshness_tickers() -> list[str]:
+    """siege_gates.asset_classes.*.freshness_primary + freshness_secondary → US/yfinance ticker list.
+
+    config/rules.yaml siege_gates 가 single source of truth. _NON_YFINANCE_FRESHNESS_TICKERS
+    에 등재된 식별자 (KOSPI 등) 는 macro/index 라 stock.py 가 못 다루므로 제외.
+    """
+    from nuri.core.rules import RULES
+
+    asset_classes = (RULES.get("siege_gates") or {}).get("asset_classes") or {}
+    out: set[str] = set()
+    for cls_policy in asset_classes.values():
+        prim = cls_policy.get("freshness_primary")
+        if prim and prim not in _NON_YFINANCE_FRESHNESS_TICKERS:
+            out.add(prim)
+        for sec in cls_policy.get("freshness_secondary") or []:
+            if sec and sec not in _NON_YFINANCE_FRESHNESS_TICKERS:
+                out.add(sec)
+    return sorted(out)
+
 
 class StockCollector(BaseCollector):
     """OpenBB Platform으로 미국 주가 수집."""
@@ -40,10 +66,15 @@ class StockCollector(BaseCollector):
         """OpenBB로 미국 종목 OHLCV 수집.
 
         Args:
-            source: 'portfolio' (default) | 'universe' | 'all'. #272 Phase 2b.
+            source: 'portfolio' (default) | 'universe' | 'all' | 'freshness'. #272 Phase 2b + #453.
+                freshness = config/rules.yaml siege_gates.asset_classes.*.freshness_primary +
+                freshness_secondary 에서 추출 (KOSPI 등 macro 식별자 제외).
         """
         # 한국 종목은 stock_kr.py에서 처리
-        tickers = self._get_tickers(market="us", source=source)
+        if source == "freshness":
+            tickers = _load_freshness_tickers()
+        else:
+            tickers = self._get_tickers(market="us", source=source)
         if not tickers:
             self.logger.warning("수집할 미국 종목이 없습니다")
             return pd.DataFrame()
@@ -213,8 +244,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--source",
         default="portfolio",
-        choices=["portfolio", "universe", "all"],
-        help="ticker 소스 (#272 Phase 2b). portfolio=보유만, universe=yaml 전체, all=합집합",
+        choices=["portfolio", "universe", "all", "freshness"],
+        help=(
+            "ticker 소스. portfolio=보유만 (#272 Phase 2b), universe=yaml 전체, "
+            "all=합집합, freshness=SIEGE freshness gate 의존 ticker (#453 — SPY/TLT/GC=F)"
+        ),
     )
     args = parser.parse_args()
 

--- a/tests/collectors/test_stock.py
+++ b/tests/collectors/test_stock.py
@@ -280,3 +280,102 @@ class TestStandardizeThreadSafety:
         for r in results:
             assert "ticker" in r.columns
             assert "adj_close" in r.columns
+
+
+class TestFreshnessSource:
+    """Issue #453 — `--source freshness` 가 SIEGE freshness gate 의존 ticker 를 추출."""
+
+    def test_load_freshness_tickers_extracts_primary_and_secondary(self, monkeypatch):
+        from nuri.collectors import stock as stock_mod
+
+        fake_rules = {
+            "siege_gates": {
+                "asset_classes": {
+                    "us_equity": {"freshness_primary": "SPY", "freshness_secondary": []},
+                    "bond": {"freshness_primary": "TLT", "freshness_secondary": ["SPY"]},
+                    "commodity": {"freshness_primary": "GC=F", "freshness_secondary": []},
+                }
+            }
+        }
+        # rules.RULES 는 module-level frozen dict — monkeypatch 로 교체.
+        from nuri.core import rules as rules_mod
+
+        monkeypatch.setattr(rules_mod, "RULES", fake_rules)
+
+        result = stock_mod._load_freshness_tickers()
+        # primary + secondary 합집합 — 중복 제거 + sorted
+        assert result == sorted({"SPY", "TLT", "GC=F"})
+
+    def test_load_freshness_tickers_excludes_non_yfinance(self, monkeypatch):
+        """KOSPI 같은 macro indicator name 은 stock.py 가 fetch 못함 → 제외."""
+        from nuri.collectors import stock as stock_mod
+        from nuri.core import rules as rules_mod
+
+        fake_rules = {
+            "siege_gates": {
+                "asset_classes": {
+                    "kr_equity": {"freshness_primary": "KOSPI", "freshness_secondary": ["SPY"]},
+                    "kr_index": {"freshness_primary": "KOSPI", "freshness_secondary": ["SPY"]},
+                }
+            }
+        }
+        monkeypatch.setattr(rules_mod, "RULES", fake_rules)
+
+        result = stock_mod._load_freshness_tickers()
+        assert "KOSPI" not in result
+        assert result == ["SPY"]
+
+    def test_load_freshness_tickers_empty_config(self, monkeypatch):
+        """siege_gates 설정 부재 시 빈 리스트 — graceful."""
+        from nuri.collectors import stock as stock_mod
+        from nuri.core import rules as rules_mod
+
+        monkeypatch.setattr(rules_mod, "RULES", {})
+        assert stock_mod._load_freshness_tickers() == []
+
+    def test_collect_freshness_source_uses_helper_not_get_tickers(self, monkeypatch, tmp_path):
+        """source='freshness' 분기는 _get_tickers 를 호출하지 않음 — siege config 직접 추출."""
+        from nuri.collectors import stock as stock_mod
+        from nuri.collectors.stock import StockCollector
+        from nuri.core import rules as rules_mod
+        from nuri.core.db import init_db
+
+        db = tmp_path / "test.db"
+        init_db(db)
+
+        fake_rules = {
+            "siege_gates": {
+                "asset_classes": {
+                    "us_equity": {"freshness_primary": "SPY", "freshness_secondary": []},
+                    "bond": {"freshness_primary": "TLT", "freshness_secondary": []},
+                }
+            }
+        }
+        monkeypatch.setattr(rules_mod, "RULES", fake_rules)
+
+        # _collect_ticker stub — 실제 yfinance call 차단, 호출 ticker 추적
+        called_tickers: list[str] = []
+
+        def _stub_collect_ticker(self, ticker, start_date, end_date):
+            called_tickers.append(ticker)
+            return None  # 빈 결과 — save 단계 스킵
+
+        monkeypatch.setattr(StockCollector, "_collect_ticker", _stub_collect_ticker)
+
+        c = StockCollector()
+        c.collect(period="5d", source="freshness")
+
+        # SPY/TLT 만 호출됐는지 — portfolio (db_with_portfolio fixture 미사용이라 비어있음) 분기
+        # 가 아니라 _load_freshness_tickers() 분기를 탔는지 검증.
+        assert sorted(called_tickers) == ["SPY", "TLT"]
+
+    def test_argparse_accepts_freshness_choice(self):
+        """CLI `--source freshness` 가 argparse choices 에 등록됨 (#453 회귀)."""
+        # stock.py __main__ block 의 argparse choices 직접 검증 — 실제 모듈 source read.
+        import inspect
+
+        from nuri.collectors import stock as stock_mod
+
+        src = inspect.getsource(stock_mod)
+        # choices 리스트에 'freshness' 포함 확인
+        assert "'freshness'" in src or '"freshness"' in src


### PR DESCRIPTION
## Summary

- Adds `--source freshness` to `nuri.collectors.stock` — pulls SPY/TLT/GC=F from `siege_gates.asset_classes.*.freshness_primary/secondary` (single source of truth: `config/rules.yaml`)
- `make collect` now runs a 1-line freshness pass, restoring SIEGE freshness gates that were dead since universe-only tickers fell outside the daily portfolio collector
- Scope: **US/yfinance-backed freshness only** (SPY/TLT/GC=F). KOSPI/macro dual-source remains issue #454

Closes #453.

## Problem (verified live)

`make collect` ran `stock --source portfolio` only, so universe-only sentinels were never refreshed by the daily Phase A pipeline:

| Ticker | Pre-fix `prices` state | Gate impact |
|---|---|---|
| SPY | last = 2026-04-20 (8 days stale) | `data_fresh_us_equity` WARN, regime classifier blocked |
| TLT | 0 rows | `data_fresh_bond` permanent FAIL |
| GC=F | 0 rows | `data_fresh_commodity` permanent FAIL |

## Fix

`nuri/collectors/stock.py`:
- `_load_freshness_tickers()` reads `RULES.siege_gates.asset_classes`, dedupes primary + secondary, sorts
- `_NON_YFINANCE_FRESHNESS_TICKERS = {\"KOSPI\"}` static blocklist (macro identifier — out of scope, owned by #454)
- `StockCollector.collect(source=\"freshness\")` branches before `_get_tickers` — keeps `BaseCollector` API generic (codex Plan consult: don't couple shared API to SIEGE-specific concerns)
- argparse `choices` adds `freshness`

`Makefile`:
- 1-line freshness pass appended to `collect:` target

## Test

`tests/collectors/test_stock.py::TestFreshnessSource` — 5 tests, all PASS:
1. extracts primary + secondary, dedupe, sorted
2. excludes `KOSPI` (macro indicator)
3. empty siege_gates → graceful empty list
4. `collect(source='freshness')` branches to helper, not `_get_tickers`
5. argparse `choices` contains `freshness`

```
$ pytest tests/collectors/test_stock.py -v
20 passed in 0.30s   # 15 existing + 5 new
$ pytest tests/collectors/ -q
492 passed in 3.60s
$ ruff check nuri/collectors/stock.py tests/collectors/test_stock.py
All checks passed!
```

## Live verify

```
$ .venv/bin/python -m nuri.collectors.stock --source freshness --period 1mo
수집 대상: 3 미국 종목 (1mo, source=freshness)
[stock] 완료: 60건, 3.8초

$ python -c \"from nuri.trading.engine.certification import _check_data_freshness; ...\"
PASS [error] data_fresh_bond:        TLT 37시간 전
PASS [error] data_fresh_commodity:   GC=F 37시간 전
PASS [error] data_fresh_us_equity:   SPY 37시간 전
```

3 freshness gates restored. Regime classifier no longer warns SPY stale.

## Notes

- **Scope clarification**: this PR fixes the US/yfinance-backed freshness path. KR (KOSPI) freshness still needs `_check_freshness_for_class()` dual-source lookup (`prices` ↔ `macro` table) — that's issue #454, deliberately deferred.
- Live verify also showed `data_fresh_kr_equity: KOSPI 13시간 전 PASS` because `prices.KOSPI` already had 374 rows from `stock_kr.py` — meaning issue #454 may be partially redundant for the kr path. Re-evaluate #454 in next session.
- `make collect-universe` still does NOT cover TLT/GC=F (they're absent from `universe.yaml`). If a future reviewer expects universe sync to cover certification sentinels, surfaced for awareness — not in scope for this PR.

## Test plan

- [x] `pytest tests/collectors/test_stock.py -v` — 20 pass
- [x] `pytest tests/collectors/ -q` — 492 pass
- [x] `ruff check` clean
- [x] Live `--source freshness` end-to-end (DB write + SIEGE gate PASS)
- [x] Codex Plan consult (verdict: ship-with-changes, applied)
- [x] Codex Round 1 Review (GATE: PASS, no P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)