### PR TITLE
fix(collectors): #532 KIS token re-issue every day

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,833 backend tests across 172 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,833 backend tests across 173 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,833 tests, 172 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,833 tests, 173 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/kis_realtime.py
+++ b/nuri/collectors/kis_realtime.py
@@ -72,8 +72,34 @@ def _resolve_kis_paths(new_dir: Path, legacy_dir: Path) -> tuple[Path, Path]:
     return legacy_dir / "config" / "kis_devlp.yaml", legacy_dir / "cache"
 
 
-# Module load 시 1회 결정. 테스트는 KIS_YAML_PATH를 monkeypatch.
-KIS_YAML_PATH, TOKEN_CACHE_DIR = _resolve_kis_paths(_KIS_NEW_DIR, _KIS_LEGACY_DIR)
+def _resolve_token_cache_dir(new_dir: Path, legacy_dir: Path) -> Path:
+    """Token cache 경로 결정 (Issue #532).
+
+    `_resolve_kis_paths` 와 다르게 **yaml 존재 여부와 무관하게 항상 project-local
+    `config/kis/cache/` 사용**. 이유:
+
+    1. **결정성**: `.env` only 셋업 (yaml 부재) 에서도 cache 위치가 예측 가능.
+       기존 로직은 yaml 없으면 `~/KIS/cache/` 로 fallback → "cache 가 어디
+       갔는지" 추적 어려움 → Issue #532 의 "매일 새 토큰 발급" 노이즈 원인.
+    2. **2-machine setup 안전**: project-local 이면 양쪽 머신에서 동일 경로
+       (각자 cache 보유, sync 는 안 되지만 위치는 동일).
+    3. **gitignored 보장**: `.gitignore` 가 `config/kis/*` 전체 ignore →
+       토큰 git 유출 위험 없음.
+
+    Args:
+        new_dir: 프로젝트 내 KIS 디렉토리 (config/kis/)
+        legacy_dir: 레거시 위치 (~/KIS/) — 현재는 사용 안 함, 호환성 위해 유지
+
+    Returns:
+        token cache 디렉토리 Path
+    """
+    del legacy_dir  # 의도적으로 미사용 (legacy fallback 제거)
+    return new_dir / "cache"
+
+
+# Module load 시 1회 결정. 테스트는 KIS_YAML_PATH / TOKEN_CACHE_DIR 를 patch.
+KIS_YAML_PATH, _ = _resolve_kis_paths(_KIS_NEW_DIR, _KIS_LEGACY_DIR)
+TOKEN_CACHE_DIR = _resolve_token_cache_dir(_KIS_NEW_DIR, _KIS_LEGACY_DIR)
 
 # KIS rate limit (KIS 공지 2026.03.20 + 실측):
 #   - 실전(prod) 신규: 초당 3건 → 0.4s 간격 (초당 2.5건, 안전 마진)

--- a/tests/collectors/test_kis_token_cache.py
+++ b/tests/collectors/test_kis_token_cache.py
@@ -1,0 +1,219 @@
+"""KIS access token 캐시 동작 회귀 테스트 (Issue #532).
+
+회귀 보호 대상:
+    - Cache 위치 결정성: `.env` only 자격 증명 환경에서도 cache 가 항상
+      project-local `config/kis/cache/` 에 쓰여야 한다 (legacy `~/KIS/cache/` 로
+      흘러가면 2-machine setup 에서 sync 불가 → 매일 새 토큰 발급 노이즈).
+    - TTL 적중: TTL 이내 두 번째 호출은 HTTP 요청 없이 캐시된 토큰을 반환.
+    - JSON 손상 시 재발급: 캐시 파일이 깨졌으면 silently 무시 + 새로 발급.
+
+Issue: https://github.com/researcherhojin/nuri-quant/issues/532
+"""
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nuri.collectors.kis_realtime import (
+    KISCredentials,
+    _resolve_token_cache_dir,
+    get_access_token,
+)
+
+
+@pytest.fixture
+def fake_creds() -> KISCredentials:
+    """테스트용 가짜 자격 증명 (실제 KIS 호출 X)."""
+    return KISCredentials(
+        app_key="fake_key",
+        app_secret="fake_secret",
+        account="00000000",
+        hts_id="fake_hts",
+        mode="prod",
+    )
+
+
+@pytest.fixture
+def project_cache_dir(tmp_path):
+    """project-local cache 위치 (config/kis/cache 시뮬레이션)."""
+    d = tmp_path / "project" / "config" / "kis" / "cache"
+    return d
+
+
+@pytest.fixture
+def legacy_cache_dir(tmp_path):
+    """레거시 ~/KIS/cache 위치."""
+    d = tmp_path / "home" / "KIS" / "cache"
+    return d
+
+
+# ═══════════════════════════════════════════════════════
+# Cache 위치 결정성 (Issue #532 핵심 회귀)
+# ═══════════════════════════════════════════════════════
+
+
+class TestCacheLocationDeterminism:
+    """Cache 는 항상 project-local 이어야 한다 (yaml 존재 여부 무관)."""
+
+    def test_cache_dir_is_project_local_when_yaml_absent(
+        self, project_cache_dir, legacy_cache_dir
+    ):
+        """`.env` only 셋업 (yaml 없음) → cache 가 project-local 로 결정됨.
+
+        이 테스트가 실패하면 Issue #532 재발: cache 가 legacy `~/KIS/cache/` 로
+        흘러가서 2-machine sync 안 되고 매일 새 토큰 발급됨.
+        """
+        # yaml 부재 (modern .env-only setup)
+        project_kis_dir = project_cache_dir.parent  # config/kis/
+        project_kis_dir.mkdir(parents=True, exist_ok=True)
+        # NOTE: kis_devlp.yaml 을 일부러 만들지 않음 (.env only 시나리오)
+
+        resolved = _resolve_token_cache_dir(project_kis_dir, legacy_cache_dir.parent)
+        assert resolved == project_cache_dir, (
+            f"`.env` only 셋업에서 cache 가 legacy 로 흘러감: {resolved} "
+            f"(expected: {project_cache_dir}). Issue #532 회귀."
+        )
+
+    def test_cache_dir_is_project_local_when_yaml_present(
+        self, project_cache_dir, legacy_cache_dir
+    ):
+        """yaml 있을 때도 동일하게 project-local cache. 결정성 보장."""
+        project_kis_dir = project_cache_dir.parent
+        project_kis_dir.mkdir(parents=True, exist_ok=True)
+        (project_kis_dir / "kis_devlp.yaml").write_text("placeholder: true")
+
+        resolved = _resolve_token_cache_dir(project_kis_dir, legacy_cache_dir.parent)
+        assert resolved == project_cache_dir
+
+
+# ═══════════════════════════════════════════════════════
+# TTL 적중 — 같은 token 반환 + HTTP 1회만
+# ═══════════════════════════════════════════════════════
+
+
+class TestTokenCacheTTL:
+    """TTL 이내 두 번째 호출은 캐시된 token 반환 (HTTP 0회)."""
+
+    def test_two_calls_within_ttl_only_one_http_request(
+        self, fake_creds, project_cache_dir
+    ):
+        """24h cache 의 핵심: 2번 호출 → HTTP 1번만 발생."""
+        project_cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = project_cache_dir / "token_prod.json"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "TOKEN_FROM_HTTP",
+            "expires_in": 86400,
+        }
+
+        with (
+            patch(
+                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
+            ),
+            patch("nuri.collectors.kis_realtime.requests.post", return_value=mock_response) as mock_post,
+        ):
+            # 1차: HTTP 호출 → cache 작성
+            tok1 = get_access_token(fake_creds)
+            # 2차: cache hit → HTTP 없음
+            tok2 = get_access_token(fake_creds)
+
+        assert tok1 == "TOKEN_FROM_HTTP"
+        assert tok2 == "TOKEN_FROM_HTTP", "Cache hit 시 같은 token 반환해야 함"
+        assert mock_post.call_count == 1, (
+            f"TTL 이내 2회 호출이 HTTP {mock_post.call_count}회 발생 — "
+            "Issue #532 회귀 (cache 미작동)"
+        )
+        assert cache_file.exists(), "Cache 파일이 작성되어야 함"
+
+    def test_expired_cache_triggers_new_issue(self, fake_creds, project_cache_dir):
+        """TTL 초과된 cache 는 무시 + 새로 발급."""
+        project_cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = project_cache_dir / "token_prod.json"
+        # 25시간 전 issued (TTL 23h 초과)
+        cache_file.write_text(
+            json.dumps({
+                "access_token": "STALE_TOKEN",
+                "issued_at": time.time() - 25 * 3600,
+                "expires_in": 86400,
+            })
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "FRESH_TOKEN",
+            "expires_in": 86400,
+        }
+
+        with (
+            patch(
+                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
+            ),
+            patch("nuri.collectors.kis_realtime.requests.post", return_value=mock_response) as mock_post,
+        ):
+            tok = get_access_token(fake_creds)
+
+        assert tok == "FRESH_TOKEN"
+        assert mock_post.call_count == 1
+
+    def test_corrupted_cache_falls_back_to_new_issue(
+        self, fake_creds, project_cache_dir
+    ):
+        """깨진 JSON cache → silently 무시 + 새로 발급."""
+        project_cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = project_cache_dir / "token_prod.json"
+        cache_file.write_text("{ corrupted json !!!")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "RECOVERY_TOKEN",
+            "expires_in": 86400,
+        }
+
+        with (
+            patch(
+                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
+            ),
+            patch("nuri.collectors.kis_realtime.requests.post", return_value=mock_response),
+        ):
+            tok = get_access_token(fake_creds)
+
+        assert tok == "RECOVERY_TOKEN"
+
+
+# ═══════════════════════════════════════════════════════
+# Mode 분리 — prod / paper 별 cache 파일
+# ═══════════════════════════════════════════════════════
+
+
+class TestModeSeparation:
+    """prod 와 paper token 은 다른 파일로 cache."""
+
+    def test_prod_and_paper_use_separate_cache_files(self, project_cache_dir):
+        """prod cache 가 paper 호출에 새지 않도록."""
+        project_cache_dir.mkdir(parents=True, exist_ok=True)
+        prod_creds = KISCredentials("k", "s", "1", "h", "prod")
+        paper_creds = KISCredentials("k", "s", "1", "h", "paper")
+
+        responses = [
+            MagicMock(status_code=200, **{"json.return_value": {"access_token": "PROD_TOK", "expires_in": 86400}}),
+            MagicMock(status_code=200, **{"json.return_value": {"access_token": "PAPER_TOK", "expires_in": 86400}}),
+        ]
+
+        with (
+            patch(
+                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
+            ),
+            patch("nuri.collectors.kis_realtime.requests.post", side_effect=responses),
+        ):
+            assert get_access_token(prod_creds) == "PROD_TOK"
+            assert get_access_token(paper_creds) == "PAPER_TOK"
+
+        assert (project_cache_dir / "token_prod.json").exists()
+        assert (project_cache_dir / "token_paper.json").exists()


### PR DESCRIPTION
## Root Cause

`_resolve_kis_paths()` 가 token cache 위치를 `kis_devlp.yaml` 존재 여부에 따라 결정:
- yaml 있음 → `config/kis/cache/` (project-local, 의도된 동작)
- yaml 없음 → `~/KIS/cache/` (legacy fallback)

Modern `.env` only 자격 증명 셋업에서는 yaml 이 부재하므로 cache 가 silently `~/KIS/cache/` 로 흘러감. 사용자 환경 (MBP + Mac mini 2-machine setup) 에서:

1. **Mac mini 에 `~/KIS/` 디렉토리 부재 가능** → cache 디렉토리 처음 만들 때 실패하거나, cache 파일이 매번 사라짐 → 매일 새 토큰 발급
2. **양쪽 머신이 각자 다른 cache** → sync 안 됨, 한쪽이 새 토큰 받으면 다른 쪽도 곧 받게 됨
3. **사용자 매일 KakaoTalk 알림** "오픈API 접근 토큰이 발급되었습니다" 수신 → KIS abuse monitoring 트리거 위험

확인:
```bash
$ ls /Users/ehbebe/workspace/nuri-quant/config/kis/
.gitkeep   # ← 비어있음 (cache 가 여기로 안 옴)

$ cat ~/KIS/cache/token_prod.json  # ← 실제로 여기 있었음
{"access_token": "...", "issued_at": ...}
```

## Fix

`_resolve_token_cache_dir()` 신설 — yaml 존재 여부 무관, **항상 project-local `config/kis/cache/`** 사용:

- 결정성: cache 위치가 자격 증명 출처와 분리됨
- 2-machine 안전: 양쪽 머신 동일 경로 (각자 cache 보유, 위치는 동일)
- gitignored 보장: `config/kis/*` 가 이미 `.gitignore` 차단

자격 증명 lookup (`_resolve_kis_paths`) 은 변경 없음 → legacy yaml 사용자 backward compat 유지.

## Test Coverage

`tests/collectors/test_kis_token_cache.py` (6 tests, 모두 PASS):

- **`test_cache_dir_is_project_local_when_yaml_absent`** — Issue #532 핵심 회귀 보호 (revert 시 FAIL)
- `test_cache_dir_is_project_local_when_yaml_present` — yaml 있을 때도 동일 결과
- `test_two_calls_within_ttl_only_one_http_request` — 24h TTL 적중 검증 (HTTP 1회만)
- `test_expired_cache_triggers_new_issue` — TTL 초과 시 재발급
- `test_corrupted_cache_falls_back_to_new_issue` — JSON 손상 시 silently 무시 + 재발급
- `test_prod_and_paper_use_separate_cache_files` — mode 분리

## Verification

```
$ .venv/bin/python -m pytest tests/collectors/ -k kis -q
103 passed, 471 deselected in 0.89s

$ .venv/bin/python -m ruff check nuri/collectors/kis_realtime.py tests/collectors/test_kis_token_cache.py
All checks passed!

$ .venv/bin/python scripts/check_privacy_leak.py
✓ No personal financial data leaks detected.
```

## Migration Note

기존 `~/KIS/cache/token_prod.json` 은 이 PR 머지 후 무시됨 (orphan). 다음 KIS 호출 1번은 새 토큰 발급 (acceptable migration cost), 이후 `config/kis/cache/token_prod.json` 에서 23h TTL 적용.

## Acceptance (#532 checklist)

- [x] Token 1일 1회만 발급 (24h cache 정상 작동)
- [x] 양쪽 머신 동일한 cache 경로 (각자 cache 보유, 1일 2회 발급 max)
- [x] Test: 같은 mode 로 `get_access_token()` 연속 호출 시 동일 token 반환 검증
- [ ] 알림톡 빈도 monitoring (1주 후 재측정 — merge 후 사용자 관찰)

Closes #532