### PR TITLE
test(coverage): sweep — kis_analyst_opinion 84→99% + backtest/engine 0→88%

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,519 backend tests across 155 files + 917 frontend vitest (67 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,547 backend tests across 156 files + 917 frontend vitest (67 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -260,7 +260,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,519 tests, 155 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,547 tests, 156 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 67 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/collectors/test_kis_analyst_opinion.py
+++ b/tests/collectors/test_kis_analyst_opinion.py
@@ -617,3 +617,218 @@ class TestRequestParams:
 
         params = mock_get.call_args_list[0].kwargs["params"]
         assert params["FID_INPUT_ISCD"] == "123456"
+
+
+class TestSmallBranches:
+    """Codecov gap-fillers for short edge-case branches missed by main suite."""
+
+    def test_format_yyyymmdd_non_eight_digit_passthrough(self):
+        from nuri.collectors.kis_analyst_opinion import _format_yyyymmdd
+
+        # Non-8-digit / non-numeric strings pass through unchanged.
+        assert _format_yyyymmdd("2026-04-21") == "2026-04-21"
+        assert _format_yyyymmdd("xxx") == "xxx"
+        assert _format_yyyymmdd("") == ""
+
+    def test_parse_kis_row_non_dict_input(self):
+        from nuri.collectors.kis_analyst_opinion import _parse_kis_row
+
+        # Non-dict input → defensive None return (covers isinstance guard).
+        assert _parse_kis_row("not a dict", "005930.KS") is None  # type: ignore[arg-type]
+        assert _parse_kis_row(None, "005930.KS") is None  # type: ignore[arg-type]
+
+    def test_upsert_empty_records_returns_zero(self, db_with_portfolio):
+        from nuri.collectors.kis_analyst_opinion import _upsert_analyst_ratings
+
+        # Early return path when records list is empty.
+        assert _upsert_analyst_ratings([], db_path=db_with_portfolio) == 0
+
+    def test_collect_no_tickers_returns_empty(self, db_with_portfolio):
+        """No KR tickers in universe → early return without load_credentials."""
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        c = KISAnalystOpinionCollector()
+        with (
+            patch.object(c, "_get_tickers", return_value=[]),
+            patch("nuri.collectors.kis_realtime.load_credentials") as mock_load,
+        ):
+            # collect() called with no tickers kwarg → falls back to _get_tickers,
+            # which we mocked to []. No load_credentials call expected.
+            result = c.collect()
+        assert result == []
+        assert mock_load.call_count == 0
+
+    def test_post_retry_http_failure_classified_failed(self, db_with_portfolio, mock_kis_creds):
+        """Rate-limited then post-retry HTTP non-200 → failed (not empty)."""
+        import json as _json
+
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        rate_limited = _resp({"rt_cd": "1", "msg_cd": "EGW00201", "msg1": "거래건수 초과", "output": []})
+        retry_fail = _resp({}, status=503)
+        with (
+            patch("nuri.collectors.kis_realtime.load_credentials", return_value=mock_kis_creds),
+            patch("nuri.collectors.kis_realtime.get_access_token", return_value="tok"),
+            patch("requests.get", side_effect=[rate_limited, retry_fail]),
+            patch("time.sleep"),
+        ):
+            KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+
+        events = query(
+            "SELECT payload FROM pipeline_events WHERE event_type='kis_analyst_opinion_run'",
+            db_path=db_with_portfolio,
+        )
+        payload = _json.loads(events[0]["payload"])
+        assert payload["failed"] == 1
+        assert payload["empty"] == 0
+
+    def test_output_dict_wrapped_to_list(self, db_with_portfolio, mock_kis_creds):
+        """KIS sometimes returns output as a single dict instead of list — collector wraps it."""
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        # Single row as bare dict (not wrapped in list).
+        body = {
+            "rt_cd": "0",
+            "msg_cd": "MCA00000",
+            "msg1": "정상",
+            "output": _default_rows()[0],  # dict, not list
+        }
+        fake = _resp(body)
+        with (
+            patch("nuri.collectors.kis_realtime.load_credentials", return_value=mock_kis_creds),
+            patch("nuri.collectors.kis_realtime.get_access_token", return_value="tok"),
+            patch("requests.get", return_value=fake),
+            patch("time.sleep"),
+        ):
+            result = KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+        assert len(result) == 1
+        assert result[0]["firm"] == "Test Securities A"
+
+    def test_save_method_upserts(self, db_with_portfolio):
+        """Cover KISAnalystOpinionCollector.save() — small wrapper around _upsert_analyst_ratings."""
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        records = [
+            {
+                "ticker": "005930.KS",
+                "date": "2026-04-21",
+                "firm": "Test Securities A",
+                "to_grade": "매수",
+                "from_grade": None,
+                "action": "init",
+                "target_price": 300000.0,
+            }
+        ]
+        c = KISAnalystOpinionCollector()
+        # save() reaches _upsert_analyst_ratings using default DB_PATH (patched
+        # by db_with_portfolio fixture's monkeypatch).
+        n = c.save(records)
+        assert n == 1
+
+
+class TestDefensiveGuards:
+    """Cover the try/except: pass guards around emit_event so those defensive
+    blocks are exercised at least once. Pipeline-event persistence failure
+    must never propagate up and abort the collector run."""
+
+    def test_no_creds_emit_event_raise_swallowed(self, db_with_portfolio, monkeypatch):
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        def _emit_raise(*a, **kw):
+            raise RuntimeError("emit failed")
+
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode="prod": None)
+        monkeypatch.setattr("nuri.collectors.kis_analyst_opinion.emit_event", _emit_raise)
+        # Should still return [] without raising.
+        result = KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+        assert result == []
+
+    def test_token_fail_emit_event_raise_swallowed(self, db_with_portfolio, mock_kis_creds, monkeypatch):
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        def _emit_raise(*a, **kw):
+            raise RuntimeError("emit failed")
+
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode="prod": mock_kis_creds)
+        monkeypatch.setattr("nuri.collectors.kis_realtime.get_access_token", lambda creds: None)
+        monkeypatch.setattr("nuri.collectors.kis_analyst_opinion.emit_event", _emit_raise)
+        result = KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+        assert result == []
+
+    def test_run_summary_emit_event_raise_swallowed(self, db_with_portfolio, mock_kis_creds, monkeypatch):
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        fake = _resp(_fake_invest_opinion_response())
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode="prod": mock_kis_creds)
+        monkeypatch.setattr("nuri.collectors.kis_realtime.get_access_token", lambda creds: "tok")
+        monkeypatch.setattr(
+            "nuri.collectors.kis_analyst_opinion.emit_event",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("emit failed")),
+        )
+        with patch("requests.get", return_value=fake), patch("time.sleep"):
+            # Even if emit_event raises, the collector returns parsed results.
+            result = KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+        assert len(result) == 2
+
+    def test_truncation_emit_event_raise_swallowed(self, db_with_portfolio, mock_kis_creds, monkeypatch):
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        pages = [_resp(_fake_invest_opinion_response(rows=[_default_rows()[0]]), tr_cont="M") for _ in range(10)]
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode="prod": mock_kis_creds)
+        monkeypatch.setattr("nuri.collectors.kis_realtime.get_access_token", lambda creds: "tok")
+        monkeypatch.setattr(
+            "nuri.collectors.kis_analyst_opinion.emit_event",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("emit failed")),
+        )
+        with patch("requests.get", side_effect=pages), patch("time.sleep"):
+            # Truncation risk emit raises but collector continues.
+            result = KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+        assert len(result) == 10  # 10 pages * 1 row
+
+    def test_safe_str_object_with_failing_str_method(self):
+        """_safe_str returns '' when str(obj) itself raises (defensive)."""
+        from nuri.collectors.kis_analyst_opinion import _safe_str
+
+        class Boom:
+            def __str__(self):
+                raise RuntimeError("str() crash")
+
+        # Triggers `try: str(raw) except: return ''` path.
+        assert _safe_str(Boom()) == ""
+
+    def test_per_row_parse_exception_skipped(self, db_with_portfolio, mock_kis_creds, monkeypatch):
+        """Per-row try/except in collect() catches anything _parse_kis_row leaks."""
+        from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
+
+        fake = _resp(_fake_invest_opinion_response())  # 2 rows
+        monkeypatch.setattr("nuri.collectors.kis_realtime.load_credentials", lambda mode="prod": mock_kis_creds)
+        monkeypatch.setattr("nuri.collectors.kis_realtime.get_access_token", lambda creds: "tok")
+
+        # Patch _parse_kis_row to raise — collect() must skip the row, not crash.
+        def _parse_raise(row, ticker):
+            raise RuntimeError("parse boom")
+
+        monkeypatch.setattr("nuri.collectors.kis_analyst_opinion._parse_kis_row", _parse_raise)
+        with patch("requests.get", return_value=fake), patch("time.sleep"):
+            result = KISAnalystOpinionCollector().collect(tickers=["005930.KS"])
+        assert result == []  # All rows skipped, no crash.
+
+
+class TestMainEntry:
+    """Cover the `if __name__ == "__main__"` argparse block."""
+
+    def test_main_with_ticker_argument(self, db_with_portfolio, mock_kis_creds, monkeypatch):
+        import runpy
+        import sys
+
+        fake = _resp(_fake_invest_opinion_response())
+
+        monkeypatch.setattr(sys, "argv", ["nuri.collectors.kis_analyst_opinion", "--ticker", "005930.KS"])
+        with (
+            patch("nuri.collectors.kis_realtime.load_credentials", return_value=mock_kis_creds),
+            patch("nuri.collectors.kis_realtime.get_access_token", return_value="tok"),
+            patch("requests.get", return_value=fake),
+            patch("time.sleep"),
+        ):
+            sys.modules.pop("nuri.collectors.kis_analyst_opinion", None)
+            runpy.run_module("nuri.collectors.kis_analyst_opinion", run_name="__main__")

--- a/tests/quant/backtest/test_engine.py
+++ b/tests/quant/backtest/test_engine.py
@@ -1,0 +1,292 @@
+"""Tests for nuri.quant.backtest.engine — VectorBT momentum backtest.
+
+Codex Plan consult v1 (2026-04-28) — focus on signal-construction correctness,
+not just line coverage. Boundary at vbt.Portfolio.from_signals (mocked) so we
+test our own logic, not vectorbt internals.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+# ──────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────
+
+
+def _make_prices_df(
+    tickers: list[str] | None = None,
+    n_days: int = 60,
+    start_date: str = "2025-01-01",
+) -> pd.DataFrame:
+    """Build a long-format prices DataFrame in the shape `query_df` returns."""
+    tickers = tickers or ["AAPL", "MSFT", "NVDA", "TSLA", "GOOGL"]
+    dates = pd.date_range(start_date, periods=n_days, freq="B")
+    rows = []
+    for i, t in enumerate(tickers):
+        base = 100 + i * 50
+        for j, d in enumerate(dates):
+            rows.append({"ticker": t, "date": d.strftime("%Y-%m-%d"), "close": base + j * 0.5})
+    return pd.DataFrame(rows)
+
+
+def _make_stub_portfolio(stats_dict: dict | None = None) -> MagicMock:
+    """Build a vbt.Portfolio mock with .stats() and .returns()."""
+    pf = MagicMock()
+    stats_dict = stats_dict or {
+        "Total Return [%]": 12.5,
+        "Sharpe Ratio": 1.4,
+        "Max Drawdown [%]": -8.2,
+        "Win Rate [%]": 62.0,
+        "Total Trades": 15,
+    }
+    pf.stats.return_value = pd.Series(stats_dict)
+    pf.returns.return_value = pd.Series(
+        [0.001 * (i % 10 - 5) for i in range(20)],
+        index=pd.date_range("2025-01-01", periods=20, freq="B"),
+    )
+    return pf
+
+
+# ──────────────────────────────────────────────────────────────
+# Empty / boundary input → empty dict
+# ──────────────────────────────────────────────────────────────
+
+
+class TestEmptyInputs:
+    def test_empty_prices_returns_empty_dict(self):
+        from nuri.quant.backtest import engine
+
+        with patch.object(engine, "query_df", return_value=pd.DataFrame(columns=["ticker", "date", "close"])):
+            result = engine.run_momentum_backtest()
+        assert result == {}
+
+    def test_kr_only_universe_returns_empty_dict(self):
+        """All `.KS` tickers are filtered out (currency-mixing guard)."""
+        from nuri.quant.backtest import engine
+
+        kr_only = _make_prices_df(tickers=["005930.KS", "000660.KS", "035420.KS"])
+        with patch.object(engine, "query_df", return_value=kr_only):
+            result = engine.run_momentum_backtest()
+        assert result == {}
+
+    def test_insufficient_history_returns_empty_dict(self):
+        """<20 rows after KR filter → returns {}."""
+        from nuri.quant.backtest import engine
+
+        # 10 days only
+        df = _make_prices_df(tickers=["AAPL", "MSFT"], n_days=10)
+        with patch.object(engine, "query_df", return_value=df):
+            result = engine.run_momentum_backtest()
+        assert result == {}
+
+
+# ──────────────────────────────────────────────────────────────
+# Happy path + signal-construction (codex Plan v1 critical test)
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stubbed_quantstats():
+    """Stub quantstats.reports.html so happy-path tests don't write real tearsheet HTML
+    (codex Round 1 review: real seaborn warnings + data/exports artifact noise)."""
+    import sys
+
+    fake_qs = MagicMock()
+    fake_qs.reports.html.return_value = None
+    with patch.dict(sys.modules, {"quantstats": fake_qs}):
+        yield fake_qs
+
+
+class TestHappyPath:
+    def test_returns_metrics_dict_with_expected_keys_and_types(self, stubbed_quantstats):
+        """Happy path → dict with strategy/period/total_return_pct/sharpe/MDD/win_rate/trades."""
+        from nuri.quant.backtest import engine
+
+        prices = _make_prices_df(n_days=60)
+        pf = _make_stub_portfolio()
+        with (
+            patch.object(engine, "query_df", return_value=prices),
+            patch.object(engine.vbt.Portfolio, "from_signals", return_value=pf),
+        ):
+            result = engine.run_momentum_backtest(period="3mo", top_n=3, rebalance_days=20)
+
+        assert result["strategy"] == "Momentum Top-3"
+        assert result["period"] == "3mo"
+        assert result["rebalance_days"] == 20
+        assert result["total_return_pct"] == 12.5
+        assert result["sharpe_ratio"] == 1.4
+        assert result["max_drawdown_pct"] == -8.2
+        assert result["win_rate_pct"] == 62.0
+        assert result["total_trades"] == 15
+
+    def test_from_signals_called_with_correct_signal_matrices(self, stubbed_quantstats):
+        """Codex Round 1 review: prove the contract by computing exact expected
+        rebalance indices AND exact top-N winners, then assert equality row-by-row.
+
+        Engine logic (engine.py:60-77):
+            lookback = min(rebalance_days, max(5, len(pivot)//4))
+            momentum = pivot.pct_change(lookback)
+            for i in range(lookback, len(pivot), rebalance_days):
+                exits.iloc[i] = True
+                top_tickers = momentum.iloc[i].nlargest(top_n).index
+                entries.loc[..., top_tickers] = True
+
+        We construct prices with KNOWN momentum so we can compute expected
+        winners deterministically without reimplementing the engine.
+        """
+        from nuri.quant.backtest import engine
+
+        # 5 US + 1 KR. KR must be filtered.
+        # Each ticker has constant linear growth; growth slope determines momentum rank.
+        # Slopes: AAPL=0.5/d, MSFT=1.0/d, NVDA=2.0/d, TSLA=3.0/d, GOOGL=4.0/d.
+        # → momentum (pct_change over lookback) ordering: GOOGL > TSLA > NVDA > MSFT > AAPL.
+        # Top-3 winners every rebalance: {GOOGL, TSLA, NVDA}.
+        n_days = 80
+        dates = pd.date_range("2025-01-01", periods=n_days, freq="B")
+        slopes = {"AAPL": 0.5, "MSFT": 1.0, "NVDA": 2.0, "TSLA": 3.0, "GOOGL": 4.0}
+        rows = []
+        for t, slope in slopes.items():
+            base = 100.0
+            for j, d in enumerate(dates):
+                rows.append({"ticker": t, "date": d.strftime("%Y-%m-%d"), "close": base + j * slope})
+        # Add KR ticker that should be filtered.
+        for j, d in enumerate(dates):
+            rows.append({"ticker": "005930.KS", "date": d.strftime("%Y-%m-%d"), "close": 60000 + j * 100})
+        prices = pd.DataFrame(rows)
+
+        pf = _make_stub_portfolio()
+        with (
+            patch.object(engine, "query_df", return_value=prices),
+            patch.object(engine.vbt.Portfolio, "from_signals", return_value=pf) as mock_from_signals,
+        ):
+            engine.run_momentum_backtest(period="3mo", top_n=3, rebalance_days=20)
+
+        assert mock_from_signals.call_count == 1
+        call_kwargs = mock_from_signals.call_args.kwargs
+        close_df = call_kwargs["close"]
+        entries_df = call_kwargs["entries"]
+        exits_df = call_kwargs["exits"]
+
+        # ── KR exclusion ──
+        assert "005930.KS" not in close_df.columns
+        assert set(close_df.columns) == {"AAPL", "MSFT", "NVDA", "TSLA", "GOOGL"}
+
+        # ── Shape alignment ──
+        assert entries_df.shape == close_df.shape == (n_days, 5)
+        assert exits_df.shape == close_df.shape
+
+        # ── Compute EXPECTED rebalance indices ──
+        # lookback = min(20, max(5, 80 // 4)) = min(20, 20) = 20
+        # range(lookback, len, rebalance) = range(20, 80, 20) = [20, 40, 60]
+        expected_rebalance_indices = [20, 40, 60]
+
+        # ── Verify exits matrix: ONLY rebalance rows are all-True ──
+        for i in range(n_days):
+            row = exits_df.iloc[i]
+            if i in expected_rebalance_indices:
+                assert row.all(), f"Row {i} should be a rebalance row (all-True exits)"
+            else:
+                assert not row.any(), f"Row {i} should be False (non-rebalance)"
+
+        # ── Verify entries matrix: only {GOOGL, TSLA, NVDA} True at rebalance rows, else False ──
+        expected_winners = {"GOOGL", "TSLA", "NVDA"}
+        expected_losers = {"AAPL", "MSFT"}
+        for i in range(n_days):
+            row = entries_df.iloc[i]
+            if i in expected_rebalance_indices:
+                truthies = set(row.index[row].tolist())
+                assert truthies == expected_winners, (
+                    f"Row {i}: expected entries True for {expected_winners}, got {truthies}"
+                )
+                # Losers explicitly False.
+                for loser in expected_losers:
+                    assert not row[loser], f"Row {i} loser {loser} should be False"
+            else:
+                assert not row.any(), f"Non-rebalance row {i} should be all-False entries"
+
+        # ── Sizing arguments ──
+        assert call_kwargs["size"] == 100000 / 3
+        assert call_kwargs["size_type"] == "value"
+        assert call_kwargs["init_cash"] == 100000
+        assert call_kwargs["freq"] == "1D"
+
+    def test_quantstats_exception_does_not_crash_backtest(self):
+        """Tear sheet generation failure must not break the metrics return path."""
+        from nuri.quant.backtest import engine
+
+        prices = _make_prices_df(n_days=60)
+        pf = _make_stub_portfolio()
+
+        # Patch quantstats import inside the function via sys.modules.
+        import sys
+
+        fake_qs = MagicMock()
+        fake_qs.reports.html.side_effect = RuntimeError("tearsheet boom")
+        with (
+            patch.object(engine, "query_df", return_value=prices),
+            patch.object(engine.vbt.Portfolio, "from_signals", return_value=pf),
+            patch.dict(sys.modules, {"quantstats": fake_qs}),
+        ):
+            # Must not raise; metrics dict still returned.
+            result = engine.run_momentum_backtest(top_n=3)
+        assert result["total_return_pct"] == 12.5
+        assert result["strategy"] == "Momentum Top-3"
+
+
+# ──────────────────────────────────────────────────────────────
+# print_backtest
+# ──────────────────────────────────────────────────────────────
+
+
+class TestPrintBacktest:
+    def test_empty_dict_prints_no_data_message(self, capsys):
+        from nuri.quant.backtest.engine import print_backtest
+
+        print_backtest({})
+        out = capsys.readouterr().out
+        assert "백테스트 데이터 없음" in out
+
+    def test_full_dict_prints_all_metrics(self, capsys):
+        from nuri.quant.backtest.engine import print_backtest
+
+        result = {
+            "strategy": "Momentum Top-5",
+            "period": "1y",
+            "rebalance_days": 20,
+            "total_return_pct": 18.34,
+            "sharpe_ratio": 1.62,
+            "max_drawdown_pct": -12.4,
+            "win_rate_pct": 58.3,
+            "total_trades": 27,
+        }
+        print_backtest(result)
+        out = capsys.readouterr().out
+        # Verify each metric label and value appears.
+        assert "Momentum Top-5" in out
+        assert "+18.34%" in out
+        assert "1.62" in out
+        assert "-12.40%" in out
+        assert "58.3%" in out
+        assert "27" in out
+
+
+# ──────────────────────────────────────────────────────────────
+# Corner case (codex)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestCornerCases:
+    def test_top_n_zero_raises_zero_division(self):
+        """Codex flagged: top_n=0 → ZeroDivisionError on size calc.
+
+        Existing code does NOT guard against this — locking the current
+        behavior so a future change doesn't silently swallow the divide-by-zero.
+        """
+        from nuri.quant.backtest import engine
+
+        prices = _make_prices_df(n_days=60)
+        with patch.object(engine, "query_df", return_value=prices):
+            with pytest.raises(ZeroDivisionError):
+                engine.run_momentum_backtest(top_n=0)


### PR DESCRIPTION
Coverage triage sweep follow-up. 2 files lifted from low/zero coverage with codex Plan + Review at each step.

## Files

| File | Before | After | Tests added |
|---|---|---|---|
| nuri/collectors/kis_analyst_opinion.py | 84% (Codecov post-#477) | **99%** | 14 |
| nuri/quant/backtest/engine.py | **0%** | **88%** | 9 |

## What changed
- **0 source code changes**. Tests only.
- New: tests/quant/backtest/test_engine.py (9 tests, 4 classes)
- Extended: tests/collectors/test_kis_analyst_opinion.py (33 → 47 tests, 3 new classes)

## Discipline
- Codex Plan consult on backtest/engine → **GATE FAIL** → adopted 7-test plan with signal-construction focus over line coverage. Codex rejected test_main_dispatch as low-value; promoted test_from_signals_called_with_correct_signal_matrices as the bug catcher.
- Codex Review Round 1 on backtest tests → **GATE FAIL** on cardinality-only assertions. Rewrote critical test with deterministic equality (synthetic slopes → predictable momentum ranking, exact rebalance indices [20, 40, 60], exact top-3 winners {GOOGL, TSLA, NVDA}, explicit losers False, no entry/exit leakage on non-rebalance rows, exact sizing args). Stubs quantstats so happy-path tests don't write tearsheet HTML.
- Codex Review Round 2 → **GATE PASS** ("No findings").

## kis_analyst_opinion gap detail
- 7 small-branch tests (defensive parse paths, post-retry failure classification, output-as-dict wrap, save() wrapper).
- 6 defensive-guard tests (try/except around emit_event for 4 paths, _safe_str __str__ RuntimeError, per-row parse exception).
- 1 runpy __main__ test.
- Remaining uncovered: lines 269-270 (tqdm ImportError, env-dependent).

## backtest/engine.py uncovered
Lines 69 (defensive break) + 144-155 (__main__ argparse, codex explicitly skipped as low-value).

## Test plan
- [x] pytest tests/quant/backtest/test_engine.py → 9/9
- [x] pytest tests/collectors/test_kis_analyst_opinion.py → 47/47
- [x] Full fast suite 3547/3547 (was 3491)
- [x] kis_analyst 99% / backtest engine 88% local coverage
- [x] ruff clean / verify_doc_counts 11/11
- [x] 0 source changes (tests-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)