### PR TITLE
docs(claude-md): narrow maintenance pass (codex-approved Tier 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,7 @@ nuri/
 - **20 signals + 2 SHADOW, YAML registry**: `config/signals.yaml` drives `signal_backtest.py` (20 actionable) + `market_signals.py` (2 SHADOW, scope `market_wide`). See `docs/ARCHITECTURE.md`.
 - **Regime classifier**: 6 base + 4 special regimes. See `docs/ARCHITECTURE.md`.
 - **External LLM gateway**: `nuri/llm/openai_client.py` is the ONLY external LLM entry point. Direct `import openai` forbidden. `chat_json` (Tier 0 JSON) / `chat_text` (Tier 2 narrative, ZDR-gated). Every call audit-logged to `external_llm_calls` (content never stored). Policy: `docs/STRATEGY.md §4.4.3`.
+- **Provisional vs canonical Learning Memory** (#468, PR #469, 2026-04-28): per-agent precedence `canonical_30d > provisional_21d > default > structurally_unsaturating`. Migration 23 added `outcome_7/14/21d` to `recommendations`. `compute_canonical_weights()` reads `outcome_30d` only; `compute_provisional_weights()` reads `outcome_21d` only — structural separation (no spy-test). Canonical cap `0.30` / provisional cap `0.10` (weaker evidence → conservative). retail/crypto agents marked `structurally_unsaturating` (BUY+SELL emit freq=0). API `/api/learning-memory/readiness` per-agent source list. See STRATEGY §3.9 for design rationale (why 30d canonical / why 21d provisional / why structural separation). **Test:** `tests/trading/agents/test_consensus.py::TestPerAgentPrecedence` (6) + `TestProvisionalLearningMemory` (5) + `TestStructuralSeparation` (3) + `tests/trading/recommend/test_tracker.py::TestOutcomeImmutability` (3) + `TestForwardCloseHelper` (5).
 
 ## Code Conventions
 
@@ -306,6 +307,8 @@ This project uses layered context files. Root files load every session; director
 | `frontend/CLAUDE.md` | Next.js 16, design system, testing gotchas | When editing frontend/ |
 | `tests/CLAUDE.md` | Fixtures, mocks, testing gotchas | When editing tests/ |
 | `config/CLAUDE.md` | YAML structure, change procedures | When editing config/ |
+| `.claude/skills/nuri-harness-debug/` | Harness failure-pattern playbook (case studies, Gotcha-Test Pair protocol detail) | On demand (debugging similar patterns) — STRATEGY §5 directs invocation |
+| `.claude/skills/nuri-siege-audit/` | SIEGE predictivity audit methodology (E4-0b v2 60-month rerun, gate eligibility matrix) | On demand (audit/replay work) — STRATEGY §3.8 directs invocation |
 | `NEXT_SESSION.md` | Session handoff doc — 다음 세션 시작 시 먼저 읽음 | gitignored (personal) |
 | `~/.claude/projects/-Users-ehbebe-workspace-nuri-quant/memory/` | User-scoped auto-memory (`MEMORY.md` index + per-topic files) | Always (cross-conversation, not committed) |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,485 backend tests across 154 files + 917 frontend vitest (67 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,491 backend tests across 154 files + 917 frontend vitest (67 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -260,7 +260,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,485 tests, 154 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,491 tests, 154 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 67 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |


### PR DESCRIPTION
Narrow maintenance pass on root \`CLAUDE.md\` after codex second-opinion consult.

## Why a consult, not a refactor
A broader CLAUDE.md "cleanup" proposal landed (move Gotchas to HARNESS.md, collapse Pipeline Defenses into cross-refs, etc.). Before spending team budget on that I asked codex for a brutal review.

**Codex verdict: 70% performative, 30% load-bearing.** Reasoning (verbatim):
> CLAUDE.md is execution-time guardrail; HARNESS.md is case-study appendix. STRATEGY §5.3.1 explicitly wants trigger + regression-test pairing in CLAUDE.md because that's the file the agent has in front of it while making changes. Moving Gotchas out of CLAUDE.md hurts discoverability for the next session.

So: only Tier 1 (truth + discoverability gaps) ships now. Tier 2/3 deferred.

## Changes (3 edits only)

1. **Key Design Patterns +1 entry** — #468 / STRATEGY §3.9 (Provisional vs canonical Learning Memory). PR #469 (today) was missing from the section. Includes \`**Test:**\` cite per §5.3.1 Gotcha-Test Pair (5 test classes named).
2. **Harness File Map +2 rows** — \`.claude/skills/nuri-harness-debug/\` and \`.claude/skills/nuri-siege-audit/\`. STRATEGY §5 / §3.8 directs invocation but the table didn't list them.
3. **Test count sync** — 3,485 → 3,491 in ARCHITECTURE.md + STRATEGY.md. Stale by 6 tests (PR #475 6 new). \`make verify-doc-counts\` passes (file count covered) but doesn't enforce the absolute test number; \`bash scripts/sync_doc_counts.sh\` did the update.

## Codex explicitly rejected
- Broad Gotchas → HARNESS.md migration. CLAUDE.md is for execution-time triggers + Test cites.
- "25 collectors" change — the doc is already correct (\`ls nuri/collectors/*.py | grep -v __init__/base = 25\`), user memory (21) is the stale one.
- Large-scale formatting refactor on the Key Design Patterns section. Some bullets are intentionally long because the invariants matter at edit time.

## Test plan
- [x] \`bash scripts/verify_doc_counts.sh\` 11/11 pass
- [x] \`bash scripts/check_privacy_leak.py\` clean
- [x] No source code changed (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)