### PR TITLE
docs(policy): canonicalize policy duplication (PR 3/5)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -612,7 +612,8 @@
     "SOXS",
     "SOXL",
     "sizeup",
-    "deferable"
+    "deferable",
+    "unconfigured"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/README.md
+++ b/README.md
@@ -171,35 +171,17 @@ make deploy-mini
 
 ## Investment Rules
 
-Defined in `config/rules.yaml` and loaded via `nuri/core/rules.py`. Sources: O'Neil (CAN SLIM), Minervini (SEPA), Shefrin & Statman (1985, 처분효과 / disposition effect).
+Rules live in `config/rules.yaml` (loaded via `nuri/core/rules.py`); code never hardcodes them. Sources: O'Neil (CAN SLIM), Minervini (SEPA), Shefrin & Statman (1985, 처분효과 / disposition effect).
 
-### Account strategy profiles
+| Strategy | Stop-loss | Risk profile |
+|----------|-----------|-------|
+| `core` | -7% | Default — strict O'Neil discipline |
+| `active` | -10% | Cut losses early, auto-trailing-stop arms at +15% |
+| `swing` | -15% | Short-term 5–20d rotations |
+| `long_term` | -20% | Buy-and-hold ETFs |
+| `pension` | -30% | Long-horizon retirement allocations |
 
-Each account in `config/portfolio.yaml` selects one strategy via the `strategy` field. Stricter strategies cut losses earlier and limit concentration; looser strategies allow winners to grow.
-
-| Strategy | Stop-Loss | Max Single Position | Notes |
-|----------|-----------|---------------------|-------|
-| `core` | -7% | 15% | Default. Strict O'Neil-style discipline |
-| `active` | -10% | 25% | + `trailing_stop_arm: 15` — trailing stop auto-arms at +15% to protect winners |
-| `swing` | -15% | 30% | Short-term rotations only |
-| `long_term` | -20% | 25% | Buy-and-hold ETFs |
-| `pension` | -30% | 40% | Long-horizon retirement allocations |
-
-### Take-profit by stock type
-
-Each ticker is tagged growth/value via `config/stock_types.yaml`. Take-profit and trailing-stop levels apply per type.
-
-| Type | 1st Target | 2nd Target | Trailing |
-|------|-----------|-----------|----------|
-| Growth | +20% (sell 50%) | +40% (sell 25%) | -15% from HWM |
-| Value | +15% (sell 50%) | +30% (sell 25%) | -15% from HWM |
-
-### Hard gates (always-on, no override)
-
-- **VIX > 30** → new buys blocked
-- **execution_priority** → stop-loss → take-profit → trailing → new-buy (loss largest first)
-- **Buy checklist** → TipRanks ≥ Moderate Buy · superinvestors ≥ 3 · PE < 100 · revenue > $0 · multi-factor top 50%
-- **SIEGE v2 gate** → 1 error-grade failure = REJECTED, no manual override (conditions count varies per asset-class expansion)
+Take-profit ladders (growth: +20% / +40% / -15% trailing; value: +15% / +30% / -15%) and hard gates (VIX > 30 blocks new buys, SIEGE v2 certification rejects on any error-grade gate fail) apply on top. Full tables with per-class thresholds and the full rationale: [`docs/STRATEGY.md §3.4-§3.5, §6`](docs/STRATEGY.md) and [`config/rules.yaml`](config/rules.yaml).
 
 ## References
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -24,17 +24,19 @@
 4. Commit the YAML change **separately** from code changes when possible — makes diffs easier to review and bisect.
 5. If you're also changing a Python-exposed constant (e.g. `STOCK_STOP_LOSS`), update the loader in `nuri/core/` AND the callers. Don't silently leave YAML and code out of sync.
 
-## Account strategy profiles (authoritative in `rules.yaml`)
+## Account strategy profiles
 
-| Strategy | stop_loss | max_single_position | max_sector_exposure | Extra |
-|----------|-----------|---------------------|---------------------|-------|
-| `core` | -7% | 15% | 35% | Default |
-| `active` | -10% | 25% | 45% | `trailing_stop_arm: 15` (auto-arm trailing stop at +15%) |
-| `swing` | -15% | 30% | 50% | — |
-| `long_term` | -20% | 25% | 50% | — |
-| `pension` | -30% | 40% | 60% | — |
+5 profiles defined; each `portfolio.yaml` account selects via the `strategy:` field; default = `core`. Cognitive map only (no values — full table is canonical in `rules.yaml account_strategies` + `docs/STRATEGY.md §3.5`):
 
-Each `portfolio.yaml` account chooses via `strategy:` field. Default = `core`. Cross-referenced in `docs/STRATEGY.md §3.5`.
+| Strategy | Risk profile |
+|----------|--------------|
+| `core` | Strict O'Neil discipline (default) |
+| `active` | Cut losses early, ride winners (auto-trailing) |
+| `swing` | Short-term rotations |
+| `long_term` | Buy-and-hold ETFs |
+| `pension` | Long-horizon retirement allocations |
+
+Editing a value? → `rules.yaml`. Editing rationale / adding a new strategy? → `STRATEGY.md §3.5` first, then YAML.
 
 ## Schema landmarks
 

--- a/nuri/trading/engine/CLAUDE.md
+++ b/nuri/trading/engine/CLAUDE.md
@@ -1,59 +1,28 @@
 # nuri/trading/engine/ — SIEGE Gated Execution
 
-## SIEGE v2 Architecture (2026-04-13~)
+Implementation pointer for SIEGE v2 (3-D certification: Account × Asset Class × Execution Market). Canonical specs live elsewhere — this file documents only what's specific to this directory's implementation.
 
-v2는 3차원 인증 모델: **Account(계좌 전략) × Asset Class(노출 기준) × Execution Market(실행 시장)**. 상세 설계: `docs/SIEGE_V2.md`.
+## Canonical references
 
-### 원본 SIEGE 생태계 반영 (nutshells3)
-- **Gate 정책은 `config/rules.yaml`의 `siege_gates` 섹션** — 코드에 임계값 하드코딩 금지 (§2.2)
-- **자산 클래스별 gate**: us_equity(SPY/VIX), kr_equity(KOSPI/USD-KRW), commodity(GC=F), bond(TLT), kr_index(KOSPI)
-- **계좌별 전략**: `account_strategies`의 stop_loss/position_limit이 gate에 자동 적용
-- **Evidence 추적**: 각 gate 결과에 증거(source, value, threshold, policy_ref) 연결 (OAE 패턴)
+- **Gate spec (full)** — `docs/SIEGE_V2.md` — 11~30+ variable conditions, asset-class per-expansion logic, evidence tracking.
+- **Canonical condition table** — `docs/STRATEGY.md §6` — base + per-asset-class conditions with grades + thresholds.
+- **Confidence scoring formula** — `docs/STRATEGY.md §3.3`. Includes Learning-Memory `drift_multiplier`, conflict penalty, regime-fit, VIX gate composition. Phase 4 (safeslice — Wilson CI + witness cliff) replacement is queued; until then the formula in §3.3 is the live one. **Do not duplicate the formula here.**
+- **Action-axis split** (`alpha_action` vs `portfolio_action`, PR A #429) — `nuri/core/axis.py` (helpers) + `docs/STRATEGY.md §3.7`. Engine emits both; concentration / sector / leverage violations route to `portfolio_action=REBALANCE` only — never urgent SELL.
 
-## Confidence Scoring Formula
+## Engine-specific implementation notes
 
-```
-base = regime_win_rate * 60% + profit_factor * 40%
-     * drift_multiplier (0.3 ~ 1.1)        <- Learning Memory
-     * conflict_penalty (0.5x if high)      <- Conflict Detection
-     * regime_fit_penalty (0.4x if avoid)    <- Strategy Map
-     * position_penalty (0.3x if minimal)    <- Regime position sizing
-     * vix_gate (0x if blocked, 0.5x caution)
-```
+These are operational details unique to this directory; the canonical sources above own the rules themselves.
 
-Phase 4 (safeslice 패턴): `drift_multiplier`를 통계적 신뢰 구간(Wilson CI + witness cliff)으로 대체 예정.
-
-## SIEGE Gate Specification (v2)
-
-All recommendations must pass. 1 error-grade failure = REJECTED. `Certificate.certified` = error severity 0건 기준.
-
-**v2 expansion (#248, PR #312)**: Gate 5/7/8 은 portfolio 를 `asset_class` 로 group
-한 뒤 per-class 정책 (`config/rules.yaml` `siege_gates`) 적용. 따라서 실행 시 실제
-`total_conditions` 는 portfolio 구성에 따라 **11 ~ 30+ 가변**. 예: US + KR + ETF
-혼합 포트폴리오면 us_equity/kr_equity/kr_index/commodity/bond 5 class × 3 gate =
-15 + 비asset 8 = 23 condition 발행. secondary spillover 지표 (예: KR 보유 시 VIX
-spillover) 는 추가 warning.
-
-| # | Condition | Grade | Threshold | v2 변경 |
-|---|-----------|-------|-----------|---------|
-| 1 | position_limit | error | Per-account strategy | 계좌별 + 전체 이중 체크 |
-| 2 | sector_limit | error | Per-account strategy | 계좌별 전략 기준 |
-| 3 | stop_loss_growth | error | Per-account strategy | 기존 유지 |
-| 4 | stop_loss_value | error | Per-account strategy | 기존 유지 |
-| 5 | data_fresh | warning | **Per-asset-class** primary + secondary | ✅ 구현 (#312): us=SPY / kr_equity=KOSPI+[SPY spillover] / kr_index=KOSPI+[SPY] / commodity=GC=F / bond=TLT |
-| 6 | leverage_ban | error | No TSLL/TQQQ etc. | 기존 유지 |
-| 7 | volatility_gate (구 vix_gate) | warning | **Per-asset-class** primary + secondary | ✅ 구현 (#312): us=VIX / kr_equity=USD/KRW_3d+[VIX] / kr_index=KOSPI_3d+[USD/KRW] / commodity=gold_3d |
-| 8 | external_data | warning | **Per-asset-class** threshold + ticker filter | ✅ 구현 (#312): us ≥ 10/3, kr_equity ≥ 5/2 (ticker IN 쿼리로 실제 카운트) |
-| 9 | conflict_free | warning | No BUY/SELL conflict | 기존 유지 |
-| 10 | drift_safe | warning | No critical drift | 기존 유지 |
-| 11 | macro_event_alignment | warning | \|event_score\| >= 10 alert | 기존 유지 (asset-class matrix 는 별도 PR 예정) |
-
-**Legacy fallback**: empty portfolio 또는 `siege_gates` 설정 부재 시 Gate 5/7/8 은
-구 SPY/VIX 단일 체크로 안전하게 돌아감.
+- **Gate policy lives in `config/rules.yaml siege_gates`** — code reads YAML, never hardcodes thresholds (§2.2).
+- **v2 expansion**: gates `data_fresh` / `volatility_gate` / `external_data` group portfolio holdings by `asset_class` and apply per-class policy from `siege_gates.asset_classes.<class>`. Result: `total_conditions` is **11–30+ variable** depending on portfolio composition. A mixed US + KR + ETF portfolio expands to ~23 conditions; an empty / unconfigured portfolio falls back to legacy SPY/VIX single-check.
+- **Severity at a glance** — useful when triaging a `certify()` failure without bouncing to STRATEGY §6: error-grade gates are `position_limit` / `sector_limit` / `stop_loss_growth` / `stop_loss_value` / `leverage_ban` (any single fail → REJECTED). Warning-grade gates (do not reject, surface only) are `data_fresh` / `volatility_gate` / `external_data` / `conflict_free` / `drift_safe` / `macro_event_alignment`. Full table with per-class thresholds: `docs/STRATEGY.md §6`.
+- **Account-strategy injection**: `account_strategies.<strategy>` (`stop_loss` / `per_position_max` / `max_sector_exposure`) is read by `_check_position_limits` / `_check_sector_limit` / `_check_stop_loss` per holding row. Strategy is determined by the holding's `account` column joined with `portfolio.yaml accounts.<account>.strategy`.
+- **Evidence record per gate** — every condition produces `(source, value, threshold, policy_ref)` for OAE traceability and persistence into the `certifications` table (E4-0a, PR #410).
+- **Snapshot invariant**: `CertSnapshot` ContextVar threads `(regime, portfolio_df, portfolio_raw, portfolio_hash, portfolio_error)` through all gate internals — single DB read derives the hash that all downstream consumers see. Any new gate must read from the snapshot, not re-fetch.
 
 ## Execution Priority
 
-Mechanical ordering: `stop_loss -> take_profit -> trailing_stop_set -> new_buy`
-- Within stop_loss: sort by loss% desc (biggest loss first)
-- Within take_profit: sort by excess% desc (biggest winner first)
-- Rationale: declining momentum loses more per hour delayed; rising momentum is forgiving
+Mechanical ordering when emitting actions: `stop_loss → take_profit → trailing_stop_set → new_buy`.
+- Within `stop_loss`: sort by `loss%` descending (biggest loss first — bleeding stops first).
+- Within `take_profit`: sort by `excess%` descending (biggest winner first — lock in gains).
+- Rationale: declining momentum loses more per hour delayed; rising momentum is more forgiving. Codified in `nuri/trading/engine/execution_priority.py` (or its caller).


### PR DESCRIPTION
## Summary

PR 3 of 5 in doc refactor sequence (codex Plan consult 2026-04-29). Scope: **R3 policy cluster** — single PR per codex guidance (*"Do not split into three tiny PRs"*).

Removes documentation duplication for 4 policy facts using `docs/SOURCE_OF_TRUTH.md` (PR #483) as the authoritative ownership map.

## Net change

| File | Before | After | Delta |
|------|--------|-------|-------|
| `nuri/trading/engine/CLAUDE.md` | 60 | 32 | -47% |
| `config/CLAUDE.md` | 86 | 80 | -7% (table replaced) |
| `README.md` Investment Rules section | 30 lines | 14 lines | -53% |
| `.cspell.json` | — | +1 word | (`unconfigured`) |

Total: -91 / +45 lines (-46 net). 4 files modified.

## Dedups applied (per SOURCE_OF_TRUTH "Forbidden in" column)

### 1. `nuri/trading/engine/CLAUDE.md`

- **Removed**: 7-line verbatim Confidence Scoring Formula (was duplicate of `STRATEGY §3.3`); 25-line SIEGE Gate Specification 11-condition table (was duplicate of `STRATEGY §6` + `SIEGE_V2.md`).
- **Added**: Canonical references section (4 pointer rows); Engine-specific implementation notes (YAML-driven gates, v2 expansion, account-strategy injection, evidence record, CertSnapshot ContextVar invariant); 1-line severity-at-a-glance summary (5 error / 6 warning gate names, no thresholds).
- **Kept**: Execution Priority (engine-impl-specific).

### 2. `config/CLAUDE.md`

- **Removed**: full data table (stop_loss / max_single_position / max_sector_exposure / Extra columns × 5 strategies).
- **Replaced with**: cognitive-map table (Strategy + 1-keyword Risk profile, no numeric values) + canonical pointer to `rules.yaml account_strategies` + `STRATEGY §3.5`.

### 3. `README.md` Investment Rules section

- **Removed**: full Account strategy profiles 5-row table; Take-profit by stock type 2-row table; Hard gates 4-bullet list.
- **Replaced with**: 5-row Stop-loss + Risk-profile table (OSS visitor at-a-glance) + take-profit ladder + hard-gate prose summary + canonical pointers.

### 4. `.cspell.json`

Added `unconfigured` (legitimate English word, was triggered by IDE warning).

## Independent review (local Qwen3.5-122B, codex unavailable)

GATE initial: FAIL. After fixes applied: PASS.

3 valid Qwen R1 edits applied (Q1 / Q2 / Q3 — all argued for minimum cognitive-map preservation, balancing dedup with local-context-overhead concern):
1. **Q1 engine trim**: original was TOO_MUCH (only paragraphs, no severity hint) → added 1-line "5 error / 6 warning gate names" summary
2. **Q2 config trim**: original was TOO_LITTLE (only profile names) → added 5-row cognitive-map table (Strategy + Risk profile)
3. **Q3 README OSS**: original was NO (link-only) → added 5-row Stop-loss + Risk profile table for at-a-glance scanning

Q5 audit for additional dedups: `agents/CLAUDE.md`, `AGENTS.md`, `STRATEGY §6` checked — no additional policy duplication found.

## Test plan

- [x] privacy scan PASS
- [x] doc-counts 11/11 PASS
- [x] All canonical sources still complete (STRATEGY §3.3 / §6 / §3.5, SIEGE_V2.md, config/rules.yaml live values)
- [x] All cross-doc links intact
- [ ] CI green

## Sequencing

1. ✅ #482 R1+R2 (CLAUDE.md trim + STRATEGY @import removal) — MERGED
2. ✅ #483 R7+taxonomy — MERGED
3. **This PR** — R3 policy cluster
4. R3 reference cluster + R6 (`.KS` / KIS / harness / HARNESS.md pointer-ize)
5. R5 README split (`docs/OPERATIONS.md` 신설)

🤖 Generated with [Claude Code](https://claude.com/claude-code)