### PR TITLE
feat(consensus): #515 신규 매수 ticker 자동 consensus 트리거

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,717 backend tests across 165 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,727 backend tests across 166 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,717 tests, 165 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,727 tests, 166 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/import_portfolio.py
+++ b/scripts/import_portfolio.py
@@ -6,17 +6,26 @@ yaml에 `holdings` 키가 정의된 계좌는 DB가 yaml 상태와 정확히 일
 건드리지 않는다.
 
 ticker/qty/avg/sector 외 추가 필드는 metadata JSON으로 보존.
+
+#515 (Session 8 발견): sync 후 신규 매수 ticker 가 있으면 자동으로 consensus
+재실행. brief 가 stale recommendation (예: 4-10 SELL conf 100) 으로 신규
+보유 종목을 잘못 표시하는 noise 차단.
 """
+
+import argparse
 import json
+import logging
 from pathlib import Path
 
 import yaml
 
-from nuri.core.db import init_db, replace_portfolio_account
+from nuri.core.db import init_db, query, replace_portfolio_account
 
 _KNOWN_FIELDS = {"ticker", "qty", "avg", "sector"}
 
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "portfolio.yaml"
+
+logger = logging.getLogger(__name__)
 
 
 def load_holdings_by_account(
@@ -52,15 +61,17 @@ def load_holdings_by_account(
 
             # ticker/qty/avg/sector 외 추가 필드 → metadata JSON
             extra = {k: v for k, v in h.items() if k not in _KNOWN_FIELDS}
-            records.append({
-                "account": account_id,
-                "ticker": str(h["ticker"]),
-                "quantity": float(h["qty"]),
-                "avg_price": float(h["avg"]),
-                "currency": currency,
-                "sector": h.get("sector", ""),
-                "metadata": json.dumps(extra, ensure_ascii=False) if extra else None,
-            })
+            records.append(
+                {
+                    "account": account_id,
+                    "ticker": str(h["ticker"]),
+                    "quantity": float(h["qty"]),
+                    "avg_price": float(h["avg"]),
+                    "currency": currency,
+                    "sector": h.get("sector", ""),
+                    "metadata": json.dumps(extra, ensure_ascii=False) if extra else None,
+                }
+            )
 
         result[account_id] = records
 
@@ -76,7 +87,52 @@ def load_holdings(config_path: Path | None = None) -> list[dict]:
     return [r for records in by_account.values() for r in records]
 
 
-def main():
+def _diff_new_tickers(by_account: dict[str, list[dict]], db_path: Path | None = None) -> set[str]:
+    """sync 호출 직전의 portfolio 테이블 ticker set vs yaml 신규 ticker set diff.
+
+    Returns: yaml 에 있고 DB 에 없는 ticker (신규 매수). 빈 set 이면 변동 없음.
+    """
+    yaml_tickers = {r["ticker"] for records in by_account.values() for r in records}
+    rows = query("SELECT DISTINCT ticker FROM portfolio WHERE quantity > 0", db_path=db_path)
+    db_tickers = {str(r["ticker"]) for r in rows}
+    return yaml_tickers - db_tickers
+
+
+def _trigger_consensus(new_tickers: set[str], db_path: Path | None = None) -> int:
+    """신규 ticker 에 대해 analyze_ticker → save_to_recommendations.
+
+    #515: 신규 매수 시 stale recommendation (예: 4-10 SELL conf 100) 이 brief 에
+    surface 되어 사용자 confusion 유발하는 문제 차단. analyze_ticker 1회 호출이
+    consensus result 1건 + save_to_recommendations 가 today date row 갱신.
+
+    Returns: 성공 ticker 수.
+    """
+    from nuri.trading.agents.consensus import analyze_ticker, save_to_recommendations
+
+    saved = 0
+    for ticker in sorted(new_tickers):
+        try:
+            result = analyze_ticker(ticker, db_path=db_path)
+        except Exception as e:
+            logger.warning("analyze_ticker(%s) 실패: %s", ticker, e)
+            continue
+        try:
+            save_to_recommendations([result], db_path=db_path)
+            saved += 1
+        except Exception as e:
+            logger.warning("save_to_recommendations(%s) 실패: %s", ticker, e)
+    return saved
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="portfolio.yaml → DB sync")
+    parser.add_argument(
+        "--no-consensus",
+        action="store_true",
+        help="신규 ticker 발견 시 자동 consensus 호출 건너뜀 (#515 옵트아웃)",
+    )
+    args = parser.parse_args(argv)
+
     print("=== Nuri-Quant Portfolio Sync ===")
 
     # DB가 없으면 먼저 생성
@@ -84,17 +140,35 @@ def main():
 
     by_account = load_holdings_by_account()
 
+    # #515: sync 직전 diff 추출 — sync 후엔 yaml=DB 라 diff 0 됨
+    new_tickers = _diff_new_tickers(by_account)
+
     total_deleted = 0
     total_inserted = 0
     for account, records in by_account.items():
         deleted, inserted = replace_portfolio_account(account, records)
         total_deleted += deleted
         total_inserted += inserted
-        marker = "" if deleted == inserted else f"  (-{deleted - inserted} stale)" if deleted > inserted else f"  (+{inserted - deleted} new)"
+        marker = (
+            ""
+            if deleted == inserted
+            else f"  (-{deleted - inserted} stale)"
+            if deleted > inserted
+            else f"  (+{inserted - deleted} new)"
+        )
         print(f"  - {account}: {inserted}종목{marker}")
 
     print(f"=== Sync complete: -{total_deleted} +{total_inserted} ===")
 
+    if new_tickers and not args.no_consensus:
+        print(f"\n=== #515 Auto-consensus for {len(new_tickers)} new ticker(s): {sorted(new_tickers)} ===")
+        saved = _trigger_consensus(new_tickers)
+        print(f"  → {saved}/{len(new_tickers)} recommendations 갱신 (today date)")
+    elif new_tickers:
+        print(f"\n--no-consensus 지정 — 신규 {len(new_tickers)}종 consensus 건너뜀: {sorted(new_tickers)}")
+
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/scripts/test_import_portfolio_consensus.py
+++ b/tests/scripts/test_import_portfolio_consensus.py
@@ -1,0 +1,278 @@
+"""#515 — scripts/import_portfolio.py 신규 ticker 자동 consensus 트리거 검증.
+
+문제: portfolio.yaml 에 신규 매수 ticker 추가 후 import 만 하면
+brief 가 stale recommendation (예: 4-10 SELL conf 100) 으로 신규 보유 종목을
+잘못 표시. import 직후 consensus 자동 호출이 today date row 갱신해 차단.
+
+이 lock-test 가 fail 하면 사용자가 `make consensus` 별도 실행 잊어버린 채
+brief 보고 잘못된 매도 권고로 confusion 가능.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nuri.core.db import get_db, init_db, query, upsert_portfolio
+from scripts.import_portfolio import _diff_new_tickers, _trigger_consensus
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    import nuri.core.db as db_mod
+
+    path = tmp_path / "test.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+# ─── _diff_new_tickers ──────────────────────────────────────────────────
+
+
+def test_diff_finds_new_ticker_added_to_yaml(db):
+    """yaml 에 추가된 ticker 가 DB 에 없으면 diff 에 포함."""
+    upsert_portfolio(
+        [{"account": "main", "ticker": "AAPL", "quantity": 10, "avg_price": 100, "currency": "USD", "sector": "Tech"}],
+        db,
+    )
+    by_account = {
+        "main": [
+            {
+                "ticker": "AAPL",
+                "quantity": 10.0,
+                "avg_price": 100.0,
+                "account": "main",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "ticker": "MSFT",
+                "quantity": 3.0,
+                "avg_price": 424.0,
+                "account": "main",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ]
+    }
+    diff = _diff_new_tickers(by_account, db_path=db)
+    assert diff == {"MSFT"}
+
+
+def test_diff_returns_empty_when_no_changes(db):
+    """yaml 과 DB 가 일치하면 diff 빈 set."""
+    upsert_portfolio(
+        [{"account": "main", "ticker": "AAPL", "quantity": 10, "avg_price": 100, "currency": "USD", "sector": "Tech"}],
+        db,
+    )
+    by_account = {
+        "main": [
+            {
+                "ticker": "AAPL",
+                "quantity": 10.0,
+                "avg_price": 100.0,
+                "account": "main",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ]
+    }
+    diff = _diff_new_tickers(by_account, db_path=db)
+    assert diff == set()
+
+
+def test_diff_skips_zero_qty_db_rows(db):
+    """DB 의 0주 row 는 'held' 아님 — 같은 ticker 가 yaml 에 있으면 신규로 분류."""
+    # qty=0 row (stale) 직접 INSERT
+    with get_db(db) as conn:
+        conn.execute(
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+            "VALUES ('main', 'TSM', 0, 200.0, 'USD', 'Tech')"
+        )
+    by_account = {
+        "main": [
+            {
+                "ticker": "TSM",
+                "quantity": 5.0,
+                "avg_price": 200.0,
+                "account": "main",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ]
+    }
+    diff = _diff_new_tickers(by_account, db_path=db)
+    assert diff == {"TSM"}
+
+
+def test_diff_multi_account(db):
+    """여러 계좌의 신규 ticker 모두 합쳐 반환."""
+    upsert_portfolio(
+        [{"account": "main", "ticker": "AAPL", "quantity": 10, "avg_price": 100, "currency": "USD", "sector": "Tech"}],
+        db,
+    )
+    by_account = {
+        "main": [
+            {
+                "ticker": "AAPL",
+                "quantity": 10.0,
+                "avg_price": 100.0,
+                "account": "main",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "ticker": "GOOGL",
+                "quantity": 3.0,
+                "avg_price": 350.0,
+                "account": "main",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ],
+        "sub": [
+            {
+                "ticker": "NVDA",
+                "quantity": 5.0,
+                "avg_price": 180.0,
+                "account": "sub",
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ],
+    }
+    diff = _diff_new_tickers(by_account, db_path=db)
+    assert diff == {"GOOGL", "NVDA"}
+
+
+# ─── _trigger_consensus ──────────────────────────────────────────────────
+
+
+def test_trigger_consensus_calls_analyze_per_ticker(db):
+    """신규 ticker 마다 analyze_ticker + save_to_recommendations 호출."""
+    fake_result = type("R", (), {"ticker": "MSFT", "action": "HOLD", "confidence": 60})()
+
+    with (
+        patch("nuri.trading.agents.consensus.analyze_ticker", return_value=fake_result) as mock_analyze,
+        patch("nuri.trading.agents.consensus.save_to_recommendations", return_value=1) as mock_save,
+    ):
+        saved = _trigger_consensus({"MSFT", "GOOGL"}, db_path=db)
+
+    assert saved == 2
+    assert mock_analyze.call_count == 2
+    assert mock_save.call_count == 2
+
+
+def test_trigger_consensus_continues_on_analyze_error(db):
+    """한 ticker analyze 실패해도 나머지 진행."""
+    fake_result = type("R", (), {"ticker": "MSFT", "action": "HOLD", "confidence": 60})()
+
+    def analyze_side_effect(ticker, db_path=None):
+        if ticker == "BAD":
+            raise RuntimeError("network error")
+        return fake_result
+
+    with (
+        patch("nuri.trading.agents.consensus.analyze_ticker", side_effect=analyze_side_effect),
+        patch("nuri.trading.agents.consensus.save_to_recommendations", return_value=1) as mock_save,
+    ):
+        saved = _trigger_consensus({"MSFT", "BAD"}, db_path=db)
+
+    # MSFT 만 성공
+    assert saved == 1
+    assert mock_save.call_count == 1
+
+
+def test_trigger_consensus_empty_set_no_calls(db):
+    """빈 set 이면 호출 0 — graceful no-op."""
+    with patch("nuri.trading.agents.consensus.analyze_ticker") as mock_analyze:
+        saved = _trigger_consensus(set(), db_path=db)
+    assert saved == 0
+    assert mock_analyze.call_count == 0
+
+
+# ─── E2E (main 함수 + --no-consensus 플래그) ────────────────────────────
+
+
+def test_main_no_consensus_flag_skips_trigger(db, tmp_path, monkeypatch):
+    """--no-consensus 지정 시 신규 ticker 있어도 consensus 호출 X."""
+    import scripts.import_portfolio as ip
+
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text(
+        """
+accounts:
+  main:
+    currency: USD
+    holdings:
+      - { ticker: NEWCO, qty: 1, avg: 100 }
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ip, "CONFIG_PATH", yaml_path)
+
+    with patch("scripts.import_portfolio._trigger_consensus") as mock_trigger:
+        rc = ip.main(["--no-consensus"])
+
+    assert rc == 0
+    mock_trigger.assert_not_called()
+    # 그래도 sync 는 일어났어야 함
+    rows = query("SELECT ticker FROM portfolio WHERE ticker = 'NEWCO'", db_path=db)
+    assert len(rows) == 1
+
+
+def test_main_default_calls_trigger_for_new_tickers(db, tmp_path, monkeypatch):
+    """default (--no-consensus 없음) 신규 ticker 발견 시 _trigger_consensus 호출."""
+    import scripts.import_portfolio as ip
+
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text(
+        """
+accounts:
+  main:
+    currency: USD
+    holdings:
+      - { ticker: NEWCO, qty: 1, avg: 100 }
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ip, "CONFIG_PATH", yaml_path)
+
+    with patch("scripts.import_portfolio._trigger_consensus", return_value=1) as mock_trigger:
+        rc = ip.main([])
+
+    assert rc == 0
+    mock_trigger.assert_called_once()
+    # 호출 인자 — 신규 ticker set 포함
+    args, _ = mock_trigger.call_args
+    assert "NEWCO" in args[0]
+
+
+def test_main_no_new_tickers_skips_trigger(db, tmp_path, monkeypatch):
+    """yaml 과 DB 일치 시 _trigger_consensus 호출 X (불필요한 LLM 호출 회피)."""
+    import scripts.import_portfolio as ip
+
+    upsert_portfolio(
+        [{"account": "main", "ticker": "AAPL", "quantity": 1, "avg_price": 100, "currency": "USD", "sector": "Tech"}],
+        db,
+    )
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text(
+        """
+accounts:
+  main:
+    currency: USD
+    holdings:
+      - { ticker: AAPL, qty: 1, avg: 100 }
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ip, "CONFIG_PATH", yaml_path)
+
+    with patch("scripts.import_portfolio._trigger_consensus") as mock_trigger:
+        rc = ip.main([])
+
+    assert rc == 0
+    mock_trigger.assert_not_called()


### PR DESCRIPTION
## Summary

Session 8 사용자 매수 시 발견 (#515 격상): 신규 ticker (MSFT 3주 + GOOGL 3주) 매수 후 \`import_portfolio.py\` 만 실행하면 brief 의 MSFT recommendation 은 stale 2026-04-10 SELL conf 100 으로 표시. \`make consensus\` 별도 실행을 잊으면 사용자가 잘못된 매도 권고로 confusion.

## Changes

\`scripts/import_portfolio.py\`:
- \`_diff_new_tickers()\`: sync 직전 DB ticker set vs yaml ticker set diff. qty>0 filter (0주 stale row 무시)
- \`_trigger_consensus()\`: 신규 ticker 마다 \`analyze_ticker\` + \`save_to_recommendations\`. 1건 실패해도 나머지 진행
- \`main()\`: argparse 도입, default ON. \`--no-consensus\` 플래그 (CI/test 격리용)
- 시그니처 \`main(argv)\` 로 변경 (테스트 호출 용이)

## Tests (10 신규 lock-tests)

\`tests/scripts/test_import_portfolio_consensus.py\`:

**_diff_new_tickers (4)**:
- 신규 ticker / 변동 없음 / 0주 stale row / multi-account

**_trigger_consensus (3)**:
- 정상 호출 / 부분 실패 graceful / empty set no-op

**main E2E (3)**:
- \`--no-consensus\` 플래그 → trigger 안 호출
- default (인자 없음) → trigger 호출 + 신규 ticker 인자 검증
- yaml=DB 동일 → trigger 호출 X (불필요한 LLM cost 회피)

## Verification

- [x] 10/10 tests/scripts/test_import_portfolio_consensus PASS
- [x] 184/184 tests/scripts/ PASS (회귀 0)
- [x] ruff clean / privacy scan PASS
- [x] doc count sync (3,727 tests / 166 files)

## Closes / Refs

- **Closes #515**
- Refs: #507 (Phase 1 brief 신뢰도 보강) / #514 (HOLD stale filter — 본 PR 이 발생 자체를 차단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)