### PR TITLE
chore(scheduler): suppress yfinance log noise — global WARNING + ETF skip

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -625,7 +625,14 @@
     "drilldown",
     "Dday",
     "dday",
-    "pathlib"
+    "pathlib",
+    "UVXY",
+    "SOXX",
+    "KWEB",
+    "INDA",
+    "MCHI",
+    "KODEX",
+    "TIGER"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/nuri/collectors/events.py
+++ b/nuri/collectors/events.py
@@ -24,6 +24,91 @@ FOMC_2026 = [
     "2026-12-15",
 ]
 
+# ETF tickers in our universe — no earnings calendar / dividend-only.
+# yfinance returns 404 on Ticker.calendar for these, which floods scheduler.log
+# until the noise is suppressed at source (here) AND at the logger level
+# (`scheduler.py::_configure_logging` sets yfinance to WARNING). This set lets
+# events.collect() short-circuit before the network round-trip.
+#
+# Coverage: index ETFs + sector SPDRs + leveraged + bond/commodity + ARK +
+# KR index/leverage ETFs found in `config/universe.yaml`. Extending the set
+# is safe — false-positive (skipping a non-ETF) just loses earnings tracking
+# for that ticker; no data corruption. Verify via `yf.Ticker(t).info["quoteType"] == "ETF"`.
+ETF_TICKERS: frozenset[str] = frozenset(
+    {
+        # US broad index
+        "SPY",
+        "QQQ",
+        "IVV",
+        "VOO",
+        "VTI",
+        "DIA",
+        "IWM",
+        "VEA",
+        "VWO",
+        "EFA",
+        "EEM",
+        # US sector SPDRs
+        "XLK",
+        "XLF",
+        "XLE",
+        "XLV",
+        "XLY",
+        "XLP",
+        "XLI",
+        "XLU",
+        "XLB",
+        "XLRE",
+        "XLC",
+        # Leveraged / inverse
+        "TQQQ",
+        "SQQQ",
+        "SOXL",
+        "SOXS",
+        "TNA",
+        "TZA",
+        "UPRO",
+        "SPXU",
+        # Bond / treasury
+        "TLT",
+        "IEF",
+        "SHY",
+        "AGG",
+        "BND",
+        "HYG",
+        "LQD",
+        "TIPS",
+        # Commodity / volatility
+        "GLD",
+        "SLV",
+        "USO",
+        "UNG",
+        "VXX",
+        "UVXY",
+        # Thematic
+        "ARKK",
+        "ARKQ",
+        "ARKW",
+        "ARKG",
+        "ARKF",
+        "SOXX",
+        "SMH",
+        "JETS",
+        "KWEB",
+        "FXI",
+        "INDA",
+        "MCHI",
+        # KR index / leverage (.KS suffix)
+        "069500.KS",  # KODEX 200
+        "229200.KS",  # KODEX KOSDAQ150
+        "233740.KS",  # KODEX 코스닥150 레버리지
+        "252670.KS",  # KODEX 200 선물인버스 2X
+        "292160.KS",  # KODEX 미국S&P500
+        "360750.KS",  # TIGER 미국S&P500
+        "381180.KS",  # TIGER 미국나스닥100
+    }
+)
+
 
 class EventsCollector(BaseCollector):
     """실적발표/FOMC/배당 이벤트 수집."""
@@ -44,8 +129,14 @@ class EventsCollector(BaseCollector):
         tickers = self._get_tickers(market="us", source=source)
         ticker_events_count = 0
         failed: list[str] = []
+        skipped_etfs = 0
         iterator = tqdm(tickers, desc=f"  events [{source}]", unit="tk", disable=len(tickers) < 20)
         for ticker in iterator:
+            if ticker in ETF_TICKERS:
+                # ETFs have no earnings calendar — yfinance returns 404. Short-circuit
+                # to avoid network round-trip + log noise.
+                skipped_etfs += 1
+                continue
             try:
                 ev = self._collect_ticker_events(ticker)
                 records.extend(ev)
@@ -56,8 +147,9 @@ class EventsCollector(BaseCollector):
         if len(tickers) >= 20:
             sample = ", ".join(failed[:5]) + (f" 외 {len(failed) - 5}개" if len(failed) > 5 else "")
             self.logger.info(
-                "📊 이벤트 캘린더: %d 이벤트 수집 / ❌ %d 종목 실패 (총 %d) — failed: %s",
+                "📊 이벤트 캘린더: %d 이벤트 수집 / 🪙 %d ETF skip / ❌ %d 종목 실패 (총 %d) — failed: %s",
                 ticker_events_count,
+                skipped_etfs,
                 len(failed),
                 len(tickers),
                 sample or "없음",

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -56,6 +56,14 @@ def _configure_logging() -> None:
     handler.setLevel(logging.INFO)
     logging.getLogger().addHandler(handler)
 
+    # yfinance internal logger emits 401 Crumb / 404 ETF-calendar noise at INFO/ERROR
+    # for routine cases (ETFs without earnings calendar, transient cookie refresh).
+    # Each line is per-ticker and floods scheduler.log on universe runs (746 tickers).
+    # Raise to WARNING — we still see real auth/network failures, but the routine
+    # 4xx-on-missing-data noise stops. fundamental.py already does this per-source
+    # (CRITICAL on universe); this is the global belt-and-suspenders.
+    logging.getLogger("yfinance").setLevel(logging.WARNING)
+
 
 _configure_logging()
 logger = logging.getLogger("nuri.scheduler")

--- a/tests/collectors/test_events.py
+++ b/tests/collectors/test_events.py
@@ -2,6 +2,7 @@
 
 Split from tests/test_collectors_all.py for module-level isolation.
 """
+
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -65,7 +66,12 @@ class TestEventsCollectorFOMCAndEarnings:
 
         c = EventsCollector()
         assert c.save([]) == 0
-        assert c.save([{"date": "2025-03-17", "event_type": "fomc", "ticker": None, "description": "FOMC", "importance": 3}]) == 1
+        assert (
+            c.save(
+                [{"date": "2025-03-17", "event_type": "fomc", "ticker": None, "description": "FOMC", "importance": 3}]
+            )
+            == 1
+        )
 
     def test_save_deduplicates(self, db_with_portfolio):
         from nuri.collectors.events import EventsCollector
@@ -74,9 +80,55 @@ class TestEventsCollectorFOMCAndEarnings:
         record = {"date": "2025-03-17", "event_type": "fomc", "ticker": None, "description": "FOMC", "importance": 3}
         c.save([record])
         c.save([record])
-        rows = query("SELECT * FROM events WHERE event_type = 'fomc' AND date = '2025-03-17'", db_path=db_with_portfolio)
+        rows = query(
+            "SELECT * FROM events WHERE event_type = 'fomc' AND date = '2025-03-17'", db_path=db_with_portfolio
+        )
         assert len(rows) == 1
 
+
+class TestEventsCollectorETFSkip:
+    """ETF tickers must short-circuit before yfinance call (no earnings calendar).
+
+    Lock-tests the (b) fix in scheduler-log-noise PR — ETF list maintained in
+    `events.ETF_TICKERS`, calendar call is skipped, log surfaces a `skipped_etfs`
+    count separate from `failed`.
+    """
+
+    def test_etf_set_contains_canonical_index_etfs(self):
+        from nuri.collectors.events import ETF_TICKERS
+
+        # Canon — these are in universe.yaml us_core; if removed, events would
+        # 404 on every run for them.
+        for canonical in ("SPY", "QQQ", "XLK", "XLF", "XLV", "ARKK", "TLT", "GLD"):
+            assert canonical in ETF_TICKERS, f"{canonical} must stay in ETF_TICKERS"
+
+    def test_etf_set_includes_kr_with_ks_suffix(self):
+        from nuri.collectors.events import ETF_TICKERS
+
+        # KR ETFs use 6-digit + .KS — the suffix MUST be present in the set
+        # otherwise the equality check (`ticker in ETF_TICKERS`) misses them.
+        for kr_etf in ("069500.KS", "229200.KS"):
+            assert kr_etf in ETF_TICKERS
+
+    def test_collect_skips_etf_calendar_call(self, monkeypatch, db_with_portfolio):
+        from nuri.collectors.events import EventsCollector
+
+        called = []
+
+        def boom(ticker):
+            called.append(ticker)
+            raise AssertionError(f"yfinance.Ticker called for ETF {ticker}")
+
+        monkeypatch.setattr("yfinance.Ticker", boom)
+        # _get_tickers normally returns portfolio holdings; force-feed ETFs to
+        # exercise the short-circuit path even on minimal portfolio fixtures.
+        monkeypatch.setattr(EventsCollector, "_get_tickers", lambda self, **kw: ["SPY", "QQQ", "XLK"])
+
+        collector = EventsCollector()
+        results = collector.collect()
+        # No ticker_events emitted; only FOMC records.
+        assert all(r["event_type"] == "fomc" for r in results)
+        assert called == [], f"yfinance was called for ETFs: {called}"
 
 
 class TestEventsCollectorDividendNoDate:
@@ -89,7 +141,6 @@ class TestEventsCollectorDividendNoDate:
         assert isinstance(EventsCollector()._collect_ticker_events("AAPL"), list)
 
 
-
 class TestEventsCollector_Uncovered:
     def test_save_empty(self, db_path):
         from nuri.collectors.events import EventsCollector
@@ -99,8 +150,15 @@ class TestEventsCollector_Uncovered:
     def test_save_records(self, db_path):
         from nuri.collectors.events import EventsCollector
 
-        count = EventsCollector().save([{
-            "date": "2025-06-01", "event_type": "earnings",
-            "ticker": "AAPL", "description": "Q2 earnings", "importance": "high",
-        }])
+        count = EventsCollector().save(
+            [
+                {
+                    "date": "2025-06-01",
+                    "event_type": "earnings",
+                    "ticker": "AAPL",
+                    "description": "Q2 earnings",
+                    "importance": "high",
+                }
+            ]
+        )
         assert count >= 0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -905,3 +905,29 @@ class TestSchedulerLogRotation:
                 if isinstance(h, logging.handlers.RotatingFileHandler):
                     h.close()
                     logging.getLogger().removeHandler(h)
+
+    def test_yfinance_logger_silenced_to_warning(self, tmp_path, monkeypatch):
+        """`_configure_logging` raises yfinance logger to WARNING.
+
+        Lock-tests TODO Tier 2 P2 #10 (a) — ETF 404 / 401 Crumb noise must be
+        suppressed at the global yfinance logger so scheduler.log doesn't flood
+        on universe runs (746 tickers × routine 4xx). If a future refactor
+        accidentally drops the line, this test catches the regression.
+        """
+        import logging as _logging
+
+        monkeypatch.setenv("NURI_SCHEDULER_LOG_DISABLE_FILE", "1")
+        import importlib
+
+        import nuri.scheduler
+
+        importlib.reload(nuri.scheduler)
+        try:
+            yflog = _logging.getLogger("yfinance")
+            assert yflog.level == _logging.WARNING, (
+                f"yfinance logger must be WARNING (got {yflog.level}) — "
+                "scheduler.py::_configure_logging silenced INFO/ERROR noise"
+            )
+        finally:
+            # Restore default for downstream tests that might assert on it.
+            _logging.getLogger("yfinance").setLevel(_logging.NOTSET)


### PR DESCRIPTION
## Summary

Closes TODO Tier 2 P2 #10 (a/b) — scheduler.log floods on universe runs (746 tickers × routine yfinance 4xx) from internals logging 401 Crumb / ETF 404 errors that the collector code already swallows. Two-pronged fix:

- **(a) Global silencing** — `nuri/scheduler.py::_configure_logging` raises `logging.getLogger("yfinance")` to WARNING. Belt-and-suspenders to `fundamental.py`'s per-source CRITICAL pattern. Real auth/network failures still surface.
- **(b) ETF short-circuit** — `nuri/collectors/events.py` introduces `ETF_TICKERS` frozenset (~50 entries: index, sector SPDRs, leveraged, bond/commodity, ARK, KR KODEX/TIGER). `EventsCollector.collect()` skips before `yfinance.Ticker(...)` call, avoiding network round-trip entirely. New log surface: `🪙 N ETF skip` separate from `❌ N failed`.

## Why this fix shape (not via yfinance.info quoteType detection)

Calling `Ticker.info` to detect ETF status would itself trigger the same noisy network roundtrip we're trying to avoid. Static set + universe yaml as ground truth keeps it cheap. False-positive (skipping a non-ETF) just loses earnings tracking for that ticker — no data corruption. Set is easy to extend.

## Lock-tests (4 new)

- `tests/test_scheduler.py::TestRotatingHandlerLockTests::test_yfinance_logger_silenced_to_warning`
- `tests/collectors/test_events.py::TestEventsCollectorETFSkip::test_etf_set_contains_canonical_index_etfs`
- `..._etf_set_includes_kr_with_ks_suffix` (regression: KR `.KS` suffix must be in the set, else equality check misses)
- `..._collect_skips_etf_calendar_call` (asserts yfinance.Ticker is NEVER called for ETF input)

## Test plan

- [x] `make test-fast` — 94/94 (events + scheduler) green
- [x] `ruff check` clean
- [x] `make verify-doc-counts` 13/13
- [x] privacy scan clean
- [x] cspell additions: UVXY/SOXX/KWEB/INDA/MCHI/KODEX/TIGER
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)