### PR TITLE
feat(collectors): KIS Open API KR fundamentals (PER/PBR) — yfinance KR limit 우회 (#465)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -372,7 +372,19 @@
     "langchain",
     "ehthumbs",
     "maint",
-    "signum"
+    "signum",
+    "FHKST",
+    "appkey",
+    "appsecret",
+    "lstn",
+    "stcn",
+    "prpr",
+    "oprc",
+    "hgpr",
+    "lwpr",
+    "acml",
+    "sdpr",
+    "yflog"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/nuri/collectors/fundamental.py
+++ b/nuri/collectors/fundamental.py
@@ -163,27 +163,30 @@ class FundamentalCollector(BaseCollector):
         from nuri.core.timezone import today_kst
 
         today = today_kst()
-        results = []
+        results: list[dict] = []
         skipped: list[str] = []
         failed: list[str] = []
-        kis_collected: set[str] = set()  # KIS 가 채운 KR ticker — yfinance loop 가 skip
 
         # ── KR sub-batch: KIS inquire-price (sequential, rate-limited) ──
-        # yfinance KR limit (trailingPE/priceToBook 미제공) 우회. KIS 실패 시 fallback to yfinance.
+        # yfinance KR limit (trailingPE/priceToBook 미제공) 우회. KIS 실패 시 KR 도
+        # yfinance fallback 으로 넘어가 forward_pe/roe/margin/growth 만이라도 채움.
         kr_tickers = [t for t in tickers if t.endswith((".KS", ".KQ"))]
+        kis_by_ticker: dict[str, dict] = {}
         if kr_tickers:
             kis_results = self._collect_kr_via_kis(kr_tickers, today)
-            results.extend(kis_results)
-            kis_collected = {r["ticker"] for r in kis_results}
+            kis_by_ticker = {r["ticker"]: r for r in kis_results}
             self.logger.info(
-                "🇰🇷 KIS 펀더멘탈: ✅ %d / %d KR ticker (남은 %d 는 yfinance fallback)",
-                len(kis_collected), len(kr_tickers), len(kr_tickers) - len(kis_collected),
+                "🇰🇷 KIS 펀더멘탈: ✅ %d / %d KR ticker (yfinance loop 가 ROE/margin/growth 보충)",
+                len(kis_by_ticker), len(kr_tickers),
             )
 
-        # ── US + KR-fallback sub-batch: yfinance 10-thread parallel ──
-        # KIS 가 채운 KR ticker (kis_collected) 는 skip — KIS 데이터가 우선.
-        yf_tickers = [t for t in tickers if t not in kis_collected]
+        # ── 전체 sub-batch: yfinance 10-thread parallel ──
+        # KIS 가 채운 KR 도 yfinance 한 번 더 돌려 ROE / revenue_growth / profit_margin /
+        # debt_to_equity 같은 yfinance-only fields 보존 (codex Round 1 P1 fix).
+        # KIS 의 pe_ratio/price_to_book/market_cap 은 merge 단계에서 우선 적용.
+        yf_tickers = list(tickers)
         if not yf_tickers:
+            results.extend(kis_by_ticker.values())
             return results
 
         # universe 모드: yfinance ERROR 노이즈 억제
@@ -232,7 +235,7 @@ class FundamentalCollector(BaseCollector):
                 )
                 for fut in iterator:
                     ticker, record, status = fut.result()
-                    if status == "ok":
+                    if status == "ok" and record is not None:
                         results.append(record)
                     elif status == "skipped":
                         skipped.append(ticker)
@@ -240,6 +243,24 @@ class FundamentalCollector(BaseCollector):
                         failed.append(ticker)
         finally:
             _yflog.setLevel(_orig_level)
+
+        # ── KIS merge: KR ticker 의 KIS pe/pbr/market_cap 을 yfinance record 에 우선 적용 ──
+        # codex Round 1 P1 — KR 가 yfinance loop 바이패스했을 때 ROE/margin/growth 손실
+        # 회귀 차단. KIS 채운 columns 만 override, yfinance enrichment 보존.
+        if kis_by_ticker:
+            yf_seen = {r["ticker"] for r in results}
+            for record in results:
+                kis_data = kis_by_ticker.get(record["ticker"])
+                if kis_data is None:
+                    continue
+                for col in ("pe_ratio", "price_to_book", "market_cap"):
+                    val = kis_data.get(col)
+                    if val is not None:
+                        record[col] = val
+            # yfinance 가 fail 한 KR ticker — KIS-only record 추가 (yfinance fallback)
+            for ticker, kis_record in kis_by_ticker.items():
+                if ticker not in yf_seen:
+                    results.append(kis_record)
 
         if len(tickers) >= 20:
             sample_failed = ", ".join((failed + skipped)[:5]) + (

--- a/nuri/collectors/fundamental.py
+++ b/nuri/collectors/fundamental.py
@@ -59,6 +59,82 @@ def _safe_num(val) -> float | None:
     return f
 
 
+# KIS Open API inquire-price (FHKST01010100) 응답 필드 → fundamentals 컬럼 매핑.
+# yfinance KR 한계 (#465): trailingPE / priceToBook 미제공 → KIS 공식 데이터로 보충.
+# eps/bps/lstn_stcn 은 market_cap 계산에만 사용 (별도 컬럼 없음 — scope creep 회피, codex Plan).
+KIS_FIELDS = {
+    "per": "pe_ratio",          # KIS trailing P/E
+    "pbr": "price_to_book",     # KIS P/B
+}
+
+
+def _kis_record_skeleton(ticker: str, today: str) -> dict:
+    """모든 fundamentals 컬럼을 None 으로 초기화 — _upsert_fundamentals named binding 호환.
+
+    KIS 가 채우지 않는 yfinance-only 컬럼 (forward_pe / roe / margin / growth 등) 은
+    None 으로 명시적 채워야 sqlite3 NamedParam binding 에러 방지.
+    """
+    return {
+        "ticker": ticker, "date": today,
+        "market_cap": None, "pe_ratio": None, "forward_pe": None, "price_to_book": None,
+        "peg_ratio": None, "roe": None, "roa": None, "gross_margin": None,
+        "operating_margin": None, "profit_margin": None, "revenue_growth": None,
+        "earnings_growth": None, "debt_to_equity": None, "current_ratio": None,
+        "dividend_yield": None, "beta": None,
+        "annual_dividend_usd": None, "dividend_yield_pct": None,
+    }
+
+
+def _fetch_kis_kr(ticker: str, creds, token, today: str) -> dict | None:
+    """KR 종목 KIS inquire-price 응답에서 fundamentals 추출.
+
+    Returns record dict (yfinance shape 호환, missing columns = None) or None on failure.
+    market_cap = stck_prpr × lstn_stcn 계산 (raw KIS 응답에 직접 없음).
+    """
+    import requests
+
+    code = ticker.replace(".KS", "").replace(".KQ", "")
+    url = f"{creds.base_url}/uapi/domestic-stock/v1/quotations/inquire-price"
+    headers = {
+        "content-type": "application/json; charset=utf-8",
+        "authorization": f"Bearer {token}",
+        "appkey": creds.app_key,
+        "appsecret": creds.app_secret,
+        "tr_id": "FHKST01010100",
+    }
+    params = {"FID_COND_MRKT_DIV_CODE": "J", "FID_INPUT_ISCD": code}
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=10)
+        if resp.status_code != 200:
+            return None
+        output = resp.json().get("output", {})
+        if not output or not output.get("stck_prpr"):
+            return None
+
+        record = _kis_record_skeleton(ticker, today)
+        non_null = 0
+        for src_field, db_field in KIS_FIELDS.items():
+            val = _safe_num(output.get(src_field))
+            if val == 0:  # KIS 가 미제공 종목 (예: 우선주) 은 0 → None 처리
+                val = None
+            record[db_field] = val
+            if val is not None:
+                non_null += 1
+
+        # market_cap = 현재가 × 상장주식수 (KIS 가 직접 제공 안함)
+        price = _safe_num(output.get("stck_prpr"))
+        shares = _safe_num(output.get("lstn_stcn"))
+        if price and shares:
+            record["market_cap"] = price * shares
+            non_null += 1
+
+        if non_null == 0:
+            return None
+        return record
+    except Exception:
+        return None
+
+
 class FundamentalCollector(BaseCollector):
     """yfinance Ticker.info로 펀더멘탈 데이터 수집."""
 
@@ -66,7 +142,13 @@ class FundamentalCollector(BaseCollector):
         super().__init__("fundamental")
 
     def collect(self, source: str = "portfolio", **kwargs) -> list[dict]:
-        """펀더멘탈 수집. source='universe' 시 S&P500/KOSPI200 전체 (#272 Phase 2b)."""
+        """펀더멘탈 수집. source='universe' 시 S&P500/KOSPI200 전체 (#272 Phase 2b).
+
+        KR 종목 (.KS/.KQ): KIS Open API inquire-price (FHKST01010100) 가 trailing PER/PBR
+        직접 제공 — yfinance KR 한계 우회 (#465). KIS 자격 증명 부재 / 토큰 발급 실패 시
+        기존 yfinance 경로로 graceful fallback (forward_pe / roe / margin / growth 만 채움).
+        US 종목: yfinance 그대로.
+        """
         import logging as _logging
 
         import yfinance as yf
@@ -84,6 +166,25 @@ class FundamentalCollector(BaseCollector):
         results = []
         skipped: list[str] = []
         failed: list[str] = []
+        kis_collected: set[str] = set()  # KIS 가 채운 KR ticker — yfinance loop 가 skip
+
+        # ── KR sub-batch: KIS inquire-price (sequential, rate-limited) ──
+        # yfinance KR limit (trailingPE/priceToBook 미제공) 우회. KIS 실패 시 fallback to yfinance.
+        kr_tickers = [t for t in tickers if t.endswith((".KS", ".KQ"))]
+        if kr_tickers:
+            kis_results = self._collect_kr_via_kis(kr_tickers, today)
+            results.extend(kis_results)
+            kis_collected = {r["ticker"] for r in kis_results}
+            self.logger.info(
+                "🇰🇷 KIS 펀더멘탈: ✅ %d / %d KR ticker (남은 %d 는 yfinance fallback)",
+                len(kis_collected), len(kr_tickers), len(kr_tickers) - len(kis_collected),
+            )
+
+        # ── US + KR-fallback sub-batch: yfinance 10-thread parallel ──
+        # KIS 가 채운 KR ticker (kis_collected) 는 skip — KIS 데이터가 우선.
+        yf_tickers = [t for t in tickers if t not in kis_collected]
+        if not yf_tickers:
+            return results
 
         # universe 모드: yfinance ERROR 노이즈 억제
         _yflog = _logging.getLogger("yfinance")
@@ -121,13 +222,13 @@ class FundamentalCollector(BaseCollector):
 
         try:
             with concurrent.futures.ThreadPoolExecutor(max_workers=10) as ex:
-                futures = {ex.submit(_fetch_one, t): t for t in tickers}
+                futures = {ex.submit(_fetch_one, t): t for t in yf_tickers}
                 iterator = tqdm(
                     concurrent.futures.as_completed(futures),
-                    total=len(tickers),
+                    total=len(yf_tickers),
                     desc=f"  fundamentals [{source}]",
                     unit="tk",
-                    disable=len(tickers) < 20,
+                    disable=len(yf_tickers) < 20,
                 )
                 for fut in iterator:
                     ticker, record, status = fut.result()
@@ -170,6 +271,47 @@ class FundamentalCollector(BaseCollector):
                         len(results),
                     )
 
+        return results
+
+    def _collect_kr_via_kis(self, kr_tickers: list[str], today: str) -> list[dict]:
+        """KR sub-batch — KIS Open API inquire-price 로 PER/PBR/시가총액 수집.
+
+        Sequential + KIS_REQUEST_INTERVAL_PROD (0.4s) 페이싱 (KIS rate limit).
+        자격 증명 / 토큰 발급 실패 시 빈 리스트 반환 → caller 가 yfinance fallback.
+        """
+        import time as _time
+
+        try:
+            from nuri.collectors.kis_realtime import (
+                KIS_REQUEST_INTERVAL_PROD,
+                get_access_token,
+                load_credentials,
+            )
+        except ImportError:
+            self.logger.warning("KIS module import 실패 — KR 전부 yfinance fallback")
+            return []
+
+        creds = load_credentials("prod")
+        if not creds:
+            self.logger.info("KIS 자격 증명 부재 — KR 전부 yfinance fallback (forward_pe 만)")
+            return []
+
+        token = get_access_token(creds)
+        if not token:
+            self.logger.warning("KIS 토큰 발급 실패 — KR 전부 yfinance fallback")
+            return []
+
+        self.logger.info(
+            "🇰🇷 KIS inquire-price sequential (interval=%.1fs, ~%.0fs total) — %d KR ticker",
+            KIS_REQUEST_INTERVAL_PROD, KIS_REQUEST_INTERVAL_PROD * len(kr_tickers), len(kr_tickers),
+        )
+
+        results: list[dict] = []
+        for ticker in kr_tickers:
+            record = _fetch_kis_kr(ticker, creds, token, today)
+            if record:
+                results.append(record)
+            _time.sleep(KIS_REQUEST_INTERVAL_PROD)
         return results
 
     def save(self, data: Any) -> int:

--- a/tests/collectors/test_fundamental.py
+++ b/tests/collectors/test_fundamental.py
@@ -5,9 +5,21 @@ Split from tests/test_collectors_all.py for module-level isolation.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from nuri.core.db import (
     init_db,
 )
+
+
+@pytest.fixture(autouse=True)
+def _block_kis_live_calls(monkeypatch):
+    """#465 — fundamental.py 가 KR ticker 를 자동으로 KIS 로 보내므로,
+    yfinance branch 만 검증하는 기존 18 test 가 실제 KIS API 를 호출하지 않도록 차단.
+    KIS-specific test (TestKISFundamentalBranch) 는 자체 monkeypatch 로 override.
+    """
+    from nuri.collectors.fundamental import FundamentalCollector
+    monkeypatch.setattr(FundamentalCollector, "_collect_kr_via_kis", lambda self, kr, today: [])
 
 
 class TestFundamentalCollector:
@@ -403,3 +415,162 @@ class TestUniverseModeCoverage:
         monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
         results = c.collect()
         assert results == []  # skipped, no records
+
+
+class TestKISFundamentalBranch:
+    """Issue #465 — KIS Open API 가 KR ticker PER/PBR/market_cap 을 yfinance 보다 정확 제공.
+
+    fundamental.py 가 .KS/.KQ ticker → KIS sequential, US → yfinance thread pool 분기.
+    KIS 자격 증명 부재 / 토큰 발급 실패 / per-ticker 실패 모두 yfinance fallback.
+    """
+
+    def _kis_response(self, *, per=33.94, pbr=3.48, prpr=222500.0, shares=5846278608) -> dict:
+        """KIS inquire-price 응답 shape (raw probe 2026-04-29 005930 기준)."""
+        return {
+            "rt_cd": "0",
+            "output": {
+                "stck_prpr": str(int(prpr)),
+                "lstn_stcn": str(shares),
+                "per": str(per) if per is not None else "0",
+                "pbr": str(pbr) if pbr is not None else "0",
+                "stck_oprc": "220000", "stck_hgpr": "224000", "stck_lwpr": "219000",
+                "acml_vol": "12345678", "stck_sdpr": "221000",
+            },
+        }
+
+    def test_fetch_kis_kr_extracts_per_pbr_market_cap(self, monkeypatch):
+        """raw KIS payload → record 에 pe_ratio / price_to_book / market_cap 채워짐."""
+        from nuri.collectors import fundamental as fund_mod
+
+        # Outer self 를 closure 로 capture → R.json 의 self 와 충돌 회피 (Pylance reportSelfClsParameterName)
+        response_data = self._kis_response()
+
+        def stub_get(url, headers=None, params=None, timeout=10):
+            class R:
+                status_code = 200
+                def json(self):
+                    return response_data
+            return R()
+
+        monkeypatch.setattr("requests.get", stub_get)
+
+        from types import SimpleNamespace
+        creds = SimpleNamespace(base_url="https://x", app_key="k", app_secret="s")
+        record = fund_mod._fetch_kis_kr("005930.KS", creds, "TOKEN", "2026-04-29")
+
+        assert record is not None
+        assert record["ticker"] == "005930.KS"
+        assert record["date"] == "2026-04-29"
+        assert record["pe_ratio"] == 33.94
+        assert record["price_to_book"] == 3.48
+        # market_cap = 222,500 × 5,846,278,608 = 1,300,796,990,000,000
+        assert record["market_cap"] == pytest.approx(222500 * 5846278608, rel=1e-9)
+
+    def test_fetch_kis_kr_zero_per_pbr_treated_as_null(self, monkeypatch):
+        """KIS 가 0 으로 반환 (예: 우선주 PER) → None 처리 (false positive 방지)."""
+        from types import SimpleNamespace
+
+        from nuri.collectors import fundamental as fund_mod
+
+        response_data = self._kis_response(per=0, pbr=0)
+
+        def stub_get(url, headers=None, params=None, timeout=10):
+            class R:
+                status_code = 200
+                def json(self):
+                    return response_data
+            return R()
+
+        monkeypatch.setattr("requests.get", stub_get)
+        creds = SimpleNamespace(base_url="https://x", app_key="k", app_secret="s")
+        record = fund_mod._fetch_kis_kr("005935.KS", creds, "TOKEN", "2026-04-29")
+
+        # per=0/pbr=0 은 None 으로 — but market_cap 은 여전히 계산됨
+        assert record is not None
+        assert record["pe_ratio"] is None
+        assert record["price_to_book"] is None
+        assert record["market_cap"] is not None
+
+    def test_fetch_kis_kr_http_error_returns_none(self, monkeypatch):
+        """HTTP 500 / 빈 응답 → per-ticker fallback 신호 (None 반환)."""
+        from types import SimpleNamespace
+
+        from nuri.collectors import fundamental as fund_mod
+
+        def stub_get(url, headers=None, params=None, timeout=10):
+            class R:
+                status_code = 500
+                def json(self):
+                    return {}
+            return R()
+
+        monkeypatch.setattr("requests.get", stub_get)
+        creds = SimpleNamespace(base_url="https://x", app_key="k", app_secret="s")
+        assert fund_mod._fetch_kis_kr("005930.KS", creds, "TOKEN", "2026-04-29") is None
+
+    def test_collect_kr_via_kis_no_credentials_returns_empty(self, monkeypatch, db_with_portfolio):
+        """KIS 자격 증명 부재 → 빈 리스트 (caller 가 yfinance fallback)."""
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode: None)
+        c = FundamentalCollector()
+        result = c._collect_kr_via_kis(["005930.KS", "000660.KS"], "2026-04-29")
+        assert result == []
+
+    def test_collect_kr_via_kis_token_failure_returns_empty(self, monkeypatch, db_with_portfolio):
+        """KIS 토큰 발급 실패 → 빈 리스트 (yfinance fallback)."""
+        from types import SimpleNamespace
+
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        creds = SimpleNamespace(base_url="https://x", app_key="k", app_secret="s")
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode: creds)
+        monkeypatch.setattr("nuri.collectors.kis_realtime.get_access_token", lambda c: None)
+
+        c = FundamentalCollector()
+        result = c._collect_kr_via_kis(["005930.KS"], "2026-04-29")
+        assert result == []
+
+    def test_collect_branches_kr_to_kis_us_to_yfinance(self, monkeypatch, db_with_portfolio):
+        """`.KS` → KIS, US → yfinance thread pool. KIS 가 채운 KR ticker 는 yfinance loop skip."""
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        # universe-only (db_with_portfolio fixture 외 추가)
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["005930.KS", "AAPL"])
+
+        # KIS path stub — 005930.KS 정상 응답
+        def stub_kis(self, kr_tickers, today):
+            return [{
+                "ticker": "005930.KS",
+                "date": today,
+                "pe_ratio": 33.94,
+                "price_to_book": 3.48,
+                "market_cap": 1.3e15,
+            }]
+        monkeypatch.setattr(FundamentalCollector, "_collect_kr_via_kis", stub_kis)
+
+        # yfinance path stub — AAPL 만 응답해야 함 (005930.KS 는 KIS 가 처리해 skip)
+        called_yf_tickers = []
+
+        class _FakeTicker:
+            def __init__(self, t):
+                called_yf_tickers.append(t)
+                self.info = {
+                    "regularMarketPrice": 200.0,
+                    "trailingPE": 25.0,
+                    "marketCap": 3e12,
+                }
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker = _FakeTicker
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        results = c.collect(source="universe")
+
+        assert "005930.KS" not in called_yf_tickers, "KIS 가 채운 KR 은 yfinance 가 다시 호출하면 안 됨"
+        assert "AAPL" in called_yf_tickers
+        tickers_in_results = {r["ticker"] for r in results}
+        assert "005930.KS" in tickers_in_results
+        assert "AAPL" in tickers_in_results

--- a/tests/collectors/test_fundamental.py
+++ b/tests/collectors/test_fundamental.py
@@ -531,36 +531,49 @@ class TestKISFundamentalBranch:
         result = c._collect_kr_via_kis(["005930.KS"], "2026-04-29")
         assert result == []
 
-    def test_collect_branches_kr_to_kis_us_to_yfinance(self, monkeypatch, db_with_portfolio):
-        """`.KS` → KIS, US → yfinance thread pool. KIS 가 채운 KR ticker 는 yfinance loop skip."""
+    def test_collect_kis_merge_preserves_yfinance_enrichment(self, monkeypatch, db_with_portfolio):
+        """codex Round 1 P1 회귀 — KIS 가 채운 KR ticker 도 yfinance loop 가 돌아 ROE/growth 보존.
+
+        KIS 의 pe_ratio/price_to_book/market_cap 은 yfinance 값을 override (정확).
+        yfinance 의 roe/revenue_growth/profit_margin/debt_to_equity 는 보존 (KIS 미제공).
+        """
         from nuri.collectors.fundamental import FundamentalCollector
 
         c = FundamentalCollector()
-        # universe-only (db_with_portfolio fixture 외 추가)
         monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["005930.KS", "AAPL"])
 
-        # KIS path stub — 005930.KS 정상 응답
+        # KIS stub — 005930.KS 에 정확한 trailing pe/pbr 제공
         def stub_kis(self, kr_tickers, today):
-            return [{
-                "ticker": "005930.KS",
-                "date": today,
-                "pe_ratio": 33.94,
-                "price_to_book": 3.48,
-                "market_cap": 1.3e15,
-            }]
+            from nuri.collectors.fundamental import _kis_record_skeleton
+            r = _kis_record_skeleton("005930.KS", today)
+            r["pe_ratio"] = 33.94
+            r["price_to_book"] = 3.48
+            r["market_cap"] = 1.3e15
+            return [r]
         monkeypatch.setattr(FundamentalCollector, "_collect_kr_via_kis", stub_kis)
 
-        # yfinance path stub — AAPL 만 응답해야 함 (005930.KS 는 KIS 가 처리해 skip)
+        # yfinance stub — KR 도 yfinance loop 거침 (forward_pe/roe/etc 채움)
         called_yf_tickers = []
 
         class _FakeTicker:
             def __init__(self, t):
                 called_yf_tickers.append(t)
-                self.info = {
-                    "regularMarketPrice": 200.0,
-                    "trailingPE": 25.0,
-                    "marketCap": 3e12,
-                }
+                if t == "005930.KS":
+                    self.info = {
+                        "regularMarketPrice": 222500.0,
+                        "trailingPE": 5.27,             # yfinance forward-derived (misleading per #465)
+                        "priceToBook": None,            # yfinance KR limit
+                        "returnOnEquity": 0.108,        # 10.8% — 보존 대상
+                        "revenueGrowth": 0.238,         # 23.8% — 보존 대상
+                        "profitMargins": 0.133,         # 13.3% — 보존 대상
+                        "debtToEquity": 6.0,            # — 보존 대상
+                    }
+                else:
+                    self.info = {
+                        "regularMarketPrice": 200.0,
+                        "trailingPE": 25.0,
+                        "marketCap": 3e12,
+                    }
 
         mock_yf = MagicMock()
         mock_yf.Ticker = _FakeTicker
@@ -569,8 +582,44 @@ class TestKISFundamentalBranch:
 
         results = c.collect(source="universe")
 
-        assert "005930.KS" not in called_yf_tickers, "KIS 가 채운 KR 은 yfinance 가 다시 호출하면 안 됨"
-        assert "AAPL" in called_yf_tickers
-        tickers_in_results = {r["ticker"] for r in results}
-        assert "005930.KS" in tickers_in_results
-        assert "AAPL" in tickers_in_results
+        # 005930.KS 가 yfinance loop 도 돌았는지 (KIS bypass 회귀 차단)
+        assert "005930.KS" in called_yf_tickers, "KR ticker 가 yfinance loop bypass 되면 ROE/growth 손실"
+
+        # 005930.KS record 검증 — KIS pe/pbr 우선 + yfinance ROE 보존
+        kr_record = next(r for r in results if r["ticker"] == "005930.KS")
+        assert kr_record["pe_ratio"] == 33.94, "KIS trailing PE 가 yfinance 5.27 override"
+        assert kr_record["price_to_book"] == 3.48, "KIS PBR (yfinance None) 채움"
+        assert kr_record["market_cap"] == 1.3e15, "KIS market_cap 우선"
+        # yfinance enrichment 보존 (codex P1)
+        assert kr_record["roe"] == pytest.approx(0.108)
+        assert kr_record["revenue_growth"] == pytest.approx(0.238)
+        assert kr_record["profit_margin"] == pytest.approx(0.133)
+
+    def test_collect_kis_only_record_when_yfinance_fails(self, monkeypatch, db_with_portfolio):
+        """KIS 가 채운 KR ticker 가 yfinance fetch 실패 시 KIS record 단독으로 results 포함."""
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["005930.KS"])
+
+        def stub_kis(self, kr_tickers, today):
+            from nuri.collectors.fundamental import _kis_record_skeleton
+            r = _kis_record_skeleton("005930.KS", today)
+            r["pe_ratio"] = 33.94
+            r["price_to_book"] = 3.48
+            return [r]
+        monkeypatch.setattr(FundamentalCollector, "_collect_kr_via_kis", stub_kis)
+
+        # yfinance fail (info 빈 dict — skipped)
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value = mock_ticker
+        import sys
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        results = c.collect(source="universe")
+        # yfinance 실패에도 KIS-only record 가 살아남아야 함
+        assert len(results) == 1
+        assert results[0]["ticker"] == "005930.KS"
+        assert results[0]["pe_ratio"] == 33.94


### PR DESCRIPTION
## Summary

- Adds KIS Open API \`inquire-price\` (FHKST01010100) integration to \`fundamental.py\` for KR ticker (.KS/.KQ) PER/PBR/market_cap collection
- Closes #465 (KR fundamentals coverage gap — yfinance trailingPE/priceToBook 미제공)
- KR coverage: total 201 / has_pe **0% → 96%** / has_pbr **0% → 96%**
- 가치주 screening (PER ≤ 15 + PBR ≤ 1.5) KR 통과: **0건 → 20건**

## Approach (codex Plan consult verdict A-batched)

Single \`fundamental\` collector with KR sub-batch (KIS sequential) + 전체 yfinance loop + merge step. \`fundamentals\` 테이블 reuse, no schema migration. Single Sunday cron unchanged.

### Why endpoint reuse

\`kis_realtime.py:258 inquire_price_kr()\` 가 이미 같은 endpoint 호출 — OHLCV 만 추출 후 75 fundamentals fields drop. **Live raw probe (2026-04-29 005930)**: per=33.94, pbr=3.48, eps=6,564원, bps=63,997원, lstn_stcn=58.46억주 모두 응답에 포함. 새 endpoint 불필요.

### Merge pattern (codex Round 1 P1 fix)

Initial commit 은 \`kis_collected\` set 으로 yfinance loop 에서 KR skip → ROE/revenue_growth/profit_margin/debt_to_equity 회귀 (fundamental_agent + quality factor + ticker page UI 영향). Round 2 fix:

\`\`\`python
yf_tickers = list(tickers)  # 전체, KR 도 yfinance 거침

# yfinance loop 완료 후 merge:
for record in results:
    kis_data = kis_by_ticker.get(record[\"ticker\"])
    if kis_data:
        for col in (\"pe_ratio\", \"price_to_book\", \"market_cap\"):
            if kis_data.get(col) is not None:
                record[col] = kis_data[col]   # KIS override only these 3
# yfinance fail 한 KR — KIS-only record 보존
\`\`\`

이 pattern 은 #362 FRED merge 와 동일 (codex 이미 승인).

## Live verify (production KIS, 746 universe)

\`\`\`
🇰🇷 KIS 펀더멘탈: ✅ 202 / 203 KR ticker (yfinance loop 가 ROE/margin/growth 보충)
collect total: 739/746 (was 535 in pre-PR universe)

필드별 coverage POST-PR:
  pe_ratio        92.8%   (KIS+yf merge)
  forward_pe      96.2%
  roe             92.0%   (P1 fix — KIS bypass 회귀 차단)
  revenue_growth  95.8%   (P1 fix — KIS bypass 회귀 차단)
  debt_to_equity  89.4%

KR ticker example (005930.KS Samsung):
  KIS:        pe=33.90 / pbr=3.48 / market_cap=₩1,300조
  yfinance:   roe=10.8% / revenue_growth=23.8% / profit_margin=13.3%
  → 모두 동시 보존
\`\`\`

KR 가치주 후보 (PER ≤ 15 + PBR ≤ 1.5):

| Ticker | 종목 | PER | PBR | Cap |
|---|---|---|---|---|
| 015760.KS | 한국전력 | 3.35 | 0.60 | ₩28.7조 |
| 001450.KS | 현대해상 | 2.70 | 0.47 | ₩2.6조 |
| 002380.KS | KCC | 3.20 | 0.52 | ₩4.9조 |
| 088350.KS | 한화생명 | 6.72 | 0.27 | ₩4.3조 |
| 005830.KS | DB손해보험 | 6.83 | 0.96 | ₩11.3조 |

총 20건 — acceptance 5건+ 초과.

## Test (7 new + 19 existing pass)

\`tests/collectors/test_fundamental.py::TestKISFundamentalBranch\`:
1. KIS field mapping (raw payload → pe/pbr/market_cap)
2. per=0/pbr=0 우선주 → None (false positive 방지)
3. HTTP 500 → None (per-ticker fallback 신호)
4. KIS unavailable (no creds) → empty list
5. Token failure → empty list
6. **Merge test (P1 fix lock-in)**: KR ticker 가 yfinance loop 도 거치고, KIS pe/pbr override + yfinance roe/growth 보존
7. yfinance fail 시 KIS-only record 보존

\`autouse fixture _block_kis_live_calls\` 가 기존 18 yfinance test 의 KIS path 차단 → 005930.KS 사용 회귀 안전.

## Codex consult log

- Plan consult — verdict A-batched (single collector / per/pbr+market_cap / single cron)
- Round 1 — GATE FAIL P1: KR yfinance bypass regresses ROE/growth/margin
- Round 2 — GATE PASS: merge pattern (#362 동일) 으로 정확 fix

## Out of scope (별도 PR 후보)

- Override list \`(\"pe_ratio\", \"price_to_book\", \"market_cap\")\` hard-coded — maintainability smell, KIS 가 더 많은 fields 제공 시 정리
- KR dividend yield (KIS 다른 endpoint 필요)
- \`_kis_record_skeleton\` schema introspection (현재 fundamentals 컬럼 hardcoded)

## Test plan

- [x] pytest tests/collectors/test_fundamental.py -q — 26 pass (19 + 7)
- [x] ruff clean
- [x] Live 746 universe collect — 739/746 success, 150s
- [x] KR 005930/000660/015760 PER/PBR/ROE 동시 채워짐 verified
- [x] Codex Plan consult (A-batched)
- [x] Codex Round 1 (FAIL → P1 fix)
- [x] Codex Round 2 (GATE: PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)