### PR TITLE
feat(agents): #529 Phase 2 closed-loop — ForwardOutcomeTracker (canonical #11, Layer B)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -678,6 +678,7 @@
     "linspace",
     "falsification",
     "spurious",
+    "insuf",
     "Hamilton",
     "MOIRAI",
     "Chronos",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flowchart TB
         E -. "agent weight drift (±30%)" .-> C
     end
 
-    DB[("SQLite WAL · 41 tables<br/>pipeline_events · certifications · audit trail")]:::sink
+    DB[("SQLite WAL · 42 tables<br/>pipeline_events · certifications · audit trail")]:::sink
 
     CFG -. policies .-> Pipeline
     Pipeline -. persist .-> DB

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-4,102 backend tests across 179 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+4,138 backend tests across 180 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,102 tests, 179 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,138 tests, 180 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/__init__.py
+++ b/nuri/agents/actors/__init__.py
@@ -8,10 +8,12 @@ Phase 2 actors (Codex Round 5):
 - RegimePosterior (#3, Layer B) — sticky-HMM smoothed regime posterior producer
 - CausalFactorAuditor (#6, Layer B) — López de Prado 4-test causal audit
 - DecisionCompiler (#8, Layer B) — Phase 2 capstone: producer/gate 통합 → emit
+- ForwardOutcomeTracker (#11, Layer B) — closed-loop: outcome 추적 → hypothesis auto-validate
 """
 
 from nuri.agents.actors.causal_factor_auditor import CausalFactorAuditor
 from nuri.agents.actors.decision_compiler import DecisionCompiler
+from nuri.agents.actors.forward_outcome_tracker import ForwardOutcomeTracker
 from nuri.agents.actors.freshness_gatekeeper import FreshnessGatekeeper
 from nuri.agents.actors.hypothesis_registry import HypothesisRegistry
 from nuri.agents.actors.regime_posterior import RegimePosterior
@@ -21,6 +23,7 @@ from nuri.agents.actors.walkforward_validator import WalkForwardValidator
 __all__ = [
     "CausalFactorAuditor",
     "DecisionCompiler",
+    "ForwardOutcomeTracker",
     "FreshnessGatekeeper",
     "HypothesisRegistry",
     "RegimePosterior",

--- a/nuri/agents/actors/forward_outcome_tracker.py
+++ b/nuri/agents/actors/forward_outcome_tracker.py
@@ -1,0 +1,485 @@
+"""ForwardOutcomeTracker — Layer B actor (#529 Phase 2 closed-loop — canonical #11).
+
+DecisionCompiler #8 가 emit 한 decision 의 *실제 결과* 추적 → HypothesisRegistry #4
+의 hypothesis 자동 validate (성공) / reject (실패). Phase 2 의 closed-loop 완성.
+
+Layer B 설계 (Codex Round 5):
+- ZERO LLM, deterministic 측정
+- Lookahead bias 차단: as_of_date + observation_window 이후 데이터만 사용
+- 미래 가격 데이터 없으면 insufficient_data (false validation 차단)
+
+Validation rule (defaults):
+- Window 7d:  realized_return >= +5% → pass / <= -5% → reject / 사이 → insufficient
+- Window 14d: realized_return >= +7% → pass / <= -7% → reject
+- Window 30d: realized_return >= +10% → pass / <= -10% → reject
+- Threshold 도달 (hit_threshold=True) 시 항상 pass
+- HOLD action 의 decision 은 추적 X (BUY/SELL 만)
+
+Anti-pattern 방지 (lock-test):
+- as_of_date + window > today → insufficient (lookahead 위반 시도 차단)
+- agent_decisions 에 ticker price 없음 → insufficient_data
+- hypothesis 가 이미 validated/rejected/expired → update X (status machine 위반 차단)
+- HOLD decision 추적 시도 → skip (의미 없음)
+
+Discord publish:
+- hypothesis 자동 validation (pass/reject) → ROLLOUT 채널
+- best-effort: publish 실패해도 actor outcome 영향 X
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
+from nuri.core.db import (
+    log_decision_outcome,
+    query,
+    reject_hypothesis,
+    validate_hypothesis,
+)
+from nuri.core.timezone import today_kst
+
+# ─── window 별 validation 임계값 (Codex consult 합의) ─────────
+WINDOW_THRESHOLDS: dict[int, tuple[float, float]] = {
+    7: (0.05, -0.05),  # ±5% within 7 days
+    14: (0.07, -0.07),  # ±7% within 14 days
+    30: (0.10, -0.10),  # ±10% within 30 days
+}
+SUPPORTED_WINDOWS: tuple[int, ...] = (7, 14, 30)
+DEFAULT_BENCHMARK_TICKER = "SPY"  # 시장 베타 — alpha 산출 baseline
+
+
+@REGISTRY.register
+class ForwardOutcomeTracker(Actor):
+    """Closed-loop outcome tracker — emit → measure → validate.
+
+    Actions (input_data['action']):
+        scan       — 추적 가능한 emitted decision 들을 일괄 측정 (cron-style)
+        track_one  — 단일 decision_id 측정
+        last_outcome — decision_id 의 가장 최근 outcome 조회 (read-only)
+
+    Outcome 매핑 (Layer B):
+        PASS — 측정 + validation 성공
+        WARN — insufficient_data (가격 부족 또는 lookahead) / HOLD skip
+        BLOCK — invalid input
+    """
+
+    name = "forward-outcome-tracker"
+    version = "0.1.0"
+    layer = Layer.B
+
+    VALID_ACTIONS: tuple[str, ...] = ("scan", "track_one", "last_outcome")
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        action = input_data.get("action")
+        if action not in self.VALID_ACTIONS:
+            return ActorResult(
+                output={"error": f"invalid action {action!r}, expected {self.VALID_ACTIONS}"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"action={action}",
+            )
+
+        if action == "scan":
+            return self._scan(input_data, ctx)
+        if action == "track_one":
+            return self._track_one(input_data, ctx)
+        return self._last_outcome(input_data)
+
+    # ─── handlers ─────────────────────────────────────────────
+
+    def _scan(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        """Emitted decisions 를 cron-style 으로 일괄 측정.
+
+        windows: 측정할 observation window list (default: 모든 supported)
+        max_decisions: 한 번에 처리할 최대 개수 (default 100)
+        """
+        windows = input_data.get("windows") or list(SUPPORTED_WINDOWS)
+        for w in windows:
+            if w not in SUPPORTED_WINDOWS:
+                return ActorResult(
+                    output={"error": f"unsupported window {w}, allowed {SUPPORTED_WINDOWS}"},
+                    outcome=Outcome.BLOCK,
+                    input_summary=f"scan windows={windows}",
+                )
+        max_decisions = int(input_data.get("max_decisions", 100))
+
+        rows = query(
+            """SELECT decision_id, ticker, as_of_date, action, inputs_json
+               FROM agent_decisions
+               WHERE status = 'emitted' AND action IN ('BUY','SELL')
+               ORDER BY created_at DESC LIMIT ?""",
+            (max_decisions,),
+        )
+
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            r = dict(row)
+            for window in windows:
+                outcome = self._measure_one(
+                    decision_id=r["decision_id"],
+                    ticker=r["ticker"],
+                    as_of_date=r["as_of_date"],
+                    action=r["action"],
+                    inputs_json=r["inputs_json"],
+                    window=window,
+                    ctx=ctx,
+                )
+                results.append(outcome)
+
+        n_pass = sum(1 for o in results if o["validation"] == "pass")
+        n_reject = sum(1 for o in results if o["validation"] == "reject")
+        n_insuf = sum(1 for o in results if o["validation"] == "insufficient_data")
+
+        return ActorResult(
+            output={
+                "scanned": len(rows),
+                "windows": windows,
+                "n_measurements": len(results),
+                "n_pass": n_pass,
+                "n_reject": n_reject,
+                "n_insufficient": n_insuf,
+                "results": results[:50],  # truncate for audit_ledger
+            },
+            outcome=Outcome.PASS,
+            sample_n=len(results),
+            input_summary=f"scan {len(rows)} dec × {len(windows)} win → {n_pass}p/{n_reject}r/{n_insuf}i",
+        )
+
+    def _track_one(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        decision_id = input_data.get("decision_id")
+        window = input_data.get("observation_window", 7)
+        if not decision_id:
+            return ActorResult(
+                output={"error": "track_one requires 'decision_id'"},
+                outcome=Outcome.BLOCK,
+                input_summary="track_one",
+            )
+        if window not in SUPPORTED_WINDOWS:
+            return ActorResult(
+                output={"error": f"observation_window must be {SUPPORTED_WINDOWS}, got {window}"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"track_one {decision_id}",
+            )
+
+        rows = query(
+            "SELECT decision_id, ticker, as_of_date, action, inputs_json FROM agent_decisions WHERE decision_id = ?",
+            (decision_id,),
+        )
+        if not rows:
+            return ActorResult(
+                output={"error": f"decision_id {decision_id!r} not found"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"track_one {decision_id}",
+            )
+        r = dict(rows[0])
+        if r["action"] == "HOLD":
+            return ActorResult(
+                output={"decision_id": decision_id, "skipped": "HOLD action — no tracking"},
+                outcome=Outcome.WARN,
+                input_summary=f"track_one {decision_id} HOLD skip",
+            )
+
+        result = self._measure_one(
+            decision_id=r["decision_id"],
+            ticker=r["ticker"],
+            as_of_date=r["as_of_date"],
+            action=r["action"],
+            inputs_json=r["inputs_json"],
+            window=window,
+            ctx=ctx,
+        )
+        outcome = Outcome.PASS if result["validation"] in ("pass", "reject") else Outcome.WARN
+        return ActorResult(
+            output=result,
+            outcome=outcome,
+            sample_n=1,
+            input_summary=f"track_one {decision_id} w{window} {result['validation']}",
+        )
+
+    @staticmethod
+    def _last_outcome(input_data: dict[str, Any]) -> ActorResult:
+        decision_id = input_data.get("decision_id")
+        if decision_id:
+            rows = query(
+                """SELECT * FROM decision_outcomes WHERE decision_id = ?
+                   ORDER BY observation_window DESC LIMIT 1""",
+                (decision_id,),
+            )
+        else:
+            rows = query("SELECT * FROM decision_outcomes ORDER BY created_at DESC, rowid DESC LIMIT 1")
+        if not rows:
+            return ActorResult(
+                output={"error": "no decision_outcomes row found"},
+                outcome=Outcome.WARN,
+                input_summary="last_outcome",
+            )
+        r = dict(rows[0])
+        return ActorResult(
+            output=r,
+            outcome=Outcome.PASS,
+            input_summary=f"last_outcome {r['decision_id']} w{r['observation_window']}",
+        )
+
+    # ─── core measurement ─────────────────────────────────────
+
+    def _measure_one(
+        self,
+        decision_id: str,
+        ticker: str,
+        as_of_date: str,
+        action: str,
+        inputs_json: str,
+        window: int,
+        ctx: RunContext,
+    ) -> dict[str, Any]:
+        """단일 (decision, window) 측정 → outcome row + 자동 validation trigger.
+
+        Returns dict with: decision_id, window, validation, realized_return, alpha, ...
+        """
+        today = today_kst()
+        from datetime import date
+
+        as_of = date.fromisoformat(as_of_date)
+        target_date = self._add_business_days(as_of, window).isoformat()
+
+        # ─── lookahead guard: target_date 가 미래면 insufficient ───
+        if target_date > today:
+            log_decision_outcome(
+                decision_id=decision_id,
+                observation_window=window,
+                tracked_as_of_date=today,
+                hypothesis_validation="insufficient_data",
+                notes=f"target_date {target_date} > today {today} (lookahead guard)",
+                run_id=ctx.run_id,
+            )
+            return {
+                "decision_id": decision_id,
+                "window": window,
+                "validation": "insufficient_data",
+                "reason": "lookahead — target_date in future",
+            }
+
+        # ─── 가격 조회 ───
+        entry = self._fetch_close(ticker, as_of_date)
+        exit_p = self._fetch_close_on_or_after(ticker, target_date)
+        bench_entry = self._fetch_close(DEFAULT_BENCHMARK_TICKER, as_of_date)
+        bench_exit = self._fetch_close_on_or_after(DEFAULT_BENCHMARK_TICKER, target_date)
+
+        if entry is None or exit_p is None:
+            log_decision_outcome(
+                decision_id=decision_id,
+                observation_window=window,
+                tracked_as_of_date=today,
+                hypothesis_validation="insufficient_data",
+                notes=f"price missing — entry={entry}, exit={exit_p}",
+                run_id=ctx.run_id,
+            )
+            return {
+                "decision_id": decision_id,
+                "window": window,
+                "validation": "insufficient_data",
+                "reason": "price data missing",
+            }
+
+        realized = (exit_p - entry) / entry
+        # SELL action → return 의 부호 반전 (short proxy)
+        if action == "SELL":
+            realized = -realized
+
+        bench_return: Optional[float] = None
+        alpha: Optional[float] = None
+        if bench_entry is not None and bench_exit is not None and bench_entry > 0:
+            bench_return = (bench_exit - bench_entry) / bench_entry
+            if action == "SELL":
+                bench_return = -bench_return
+            alpha = realized - bench_return
+
+        # ─── validation rule ───
+        up_thresh, down_thresh = WINDOW_THRESHOLDS[window]
+        hit_threshold = realized >= up_thresh
+        if hit_threshold:
+            validation = "pass"
+        elif realized <= down_thresh:
+            validation = "reject"
+        else:
+            validation = "insufficient_data"
+
+        log_decision_outcome(
+            decision_id=decision_id,
+            observation_window=window,
+            tracked_as_of_date=today,
+            entry_price=entry,
+            exit_price=exit_p,
+            realized_return=realized,
+            benchmark_return=bench_return,
+            alpha=alpha,
+            hit_threshold=hit_threshold,
+            hypothesis_validation=validation,
+            notes=f"action={action} ticker={ticker}",
+            run_id=ctx.run_id,
+        )
+
+        # ─── auto-trigger HypothesisRegistry validate/reject ───
+        hypothesis_id = self._extract_hypothesis_id(inputs_json)
+        if hypothesis_id and validation in ("pass", "reject"):
+            self._trigger_hypothesis_update(
+                hypothesis_id=hypothesis_id,
+                validation=validation,
+                window=window,
+                realized=realized,
+                alpha=alpha,
+                run_id=ctx.run_id,
+            )
+
+        return {
+            "decision_id": decision_id,
+            "ticker": ticker,
+            "window": window,
+            "validation": validation,
+            "realized_return": realized,
+            "alpha": alpha,
+            "hit_threshold": hit_threshold,
+            "hypothesis_id": hypothesis_id,
+        }
+
+    # ─── helpers ──────────────────────────────────────────────
+
+    @staticmethod
+    def _add_business_days(start, n: int):
+        """간단 calendar-day add (주말/휴장 정확 처리는 prices 의 on_or_after 가 흡수)."""
+        from datetime import timedelta
+
+        return start + timedelta(days=n)
+
+    @staticmethod
+    def _fetch_close(ticker: str, date_str: str) -> Optional[float]:
+        rows = query(
+            "SELECT close FROM prices WHERE ticker = ? AND date = ? LIMIT 1",
+            (ticker, date_str),
+        )
+        if not rows:
+            return None
+        v = dict(rows[0]).get("close")
+        return float(v) if v is not None else None
+
+    @staticmethod
+    def _fetch_close_on_or_after(ticker: str, date_str: str) -> Optional[float]:
+        """target_date 이후 첫 거래일의 close (주말/휴장 자동 흡수)."""
+        rows = query(
+            "SELECT close FROM prices WHERE ticker = ? AND date >= ? ORDER BY date LIMIT 1",
+            (ticker, date_str),
+        )
+        if not rows:
+            return None
+        v = dict(rows[0]).get("close")
+        return float(v) if v is not None else None
+
+    @staticmethod
+    def _extract_hypothesis_id(inputs_json: str) -> Optional[str]:
+        try:
+            return json.loads(inputs_json or "{}").get("hypothesis_id")
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def _trigger_hypothesis_update(
+        hypothesis_id: str,
+        validation: str,
+        window: int,
+        realized: float,
+        alpha: Optional[float],
+        run_id: str,
+    ) -> None:
+        """auto-validate/reject — 이미 종결된 hypothesis 는 silently skip (status machine 보존)."""
+        # status check first (silent skip if not open)
+        rows = query(
+            "SELECT status FROM hypotheses WHERE hypothesis_id = ?",
+            (hypothesis_id,),
+        )
+        if not rows or dict(rows[0])["status"] != "open":
+            return  # 이미 validated/rejected/expired → skip
+
+        try:
+            if validation == "pass":
+                metrics = {
+                    "auto_trigger": "forward-outcome-tracker",
+                    "observation_window": window,
+                    "realized_return": realized,
+                    "alpha": alpha,
+                }
+                validate_hypothesis(hypothesis_id, metrics)
+                ForwardOutcomeTracker._publish_validation(hypothesis_id, "validated", realized, alpha, run_id)
+            elif validation == "reject":
+                reason = (
+                    f"forward outcome reject: w={window}d "
+                    f"realized={realized:.4f}, alpha={alpha if alpha is not None else 'N/A'}"
+                )
+                reject_hypothesis(hypothesis_id, reason)
+                ForwardOutcomeTracker._publish_validation(hypothesis_id, "rejected", realized, alpha, run_id)
+        except ValueError:  # status machine race / already changed → skip
+            pass
+
+    @staticmethod
+    def _publish_validation(
+        hypothesis_id: str,
+        new_status: str,
+        realized: float,
+        alpha: Optional[float],
+        run_id: str,
+    ) -> None:
+        try:
+            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+
+            color = 0x2ECC71 if new_status == "validated" else 0xE74C3C
+            embed = {
+                "title": f"Hypothesis auto-{new_status} — {hypothesis_id}",
+                "description": (
+                    f"trigger: forward-outcome-tracker\n"
+                    f"realized_return: **{realized:.4f}**\n"
+                    f"alpha: {alpha if alpha is not None else 'N/A'}"
+                ),
+                "color": color,
+                "footer": {"text": f"nuri-quant • run_id={run_id[:8]}"},
+            }
+            DiscordPublisher().publish_embed(
+                Channel.ROLLOUT,
+                embed=embed,
+                actor_name="forward-outcome-tracker",
+                run_id=run_id,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.agents.actors.forward_outcome_tracker {scan,last_outcome}"""
+    import argparse
+    import json as _json
+
+    parser = argparse.ArgumentParser(prog="forward-outcome-tracker")
+    parser.add_argument("action", choices=["scan", "last_outcome", "track_one"])
+    parser.add_argument("--decision-id", default=None)
+    parser.add_argument("--observation-window", type=int, default=7)
+    parser.add_argument("--max-decisions", type=int, default=100)
+    args = parser.parse_args(argv)
+
+    actor = ForwardOutcomeTracker()
+    payload: dict[str, Any] = {"action": args.action}
+    if args.action == "scan":
+        payload["max_decisions"] = args.max_decisions
+    elif args.action == "track_one":
+        payload["decision_id"] = args.decision_id
+        payload["observation_window"] = args.observation_window
+    elif args.action == "last_outcome" and args.decision_id:
+        payload["decision_id"] = args.decision_id
+
+    result = actor.run(payload)
+    print(_json.dumps(result.output, indent=2, ensure_ascii=False, default=str))
+    return 0 if result.outcome in (Outcome.PASS, Outcome.WARN) else 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/core/db.py
+++ b/nuri/core/db.py
@@ -1014,6 +1014,43 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_agent_decisions_run ON agent_decisions(run_id);
     """,
     ),
+    (
+        34,
+        "decision_outcomes — Forward-Outcome-Tracker closed-loop (#529 Phase 2 actor #11, Layer B)",
+        # #529 Phase 2 closed-loop — DecisionCompiler #8 가 emit 한 decision 의 realized
+        # outcome 추적. observation_window (7/14/30d) 후 가격 데이터로 realized_return,
+        # benchmark_return (alpha), hit_threshold (target 도달) 측정 → hypothesis 자동
+        # validate/reject trigger.
+        #
+        # 핵심 invariant:
+        # - (decision_id, observation_window) PK → 동일 decision 의 7d/14d/30d 별도 row
+        # - hypothesis_validation enum: pass/reject/insufficient_data
+        # - tracked_as_of_date: 측정 시점의 KST date (lookahead 검증용)
+        # - benchmark_return: 시장 베타 (예: SPY 또는 portfolio benchmark) 의 같은 기간 return
+        #   alpha = realized_return - benchmark_return
+        """
+        CREATE TABLE IF NOT EXISTS decision_outcomes (
+            decision_id TEXT NOT NULL,
+            observation_window INTEGER NOT NULL CHECK(observation_window IN (7, 14, 30)),
+            tracked_as_of_date TEXT NOT NULL,
+            entry_price REAL,
+            exit_price REAL,
+            realized_return REAL,
+            benchmark_return REAL,
+            alpha REAL,
+            hit_threshold INTEGER NOT NULL DEFAULT 0,
+            hypothesis_validation TEXT NOT NULL CHECK(hypothesis_validation IN ('pass','reject','insufficient_data')),
+            notes TEXT,
+            run_id TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (decision_id, observation_window),
+            FOREIGN KEY (decision_id) REFERENCES agent_decisions(decision_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_outcomes_decision ON decision_outcomes(decision_id);
+        CREATE INDEX IF NOT EXISTS idx_outcomes_validation ON decision_outcomes(hypothesis_validation, tracked_as_of_date);
+        CREATE INDEX IF NOT EXISTS idx_outcomes_run ON decision_outcomes(run_id);
+    """,
+    ),
 ]
 
 
@@ -2099,6 +2136,76 @@ def log_decision(
                 json.dumps(rationale, sort_keys=True, default=str),
                 status,
                 block_reason,
+                run_id,
+            ),
+        )
+
+
+# ═══════════════════════════════════════════════════════
+# Forward-Outcome-Tracker helper (#529 Phase 2 actor #11 — Layer B)
+# ═══════════════════════════════════════════════════════
+
+_OUTCOME_VALIDATIONS = ("pass", "reject", "insufficient_data")
+_OUTCOME_WINDOWS = (7, 14, 30)
+
+
+def log_decision_outcome(
+    decision_id: str,
+    observation_window: int,
+    tracked_as_of_date: str,
+    hypothesis_validation: str,
+    entry_price: Optional[float] = None,
+    exit_price: Optional[float] = None,
+    realized_return: Optional[float] = None,
+    benchmark_return: Optional[float] = None,
+    alpha: Optional[float] = None,
+    hit_threshold: bool = False,
+    notes: Optional[str] = None,
+    run_id: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> None:
+    """Decision outcome audit (#529 Phase 2 closed-loop — Forward-Outcome-Tracker).
+
+    (decision_id, observation_window) PK 로 동일 decision 의 7d/14d/30d 별도 row.
+    동일 (decision_id, window) 재계산 시 idempotent upsert.
+
+    hypothesis_validation: pass/reject/insufficient_data — Hypothesis-Registry 의 validate/reject
+    호출 trigger. insufficient_data 는 false validation 차단 (가격 데이터 부족).
+    """
+    if observation_window not in _OUTCOME_WINDOWS:
+        raise ValueError(f"observation_window must be {_OUTCOME_WINDOWS}, got {observation_window}")
+    if hypothesis_validation not in _OUTCOME_VALIDATIONS:
+        raise ValueError(f"hypothesis_validation must be {_OUTCOME_VALIDATIONS}, got {hypothesis_validation!r}")
+    with get_db(db_path) as conn:
+        conn.execute(
+            """INSERT INTO decision_outcomes
+               (decision_id, observation_window, tracked_as_of_date,
+                entry_price, exit_price, realized_return, benchmark_return, alpha,
+                hit_threshold, hypothesis_validation, notes, run_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(decision_id, observation_window) DO UPDATE SET
+                 tracked_as_of_date = excluded.tracked_as_of_date,
+                 entry_price = excluded.entry_price,
+                 exit_price = excluded.exit_price,
+                 realized_return = excluded.realized_return,
+                 benchmark_return = excluded.benchmark_return,
+                 alpha = excluded.alpha,
+                 hit_threshold = excluded.hit_threshold,
+                 hypothesis_validation = excluded.hypothesis_validation,
+                 notes = excluded.notes,
+                 run_id = excluded.run_id""",
+            (
+                decision_id,
+                observation_window,
+                tracked_as_of_date,
+                entry_price,
+                exit_price,
+                realized_return,
+                benchmark_return,
+                alpha,
+                int(hit_threshold),
+                hypothesis_validation,
+                notes,
                 run_id,
             ),
         )

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -34,15 +34,15 @@ fi
 
 # 1) Schema version
 SCHEMA_VERSION=$(.venv/bin/python -c "from nuri.core.db import get_schema_version; print(get_schema_version())" 2>/dev/null || echo "0")
-if [ "$SCHEMA_VERSION" -ge 33 ]; then
-    echo " ✅ schema version: $SCHEMA_VERSION (>=33)"
+if [ "$SCHEMA_VERSION" -ge 34 ]; then
+    echo " ✅ schema version: $SCHEMA_VERSION (>=34)"
 else
-    echo " ❌ schema version: $SCHEMA_VERSION (need >=33 for #529 Phase 1+2)"
+    echo " ❌ schema version: $SCHEMA_VERSION (need >=34 for #529 Phase 1+2)"
     EXIT_CODE=2
 fi
 
 # 2) Required Phase 1+2 tables
-for table in agent_audit_ledger feature_flags agent_run_ledger agent_messages walkforward_runs regime_posteriors hypotheses causal_audits agent_decisions; do
+for table in agent_audit_ledger feature_flags agent_run_ledger agent_messages walkforward_runs regime_posteriors hypotheses causal_audits agent_decisions decision_outcomes; do
     EXISTS=$(.venv/bin/python -c "from nuri.core.db import query; r=query(\"SELECT 1 FROM sqlite_master WHERE type='table' AND name='$table'\"); print(len(r))" 2>/dev/null || echo "0")
     if [ "$EXISTS" = "1" ]; then
         echo " ✅ table exists: $table"

--- a/tests/agent_infra/test_forward_outcome_tracker.py
+++ b/tests/agent_infra/test_forward_outcome_tracker.py
@@ -1,0 +1,686 @@
+"""ForwardOutcomeTracker tests (#529 Phase 2 closed-loop — actor #11, canonical).
+
+검증 (Codex Round 5 Layer B closed-loop):
+- Layer B (deterministic, ZERO LLM)
+- 3 actions: scan / track_one / last_outcome
+- Closed-loop: emit → measure → auto-validate/reject HypothesisRegistry
+- Anti-pattern lock-tests:
+    1. lookahead bias — as_of + window > today → insufficient (false validation 차단)
+    2. price 데이터 missing → insufficient_data
+    3. 이미 validated/rejected/expired hypothesis → silently skip (status machine 보존)
+    4. HOLD action → tracking skip
+    5. invalid window (5/21/60 등) → BLOCK
+- Discord publish: pass/reject auto-trigger 시 ROLLOUT (mock)
+- Closed-loop integration: DecisionCompiler emit → 시간 경과 → Tracker → Hypothesis auto-validated
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nuri.agents.actors.forward_outcome_tracker import (
+    SUPPORTED_WINDOWS,
+    WINDOW_THRESHOLDS,
+    ForwardOutcomeTracker,
+)
+from nuri.agents.base import Layer, Outcome
+from nuri.core.db import (
+    init_db,
+    log_decision,
+    log_decision_outcome,
+    query,
+    register_hypothesis,
+)
+
+# ═══════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "fot.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def patched_db(db_path):
+    """모든 DB 호출 redirect."""
+    from nuri.core import db as db_module
+
+    def make_redirect(fn):
+        def wrapped(*args, **kwargs):
+            kwargs.setdefault("db_path", db_path)
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    patches = [
+        patch("nuri.agents.base.log_agent_audit", side_effect=make_redirect(db_module.log_agent_audit)),
+        patch("nuri.agents.base.start_agent_run", side_effect=make_redirect(db_module.start_agent_run)),
+        patch("nuri.agents.base.finish_agent_run", side_effect=make_redirect(db_module.finish_agent_run)),
+        patch(
+            "nuri.agents.actors.forward_outcome_tracker.log_decision_outcome",
+            side_effect=make_redirect(db_module.log_decision_outcome),
+        ),
+        patch(
+            "nuri.agents.actors.forward_outcome_tracker.query",
+            side_effect=make_redirect(db_module.query),
+        ),
+        patch(
+            "nuri.agents.actors.forward_outcome_tracker.validate_hypothesis",
+            side_effect=make_redirect(db_module.validate_hypothesis),
+        ),
+        patch(
+            "nuri.agents.actors.forward_outcome_tracker.reject_hypothesis",
+            side_effect=make_redirect(db_module.reject_hypothesis),
+        ),
+    ]
+    for p in patches:
+        p.start()
+    yield db_path
+    for p in patches:
+        p.stop()
+
+
+def _seed_decision(
+    db_path,
+    *,
+    decision_id: str,
+    ticker: str,
+    as_of_date: str = "2026-04-20",
+    action: str = "BUY",
+    hypothesis_id: str | None = "h1",
+):
+    """agent_decisions row 시드 (FK + valid input)."""
+    inputs = {
+        "regime_run_id": "r1",
+        "hypothesis_id": hypothesis_id or "h1",
+        "causal_audit_id": "c1",
+    }
+    log_decision(
+        decision_id=decision_id,
+        ticker=ticker,
+        as_of_date=as_of_date,
+        action=action,
+        conviction=0.85,
+        inputs=inputs,
+        rationale={},
+        status="emitted",
+        db_path=db_path,
+    )
+
+
+def _seed_hypothesis(db_path, hypothesis_id: str, claim: str):
+    """open hypothesis 시드 — claim 다르면 새 row."""
+    register_hypothesis(
+        hypothesis_id=hypothesis_id,
+        name=hypothesis_id,
+        version="1.0.0",
+        producer_actor="regime-posterior",
+        claim_text=claim,
+        evidence={},
+        expiry_date="2026-12-31",
+        db_path=db_path,
+    )
+
+
+def _seed_prices(db_path, rows: list[tuple[str, str, float]]):
+    """[(ticker, date, close), ...] 직접 INSERT."""
+    from nuri.core.db import get_db
+
+    with get_db(db_path) as conn:
+        for t, d, c in rows:
+            conn.execute(
+                "INSERT OR IGNORE INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                (t, d, c),
+            )
+
+
+# ═══════════════════════════════════════════════════════
+# Layer B invariants
+# ═══════════════════════════════════════════════════════
+
+
+class TestActorRegistration:
+    def test_layer_is_b(self):
+        assert ForwardOutcomeTracker.layer == Layer.B
+
+    def test_no_llm_dependency(self):
+        assert getattr(ForwardOutcomeTracker, "_uses_llm", False) is False
+
+    def test_registered_in_canonical_15(self):
+        from nuri.agents.base import REGISTRY
+
+        assert REGISTRY.get("forward-outcome-tracker") is ForwardOutcomeTracker
+
+
+# ═══════════════════════════════════════════════════════
+# Action: track_one — happy paths
+# ═══════════════════════════════════════════════════════
+
+
+class TestTrackOnePass:
+    def test_pass_validation_8pct_return(self, patched_db):
+        """7d window, +8% realized → pass + hypothesis auto-validated."""
+        _seed_hypothesis(patched_db, "h-pass", "claim-pass")
+        _seed_decision(patched_db, decision_id="dc-pass", ticker="TESTAA", hypothesis_id="h-pass")
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTAA", "2026-04-20", 100.0),
+                ("TESTAA", "2026-04-27", 108.0),
+                ("SPY", "2026-04-20", 500.0),
+                ("SPY", "2026-04-27", 505.0),
+            ],
+        )
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-pass", "observation_window": 7})
+        assert result.outcome == Outcome.PASS
+        assert result.output["validation"] == "pass"
+        assert result.output["realized_return"] == pytest.approx(0.08)
+        assert result.output["alpha"] == pytest.approx(0.08 - 0.01)
+
+        # hypothesis 자동 validated
+        rows = query(
+            "SELECT status, validation_metrics_json FROM hypotheses WHERE hypothesis_id=?",
+            ("h-pass",),
+            db_path=patched_db,
+        )
+        assert dict(rows[0])["status"] == "validated"
+
+    def test_reject_validation_negative_return(self, patched_db):
+        """7d window, -8% realized → reject + hypothesis auto-rejected."""
+        _seed_hypothesis(patched_db, "h-rej", "claim-rej")
+        _seed_decision(patched_db, decision_id="dc-rej", ticker="TESTBB", hypothesis_id="h-rej")
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTBB", "2026-04-20", 100.0),
+                ("TESTBB", "2026-04-27", 92.0),
+                ("SPY", "2026-04-20", 500.0),
+                ("SPY", "2026-04-27", 505.0),
+            ],
+        )
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-rej", "observation_window": 7})
+        assert result.outcome == Outcome.PASS  # measurement 자체는 성공
+        assert result.output["validation"] == "reject"
+        assert result.output["realized_return"] == pytest.approx(-0.08)
+
+        rows = query(
+            "SELECT status, rejection_reason FROM hypotheses WHERE hypothesis_id=?",
+            ("h-rej",),
+            db_path=patched_db,
+        )
+        r = dict(rows[0])
+        assert r["status"] == "rejected"
+        assert "forward outcome reject" in r["rejection_reason"]
+
+    def test_sell_action_inverts_return(self, patched_db):
+        """SELL action: 가격 하락 → positive return (short proxy)."""
+        _seed_hypothesis(patched_db, "h-sell", "claim-sell")
+        _seed_decision(patched_db, decision_id="dc-sell", ticker="TESTCC", action="SELL", hypothesis_id="h-sell")
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTCC", "2026-04-20", 100.0),
+                ("TESTCC", "2026-04-27", 92.0),
+            ],
+        )
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-sell", "observation_window": 7})
+        # SELL + 가격 -8% → realized = +0.08 → pass
+        assert result.output["validation"] == "pass"
+        assert result.output["realized_return"] == pytest.approx(0.08)
+
+
+# ═══════════════════════════════════════════════════════
+# Anti-pattern lock-tests
+# ═══════════════════════════════════════════════════════
+
+
+class TestLookaheadBiasLockTest:
+    """LOCK-TEST: as_of_date + window > today → insufficient (false validation 차단)."""
+
+    def test_future_as_of_blocks_with_insufficient(self, patched_db):
+        _seed_hypothesis(patched_db, "h-future", "claim-future")
+        _seed_decision(
+            patched_db,
+            decision_id="dc-future",
+            ticker="TESTFF",
+            as_of_date="2027-01-01",
+            hypothesis_id="h-future",
+        )
+        result = ForwardOutcomeTracker().run(
+            {"action": "track_one", "decision_id": "dc-future", "observation_window": 7}
+        )
+        assert result.outcome == Outcome.WARN
+        assert result.output["validation"] == "insufficient_data"
+        assert "lookahead" in result.output["reason"].lower()
+
+        # hypothesis status 변동 X
+        rows = query(
+            "SELECT status FROM hypotheses WHERE hypothesis_id=?",
+            ("h-future",),
+            db_path=patched_db,
+        )
+        assert dict(rows[0])["status"] == "open"
+
+    def test_outcome_row_persisted_with_insufficient(self, patched_db):
+        _seed_hypothesis(patched_db, "h-future2", "claim-future2")
+        _seed_decision(
+            patched_db,
+            decision_id="dc-future2",
+            ticker="TESTFG",
+            as_of_date="2027-01-01",
+            hypothesis_id="h-future2",
+        )
+        ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-future2", "observation_window": 7})
+        rows = query(
+            "SELECT hypothesis_validation, notes FROM decision_outcomes WHERE decision_id=?",
+            ("dc-future2",),
+            db_path=patched_db,
+        )
+        r = dict(rows[0])
+        assert r["hypothesis_validation"] == "insufficient_data"
+        assert "lookahead" in r["notes"].lower()
+
+
+class TestMissingPriceDataLockTest:
+    """LOCK-TEST: price 데이터 없음 → insufficient_data, hypothesis 상태 변동 X."""
+
+    def test_no_entry_price_returns_insufficient(self, patched_db):
+        _seed_hypothesis(patched_db, "h-noprice", "claim-np")
+        _seed_decision(patched_db, decision_id="dc-np", ticker="MISSING", hypothesis_id="h-noprice")
+        # no prices seeded
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-np", "observation_window": 7})
+        assert result.output["validation"] == "insufficient_data"
+        assert "price" in result.output["reason"].lower()
+
+    def test_no_exit_price_returns_insufficient(self, patched_db):
+        _seed_hypothesis(patched_db, "h-noexit", "claim-ne")
+        _seed_decision(patched_db, decision_id="dc-ne", ticker="TESTNE", hypothesis_id="h-noexit")
+        _seed_prices(patched_db, [("TESTNE", "2026-04-20", 100.0)])  # only entry
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-ne", "observation_window": 7})
+        assert result.output["validation"] == "insufficient_data"
+
+
+class TestStatusMachineLockTest:
+    """LOCK-TEST: 이미 종결된 hypothesis 의 update 시도는 silently skip (status machine 보존)."""
+
+    def test_validated_hypothesis_not_re_updated(self, patched_db):
+        from nuri.core.db import validate_hypothesis
+
+        _seed_hypothesis(patched_db, "h-already", "claim-already")
+        validate_hypothesis("h-already", {"realized_brier": 0.1}, db_path=patched_db)
+        # status: validated
+
+        _seed_decision(patched_db, decision_id="dc-already", ticker="TESTAL", hypothesis_id="h-already")
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTAL", "2026-04-20", 100.0),
+                ("TESTAL", "2026-04-27", 92.0),  # would normally trigger reject
+            ],
+        )
+        result = ForwardOutcomeTracker().run(
+            {"action": "track_one", "decision_id": "dc-already", "observation_window": 7}
+        )
+        # outcome row 는 기록되지만 hypothesis status 그대로
+        assert result.output["validation"] == "reject"
+        rows = query(
+            "SELECT status FROM hypotheses WHERE hypothesis_id=?",
+            ("h-already",),
+            db_path=patched_db,
+        )
+        assert dict(rows[0])["status"] == "validated"  # 변동 X
+
+    def test_rejected_hypothesis_not_re_updated(self, patched_db):
+        from nuri.core.db import reject_hypothesis
+
+        _seed_hypothesis(patched_db, "h-rejected", "claim-rejected")
+        reject_hypothesis("h-rejected", "manual reject", db_path=patched_db)
+
+        _seed_decision(patched_db, decision_id="dc-rejected", ticker="TESTRJ", hypothesis_id="h-rejected")
+        _seed_prices(
+            patched_db,
+            [("TESTRJ", "2026-04-20", 100.0), ("TESTRJ", "2026-04-27", 110.0)],
+        )
+        ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-rejected", "observation_window": 7})
+        rows = query(
+            "SELECT status FROM hypotheses WHERE hypothesis_id=?",
+            ("h-rejected",),
+            db_path=patched_db,
+        )
+        assert dict(rows[0])["status"] == "rejected"  # 변동 X
+
+
+class TestHoldSkipLockTest:
+    """LOCK-TEST: HOLD action → tracking skip (의미 없음)."""
+
+    def test_hold_action_skipped(self, patched_db):
+        _seed_hypothesis(patched_db, "h-hold", "claim-hold")
+        _seed_decision(patched_db, decision_id="dc-hold", ticker="TESTHO", action="HOLD", hypothesis_id="h-hold")
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-hold", "observation_window": 7})
+        assert result.outcome == Outcome.WARN
+        assert "HOLD" in result.output.get("skipped", "")
+
+    def test_hold_skipped_in_scan(self, patched_db):
+        _seed_hypothesis(patched_db, "h-h2", "claim-h2")
+        _seed_decision(patched_db, decision_id="dc-h2", ticker="TESTHX", action="HOLD", hypothesis_id="h-h2")
+        result = ForwardOutcomeTracker().run({"action": "scan", "windows": [7]})
+        # scan 은 status='emitted' AND action IN ('BUY','SELL') 만 포함
+        # HOLD 는 emitted 라도 query 단계 제외
+        assert result.output["scanned"] == 0
+
+
+# ═══════════════════════════════════════════════════════
+# Input validation
+# ═══════════════════════════════════════════════════════
+
+
+class TestInputValidation:
+    def test_invalid_action_blocked(self, patched_db):
+        result = ForwardOutcomeTracker().run({"action": "weird"})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_track_one_missing_decision_id_blocked(self, patched_db):
+        result = ForwardOutcomeTracker().run({"action": "track_one"})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_track_one_unknown_decision_blocked(self, patched_db):
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "nonexistent"})
+        assert result.outcome == Outcome.BLOCK
+        assert "not found" in result.output["error"]
+
+    def test_track_one_invalid_window_blocked(self, patched_db):
+        _seed_hypothesis(patched_db, "h-w", "claim-w")
+        _seed_decision(patched_db, decision_id="dc-w", ticker="TESTWW", hypothesis_id="h-w")
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-w", "observation_window": 21})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_scan_invalid_window_blocked(self, patched_db):
+        result = ForwardOutcomeTracker().run({"action": "scan", "windows": [60]})
+        assert result.outcome == Outcome.BLOCK
+
+
+# ═══════════════════════════════════════════════════════
+# Action: scan
+# ═══════════════════════════════════════════════════════
+
+
+class TestActionScan:
+    def test_scan_empty_db(self, patched_db):
+        result = ForwardOutcomeTracker().run({"action": "scan"})
+        assert result.outcome == Outcome.PASS
+        assert result.output["scanned"] == 0
+        assert result.output["n_measurements"] == 0
+
+    def test_scan_aggregates_pass_reject_insuf(self, patched_db):
+        # pass
+        _seed_hypothesis(patched_db, "h-p", "p-claim")
+        _seed_decision(patched_db, decision_id="dc-p", ticker="TESTP", hypothesis_id="h-p")
+        _seed_prices(
+            patched_db,
+            [("TESTP", "2026-04-20", 100.0), ("TESTP", "2026-04-27", 110.0)],
+        )
+        # reject
+        _seed_hypothesis(patched_db, "h-r", "r-claim")
+        _seed_decision(patched_db, decision_id="dc-r", ticker="TESTR", hypothesis_id="h-r")
+        _seed_prices(
+            patched_db,
+            [("TESTR", "2026-04-20", 100.0), ("TESTR", "2026-04-27", 90.0)],
+        )
+        # insufficient (no prices)
+        _seed_hypothesis(patched_db, "h-i", "i-claim")
+        _seed_decision(patched_db, decision_id="dc-i", ticker="TESTI", hypothesis_id="h-i")
+
+        result = ForwardOutcomeTracker().run({"action": "scan", "windows": [7]})
+        assert result.outcome == Outcome.PASS
+        assert result.output["n_pass"] == 1
+        assert result.output["n_reject"] == 1
+        assert result.output["n_insufficient"] == 1
+
+    def test_scan_default_windows(self, patched_db):
+        _seed_hypothesis(patched_db, "h-d", "d-claim")
+        _seed_decision(patched_db, decision_id="dc-d", ticker="TESTD", hypothesis_id="h-d")
+        result = ForwardOutcomeTracker().run({"action": "scan"})
+        # default = all 3 windows
+        assert result.output["windows"] == list(SUPPORTED_WINDOWS)
+
+
+# ═══════════════════════════════════════════════════════
+# Action: last_outcome
+# ═══════════════════════════════════════════════════════
+
+
+class TestLastOutcome:
+    def test_no_data_warn(self, patched_db):
+        result = ForwardOutcomeTracker().run({"action": "last_outcome"})
+        assert result.outcome == Outcome.WARN
+
+    def test_returns_latest_for_decision(self, patched_db):
+        _seed_hypothesis(patched_db, "h-l", "l-claim")
+        _seed_decision(patched_db, decision_id="dc-l", ticker="TESTL", hypothesis_id="h-l")
+        # manually log 7d + 14d outcomes
+        log_decision_outcome(
+            decision_id="dc-l",
+            observation_window=7,
+            tracked_as_of_date="2026-04-27",
+            hypothesis_validation="insufficient_data",
+            db_path=patched_db,
+        )
+        log_decision_outcome(
+            decision_id="dc-l",
+            observation_window=14,
+            tracked_as_of_date="2026-05-04",
+            hypothesis_validation="pass",
+            db_path=patched_db,
+        )
+        result = ForwardOutcomeTracker().run({"action": "last_outcome", "decision_id": "dc-l"})
+        assert result.outcome == Outcome.PASS
+        # ORDER BY observation_window DESC → 14 returned
+        assert result.output["observation_window"] == 14
+
+
+# ═══════════════════════════════════════════════════════
+# Discord publish
+# ═══════════════════════════════════════════════════════
+
+
+class TestDiscordPublish:
+    def test_validate_publishes_to_rollout(self, patched_db):
+        _seed_hypothesis(patched_db, "h-pub", "pub-claim")
+        _seed_decision(patched_db, decision_id="dc-pub", ticker="TESTPB", hypothesis_id="h-pub")
+        _seed_prices(
+            patched_db,
+            [("TESTPB", "2026-04-20", 100.0), ("TESTPB", "2026-04-27", 110.0)],
+        )
+        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+            ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-pub", "observation_window": 7})
+            mock_publish.assert_called_once()
+            kw = mock_publish.call_args.kwargs
+            assert kw["actor_name"] == "forward-outcome-tracker"
+            assert "validated" in kw["embed"]["title"]
+
+    def test_reject_publishes_to_rollout(self, patched_db):
+        _seed_hypothesis(patched_db, "h-pub2", "pub2-claim")
+        _seed_decision(patched_db, decision_id="dc-pub2", ticker="TESTPC", hypothesis_id="h-pub2")
+        _seed_prices(
+            patched_db,
+            [("TESTPC", "2026-04-20", 100.0), ("TESTPC", "2026-04-27", 90.0)],
+        )
+        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+            ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-pub2", "observation_window": 7})
+            mock_publish.assert_called_once()
+            assert "rejected" in mock_publish.call_args.kwargs["embed"]["title"]
+
+    def test_insufficient_does_not_publish(self, patched_db):
+        _seed_hypothesis(patched_db, "h-np", "np-claim")
+        _seed_decision(patched_db, decision_id="dc-np", ticker="MISSING2", hypothesis_id="h-np")
+        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+            ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-np", "observation_window": 7})
+            mock_publish.assert_not_called()
+
+    def test_publish_failure_does_not_block_actor(self, patched_db):
+        _seed_hypothesis(patched_db, "h-pf", "pf-claim")
+        _seed_decision(patched_db, decision_id="dc-pf", ticker="TESTPF", hypothesis_id="h-pf")
+        _seed_prices(
+            patched_db,
+            [("TESTPF", "2026-04-20", 100.0), ("TESTPF", "2026-04-27", 110.0)],
+        )
+        with patch(
+            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
+            side_effect=RuntimeError("network"),
+        ):
+            result = ForwardOutcomeTracker().run(
+                {"action": "track_one", "decision_id": "dc-pf", "observation_window": 7}
+            )
+            assert result.outcome == Outcome.PASS
+            assert result.output["validation"] == "pass"
+
+
+# ═══════════════════════════════════════════════════════
+# Helper direct lock-tests
+# ═══════════════════════════════════════════════════════
+
+
+class TestHelperLockTests:
+    def test_invalid_window_rejected(self, db_path):
+        # 부모 row 시드
+        _seed_hypothesis(db_path, "hx", "cx")
+        _seed_decision(db_path, decision_id="dx", ticker="TX", hypothesis_id="hx")
+        with pytest.raises(ValueError, match="observation_window must be"):
+            log_decision_outcome(
+                decision_id="dx",
+                observation_window=21,
+                tracked_as_of_date="2026-05-08",
+                hypothesis_validation="pass",
+                db_path=db_path,
+            )
+
+    def test_invalid_validation_rejected(self, db_path):
+        _seed_hypothesis(db_path, "hy", "cy")
+        _seed_decision(db_path, decision_id="dy", ticker="TY", hypothesis_id="hy")
+        with pytest.raises(ValueError, match="hypothesis_validation must be"):
+            log_decision_outcome(
+                decision_id="dy",
+                observation_window=7,
+                tracked_as_of_date="2026-05-08",
+                hypothesis_validation="maybe",
+                db_path=db_path,
+            )
+
+    def test_idempotent_upsert(self, db_path):
+        _seed_hypothesis(db_path, "hz", "cz")
+        _seed_decision(db_path, decision_id="dz", ticker="TZ", hypothesis_id="hz")
+        for ret in (0.05, 0.10):
+            log_decision_outcome(
+                decision_id="dz",
+                observation_window=7,
+                tracked_as_of_date="2026-05-08",
+                realized_return=ret,
+                hypothesis_validation="pass",
+                db_path=db_path,
+            )
+        rows = query(
+            "SELECT COUNT(*) AS c, realized_return FROM decision_outcomes WHERE decision_id=?",
+            ("dz",),
+            db_path=db_path,
+        )
+        r = dict(rows[0])
+        assert r["c"] == 1
+        assert r["realized_return"] == 0.10  # 두 번째 값으로 update
+
+
+# ═══════════════════════════════════════════════════════
+# Constants smoke
+# ═══════════════════════════════════════════════════════
+
+
+class TestConstants:
+    def test_supported_windows_match_thresholds(self):
+        assert set(WINDOW_THRESHOLDS.keys()) == set(SUPPORTED_WINDOWS)
+
+    def test_thresholds_symmetric(self):
+        for w, (up, down) in WINDOW_THRESHOLDS.items():
+            assert up > 0
+            assert down < 0
+            assert abs(up + down) < 1e-9  # symmetric ±
+
+
+# ═══════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════
+
+
+class TestCli:
+    def test_cli_scan_empty(self, patched_db, capsys):
+        from nuri.agents.actors.forward_outcome_tracker import main
+
+        rc = main(["scan"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "scanned" in out
+
+    def test_cli_last_outcome_empty(self, patched_db, capsys):
+        from nuri.agents.actors.forward_outcome_tracker import main
+
+        rc = main(["last_outcome"])
+        assert rc == 0
+
+
+# ═══════════════════════════════════════════════════════
+# Closed-loop integration — DecisionCompiler emit → Tracker → Hypothesis auto-validated
+# ═══════════════════════════════════════════════════════
+
+
+class TestClosedLoopIntegration:
+    """Phase 2 closed-loop 의 진짜 가치 — 4-actor chain 의 outcome attribution."""
+
+    def test_decision_compiler_emit_then_tracker_validates(self, patched_db, monkeypatch):
+        # 1) Hypothesis register + validate (DecisionCompiler 가 통과시키려면)
+        _seed_hypothesis(patched_db, "h-loop", "loop-claim")
+        from nuri.core.db import validate_hypothesis
+
+        # validate manually (실제로는 다른 mechanism — register 직후엔 open)
+        # 그래서 새 hypothesis 만들고 그 자체로 closed-loop test 만 검증
+        # 여기선 decision 만 있고 tracker 가 hypothesis 종결시키는 흐름
+
+        _seed_decision(
+            patched_db,
+            decision_id="dc-loop",
+            ticker="TESTLP",
+            as_of_date="2026-04-20",
+            hypothesis_id="h-loop",  # open status
+        )
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTLP", "2026-04-20", 100.0),
+                ("TESTLP", "2026-04-27", 115.0),  # +15% strong pass
+                ("SPY", "2026-04-20", 500.0),
+                ("SPY", "2026-04-27", 505.0),
+            ],
+        )
+
+        # 2) Tracker scan → validates h-loop automatically
+        result = ForwardOutcomeTracker().run({"action": "scan", "windows": [7]})
+        assert result.outcome == Outcome.PASS
+        assert result.output["n_pass"] >= 1
+
+        # 3) Verify hypothesis auto-transitioned open → validated
+        rows = query(
+            "SELECT status, validation_metrics_json FROM hypotheses WHERE hypothesis_id=?",
+            ("h-loop",),
+            db_path=patched_db,
+        )
+        r = dict(rows[0])
+        assert r["status"] == "validated"
+        # metrics 에 auto_trigger 표식
+        import json
+
+        metrics = json.loads(r["validation_metrics_json"])
+        assert metrics["auto_trigger"] == "forward-outcome-tracker"
+        assert metrics["realized_return"] == pytest.approx(0.15)

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -27,11 +27,11 @@ def db_path(tmp_path):
 
 
 class TestSchemaMigrations:
-    """9 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions) 적용 확인."""
+    """10 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes) 적용 확인."""
 
-    def test_schema_version_at_33(self, db_path):
-        """Phase 1+2 migrations 모두 적용 → schema version 33 (#33 agent_decisions 포함)."""
-        assert get_schema_version(db_path) == 33
+    def test_schema_version_at_34(self, db_path):
+        """Phase 1+2 migrations 모두 적용 → schema version 34 (#34 decision_outcomes 포함)."""
+        assert get_schema_version(db_path) == 34
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
## Summary

**Phase 2 closed-loop complete** — DecisionCompiler #8 가 emit 한 decision 의 *실제 결과* 추적 → HypothesisRegistry #4 의 hypothesis 자동 validate (성공) / reject (실패).

ZERO LLM, deterministic. 4-actor 통합 chain 의 closed loop 가 이제 작동:
`Regime → Hypothesis → Causal → Decision → emit → Tracker → Hypothesis update`

## Why

Phase 2 의 evidence chain 이 *open loop* 면 hypothesis 가 stale 채로 영원히 open. Tracker 가 forward outcome 으로 hypothesis 를 자동 종결시켜 *학습 시스템* 완성. realized return 은 거짓말 안 함.

## Validation rule (per window)

| Window | Pass threshold | Reject threshold |
|---|---|---|
| 7d  | ≥ +5% | ≤ -5% |
| 14d | ≥ +7% | ≤ -7% |
| 30d | ≥ +10% | ≤ -10% |
| Between | insufficient_data |

SELL action → return 부호 반전 (short proxy). alpha = realized - SPY benchmark.

## Changes

| File | Purpose |
|---|---|
| `nuri/core/db.py` | Migration #34 + `log_decision_outcome()` helper |
| `nuri/agents/actors/forward_outcome_tracker.py` | ForwardOutcomeTracker — 3 actions |
| `tests/agent_infra/test_forward_outcome_tracker.py` | 36 tests, 94% coverage + closed-loop integration |
| `scripts/health_check.sh` | schema 34 + decision_outcomes 검증 |
| `tests/core/test_agent_infra.py` | schema_version 34 갱신 |

## Schema #34 (decision_outcomes)

(decision_id, observation_window) PK, FK → agent_decisions. validation enum 3-state. tracked_as_of_date (lookahead 검증).

## Anti-pattern lock-tests (5개)

1. **Lookahead bias**: as_of + window > today → insufficient (false validation 차단)
2. **Price 데이터 missing** → insufficient_data
3. **Already validated/rejected/expired hypothesis** → silently skip (status machine 보존)
4. **HOLD action** → tracking skip
5. **Invalid window** (5/21/60 등) → BLOCK

## Closed-loop integration test

`emit decision (open hypothesis) → seed prices → Tracker scan → hypothesis 자동 open→validated, validation_metrics_json 에 auto_trigger 기록`

## Test plan

- [x] `pytest tests/agent_infra/test_forward_outcome_tracker.py` — 36/36
- [x] `pytest tests/agent_infra/` — 386/386
- [x] Coverage 94% (177 stmts, 11 missing)
- [x] `make lint` — 0 errors
- [x] Migration #34 applied to production DB (schema 34)
- [x] Smoke: pass / reject / lookahead / HOLD / scan all 정상

## 8/15 actors live — Phase 2 closed-loop complete

- Layer A: ReleaseRollbackManager (#13), FreshnessGatekeeper (#2), HypothesisRegistry (#4)
- Layer B: WalkForwardValidator (#5), RegimePosterior (#3), CausalFactorAuditor (#6), DecisionCompiler (#8), **ForwardOutcomeTracker (#11)** ← closed-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)