### PR TITLE
chore(frontend): clear remaining lint warnings (round 2 — 5 files)

### DIFF
--- a/frontend/src/__tests__/components/charts.test.tsx
+++ b/frontend/src/__tests__/components/charts.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { ReactNode } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 
 // Mock recharts — jsdom can't render SVG charts
 vi.mock("recharts", () => ({
-  ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
-  ComposedChart: ({ children }: any) => <div data-testid="composed-chart">{children}</div>,
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+  ComposedChart: ({ children }: { children: ReactNode }) => <div data-testid="composed-chart">{children}</div>,
   Area: () => <div data-testid="area" />,
   Line: () => <div data-testid="line" />,
   Bar: () => <div data-testid="bar" />,

--- a/frontend/src/__tests__/components/client-table.test.tsx
+++ b/frontend/src/__tests__/components/client-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ClientTable } from "@/components/ui/client-table";
 

--- a/frontend/src/__tests__/components/composition-section.test.tsx
+++ b/frontend/src/__tests__/components/composition-section.test.tsx
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
+import type { ReactNode, AnchorHTMLAttributes } from "react";
 import { render, screen } from "@testing-library/react";
 
 // jsdom can't render Recharts; mock the chart primitives so the
 // CompositionSection's child donut renders as a stub container.
 vi.mock("recharts", () => ({
-  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
-  PieChart: ({ children }: any) => <div>{children}</div>,
-  Pie: ({ children }: any) => <div>{children}</div>,
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PieChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Pie: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Cell: () => <div />,
   Tooltip: () => <div />,
 }));
 
 vi.mock("next/link", () => ({
-  default: ({ children, href, ...rest }: any) => (
+  default: ({ children, href, ...rest }: { children: ReactNode; href: string } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a href={href} {...rest}>{children}</a>
   ),
 }));

--- a/frontend/src/__tests__/components/data-table.test.tsx
+++ b/frontend/src/__tests__/components/data-table.test.tsx
@@ -232,7 +232,7 @@ describe("DataTable", () => {
 
   // ─── rowClassName ──────────────────────────────────────
   it("applies rowClassName function to matching rows", () => {
-    const rowClassName = (row: any) => row.ticker === "TSLA" ? "bg-red-500/10" : "";
+    const rowClassName = (row: (typeof basicData)[number]) => row.ticker === "TSLA" ? "bg-red-500/10" : "";
     const { container } = render(
       <DataTable columns={basicColumns} data={basicData} rowClassName={rowClassName} />
     );

--- a/frontend/src/__tests__/components/hero-stats.test.tsx
+++ b/frontend/src/__tests__/components/hero-stats.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
+import type { ReactNode, AnchorHTMLAttributes } from "react";
 import { render, screen } from "@testing-library/react";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href, ...rest }: any) => (
+  default: ({ children, href, ...rest }: { children: ReactNode; href: string } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a href={href} {...rest}>{children}</a>
   ),
 }));


### PR DESCRIPTION
## Summary

Clears 10 frontend Lint warnings flagged on the post-#489 CI run — 5 additional test files (round 2).

## Files

| File | Warning type | Before | After |
|------|--------------|--------|-------|
| `hero-stats.test.tsx` | `any` | 1 | 0 |
| `data-table.test.tsx` | `any` | 1 | 0 |
| `composition-section.test.tsx` | `any` | 4 | 0 |
| `client-table.test.tsx` | unused `vi` | 1 | 0 |
| `charts.test.tsx` | `any` + unused `beforeEach` | 3 | 0 |

## Approach (same as #489)

- **`any` for component props/mocks** → typed via existing exports or `ReactNode` / `AnchorHTMLAttributes` for `next/link`; `ReactNode` for recharts mock children.
- **Unused imports** removed (eslint `no-unused-vars` only allows `_`-prefixed).

## Heads-up — there are still ~171 lint warnings repo-wide

After this PR ships, a full `npx eslint src` shows **~171 warnings across 36 files** (146 `no-explicit-any` + 20 `no-unused-vars` + 4 `no-require-imports`). CI annotation surface caps at top-10 per file, so each PR ship reveals a fresh batch. Three options for follow-up:

1. **Bulk sweep PR** — fix all 171 in one large PR (36-file change)
2. **Leave as legacy** — they're warnings (not errors), CI passes
3. **Config change** — demote `no-explicit-any` to `off` for `**/__tests__/**/*` only (most `any` is in test mocks where the type-safety value is low)

Recommend (3) as a separate PR — most `any` is legitimately in vitest mocks of typed third-party libraries (next/link, recharts, etc).

## Verification

- `npx eslint` PASS on all 5 modified files
- `npx tsc --noEmit` PASS
- 78 tests across touched files PASS (vitest)
- privacy scan PASS
- doc-counts 11/11 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)