### PR TITLE
fix(freshness): consensus query → recommendations.date (always-FAIL bug)

### DIFF
--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -27,7 +27,11 @@ FRESHNESS_POLICIES = {
         "label": "Fear & Greed",
     },
     "consensus": {
-        "query": "SELECT MAX(timestamp) FROM pipeline_events WHERE step = 'diagnose' AND event_type = 'step_completed'",
+        # FIX (Session 10): `diagnose` step_completed event 가 실제로 emit 되지 않아 항상 FAIL.
+        # `recommendations.date` (consensus 결과 persist) 를 source of truth 로 변경.
+        # save_to_recommendations 가 매 consensus run 마다 today date row 갱신.
+        # date 는 'YYYY-MM-DD' string — datetime 비교 위해 datetime() 캐스트.
+        "query": "SELECT datetime(MAX(date)) FROM recommendations",
         "warn_hours": 24,
         "fail_hours": 48,
         "label": "에이전트 합의",

--- a/tests/core/test_pipeline_events.py
+++ b/tests/core/test_pipeline_events.py
@@ -252,8 +252,21 @@ class TestCheckFreshness:
         assert result["message"] == "데이터 없음"
 
     def test_consensus_freshness(self, db_path):
-        """pipeline_events 기반 consensus 신선도 체크."""
-        emit_event("step_completed", "diagnose", db_path=db_path)
+        """recommendations.date 기반 consensus 신선도 체크.
+
+        Session 10 fix (PR #526): query 가 'pipeline_events.diagnose step_completed'
+        를 보던 always-FAIL bug → 'recommendations.date' 로 교체. save_to_recommendations
+        가 매 consensus run 마다 today date row 갱신하므로 정확한 source.
+        """
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence) VALUES (?, 'AAPL', 'HOLD', 80.0)",
+                (today_kst(),),
+            )
+            conn.commit()
         result = check_freshness("consensus", db_path)
         assert result["status"] == "PASS"
         assert result["key"] == "consensus"


### PR DESCRIPTION
## Summary

**Pre-existing bug 발견 (Session 10 brief 검증)**: \`freshness.consensus\` policy 가 \`pipeline_events.step='diagnose' AND event_type='step_completed'\` 을 source로 사용했지만 해당 event 는 코드 어디에서도 emit 안 됨 (orphan spec).

→ \`make consensus\` 매일 정상 실행 + recommendations 갱신해도 freshness 항상 \`FAIL: 데이터 없음\`. PR #523 brief freshness section 도 매번 ❌ 표시.

## Fix

\`nuri/core/freshness.py::FRESHNESS_POLICIES["consensus"].query\`:

\`\`\`diff
- "SELECT MAX(timestamp) FROM pipeline_events WHERE step = 'diagnose' AND event_type = 'step_completed'"
+ "SELECT datetime(MAX(date)) FROM recommendations"
\`\`\`

- \`save_to_recommendations\` 가 매 consensus run 마다 today date row 갱신 → source of truth
- \`date\` 는 \`'YYYY-MM-DD'\` string — datetime 비교 위해 \`datetime()\` 캐스트

## Verification

- 변경 전: \`FAIL: 데이터 없음\`
- 변경 후: \`PASS: 최신 (4.7h)\` (4-30 consensus 4.7h ago)
- 기존 freshness + P0 stale-data 테스트 42개 회귀 0
- ruff clean / privacy scan PASS

## Refs

- PR #523 (brief freshness surface — 본 PR 의 사용자 가시성 가치 회복)
- Phase 1 #508 (consensus emit, recommendations writer)

## Test plan

- [ ] CI green
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)