### PR TITLE
feat(macro): add 10 missing yfinance indicators (#362 Part A)

### DIFF
--- a/nuri/collectors/macro.py
+++ b/nuri/collectors/macro.py
@@ -56,6 +56,20 @@ YFINANCE_SYMBOLS = {
     "usd_krw": "KRW=X",          # USD/KRW
     # btc_usd는 CoinGecko collector에서 전담 (btc_usd_cg)
     "gold": "GC=F",              # Gold Futures (안전자산)
+    # 추가 지표 (#362 Part A, 2026-04-28 live probe 9/10 + DXY 대체 symbol)
+    # 지수 — regime classifier + macro agent breadth 지표
+    "nasdaq_composite": "^IXIC",   # NASDAQ Composite (tech breadth)
+    "sp500": "^GSPC",              # S&P 500 (broad US market — SPY 와 별도 index 직접 추적)
+    "dow": "^DJI",                 # Dow Jones (blue-chip 30)
+    "nasdaq100_futures": "NQ=F",   # NASDAQ 100 Futures (after-hours sentiment)
+    "sox": "^SOX",                 # Philadelphia Semiconductor (KR 반도체 spillover proxy)
+    # 환율 — DX=F yfinance 미제공 (live probe), DX-Y.NYB ICE Dollar Index 채택
+    "dxy": "DX-Y.NYB",             # ICE U.S. Dollar Index (USD strength)
+    # 원자재 — gold/wti 외 산업/안전자산 polish
+    "silver": "SI=F",              # Silver Futures
+    "natgas": "NG=F",              # Natural Gas Futures
+    "copper": "HG=F",              # Copper Futures (industrial demand barometer)
+    "wheat": "ZW=F",               # Wheat Futures (food inflation)
 }
 
 

--- a/nuri/collectors/macro.py
+++ b/nuri/collectors/macro.py
@@ -81,19 +81,36 @@ class MacroCollector(BaseCollector):
         self.api_key = os.getenv("FRED_API_KEY", "")
 
     def collect(self, days: int = 365, **kwargs) -> list[dict]:
-        """매크로 지표 수집. FRED 우선, 실패 시 yfinance fallback."""
-        records = []
+        """매크로 지표 수집 — FRED 우선 + yfinance 보충 (#362 codex Review P1).
 
-        # 1. FRED 시도
+        Pre-#362 동작: FRED 결과 1건이라도 있으면 즉시 return → yfinance 분기 stub.
+        결과적으로 FRED_API_KEY 환경에서는 yfinance-only indicator (^IXIC, ^GSPC,
+        DX-Y.NYB 등 #362 Part A 10개 + Part B 향후 ECOS missing 도) 가 영구 미수집.
+
+        Fix: 두 source 모두 호출 후 indicator 단위로 merge — FRED 우선, FRED 에
+        없는 key 는 yfinance 보충. legacy 8 indicator 는 FRED 가 채우면 yfinance
+        를 무시 (per-row dup 방지).
+        """
+        fred_records: list[dict] = []
         if self.api_key and self.api_key != "your_fred_api_key_here":
-            records = self._collect_fred(days)
-            if records:
-                return records
+            fred_records = self._collect_fred(days)
 
-        # 2. yfinance fallback
-        self.logger.info("FRED 미사용 → yfinance fallback으로 매크로 수집")
-        records = self._collect_yfinance(days)
-        return records
+        # FRED 가 비었으면 legacy 경로 — yfinance only.
+        if not fred_records:
+            self.logger.info("FRED 미사용 → yfinance fallback으로 매크로 수집")
+            return self._collect_yfinance(days)
+
+        # FRED + yfinance merge — yfinance-only indicator 보충.
+        yf_records = self._collect_yfinance(days)
+        fred_indicators = {r["indicator"] for r in fred_records}
+        yf_supplement = [r for r in yf_records if r["indicator"] not in fred_indicators]
+        if yf_supplement:
+            yf_only_keys = sorted({r["indicator"] for r in yf_supplement})
+            self.logger.info(
+                "FRED + yfinance merge — FRED 외 yfinance-only %d개 보충: %s",
+                len(yf_only_keys), yf_only_keys,
+            )
+        return fred_records + yf_supplement
 
     def _collect_fred(self, days: int) -> list[dict]:
         """FRED API에서 매크로 지표 수집."""

--- a/tests/collectors/test_macro.py
+++ b/tests/collectors/test_macro.py
@@ -165,3 +165,53 @@ class TestMacroCollectorEdgeCases:
         collector = MacroCollector()
         collector.api_key = "real_key"
         assert isinstance(collector.collect(days=30), list)
+
+
+class TestPartAIndicatorRegistry:
+    """Issue #362 Part A — 10 신규 yfinance 지표 등록 lock-in."""
+
+    def test_part_a_indicators_present_in_registry(self):
+        """YFINANCE_SYMBOLS 에 #362 Part A 10개 indicator key 가 모두 존재."""
+        from nuri.collectors.macro import YFINANCE_SYMBOLS
+
+        expected = {
+            "nasdaq_composite", "sp500", "dow", "nasdaq100_futures", "sox",
+            "dxy", "silver", "natgas", "copper", "wheat",
+        }
+        missing = expected - set(YFINANCE_SYMBOLS.keys())
+        assert not missing, (
+            f"#362 Part A indicator key 누락: {missing}. 한 줄이라도 빠지면 "
+            f"daily macro collect 가 그 지표를 silently 스킵."
+        )
+
+    def test_part_a_symbols_match_2026_04_28_live_probe(self):
+        """2026-04-28 live probe 결과와 등록 symbol 일치 — DXY 는 DX-Y.NYB (DX=F empty)."""
+        from nuri.collectors.macro import YFINANCE_SYMBOLS
+
+        expected_mapping = {
+            "nasdaq_composite": "^IXIC",
+            "sp500": "^GSPC",
+            "dow": "^DJI",
+            "nasdaq100_futures": "NQ=F",
+            "sox": "^SOX",
+            "dxy": "DX-Y.NYB",  # NOT DX=F (issue body 의 'DX=F' 는 yfinance empty — live probe)
+            "silver": "SI=F",
+            "natgas": "NG=F",
+            "copper": "HG=F",
+            "wheat": "ZW=F",
+        }
+        for key, expected_sym in expected_mapping.items():
+            actual = YFINANCE_SYMBOLS.get(key)
+            assert actual == expected_sym, (
+                f"{key}: expected {expected_sym!r}, got {actual!r}. "
+                f"DXY 가 DX=F 로 되돌아가면 yfinance empty → DB 영구 누락 (live probe 2026-04-28)."
+            )
+
+    def test_part_a_does_not_displace_existing_indicators(self):
+        """기존 vix/gold/wti_oil/us_*_yield/usd_krw 가 그대로 남아있음 — 회귀 방지."""
+        from nuri.collectors.macro import YFINANCE_SYMBOLS
+
+        legacy = {"us_10y_yield", "us_2y_yield", "us_5y_yield", "us_30y_yield",
+                  "vix", "wti_oil", "usd_krw", "gold"}
+        missing = legacy - set(YFINANCE_SYMBOLS.keys())
+        assert not missing, f"기존 지표 회귀 — {missing} 사라짐"

--- a/tests/collectors/test_macro.py
+++ b/tests/collectors/test_macro.py
@@ -97,7 +97,8 @@ class TestMacroCollectorFREDAndYFinance:
         assert MacroCollector()._collect_yfinance(days=30) == []
 
     def test_collect_prefers_fred(self, monkeypatch, db_with_portfolio):
-        from nuri.collectors.macro import MacroCollector
+        """FRED 가 cover 하는 indicator 는 source='FRED' (yfinance dup 제외) — #362 merge 후."""
+        from nuri.collectors.macro import FRED_SERIES, MacroCollector
 
         mock_series = pd.Series([4.5], index=pd.to_datetime(["2025-01-15"]))
         mock_fred = MagicMock()
@@ -105,10 +106,18 @@ class TestMacroCollectorFREDAndYFinance:
         import sys
 
         monkeypatch.setitem(sys.modules, "fredapi", MagicMock(Fred=MagicMock(return_value=mock_fred)))
+        # yfinance 분기 차단 — _collect_yfinance 에서 yfinance.download mock 안 하면
+        # 실제 네트워크 호출 됨. conftest.py 의 yfinance.download stub (빈 df) 활용.
         collector = MacroCollector()
         collector.api_key = "real_key"
         results = collector.collect(days=30)
-        assert all(r["source"] == "FRED" for r in results)
+        # FRED 가 cover 하는 indicator 들은 모두 source='FRED'
+        fred_keys = set(FRED_SERIES.keys())
+        for r in results:
+            if r["indicator"] in fred_keys:
+                assert r["source"] == "FRED", (
+                    f"{r['indicator']} 는 FRED 에 정의됨 → source='FRED' 여야 함 (yfinance dup 제거 실패)"
+                )
 
     def test_collect_nan_value_skipped(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.macro import MacroCollector
@@ -215,3 +224,49 @@ class TestPartAIndicatorRegistry:
                   "vix", "wti_oil", "usd_krw", "gold"}
         missing = legacy - set(YFINANCE_SYMBOLS.keys())
         assert not missing, f"기존 지표 회귀 — {missing} 사라짐"
+
+    def test_collect_merges_yf_supplement_when_fred_set(self, monkeypatch, db_with_portfolio):
+        """FRED_API_KEY 설정 시 — yfinance-only indicator (#362 Part A) 가 보충 수집됨.
+
+        Codex Review #362 P1: FRED 가 일부 indicator 만 cover 하는데 collect() 가
+        FRED 결과 있으면 즉시 return → yfinance-only 영구 미수집.
+
+        Fix: collect() 가 두 source 모두 호출 + indicator dedupe (FRED 우선).
+        Lock-in: 이 test 가 fail 하면 P1 회귀.
+        """
+        import sys
+
+        import pandas as pd
+
+        from nuri.collectors.macro import MacroCollector
+
+        # FRED stub — vix 만 응답 (cover 일부)
+        mock_series = pd.Series([18.5], index=pd.to_datetime(["2025-01-15"]))
+        mock_fred = MagicMock()
+        mock_fred.get_series.return_value = mock_series
+
+        monkeypatch.setitem(sys.modules, "fredapi", MagicMock(Fred=MagicMock(return_value=mock_fred)))
+
+        # yfinance stub — _collect_yfinance 가 호출되면 fake 새 indicator 반환
+        # (실제 yfinance.download 는 conftest mock 으로 빈 df → records=[] 반환됨)
+        # 따라서 _collect_yfinance 자체를 monkeypatch.
+        def stub_yf(self, days):
+            return [
+                {"indicator": "vix",   "date": "2025-01-15", "value": 19.0, "source": "yfinance"},  # FRED dup
+                {"indicator": "sp500", "date": "2025-01-15", "value": 7000.0, "source": "yfinance"},  # yf-only
+                {"indicator": "dxy",   "date": "2025-01-15", "value": 98.5, "source": "yfinance"},  # yf-only
+            ]
+        monkeypatch.setattr(MacroCollector, "_collect_yfinance", stub_yf)
+
+        collector = MacroCollector()
+        collector.api_key = "real_key"
+        results = collector.collect(days=30)
+
+        indicators = {r["indicator"]: r["source"] for r in results}
+        # FRED-covered indicator (vix) 는 FRED 우선 (yfinance dup 제외)
+        # vix 는 fred_records 도 있고 yf 도 있는데, FRED 우선이라 source='FRED' 여야 함
+        # FRED_SERIES 에 vix 가 있어 _collect_fred 가 vix records 생성
+        assert "sp500" in indicators, "yfinance-only indicator 보충 안 됨 — P1 회귀"
+        assert "dxy" in indicators, "yfinance-only indicator 보충 안 됨 — P1 회귀"
+        assert indicators["sp500"] == "yfinance"
+        assert indicators["dxy"] == "yfinance"


### PR DESCRIPTION
## Summary

- Adds 10 missing yfinance indicators to \`YFINANCE_SYMBOLS\` (#362 Part A): nasdaq_composite, sp500, dow, nasdaq100_futures, sox, dxy, silver, natgas, copper, wheat
- Refactors \`collect()\` to merge FRED + yfinance (FRED priority, yfinance supplements missing keys) — fixes P1 codex caught: pre-fix \`FRED_API_KEY\` users would silently miss the new 10 indicators
- Closes #362 partially. Part B (KR yields via ECOS API) deferred to separate PR.

## Symbol mapping (with live probe deviation)

| Indicator | Issue body proposed | Live probe (2026-04-28) | Final |
|---|---|---|---|
| nasdaq_composite | \`^IXIC\` | OK 24887.10 | \`^IXIC\` |
| sp500 | \`^GSPC\` | OK 7173.91 | \`^GSPC\` |
| dow | \`^DJI\` | OK 49167.79 | \`^DJI\` |
| nasdaq100_futures | \`NQ=F\` | OK 27432.00 | \`NQ=F\` |
| sox | \`^SOX\` | OK 10408.04 | \`^SOX\` |
| **dxy** | \`DX=F\` | **EMPTY** | \`DX-Y.NYB\` (98.51) ← live deviation |
| silver | \`SI=F\` | OK 74.48 | \`SI=F\` |
| natgas | \`NG=F\` | OK 2.72 | \`NG=F\` |
| copper | \`HG=F\` | OK 6.07 | \`HG=F\` |
| wheat | \`ZW=F\` | OK 631.50 | \`ZW=F\` |

\`DX=F\` returned empty df at probe time — \`DX-Y.NYB\` (ICE Dollar Index) substituted, locked in regression test.

## Why FRED merge change

Codex Round 1 GATE: FAIL — P1: pre-fix \`collect()\` returned early on FRED success, so \`FRED_API_KEY\` users would never receive the new 10 yfinance-only indicators (none have FRED IDs). Fix:

- \`fred_records\` + \`yf_records\` 둘 다 호출
- \`fred_indicators\` 가 cover 하는 key 는 yfinance dup 제외
- 나머지 yfinance-only key 는 보충
- Legacy: \`FRED_API_KEY\` unset 시 \`fred_records=[]\` → yfinance-only path 그대로

Round 2 GATE: PASS — codex confirmed merge semantics + backward compat OK.

## Test

\`tests/collectors/test_macro.py\` (3 new + 1 modified):
1. \`TestPartAIndicatorRegistry::test_part_a_indicators_present_in_registry\`
2. \`TestPartAIndicatorRegistry::test_part_a_symbols_match_2026_04_28_live_probe\` (DXY=DX-Y.NYB lock)
3. \`TestPartAIndicatorRegistry::test_part_a_does_not_displace_existing_indicators\` (legacy 회귀)
4. \`TestPartAIndicatorRegistry::test_collect_merges_yf_supplement_when_fred_set\` (P1 lock)
5. \`TestMacroCollectorFREDAndYFinance::test_collect_prefers_fred\` updated for per-indicator priority semantic

## Live verify

\`\`\`
$ python -m nuri.collectors.macro --days 30
[macro] 완료: 370건, 7.0초

10 NEW indicators all collected:
  nasdaq_composite (^IXIC): 20건
  sp500 (^GSPC): 20건
  dow (^DJI): 20건
  nasdaq100_futures (NQ=F): 21건
  sox (^SOX): 20건
  dxy (DX-Y.NYB): 21건
  silver (SI=F): 21건
  natgas (NG=F): 21건
  copper (HG=F): 21건
  wheat (ZW=F): 21건

8 legacy indicators preserved (us_*_yield, vix, wti_oil, usd_krw, gold).
\`\`\`

## Out of scope (flagged but not in this PR)

- VKOSPI (#419) — re-probe 2026-04-28 confirms 8 yfinance candidates still empty. Alternative source (KRX/KIS/proxy) needs separate session.
- KIS Research (#418) — design-blocked (Playwright DOM inspection requires live login).
- KR yields (#362 Part B) — ECOS API integration, separate PR.

## Test plan

- [x] pytest tests/collectors/test_macro.py -v — 17 pass (13 existing + 1 modified + 3 new)
- [x] ruff clean
- [x] Live macro collect — 18 indicators, 370 rows, 7.0s
- [x] Codex Plan consult — verdict (A) ship Part A only
- [x] Codex Round 1 — GATE: FAIL, P1 FRED early return → fixed
- [x] Codex Round 2 — GATE: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)