### PR TITLE
test(alerts): close discord_bot.py coverage gap (55% → 100%)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -5,6 +5,7 @@
   "words": [
     "nuri",
     "Nuri",
+    "xyflow",
     "polyfit",
     "elig",
     "premarket",

--- a/tests/alerts/test_discord_bot.py
+++ b/tests/alerts/test_discord_bot.py
@@ -1,4 +1,5 @@
 """Tests for nuri.alerts.discord_bot."""
+
 import asyncio
 from unittest.mock import MagicMock, patch
 
@@ -9,12 +10,14 @@ class TestDiscordBot:
     def test_send_webhook_no_url(self, monkeypatch):
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         from nuri.alerts.discord_bot import send_webhook
+
         result = send_webhook({"title": "test"})
         assert result is False
 
     def test_send_text_no_url(self, monkeypatch):
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         from nuri.alerts.discord_bot import send_webhook_text
+
         result = send_webhook_text("test message")
         assert result is False
 
@@ -23,6 +26,7 @@ class TestDiscordWebhook:
     @patch("nuri.alerts.discord_bot.requests.post")
     def test_send_webhook_success(self, mock_post):
         from nuri.alerts.discord_bot import send_webhook
+
         mock_post.return_value = MagicMock(status_code=200)
         mock_post.return_value.raise_for_status = MagicMock()
         embed = {"title": "Test", "description": "Hello"}
@@ -35,6 +39,7 @@ class TestDiscordWebhook:
     @patch("nuri.alerts.discord_bot.requests.post")
     def test_send_webhook_text_success(self, mock_post):
         from nuri.alerts.discord_bot import send_webhook_text
+
         mock_post.return_value = MagicMock(status_code=200)
         mock_post.return_value.raise_for_status = MagicMock()
         result = send_webhook_text("hello", webhook_url="https://example.com/webhook")
@@ -44,12 +49,14 @@ class TestDiscordWebhook:
 
     def test_send_webhook_no_url(self, monkeypatch):
         from nuri.alerts.discord_bot import send_webhook
+
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         result = send_webhook({"title": "Test"})
         assert result is False
 
     def test_send_webhook_text_no_url(self, monkeypatch):
         from nuri.alerts.discord_bot import send_webhook_text
+
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         result = send_webhook_text("hello")
         assert result is False
@@ -57,6 +64,7 @@ class TestDiscordWebhook:
     @patch("nuri.alerts.discord_bot.requests.post", side_effect=Exception("network error"))
     def test_send_webhook_text_exception(self, mock_post):
         from nuri.alerts.discord_bot import send_webhook_text
+
         with pytest.raises(Exception, match="network error"):
             send_webhook_text("hello", webhook_url="https://example.com/webhook")
 
@@ -64,6 +72,7 @@ class TestDiscordWebhook:
 class TestDiscordBot_R20:
     def test_send_bot_missing_credentials(self, monkeypatch):
         from nuri.alerts.discord_bot import send_bot
+
         monkeypatch.delenv("DISCORD_TOKEN", raising=False)
         monkeypatch.delenv("DISCORD_CHANNEL_ID", raising=False)
         monkeypatch.setenv("DISCORD_TOKEN", "")
@@ -79,6 +88,7 @@ class TestDiscordBot_R20:
 class TestDiscordWebhook_R22:
     def test_send_webhook_no_url(self, monkeypatch):
         from nuri.alerts.discord_bot import send_webhook
+
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         assert send_webhook({"title": "test"}, webhook_url="") is False
 
@@ -95,6 +105,7 @@ class TestDiscordWebhook_R22:
 
     def test_send_webhook_text_no_url(self, monkeypatch):
         from nuri.alerts.discord_bot import send_webhook_text
+
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         assert send_webhook_text("hello", webhook_url="") is False
 
@@ -116,6 +127,7 @@ class TestDiscordBot_R22:
         monkeypatch.setenv("DISCORD_TOKEN", "")
         monkeypatch.setenv("DISCORD_CHANNEL_ID", "0")
         from nuri.alerts.discord_bot import send_bot
+
         try:
             loop = asyncio.get_event_loop()
             if loop.is_closed():
@@ -132,9 +144,20 @@ class TestDiscordMain:
     def test_main_webhook(self, monkeypatch, capsys):
         """Test send_webhook_text with actual webhook URL."""
         import nuri.alerts.discord_bot as mod
-        monkeypatch.setattr(mod, "requests", type("R", (), {
-            "post": staticmethod(lambda url, json, timeout: type("Resp", (), {"raise_for_status": lambda self: None})())
-        })())
+
+        monkeypatch.setattr(
+            mod,
+            "requests",
+            type(
+                "R",
+                (),
+                {
+                    "post": staticmethod(
+                        lambda url, json, timeout: type("Resp", (), {"raise_for_status": lambda self: None})()
+                    )
+                },
+            )(),
+        )
         result = mod.send_webhook_text("Test msg", webhook_url="https://example.com/webhook")
         assert result is True
 
@@ -143,3 +166,255 @@ class TestDiscordMain:
         print("사용법: --webhook --message '메시지'")
         out = capsys.readouterr().out
         assert "사용법" in out
+
+
+class TestSendBotEmbedConstruction:
+    """Exercise nuri/alerts/discord_bot.py lines 63-93 — the actual send_bot body
+    (intents, client, on_ready callback, embed construction, channel.send).
+    Existing TestDiscordBot_R20/_R22 only hit the early-return credential check.
+    """
+
+    def _build_discord_module(self, captured: dict, channel: object | None):
+        """Build a mock `discord` module that records every interaction.
+
+        Returns a SimpleNamespace whose Client() captures the registered
+        on_ready coroutine and invokes it from start() so we exercise the
+        embed-build + channel.send path under pytest's event loop.
+        """
+        import sys
+        from types import SimpleNamespace
+
+        class FakeIntents:
+            @classmethod
+            def default(cls):
+                captured["intents_default_called"] = True
+                return cls()
+
+        class FakeEmbed:
+            def __init__(self, title="", color=0, description=""):
+                captured["embed_init"] = {"title": title, "color": color, "description": description}
+                self.fields: list[dict] = []
+                self.footer_text: str | None = None
+
+            def add_field(self, name, value, inline=False):
+                self.fields.append({"name": name, "value": value, "inline": inline})
+
+            def set_footer(self, text=""):
+                self.footer_text = text
+
+        class FakeClient:
+            def __init__(self, intents):
+                captured["client_init_intents"] = intents
+                self._on_ready = None
+                self.closed = False
+
+            def event(self, fn):
+                # @client.event decorator registers `on_ready`.
+                self._on_ready = fn
+                return fn
+
+            def get_channel(self, channel_id):
+                captured["get_channel_arg"] = channel_id
+                return channel  # Either a fake channel or None.
+
+            async def start(self, token):
+                captured["start_token"] = token
+                # Real discord.py invokes on_ready after gateway connect; we
+                # invoke it directly so the rest of send_bot's body executes.
+                if self._on_ready is not None:
+                    await self._on_ready()
+
+            async def close(self):
+                self.closed = True
+                captured["close_called"] = True
+
+        fake = SimpleNamespace(
+            Intents=FakeIntents,
+            Embed=FakeEmbed,
+            Client=FakeClient,
+        )
+        # send_bot does `import discord` inside the function — patch sys.modules
+        # so the local import resolves to our fake (CLAUDE.md OpenBB pattern).
+        sys.modules["discord"] = fake  # noqa: B003 (test-only)
+        return fake
+
+    @pytest.fixture
+    def _restore_discord(self):
+        import sys
+
+        original = sys.modules.get("discord")
+        yield
+        if original is not None:
+            sys.modules["discord"] = original
+        else:
+            sys.modules.pop("discord", None)
+
+    def test_full_embed_dispatch_happy_path(self, monkeypatch, _restore_discord):
+        """Lines 63-86, 90, 92 — credentials present, channel found, embed sent."""
+        import asyncio
+
+        captured: dict = {}
+        channel_sends: list = []
+
+        class FakeChannel:
+            name = "alerts"
+
+            async def send(self, embed):
+                channel_sends.append(embed)
+
+        self._build_discord_module(captured, FakeChannel())
+        monkeypatch.setenv("DISCORD_TOKEN", "tok-x")
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "12345")
+
+        from nuri.alerts.discord_bot import send_bot
+
+        result = asyncio.run(
+            send_bot(
+                {
+                    "title": "Daily Report",
+                    "color": 0xFF00FF,
+                    "description": "today's PnL",
+                    "fields": [
+                        {"name": "BUY", "value": "TICKER_A", "inline": True},
+                        {"name": "SELL", "value": "TICKER_B"},  # default inline=False
+                    ],
+                    "footer": {"text": "nuri-quant"},
+                }
+            )
+        )
+
+        assert result is True
+        assert captured["intents_default_called"] is True
+        assert captured["start_token"] == "tok-x"
+        assert captured["get_channel_arg"] == 12345
+        assert captured["close_called"] is True
+        assert captured["embed_init"] == {
+            "title": "Daily Report",
+            "color": 0xFF00FF,
+            "description": "today's PnL",
+        }
+        assert len(channel_sends) == 1
+        sent = channel_sends[0]
+        assert sent.fields == [
+            {"name": "BUY", "value": "TICKER_A", "inline": True},
+            {"name": "SELL", "value": "TICKER_B", "inline": False},
+        ]
+        assert sent.footer_text == "nuri-quant"
+
+    def test_embed_defaults_when_keys_missing(self, monkeypatch, _restore_discord):
+        """Lines 71-83 default branches — empty embed_dict still constructs cleanly."""
+        import asyncio
+
+        captured: dict = {}
+        channel_sends: list = []
+
+        class FakeChannel:
+            name = "alerts"
+
+            async def send(self, embed):
+                channel_sends.append(embed)
+
+        self._build_discord_module(captured, FakeChannel())
+        monkeypatch.setenv("DISCORD_TOKEN", "tok-y")
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "999")
+
+        from nuri.alerts.discord_bot import send_bot
+
+        # No fields, no footer — exercise the .get(..., "") + empty-list branches.
+        result = asyncio.run(send_bot({}))
+
+        assert result is True
+        assert captured["embed_init"] == {"title": "", "color": 0x3498DB, "description": ""}
+        sent = channel_sends[0]
+        assert sent.fields == []
+        # No footer key → set_footer never called.
+        assert sent.footer_text is None
+
+    def test_channel_not_found_logs_error(self, monkeypatch, caplog, _restore_discord):
+        """Line 88 — get_channel returns None branch."""
+        import asyncio
+        import logging
+
+        captured: dict = {}
+        self._build_discord_module(captured, None)  # No channel found.
+        monkeypatch.setenv("DISCORD_TOKEN", "tok-z")
+        monkeypatch.setenv("DISCORD_CHANNEL_ID", "404")
+
+        from nuri.alerts.discord_bot import send_bot
+
+        with caplog.at_level(logging.ERROR, logger="nuri.alerts.discord_bot"):
+            result = asyncio.run(send_bot({"title": "x"}))
+
+        assert result is True  # Function still returns True after start() resolves.
+        assert captured["close_called"] is True
+        assert any("404" in rec.message for rec in caplog.records)
+
+
+class TestDiscordMainEntry:
+    """Exercise lines 97-108 — the `if __name__ == '__main__'` block.
+
+    runpy re-executes the module source; tests/CLAUDE.md gotcha "runpy + mock"
+    means we cannot patch nuri.alerts.discord_bot.send_webhook_text (the
+    re-execution rebinds it). Instead we mock requests.post so the actual
+    send_webhook_text body executes during runpy, and observe the side effect.
+    """
+
+    def test_main_webhook_dispatches_to_send_webhook_text(self, monkeypatch):
+        import runpy
+        import sys
+
+        calls: list[dict] = []
+
+        class FakeResp:
+            def raise_for_status(self):
+                return None
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json, "timeout": timeout})
+            return FakeResp()
+
+        # Patch via real `requests` module (re-exec preserves `import requests`).
+        import requests
+
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://example.test/wh")
+        monkeypatch.setattr(sys, "argv", ["nuri.alerts.discord_bot", "--webhook", "--message", "ping"])
+
+        # Force re-execution; pop cached module so module-level code re-runs.
+        sys.modules.pop("nuri.alerts.discord_bot", None)
+        runpy.run_module("nuri.alerts.discord_bot", run_name="__main__")
+
+        assert len(calls) == 1
+        assert calls[0]["url"] == "https://example.test/wh"
+        assert calls[0]["json"] == {"content": "ping"}
+
+    def test_main_without_webhook_prints_usage(self, monkeypatch, capsys):
+        """No --webhook flag → prints two-line usage hint (lines 107-108)."""
+        import runpy
+        import sys
+
+        monkeypatch.setattr(sys, "argv", ["nuri.alerts.discord_bot"])
+        sys.modules.pop("nuri.alerts.discord_bot", None)
+        runpy.run_module("nuri.alerts.discord_bot", run_name="__main__")
+
+        out = capsys.readouterr().out
+        assert "사용법" in out
+        assert "DISCORD_WEBHOOK_URL" in out
+
+
+class TestWebhookExceptionPropagation:
+    """raise_for_status() failure must surface (line 34) — extends existing
+    TestDiscordWebhook::test_send_webhook_text_exception with the embed path."""
+
+    def test_send_webhook_raises_on_http_error(self, monkeypatch):
+        import requests
+
+        from nuri.alerts.discord_bot import send_webhook
+
+        class FakeResp:
+            def raise_for_status(self):
+                raise requests.HTTPError("403 Forbidden")
+
+        monkeypatch.setattr("nuri.alerts.discord_bot.requests.post", lambda *a, **kw: FakeResp())
+        with pytest.raises(requests.HTTPError, match="403"):
+            send_webhook({"title": "x"}, webhook_url="https://example.test/wh")


### PR DESCRIPTION
## Why
PR #469 codecov surfaced `nuri/alerts/discord_bot.py` at **55%** (27/60 stmts uncovered, [Codecov tree link](https://app.codecov.io/gh/researcherhojin/nuri-quant/pull/469#diff-bnVyaS9hbGVydHMvZGlzY29yZF9ib3QucHk=)). Pre-existing gap, not introduced by #469. Existing tests only hit the early-return credential checks in `send_bot`; the actual body (intents/client/on_ready/embed/channel.send, lines 63-93) and the `__main__` entry block (lines 97-108) were never exercised.

## What
6 new tests in 3 classes, no `nuri/` source changes.

| Class | Coverage target | Approach |
|---|---|---|
| `TestSendBotEmbedConstruction` (3) | lines 63-93 | `sys.modules["discord"]` patched with `SimpleNamespace` (CLAUDE.md OpenBB pattern — `import discord` happens inside `send_bot`, so module-level patch fails). `FakeClient` captures the `@client.event`-registered `on_ready` and invokes it from `start()` so embed-build + `channel.send` runs under pytest's event loop. Covers: full embed, default branches (empty embed_dict), `get_channel` returns None. |
| `TestDiscordMainEntry` (2) | lines 97-108 | `runpy.run_module(..., run_name="__main__")`. Per CLAUDE.md "runpy + mock" gotcha, patching the re-executed module's `send_webhook_text` is brittle, so we mock `requests.post` and observe the side effect through the real function. Covers: `--webhook --message` POST + no-flags usage hint. |
| `TestWebhookExceptionPropagation` (1) | line 34 | Extends existing text-message HTTPError test to the embed (`send_webhook`) path's `raise_for_status` branch. |

Also: `xyflow` added to `.cspell.json` (cSpell warned on `package.json:16` `@xyflow/react@12.10.2` dep — legitimate React Flow rebrand).

## Local verify
- `pytest tests/alerts/test_discord_bot.py --cov=nuri.alerts.discord_bot` → **60/60 stmts, 0 misses, 100%** (was 55%). 21 tests pass (was 15).
- `pytest -m "not slow" -n auto` → **3468 pass** (was 3462).
- `verify_doc_counts.sh` → 11/11 pass (no new test files, only test classes).
- `check_privacy_leak.py` → no leaks.
- Pre-commit hook (just shipped in #471) auto-formatted on commit — verified working live.

## Out of scope
Other low-coverage files surfaced by #469 (e.g. `cboe.py` -25 lines deleted) handled in their own PRs. This PR sticks to the file the user pointed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)