### PR TITLE
docs(operations): Local LLM dual-stack — LM Studio dev / llama.cpp production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,16 @@ OPENAI_MODEL=gpt-5.4-nano                # override 원할 때만 변경
 # llama.cpp (GGUF 직접 실행)
 # LLAMA_MODEL_PATH=/path/to/model.gguf
 
+# scripts/llm_consult.py — codex + Qwen3.5 dual-LLM consult helper.
+# OpenAI-compat endpoint; default LM Studio :1234 (MLX, M5 Max dev).
+# Mac mini production override: llama.cpp :8081 (headless, smaller footprint).
+# Both unset → uses LM Studio default. See docs/OPERATIONS.md "Local LLM stack".
+# NURI_LLM_QWEN_URL=http://127.0.0.1:1234/v1/chat/completions
+# NURI_LLM_QWEN_MODEL=qwen3.5-122b-a10b
+# Mac mini llama.cpp override example:
+# NURI_LLM_QWEN_URL=http://127.0.0.1:8081/v1/chat/completions
+# NURI_LLM_QWEN_MODEL=qwen3.5-122b-a10b-q4
+
 # LLM 전체 비활성화 (CI, 오프라인 모드, 프라이버시 최상 모드)
 # NURI_DISABLE_EXTERNAL_LLM=1
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -87,6 +87,21 @@ Scheduler runs under separate launchd `com.nuri-quant.scheduler.plist`. It is **
 
 DB (`data/portfolio.db`) is intentionally NOT synced — Mac mini DB is the canonical production state. Backup only.
 
+## Local LLM stack (M5 Max ↔ Mac mini)
+
+Dual-stack pattern, single helper: `scripts/llm_consult.py` (codex + Qwen3.5 archive). Both backends expose the OpenAI-compatible `/v1/chat/completions` shape; the helper picks via `NURI_LLM_QWEN_URL` / `NURI_LLM_QWEN_MODEL` env vars (`.env.example` has both forms commented).
+
+| Machine | Backend | Port | Model | When to use |
+|---------|---------|------|-------|-------------|
+| **M5 Max MBP** (dev) | LM Studio (MLX) | 1234 | `qwen3.5-122b-a10b` (4-bit MLX) | Interactive `make llm-consult` during sessions. MLX = ~63 tok/s on M5 Max, GUI lifecycle, multi-model concurrency. |
+| **M2 Pro Mac mini** (24/7 receiver) | llama.cpp (GGUF) | 8081 | `qwen3.5-122b-a10b-q4` (Q4_K_M GGUF) | Headless production. Smaller footprint than Electron-based LM Studio. Currently not load-bearing — install only when a Mac mini consumer (e.g. scheduler-side classifier) actually needs local LLM. |
+
+**Why dual-stack rather than one**: MLX 4-bit quantization preserves accuracy better than GGUF Q4_K_M on Apple Silicon and is faster (~50% throughput at the same model size). LM Studio's GUI is convenient on the dev box. Mac mini, conversely, runs headlessly under launchd — `brew install llama.cpp` + GGUF + a `keepalive` plist is more hermetic than an Electron app and survives reboots without the desktop session.
+
+**No code changes needed to swap** — `scripts/llm_consult.py` reads `NURI_LLM_QWEN_URL` / `NURI_LLM_QWEN_MODEL` from env. Defaults are the LM Studio dev shape; Mac mini sets the llama.cpp shape in its `.env` only when local LLM consumers are actually deployed there.
+
+**Current state (2026-04-29)**: only the dev box runs LM Studio. Mac mini has no local LLM running because no Mac mini code path calls one — `nuri/llm/openai_client.py` is the only LLM gateway and it talks to OpenAI cloud (gpt-5.4-nano). Set up Mac mini llama.cpp **only when** a code path on the receiver needs local inference (e.g. if `macro_news` classifier ever migrates from OpenAI cloud to local for cost / privacy).
+
 ## Reference
 
 - Deploy script: `scripts/deploy_mini.sh`


### PR DESCRIPTION
## Summary

Codify the dual-stack local LLM pattern that emerged in session 6: MLX/LM Studio on M5 Max for interactive consults, headless llama.cpp on Mac mini when (and only when) a production code path needs local inference.

- \`docs/OPERATIONS.md\`: new "Local LLM stack" section — table of which backend goes where + why, swap mechanism (env vars only, no code), and honest caveat about current state.
- \`.env.example\`: \`NURI_LLM_QWEN_URL\` / \`NURI_LLM_QWEN_MODEL\` examples for both backends, both commented (helper defaults to LM Studio).

## Honest scope

Doc-only. Mac mini llama.cpp is **NOT pre-installed** in this PR. \`nuri/llm/openai_client.py\` (the only LLM gateway used by Mac mini code paths) talks to OpenAI cloud — installing local LLM today would solve no real problem. The receiver-side install is a future task gated by an actual consumer migration (e.g. \`macro_news\` classifier moving from OpenAI to local).

## Test plan

- [x] \`make verify-doc-counts\` 13/13
- [x] \`scripts/check_privacy_leak.py\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)