### PR TITLE
feat(agents): #529 Phase 2 — WalkForwardValidator (canonical actor #5, Layer B)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -689,7 +689,13 @@
     "qualname",
     "PSI",
     "apublish",
-    "ROLLOUT"
+    "ROLLOUT",
+    "López",
+    "overfit",
+    "tobytes",
+    "ddof",
+    "logloss",
+    "preds"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,21 @@ discord-bot-uninstall: ## (Mac mini) Uninstall discord-bot launchd plist.
 	    echo "  ✅ uninstalled: $$NAME"; \
 	  else echo "  (not installed)"; fi
 
+# ═══════════════════════════════════════════════════════════════
+# Walk-Forward Validator (#529 Phase 2 — actor #5)
+# ═══════════════════════════════════════════════════════════════
+
+walkforward-history: ## Print recent walk-forward runs. usage: make walkforward-history [limit=N]
+	@LIMIT=$${limit:-10}; \
+	.venv/bin/python -c "from nuri.core.db import query; \
+	  rows = query('SELECT run_id, model_id, n_folds, pit_hash, started_at, finished_at FROM walkforward_runs ORDER BY started_at DESC LIMIT ?', ($$LIMIT,)); \
+	  print(f'recent {len(rows)} walk-forward runs:'); \
+	  print(chr(10).join(f'  {r[\"started_at\"]:<25} {r[\"model_id\"]:<20} folds={r[\"n_folds\"]:<3} pit={r[\"pit_hash\"]} run={r[\"run_id\"][:8]}' for r in rows))"
+
+walkforward-pit-hash: ## Compute PIT hash for a CSV. usage: make walkforward-pit-hash csv=path/to.csv [model=name]
+	@test -n "$(csv)" || (echo "usage: make walkforward-pit-hash csv=path [model=name]"; exit 1)
+	@.venv/bin/python -m nuri.agents.actors.walkforward_validator pit_hash --csv "$(csv)" --model-id "$${model:-cli}"
+
 sync-start:
 	bash scripts/dev_sync.sh start
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flowchart TB
         E -. "agent weight drift (±30%)" .-> C
     end
 
-    DB[("SQLite WAL · 36 tables<br/>pipeline_events · certifications · audit trail")]:::sink
+    DB[("SQLite WAL · 37 tables<br/>pipeline_events · certifications · audit trail")]:::sink
 
     CFG -. policies .-> Pipeline
     Pipeline -. persist .-> DB

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-3,833 backend tests across 174 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+3,911 backend tests across 175 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,833 tests, 174 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 3,911 tests, 175 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/__init__.py
+++ b/nuri/agents/actors/__init__.py
@@ -3,9 +3,11 @@
 Phase 2 actors (Codex Round 5):
 - ReleaseRollbackManager (#13, Layer A) — canary rollout + emergency rollback
 - FreshnessGatekeeper (#2, Layer A) — stale data emit block
+- WalkForwardValidator (#5, Layer B) — point-in-time model evaluation primitive
 """
 
 from nuri.agents.actors.freshness_gatekeeper import FreshnessGatekeeper
 from nuri.agents.actors.release_rollback_manager import ReleaseRollbackManager
+from nuri.agents.actors.walkforward_validator import WalkForwardValidator
 
-__all__ = ["FreshnessGatekeeper", "ReleaseRollbackManager"]
+__all__ = ["FreshnessGatekeeper", "ReleaseRollbackManager", "WalkForwardValidator"]

--- a/nuri/agents/actors/walkforward_validator.py
+++ b/nuri/agents/actors/walkforward_validator.py
@@ -1,0 +1,429 @@
+"""WalkForwardValidator — Layer B actor (#529 Phase 2 — canonical #5).
+
+Responsibilities:
+- Rolling/Expanding fold spec → model fit/eval split (point-in-time enforced)
+- Aggregate metrics (Brier, log-loss, Sharpe, hit-rate)
+- pit_hash 로 reproducibility 보장 (동일 입력 → 동일 hash)
+- 모든 결과 walkforward_runs 영구 기록
+
+Layer B 설계 (Codex Round 5):
+- 100% deterministic — 통계적 계산만, ZERO LLM
+- 각 fold 의 train_data 는 test_data 보다 *strictly before* (PIT 위반 시 즉시 fail)
+- Anti-leak lock-test: future data 가 train 에 섞이면 무조건 ValueError
+- Layer A actor 가 enforce 결정 시 우리 결과 참조 가능 (e.g. Brier > threshold → block)
+
+Design rationale (Codex consult 2026-05-01):
+- signal_backtest 는 이미 PIT-safe (rule eval, no fit) → refactor 불필요
+- 우리는 *모델 fit 하는 future actor 들* (Regime-Posterior sticky-HMM, Causal-Factor-Auditor,
+  Foundation-Benchmark) 을 위한 evaluation primitive
+- López de Prado *Causal Factor Investing 2025*: walk-forward = backtest discipline 의 core
+
+Anti-pattern 방지:
+- 전체 데이터 single fit → in-sample overfit → SIEGE gate 통과한 것처럼 보이지만 production 실패
+- Train-test contamination → metrics 가 진짜 OOS 성능 X → user 손실
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+
+from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
+from nuri.core.db import log_walkforward_run
+from nuri.core.timezone import kst_now
+
+
+@dataclass
+class FoldSpec:
+    """Walk-forward fold 정의.
+
+    kind:
+        'rolling'    — train window 가 step 만큼 이동 (window 크기 고정)
+        'expanding'  — train window 가 점점 확장 (시작 고정)
+    train_size: train 의 row 수
+    test_size:  test 의 row 수
+    step:       다음 fold 까지 이동할 step (보통 = test_size)
+    """
+
+    kind: str
+    train_size: int
+    test_size: int
+    step: int
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("rolling", "expanding"):
+            raise ValueError(f"kind must be rolling/expanding, got {self.kind!r}")
+        if self.train_size < 1 or self.test_size < 1 or self.step < 1:
+            raise ValueError("train_size/test_size/step must be >= 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "train_size": self.train_size,
+            "test_size": self.test_size,
+            "step": self.step,
+        }
+
+
+def _generate_folds(n: int, spec: FoldSpec) -> list[tuple[slice, slice]]:
+    """fold spec + 데이터 길이 → list of (train_slice, test_slice).
+
+    각 fold 는 (train, test) 쌍. train 은 test 보다 *strictly before*.
+    rolling: train 시작점이 step 만큼 이동 (window 크기 train_size 고정)
+    expanding: train 시작점은 0 고정, 끝점만 확장
+    """
+    folds: list[tuple[slice, slice]] = []
+    test_start = spec.train_size
+    while test_start + spec.test_size <= n:
+        if spec.kind == "rolling":
+            train_start = test_start - spec.train_size
+        else:  # expanding
+            train_start = 0
+        train_slice = slice(train_start, test_start)
+        test_slice = slice(test_start, test_start + spec.test_size)
+        folds.append((train_slice, test_slice))
+        test_start += spec.step
+    return folds
+
+
+def _compute_pit_hash(
+    data: pd.DataFrame,
+    model_id: str,
+    spec: FoldSpec,
+) -> str:
+    """data 디지털 + model_id + spec → SHA256[:16].
+
+    Reproducibility key: 동일 입력 → 동일 hash → 동일 metrics 보장 검증.
+    """
+    h = hashlib.sha256()
+    h.update(model_id.encode())
+    h.update(json.dumps(spec.to_dict(), sort_keys=True).encode())
+    # data digest: shape + first/last row + col sums (full hash 면 비싸므로 sample)
+    h.update(str(data.shape).encode())
+    if not data.empty:
+        h.update(pd.util.hash_pandas_object(data.iloc[[0, -1]], index=True).to_numpy().tobytes())
+        # column sum 으로 row 순서 변화 detect
+        for col in data.select_dtypes(include=[np.number]).columns:
+            h.update(f"{col}={data[col].sum():.6f}".encode())
+    return h.hexdigest()[:16]
+
+
+def _verify_pit(train: pd.DataFrame, test: pd.DataFrame) -> None:
+    """Anti-leak: train 의 모든 row 가 test 의 첫 row 보다 *strictly before* 인지 확인.
+
+    DataFrame 이 'date' column 보유 시 그 column 으로, 아니면 index 로 비교.
+    위반 시 ValueError (Layer B enforcement: 데이터 leak 은 panic).
+    """
+    if train.empty or test.empty:
+        return
+    if "date" in train.columns and "date" in test.columns:
+        train_max = pd.to_datetime(train["date"]).max()
+        test_min = pd.to_datetime(test["date"]).min()
+    else:
+        train_max = train.index.max()
+        test_min = test.index.min()
+    if train_max >= test_min:
+        raise ValueError(
+            f"PIT leak detected: train.max ({train_max}) >= test.min ({test_min}). "
+            "Walk-forward fold contamination — this is the bug we hunt."
+        )
+
+
+def _brier_score(y_true: np.ndarray, y_prob: np.ndarray) -> float:
+    """Mean squared error of probabilistic predictions. Lower = better. [0, 1] range."""
+    return float(np.mean((y_prob - y_true) ** 2))
+
+
+def _log_loss(y_true: np.ndarray, y_prob: np.ndarray, eps: float = 1e-15) -> float:
+    """Binary cross-entropy. Lower = better. probs 를 (eps, 1-eps) 로 clip."""
+    p = np.clip(y_prob, eps, 1 - eps)
+    return float(-np.mean(y_true * np.log(p) + (1 - y_true) * np.log(1 - p)))
+
+
+def _hit_rate(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Binary classification accuracy (y_pred 는 0/1 hard label)."""
+    return float(np.mean((y_pred >= 0.5) == (y_true >= 0.5)))
+
+
+def _sharpe_from_returns(returns: np.ndarray, risk_free: float = 0.0) -> float:
+    """Annualized Sharpe (252 trading days). returns is daily.
+
+    sample size <2 또는 std=0 시 0.0 반환 (degenerate case).
+    """
+    if len(returns) < 2:
+        return 0.0
+    excess = returns - risk_free / 252
+    sd = float(np.std(excess, ddof=1))
+    if sd == 0:
+        return 0.0
+    return float(np.mean(excess) / sd * np.sqrt(252))
+
+
+def _aggregate_metrics(fold_metrics: list[dict[str, float]]) -> dict[str, float]:
+    """fold-별 metrics → 평균 + std. 빈 list 면 빈 dict."""
+    if not fold_metrics:
+        return {}
+    agg: dict[str, float] = {}
+    for key in fold_metrics[0]:
+        vals = np.array([m[key] for m in fold_metrics if key in m])
+        agg[f"{key}_mean"] = float(np.mean(vals))
+        agg[f"{key}_std"] = float(np.std(vals, ddof=1)) if len(vals) > 1 else 0.0
+    return agg
+
+
+@REGISTRY.register
+class WalkForwardValidator(Actor):
+    """Walk-forward model evaluation primitive.
+
+    Actions (input_data['action']):
+        run    — execute walk-forward eval (model_fn, data, fold_spec, metrics 필수)
+        pit_hash — read-only: data + spec → pit_hash 만 계산 (cache key 용도)
+
+    Outcome 매핑 (Codex Round 5 Layer B):
+        PASS  — 모든 fold 정상 완료
+        WARN  — 일부 fold 실패 (degenerate case, e.g. test 안에 unique class 1개)
+        BLOCK — PIT leak 검출 (data contamination 은 panic)
+        BLOCK — invalid input (model_fn 미지정 등)
+
+    model_fn signature:
+        model_fn(train_df: pd.DataFrame) -> predict_fn
+        predict_fn(test_df: pd.DataFrame) -> np.ndarray (probabilities or returns)
+
+    metrics 옵션:
+        'classification' — brier + logloss + hit_rate (y_true ∈ {0,1})
+        'regression'     — mse + mae + sharpe (y_true 는 returns)
+    """
+
+    name = "walkforward-validator"
+    version = "0.1.0"
+    layer = Layer.B
+
+    VALID_ACTIONS: tuple[str, ...] = ("run", "pit_hash")
+    VALID_METRIC_KINDS: tuple[str, ...] = ("classification", "regression")
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        action = input_data.get("action")
+
+        if action not in self.VALID_ACTIONS:
+            return ActorResult(
+                output={"error": f"invalid action {action!r}, expected {self.VALID_ACTIONS}"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"action={action}",
+            )
+
+        # ─── Common input parse ───
+        data = input_data.get("data")
+        if not isinstance(data, pd.DataFrame):
+            return ActorResult(
+                output={"error": "data (pd.DataFrame) required"},
+                outcome=Outcome.BLOCK,
+                input_summary=action,
+            )
+
+        spec_dict = input_data.get("fold_spec")
+        if not isinstance(spec_dict, dict):
+            return ActorResult(
+                output={"error": "fold_spec (dict) required"},
+                outcome=Outcome.BLOCK,
+                input_summary=action,
+            )
+        try:
+            spec = FoldSpec(**spec_dict)
+        except (TypeError, ValueError) as exc:
+            return ActorResult(
+                output={"error": f"invalid fold_spec: {exc}"},
+                outcome=Outcome.BLOCK,
+                input_summary=action,
+            )
+
+        model_id = str(input_data.get("model_id", "unknown"))
+        pit_hash = _compute_pit_hash(data, model_id, spec)
+
+        if action == "pit_hash":
+            return ActorResult(
+                output={"pit_hash": pit_hash, "model_id": model_id, "n_rows": len(data)},
+                outcome=Outcome.PASS,
+                sample_n=len(data),
+                input_summary=f"pit_hash {model_id} ({len(data)} rows)",
+            )
+
+        # ─── action == "run" ───
+        model_fn = input_data.get("model_fn")
+        if not callable(model_fn):
+            return ActorResult(
+                output={"error": "model_fn (callable) required for action=run"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"run {model_id}",
+            )
+
+        target_col = input_data.get("target_col")
+        if not target_col or target_col not in data.columns:
+            return ActorResult(
+                output={"error": f"target_col {target_col!r} not in data columns {list(data.columns)}"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"run {model_id}",
+            )
+
+        metric_kind = input_data.get("metric_kind", "classification")
+        if metric_kind not in self.VALID_METRIC_KINDS:
+            return ActorResult(
+                output={"error": f"metric_kind {metric_kind!r}, expected {self.VALID_METRIC_KINDS}"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"run {model_id}",
+            )
+
+        folds = _generate_folds(len(data), spec)
+        if not folds:
+            return ActorResult(
+                output={
+                    "error": f"no valid folds: data has {len(data)} rows but train_size={spec.train_size} + test_size={spec.test_size} required"
+                },
+                outcome=Outcome.BLOCK,
+                input_summary=f"run {model_id}",
+            )
+
+        run_id = str(uuid.uuid4())
+        fold_results: list[dict[str, Any]] = []
+        n_train_total = 0
+        n_test_total = 0
+        any_failed = False
+        start_time = time.monotonic()
+
+        for fold_idx, (tr_slice, te_slice) in enumerate(folds):
+            train_df = data.iloc[tr_slice].copy()
+            test_df = data.iloc[te_slice].copy()
+            n_train_total += len(train_df)
+            n_test_total += len(test_df)
+
+            # PIT enforcement (Layer B core invariant)
+            _verify_pit(train_df, test_df)
+
+            try:
+                predict_fn = cast(Any, model_fn)(train_df)
+                y_prob = np.asarray(cast(Any, predict_fn)(test_df), dtype=np.float64)
+                y_true = np.asarray(test_df[target_col].values, dtype=np.float64)
+
+                if len(y_prob) != len(y_true):
+                    raise ValueError(f"predict_fn returned {len(y_prob)} preds, expected {len(y_true)}")
+
+                fold_metrics = self._compute_fold_metrics(y_true, y_prob, metric_kind)
+                fold_results.append(
+                    {"fold": fold_idx, "n_train": len(train_df), "n_test": len(test_df), **fold_metrics}
+                )
+            except Exception as exc:
+                any_failed = True
+                fold_results.append(
+                    {
+                        "fold": fold_idx,
+                        "n_train": len(train_df),
+                        "n_test": len(test_df),
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+
+        successful = [f for f in fold_results if "error" not in f]
+        aggregate = _aggregate_metrics(
+            [{k: v for k, v in f.items() if k not in ("fold", "n_train", "n_test")} for f in successful]
+        )
+
+        metrics_payload = {"folds": fold_results, "aggregate": aggregate}
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+
+        log_walkforward_run(
+            run_id=run_id,
+            model_id=model_id,
+            fold_spec=spec.to_dict(),
+            metrics=metrics_payload,
+            pit_hash=pit_hash,
+            n_folds=len(folds),
+            n_train_obs=n_train_total,
+            n_test_obs=n_test_total,
+            finished_at=kst_now().isoformat(),
+        )
+
+        outcome = Outcome.WARN if any_failed else Outcome.PASS
+        return ActorResult(
+            output={
+                "run_id": run_id,
+                "model_id": model_id,
+                "pit_hash": pit_hash,
+                "n_folds": len(folds),
+                "n_successful": len(successful),
+                "metrics": metrics_payload,
+            },
+            outcome=outcome,
+            sample_n=n_test_total,
+            input_summary=f"run {model_id} folds={len(folds)} duration={duration_ms}ms",
+        )
+
+    @staticmethod
+    def _compute_fold_metrics(y_true: np.ndarray, y_prob: np.ndarray, kind: str) -> dict[str, float]:
+        if kind == "classification":
+            return {
+                "brier": _brier_score(y_true, y_prob),
+                "logloss": _log_loss(y_true, y_prob),
+                "hit_rate": _hit_rate(y_true, y_prob),
+            }
+        # regression
+        residuals = y_prob - y_true
+        return {
+            "mse": float(np.mean(residuals**2)),
+            "mae": float(np.mean(np.abs(residuals))),
+            "sharpe": _sharpe_from_returns(y_prob),
+        }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.agents.actors.walkforward_validator <action>
+
+    pit_hash 만 의미 있는 CLI 사용 — run 은 model_fn callable 필요해서 Python 내부 호출 전용.
+    """
+    import argparse
+    import json as _json
+    import sys
+
+    parser = argparse.ArgumentParser(prog="walkforward-validator")
+    parser.add_argument("action", choices=["pit_hash"])  # CLI 는 pit_hash 만 노출
+    parser.add_argument("--model-id", default="cli")
+    parser.add_argument("--csv", required=True, help="path to CSV with date column")
+    parser.add_argument("--train-size", type=int, default=252)
+    parser.add_argument("--test-size", type=int, default=21)
+    parser.add_argument("--step", type=int, default=21)
+    parser.add_argument("--kind", choices=["rolling", "expanding"], default="rolling")
+    args = parser.parse_args(argv)
+
+    df = pd.read_csv(args.csv)
+    actor = WalkForwardValidator()
+    try:
+        result = actor.run(
+            {
+                "action": "pit_hash",
+                "data": df,
+                "fold_spec": {
+                    "kind": args.kind,
+                    "train_size": args.train_size,
+                    "test_size": args.test_size,
+                    "step": args.step,
+                },
+                "model_id": args.model_id,
+            }
+        )
+    except Exception as exc:
+        print(_json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 2
+
+    print(_json.dumps(result.output, indent=2, ensure_ascii=False))
+    return 0 if result.outcome == Outcome.PASS else 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/core/db.py
+++ b/nuri/core/db.py
@@ -5,6 +5,7 @@ Nuri-Quant 데이터베이스 모듈 — 모든 DB 접근의 단일 진입점.
 모든 DB 작업은 이 모듈의 함수를 통해서만 수행한다.
 """
 
+import json
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
@@ -841,6 +842,33 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_msg_status ON agent_messages(http_status, timestamp);
     """,
     ),
+    (
+        29,
+        "walkforward_runs — model evaluation audit (#529 Phase 2 — WalkForward-Validator)",
+        # #529 Phase 2 actor #5 — Layer B (deterministic, ZERO LLM).
+        # Rolling/expanding fold 기반 model evaluation 결과 영구 기록.
+        # pit_hash = (data range + fold spec + model_id) digest →
+        # 동일 입력 → 동일 hash → reproducibility 검증 가능.
+        # metrics_json = {"folds": [{"fold": 0, "brier": 0.21, ...}, ...], "aggregate": {...}}
+        # 향후 Regime-Posterior, Causal-Factor-Auditor, Foundation-Benchmark 가 모두 이 테이블 사용.
+        """
+        CREATE TABLE IF NOT EXISTS walkforward_runs (
+            run_id TEXT PRIMARY KEY,
+            model_id TEXT NOT NULL,
+            fold_spec_json TEXT NOT NULL,
+            metrics_json TEXT NOT NULL,
+            pit_hash TEXT NOT NULL,
+            n_folds INTEGER NOT NULL,
+            n_train_obs INTEGER,
+            n_test_obs INTEGER,
+            started_at TEXT NOT NULL DEFAULT (datetime('now')),
+            finished_at TEXT,
+            error_message TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_wf_model_time ON walkforward_runs(model_id, started_at);
+        CREATE INDEX IF NOT EXISTS idx_wf_pit ON walkforward_runs(pit_hash);
+    """,
+    ),
 ]
 
 
@@ -1492,6 +1520,51 @@ def finish_agent_run(
                    duration_ms = ?, error_message = ?
                WHERE run_id = ?""",
             (status, duration_ms, error_message, run_id),
+        )
+
+
+def log_walkforward_run(
+    run_id: str,
+    model_id: str,
+    fold_spec: dict,
+    metrics: dict,
+    pit_hash: str,
+    n_folds: int,
+    n_train_obs: Optional[int] = None,
+    n_test_obs: Optional[int] = None,
+    finished_at: Optional[str] = None,
+    error_message: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> None:
+    """Walk-forward evaluation result audit (#529 Phase 2 — WalkForward-Validator).
+
+    fold_spec: {"kind": "rolling"|"expanding", "train_size": N, "test_size": M, "step": K}
+    metrics: {"aggregate": {"brier": .., "logloss": ..}, "folds": [{"fold": 0, ..}, ...]}
+    pit_hash: data digest + fold spec + model_id → reproducibility key.
+    finished_at None → run still in progress (started_at default).
+    """
+    with get_db(db_path) as conn:
+        conn.execute(
+            """INSERT INTO walkforward_runs
+               (run_id, model_id, fold_spec_json, metrics_json, pit_hash,
+                n_folds, n_train_obs, n_test_obs, finished_at, error_message)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(run_id) DO UPDATE SET
+                 metrics_json = excluded.metrics_json,
+                 finished_at = COALESCE(excluded.finished_at, finished_at),
+                 error_message = excluded.error_message""",
+            (
+                run_id,
+                model_id,
+                json.dumps(fold_spec, sort_keys=True),
+                json.dumps(metrics, default=str),
+                pit_hash,
+                n_folds,
+                n_train_obs,
+                n_test_obs,
+                finished_at,
+                error_message,
+            ),
         )
 
 

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -5,7 +5,7 @@
 # Mac mini = sole writer (production), MBP = read-only replica.
 #
 # 검증 항목:
-#   1. DB schema version >= 28 (Phase 1+2 migrations 적용)
+#   1. DB schema version >= 29 (Phase 1+2 migrations 적용)
 #   2. agent_audit_ledger / feature_flags / agent_run_ledger / agent_messages 테이블 존재
 #   3. orphan run 탐지 (started + finished_at NULL + 1h 경과) → SRE alert
 #   4. 머신 식별 (Mac mini vs MBP) + writer 권한 추정
@@ -35,14 +35,14 @@ fi
 # 1) Schema version
 SCHEMA_VERSION=$(.venv/bin/python -c "from nuri.core.db import get_schema_version; print(get_schema_version())" 2>/dev/null || echo "0")
 if [ "$SCHEMA_VERSION" -ge 28 ]; then
-    echo " ✅ schema version: $SCHEMA_VERSION (>=28)"
+    echo " ✅ schema version: $SCHEMA_VERSION (>=29)"
 else
-    echo " ❌ schema version: $SCHEMA_VERSION (need >=28 for #529 Phase 1+2)"
+    echo " ❌ schema version: $SCHEMA_VERSION (need >=29 for #529 Phase 1+2)"
     EXIT_CODE=2
 fi
 
 # 2) Required Phase 1+2 tables
-for table in agent_audit_ledger feature_flags agent_run_ledger agent_messages; do
+for table in agent_audit_ledger feature_flags agent_run_ledger agent_messages walkforward_runs; do
     EXISTS=$(.venv/bin/python -c "from nuri.core.db import query; r=query(\"SELECT 1 FROM sqlite_master WHERE type='table' AND name='$table'\"); print(len(r))" 2>/dev/null || echo "0")
     if [ "$EXISTS" = "1" ]; then
         echo " ✅ table exists: $table"

--- a/tests/agent_infra/test_walkforward_validator.py
+++ b/tests/agent_infra/test_walkforward_validator.py
@@ -1,0 +1,627 @@
+"""WalkForwardValidator tests (#529 Phase 2 — actor #5, canonical).
+
+검증:
+- Layer B (deterministic, ZERO LLM)
+- 4 actions: run / pit_hash, classification + regression metrics
+- Anti-leak lock-test: future data injection 시 PIT 위반 panic
+- Rolling vs Expanding fold 정확성
+- Reproducibility: 동일 입력 → 동일 pit_hash + 동일 metrics
+- 모든 결정 walkforward_runs + agent_audit_ledger 자동 기록
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from nuri.agents.actors.walkforward_validator import (
+    FoldSpec,
+    WalkForwardValidator,
+    _aggregate_metrics,
+    _brier_score,
+    _generate_folds,
+    _hit_rate,
+    _log_loss,
+    _sharpe_from_returns,
+    _verify_pit,
+)
+from nuri.agents.base import Layer, Outcome
+from nuri.core.db import init_db, query
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "wf.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def patched_db(db_path):
+    """base + actor 의 db 호출을 임시 path 로 redirect."""
+    from nuri.core import db as db_module
+
+    def make_redirect(fn):
+        def wrapped(*args, **kwargs):
+            kwargs.setdefault("db_path", db_path)
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    patches = [
+        patch("nuri.agents.base.log_agent_audit", side_effect=make_redirect(db_module.log_agent_audit)),
+        patch("nuri.agents.base.start_agent_run", side_effect=make_redirect(db_module.start_agent_run)),
+        patch("nuri.agents.base.finish_agent_run", side_effect=make_redirect(db_module.finish_agent_run)),
+        patch(
+            "nuri.agents.actors.walkforward_validator.log_walkforward_run",
+            side_effect=make_redirect(db_module.log_walkforward_run),
+        ),
+    ]
+    for p in patches:
+        p.start()
+    yield db_path
+    for p in patches:
+        p.stop()
+
+
+@pytest.fixture
+def synthetic_data():
+    """100 rows, date column, target binary, feature numeric."""
+    n = 100
+    dates = pd.date_range("2026-01-01", periods=n, freq="D")
+    rng = np.random.default_rng(42)
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "feature": rng.normal(0, 1, n),
+            "target": rng.integers(0, 2, n).astype(float),
+        }
+    )
+
+
+# ═══════════════════════════════════════════════════════
+# Layer A/B/C invariants
+# ═══════════════════════════════════════════════════════
+
+
+class TestActorRegistration:
+    def test_layer_is_b(self):
+        assert WalkForwardValidator.layer == Layer.B
+
+    def test_no_llm_dependency(self):
+        assert getattr(WalkForwardValidator, "_uses_llm", False) is False
+
+    def test_registered_in_canonical_15(self):
+        from nuri.agents.base import REGISTRY
+
+        assert REGISTRY.get("walkforward-validator") is WalkForwardValidator
+
+
+# ═══════════════════════════════════════════════════════
+# FoldSpec validation
+# ═══════════════════════════════════════════════════════
+
+
+class TestFoldSpec:
+    def test_valid_rolling(self):
+        s = FoldSpec(kind="rolling", train_size=10, test_size=5, step=5)
+        assert s.kind == "rolling"
+
+    def test_valid_expanding(self):
+        s = FoldSpec(kind="expanding", train_size=10, test_size=5, step=5)
+        assert s.kind == "expanding"
+
+    def test_invalid_kind_raises(self):
+        with pytest.raises(ValueError, match="rolling/expanding"):
+            FoldSpec(kind="weird", train_size=10, test_size=5, step=5)
+
+    def test_zero_size_raises(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            FoldSpec(kind="rolling", train_size=0, test_size=5, step=5)
+
+
+# ═══════════════════════════════════════════════════════
+# _generate_folds correctness
+# ═══════════════════════════════════════════════════════
+
+
+class TestGenerateFolds:
+    def test_rolling_fold_count(self):
+        # n=100, train=20, test=10, step=10 → test_start ∈ {20, 30, 40, 50, 60, 70, 80, 90}
+        # while test_start + test_size <= 100 → 90 + 10 = 100 ✓ → 8 folds
+        folds = _generate_folds(100, FoldSpec("rolling", 20, 10, 10))
+        assert len(folds) == 8
+
+    def test_rolling_train_window_fixed(self):
+        folds = _generate_folds(100, FoldSpec("rolling", 20, 10, 10))
+        for tr, te in folds:
+            assert tr.stop - tr.start == 20  # train window fixed
+            assert te.stop - te.start == 10
+            assert tr.stop == te.start  # train ends right before test
+
+    def test_expanding_train_window_grows(self):
+        folds = _generate_folds(100, FoldSpec("expanding", 20, 10, 10))
+        prev_size = 0
+        for tr, te in folds:
+            assert tr.start == 0  # expanding always starts at 0
+            curr_size = tr.stop - tr.start
+            assert curr_size > prev_size
+            prev_size = curr_size
+            assert tr.stop == te.start  # PIT boundary
+
+    def test_no_folds_when_data_too_small(self):
+        folds = _generate_folds(10, FoldSpec("rolling", 20, 10, 10))
+        assert folds == []
+
+
+# ═══════════════════════════════════════════════════════
+# _verify_pit — Anti-leak Lock-Test
+# ═══════════════════════════════════════════════════════
+
+
+class TestAntiLeakLockTest:
+    """LOCK-TEST (Gotcha-Test Pair §5.3.1): future data injection MUST panic.
+
+    이 테스트가 fail 하면 fix 가 reverted 된 것 — Walk-forward primitive 의 PIT
+    enforcement 가 무력화된 상태. 모든 future actor 의 metric 신뢰성 박살.
+    """
+
+    def test_future_data_in_train_panics(self):
+        """train 에 test 보다 늦은 row 가 섞이면 ValueError."""
+        train = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2026-01-01", "2026-12-31"]),  # 12-31 이 미래
+                "x": [1.0, 2.0],
+            }
+        )
+        test = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2026-06-01", "2026-06-02"]),
+                "x": [3.0, 4.0],
+            }
+        )
+        with pytest.raises(ValueError, match="PIT leak"):
+            _verify_pit(train, test)
+
+    def test_train_strictly_before_test_passes(self):
+        train = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+                "x": [1.0, 2.0],
+            }
+        )
+        test = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2026-01-03", "2026-01-04"]),
+                "x": [3.0, 4.0],
+            }
+        )
+        _verify_pit(train, test)  # no raise
+
+    def test_overlap_panics(self):
+        """train.max == test.min 도 leak (PIT 는 strict less-than)."""
+        d = pd.to_datetime(["2026-01-01", "2026-01-02"])
+        train = pd.DataFrame({"date": d, "x": [1.0, 2.0]})
+        test = pd.DataFrame({"date": d[1:], "x": [2.5]})
+        with pytest.raises(ValueError, match="PIT leak"):
+            _verify_pit(train, test)
+
+    def test_index_based_pit_when_no_date_col(self):
+        """date column 없으면 index 비교 — DatetimeIndex 등."""
+        train = pd.DataFrame({"x": [1, 2]}, index=pd.date_range("2026-01-01", periods=2))
+        test = pd.DataFrame({"x": [3, 4]}, index=pd.date_range("2026-01-03", periods=2))
+        _verify_pit(train, test)
+        # leak case
+        bad_test = pd.DataFrame({"x": [3]}, index=pd.date_range("2026-01-02", periods=1))
+        with pytest.raises(ValueError, match="PIT leak"):
+            _verify_pit(train, bad_test)
+
+
+# ═══════════════════════════════════════════════════════
+# Metrics primitives
+# ═══════════════════════════════════════════════════════
+
+
+class TestMetrics:
+    def test_brier_perfect_pred(self):
+        assert _brier_score(np.array([0, 1, 1, 0]), np.array([0, 1, 1, 0])) == 0.0
+
+    def test_brier_worst_pred(self):
+        assert _brier_score(np.array([0, 1]), np.array([1, 0])) == 1.0
+
+    def test_log_loss_perfect_clipped(self):
+        # exact 0 / 1 prob → eps clip → small but nonzero
+        loss = _log_loss(np.array([0, 1]), np.array([0.0, 1.0]))
+        assert loss < 1e-10
+
+    def test_hit_rate_50_50(self):
+        assert _hit_rate(np.array([0, 1, 0, 1]), np.array([0.6, 0.4, 0.6, 0.4])) == 0.0
+
+    def test_sharpe_zero_std(self):
+        assert _sharpe_from_returns(np.array([0.01, 0.01, 0.01])) == 0.0
+
+    def test_sharpe_positive(self):
+        # consistent positive returns → high Sharpe
+        s = _sharpe_from_returns(np.array([0.01, 0.012, 0.008, 0.011, 0.009]))
+        assert s > 5.0
+
+
+class TestAggregate:
+    def test_empty_returns_empty(self):
+        assert _aggregate_metrics([]) == {}
+
+    def test_mean_and_std(self):
+        agg = _aggregate_metrics([{"brier": 0.2}, {"brier": 0.4}])
+        assert agg["brier_mean"] == pytest.approx(0.3)
+        assert agg["brier_std"] == pytest.approx(0.14142, rel=1e-3)
+
+
+# ═══════════════════════════════════════════════════════
+# Action: pit_hash (read-only reproducibility key)
+# ═══════════════════════════════════════════════════════
+
+
+class TestActionPitHash:
+    def test_pit_hash_deterministic(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        r1 = actor.run(
+            {
+                "action": "pit_hash",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "test_v1",
+            }
+        )
+        r2 = actor.run(
+            {
+                "action": "pit_hash",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "test_v1",
+            }
+        )
+        assert r1.outcome == Outcome.PASS
+        assert r1.output["pit_hash"] == r2.output["pit_hash"]
+
+    def test_pit_hash_changes_with_model_id(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        r1 = actor.run(
+            {
+                "action": "pit_hash",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "v1",
+            }
+        )
+        r2 = actor.run(
+            {
+                "action": "pit_hash",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "v2",
+            }
+        )
+        assert r1.output["pit_hash"] != r2.output["pit_hash"]
+
+    def test_pit_hash_changes_with_data(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        r1 = actor.run(
+            {
+                "action": "pit_hash",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "v1",
+            }
+        )
+        modified = synthetic_data.copy()
+        modified.loc[0, "feature"] = 999.0
+        r2 = actor.run(
+            {
+                "action": "pit_hash",
+                "data": modified,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "v1",
+            }
+        )
+        assert r1.output["pit_hash"] != r2.output["pit_hash"]
+
+
+# ═══════════════════════════════════════════════════════
+# Action: run (full walk-forward)
+# ═══════════════════════════════════════════════════════
+
+
+def _dummy_classifier(train_df: pd.DataFrame):
+    """Returns a predict_fn that outputs constant 0.5 (uninformed prior)."""
+
+    def predict(test_df):
+        return np.full(len(test_df), 0.5)
+
+    return predict
+
+
+def _smart_classifier(train_df: pd.DataFrame):
+    """Predicts target using feature mean of train (deterministic, learns from train only)."""
+    target_mean = float(train_df["target"].mean())
+
+    def predict(test_df):
+        return np.full(len(test_df), target_mean)
+
+    return predict
+
+
+class TestActionRun:
+    def test_classification_run_pass(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "dummy_clf",
+                "model_fn": _dummy_classifier,
+                "target_col": "target",
+                "metric_kind": "classification",
+            }
+        )
+        assert result.outcome == Outcome.PASS
+        assert result.output["n_folds"] >= 1
+        assert "brier_mean" in result.output["metrics"]["aggregate"]
+        assert "logloss_mean" in result.output["metrics"]["aggregate"]
+        assert "hit_rate_mean" in result.output["metrics"]["aggregate"]
+
+    def test_regression_run_pass(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "dummy_reg",
+                "model_fn": _smart_classifier,
+                "target_col": "target",
+                "metric_kind": "regression",
+            }
+        )
+        assert result.outcome == Outcome.PASS
+        assert "mse_mean" in result.output["metrics"]["aggregate"]
+        assert "mae_mean" in result.output["metrics"]["aggregate"]
+
+    def test_persisted_to_walkforward_runs(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "persist_test",
+                "model_fn": _dummy_classifier,
+                "target_col": "target",
+                "metric_kind": "classification",
+            }
+        )
+        rows = query(
+            "SELECT model_id, n_folds, pit_hash, finished_at FROM walkforward_runs WHERE run_id = ?",
+            (result.output["run_id"],),
+            db_path=patched_db,
+        )
+        assert len(rows) == 1
+        assert rows[0]["model_id"] == "persist_test"
+        assert rows[0]["finished_at"] is not None
+
+    def test_failed_fold_returns_warn(self, patched_db, synthetic_data):
+        """일부 fold 의 model_fn 이 raise 하면 outcome=WARN (전체 panic 아님)."""
+        call_count = {"n": 0}
+
+        def flaky_model(train_df):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated train failure")
+            return _dummy_classifier(train_df)
+
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "flaky",
+                "model_fn": flaky_model,
+                "target_col": "target",
+                "metric_kind": "classification",
+            }
+        )
+        assert result.outcome == Outcome.WARN
+        assert result.output["n_successful"] < result.output["n_folds"]
+        # error 가 metrics 에 기록되어 있어야 함
+        errored = [f for f in result.output["metrics"]["folds"] if "error" in f]
+        assert len(errored) >= 1
+
+    def test_predict_length_mismatch_marks_fold_failed(self, patched_db, synthetic_data):
+        """predict_fn 이 잘못된 길이 반환 → 해당 fold error 처리."""
+
+        def broken_model(train_df):
+            return lambda test_df: np.array([0.5])  # length 1, expected len(test)
+
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "len_mismatch",
+                "model_fn": broken_model,
+                "target_col": "target",
+                "metric_kind": "classification",
+            }
+        )
+        assert result.outcome == Outcome.WARN
+        assert result.output["n_successful"] == 0
+
+
+# ═══════════════════════════════════════════════════════
+# Input validation
+# ═══════════════════════════════════════════════════════
+
+
+class TestInputValidation:
+    def test_invalid_action_blocks(self, patched_db):
+        actor = WalkForwardValidator()
+        result = actor.run({"action": "weird"})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_missing_data_blocks(self, patched_db):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "fold_spec": {"kind": "rolling", "train_size": 10, "test_size": 5, "step": 5},
+            }
+        )
+        assert result.outcome == Outcome.BLOCK
+
+    def test_missing_fold_spec_blocks(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run({"action": "run", "data": synthetic_data})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_invalid_fold_spec_blocks(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "weird", "train_size": 10, "test_size": 5, "step": 5},
+            }
+        )
+        assert result.outcome == Outcome.BLOCK
+
+    def test_missing_model_fn_blocks(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "target_col": "target",
+            }
+        )
+        assert result.outcome == Outcome.BLOCK
+
+    def test_invalid_target_col_blocks(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_fn": _dummy_classifier,
+                "target_col": "nonexistent",
+            }
+        )
+        assert result.outcome == Outcome.BLOCK
+
+    def test_invalid_metric_kind_blocks(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_fn": _dummy_classifier,
+                "target_col": "target",
+                "metric_kind": "weird",
+            }
+        )
+        assert result.outcome == Outcome.BLOCK
+
+    def test_data_too_small_blocks(self, patched_db):
+        actor = WalkForwardValidator()
+        small = pd.DataFrame(
+            {
+                "date": pd.date_range("2026-01-01", periods=5),
+                "target": [0, 1, 0, 1, 0],
+            }
+        )
+        result = actor.run(
+            {
+                "action": "run",
+                "data": small,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_fn": _dummy_classifier,
+                "target_col": "target",
+            }
+        )
+        assert result.outcome == Outcome.BLOCK
+        assert "no valid folds" in result.output["error"]
+
+
+# ═══════════════════════════════════════════════════════
+# Audit trail integration
+# ═══════════════════════════════════════════════════════
+
+
+class TestAuditTrail:
+    def test_run_logged_to_audit_ledger(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "audit_test",
+                "model_fn": _dummy_classifier,
+                "target_col": "target",
+                "metric_kind": "classification",
+            }
+        )
+        rows = query(
+            "SELECT actor_name, layer, outcome FROM agent_audit_ledger WHERE actor_name = 'walkforward-validator'",
+            db_path=patched_db,
+        )
+        assert len(rows) >= 1
+        assert rows[0]["layer"] == "B"
+        assert rows[0]["outcome"] == "pass"
+
+    def test_pit_hash_action_logged(self, patched_db, synthetic_data):
+        actor = WalkForwardValidator()
+        actor.run(
+            {
+                "action": "pit_hash",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "hash_test",
+            }
+        )
+        rows = query(
+            "SELECT outcome FROM agent_audit_ledger WHERE actor_name = 'walkforward-validator'",
+            db_path=patched_db,
+        )
+        assert any(r["outcome"] == "pass" for r in rows)
+
+
+# ═══════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════
+
+
+class TestCli:
+    def test_cli_pit_hash(self, tmp_path, patched_db, capsys):
+        from nuri.agents.actors.walkforward_validator import main
+
+        csv_path = tmp_path / "data.csv"
+        df = pd.DataFrame(
+            {
+                "date": pd.date_range("2026-01-01", periods=100),
+                "feature": np.random.default_rng(0).normal(0, 1, 100),
+                "target": np.random.default_rng(0).integers(0, 2, 100),
+            }
+        )
+        df.to_csv(csv_path, index=False)
+        rc = main(["pit_hash", "--csv", str(csv_path), "--model-id", "cli_test"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "pit_hash" in out

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -27,11 +27,11 @@ def db_path(tmp_path):
 
 
 class TestSchemaMigrations:
-    """4 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages) 적용 확인."""
+    """5 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs) 적용 확인."""
 
-    def test_schema_version_at_28(self, db_path):
-        """Phase 1+2 migrations 모두 적용 → schema version 28."""
-        assert get_schema_version(db_path) == 28
+    def test_schema_version_at_29(self, db_path):
+        """Phase 1+2 migrations 모두 적용 → schema version 29."""
+        assert get_schema_version(db_path) == 29
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
## Summary

Walk-forward model evaluation primitive — point-in-time enforced. Codex consult 2026-05-01 권고 sequencing 따름:
- **Why now**: Regime-Posterior / Causal-Factor-Auditor / Foundation-Benchmark 가 모두 model fit 하므로 evaluation primitive 가 dependency. WalkForward-Validator 먼저 두면 다음 3-5 actor 가 자연스럽게 얹힘.
- **Why not bundle**: Decision-Compiler (#8) 와 묶지 않음 — producer/consumer 동시 설계 시 출력 over-design.

## Scope

- `nuri/agents/actors/walkforward_validator.py` (Layer B, ZERO LLM)
- Migration #29: `walkforward_runs` table (run_id, model_id, fold_spec_json, metrics_json, pit_hash, n_folds, n_train_obs, n_test_obs, started_at, finished_at)
- `nuri/core/db.py::log_walkforward_run` helper
- 42 tests, agent infra coverage 96% TOTAL (walkforward_validator 96% 단독)
- Make targets: `walkforward-history`, `walkforward-pit-hash`
- Anti-leak lock-test (Gotcha-Test Pair §5.3.1)

## Anti-leak Lock-Test

`tests/agent_infra/test_walkforward_validator.py::TestAntiLeakLockTest`:
- `test_future_data_in_train_panics` — train.max < test.min strict 위반 → ValueError
- `test_overlap_panics` — train.max == test.min 도 leak (PIT 는 strict less-than)
- `test_index_based_pit_when_no_date_col` — DatetimeIndex 기반 비교

이 테스트가 fail 하면 fix 가 reverted 된 것 — Walk-forward primitive 의 PIT enforcement 무력화 → 모든 future actor 의 metric 신뢰성 박살.

## signal_backtest audit 결과

`nuri/quant/validation/signal_backtest.py` 의 PIT-leak 가능성 audit:
- `compute_indicators` → `.rolling()` / `.ewm()` (backward-only). Clean.
- `compute_exit(df, entry_idx, sig_id)` → forward 보지만 그게 *target* (forward outcome 측정), leak 아님.
- 결론: signal_backtest 는 이미 PIT-safe. 별도 refactor 불필요.

WalkForwardValidator 는 *모델 fit 하는 future actor 들* (Regime-Posterior sticky-HMM 등) 을 위한 evaluation primitive — signal_backtest 와 다른 paradigm.

## API

\`\`\`python
from nuri.agents.actors.walkforward_validator import WalkForwardValidator

actor = WalkForwardValidator()
result = actor.run({
    \"action\": \"run\",
    \"data\": df,                       # pd.DataFrame with date column
    \"fold_spec\": {\"kind\": \"rolling\", \"train_size\": 252, \"test_size\": 21, \"step\": 21},
    \"model_fn\": my_model_factory,    # train_df → predict_fn
    \"target_col\": \"target\",
    \"metric_kind\": \"classification\",  # or \"regression\"
    \"model_id\": \"ridge_v1\",
})
# result.output: {run_id, pit_hash, n_folds, n_successful, metrics: {folds: [...], aggregate: {...}}}
\`\`\`

## Metrics

- **classification**: Brier score, log-loss, hit-rate
- **regression**: MSE, MAE, annualized Sharpe (252)
- **aggregate**: per-metric mean + std across folds

## Test plan

- [x] 42 new tests pass (anti-leak / fold generation / metrics / actions / validation / audit / CLI)
- [x] Lint clean (ruff)
- [x] Migration #29 applies cleanly (schema 28 → 29)
- [x] Agent infra coverage 96% (walkforward_validator 96% standalone)
- [x] All 178 tests in tests/agent_infra/ + tests/core/test_agent_infra.py green
- [ ] CI checks all green (pending push)

## Decision-Compiler (#8) — deferred

Codex 권고 따름: producer 만 우선, consumer 추후. `walkforward_runs` 테이블은 향후 Decision-Compiler 가 직접 query 가능 (model_id + pit_hash 로 reproducibility 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)