### PR TITLE
chore(automation): pre-commit hook + frontend ESLint CI + VS Code workspace settings (#470)

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -187,6 +187,47 @@ jobs:
         if: needs.changes.outputs.run_frontend == 'true'
         run: npm run build
 
+  # Frontend lint (eslint). Phase 1 (#470): errors-only gate; warnings tolerated
+  # while the existing 193 `any`/unused warnings are paid down. Promotion to
+  # `--max-warnings=0` is a separate cleanup PR. Default `npm run lint` already
+  # exits non-zero on errors, so `npm run lint` is sufficient here.
+  frontend-lint:
+    name: Frontend Lint
+    needs: changes
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Guard — require changes to succeed
+        if: needs.changes.result != 'success'
+        working-directory: .
+        run: |
+          echo "::error::changes job did not succeed (result=${{ needs.changes.result }}) — cannot verify gates"
+          exit 1
+
+      - uses: actions/checkout@v6
+
+      - name: Skip notice (no frontend changes)
+        if: needs.changes.outputs.run_frontend != 'true'
+        run: echo "✓ No frontend changes — fast-pass to satisfy required check"
+
+      - uses: actions/setup-node@v6
+        if: needs.changes.outputs.run_frontend == 'true'
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - if: needs.changes.outputs.run_frontend == 'true'
+        run: npm ci
+
+      - name: ESLint (errors-only gate)
+        if: needs.changes.outputs.run_frontend == 'true'
+        run: npm run lint
+
   # ─── Backend ───
 
   backend-lint:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,13 +26,20 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
   },
+  "eslint.workingDirectories": [{ "pattern": "frontend" }],
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
     ["cn\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ setup:
 	bash scripts/setup.sh
 	$(PYTHON) scripts/migrate_db.py
 	$(PYTHON) scripts/import_portfolio.py
+	$(MAKE) setup-hooks
+
+setup-hooks: ## Install repo-tracked git hooks (pre-commit auto-fix). Idempotent.
+	bash scripts/install_hooks.sh
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ brew install uv ta-lib fnm && fnm install 22
 
 # Setup
 git clone https://github.com/researcherhojin/nuri-quant.git && cd nuri-quant
-make setup                                              # backend (uv venv + deps + DB init)
+make setup                                              # backend (uv venv + deps + DB init + git hooks)
 cd frontend && npm ci && cd ..                          # frontend
 cp .env.example .env                                    # API keys (all optional)
 cp config/portfolio.example.yaml config/portfolio.yaml  # your holdings (gitignored)

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Auto-fix lint issues before commit (advisory, not blocking).
+# Installed via `make setup-hooks` → symlink at .git/hooks/pre-commit.
+# Bypass with `git commit --no-verify` (use sparingly).
+#
+# NUL-delimited git output → bash arrays via `read -d ''` keeps things
+# safe for paths-with-spaces and portable across macOS BSD / Linux GNU
+# tooling (no awk/sed -z dependency).
+set -u
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$REPO_ROOT" ] && exit 0
+cd "$REPO_ROOT" || exit 0
+
+py_files=()
+ts_files=()
+ts_rel=()
+
+while IFS= read -r -d '' f; do
+    if [[ "$f" == *.py ]]; then
+        py_files+=("$f")
+    elif [[ "$f" == frontend/* && "$f" =~ \.(ts|tsx|js|jsx|mjs|cjs)$ ]]; then
+        ts_files+=("$f")
+        ts_rel+=("${f#frontend/}")
+    fi
+done < <(git diff --cached --name-only --diff-filter=ACM -z 2>/dev/null)
+
+# Python — ruff auto-fix on staged .py files.
+if [ "${#py_files[@]}" -gt 0 ] && [ -x ".venv/bin/ruff" ]; then
+    .venv/bin/ruff check --fix --exit-zero --quiet "${py_files[@]}" 2>/dev/null || true
+    .venv/bin/ruff format --quiet "${py_files[@]}" 2>/dev/null || true
+    git add -- "${py_files[@]}" 2>/dev/null || true
+fi
+
+# Frontend — eslint auto-fix on staged ts/tsx/js/jsx under frontend/.
+# Skip if frontend/node_modules absent (fresh clone before npm ci).
+if [ "${#ts_files[@]}" -gt 0 ] && [ -d "frontend/node_modules" ]; then
+    (cd frontend && npx --no-install eslint --fix --quiet "${ts_rel[@]}" 2>/dev/null) || true
+    git add -- "${ts_files[@]}" 2>/dev/null || true
+fi
+
+exit 0

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Idempotent installer for repo-tracked git hooks.
+# Symlinks .git/hooks/* → scripts/hooks/* so hook updates ride with the repo.
+# Safe to re-run: replaces existing symlinks, refuses to clobber non-symlink hooks.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_SRC_DIR="$REPO_ROOT/scripts/hooks"
+HOOK_DST_DIR="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$HOOK_SRC_DIR" ]; then
+    echo "error: $HOOK_SRC_DIR missing" >&2
+    exit 1
+fi
+
+mkdir -p "$HOOK_DST_DIR"
+installed=0
+skipped=0
+
+for src in "$HOOK_SRC_DIR"/*; do
+    [ -f "$src" ] || continue
+    name=$(basename "$src")
+    dst="$HOOK_DST_DIR/$name"
+    chmod +x "$src"
+
+    if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -sf "$src" "$dst"
+        echo "  ✓ $name → scripts/hooks/$name"
+        installed=$((installed + 1))
+    else
+        echo "  ⚠ $name exists as regular file — skipped (remove manually to install)"
+        skipped=$((skipped + 1))
+    fi
+done
+
+echo ""
+echo "Installed $installed hook(s), skipped $skipped."
+echo "Bypass any hook with: git commit --no-verify"


### PR DESCRIPTION
Closes #470.

## Summary

PR #469 보면서 사용자가 IDE problems panel 의 lint 경고를 12회 이상 paste 한 사건의 자동화 fix.

3 commits, 3 layers (issue body order):

1. **Pre-commit hook** — `scripts/hooks/pre-commit` + `scripts/install_hooks.sh` + `make setup-hooks`
   - ruff + eslint auto-fix on staged files (advisory, exit 0)
   - Bash arrays + `read -d ''` portable on macOS BSD / Linux GNU (no `-z` extensions)
   - Idempotent symlink installer; refuses to clobber non-symlink hooks
   - Wired into `make setup` for fresh clones
2. **VS Code settings** — `editor.codeActionsOnSave: source.fixAll.eslint` for `[typescript]` + `[typescriptreact]`, `eslint.workingDirectories` → `frontend/`
3. **CI Frontend Lint job** — `npm run lint` errors-only gate, mirrors `backend-lint` pattern (`!cancelled()` + changes guard + `run_frontend` skip notice)

## Phase 1 vs Phase 2

Issue body proposed staged rollout:
- **Phase 1 (this PR)**: errors-only — passes against current 193 warnings / 0 errors
- **Phase 2 (deferred)**: `--max-warnings=0` after the existing `any`/unused warnings are paid down (separate cleanup PR)

## Branch protection follow-up

Not added to `required_status_checks` here — promotion is a manual `gh api` step after the new check name is confirmed on this PR's first run (CLAUDE.md "Branch protection conditional skip trap"). Review once status check name renders.

## Trade-off (documented)

Auto-fix hooks restage modified files via `git add` — this can clobber `git add -p` partial staging. Standard limitation; bypass with `git commit --no-verify`. Documented in hook header.

## Test plan
- [x] `shellcheck scripts/install_hooks.sh scripts/hooks/pre-commit` clean
- [x] `bash scripts/install_hooks.sh` idempotent (symlink replace, refuses regular file clobber)
- [x] Hook smoke test: tmpdir repo, stage `.py`, hook exits 0 (no `.venv` → fail-soft)
- [x] `cd frontend && npm run lint` exit 0 (193 warnings / 0 errors)
- [x] `python -c yaml.safe_load(...)` parses CI workflow OK
- [x] `bash scripts/pre_push_check.sh` PASS (3476 tests, 89% coverage, no privacy leaks)
- [x] `bash scripts/verify_doc_counts.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)