### PR TITLE
fix(alerts): #513 brief freshness gate surface (사용자 가시성 회복)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,711 backend tests across 165 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,716 backend tests across 165 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,711 tests, 165 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,716 tests, 165 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -70,7 +70,18 @@ def _collect_context() -> dict:
         "portfolio_totals": None,
         "shadow_signals": [],  # PR C (codex #3): market-wide crash precursor
         "buy_candidates": None,  # #507 Phase 1: cash deploy candidate emit
+        "freshness": None,  # #513: 데이터 신선도 surface (PASS/WARN/FAIL 3-tier)
     }
+
+    # Data freshness (#513) — backend gate (#512 PR) 가 작동해도 brief 에 surface 되지 않으면
+    # 사용자 가시성 0. 매 brief 에 PASS/WARN/FAIL 3-tier summary + per-policy detail 표시.
+    # FAIL 1+ → embed RED, WARN 1+ → embed AMBER 가능 (기존 SIEGE AMBER 와 동일 priority).
+    try:
+        from nuri.core.freshness import get_freshness_summary
+
+        ctx["freshness"] = get_freshness_summary()
+    except Exception:
+        logger.warning("freshness summary 실패", exc_info=True)
 
     # BUY candidates (#507) — sell-bias 결함 fix. emitter 가 0 emit 일때도
     # blocked_reason 으로 surface (VIX>30 / regime / threshold 미달 모두 표시).
@@ -234,12 +245,18 @@ def _collect_context() -> dict:
 
 
 def _brief_color(ctx: dict) -> int:
-    """Brief 색상 — urgent bucket 있으면 red, siege not certified → amber, 평상시 blue."""
+    """Brief 색상 priority — RED > AMBER > BLUE.
+
+    RED:    urgent action OR freshness FAIL (#513)
+    AMBER:  SIEGE not certified OR freshness WARN (#513)
+    BLUE:   평상시
+    """
     actions = ctx.get("actions") or {}
-    if actions.get("urgent"):
+    fresh = ctx.get("freshness") or {}
+    if actions.get("urgent") or fresh.get("fail", 0) > 0:
         return COLOR_RED
     siege = ctx.get("siege") or {}
-    if siege.get("certified") is False:
+    if siege.get("certified") is False or fresh.get("warn", 0) > 0:
         return COLOR_AMBER
     return COLOR_BLUE
 
@@ -290,6 +307,28 @@ def format_brief_embed(ctx: dict) -> dict:
         if siege["failing_errors"]:
             siege_line += "\n" + "\n".join(f"❌ {e['id']}: {e['detail']}" for e in siege["failing_errors"][:3])
         fields.append({"name": "🛡️ SIEGE", "value": siege_line, "inline": False})
+
+    # Data Freshness (#513) — backend gate 결과를 사용자에게 surface.
+    # PR #512 가 portfolio policy 등록 + dual-layer write/read filter 했지만
+    # brief 본문에 표시되지 않으면 사용자 가시성 0. WARN/FAIL 시 즉시 attention.
+    fresh = ctx.get("freshness") or {}
+    if fresh.get("details"):
+        n_pass, n_warn, n_fail = fresh.get("pass", 0), fresh.get("warn", 0), fresh.get("fail", 0)
+        if n_fail > 0:
+            tier_emoji = "❌"
+        elif n_warn > 0:
+            tier_emoji = "⚠️"
+        else:
+            tier_emoji = "✅"
+        header = f"{tier_emoji} {n_pass}P / {n_warn}W / {n_fail}F"
+        # WARN/FAIL 만 detail 출력 (PASS 는 count 만으로 충분 — noise 절감)
+        problem_lines = [
+            f"{'❌' if d['status'] == 'FAIL' else '⚠️'} {d['label']}: {d['message']}"
+            for d in fresh["details"]
+            if d["status"] != "PASS"
+        ]
+        value = header + ("\n" + "\n".join(problem_lines) if problem_lines else "")
+        fields.append({"name": "🕐 Data Freshness", "value": value, "inline": False})
 
     # SHADOW crash precursor signals (PR C, codex #3). `actionable: false` 이므로
     # action 에 직접 영향 없음 — "Surface" 단계 추적용. fired=True 는 주목 필요.
@@ -429,6 +468,27 @@ def format_brief_markdown(ctx: dict) -> str:
         lines.append(f"- {siege['passed']}P / {siege['failed']}F / {siege['warnings']}W of {siege['total']}")
         for e in siege["failing_errors"]:
             lines.append(f"- ❌ {e['id']}: {e['desc']} — {e['detail']}")
+        lines.append("")
+
+    # Data Freshness (#513) — markdown 출력. embed 와 동일 로직 (#512 backend → user surface).
+    fresh = ctx.get("freshness") or {}
+    if fresh.get("details"):
+        n_pass, n_warn, n_fail = fresh.get("pass", 0), fresh.get("warn", 0), fresh.get("fail", 0)
+        if n_fail > 0:
+            tier_emoji = "❌"
+        elif n_warn > 0:
+            tier_emoji = "⚠️"
+        else:
+            tier_emoji = "✅"
+        lines.append(f"## Data Freshness {tier_emoji} {n_pass}P / {n_warn}W / {n_fail}F")
+        for d in fresh["details"]:
+            if d["status"] == "PASS":
+                emoji = "✅"
+            elif d["status"] == "WARN":
+                emoji = "⚠️"
+            else:
+                emoji = "❌"
+            lines.append(f"- {emoji} {d['label']}: {d['message']}")
         lines.append("")
 
     shadow = ctx.get("shadow_signals") or []

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -10,6 +10,7 @@ Scope — codex Plan consult 권고 반영:
 이 테스트가 fail 하면 brief 가 silent 로 empty field 를 produce 해 사용자가
 "오늘 brief 가 왜 없지?" 라고 묻는 regression 발생. 유사 재발 방지.
 """
+
 from unittest.mock import patch
 
 import pytest
@@ -20,12 +21,12 @@ def empty_db_ctx():
     """모든 subsystem helper 를 빈 결과로 mock."""
     with (
         patch("nuri.quant.regime.classifier.classify_regime", return_value=None),
-        patch("nuri.quant.regime.macro_score.compute_macro_score",
-              side_effect=RuntimeError("no macro")),
-        patch("nuri.trading.engine.certification.certify",
-              side_effect=RuntimeError("no certify")),
-        patch("nuri.api.routes.actions._build_actions",
-              return_value={"urgent": [], "portfolio": [], "check": [], "hold": []}),
+        patch("nuri.quant.regime.macro_score.compute_macro_score", side_effect=RuntimeError("no macro")),
+        patch("nuri.trading.engine.certification.certify", side_effect=RuntimeError("no certify")),
+        patch(
+            "nuri.api.routes.actions._build_actions",
+            return_value={"urgent": [], "portfolio": [], "check": [], "hold": []},
+        ),
         patch("nuri.api.routes.actions._build_opportunities", return_value=[]),
         patch("nuri.core.db.query", return_value=[]),
     ):
@@ -37,6 +38,7 @@ class TestContextCollection:
 
     def test_all_subsystems_fail_returns_none_values(self, empty_db_ctx):
         from nuri.alerts.premarket_brief import _collect_context
+
         ctx = _collect_context()
         # 실패한 subsystem 은 None 또는 빈 list, 결코 raise 하지 않음
         assert ctx["regime"] is None
@@ -50,15 +52,25 @@ class TestContextCollection:
     def test_actions_key_has_all_4_buckets(self):
         """4-bucket shape 보존 — PR #429 가 추가한 portfolio bucket 이 brief 에도 노출."""
         from nuri.alerts.premarket_brief import _collect_context
-        with patch("nuri.api.routes.actions._build_actions",
-                   return_value={
-                       "urgent": [],
-                       "portfolio": [{"ticker": "BAC", "action": "HOLD",
-                                     "confidence": 62, "pnl_pct": -1.1, "position_pct": 19.8,
-                                     "reasons": ["리밸런스 권고"]}],
-                       "check": [],
-                       "hold": [],
-                   }):
+
+        with patch(
+            "nuri.api.routes.actions._build_actions",
+            return_value={
+                "urgent": [],
+                "portfolio": [
+                    {
+                        "ticker": "BAC",
+                        "action": "HOLD",
+                        "confidence": 62,
+                        "pnl_pct": -1.1,
+                        "position_pct": 19.8,
+                        "reasons": ["리밸런스 권고"],
+                    }
+                ],
+                "check": [],
+                "hold": [],
+            },
+        ):
             ctx = _collect_context()
         assert "portfolio" in ctx["actions"]
         assert ctx["actions"]["portfolio"][0]["ticker"] == "BAC"
@@ -69,9 +81,19 @@ class TestFormatBriefEmbed:
 
     def test_empty_ctx_still_produces_valid_embed(self):
         from nuri.alerts.premarket_brief import format_brief_embed
-        ctx = {"regime": None, "macro": None, "vix": None, "usd_krw": None,
-               "fear_greed": None, "siege": None, "actions": {}, "opportunities": [],
-               "macro_events": [], "portfolio_totals": None}
+
+        ctx = {
+            "regime": None,
+            "macro": None,
+            "vix": None,
+            "usd_krw": None,
+            "fear_greed": None,
+            "siege": None,
+            "actions": {},
+            "opportunities": [],
+            "macro_events": [],
+            "portfolio_totals": None,
+        }
         embed = format_brief_embed(ctx)
         # Title/color/footer 는 empty 여도 존재해야 Discord 렌더 가능
         assert "title" in embed
@@ -81,26 +103,52 @@ class TestFormatBriefEmbed:
 
     def test_urgent_bucket_triggers_red_color(self):
         from nuri.alerts.premarket_brief import COLOR_RED, format_brief_embed
-        ctx = {"actions": {"urgent": [{"ticker": "CRASH", "action": "SELL",
-                                        "confidence": 85, "pnl_pct": -30, "position_pct": 5}]}}
+
+        ctx = {
+            "actions": {
+                "urgent": [{"ticker": "CRASH", "action": "SELL", "confidence": 85, "pnl_pct": -30, "position_pct": 5}]
+            }
+        }
         assert format_brief_embed(ctx)["color"] == COLOR_RED
 
     def test_siege_rejected_triggers_amber_color(self):
         from nuri.alerts.premarket_brief import COLOR_AMBER, format_brief_embed
-        ctx = {"actions": {}, "siege": {"certified": False, "score": 58, "passed": 10,
-                                         "failed": 1, "warnings": 6, "total": 17,
-                                         "failing_errors": []}}
+
+        ctx = {
+            "actions": {},
+            "siege": {
+                "certified": False,
+                "score": 58,
+                "passed": 10,
+                "failed": 1,
+                "warnings": 6,
+                "total": 17,
+                "failing_errors": [],
+            },
+        }
         assert format_brief_embed(ctx)["color"] == COLOR_AMBER
 
     def test_portfolio_bucket_rendered_distinct_from_urgent(self):
         """PR #429 alpha/portfolio 분리 — brief 도 두 bucket 따로 label."""
         from nuri.alerts.premarket_brief import format_brief_embed
-        ctx = {"actions": {
-            "urgent": [],
-            "portfolio": [{"ticker": "BAC", "action": "HOLD", "confidence": 62,
-                          "pnl_pct": -1.1, "position_pct": 19.8, "reasons": []}],
-            "check": [], "hold": [],
-        }}
+
+        ctx = {
+            "actions": {
+                "urgent": [],
+                "portfolio": [
+                    {
+                        "ticker": "BAC",
+                        "action": "HOLD",
+                        "confidence": 62,
+                        "pnl_pct": -1.1,
+                        "position_pct": 19.8,
+                        "reasons": [],
+                    }
+                ],
+                "check": [],
+                "hold": [],
+            }
+        }
         fields = format_brief_embed(ctx)["fields"]
         labels = [f["name"] for f in fields]
         # Portfolio label 포함 + "매도" 어휘 금지 (PR #429 rule)
@@ -114,8 +162,8 @@ class TestMarkdownPersist:
 
     def test_persist_always_writes_file_even_with_empty_content(self, tmp_path, monkeypatch):
         from nuri.alerts import premarket_brief as pb
-        monkeypatch.setattr(pb, "__file__",
-                            str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
+
+        monkeypatch.setattr(pb, "__file__", str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
         # parents[2] = tmp_path
         (tmp_path / "nuri" / "alerts").mkdir(parents=True)
         path = pb.persist_brief("# test\n\nempty ctx", date="2026-04-21")
@@ -124,23 +172,48 @@ class TestMarkdownPersist:
 
     def test_markdown_includes_all_sections_when_populated(self):
         from nuri.alerts.premarket_brief import format_brief_markdown
+
         ctx = {
             "regime": {"regime": "bull_low_vol", "trend": "bull", "volatility": "low", "confidence": 80},
             "macro": {"score": 65.0, "interpretation": "Good"},
             "vix": {"value": 15.5, "date": "2026-04-20"},
             "fear_greed": {"value": 70, "date": "2026-04-21"},
             "usd_krw": {"value": 1470, "date": "2026-04-20"},
-            "siege": {"certified": True, "score": 95, "passed": 16, "failed": 0,
-                      "warnings": 1, "total": 17, "failing_errors": []},
-            "actions": {
-                "urgent": [], "portfolio": [], "check": [],
-                "hold": [{"ticker": "NVDA", "action": "BUY", "confidence": 62,
-                         "pnl_pct": 11.5, "position_pct": 14.7, "reasons": []}],
+            "siege": {
+                "certified": True,
+                "score": 95,
+                "passed": 16,
+                "failed": 0,
+                "warnings": 1,
+                "total": 17,
+                "failing_errors": [],
             },
-            "opportunities": [{"ticker": "AMD", "score": 57, "change_5d": 5,
-                              "rsi": 60, "signal": "momentum", "pros": [], "cons": []}],
-            "macro_events": [{"category": "demand_growth", "sentiment": 0.85,
-                             "confidence": 0.82, "headline": "AI chip demand surges"}],
+            "actions": {
+                "urgent": [],
+                "portfolio": [],
+                "check": [],
+                "hold": [
+                    {
+                        "ticker": "NVDA",
+                        "action": "BUY",
+                        "confidence": 62,
+                        "pnl_pct": 11.5,
+                        "position_pct": 14.7,
+                        "reasons": [],
+                    }
+                ],
+            },
+            "opportunities": [
+                {"ticker": "AMD", "score": 57, "change_5d": 5, "rsi": 60, "signal": "momentum", "pros": [], "cons": []}
+            ],
+            "macro_events": [
+                {
+                    "category": "demand_growth",
+                    "sentiment": 0.85,
+                    "confidence": 0.82,
+                    "headline": "AI chip demand surges",
+                }
+            ],
             "portfolio_totals": {"total_usd": 27000, "by_account": [("brokerage_alpha", 18000)]},
         }
         md = format_brief_markdown(ctx)
@@ -153,14 +226,126 @@ class TestMarkdownPersist:
         assert "$27,000" in md
 
 
+class TestFreshnessSurface:
+    """#513 — premarket_brief 가 freshness gate 결과를 사용자에게 surface.
+
+    PR #512 가 backend 정책 (FRESHNESS_POLICIES) 등록 + dual-layer write/read filter
+    추가했지만 brief 본문에 표시되지 않으면 사용자 가시성 0. 이 테스트는 surface
+    누락 (regression) 방지.
+    """
+
+    def test_freshness_pass_only_renders_compact_summary(self):
+        from nuri.alerts.premarket_brief import format_brief_embed
+
+        ctx = {
+            "actions": {},
+            "freshness": {
+                "pass": 6,
+                "warn": 0,
+                "fail": 0,
+                "details": [
+                    {"key": "prices", "label": "주가", "status": "PASS", "message": "최신 (2h)"},
+                    {"key": "portfolio", "label": "포트폴리오 sync", "status": "PASS", "message": "최신 (11h)"},
+                ],
+            },
+        }
+        fields = format_brief_embed(ctx)["fields"]
+        labels = [f["name"] for f in fields]
+        assert any("Data Freshness" in lbl for lbl in labels), f"Got: {labels}"
+        fresh_field = next(f for f in fields if "Data Freshness" in f["name"])
+        # PASS-only → compact summary "6P / 0W / 0F" 만, 항목별 detail 안 포함
+        assert "6P" in fresh_field["value"]
+        assert "0W" in fresh_field["value"]
+        assert "0F" in fresh_field["value"]
+
+    def test_freshness_warn_renders_amber_color(self):
+        from nuri.alerts.premarket_brief import COLOR_AMBER, format_brief_embed
+
+        ctx = {
+            "actions": {},
+            "freshness": {
+                "pass": 5,
+                "warn": 1,
+                "fail": 0,
+                "details": [
+                    {"key": "portfolio", "label": "포트폴리오 sync", "status": "WARN", "message": "30h 경과"},
+                ],
+            },
+        }
+        # WARN 1+ → AMBER (기존 SIEGE AMBER 와 동일 priority)
+        assert format_brief_embed(ctx)["color"] == COLOR_AMBER
+
+    def test_freshness_fail_renders_red_color_and_problem_detail(self):
+        from nuri.alerts.premarket_brief import COLOR_RED, format_brief_embed
+
+        ctx = {
+            "actions": {},
+            "freshness": {
+                "pass": 4,
+                "warn": 0,
+                "fail": 2,
+                "details": [
+                    {"key": "prices", "label": "주가", "status": "PASS", "message": "최신"},
+                    {
+                        "key": "portfolio",
+                        "label": "포트폴리오 sync",
+                        "status": "FAIL",
+                        "message": "80h 경과 — sync 필요",
+                    },
+                    {"key": "consensus", "label": "Consensus", "status": "FAIL", "message": "stale"},
+                ],
+            },
+        }
+        # FAIL 1+ → RED (urgent action 과 동일 priority — 사용자 즉시 attention)
+        assert format_brief_embed(ctx)["color"] == COLOR_RED
+        # FAIL 항목 detail 표시 (PASS 항목은 noise 절감으로 생략)
+        fields = format_brief_embed(ctx)["fields"]
+        fresh_field = next(f for f in fields if "Data Freshness" in f["name"])
+        assert "포트폴리오 sync" in fresh_field["value"]
+        assert "Consensus" in fresh_field["value"]
+        assert "주가" not in fresh_field["value"]  # PASS 는 detail 생략
+
+    def test_freshness_section_in_markdown(self):
+        from nuri.alerts.premarket_brief import format_brief_markdown
+
+        ctx = {
+            "freshness": {
+                "pass": 5,
+                "warn": 1,
+                "fail": 0,
+                "details": [
+                    {"key": "prices", "label": "주가", "status": "PASS", "message": "최신 (2h)"},
+                    {"key": "portfolio", "label": "포트폴리오 sync", "status": "WARN", "message": "30h 경과"},
+                ],
+            },
+        }
+        md = format_brief_markdown(ctx)
+        assert "## Data Freshness" in md
+        # 모든 항목 detail 출력 (markdown 은 noise 절감 룰 X)
+        assert "주가" in md
+        assert "포트폴리오 sync" in md
+        assert "5P / 1W / 0F" in md
+
+    def test_freshness_missing_skips_section(self):
+        """ctx 에 freshness 없으면 section 자체 생략 (graceful)."""
+        from nuri.alerts.premarket_brief import format_brief_embed, format_brief_markdown
+
+        ctx = {"actions": {}}  # freshness key 부재
+        embed = format_brief_embed(ctx)
+        labels = [f["name"] for f in embed["fields"]]
+        assert not any("Freshness" in lbl for lbl in labels)
+        md = format_brief_markdown(ctx)
+        assert "Data Freshness" not in md
+
+
 class TestGenerateBrief:
     """E2E — generate_brief 가 ctx + embed + markdown + persist 경로를 모두 반환."""
 
     def test_returns_dict_with_expected_keys(self, empty_db_ctx, tmp_path, monkeypatch):
         from nuri.alerts import premarket_brief as pb
+
         # persist target 을 tmp 로 redirect
-        monkeypatch.setattr(pb, "__file__",
-                            str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
+        monkeypatch.setattr(pb, "__file__", str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
         (tmp_path / "nuri" / "alerts").mkdir(parents=True)
         result = pb.generate_brief()
         for k in ("ctx", "embed", "markdown", "path"):
@@ -171,6 +356,7 @@ class TestGenerateBrief:
         """Discord webhook 미설정 시 send_brief 는 False 반환 (scheduler 중단 안 함)."""
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         from nuri.alerts.premarket_brief import send_brief
+
         assert send_brief({"title": "test"}) is False
 
     def test_subsystem_exceptions_are_caught_not_raised(self, tmp_path, monkeypatch):
@@ -180,16 +366,11 @@ class TestGenerateBrief:
 
         # 모든 subsystem 에 실제 exception raise 주입 → except 블록이 전부 실행
         with (
-            patch("nuri.quant.regime.classifier.classify_regime",
-                  side_effect=RuntimeError("regime fail")),
-            patch("nuri.quant.regime.macro_score.compute_macro_score",
-                  side_effect=RuntimeError("macro fail")),
-            patch("nuri.trading.engine.certification.certify",
-                  side_effect=RuntimeError("siege fail")),
-            patch("nuri.api.routes.actions._build_actions",
-                  side_effect=RuntimeError("actions fail")),
-            patch("nuri.api.routes.actions._build_opportunities",
-                  side_effect=RuntimeError("ops fail")),
+            patch("nuri.quant.regime.classifier.classify_regime", side_effect=RuntimeError("regime fail")),
+            patch("nuri.quant.regime.macro_score.compute_macro_score", side_effect=RuntimeError("macro fail")),
+            patch("nuri.trading.engine.certification.certify", side_effect=RuntimeError("siege fail")),
+            patch("nuri.api.routes.actions._build_actions", side_effect=RuntimeError("actions fail")),
+            patch("nuri.api.routes.actions._build_opportunities", side_effect=RuntimeError("ops fail")),
             patch("nuri.core.db.query", side_effect=RuntimeError("db fail")),
         ):
             ctx = pb._collect_context()
@@ -203,39 +384,47 @@ class TestGenerateBrief:
         """ctx 전부 채워서 format_brief_embed 내 모든 conditional branch 실행.
         (226/230/239/241/243/245/253/278-288/297-301 miss line)."""
         from nuri.alerts.premarket_brief import format_brief_embed
+
         ctx = {
-            "regime": {"regime": "bull_low_vol", "trend": "bull",
-                       "volatility": "low", "confidence": 80},
+            "regime": {"regime": "bull_low_vol", "trend": "bull", "volatility": "low", "confidence": 80},
             "macro": {"score": 65.0, "interpretation": "Good"},
             "vix": {"value": 15.0, "date": "2026-04-20"},
             "fear_greed": {"value": 70, "date": "2026-04-21"},
             "usd_krw": {"value": 1470, "date": "2026-04-20"},
-            "siege": {"certified": False, "score": 58, "passed": 10, "failed": 1,
-                      "warnings": 6, "total": 17,
-                      "failing_errors": [{"id": "position_limit",
-                                          "desc": "종목 비중", "detail": "BAC>15%"}]},
+            "siege": {
+                "certified": False,
+                "score": 58,
+                "passed": 10,
+                "failed": 1,
+                "warnings": 6,
+                "total": 17,
+                "failing_errors": [{"id": "position_limit", "desc": "종목 비중", "detail": "BAC>15%"}],
+            },
             "actions": {
-                "urgent": [{"ticker": "CRASH", "action": "SELL", "confidence": 85,
-                            "pnl_pct": -30, "position_pct": 5}],
-                "portfolio": [{"ticker": "BAC", "action": "HOLD", "confidence": 62,
-                               "pnl_pct": -1, "position_pct": 19.8}],
-                "check": [{"ticker": "PL", "action": "HOLD", "confidence": 74,
-                           "pnl_pct": 46.8, "position_pct": 1.4}],
+                "urgent": [{"ticker": "CRASH", "action": "SELL", "confidence": 85, "pnl_pct": -30, "position_pct": 5}],
+                "portfolio": [
+                    {"ticker": "BAC", "action": "HOLD", "confidence": 62, "pnl_pct": -1, "position_pct": 19.8}
+                ],
+                "check": [{"ticker": "PL", "action": "HOLD", "confidence": 74, "pnl_pct": 46.8, "position_pct": 1.4}],
                 "hold": [],
             },
             "opportunities": [
-                {"ticker": "AMD", "score": 57, "change_5d": 5, "rsi": 60,
-                 "verdict_level": "positive"},
-                {"ticker": "IONQ", "score": 63, "change_5d": 31, "rsi": 84,
-                 "verdict_level": "neutral"},
-                {"ticker": "XLE", "score": 35, "change_5d": -1, "rsi": 22,
-                 "verdict_level": "danger"},
+                {"ticker": "AMD", "score": 57, "change_5d": 5, "rsi": 60, "verdict_level": "positive"},
+                {"ticker": "IONQ", "score": 63, "change_5d": 31, "rsi": 84, "verdict_level": "neutral"},
+                {"ticker": "XLE", "score": 35, "change_5d": -1, "rsi": 22, "verdict_level": "danger"},
             ],
-            "macro_events": [{"category": "demand_growth", "sentiment": 0.85,
-                              "confidence": 0.82, "headline": "AI chip demand surges"}],
-            "portfolio_totals": {"total_usd": 27000,
-                                 "by_account": [("brokerage_alpha", 18000),
-                                                ("brokerage_beta", 9000)]},
+            "macro_events": [
+                {
+                    "category": "demand_growth",
+                    "sentiment": 0.85,
+                    "confidence": 0.82,
+                    "headline": "AI chip demand surges",
+                }
+            ],
+            "portfolio_totals": {
+                "total_usd": 27000,
+                "by_account": [("brokerage_alpha", 18000), ("brokerage_beta", 9000)],
+            },
         }
         embed = format_brief_embed(ctx)
         assert "fields" in embed
@@ -259,8 +448,7 @@ class TestMainCLI:
         """--stdout 로 호출 시 markdown 표준출력 + Discord skip + exit 0."""
         from nuri.alerts import premarket_brief as pb
 
-        monkeypatch.setattr(pb, "__file__",
-                            str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
+        monkeypatch.setattr(pb, "__file__", str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
         (tmp_path / "nuri" / "alerts").mkdir(parents=True)
         # Discord webhook 없는 env 에서 실행 — send_brief 는 silent fallback
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
@@ -274,8 +462,7 @@ class TestMainCLI:
         """default (no --no-discord) 경로 — send_brief 호출 branch cover."""
         from nuri.alerts import premarket_brief as pb
 
-        monkeypatch.setattr(pb, "__file__",
-                            str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
+        monkeypatch.setattr(pb, "__file__", str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
         (tmp_path / "nuri" / "alerts").mkdir(parents=True)
 
         send_calls = []
@@ -288,8 +475,7 @@ class TestMainCLI:
         """send_brief False 반환해도 main() exit 0 (scheduler job 중단 금지)."""
         from nuri.alerts import premarket_brief as pb
 
-        monkeypatch.setattr(pb, "__file__",
-                            str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
+        monkeypatch.setattr(pb, "__file__", str(tmp_path / "nuri" / "alerts" / "premarket_brief.py"))
         (tmp_path / "nuri" / "alerts").mkdir(parents=True)
         monkeypatch.setattr(pb, "send_brief", lambda _embed: False)
         assert pb.main([]) == 0
@@ -300,10 +486,18 @@ class TestMarkdownEdgeCases:
 
     def test_markdown_with_opportunities_pros_cons_rendered(self):
         from nuri.alerts.premarket_brief import format_brief_markdown
+
         ctx = {
             "opportunities": [
-                {"ticker": "AMD", "score": 57, "change_5d": 5, "rsi": 60,
-                 "signal": "momentum", "pros": ["pro1", "pro2"], "cons": ["con1"]},
+                {
+                    "ticker": "AMD",
+                    "score": 57,
+                    "change_5d": 5,
+                    "rsi": 60,
+                    "signal": "momentum",
+                    "pros": ["pro1", "pro2"],
+                    "cons": ["con1"],
+                },
             ],
         }
         md = format_brief_markdown(ctx)
@@ -312,11 +506,17 @@ class TestMarkdownEdgeCases:
 
     def test_markdown_with_siege_failing_errors_rendered(self):
         from nuri.alerts.premarket_brief import format_brief_markdown
+
         ctx = {
-            "siege": {"certified": False, "score": 58, "passed": 10, "failed": 1,
-                      "warnings": 6, "total": 17,
-                      "failing_errors": [{"id": "position_limit", "desc": "비중 초과",
-                                          "detail": "BAC 19.8%>15%"}]},
+            "siege": {
+                "certified": False,
+                "score": 58,
+                "passed": 10,
+                "failed": 1,
+                "warnings": 6,
+                "total": 17,
+                "failing_errors": [{"id": "position_limit", "desc": "비중 초과", "detail": "BAC 19.8%>15%"}],
+            },
         }
         md = format_brief_markdown(ctx)
         assert "❌ position_limit" in md
@@ -328,6 +528,7 @@ class TestSchedulerRegistration:
 
     def test_premarket_brief_job_registered(self):
         from nuri.scheduler import SCHEDULES
+
         names = [j["name"] for j in SCHEDULES]
         assert "premarket_brief" in names
 
@@ -335,23 +536,24 @@ class TestSchedulerRegistration:
         """DST 자동 처리 — cron literal `0 22 * * 1-5` 대신 `0 9 * * 1-5 US/Eastern`.
         EDT 기간 KST 22:00, EST 기간 KST 23:00. codex Plan consult Q1 risk #1."""
         from nuri.scheduler import SCHEDULES
+
         job = next(j for j in SCHEDULES if j["name"] == "premarket_brief")
-        assert job.get("tz") == "US/Eastern", \
-            "premarket_brief must use US/Eastern tz for DST auto-handling"
-        assert job["cron"] == "0 9 * * 1-5", \
-            "premarket_brief must fire at US 09:00 weekdays (pre-market 30min before)"
+        assert job.get("tz") == "US/Eastern", "premarket_brief must use US/Eastern tz for DST auto-handling"
+        assert job["cron"] == "0 9 * * 1-5", "premarket_brief must fire at US 09:00 weekdays (pre-market 30min before)"
 
     def test_create_scheduler_accepts_tz_job(self):
         """create_scheduler 가 tz kwarg 가 있는 job 도 crash 없이 등록 + tz 반영."""
         from nuri.scheduler import create_scheduler
+
         scheduler = create_scheduler()
         try:
             job = scheduler.get_job("premarket_brief")
             assert job is not None
             # APScheduler CronTrigger.timezone 은 pytz tzinfo — zone 이름으로 직접 확인.
             tz_name = str(getattr(job.trigger, "timezone", ""))
-            assert tz_name in ("US/Eastern", "America/New_York"), \
+            assert tz_name in ("US/Eastern", "America/New_York"), (
                 f"premarket_brief trigger timezone should be US/Eastern, got {tz_name!r}"
+            )
         finally:
             # BlockingScheduler 는 start() 전 shutdown() 이 raise. 등록만 검증하고 조용히 종료.
             if getattr(scheduler, "running", False):
@@ -381,23 +583,26 @@ class TestSchedulerRegistration:
             mon_0859 = eastern.localize(datetime(2026, 4, 20, 8, 59, 0))  # Monday
             next_fire = trig.get_next_fire_time(None, mon_0859)
             assert next_fire is not None
-            assert next_fire.weekday() == 0, \
+            assert next_fire.weekday() == 0, (
                 f"Monday 08:59 이후 다음 fire 가 Monday(weekday=0) 여야 함 — got weekday={next_fire.weekday()} ({next_fire})"
+            )
             assert next_fire.hour == 9 and next_fire.minute == 0
 
             # (b) Friday 09:00 직후에서 찾은 다음 fire time = Monday (Sat 아님)
             fri_0901 = eastern.localize(datetime(2026, 4, 24, 9, 1, 0))  # Friday
             next_after_fri = trig.get_next_fire_time(None, fri_0901)
             assert next_after_fri is not None
-            assert next_after_fri.weekday() == 0, \
+            assert next_after_fri.weekday() == 0, (
                 f"Friday 09:01 이후 다음 fire 가 Monday 여야 함 (Saturday 발화 금지). got weekday={next_after_fri.weekday()} ({next_after_fri})"
+            )
 
             # (c) Saturday 08:00 에서 찾은 다음 fire time 도 Monday (Saturday 자체 skip)
             sat_0800 = eastern.localize(datetime(2026, 4, 25, 8, 0, 0))
             next_after_sat = trig.get_next_fire_time(None, sat_0800)
             assert next_after_sat is not None
-            assert next_after_sat.weekday() == 0, \
+            assert next_after_sat.weekday() == 0, (
                 f"Saturday 에서 찾은 다음 fire 는 Monday 여야 함. got weekday={next_after_sat.weekday()}"
+            )
         finally:
             if getattr(scheduler, "running", False):
                 scheduler.shutdown(wait=False)


### PR DESCRIPTION
## Summary

PR #512 가 \`FRESHNESS_POLICIES\` 정책 + dual-layer write/read filter ship 했지만 \`premarket_brief.py\` 가 결과를 brief 본문에 surface 안 함 → 사용자 가시성 0.

Session 8 brief 검증 (#513 격상) 시 발견 — backend 작동, 단 사용자가 stale data 위에서 의사결정 내려도 brief에서 경고 못 받음.

## Changes

\`nuri/alerts/premarket_brief.py\`:
- \`_collect_context\`: \`freshness\` key 추가 (\`get_freshness_summary()\` 호출, fault-tolerant degrade)
- \`format_brief_embed\`: 🕐 Data Freshness field 추가
  - PASS-only → compact \`NP / 0W / 0F\` header
  - WARN/FAIL → header + 문제 항목 detail (PASS noise 절감으로 생략)
- \`format_brief_markdown\`: \`## Data Freshness\` section 추가 (모든 항목 detail)
- \`_brief_color\` priority 확장:
  - **RED**: urgent action OR freshness FAIL
  - **AMBER**: SIEGE not certified OR freshness WARN
  - **BLUE**: 평상시

## Tests (5 신규 lock-tests)

\`tests/alerts/test_premarket_brief.py::TestFreshnessSurface\`:
- \`test_freshness_pass_only_renders_compact_summary\`
- \`test_freshness_warn_renders_amber_color\`
- \`test_freshness_fail_renders_red_color_and_problem_detail\`
- \`test_freshness_section_in_markdown\`
- \`test_freshness_missing_skips_section\` (graceful degrade)

## Verification

- [x] 26/26 tests/alerts/test_premarket_brief PASS (5 신규 + 21 회귀)
- [x] ruff clean
- [x] privacy scan PASS
- [x] make verify-doc-counts (165 files / 3,716 tests 갱신)

## Closes / Refs

- **Closes #513**
- Refs: #507 (Phase 1 complement) / #512 (backend filter — 본 PR이 user-facing 보강)

## Test plan

- [ ] CI green
- [ ] Codecov: freshness section 5 lock-tests로 ≥80% changed lines
- [ ] Auto-merge after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)