### PR TITLE
chore(docs): make README Architecture rigorously verifiable — drift coverage + factual fixes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -624,7 +624,8 @@
     "XYZZZZ",
     "drilldown",
     "Dday",
-    "dday"
+    "dday",
+    "pathlib"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ flowchart TB
 | Phase | What it does | Inputs → Outputs |
 |-------|--------------|------------------|
 | ① **Collect** | 25 collectors — US: yfinance / OpenBB · KR: pykrx · Macro: FRED · News: GoogleNews RSS · 13F: edgartools · KIS Open API | external APIs → `prices` · `fundamentals` · `macro` · `news` · `institutional_flows` |
-| ② **Analyze** | 22 signals (20 actionable + 2 SHADOW crash precursors) · 10 regimes (6 base + 4 special) · 4 multi-factor scorers · 15 macro event categories | DB → `signal_results` · `factors` · `regime_transitions` · `macro_events` |
-| ③ **Consensus** | 10 specialist agents · weighted vote · risk-agent veto fires on `alpha_action==FLAT` only | DB → `recommendations` · `agent_verdicts` · `scoring_detail` |
-| ④ **Certify** | SIEGE v2 — Account × Asset Class × Execution Market. 1 error-grade fail → REJECTED, no manual override | DB → `certifications` · `conditions` (evidence + `portfolio_hash`) |
-| ⑤ **Track** | 30d / 60d / 90d outcomes vs prediction → agent accuracy snapshot → weight drift bounded ±30% (feedback to ③) | DB → `outcomes` (re-reads `recommendations`) |
+| ② **Analyze** | 22 signals (20 actionable + 2 SHADOW crash precursors) · 10 regimes (6 base + 4 special) · 3 factor scorers + composite aggregator · 15 macro event categories | DB → `signals` · `factors` · `regime_transitions` · `macro_events` |
+| ③ **Consensus** | 10 specialist agents · weighted vote · risk-agent veto fires on `alpha_action==FLAT` only | DB → `recommendations` (incl. `agent_verdicts`, `scoring_detail` JSON columns) |
+| ④ **Certify** | SIEGE v2 — Account × Asset Class × Execution Market. 1 error-grade fail → REJECTED, no manual override | DB → `certifications` (incl. `conditions_json` evidence + `portfolio_hash`) |
+| ⑤ **Track** | 30 / 60 / 90 d outcomes vs prediction → agent accuracy snapshot → weight drift bounded ±30 % (feedback to ③) | DB → `recommendations.outcome_{30,60,90}d` columns (in-place update); `strategy_memory` rows for agent accuracy snapshots |
 
 Phases never import each other — communication is via SQLite tables / CSV only. Rerun any upstream phase and downstream consumers refresh automatically. Per-phase implementation detail: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). SIEGE certification spec: [`docs/SIEGE_V2.md`](docs/SIEGE_V2.md).
 

--- a/nuri/quant/regime/classifier.py
+++ b/nuri/quant/regime/classifier.py
@@ -8,6 +8,7 @@ D-1: 시장 레짐 분류기 — Bull/Bear/Sideways x High/Low Volatility.
     python -m nuri.quant.regime.classifier
     python -m nuri.quant.regime.classifier --history
 """
+
 import argparse
 import logging
 from dataclasses import asdict, dataclass
@@ -36,12 +37,13 @@ LOOKBACK_WINDOW = 252
 @dataclass
 class RegimeState:
     """시장 레짐 상태."""
+
     date: str
-    trend: str            # "bull", "bear", "sideways"
-    volatility: str       # "high", "low"
-    regime: str           # "bull_low_vol" 등
-    confidence: float     # 0.0 ~ 1.0
-    details: dict         # 개별 지표 값 + 사용된 임계값
+    trend: str  # "bull", "bear", "sideways"
+    volatility: str  # "high", "low"
+    regime: str  # "bull_low_vol" 등
+    confidence: float  # 0.0 ~ 1.0
+    details: dict  # 개별 지표 값 + 사용된 임계값
 
 
 # ═══════════════════════════════════════════════════════
@@ -60,8 +62,7 @@ def compute_dynamic_thresholds(db_path=None, date: str | None = None) -> dict:
 
     # VIX 이력
     vix_df = query_df(
-        f"SELECT value FROM macro WHERE indicator = 'vix' {date_filter} "
-        f"ORDER BY date DESC LIMIT {LOOKBACK_WINDOW}",
+        f"SELECT value FROM macro WHERE indicator = 'vix' {date_filter} ORDER BY date DESC LIMIT {LOOKBACK_WINDOW}",
         db_path=db_path,
     )
 
@@ -76,7 +77,8 @@ def compute_dynamic_thresholds(db_path=None, date: str | None = None) -> dict:
     # SPY SMA gap 이력 → sideways 범위 결정
     spy_df = query_df(
         f"SELECT date, close FROM prices WHERE ticker = ? {date_filter} ORDER BY date",
-        (MARKET_TICKER,), db_path=db_path,
+        (MARKET_TICKER,),
+        db_path=db_path,
     )
 
     if not spy_df.empty and len(spy_df) >= 250:
@@ -119,7 +121,8 @@ def _load_spy_series(date: str | None = None, db_path=None) -> pd.DataFrame | No
     date_filter = f"AND date <= '{date}'" if date else ""
     df = query_df(
         f"SELECT date, close FROM prices WHERE ticker = ? {date_filter} ORDER BY date",
-        (MARKET_TICKER,), db_path=db_path,
+        (MARKET_TICKER,),
+        db_path=db_path,
     )
     if df.empty or len(df) < 200:
         return None
@@ -202,11 +205,26 @@ def _classify_single(close, sma50, sma200, vix, bb_width, thresholds) -> tuple[s
 
 # 특수 레짐 → 포지션 사이징 매핑 (strategy_map 호환)
 SPECIAL_REGIME_SIZING = {
-    "euphoria": "defensive",       # 과열 → 방어적 (과매수 경고)
-    "stagflation": "minimal",      # 침체+인플레 → 최소
-    "recovery": "aggressive",      # 회복 초기 → 공격적
-    "sector_rotation": "normal",   # 섹터 순환 → 중립
+    "euphoria": "defensive",  # 과열 → 방어적 (과매수 경고)
+    "stagflation": "minimal",  # 침체+인플레 → 최소
+    "recovery": "aggressive",  # 회복 초기 → 공격적
+    "sector_rotation": "normal",  # 섹터 순환 → 중립
 }
+
+# Explicit regime enumeration — single source of truth for "10 regimes (6 base + 4 special)"
+# claims in README / STRATEGY / ARCHITECTURE. Keep this in sync with the classifier
+# logic: base regimes are generated from {trend} × {volatility} (`f"{trend}_{volatility}_vol"`
+# in classify()), and special regimes are the keys of SPECIAL_REGIME_SIZING.
+BASE_REGIMES: tuple[str, ...] = (
+    "bull_low_vol",
+    "bull_high_vol",
+    "bear_low_vol",
+    "bear_high_vol",
+    "sideways_low_vol",
+    "sideways_high_vol",
+)
+SPECIAL_REGIMES: tuple[str, ...] = tuple(SPECIAL_REGIME_SIZING.keys())
+ALL_REGIMES: tuple[str, ...] = BASE_REGIMES + SPECIAL_REGIMES  # 6 + 4 = 10
 
 
 def _detect_euphoria(vix: float | None, fear_greed: float | None) -> bool:
@@ -294,7 +312,8 @@ def _detect_sector_rotation(db_path=None, date: str | None = None) -> bool:
     for etf in sector_etfs:
         etf_prices = query(
             f"SELECT close FROM prices WHERE ticker = ? {date_filter} ORDER BY date DESC LIMIT 21",
-            (etf,), db_path=db_path,
+            (etf,),
+            db_path=db_path,
         )
         if len(etf_prices) < 21:
             continue
@@ -319,6 +338,7 @@ def _check_data_freshness(db_path=None) -> bool:
     """
     global _freshness_warned
     from nuri.core.db import query as _query
+
     rows = _query(
         "SELECT MAX(date) as latest FROM prices WHERE ticker = 'SPY'",
         db_path=db_path,
@@ -379,7 +399,9 @@ def classify_regime(date: str | None = None, db_path=None) -> RegimeState | None
             row_date = spy_df["date"].iloc[i]
             day_vix = _get_vix(date=row_date, db_path=db_path) if row_date else vix
             t, v = _classify_single(
-                row["close"], row["sma50"], row["sma200"],
+                row["close"],
+                row["sma50"],
+                row["sma200"],
                 day_vix,
                 float(row["bb_width"]) if pd.notna(row["bb_width"]) else 0,
                 thresholds,
@@ -390,6 +412,7 @@ def classify_regime(date: str | None = None, db_path=None) -> RegimeState | None
         if recent_trends:
             # 다수결
             from collections import Counter
+
             trend_counts = Counter(recent_trends)
             vol_counts = Counter(recent_vols)
             trend = trend_counts.most_common(1)[0][0]
@@ -418,6 +441,7 @@ def classify_regime(date: str | None = None, db_path=None) -> RegimeState | None
     if special_regime is None:
         try:
             from nuri.quant.regime.event_score import compute_event_score
+
             es = compute_event_score(date=date, db_path=db_path)
             if es.event_count >= 3 and abs(es.score) >= 10:
                 hint = es.regime_hint
@@ -509,7 +533,8 @@ def classify_regime_history(
 
     dates = query(
         f"SELECT DISTINCT date FROM prices WHERE ticker = ? {date_filter} ORDER BY date",
-        (MARKET_TICKER,), db_path=db_path,
+        (MARKET_TICKER,),
+        db_path=db_path,
     )
     if not dates:
         return []
@@ -547,16 +572,22 @@ def print_regime(state: RegimeState | None) -> None:
 
     trend_label = {"bull": "BULL", "bear": "BEAR", "sideways": "SIDEWAYS"}
     vol_label = {"high": "HIGH VOL", "low": "LOW VOL"}
-    special_label = {"euphoria": "EUPHORIA", "stagflation": "STAGFLATION",
-                     "recovery": "RECOVERY", "sector_rotation": "SECTOR ROTATION"}
+    special_label = {
+        "euphoria": "EUPHORIA",
+        "stagflation": "STAGFLATION",
+        "recovery": "RECOVERY",
+        "sector_rotation": "SECTOR ROTATION",
+    }
     d = state.details
     th = d.get("thresholds", {})
     special = d.get("special_regime")
 
     print(f"\n{'=' * 60}")
     if special:
-        print(f"  Market Regime: {special_label.get(special, special.upper())} "
-              f"(base: {trend_label[state.trend]} + {vol_label[state.volatility]})")
+        print(
+            f"  Market Regime: {special_label.get(special, special.upper())} "
+            f"(base: {trend_label[state.trend]} + {vol_label[state.volatility]})"
+        )
     else:
         print(f"  Market Regime: {trend_label[state.trend]} + {vol_label[state.volatility]}")
     print(f"  ({state.regime})  Confidence: {state.confidence:.0%}")
@@ -595,8 +626,7 @@ def print_history(history: list[RegimeState]) -> None:
         d = s.details
         vix = f"{d['vix']:.0f}" if d.get("vix") else "—"
         fg = f"{d['fear_greed']:.0f}" if d.get("fear_greed") else "—"
-        print(f"  {s.date:<12} {s.regime:<22} {s.confidence:>4.0%} "
-              f"${d['spy_close']:>8,.2f} {vix:>6} {fg:>5}")
+        print(f"  {s.date:<12} {s.regime:<22} {s.confidence:>4.0%} ${d['spy_close']:>8,.2f} {vix:>6} {fg:>5}")
     print()
 
 
@@ -619,9 +649,7 @@ if __name__ == "__main__":
             today = today_kst()
             output_dir = REPORT_DIR / today
             output_dir.mkdir(parents=True, exist_ok=True)
-            pd.DataFrame([asdict(s) for s in history]).to_csv(
-                output_dir / "regime_history.csv", index=False
-            )
+            pd.DataFrame([asdict(s) for s in history]).to_csv(output_dir / "regime_history.csv", index=False)
     else:
         state = classify_regime()
         print_regime(state)

--- a/scripts/sync_doc_counts.sh
+++ b/scripts/sync_doc_counts.sh
@@ -42,6 +42,20 @@ live_test_files_fe() { find frontend \( -name "*.test.ts" -o -name "*.test.tsx" 
 live_e2e_specs()    { find frontend/e2e -name "*.spec.ts" \
     ! -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' '; }
 
+# 2026-04-29: regime + DB-table counts (mirrors verify_doc_counts.sh additions).
+live_regimes()      { .venv/bin/python -c \
+    "from nuri.quant.regime.classifier import ALL_REGIMES; print(len(ALL_REGIMES))" 2>/dev/null; }
+
+live_db_tables()    { .venv/bin/python -c "
+import tempfile, sqlite3
+from pathlib import Path
+from nuri.core.db import init_db
+with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as _f:
+    _p = _f.name
+init_db(Path(_p))
+print(sqlite3.connect(_p).execute(\"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'\").fetchone()[0])
+" 2>/dev/null; }
+
 live_tests_be() {
     $PYTHON -m pytest tests/ --collect-only -q 2>/dev/null \
         | grep -oE '[0-9]+/[0-9]+ tests collected' \
@@ -115,6 +129,9 @@ update_claim live_test_files_fe  docs/STRATEGY.md              'Frontend tests.*
 
 # E2E specs (1 site)
 update_claim live_e2e_specs      docs/ARCHITECTURE.md          'Playwright E2E \([0-9]+ spec files\)'
+
+update_claim live_regimes        README.md                     '· [0-9]+ regimes'
+update_claim live_db_tables      README.md                     'SQLite WAL · [0-9]+ tables'
 
 # Pytest collect count — runs pytest which is slow; do last so failures above
 # don't waste the call. Updates any "[0-9,]+ backend tests" / "[0-9,]+ tests,"

--- a/scripts/verify_doc_counts.sh
+++ b/scripts/verify_doc_counts.sh
@@ -25,6 +25,33 @@ live_test_files_fe() { find frontend \( -name "*.test.ts" -o -name "*.test.tsx" 
 live_e2e_specs()    { find frontend/e2e -name "*.spec.ts" \
     ! -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' '; }
 
+# 2026-04-29: regime + DB-table counts. README claims "10 regimes (6 base + 4 special)"
+# and "32 tables" were drift-prone (no code-truth verification). Backed by
+# nuri.quant.regime.classifier.ALL_REGIMES tuple + live init_db sqlite_master count.
+#
+# CI contract preservation: this script must run in <1s with no Python env (per
+# CI workflow comment "find + grep only"). When .venv/bin/python is absent
+# (CI / fresh clone), these checks gracefully skip (return empty → check_claim
+# emits warning, not failure). Local `make verify-doc-counts` catches drift.
+live_regimes()      {
+    [ -x .venv/bin/python ] || { echo ""; return; }
+    .venv/bin/python -c \
+        "from nuri.quant.regime.classifier import ALL_REGIMES; print(len(ALL_REGIMES))" 2>/dev/null || echo ""
+}
+
+live_db_tables()    {
+    [ -x .venv/bin/python ] || { echo ""; return; }
+    .venv/bin/python -c "
+import tempfile, sqlite3
+from pathlib import Path
+from nuri.core.db import init_db
+with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as _f:
+    _p = _f.name
+init_db(Path(_p))
+print(sqlite3.connect(_p).execute(\"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'\").fetchone()[0])
+" 2>/dev/null || echo ""
+}
+
 # Extract the target integer from a file.
 # Strategy: match the claim's context substring (must be unique in the file),
 # then take the LAST [0-9]+ in that substring. Target numbers are consistently
@@ -62,6 +89,8 @@ EP=$(live_endpoints)
 TFBE=$(live_test_files_be)
 TFFE=$(live_test_files_fe)
 E2E=$(live_e2e_specs)
+REGIMES=$(live_regimes)
+DBT=$(live_db_tables)
 
 # Claim checks: pattern must uniquely identify the phrase containing the target
 # number. Target is always the LAST [0-9]+ in the matched substring.
@@ -76,6 +105,17 @@ check_claim "test_files_be"  "$TFBE" "docs/STRATEGY.md"           'Backend tests
 check_claim "test_files_fe"  "$TFFE" "docs/ARCHITECTURE.md"       'frontend vitest \([0-9]+ files\)' || true
 check_claim "test_files_fe"  "$TFFE" "docs/STRATEGY.md"           'Frontend tests.*tests, [0-9]+ files' || true
 check_claim "e2e_specs"      "$E2E"  "docs/ARCHITECTURE.md"       'Playwright E2E \([0-9]+ spec files\)' || true
+# Python-dependent checks: skip silently when .venv absent (CI contract — see live_regimes comment)
+if [ -n "$REGIMES" ]; then
+    check_claim "regimes"    "$REGIMES" "README.md"                '· [0-9]+ regimes' || true
+else
+    info "regimes: skipped (no .venv/bin/python — local check via make verify-doc-counts)"
+fi
+if [ -n "$DBT" ]; then
+    check_claim "db_tables"  "$DBT"  "README.md"                   'SQLite WAL · [0-9]+ tables' || true
+else
+    info "db_tables: skipped (no .venv/bin/python)"
+fi
 
 # Note: agent count + pytest collect count intentionally excluded from hard
 # verify. Agent count has no single stable grep pattern across docs (multiple


### PR DESCRIPTION
## Summary

Per honest user critique on README Architecture rigor: 4 issues found, all fixed.

## Factual fixes (README.md ## Architecture)

| # | Before | After | Why |
|---|--------|-------|-----|
| 1 | ⑤ Track Outputs: `outcomes (re-reads recommendations)` | `recommendations.outcome_{30,60,90}d columns; strategy_memory rows` | No `outcomes` table exists. Migration 23 (#469) added outcome columns to `recommendations`. Reader following the doc would have failed to find `outcomes` table. |
| 2 | ② Analyze: `4 multi-factor scorers` | `3 factor scorers + composite aggregator` | `nuri/quant/factors/` has momentum/value/quality (3 factors) + composite (the aggregate). Saying "4" implies a 4th independent factor that doesn't exist. |
| 3 | ② Analyze Outputs: `signal_results · ...` | `signals · factors · regime_transitions · macro_events` | Actual table name is `signals` (not `signal_results`). Verified via live `init_db` + sqlite_master. |
| 4 | ③ ④ over-precise sub-table claims | tightened to canonical tables (`recommendations` with JSON columns; `certifications` with `conditions_json` evidence) | Fewer sub-table names to drift. |

## Drift coverage additions (verify_doc_counts.sh + sync_doc_counts.sh)

Two README claims were drift-prone (no verify-doc-counts coverage):

### "10 regimes (6 base + 4 special)"

Was a STRATEGY-only claim with no code-truth source — `nuri/quant/regime/classifier.py` had no enumeration. Fixed by adding explicit constants:

```python
BASE_REGIMES: tuple[str, ...] = (
    "bull_low_vol", "bull_high_vol", "bear_low_vol", "bear_high_vol",
    "sideways_low_vol", "sideways_high_vol",
)
SPECIAL_REGIMES: tuple[str, ...] = tuple(SPECIAL_REGIME_SIZING.keys())  # 4
ALL_REGIMES: tuple[str, ...] = BASE_REGIMES + SPECIAL_REGIMES  # 10
```

`verify_doc_counts.sh` now checks `· N regimes` pattern in README against `len(ALL_REGIMES)`.

### "32 tables"

Was hardcoded with no automatic check. Fixed by `live_db_tables()` that runs `init_db` on a temp DB and counts via `sqlite_master`. Catches future migration adds/removes silently.

## .cspell.json

Added `pathlib` (legitimate Python stdlib name flagged by IDE in shell heredoc).

## Verifications

- `make verify-doc-counts` — **13/13 PASS** (was 11; +2 new checks: regimes, db_tables)
- `make lint-sh` — clean (shellcheck on the bash modifications)
- 15 regime tests still pass (no regression on classifier)
- privacy scan PASS

## Why this matters

Earlier #487 + #488 fixed numeric drift (test counts, signal counts). This PR catches **schema-shape drift** that count-only verification misses — table-name claims, factor count semantics, regime enumeration. The new constants in `classifier.py` give "10 regimes" a code-truth source for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)