### PR TITLE
feat(discord): #529 rich embed format for slash commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,9 @@ discord-test: ## Smoke test webhook publish. usage: make discord-test channel=br
 	@test -n "$(msg)" || (echo "usage: make discord-test channel=<brief|ops|incidents|rollout> msg=<text>"; exit 1)
 	@.venv/bin/python -m nuri.agents.discord.publisher "$(channel)" "$(msg)"
 
+discord-test-embed: ## Visual smoke test — publish 4 sample embeds (status ok/fail + freshness + actor) to #brief.
+	@PYTHONPATH=. .venv/bin/python scripts/discord_embed_smoke.py
+
 discord-sync-commands: ## Register slash commands to guild (no long-running). Requires DISCORD_BOT_TOKEN + DISCORD_GUILD_ID.
 	@.venv/bin/python -m nuri.agents.discord.bot --sync-only
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,833 backend tests across 173 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,833 backend tests across 174 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,833 tests, 173 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,833 tests, 174 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/discord/bot.py
+++ b/nuri/agents/discord/bot.py
@@ -21,11 +21,14 @@ import asyncio
 import logging
 import os
 import shlex
+import socket
 import subprocess
 from pathlib import Path
 from typing import Optional
 
 from dotenv import load_dotenv
+
+from nuri.agents.discord.embeds import build_status_embed
 
 logger = logging.getLogger(__name__)
 
@@ -83,8 +86,13 @@ def build_bot():
     async def buy_candidates(interaction: "discord.Interaction") -> None:  # pragma: no cover
         await interaction.response.defer(thinking=True)
         rc, out = await asyncio.to_thread(_run_make, "buy-candidates")
-        status = "✅ OK" if rc == 0 else f"❌ exit {rc}"
-        await interaction.followup.send(f"**buy-candidates** {status}\n```\n{out[-1500:]}\n```")
+        embed_dict = build_status_embed(
+            title="Buy Candidates",
+            success=(rc == 0),
+            body=out[-3500:],
+            fields={"exit": str(rc), "host": socket.gethostname()},
+        )
+        await interaction.followup.send(embed=discord.Embed.from_dict(embed_dict))
 
     # ─── /thesis ticker:<TICKER> ───
     @tree.command(name="thesis", description="ticker thesis Q&A (Codex + Qwen3.5 dual archive)", guild=guild)
@@ -96,8 +104,13 @@ def build_bot():
             return
         await interaction.response.defer(thinking=True)
         rc, out = await asyncio.to_thread(_run_make, "thesis", {"ticker": ticker}, 300)
-        status = "✅ OK" if rc == 0 else f"❌ exit {rc}"
-        await interaction.followup.send(f"**thesis {ticker}** {status}\n```\n{out[-1500:]}\n```")
+        embed_dict = build_status_embed(
+            title=f"Thesis · {ticker}",
+            success=(rc == 0),
+            body=out[-3500:],
+            fields={"ticker": ticker, "exit": str(rc), "host": socket.gethostname()},
+        )
+        await interaction.followup.send(embed=discord.Embed.from_dict(embed_dict))
 
     # ─── /health ───
     @tree.command(name="health", description="agent infra health check (single-writer + schema + tables)", guild=guild)
@@ -119,8 +132,13 @@ def build_bot():
                 return 124, "timeout 30s"
 
         rc, out = await asyncio.to_thread(_run)
-        emoji = {0: "✅", 1: "⚠️", 2: "❌"}.get(rc, "❌")
-        await interaction.followup.send(f"{emoji} health (exit {rc})\n```\n{out}\n```")
+        embed_dict = build_status_embed(
+            title="Health Check",
+            success=(rc == 0),
+            body=out[-3500:],
+            fields={"exit": str(rc), "host": socket.gethostname()},
+        )
+        await interaction.followup.send(embed=discord.Embed.from_dict(embed_dict))
 
     @bot.event
     async def on_ready() -> None:  # pragma: no cover

--- a/nuri/agents/discord/embeds.py
+++ b/nuri/agents/discord/embeds.py
@@ -1,0 +1,214 @@
+"""Discord embed builder helpers (#529 Phase 2 polish).
+
+Pure builder functions — no Discord SDK / no I/O. 결과 dict 는
+`DiscordPublisher.publish_embed(channel, embed=...)` 또는
+`discord.Embed.from_dict(embed_dict)` 어느 쪽에도 그대로 투입 가능.
+
+Discord embed limits (2026-04 docs):
+    - title         ≤ 256
+    - description   ≤ 4000   (실제 4096 이지만 안전 마진)
+    - field.name    ≤ 256
+    - field.value   ≤ 1024
+    - footer.text   ≤ 2048
+    - 최대 25 fields (그 이상은 Discord 가 reject)
+
+설계:
+    - 길이 초과 → 자동 truncate (`…` suffix). raise X — 알림 손실 방지.
+    - 25 fields 초과 → warn log + 24개로 truncate (마지막 1 field 는 "+N more" 요약).
+    - footer 기본값: "nuri-quant • {today_kst()}".
+    - color 는 status/outcome 별 4-tier 팔레트.
+
+Color palette (hex int):
+    GREEN  0x2ECC71  pass / success
+    AMBER  0xF39C12  warn
+    RED    0xE74C3C  fail / block / error
+    BLUE   0x3498DB  info / neutral
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from nuri.core.timezone import kst_now, today_kst
+
+logger = logging.getLogger(__name__)
+
+# ─── 길이 제약 ───
+TITLE_MAX = 256
+DESCRIPTION_MAX = 4000
+FIELD_NAME_MAX = 256
+FIELD_VALUE_MAX = 1024
+FOOTER_MAX = 2048
+MAX_FIELDS = 25
+
+# ─── 색상 팔레트 ───
+COLOR_GREEN = 0x2ECC71
+COLOR_AMBER = 0xF39C12
+COLOR_RED = 0xE74C3C
+COLOR_BLUE = 0x3498DB
+
+# Outcome → color map (build_actor_outcome_embed)
+_OUTCOME_COLORS = {
+    "pass": COLOR_GREEN,
+    "warn": COLOR_AMBER,
+    "block": COLOR_RED,
+    "error": COLOR_RED,
+}
+
+# Freshness status → color map (build_freshness_embed)
+_FRESHNESS_COLORS = {
+    "PASS": COLOR_GREEN,
+    "WARN": COLOR_AMBER,
+    "FAIL": COLOR_RED,
+}
+
+
+def _truncate(text: str, limit: int) -> str:
+    """초과분은 잘라내고 ellipsis(…) 부착."""
+    if text is None:
+        return ""
+    if len(text) <= limit:
+        return text
+    # 1자 ellipsis 자리 확보
+    return text[: max(0, limit - 1)] + "…"
+
+
+def _default_footer() -> str:
+    """기본 footer: 'nuri-quant • YYYY-MM-DD HH:MM KST'."""
+    return f"nuri-quant • {today_kst()} {kst_now().strftime('%H:%M')} KST"
+
+
+def _normalize_fields(fields: Optional[dict[str, str]]) -> list[dict[str, Any]]:
+    """fields dict → Discord embed fields list.
+
+    25 초과 시 24개로 자르고 마지막에 "(+N more)" 요약 field 추가.
+    """
+    if not fields:
+        return []
+
+    items = list(fields.items())
+    if len(items) > MAX_FIELDS:
+        overflow = len(items) - (MAX_FIELDS - 1)
+        logger.warning("discord embed fields=%d > %d, truncating", len(items), MAX_FIELDS)
+        kept = items[: MAX_FIELDS - 1]
+        result = [
+            {
+                "name": _truncate(str(name), FIELD_NAME_MAX),
+                "value": _truncate(str(value), FIELD_VALUE_MAX),
+                "inline": True,
+            }
+            for name, value in kept
+        ]
+        result.append({"name": "…", "value": f"(+{overflow} more)", "inline": False})
+        return result
+
+    return [
+        {
+            "name": _truncate(str(name), FIELD_NAME_MAX),
+            "value": _truncate(str(value), FIELD_VALUE_MAX),
+            "inline": True,
+        }
+        for name, value in items
+    ]
+
+
+def build_status_embed(
+    title: str,
+    success: bool,
+    body: str,
+    fields: Optional[dict[str, str]] = None,
+    footer: Optional[str] = None,
+) -> dict[str, Any]:
+    """일반 상태 embed (success → green / fail → red).
+
+    /buy-candidates, /health 같은 명령 결과 surfacing 에 사용.
+    """
+    color = COLOR_GREEN if success else COLOR_RED
+    return {
+        "title": _truncate(title, TITLE_MAX),
+        "description": _truncate(body, DESCRIPTION_MAX),
+        "color": color,
+        "fields": _normalize_fields(fields),
+        "footer": {"text": _truncate(footer or _default_footer(), FOOTER_MAX)},
+    }
+
+
+def build_warn_embed(
+    title: str,
+    body: str,
+    fields: Optional[dict[str, str]] = None,
+    footer: Optional[str] = None,
+) -> dict[str, Any]:
+    """경고 embed (amber). 데이터 stale, soft-penalty surface 등."""
+    return {
+        "title": _truncate(title, TITLE_MAX),
+        "description": _truncate(body, DESCRIPTION_MAX),
+        "color": COLOR_AMBER,
+        "fields": _normalize_fields(fields),
+        "footer": {"text": _truncate(footer or _default_footer(), FOOTER_MAX)},
+    }
+
+
+def build_freshness_embed(check_results: list[dict]) -> dict[str, Any]:
+    """`nuri.core.freshness.check_all_freshness()` 결과 → embed.
+
+    title: "Data Freshness — N/M PASS"
+    color: 최악 status 기준 (FAIL > WARN > PASS)
+    fields: 각 check 별 "{key}" → "{status} • {age_hours}h"
+    """
+    total = len(check_results)
+    passed = sum(1 for r in check_results if r.get("status") == "PASS")
+    has_fail = any(r.get("status") == "FAIL" for r in check_results)
+    has_warn = any(r.get("status") == "WARN" for r in check_results)
+
+    if has_fail:
+        color = COLOR_RED
+    elif has_warn:
+        color = COLOR_AMBER
+    else:
+        color = COLOR_GREEN
+
+    fields_dict: dict[str, str] = {}
+    for r in check_results:
+        key = str(r.get("key", "?"))
+        status = str(r.get("status", "?"))
+        age = r.get("age_hours")
+        age_str = f"{age}h" if age is not None else "n/a"
+        fields_dict[key] = f"{status} • {age_str}"
+
+    return {
+        "title": _truncate(f"Data Freshness — {passed}/{total} PASS", TITLE_MAX),
+        "description": _truncate(
+            "신선도 정책별 SLA 점검 결과 (PASS=초록 / WARN=호박 / FAIL=빨강).",
+            DESCRIPTION_MAX,
+        ),
+        "color": color,
+        "fields": _normalize_fields(fields_dict),
+        "footer": {"text": _truncate(_default_footer(), FOOTER_MAX)},
+    }
+
+
+def build_actor_outcome_embed(
+    actor_name: str,
+    outcome: str,
+    summary: str,
+    run_id: str,
+) -> dict[str, Any]:
+    """Layer A actor decision surface.
+
+    outcome ∈ {pass, warn, block, error} — 그 외는 BLUE (neutral) 로 fallback.
+    title: "{actor} → {OUTCOME}"
+    footer: "{run_id} • {today_kst()} HH:MM KST"
+    """
+    outcome_norm = (outcome or "").lower().strip()
+    color = _OUTCOME_COLORS.get(outcome_norm, COLOR_BLUE)
+    title = f"{actor_name} → {outcome_norm.upper() or 'UNKNOWN'}"
+    footer = f"run_id={run_id} • {today_kst()} {kst_now().strftime('%H:%M')} KST"
+    return {
+        "title": _truncate(title, TITLE_MAX),
+        "description": _truncate(summary, DESCRIPTION_MAX),
+        "color": color,
+        "fields": [],
+        "footer": {"text": _truncate(footer, FOOTER_MAX)},
+    }

--- a/scripts/discord_embed_smoke.py
+++ b/scripts/discord_embed_smoke.py
@@ -1,0 +1,88 @@
+"""Discord embed visual smoke test (#529 Phase 2 polish).
+
+publish 4 sample embeds to #brief so user can visually verify formatting:
+    1. status_embed success → Buy Candidates OK (green)
+    2. status_embed fail    → Health Check fail (red)
+    3. freshness_embed      → 3-check sample (mixed PASS/WARN/FAIL → red)
+    4. actor_outcome_embed  → freshness-gatekeeper warn (amber)
+
+Usage:
+    make discord-test-embed
+    # 또는 직접:
+    .venv/bin/python scripts/discord_embed_smoke.py
+
+ENV:
+    DISCORD_WEBHOOK_BRIEF — 미설정 시 graceful skip (publisher 가 audit 에 'webhook missing' 기록).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from nuri.agents.discord.embeds import (
+    build_actor_outcome_embed,
+    build_freshness_embed,
+    build_status_embed,
+)
+from nuri.agents.discord.publisher import Channel, DiscordPublisher
+
+
+def main() -> int:
+    pub = DiscordPublisher()
+
+    samples = [
+        (
+            "status (success)",
+            build_status_embed(
+                title="Buy Candidates",
+                success=True,
+                body="3 candidates passed all 10 SIEGE gates:\n- AAPL\n- NVDA\n- MSFT",
+                fields={"exit": "0", "host": "Ehbebeui-MacBookPro.local"},
+            ),
+        ),
+        (
+            "status (failure)",
+            build_status_embed(
+                title="Health Check",
+                success=False,
+                body="single_writer.lock missing — pipeline halted.\n5 tables out of sync.",
+                fields={"exit": "2", "host": "Ehbebeui-Macmini.local"},
+            ),
+        ),
+        (
+            "freshness",
+            build_freshness_embed(
+                [
+                    {"key": "prices", "status": "PASS", "age_hours": 2.5},
+                    {"key": "vix", "status": "WARN", "age_hours": 30.0},
+                    {"key": "recommendations", "status": "FAIL", "age_hours": 200.5},
+                ]
+            ),
+        ),
+        (
+            "actor outcome",
+            build_actor_outcome_embed(
+                actor_name="freshness-gatekeeper",
+                outcome="warn",
+                summary="VIX stale (30h > 24h SLA). Soft penalty: position cap 80%.",
+                run_id="run-2026-04-30-smoke",
+            ),
+        ),
+    ]
+
+    rc = 0
+    for label, embed_dict in samples:
+        try:
+            result = pub.publish_embed(Channel.BRIEF, embed_dict, actor_name="embed-smoke")
+            status = "ok" if result.ok else f"fail ({result.error})"
+            if not result.ok and result.error and "missing" not in result.error.lower():
+                rc = 1  # webhook present 인데 실패 → 비정상
+        except Exception as exc:  # noqa: BLE001 — smoke 는 audit/DB 부재 환경도 내성
+            status = f"audit error ({type(exc).__name__}: {exc})"
+        print(f"  [{label}] {status}", flush=True)
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent_infra/test_discord_embeds.py
+++ b/tests/agent_infra/test_discord_embeds.py
@@ -1,0 +1,206 @@
+"""Discord embed builder tests (#529 Phase 2 polish).
+
+Builders are pure functions — no Discord SDK / network. Bot slash handlers
+remain `# pragma: no cover` (Interaction mock cost > value, established convention).
+
+검증:
+- 4 builder 의 title / color / footer 기본값
+- body > 4000 → truncate + ellipsis
+- fields > 25 → 24 + "(+N more)" 요약 (raise X — 알림 손실 방지)
+- freshness PASS/WARN/FAIL color routing
+- actor outcome → color 매핑 4종 (pass/warn/block/error) + unknown fallback
+- field/footer 길이 제약
+"""
+
+from __future__ import annotations
+
+from nuri.agents.discord.embeds import (
+    COLOR_AMBER,
+    COLOR_BLUE,
+    COLOR_GREEN,
+    COLOR_RED,
+    DESCRIPTION_MAX,
+    FIELD_NAME_MAX,
+    FIELD_VALUE_MAX,
+    FOOTER_MAX,
+    MAX_FIELDS,
+    TITLE_MAX,
+    build_actor_outcome_embed,
+    build_freshness_embed,
+    build_status_embed,
+    build_warn_embed,
+)
+
+
+class TestBuildStatusEmbed:
+    def test_success_is_green(self):
+        e = build_status_embed("Hi", success=True, body="ok", fields=None)
+        assert e["title"] == "Hi"
+        assert e["color"] == COLOR_GREEN
+        assert e["description"] == "ok"
+        assert e["footer"]["text"]  # 기본 footer 채워짐
+
+    def test_failure_is_red(self):
+        e = build_status_embed("Bad", success=False, body="boom", fields=None)
+        assert e["color"] == COLOR_RED
+
+    def test_fields_become_inline(self):
+        e = build_status_embed("T", success=True, body="b", fields={"k1": "v1", "k2": "v2"})
+        assert len(e["fields"]) == 2
+        assert e["fields"][0]["name"] == "k1"
+        assert e["fields"][0]["value"] == "v1"
+        assert e["fields"][0]["inline"] is True
+
+    def test_custom_footer(self):
+        e = build_status_embed("T", success=True, body="b", fields=None, footer="custom")
+        assert e["footer"]["text"] == "custom"
+
+    def test_body_truncated_when_over_limit(self):
+        big = "x" * (DESCRIPTION_MAX + 500)
+        e = build_status_embed("T", success=True, body=big, fields=None)
+        assert len(e["description"]) == DESCRIPTION_MAX
+        assert e["description"].endswith("…")
+
+    def test_title_truncated(self):
+        e = build_status_embed("y" * (TITLE_MAX + 50), success=True, body="b", fields=None)
+        assert len(e["title"]) == TITLE_MAX
+        assert e["title"].endswith("…")
+
+    def test_footer_truncated(self):
+        e = build_status_embed("T", success=True, body="b", fields=None, footer="z" * (FOOTER_MAX + 20))
+        assert len(e["footer"]["text"]) == FOOTER_MAX
+        assert e["footer"]["text"].endswith("…")
+
+    def test_field_value_truncated(self):
+        long_val = "v" * (FIELD_VALUE_MAX + 10)
+        e = build_status_embed("T", success=True, body="b", fields={"k": long_val})
+        assert len(e["fields"][0]["value"]) == FIELD_VALUE_MAX
+        assert e["fields"][0]["value"].endswith("…")
+
+    def test_field_name_truncated(self):
+        long_name = "n" * (FIELD_NAME_MAX + 5)
+        e = build_status_embed("T", success=True, body="b", fields={long_name: "v"})
+        assert len(e["fields"][0]["name"]) == FIELD_NAME_MAX
+
+    def test_empty_fields_dict_yields_no_fields(self):
+        e = build_status_embed("T", success=True, body="b", fields={})
+        assert e["fields"] == []
+
+
+class TestBuildWarnEmbed:
+    def test_color_amber(self):
+        e = build_warn_embed("Stale", "120h old", fields={"k": "v"})
+        assert e["color"] == COLOR_AMBER
+        assert e["title"] == "Stale"
+        assert e["description"] == "120h old"
+
+    def test_default_footer_present(self):
+        e = build_warn_embed("T", "b")
+        assert e["footer"]["text"]
+
+
+class TestFieldOverflow:
+    def test_fields_over_25_truncates_with_summary(self):
+        # 30 fields → 24 kept + 1 "(+6 more)" summary = 25 total
+        many = {f"k{i}": f"v{i}" for i in range(30)}
+        e = build_status_embed("T", success=True, body="b", fields=many)
+        assert len(e["fields"]) == MAX_FIELDS
+        # 마지막 field 가 overflow 요약
+        last = e["fields"][-1]
+        assert "more" in last["value"]
+        assert "+6" in last["value"]
+
+    def test_fields_exactly_25_no_truncation(self):
+        many = {f"k{i}": f"v{i}" for i in range(MAX_FIELDS)}
+        e = build_status_embed("T", success=True, body="b", fields=many)
+        assert len(e["fields"]) == MAX_FIELDS
+        # 마지막 값에 "more" overflow 요약 없음
+        assert "more" not in e["fields"][-1]["value"]
+
+
+class TestBuildFreshnessEmbed:
+    def _result(self, key: str, status: str, age: float = 12.5) -> dict:
+        return {"key": key, "status": status, "age_hours": age, "label": key}
+
+    def test_all_pass_is_green(self):
+        results = [self._result("prices", "PASS"), self._result("vix", "PASS")]
+        e = build_freshness_embed(results)
+        assert e["color"] == COLOR_GREEN
+        assert "2/2 PASS" in e["title"]
+
+    def test_any_warn_is_amber(self):
+        results = [self._result("prices", "PASS"), self._result("vix", "WARN")]
+        e = build_freshness_embed(results)
+        assert e["color"] == COLOR_AMBER
+        assert "1/2 PASS" in e["title"]
+
+    def test_any_fail_is_red_dominates_warn(self):
+        results = [
+            self._result("prices", "PASS"),
+            self._result("vix", "WARN"),
+            self._result("recs", "FAIL"),
+        ]
+        e = build_freshness_embed(results)
+        assert e["color"] == COLOR_RED
+        assert "1/3 PASS" in e["title"]
+
+    def test_field_format_status_age(self):
+        results = [self._result("prices", "PASS", 24.0)]
+        e = build_freshness_embed(results)
+        assert len(e["fields"]) == 1
+        assert e["fields"][0]["name"] == "prices"
+        assert "PASS" in e["fields"][0]["value"]
+        assert "24.0h" in e["fields"][0]["value"]
+
+    def test_missing_age_renders_na(self):
+        results = [{"key": "x", "status": "PASS", "age_hours": None}]
+        e = build_freshness_embed(results)
+        assert "n/a" in e["fields"][0]["value"]
+
+    def test_empty_results(self):
+        e = build_freshness_embed([])
+        assert e["color"] == COLOR_GREEN  # 0/0 → 모든 PASS 로 간주 (no FAIL/WARN)
+        assert "0/0 PASS" in e["title"]
+        assert e["fields"] == []
+
+
+class TestBuildActorOutcomeEmbed:
+    def test_pass_is_green(self):
+        e = build_actor_outcome_embed("freshness-gatekeeper", "pass", "all checks ok", "run-1")
+        assert e["color"] == COLOR_GREEN
+        assert "freshness-gatekeeper" in e["title"]
+        assert "PASS" in e["title"]
+        assert "run-1" in e["footer"]["text"]
+
+    def test_warn_is_amber(self):
+        e = build_actor_outcome_embed("actor", "warn", "soft penalty", "r2")
+        assert e["color"] == COLOR_AMBER
+        assert "WARN" in e["title"]
+
+    def test_block_is_red(self):
+        e = build_actor_outcome_embed("actor", "block", "veto fired", "r3")
+        assert e["color"] == COLOR_RED
+        assert "BLOCK" in e["title"]
+
+    def test_error_is_red(self):
+        e = build_actor_outcome_embed("actor", "error", "exception raised", "r4")
+        assert e["color"] == COLOR_RED
+        assert "ERROR" in e["title"]
+
+    def test_unknown_outcome_falls_back_to_blue(self):
+        e = build_actor_outcome_embed("actor", "weird", "?", "r5")
+        assert e["color"] == COLOR_BLUE
+        assert "WEIRD" in e["title"]
+
+    def test_uppercases_outcome_in_title(self):
+        e = build_actor_outcome_embed("a", "pass", "s", "r")
+        assert "→ PASS" in e["title"]
+
+    def test_summary_truncated(self):
+        big = "z" * (DESCRIPTION_MAX + 100)
+        e = build_actor_outcome_embed("a", "pass", big, "r")
+        assert len(e["description"]) == DESCRIPTION_MAX
+
+    def test_run_id_in_footer(self):
+        e = build_actor_outcome_embed("a", "pass", "s", "abc-123")
+        assert "abc-123" in e["footer"]["text"]


### PR DESCRIPTION
## Summary

Phase 2 polish of #529 Discord bridge — replace plain text + markdown code blocks with rich embeds in the bot's slash command responses, so users see clean status cards instead of walls of stderr.

### Builders (`nuri/agents/discord/embeds.py`, new — 198 LoC)

Pure functions, no Discord SDK / no I/O. Result dict feeds either `DiscordPublisher.publish_embed(...)` or `discord.Embed.from_dict(...)`.

- `build_status_embed(title, success, body, fields, footer=None)` — green/red by success
- `build_warn_embed(title, body, fields, footer=None)` — amber
- `build_freshness_embed(check_results)` — wraps `nuri.core.freshness.check_all_freshness()` output, color = worst (PASS=green / WARN=amber / FAIL=red)
- `build_actor_outcome_embed(actor_name, outcome, summary, run_id)` — 4-tier outcome map (pass/warn/block/error) + BLUE fallback

Auto-truncates to Discord limits (title 256, description 4000, field name 256, value 1024, footer 2048). Field count > 25 → keeps 24 + `(+N more)` summary, never raises (alert delivery > strict validation).

### Bot refactor (`nuri/agents/discord/bot.py`)

`/buy-candidates` · `/thesis · {ticker}` · `/health` — all 3 handlers swapped from `interaction.followup.send(f"**...** ...\n\`\`\`{out}\`\`\`")` to `interaction.followup.send(embed=discord.Embed.from_dict(build_status_embed(...)))`. Body bumped from 1500 → 3500 char tail (embed description fits 4000).

### Tests + smoke

- `tests/agent_infra/test_discord_embeds.py` (new, 28 tests) — title/color/footer/truncation/field overflow/freshness color routing/all 4 outcome→color mappings + unknown fallback
- Coverage on `embeds.py`: **98%** (only line 70 — defensive `text is None` early-return — uncovered)
- Bot slash handlers remain `# pragma: no cover` per existing convention (Interaction mock cost > value)
- `scripts/discord_embed_smoke.py` + `make discord-test-embed` — publishes 4 sample embeds (success status / fail status / mixed-status freshness / amber actor-outcome) to `#brief` for visual verification. Tolerant of missing webhook env + missing DB (smoke ≠ test).

## Test plan

- [x] `pytest tests/agent_infra/test_discord_embeds.py -v` → 28 passed
- [x] `pytest tests/agent_infra/` → 117 passed (no regression)
- [x] `ruff check nuri/agents/discord/ tests/agent_infra/test_discord_embeds.py scripts/discord_embed_smoke.py` → clean
- [x] `python scripts/check_privacy_leak.py` → no leaks
- [x] Smoke runs end-to-end in worktree (audit DB absence falls through gracefully)
- [ ] On Mac mini with `DISCORD_WEBHOOK_BRIEF` set: `make discord-test-embed` → 4 visible embeds in #brief

## Constraints honored

- 1 PR / 1 commit (well under 3-commit cap)
- No `nuri/collectors/` touched
- No new dependencies (`discord.py` already present)
- Bot Interaction not mocked — builders tested in isolation
- Korean comments, English names, `kst_now()` / `today_kst()` only

## Edge cases hit

- Discord 25-field cap → designed `(+N more)` summary instead of raise (alert delivery is the goal)
- Worktree script execution: `nuri.agents.discord` resolved via main repo via `sys.path = [..., '/Users/ehbebe/workspace/nuri-quant']`. `make discord-test-embed` uses `PYTHONPATH=.` to force worktree resolution. Production launchd plist runs from main checkout, so unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)