### PR TITLE
docs(collectors): #454 freshness redundancy debt note (close, no code change)

### DIFF
--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -62,3 +62,12 @@ ThreadPoolExecutor caveat: `.result(timeout=)` cancels FUTURE only — underlyin
 ## Macro Data Quirk
 
 `us_3m_yield` (FRED) is absent in yfinance fallback — `^IRX` (13-week T-Bill) is stored as `us_2y_yield`. `merge_macro_data()` queries `us_2y_yield` when `us_3m_yield` is empty.
+
+## Freshness Sentinel Redundancy (#453/#454, post-#457)
+
+SIEGE freshness gate (`certification.py::_check_freshness_for_class`) reads **`prices` only**. `--source freshness` (#457) feeds SPY/TLT/GC=F into `prices` daily. Two known redundancies:
+
+- **`gold` lives in two tables**: `macro.indicator='gold'` (~5Y backfill, 264 rows) AND `prices."GC=F"` (1mo, ~20 rows after each daily refresh). Same yfinance source, separate writers (`macro.py` vs `stock.py --source freshness`). No current historical consumer of `prices."GC=F"` beyond the gate, so single-source-of-truth not enforced — accept as debt.
+- **TLT shallow history**: `prices.TLT` is 1mo only (freshness pass period). If a future backtest/analysis needs TLT 5Y, add TLT to `universe.yaml` (don't promote freshness gate to dual-source — drift risk per #454 codex consult 2026-04-28).
+
+**Why not dual-source the gate** (option A in #454, rejected): if gate accepts `macro.gold` 37h-fresh while a downstream consumer reads stale `prices."GC=F"`, gate PASS but downstream gets stale data → silent split-brain. Single-source gate = single truth.


### PR DESCRIPTION
## Summary

Closes #454 without code change — codex Plan consult verdict (c).

Post-#457 (\`--source freshness\` daily pass), TLT/GC=F now refresh in \`prices\` daily, restoring \`data_fresh_bond\` and \`data_fresh_commodity\` SIEGE gates. Issue #454's reported symptoms (영구 warning) are resolved.

Option A (dual-source gate, prices+macro lookup) was rejected because:

1. **No current consumer**: zero historical readers of \`prices.TLT\` or \`macro.gold\` found in \`nuri/\` beyond the freshness gate itself. TLT-depth justification evaporates.
2. **Drift risk**: gate accepting \`macro.gold\` 37h-fresh while downstream reads stale \`prices.\"GC=F\"\` = silent split-brain. Single-source = single truth.
3. **Schema churn**: \`freshness_primary: TLT\` (string) → \`{source, ticker}\` (dict) breaks every reader for speculative future need.

## Change

\`nuri/collectors/CLAUDE.md\` — new §"Freshness Sentinel Redundancy (#453/#454, post-#457)" documents:
- gold lives in two tables (macro 5Y / prices 1mo) — accepted debt
- TLT shallow history — add to \`universe.yaml\` if future backtest needs it
- Why not dual-source — drift risk

## Verification (post-#457, current main)

\`\`\`
SIEGE _check_data_freshness:
  PASS data_fresh_us_equity:  SPY 37h
  PASS data_fresh_bond:       TLT 37h    (was permanent FAIL)
  PASS data_fresh_commodity:  GC=F 37h   (was permanent FAIL)
  PASS data_fresh_kr_equity:  KOSPI 13h
  PASS data_fresh_kr_equity_SPY: SPY 37h
\`\`\`

Codex consult archive: see prompt at \`/tmp/issue_454_plan_consult.md\` (gitignored).

## Test plan

- [x] Codex Plan consult — verdict (c)
- [x] grep verified — 0 historical TLT consumers
- [x] Live SIEGE freshness 5/5 PASS
- [x] No code changes — no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)