### PR TITLE
feat(events): #517 Phase 2b cooldown SELL-type split (forward-only)

### DIFF
--- a/config/buy_signals.yaml
+++ b/config/buy_signals.yaml
@@ -28,7 +28,18 @@ quality_bar:
 gates:
   vix_block_above: 30         # VIX > 30 → 모든 candidate 0 (rules.yaml entry_rules.vix_gate.block_above 와 동일)
   vix_caution_above: 25       # VIX 25-30 → 사이즈 절반
-  cooldown_days: 5            # 최근 N일 내 trim/sell 한 ticker 제외 (cascade 차단)
+
+  # #517 Phase 2b — Cooldown SELL-type split (codex+Qwen consult B3 REFINE: hard_sell 14→21d).
+  # event taxonomy unified: payload.action_type ∈ {hard_sell, trim_action, position_reduce, divergence_alert}.
+  # Forward-only: 신규 emit 부터 type-aware. Legacy row (NULL action_type) 는 fallback_days 적용.
+  cooldown:
+    hard_sell_days: 21        # SIEGE veto / stop_loss breach / alpha=FLAT — thesis 회복 시간
+    trim_days: 0              # TP1 partial — re-add 허용 (50% 잔여 holding, thesis intact)
+    reduce_days: 7            # cap rebalance — 기계적 사이징, 짧음
+    divergence_days: 3        # divergence alert — 정보성, 빠른 회복
+    fallback_days: 5          # legacy event (action_type IS NULL) — 보수적 default
+
+  cooldown_days: 5            # DEPRECATED (#517 cooldown.fallback_days 로 대체). 호환성 유지 — 다음 세션 제거.
 
 # ─── Allocation (regime-gated total deploy %) ──────────────────────
 # 사용자 cash * total_pct = 이번 세션 deploy 추천 금액

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,698 backend tests across 164 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,711 backend tests across 165 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,698 tests, 164 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,711 tests, 165 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/core/db.py
+++ b/nuri/core/db.py
@@ -724,6 +724,19 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         ALTER TABLE recommendations ADD COLUMN outcome_21d REAL;
     """,
     ),
+    (
+        24,
+        "add event_subtype to pipeline_events for cooldown SELL-type split (#517)",
+        # #517 Phase 2b — Forward-only event taxonomy. holdings_monitor.payload.action_type
+        # 가 신규 emit 부터 채움 ('hard_sell' / 'trim_action' / 'position_reduce' /
+        # 'divergence_alert'). 레거시 row 는 NULL 유지 (B2 STOP — backfill heuristic 위험).
+        # buy_candidate_emitter._get_cooldown_tickers_by_type 가 NULL 일 때
+        # legacy event_type fallback (holdings_monitor_alert / take_profit_trigger /
+        # trim_recommendation) 으로 5d cooldown 적용.
+        """
+        ALTER TABLE pipeline_events ADD COLUMN event_subtype TEXT;
+    """,
+    ),
 ]
 
 
@@ -1149,7 +1162,16 @@ def insert_certification(data: dict, db_path: Optional[Path] = None) -> int:
 
     Returns: inserted row id (lastrowid).
     """
-    required = {"timestamp", "certified", "score", "total_conditions", "passed", "failed", "warnings", "conditions_json"}
+    required = {
+        "timestamp",
+        "certified",
+        "score",
+        "total_conditions",
+        "passed",
+        "failed",
+        "warnings",
+        "conditions_json",
+    }
     missing = required - data.keys()
     if missing:
         raise ValueError(f"insert_certification: missing required keys {missing}")

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -104,10 +104,9 @@ def _get_held_tickers() -> set[str]:
 
 
 def _get_cooldown_tickers(days: int) -> set[str]:
-    """Tickers with recent SELL/trim events — suppress BUY emit for N trading days.
+    """DEPRECATED — Phase 1 single-window cooldown. Use _get_cooldown_tickers_by_type (#517 Phase 2b).
 
-    Reads pipeline_events for holdings_monitor SELL alerts + take-profit triggers.
-    Phase 1 simplified: any pipeline_events with SELL/trim event_type in last N days.
+    유지 이유: 호환성 (외부 caller / 테스트 fixture). 다음 세션에 제거 예정.
     """
     df = query_df(
         f"""SELECT DISTINCT
@@ -118,6 +117,63 @@ def _get_cooldown_tickers(days: int) -> set[str]:
               AND json_extract(payload, '$.ticker') IS NOT NULL"""
     )
     return {str(t) for t in df["ticker"].dropna().tolist()} if not df.empty else set()
+
+
+def _get_cooldown_tickers_by_type(cooldown_cfg: dict) -> set[str]:
+    """#517 Phase 2b — Type-aware cooldown.
+
+    payload.action_type ∈ {hard_sell, trim_action, position_reduce, divergence_alert}
+    각각 별도 days. action_type IS NULL (legacy) → fallback_days.
+
+    forward-only: 신규 emit 부터 action_type 채워짐 (holdings_monitor.py).
+    backfill 폐기 (codex+Qwen B2 STOP — heuristic 위험).
+
+    Returns: ticker set 으로 BUY emit 차단.
+    """
+    suppressed: set[str] = set()
+    type_map = {
+        "hard_sell": cooldown_cfg.get("hard_sell_days", 21),
+        "trim_action": cooldown_cfg.get("trim_days", 0),
+        "position_reduce": cooldown_cfg.get("reduce_days", 7),
+        "divergence_alert": cooldown_cfg.get("divergence_days", 3),
+    }
+
+    # Type-aware (post-#517 events)
+    for action_type, days in type_map.items():
+        if days <= 0:
+            continue  # trim_days=0 → cooldown 차단 안 함 (re-add 허용)
+        df = query_df(
+            f"""SELECT DISTINCT json_extract(payload, '$.ticker') AS ticker
+                  FROM pipeline_events
+                  WHERE json_extract(payload, '$.action_type') = ?
+                    AND timestamp >= datetime('now', '-{days} days')
+                    AND json_extract(payload, '$.ticker') IS NOT NULL""",
+            params=(action_type,),
+        )
+        if not df.empty:
+            suppressed.update(str(t) for t in df["ticker"].dropna().tolist())
+
+    # Legacy fallback (pre-#517: payload.action_type IS NULL)
+    fallback = cooldown_cfg.get("fallback_days", 5)
+    if fallback > 0:
+        df_legacy = query_df(
+            f"""SELECT DISTINCT json_extract(payload, '$.ticker') AS ticker
+                  FROM pipeline_events
+                  WHERE json_extract(payload, '$.action_type') IS NULL
+                    AND event_type IN (
+                        'holdings_monitor_alert',
+                        'holdings_monitor_technical_sell',
+                        'holdings_monitor_divergence',
+                        'take_profit_trigger',
+                        'trim_recommendation'
+                    )
+                    AND timestamp >= datetime('now', '-{fallback} days')
+                    AND json_extract(payload, '$.ticker') IS NOT NULL"""
+        )
+        if not df_legacy.empty:
+            suppressed.update(str(t) for t in df_legacy["ticker"].dropna().tolist())
+
+    return suppressed
 
 
 def _get_factor_scores() -> dict[str, dict[str, float]]:
@@ -325,7 +381,13 @@ def emit_buy_candidates(
         return result
 
     held = _get_held_tickers() if cfg.get("exclude_held", True) else set()
-    cooldown = _get_cooldown_tickers(gates.get("cooldown_days", 5))
+    # #517 Phase 2b — type-aware cooldown 우선. legacy gates.cooldown_days 는 fallback 용.
+    cooldown_cfg = gates.get("cooldown")
+    if cooldown_cfg:
+        cooldown = _get_cooldown_tickers_by_type(cooldown_cfg)
+    else:
+        # 호환성: gates.cooldown 미정의 시 legacy single-window
+        cooldown = _get_cooldown_tickers(gates.get("cooldown_days", 5))
     factors = _get_factor_scores()
     prices = _get_price_signals()
     rsi_map = _get_rsi_snapshot()

--- a/nuri/trading/recommend/holdings_monitor.py
+++ b/nuri/trading/recommend/holdings_monitor.py
@@ -63,6 +63,11 @@ class AlertPayload:
     dedupe_key: str  # f"{ticker}:{trigger_type}"
     price_date: str | None
     technical_reasoning: str  # short excerpt (≤120 chars)
+    # #517 Phase 2b — Cooldown SELL-type split. trigger_type → action_type 매핑:
+    #   technical_sell → "hard_sell" (SELL conf ≥ 80, thesis 회복 21d cooldown)
+    #   divergence    → "divergence_alert" (정보성, 3d cooldown)
+    # buy_candidate_emitter._get_cooldown_tickers_by_type 가 SQL filter.
+    action_type: str = ""  # "hard_sell" | "divergence_alert" (set in _emit_alert)
 
 
 @dataclass
@@ -275,6 +280,9 @@ def run_monitor(db_path=None, dry_run: bool = False) -> RunSummary:
         avg = h.get("avg_price")
         pnl_pct = (cur / float(avg) - 1.0) * 100 if (cur and avg) else None
 
+        # #517 Phase 2b — trigger_type → action_type 매핑 (cooldown SELL-type split)
+        action_type = "hard_sell" if trigger_type == TRIGGER_TECHNICAL_SELL else "divergence_alert"
+
         payload = AlertPayload(
             ticker=ticker,
             account=h["account"],
@@ -290,6 +298,7 @@ def run_monitor(db_path=None, dry_run: bool = False) -> RunSummary:
             dedupe_key=dedupe_key,
             price_date=price_date,
             technical_reasoning=diag["technical_reasoning"],
+            action_type=action_type,
         )
 
         event_type = EVENT_TYPE_TECHNICAL_SELL if trigger_type == TRIGGER_TECHNICAL_SELL else EVENT_TYPE_DIVERGENCE

--- a/tests/trading/recommend/test_cooldown_split.py
+++ b/tests/trading/recommend/test_cooldown_split.py
@@ -1,0 +1,211 @@
+"""#517 Phase 2b — Cooldown SELL-type split lock-tests.
+
+Spec: docs/plans/507_buy_candidate_emitter_phase2_spec.md §3
+LLM consult: data/llm_consults/2026-04-30_507-phase2-spec-review.md (codex+Qwen B3 REFINE: 14→21d).
+
+Forward-only event taxonomy:
+- payload.action_type ∈ {hard_sell, trim_action, position_reduce, divergence_alert}
+- legacy event_type IN (holdings_monitor_alert / take_profit_trigger / trim_recommendation) → fallback_days
+
+각 케이스: emit → cooldown days 안 cooldown set 포함 / 밖 미포함 검증.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.trading.recommend.buy_candidate_emitter import _get_cooldown_tickers_by_type
+
+COOLDOWN_CFG = {
+    "hard_sell_days": 21,
+    "trim_days": 0,  # re-add 허용
+    "reduce_days": 7,
+    "divergence_days": 3,
+    "fallback_days": 5,
+}
+
+
+@pytest.fixture()
+def isolated_db(tmp_path, monkeypatch):
+    """tmp_path DB + module-level CONFIG_PATH 격리. event 직접 INSERT 로 timestamp 제어."""
+    db = tmp_path / "test_cooldown.db"
+    init_db(db)
+    monkeypatch.setattr(
+        "nuri.trading.recommend.buy_candidate_emitter.query_df", lambda sql, params=None: _run_query_df(db, sql, params)
+    )
+    yield db
+
+
+def _run_query_df(db_path, sql, params=None):
+    """params 시그니처 호환 — buy_candidate_emitter._get_cooldown_tickers_by_type 가 params= 사용."""
+    import pandas as pd
+
+    from nuri.core.db import query_df
+
+    return query_df(sql, params=params or (), db_path=db_path)
+
+
+def _insert_event(
+    db_path,
+    *,
+    ticker: str,
+    action_type: str | None,
+    days_ago: int = 0,
+    event_type: str = "holdings_monitor_technical_sell",
+):
+    """직접 INSERT — timestamp 제어. action_type=None 이면 legacy row."""
+    payload = {"ticker": ticker}
+    if action_type is not None:
+        payload["action_type"] = action_type
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO pipeline_events (event_type, payload, timestamp) VALUES (?, ?, datetime('now', ?))",
+            (event_type, json.dumps(payload), f"-{days_ago} days"),
+        )
+        conn.commit()
+
+
+# ─── Case 1: hard_sell (21d) ─────────────────────────────────────────────
+
+
+def test_hard_sell_within_21d_suppressed(isolated_db):
+    """hard_sell 14d ago → cooldown set 포함 (21d 한도 안)."""
+    _insert_event(isolated_db, ticker="AAPL", action_type="hard_sell", days_ago=14)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "AAPL" in result
+
+
+def test_hard_sell_after_21d_released(isolated_db):
+    """hard_sell 22d ago → cooldown 해제 (21d 한도 밖)."""
+    _insert_event(isolated_db, ticker="AAPL", action_type="hard_sell", days_ago=22)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "AAPL" not in result
+
+
+# ─── Case 2: trim_action (0d — re-add 허용) ─────────────────────────────
+
+
+def test_trim_action_zero_days_no_suppression(isolated_db):
+    """trim_action 1d ago → cooldown 차단 안 됨 (trim_days=0, 50% 잔여 holding 동안 re-add 허용).
+
+    B1 mitigation: same-session spam 은 holdings_monitor.dedupe_key 가 24h 차단.
+    """
+    _insert_event(isolated_db, ticker="MSFT", action_type="trim_action", days_ago=1)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "MSFT" not in result
+
+
+# ─── Case 3: position_reduce (7d) ────────────────────────────────────────
+
+
+def test_position_reduce_within_7d_suppressed(isolated_db):
+    """position_reduce 5d ago → cooldown 포함."""
+    _insert_event(isolated_db, ticker="GOOGL", action_type="position_reduce", days_ago=5)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "GOOGL" in result
+
+
+def test_position_reduce_after_7d_released(isolated_db):
+    """position_reduce 8d ago → 해제."""
+    _insert_event(isolated_db, ticker="GOOGL", action_type="position_reduce", days_ago=8)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "GOOGL" not in result
+
+
+# ─── Case 4: divergence_alert (3d) ───────────────────────────────────────
+
+
+def test_divergence_alert_within_3d_suppressed(isolated_db):
+    """divergence_alert 2d ago → cooldown 포함 (3d 한도 안)."""
+    _insert_event(isolated_db, ticker="NVDA", action_type="divergence_alert", days_ago=2)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "NVDA" in result
+
+
+def test_divergence_alert_after_3d_released(isolated_db):
+    """divergence_alert 4d ago → 해제 (정보성, 빠른 회복)."""
+    _insert_event(isolated_db, ticker="NVDA", action_type="divergence_alert", days_ago=4)
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "NVDA" not in result
+
+
+# ─── Case 5: legacy event (action_type IS NULL → fallback_days) ─────────
+
+
+def test_legacy_event_within_fallback_5d_suppressed(isolated_db):
+    """legacy holdings_monitor_alert (action_type=NULL) 2d ago → fallback_days=5 cooldown 포함.
+
+    B2 STOP fix — backfill 폐기, 레거시 row 는 보수적 fallback 적용.
+    """
+    _insert_event(
+        isolated_db,
+        ticker="TSLA",
+        action_type=None,
+        days_ago=2,
+        event_type="holdings_monitor_alert",
+    )
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "TSLA" in result
+
+
+def test_legacy_event_after_fallback_5d_released(isolated_db):
+    """legacy event 6d ago → fallback 5d 한도 밖 해제."""
+    _insert_event(
+        isolated_db,
+        ticker="TSLA",
+        action_type=None,
+        days_ago=6,
+        event_type="holdings_monitor_alert",
+    )
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "TSLA" not in result
+
+
+def test_legacy_take_profit_trigger_fallback(isolated_db):
+    """legacy take_profit_trigger (action_type=NULL) 도 fallback 적용."""
+    _insert_event(
+        isolated_db,
+        ticker="META",
+        action_type=None,
+        days_ago=3,
+        event_type="take_profit_trigger",
+    )
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert "META" in result
+
+
+# ─── 혼합 케이스 ──────────────────────────────────────────────────────────
+
+
+def test_mixed_action_types_all_correctly_classified(isolated_db):
+    """다중 ticker × 다중 action_type — 각 cooldown 정책 독립 적용."""
+    _insert_event(isolated_db, ticker="AAA", action_type="hard_sell", days_ago=14)  # 21d 안
+    _insert_event(isolated_db, ticker="BBB", action_type="trim_action", days_ago=0)  # 0d (release)
+    _insert_event(isolated_db, ticker="CCC", action_type="position_reduce", days_ago=5)  # 7d 안
+    _insert_event(isolated_db, ticker="DDD", action_type="divergence_alert", days_ago=2)  # 3d 안
+    _insert_event(
+        isolated_db,
+        ticker="EEE",
+        action_type=None,
+        days_ago=2,
+        event_type="holdings_monitor_alert",
+    )  # fallback 5d 안
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert result == {"AAA", "CCC", "DDD", "EEE"}, f"Got: {result}"
+
+
+def test_no_events_empty_set(isolated_db):
+    """이벤트 없으면 cooldown set 비어있음."""
+    result = _get_cooldown_tickers_by_type(COOLDOWN_CFG)
+    assert result == set()
+
+
+def test_disabled_days_zero_skipped(isolated_db):
+    """trim_days=0 같이 days <= 0 인 type 은 SQL query 건너뜀."""
+    cfg_no_trim = {**COOLDOWN_CFG, "trim_days": 0}
+    _insert_event(isolated_db, ticker="ZZZ", action_type="trim_action", days_ago=0)
+    result = _get_cooldown_tickers_by_type(cfg_no_trim)
+    assert "ZZZ" not in result


### PR DESCRIPTION
## Summary

Phase 2 spec v2 sequence #1 (PR-1). Single 5d cooldown 이 hard SELL / TP1 trim / cap reduce / divergence 모두 한 묶음으로 차단하던 문제 해결. forward-only event taxonomy + type-aware cooldown으로 분리.

- 13 신규 lock-tests + 47 회귀 tests 통과
- LLM consult 8개 STOP/REFINE 중 B2/B3 반영 (D2 GO per Codex — 3-LLM consult 면제)

## Changes

### Migration M-24 (forward-only, no backfill)
- `pipeline_events.event_subtype` TEXT 컬럼 추가
- legacy row NULL 유지 — backfill 폐기 (B2 STOP: \`take_profit_trigger → trim_action\` 항상 안전 X)

### Cooldown rules (`config/buy_signals.yaml::gates.cooldown`)

| action_type | days | 근거 |
|---|---|---|
| `hard_sell` | **21** | thesis 회복 시간 (B3 REFINE: was 14, codex+Qwen 합의) |
| `trim_action` | **0** | TP1 partial → re-add 허용 (B1 mitigation: holdings_monitor.dedupe_key 24h) |
| `position_reduce` | **7** | cap rebalance, 기계적 |
| `divergence_alert` | **3** | 정보성, 빠른 회복 |
| `fallback_days` | **5** | legacy row (action_type IS NULL) |

### Event taxonomy (`holdings_monitor.py`)
- \`AlertPayload.action_type\` 필드 추가
- TRIGGER_TECHNICAL_SELL → \`hard_sell\`
- TRIGGER_DIVERGENCE → \`divergence_alert\`

### Buy candidate emitter
- \`_get_cooldown_tickers_by_type()\` 신규 (type-aware)
- 호출부: \`gates.cooldown\` 우선, 미정의 시 legacy single-window fallback
- 기존 \`_get_cooldown_tickers()\` DEPRECATED (다음 세션 제거)

## Tests (13 신규)

\`tests/trading/recommend/test_cooldown_split.py\`:
- hard_sell within/after 21d
- trim_action 0d (re-add 허용)
- position_reduce within/after 7d
- divergence_alert within/after 3d
- legacy holdings_monitor_alert + take_profit_trigger fallback 5d
- mixed action_types 독립 분류
- empty set + days<=0 skip

## Verification

- [x] 13 신규 lock-tests PASS
- [x] 47 회귀 (test_holdings_monitor + test_buy_candidate_emitter) PASS
- [x] 1151 tests/trading + tests/core/test_db PASS
- [x] ruff clean
- [x] privacy scan PASS
- [x] make verify-doc-counts 13/13 (165 files / 3,711 tests 갱신)

## Refs

- #517 (parent)
- #507 Phase 2 spec v2 §3
- #518 (next, 2a held add-mode — depends on 2b for action_type emit point)
- #519 (then, 2c threshold tune — depends on 2a shadow 14d)

LLM consult archive: \`data/llm_consults/2026-04-30_507-phase2-spec-review.md\`
Spec: \`docs/plans/507_buy_candidate_emitter_phase2_spec.md\` §3

## Test plan

- [ ] CI green
- [ ] Codecov: 신규 \`_get_cooldown_tickers_by_type\` 13 tests로 ≥80% coverage
- [ ] Auto-merge after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)