### PR TITLE
test(regime): lock-tests for ALL_REGIMES enumeration (PR #494 follow-up)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,577 backend tests across 158 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,584 backend tests across 158 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -260,7 +260,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,577 tests, 158 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,584 tests, 158 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/quant/test_regime_classifier.py
+++ b/tests/quant/test_regime_classifier.py
@@ -1,4 +1,5 @@
 """Tests for regime_classifier — split from test_quant_all.py."""
+
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -23,6 +24,7 @@ class TestRegimeClassifier:
 
     def test_bull_regime_detection(self, bull_market):
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=bull_market)
         assert state is not None
         assert state.trend == "bull"
@@ -31,6 +33,7 @@ class TestRegimeClassifier:
 
     def test_bear_regime_detection(self, bear_market):
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=bear_market)
         assert state is not None
         assert state.trend == "bear"
@@ -39,12 +42,14 @@ class TestRegimeClassifier:
 
     def test_confidence_range(self, bull_market):
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=bull_market)
         assert state is not None
         assert 0.0 <= state.confidence <= 1.0
 
     def test_insufficient_data(self, db_path):
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=db_path)
         assert state is None
 
@@ -54,6 +59,7 @@ class TestEuphoria:
 
     def test_euphoria_detection(self, euphoria_market):
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=euphoria_market)
         assert state is not None
         assert state.regime == "euphoria"
@@ -63,14 +69,17 @@ class TestEuphoria:
 
     def test_euphoria_not_triggered_vix_high(self, db_path):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(15.0, 85.0) is False
 
     def test_euphoria_not_triggered_fg_low(self, db_path):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(10.0, 75.0) is False
 
     def test_euphoria_unit(self):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(11.9, 81.0) is True
         assert _detect_euphoria(None, 85.0) is False
         assert _detect_euphoria(10.0, None) is False
@@ -81,29 +90,42 @@ class TestStagflation:
 
     def test_stagflation_detection(self, db_path):
         from nuri.quant.regime.classifier import _detect_stagflation
-        upsert_macro([
-            {"indicator": "cpi_yoy", "date": "2025-01-15", "value": 5.5, "source": "test"},
-            {"indicator": "gdp_growth", "date": "2025-01-15", "value": 0.5, "source": "test"},
-        ], db_path)
+
+        upsert_macro(
+            [
+                {"indicator": "cpi_yoy", "date": "2025-01-15", "value": 5.5, "source": "test"},
+                {"indicator": "gdp_growth", "date": "2025-01-15", "value": 0.5, "source": "test"},
+            ],
+            db_path,
+        )
         assert _detect_stagflation(db_path=db_path) is True
 
     def test_stagflation_no_gdp_graceful(self, db_path):
         from nuri.quant.regime.classifier import _detect_stagflation
-        upsert_macro([
-            {"indicator": "cpi_yoy", "date": "2025-01-15", "value": 5.5, "source": "test"},
-        ], db_path)
+
+        upsert_macro(
+            [
+                {"indicator": "cpi_yoy", "date": "2025-01-15", "value": 5.5, "source": "test"},
+            ],
+            db_path,
+        )
         assert _detect_stagflation(db_path=db_path) is False
 
     def test_stagflation_no_cpi(self, db_path):
         from nuri.quant.regime.classifier import _detect_stagflation
+
         assert _detect_stagflation(db_path=db_path) is False
 
     def test_stagflation_normal_conditions(self, db_path):
         from nuri.quant.regime.classifier import _detect_stagflation
-        upsert_macro([
-            {"indicator": "cpi_yoy", "date": "2025-01-15", "value": 2.5, "source": "test"},
-            {"indicator": "gdp_growth", "date": "2025-01-15", "value": 2.5, "source": "test"},
-        ], db_path)
+
+        upsert_macro(
+            [
+                {"indicator": "cpi_yoy", "date": "2025-01-15", "value": 2.5, "source": "test"},
+                {"indicator": "gdp_growth", "date": "2025-01-15", "value": 2.5, "source": "test"},
+            ],
+            db_path,
+        )
         assert _detect_stagflation(db_path=db_path) is False
 
 
@@ -112,6 +134,7 @@ class TestRecovery:
 
     def test_recovery_unit(self):
         from nuri.quant.regime.classifier import _detect_recovery
+
         phase1 = np.full(100, 180.0)
         phase2 = np.linspace(180, 120, 100)
         phase3 = np.linspace(120, 200, 100)
@@ -124,6 +147,7 @@ class TestRecovery:
 
     def test_recovery_insufficient_data(self):
         from nuri.quant.regime.classifier import _detect_recovery
+
         df = pd.DataFrame({"close": np.linspace(100, 200, 200)})
         df["sma50"] = df["close"].rolling(50).mean()
         df["sma200"] = df["close"].rolling(200).mean()
@@ -131,6 +155,7 @@ class TestRecovery:
 
     def test_recovery_none_input(self):
         from nuri.quant.regime.classifier import _detect_recovery
+
         assert _detect_recovery(None) is False  # type: ignore[arg-type]
 
 
@@ -139,43 +164,61 @@ class TestSectorRotation:
 
     def test_sector_rotation_detection(self, db_path):
         from nuri.quant.regime.classifier import _detect_sector_rotation
+
         dates = pd.date_range(end=today_kst(), periods=25)
         spy_close = np.full(25, 500.0)
-        df_spy = pd.DataFrame({
-            "ticker": "SPY",
-            "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": spy_close * 0.999, "high": spy_close * 1.01,
-            "low": spy_close * 0.99, "close": spy_close,
-            "volume": [50_000_000] * 25, "adj_close": spy_close,
-        })
+        df_spy = pd.DataFrame(
+            {
+                "ticker": "SPY",
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": spy_close * 0.999,
+                "high": spy_close * 1.01,
+                "low": spy_close * 0.99,
+                "close": spy_close,
+                "volume": [50_000_000] * 25,
+                "adj_close": spy_close,
+            }
+        )
         upsert_prices(df_spy, db_path)
         xlk_close = np.linspace(200, 210, 25)
-        df_xlk = pd.DataFrame({
-            "ticker": "XLK",
-            "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": xlk_close * 0.999, "high": xlk_close * 1.01,
-            "low": xlk_close * 0.99, "close": xlk_close,
-            "volume": [10_000_000] * 25, "adj_close": xlk_close,
-        })
+        df_xlk = pd.DataFrame(
+            {
+                "ticker": "XLK",
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": xlk_close * 0.999,
+                "high": xlk_close * 1.01,
+                "low": xlk_close * 0.99,
+                "close": xlk_close,
+                "volume": [10_000_000] * 25,
+                "adj_close": xlk_close,
+            }
+        )
         upsert_prices(df_xlk, db_path)
         assert _detect_sector_rotation(db_path=db_path) is True
 
     def test_sector_rotation_spy_not_flat(self, db_path):
         from nuri.quant.regime.classifier import _detect_sector_rotation
+
         dates = pd.date_range(end=today_kst(), periods=25)
         spy_close = np.linspace(500, 525, 25)
-        df = pd.DataFrame({
-            "ticker": "SPY",
-            "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": spy_close * 0.999, "high": spy_close * 1.01,
-            "low": spy_close * 0.99, "close": spy_close,
-            "volume": [50_000_000] * 25, "adj_close": spy_close,
-        })
+        df = pd.DataFrame(
+            {
+                "ticker": "SPY",
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": spy_close * 0.999,
+                "high": spy_close * 1.01,
+                "low": spy_close * 0.99,
+                "close": spy_close,
+                "volume": [50_000_000] * 25,
+                "adj_close": spy_close,
+            }
+        )
         upsert_prices(df, db_path)
         assert _detect_sector_rotation(db_path=db_path) is False
 
     def test_sector_rotation_no_data(self, db_path):
         from nuri.quant.regime.classifier import _detect_sector_rotation
+
         assert _detect_sector_rotation(db_path=db_path) is False
 
 
@@ -184,10 +227,12 @@ class TestSpecialRegimePriority:
 
     def test_euphoria_beats_recovery(self, db_path):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(10.0, 85.0) is True
 
     def test_special_regime_sizing(self):
         from nuri.quant.regime.classifier import SPECIAL_REGIME_SIZING
+
         assert SPECIAL_REGIME_SIZING["euphoria"] == "defensive"
         assert SPECIAL_REGIME_SIZING["stagflation"] == "minimal"
         assert SPECIAL_REGIME_SIZING["recovery"] == "aggressive"
@@ -196,11 +241,15 @@ class TestSpecialRegimePriority:
     def test_base_regime_unchanged_when_no_special(self, db_path):
         close = np.linspace(100, 200, 300) + np.random.normal(0, 0.5, 300)
         dates = _insert_spy_data(db_path, close)
-        upsert_macro([
-            {"indicator": "vix", "date": dates[-1].strftime("%Y-%m-%d"), "value": 16.0, "source": "test"},
-            {"indicator": "fear_greed", "date": dates[-1].strftime("%Y-%m-%d"), "value": 60.0, "source": "test"},
-        ], db_path)
+        upsert_macro(
+            [
+                {"indicator": "vix", "date": dates[-1].strftime("%Y-%m-%d"), "value": 16.0, "source": "test"},
+                {"indicator": "fear_greed", "date": dates[-1].strftime("%Y-%m-%d"), "value": 60.0, "source": "test"},
+            ],
+            db_path,
+        )
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=db_path)
         assert state is not None
         assert state.details["special_regime"] is None
@@ -212,6 +261,7 @@ class TestDynamicThresholds:
 
     def test_thresholds_with_vix_data(self, bull_market):
         from nuri.quant.regime.classifier import compute_dynamic_thresholds
+
         th = compute_dynamic_thresholds(db_path=bull_market)
         assert "vix_threshold" in th
         assert "sideways_pct" in th
@@ -219,6 +269,7 @@ class TestDynamicThresholds:
 
     def test_thresholds_without_data(self, db_path):
         from nuri.quant.regime.classifier import compute_dynamic_thresholds
+
         th = compute_dynamic_thresholds(db_path=db_path)
         assert th["vix_threshold"] == 18.0
         assert th["sideways_pct"] == 2.0
@@ -233,6 +284,7 @@ class TestVixHysteresis:
             upsert_macro([{"indicator": "vix", "date": dates[-(5 - i)], "value": vix_val, "source": "test"}], db_path)
         upsert_macro([{"indicator": "fear_greed", "date": dates[-1], "value": 55.0, "source": "test"}], db_path)
         from nuri.quant.regime.classifier import _get_vix
+
         assert _get_vix(date=dates[-5], db_path=db_path) == 14.0
         assert _get_vix(date=dates[-4], db_path=db_path) == 15.0
         assert _get_vix(date=dates[-3], db_path=db_path) == 16.0
@@ -242,17 +294,20 @@ class TestVixHysteresis:
     def test_hysteresis_calls_get_vix_per_day(self, db_path):
         dates = _insert_spy_data_trend(db_path, n_days=300, trend="bull")
         for i in range(10):
-            upsert_macro([{"indicator": "vix", "date": dates[-(10 - i)], "value": 15.0 + i * 0.1, "source": "test"}], db_path)
+            upsert_macro(
+                [{"indicator": "vix", "date": dates[-(10 - i)], "value": 15.0 + i * 0.1, "source": "test"}], db_path
+            )
         upsert_macro([{"indicator": "fear_greed", "date": dates[-1], "value": 60.0, "source": "test"}], db_path)
         call_dates = []
         from nuri.quant.regime import classifier
+
         original_get_vix = classifier._get_vix
 
         def tracking_get_vix(date=None, db_path=None):
             call_dates.append(date)
             return original_get_vix(date=date, db_path=db_path)
 
-        with patch.object(classifier, '_get_vix', side_effect=tracking_get_vix):
+        with patch.object(classifier, "_get_vix", side_effect=tracking_get_vix):
             state = classifier.classify_regime(db_path=db_path)
         assert state is not None
         hysteresis_calls = [d for d in call_dates if d is not None]
@@ -263,6 +318,7 @@ class TestVixHysteresis:
         upsert_macro([{"indicator": "vix", "date": dates[-1], "value": 15.0, "source": "test"}], db_path)
         upsert_macro([{"indicator": "fear_greed", "date": dates[-1], "value": 55.0, "source": "test"}], db_path)
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=db_path)
         assert state is not None
         assert state.trend == "bull"
@@ -274,6 +330,7 @@ class TestDataFreshnessEnforcement:
     @pytest.fixture(autouse=True)
     def reset_freshness_warned(self):
         from nuri.quant.regime import classifier
+
         classifier._freshness_warned = False
         yield
         classifier._freshness_warned = False
@@ -283,6 +340,7 @@ class TestDataFreshnessEnforcement:
         _insert_spy_data_trend(db_path, n_days=300, trend="bull", last_date=stale_date)
         upsert_macro([{"indicator": "vix", "date": stale_date, "value": 15.0, "source": "test"}], db_path)
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=db_path)
         assert state is None
 
@@ -292,6 +350,7 @@ class TestDataFreshnessEnforcement:
         upsert_macro([{"indicator": "vix", "date": dates[-1], "value": 15.0, "source": "test"}], db_path)
         upsert_macro([{"indicator": "fear_greed", "date": dates[-1], "value": 60.0, "source": "test"}], db_path)
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(db_path=db_path)
         assert state is not None
 
@@ -301,17 +360,20 @@ class TestDataFreshnessEnforcement:
         upsert_macro([{"indicator": "vix", "date": stale_date, "value": 15.0, "source": "test"}], db_path)
         upsert_macro([{"indicator": "fear_greed", "date": stale_date, "value": 60.0, "source": "test"}], db_path)
         from nuri.quant.regime.classifier import classify_regime
+
         state = classify_regime(date=stale_date, db_path=db_path)
         assert state is not None
 
     def test_no_data_returns_false(self, db_path):
         from nuri.quant.regime.classifier import _check_data_freshness
+
         assert _check_data_freshness(db_path=db_path) is False
 
     def test_freshness_check_returns_true_for_fresh(self, db_path):
         today = today_kst()
         _insert_spy_data_trend(db_path, n_days=300, trend="bull", last_date=today)
         from nuri.quant.regime.classifier import _check_data_freshness
+
         assert _check_data_freshness(db_path=db_path) is True
 
 
@@ -320,6 +382,7 @@ class TestClassifySingle:
 
     def test_bull(self):
         from nuri.quant.regime.classifier import _classify_single
+
         th = {"sideways_pct": 2.0, "vix_threshold": 18.0, "vix_bear_threshold": 24.0, "bb_width_threshold": 6.0}
         trend, vol = _classify_single(close=500, sma50=490, sma200=460, vix=15.0, bb_width=5.0, thresholds=th)
         assert trend == "bull"
@@ -327,6 +390,7 @@ class TestClassifySingle:
 
     def test_bear(self):
         from nuri.quant.regime.classifier import _classify_single
+
         th = {"sideways_pct": 2.0, "vix_threshold": 18.0, "vix_bear_threshold": 24.0, "bb_width_threshold": 6.0}
         trend, vol = _classify_single(close=400, sma50=420, sma200=460, vix=30.0, bb_width=8.0, thresholds=th)
         assert trend == "bear"
@@ -334,12 +398,14 @@ class TestClassifySingle:
 
     def test_sideways_narrow_gap(self):
         from nuri.quant.regime.classifier import _classify_single
+
         th = {"sideways_pct": 2.0, "vix_threshold": 18.0, "vix_bear_threshold": 24.0, "bb_width_threshold": 6.0}
         trend, vol = _classify_single(close=460, sma50=461, sma200=460, vix=16.0, bb_width=5.0, thresholds=th)
         assert trend == "sideways"
 
     def test_volatility_from_bb_when_no_vix(self):
         from nuri.quant.regime.classifier import _classify_single
+
         th = {"sideways_pct": 2.0, "vix_threshold": 18.0, "vix_bear_threshold": 24.0, "bb_width_threshold": 6.0}
         trend, vol = _classify_single(close=500, sma50=490, sma200=460, vix=None, bb_width=8.0, thresholds=th)
         assert vol == "high"
@@ -350,6 +416,7 @@ class TestClassifyRegime_R19:
 
     def test_full_classification(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         cls_mod._freshness_warned = False
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         result = cls_mod.classify_regime(db_path=rich_db)
@@ -361,28 +428,44 @@ class TestClassifyRegime_R19:
 
     def test_with_date_param(self, rich_db):
         from nuri.quant.regime.classifier import classify_regime
+
         result = classify_regime(date="2025-06-01", db_path=rich_db)
         if result is not None:
             assert result.date <= "2025-06-01"
 
     def test_print_regime_none(self, capsys):
         from nuri.quant.regime.classifier import print_regime
+
         print_regime(None)
         captured = capsys.readouterr()
         assert "불가" in captured.out
 
     def test_print_regime_with_state(self, capsys):
         from nuri.quant.regime.classifier import RegimeState, print_regime
+
         state = RegimeState(
-            date="2025-06-01", trend="bull", volatility="low",
-            regime="bull_low_vol", confidence=0.75,
+            date="2025-06-01",
+            trend="bull",
+            volatility="low",
+            regime="bull_low_vol",
+            confidence=0.75,
             details={
-                "spy_close": 500.0, "sma50": 490.0, "sma200": 460.0,
-                "sma_diff_pct": 6.5, "vix": 15.0, "fear_greed": 65.0,
-                "rsi": 55.0, "bb_width": 5.0,
-                "thresholds": {"vix_threshold": 18.0, "vix_bear_threshold": 24.0,
-                               "sideways_pct": 2.0, "bb_width_threshold": 6.0},
-                "base_regime": "bull_low_vol", "special_regime": None,
+                "spy_close": 500.0,
+                "sma50": 490.0,
+                "sma200": 460.0,
+                "sma_diff_pct": 6.5,
+                "vix": 15.0,
+                "fear_greed": 65.0,
+                "rsi": 55.0,
+                "bb_width": 5.0,
+                "thresholds": {
+                    "vix_threshold": 18.0,
+                    "vix_bear_threshold": 24.0,
+                    "sideways_pct": 2.0,
+                    "bb_width_threshold": 6.0,
+                },
+                "base_regime": "bull_low_vol",
+                "special_regime": None,
             },
         )
         print_regime(state)
@@ -392,14 +475,24 @@ class TestClassifyRegime_R19:
 
     def test_print_regime_special(self, capsys):
         from nuri.quant.regime.classifier import RegimeState, print_regime
+
         state = RegimeState(
-            date="2025-06-01", trend="bull", volatility="low",
-            regime="euphoria", confidence=0.8,
+            date="2025-06-01",
+            trend="bull",
+            volatility="low",
+            regime="euphoria",
+            confidence=0.8,
             details={
-                "spy_close": 500.0, "sma50": 490.0, "sma200": 460.0,
-                "sma_diff_pct": 6.5, "vix": 10.0, "fear_greed": 85.0,
-                "rsi": None, "bb_width": 5.0,
-                "thresholds": {}, "base_regime": "bull_low_vol",
+                "spy_close": 500.0,
+                "sma50": 490.0,
+                "sma200": 460.0,
+                "sma_diff_pct": 6.5,
+                "vix": 10.0,
+                "fear_greed": 85.0,
+                "rsi": None,
+                "bb_width": 5.0,
+                "thresholds": {},
+                "base_regime": "bull_low_vol",
                 "special_regime": "euphoria",
             },
         )
@@ -409,20 +502,36 @@ class TestClassifyRegime_R19:
 
     def test_print_history_empty(self, capsys):
         from nuri.quant.regime.classifier import print_history
+
         print_history([])
         captured = capsys.readouterr()
         assert "없음" in captured.out
 
     def test_print_history_with_data(self, capsys):
         from nuri.quant.regime.classifier import RegimeState, print_history
-        states = [RegimeState(
-            date="2025-06-01", trend="bull", volatility="low",
-            regime="bull_low_vol", confidence=0.75,
-            details={"spy_close": 500.0, "sma50": 490.0, "sma200": 460.0,
-                     "sma_diff_pct": 6.5, "vix": 15.0, "fear_greed": 65.0,
-                     "rsi": 55.0, "bb_width": 5.0, "thresholds": {},
-                     "base_regime": "bull_low_vol", "special_regime": None},
-        )]
+
+        states = [
+            RegimeState(
+                date="2025-06-01",
+                trend="bull",
+                volatility="low",
+                regime="bull_low_vol",
+                confidence=0.75,
+                details={
+                    "spy_close": 500.0,
+                    "sma50": 490.0,
+                    "sma200": 460.0,
+                    "sma_diff_pct": 6.5,
+                    "vix": 15.0,
+                    "fear_greed": 65.0,
+                    "rsi": 55.0,
+                    "bb_width": 5.0,
+                    "thresholds": {},
+                    "base_regime": "bull_low_vol",
+                    "special_regime": None,
+                },
+            )
+        ]
         print_history(states)
         captured = capsys.readouterr()
         assert "Regime History" in captured.out
@@ -433,6 +542,7 @@ class TestDynamicThresholds_R19:
 
     def test_with_data(self, rich_db):
         from nuri.quant.regime.classifier import compute_dynamic_thresholds
+
         th = compute_dynamic_thresholds(db_path=rich_db)
         assert "vix_threshold" in th
         assert "sideways_pct" in th
@@ -442,6 +552,7 @@ class TestDynamicThresholds_R19:
         path = tmp_path / "empty.db"
         init_db(path)
         from nuri.quant.regime.classifier import compute_dynamic_thresholds
+
         th = compute_dynamic_thresholds(db_path=path)
         assert th["vix_threshold"] == 18.0
         assert th["sideways_pct"] == 2.0
@@ -452,43 +563,56 @@ class TestSpecialRegimes_R19:
 
     def test_euphoria_detected(self):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(vix=10.0, fear_greed=85.0) is True
 
     def test_euphoria_not_detected_high_vix(self):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(vix=15.0, fear_greed=85.0) is False
 
     def test_euphoria_not_detected_low_fg(self):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(vix=10.0, fear_greed=60.0) is False
 
     def test_euphoria_none_inputs(self):
         from nuri.quant.regime.classifier import _detect_euphoria
+
         assert _detect_euphoria(vix=None, fear_greed=85.0) is False
         assert _detect_euphoria(vix=10.0, fear_greed=None) is False
 
     def test_stagflation_detected(self, tmp_path):
         from nuri.quant.regime.classifier import _detect_stagflation
+
         path = tmp_path / "test.db"
         init_db(path)
-        upsert_macro([
-            {"indicator": "cpi_yoy", "date": "2025-01-01", "value": 5.0, "source": "test"},
-            {"indicator": "gdp_growth", "date": "2025-01-01", "value": 0.5, "source": "test"},
-        ], path)
+        upsert_macro(
+            [
+                {"indicator": "cpi_yoy", "date": "2025-01-01", "value": 5.0, "source": "test"},
+                {"indicator": "gdp_growth", "date": "2025-01-01", "value": 0.5, "source": "test"},
+            ],
+            path,
+        )
         assert _detect_stagflation(db_path=path) is True
 
     def test_stagflation_not_detected_normal_economy(self, tmp_path):
         from nuri.quant.regime.classifier import _detect_stagflation
+
         path = tmp_path / "test.db"
         init_db(path)
-        upsert_macro([
-            {"indicator": "cpi_yoy", "date": "2025-01-01", "value": 2.5, "source": "test"},
-            {"indicator": "gdp_growth", "date": "2025-01-01", "value": 2.5, "source": "test"},
-        ], path)
+        upsert_macro(
+            [
+                {"indicator": "cpi_yoy", "date": "2025-01-01", "value": 2.5, "source": "test"},
+                {"indicator": "gdp_growth", "date": "2025-01-01", "value": 2.5, "source": "test"},
+            ],
+            path,
+        )
         assert _detect_stagflation(db_path=path) is False
 
     def test_stagflation_no_gdp_data(self, tmp_path):
         from nuri.quant.regime.classifier import _detect_stagflation
+
         path = tmp_path / "test.db"
         init_db(path)
         upsert_macro([{"indicator": "cpi_yoy", "date": "2025-01-01", "value": 5.0, "source": "test"}], path)
@@ -496,6 +620,7 @@ class TestSpecialRegimes_R19:
 
     def test_recovery_detected(self):
         from nuri.quant.regime.classifier import _detect_recovery
+
         n = 300
         df = pd.DataFrame({"date": pd.date_range("2024-01-01", periods=n), "close": np.linspace(100, 200, n)})
         sma50 = np.ones(n) * 150.0
@@ -508,6 +633,7 @@ class TestSpecialRegimes_R19:
 
     def test_recovery_not_detected_bull_to_bull(self):
         from nuri.quant.regime.classifier import _detect_recovery
+
         n = 300
         df = pd.DataFrame({"date": pd.date_range("2024-01-01", periods=n), "close": np.linspace(100, 200, n)})
         df["sma50"] = 170.0
@@ -516,39 +642,69 @@ class TestSpecialRegimes_R19:
 
     def test_recovery_short_data(self):
         from nuri.quant.regime.classifier import _detect_recovery
+
         df = pd.DataFrame({"date": ["2024-01-01"], "close": [100], "sma50": [100], "sma200": [100]})
         assert _detect_recovery(df) is False
         assert _detect_recovery(None) is False  # type: ignore[arg-type]
 
     def test_sector_rotation_detected(self, tmp_path):
         from nuri.quant.regime.classifier import _detect_sector_rotation
+
         path = tmp_path / "test.db"
         init_db(path)
         dates = pd.date_range("2025-01-01", periods=21, freq="B")
         rows = []
         for d in dates:
-            rows.append({"ticker": "SPY", "date": d.strftime("%Y-%m-%d"),
-                         "open": 450, "high": 451, "low": 449,
-                         "close": 450, "volume": 1000000, "adj_close": 450})
+            rows.append(
+                {
+                    "ticker": "SPY",
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": 450,
+                    "high": 451,
+                    "low": 449,
+                    "close": 450,
+                    "volume": 1000000,
+                    "adj_close": 450,
+                }
+            )
         for i, d in enumerate(dates):
             p = 200 + i * 0.5
-            rows.append({"ticker": "XLK", "date": d.strftime("%Y-%m-%d"),
-                         "open": p, "high": p + 1, "low": p - 1,
-                         "close": p, "volume": 1000000, "adj_close": p})
+            rows.append(
+                {
+                    "ticker": "XLK",
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 1,
+                    "low": p - 1,
+                    "close": p,
+                    "volume": 1000000,
+                    "adj_close": p,
+                }
+            )
         upsert_prices(pd.DataFrame(rows), path)
         assert _detect_sector_rotation(db_path=path) is True
 
     def test_sector_rotation_spy_not_flat(self, tmp_path):
         from nuri.quant.regime.classifier import _detect_sector_rotation
+
         path = tmp_path / "test.db"
         init_db(path)
         dates = pd.date_range("2025-01-01", periods=21, freq="B")
         rows = []
         for i, d in enumerate(dates):
             p = 450 + i * 2
-            rows.append({"ticker": "SPY", "date": d.strftime("%Y-%m-%d"),
-                         "open": p, "high": p + 1, "low": p - 1,
-                         "close": p, "volume": 1000000, "adj_close": p})
+            rows.append(
+                {
+                    "ticker": "SPY",
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 1,
+                    "low": p - 1,
+                    "close": p,
+                    "volume": 1000000,
+                    "adj_close": p,
+                }
+            )
         upsert_prices(pd.DataFrame(rows), path)
         assert _detect_sector_rotation(db_path=path) is False
 
@@ -558,6 +714,7 @@ class TestClassifierExtended:
 
     def test_classify_regime(self, rich_db):
         from nuri.quant.regime.classifier import classify_regime
+
         result = classify_regime(db_path=rich_db)
         if result:
             assert result.trend in ("bull", "bear", "sideways")
@@ -566,6 +723,7 @@ class TestClassifierExtended:
 
     def test_classify_single(self, rich_db):
         from nuri.quant.regime.classifier import _classify_single, compute_dynamic_thresholds
+
         thresholds = compute_dynamic_thresholds(db_path=rich_db)
         trend, vol = _classify_single(500, 480, 440, 15, 0.03, thresholds)
         assert trend == "bull"
@@ -573,12 +731,14 @@ class TestClassifierExtended:
 
     def test_classify_bear(self, rich_db):
         from nuri.quant.regime.classifier import _classify_single, compute_dynamic_thresholds
+
         thresholds = compute_dynamic_thresholds(db_path=rich_db)
         trend, vol = _classify_single(400, 450, 480, 15, 0.03, thresholds)
         assert trend == "bear"
 
     def test_high_vol(self, rich_db):
         from nuri.quant.regime.classifier import _classify_single, compute_dynamic_thresholds
+
         thresholds = compute_dynamic_thresholds(db_path=rich_db)
         trend, vol = _classify_single(500, 480, 440, 30, 0.08, thresholds)
         assert vol == "high"
@@ -589,6 +749,7 @@ class TestRegimeDeep:
 
     def test_classify_regime(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         state = cls_mod.classify_regime(db_path=rich_db)
         assert state is not None
@@ -597,6 +758,7 @@ class TestRegimeDeep:
 
     def test_classify_with_historical_vix(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         state = cls_mod.classify_regime(db_path=rich_db)
         assert state is not None
@@ -608,6 +770,7 @@ class TestRegimeSpecial_R12:
 
     def test_classify_volatility(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         state = cls_mod.classify_regime(db_path=rich_db)
         assert state is not None
@@ -615,6 +778,7 @@ class TestRegimeSpecial_R12:
 
     def test_regime_details(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         state = cls_mod.classify_regime(db_path=rich_db)
         assert state is not None
@@ -626,9 +790,11 @@ class TestClassifyRegimeHistory:
 
     def test_history_with_data(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         cls_mod._freshness_warned = False
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         from nuri.quant.regime.classifier import classify_regime_history
+
         history = classify_regime_history(start_date="2024-06-01", end_date="2025-06-01", db_path=rich_db)
         assert isinstance(history, list)
         if history:
@@ -638,6 +804,7 @@ class TestClassifyRegimeHistory:
         path = tmp_path / "empty.db"
         init_db(path)
         from nuri.quant.regime.classifier import classify_regime_history
+
         history = classify_regime_history(db_path=path)
         assert history == []
 
@@ -647,21 +814,26 @@ class TestDataFreshness_R19:
 
     def test_no_data(self, tmp_path, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         cls_mod._freshness_warned = False
         path = tmp_path / "empty.db"
         init_db(path)
         import nuri.core.db as db_mod
+
         monkeypatch.setattr(db_mod, "DB_PATH", path)
         result = cls_mod._check_data_freshness(db_path=path)
         assert result is False
 
     def test_recent_data(self, rich_db, monkeypatch):
         from nuri.quant.regime import classifier as cls_mod
+
         cls_mod._freshness_warned = False
         from nuri.core.db import query as _query
+
         rows = _query("SELECT MAX(date) as latest FROM prices WHERE ticker = 'SPY'", db_path=rich_db)
         latest_str = rows[0]["latest"]
         from datetime import datetime
+
         latest_dt = datetime.strptime(latest_str, "%Y-%m-%d")
         mock_now = latest_dt + timedelta(hours=24)
         with patch("nuri.core.timezone.kst_now", return_value=mock_now):
@@ -674,6 +846,7 @@ class TestClassifierDeep:
 
     def test_print_regime(self, full_db, capsys):
         from nuri.quant.regime.classifier import classify_regime, print_regime
+
         result = classify_regime(db_path=full_db)
         print_regime(result)
         output = capsys.readouterr().out
@@ -681,7 +854,95 @@ class TestClassifierDeep:
 
     def test_compute_thresholds(self, full_db):
         from nuri.quant.regime.classifier import compute_dynamic_thresholds
+
         thresholds = compute_dynamic_thresholds(db_path=full_db)
         assert isinstance(thresholds, dict)
         assert "vix_threshold" in thresholds
         assert "sideways_pct" in thresholds
+
+
+class TestRegimeEnumeration:
+    """Lock-tests for `BASE_REGIMES` / `SPECIAL_REGIMES` / `ALL_REGIMES` constants
+    added 2026-04-29 in PR #494 to give README claim "10 regimes (6 base + 4
+    special)" a code-truth source. STRATEGY §5.3.1 Gotcha-Test Pair — these tests
+    fail if anyone changes the count without also updating the verify-doc-counts
+    pipeline / README claims.
+
+    Why these matter: `verify_doc_counts.sh live_regimes()` reads `len(ALL_REGIMES)`
+    and compares to README's `· N regimes` pattern. If ALL_REGIMES drifts silently
+    (e.g., someone adds a 5th special regime) without updating the README claim,
+    the next CI / `make verify-doc-counts` run breaks. These tests catch the
+    inverse: someone changes the tuple shape but the README claim still says 10.
+    """
+
+    def test_base_regimes_count_is_six(self):
+        from nuri.quant.regime.classifier import BASE_REGIMES
+
+        assert len(BASE_REGIMES) == 6, (
+            f"BASE_REGIMES count drifted: expected 6 (3 trend × 2 volatility), got {len(BASE_REGIMES)}"
+        )
+
+    def test_special_regimes_count_is_four(self):
+        from nuri.quant.regime.classifier import SPECIAL_REGIMES
+
+        assert len(SPECIAL_REGIMES) == 4, (
+            f"SPECIAL_REGIMES count drifted: expected 4 (euphoria/stagflation/recovery/sector_rotation), got {len(SPECIAL_REGIMES)}"
+        )
+
+    def test_all_regimes_total_is_ten(self):
+        """Critical README sync — '10 regimes (6 base + 4 special)' canonical."""
+        from nuri.quant.regime.classifier import ALL_REGIMES
+
+        assert len(ALL_REGIMES) == 10, (
+            f"ALL_REGIMES count drifted: expected 10, got {len(ALL_REGIMES)}. "
+            f"Update README.md '· N regimes' AND verify_doc_counts.sh in same PR."
+        )
+
+    def test_special_regimes_synced_with_sizing_dict(self):
+        """SPECIAL_REGIMES tuple must equal SPECIAL_REGIME_SIZING.keys() — single source.
+
+        Why: SPECIAL_REGIME_SIZING is the strategy-map sizing dict (used by callers).
+        If someone adds a regime to the dict but forgets to update the tuple,
+        ALL_REGIMES drifts silently. This test enforces sync.
+        """
+        from nuri.quant.regime.classifier import SPECIAL_REGIME_SIZING, SPECIAL_REGIMES
+
+        assert set(SPECIAL_REGIMES) == set(SPECIAL_REGIME_SIZING.keys()), (
+            f"SPECIAL_REGIMES tuple {SPECIAL_REGIMES} drifted from SPECIAL_REGIME_SIZING keys "
+            f"{tuple(SPECIAL_REGIME_SIZING.keys())} — update both in the same edit."
+        )
+
+    def test_base_regime_literals_match_classifier_construction(self):
+        """BASE_REGIMES literals must match what `_classify_single` actually emits via
+        `f'{trend}_{volatility}_vol'`. If trend or volatility values drift, this catches it.
+        """
+        from nuri.quant.regime.classifier import BASE_REGIMES
+
+        # `_classify_single` returns trend ∈ {bull, bear, sideways} × volatility ∈ {low, high}
+        expected = {f"{trend}_{vol}_vol" for trend in ("bull", "bear", "sideways") for vol in ("low", "high")}
+        assert set(BASE_REGIMES) == expected, (
+            f"BASE_REGIMES tuple {BASE_REGIMES} drifted from classifier emission shape "
+            f"{expected} — `_classify_single` produces these literals."
+        )
+
+    def test_no_duplicate_regime_names(self):
+        """Defense against silent collision when adding a regime."""
+        from nuri.quant.regime.classifier import ALL_REGIMES
+
+        assert len(ALL_REGIMES) == len(set(ALL_REGIMES)), f"ALL_REGIMES has duplicates: {ALL_REGIMES}"
+
+    def test_classifier_only_emits_known_regimes(self, bull_market):
+        """End-to-end: classify_regime() output regime label MUST be in ALL_REGIMES.
+
+        Why: caller code (strategy_map, position sizing) often switches on regime
+        label. An unknown label silently falls into default branches. This test
+        prevents the classifier from emitting a label not declared in ALL_REGIMES.
+        """
+        from nuri.quant.regime.classifier import ALL_REGIMES, classify_regime
+
+        state = classify_regime(db_path=bull_market)
+        assert state is not None, "bull_market fixture should produce a non-None regime state"
+        assert state.regime in ALL_REGIMES, (
+            f"classify_regime() emitted unknown label '{state.regime}' — not in ALL_REGIMES "
+            f"({ALL_REGIMES}). Either add to the enumeration or fix the classifier."
+        )


### PR DESCRIPTION
## Summary

Per user directive — coverage must be rigorous. PR #494 added `BASE_REGIMES` / `SPECIAL_REGIMES` / `ALL_REGIMES` constants in `nuri/quant/regime/classifier.py` to give the README "10 regimes (6 base + 4 special)" claim a code-truth source. But those constants had no Gotcha-Test Pair (STRATEGY §5.3.1) — drift would be silent until `verify_doc_counts.sh` CI catches the mismatch (and only when `.venv` is present per #494 graceful skip).

This PR adds **7 lock-tests** in `TestRegimeEnumeration` class. They fail if anyone changes the tuple shape or count without updating the README claim AND/OR the verify-doc-counts pipeline.

## Lock tests

| # | Test | Catches |
|---|------|---------|
| 1 | `test_base_regimes_count_is_six` | 3 trend × 2 volatility = 6 invariant |
| 2 | `test_special_regimes_count_is_four` | 4 special regimes (euphoria/stagflation/recovery/sector_rotation) |
| 3 | `test_all_regimes_total_is_ten` | README "10 regimes" claim sync — **most critical** |
| 4 | `test_special_regimes_synced_with_sizing_dict` | `SPECIAL_REGIMES` tuple ≡ `tuple(SPECIAL_REGIME_SIZING.keys())` — adding to dict but forgetting tuple update would silently break ALL_REGIMES |
| 5 | `test_base_regime_literals_match_classifier_construction` | `BASE_REGIMES` set equals what `_classify_single` actually emits via `f"{trend}_{volatility}_vol"` |
| 6 | `test_no_duplicate_regime_names` | Defense against silent collision |
| 7 | `test_classifier_only_emits_known_regimes` | End-to-end: `classify_regime()` output label MUST be in `ALL_REGIMES` (caller code switches on regime — unknown label falls into default silently) |

## Why this matters (Gotcha-Test Pair lock)

Without these tests, this drift sequence is undetectable:
- Someone adds 5th special regime to `SPECIAL_REGIME_SIZING` dict
- `SPECIAL_REGIMES` tuple updates automatically (synced)
- `ALL_REGIMES` becomes 11
- README still says "10 regimes" → CI verify-doc-counts.sh catches **only if** `.venv` is available. CI without `.venv` (per #494 graceful skip) → **silent drift**.

Test 3 (`test_all_regimes_total_is_ten`) fails immediately in pytest CI even without `.venv`-dependent verify path. **Catches drift in tests, not just docs**.

## Verifications

- 7 new tests PASS (`pytest tests/quant/test_regime_classifier.py::TestRegimeEnumeration -v`)
- 77 tests in test_regime_classifier.py pass total (no regression)
- `make verify-doc-counts` 13/13 PASS
- `ruff check` PASS (import block sorted)
- Pylance clean (added `assert state is not None` guard for end-to-end test)
- privacy scan PASS
- doc-counts synced: 3,577 → 3,584 backend tests (test count drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)