### PR TITLE
docs(todo): close Tier 2 P2 #10 — scheduler log noise fully shipped

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,7 +21,7 @@
 | 🟢 P2 | 6 | **OpenBB 호환성 fix** | [#274](https://github.com/researcherhojin/nuri-quant/issues/274) | bug(collectors) | 1 세션 | openbb-core==1.6.7 ↔ openbb-news==1.6.1 충돌로 news/etf_flows 수집 불가. 점진적 upgrade 필요 (콜렉터별 smoke test 후 진행) |
 | 🟢 P2 | 7 | **#272 Phase 2c-3 — universe-check 필수 게이트화** | — | ops | 10분 | `make collect-universe` 5/5 PASS 상태 유지 중 → 사용자 수동으로 branch protection required check 토글 |
 | ⚪ P3 | 9 | **flaky test 일반 stabilization** | — | test | 1 세션 | #295는 resolved. 다른 flaky 후보 (parallel sys.modules 오염 패턴) 전수 감사 |
-| 🟢 P2 | 10 | **Scheduler 로그 노이즈 감축 (잔여)** | — | chore(scheduler) | 0.5 세션 | 2026-04-18 Mac mini 첫 감사 발견. (c) `RotatingFileHandler` **shipped 2026-04-29 (PR #498)** — 5MB × 3 backup, env var (`NURI_SCHEDULER_LOG_DIR` / `NURI_SCHEDULER_LOG_DISABLE_FILE`) tunable. 잔여 (a/b): `logging.getLogger("yfinance").setLevel(WARNING)` 로 401 Crumb / ETF 404 noise suppress + events collector 가 ETF ticker 에 대해 fundamentals 호출 skip. 별도 PR. |
+| ~~🟢 P2~~ | ~~10~~ | ~~**Scheduler 로그 노이즈 감축 (잔여)**~~ | — | ~~chore(scheduler)~~ | ~~0.5 세션~~ | **Fully shipped 2026-04-29**. (c) RotatingFileHandler PR #498 (5MB × 3 backup, env var tunable). (a/b) PR #501 — global yfinance logger WARNING in `_configure_logging` + `events.ETF_TICKERS` frozenset (~50 entries) short-circuit before yfinance call. 4 lock-tests (1 logger silencing + 3 ETF skip). 새 log surface: `🪙 N ETF skip` separate from `❌ N failed`. |
 
 ## Tier 3 — 다음 분기 (P2)
 


### PR DESCRIPTION
Tier 2 P2 #10 (a/b/c) all shipped. Strike-out + reference PR #498 (RotatingFileHandler) + PR #501 (yfinance WARNING + ETF skip). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)