### PR TITLE
fix(api): #514 0주 ticker HOLD stale filter (PR #512 SELL 패턴 확장)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,716 backend tests across 165 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,717 backend tests across 165 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,716 tests, 165 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,717 tests, 165 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -376,6 +376,10 @@ def _get_recommendations() -> list[dict]:
     # P0 stale-data fix (#507 audit 2026-04-30): SELL/TRIM/REDUCE 는 portfolio.qty>0
     # 인 경우만 surface. tracker.py write-side filter 가 1차 차단하지만, 이미 persist
     # 된 stale row + 다른 writer 경로 (legacy / future) 도 이중으로 막음.
+    #
+    # #514 (Session 8 발견): HOLD 도 동일 filter 확장. 4-18 매도된 TSM 의 stale HOLD
+    # row (conf 80) 가 brief 에 surface 되는 noise 차단. BUY 는 비보유 ticker 도 valid
+    # emit 이므로 filter 제외.
     rows = query("""
         SELECT r.ticker, r.action, r.confidence, r.signals,
                r.scoring_detail, r.agent_verdicts,
@@ -383,7 +387,7 @@ def _get_recommendations() -> list[dict]:
         FROM recommendations r
         WHERE r.date = (SELECT MAX(date) FROM recommendations)
           AND (
-              r.action NOT IN ('SELL', 'TRIM', 'REDUCE')
+              r.action NOT IN ('SELL', 'TRIM', 'REDUCE', 'HOLD')
               OR r.ticker IN (SELECT ticker FROM portfolio WHERE quantity > 0)
           )
         ORDER BY r.confidence DESC

--- a/tests/test_p0_stale_data_guards.py
+++ b/tests/test_p0_stale_data_guards.py
@@ -258,3 +258,51 @@ def test_get_recommendations_filters_sell_on_zero_qty(db):
     assert ("AAPL", "SELL") in tickers_actions
     assert ("MSFT", "BUY") in tickers_actions
     assert ("GOOGL", "SELL") not in tickers_actions, "stale SELL 누설"
+
+
+# --- 4. #514 (Session 8): HOLD 도 portfolio JOIN filter ----------------
+
+
+def test_get_recommendations_filters_hold_on_zero_qty(db):
+    """0주 ticker 의 stale HOLD recommendation 도 surface 차단 (#514).
+
+    원인: 4-18 매도된 TSM 의 4-30 latest HOLD conf 80 row 가 brief Hold 섹션에 surface.
+    수정: SELL/TRIM/REDUCE 와 동일 패턴으로 HOLD 도 portfolio JOIN filter 적용.
+    BUY 는 비보유 ticker 도 valid emit 이므로 filter 제외.
+    """
+    from nuri.api.routes.actions import _get_recommendations
+
+    upsert_portfolio(
+        [
+            {
+                "account": "main",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 100,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ],
+        db,
+    )
+    # Direct DB write — stale HOLD on non-held ticker (TSM 4-18 매도 시뮬레이션)
+    with get_db(db) as conn:
+        for ticker, action in [
+            ("AAPL", "HOLD"),  # held → surface
+            ("TSM", "HOLD"),  # 0주 → 차단되어야 함
+            ("MSFT", "BUY"),  # 비보유 BUY → surface 유지 (BUY 는 valid)
+        ]:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence) VALUES ('2026-04-30', ?, ?, 80.0)",
+                (ticker, action),
+            )
+
+    import nuri.core.db as db_mod
+
+    db_mod.DB_PATH = db
+    results = _get_recommendations()
+
+    tickers_actions = {(r["ticker"], r["action"]) for r in results}
+    assert ("AAPL", "HOLD") in tickers_actions, "held HOLD 누락"
+    assert ("MSFT", "BUY") in tickers_actions, "비보유 BUY 누락 (BUY 는 filter 제외)"
+    assert ("TSM", "HOLD") not in tickers_actions, "stale HOLD 누설 (#514 fix)"


### PR DESCRIPTION
## Summary

PR #512 가 SELL/TRIM/REDUCE 만 portfolio JOIN filter 적용 — HOLD 는 leak. 4-18 매도된 TSM 의 stale HOLD conf 80 row 가 brief Hold 섹션에 surface 되는 noise (Session 8 #514 격상).

## Change

\`nuri/api/routes/actions.py::_get_recommendations\` SQL 한 줄:

\`\`\`diff
- r.action NOT IN ('SELL', 'TRIM', 'REDUCE')
+ r.action NOT IN ('SELL', 'TRIM', 'REDUCE', 'HOLD')
  OR r.ticker IN (SELECT ticker FROM portfolio WHERE quantity > 0)
\`\`\`

BUY 는 비보유 ticker 도 valid emit (universe scan)이라 filter 제외.

## Test (1 신규 lock-test)

\`tests/test_p0_stale_data_guards.py::test_get_recommendations_filters_hold_on_zero_qty\`:
- AAPL HOLD (held) → surface ✅
- TSM HOLD (0주) → 차단 ✅ (#514 fix 검증)
- MSFT BUY (비보유) → surface ✅ (BUY 제외)

## Verification

- [x] 10/10 tests/test_p0_stale_data_guards (1 신규 + 9 회귀)
- [x] 483/483 tests/api + tests/test_p0_stale_data_guards
- [x] ruff clean / privacy scan PASS
- [x] doc count sync (3,717 tests)

## Closes / Refs

- **Closes #514**
- Refs: #507 #512 #513 (Session 8 결함 4건 중 3번째 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)