### PR TITLE
feat(agents): #529 Phase 2 — AuditLedger (canonical #10, Layer A query interface)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-4,183 backend tests across 181 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+4,183 backend tests across 182 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,183 tests, 181 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,183 tests, 182 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/__init__.py
+++ b/nuri/agents/actors/__init__.py
@@ -10,8 +10,10 @@ Phase 2 actors (Codex Round 5):
 - DecisionCompiler (#8, Layer B) — Phase 2 capstone: producer/gate 통합 → emit
 - ForwardOutcomeTracker (#11, Layer B) — closed-loop: outcome 추적 → hypothesis auto-validate
 - ExecutionFirewall (#9, Layer A) — emit 직전 마지막 hard constraint gate
+- AuditLedger (#10, Layer A) — read-only audit ledger query + retention policy
 """
 
+from nuri.agents.actors.audit_ledger import AuditLedger
 from nuri.agents.actors.causal_factor_auditor import CausalFactorAuditor
 from nuri.agents.actors.decision_compiler import DecisionCompiler
 from nuri.agents.actors.execution_firewall import ExecutionFirewall
@@ -23,6 +25,7 @@ from nuri.agents.actors.release_rollback_manager import ReleaseRollbackManager
 from nuri.agents.actors.walkforward_validator import WalkForwardValidator
 
 __all__ = [
+    "AuditLedger",
     "CausalFactorAuditor",
     "DecisionCompiler",
     "ExecutionFirewall",

--- a/nuri/agents/actors/audit_ledger.py
+++ b/nuri/agents/actors/audit_ledger.py
@@ -1,0 +1,398 @@
+"""AuditLedger — Layer A actor (#529 Phase 2 — canonical #10).
+
+Read-only query interface + retention policy on top of the existing
+`agent_audit_ledger` table (created in migration #25).
+
+Layer A 설계 (Codex Round 5):
+- 100% rule-based — ZERO LLM
+- Schema 변동 없음 — 기존 audit ledger 의 consumer
+- 4 actions: query / summarize_by_outcome / summarize_by_actor / retention_check
+- retention_check 만 enforcement 결정 (PASS / WARN / BLOCK)
+
+Anti-pattern 방지:
+- Layer A 는 LLM 의존 절대 금지
+- 모든 row 추가는 Actor.base.run() 이 자동 — 이 actor 는 read-only
+- archive 로직은 직접 구현 X (다음 phase) — 측정 + 권고만
+
+Discord publish:
+- retention_check BLOCK → INCIDENTS (DB bloat 위험, RED)
+- retention_check WARN → OPS (cleanup 권고, AMBER)
+- query / summarize 결과는 publish X (조회 noise 방지)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
+from nuri.core.db import query
+
+# ─── retention 임계값 (config 화 Phase 3+ 예정) ───────────────
+DEFAULT_MAX_ROWS = 1_000_000
+DEFAULT_RETENTION_DAYS = 90
+BLOCK_MULTIPLIER = 1.5  # max_rows * 1.5 → 즉시 archive (BLOCK)
+
+
+@REGISTRY.register
+class AuditLedger(Actor):
+    """Read-only consumer of `agent_audit_ledger` + retention policy.
+
+    Actions (input_data['action']):
+        query                  — filter rows (actor / layer / outcome / since)
+        summarize_by_outcome   — GROUP BY outcome
+        summarize_by_actor     — GROUP BY actor_name
+        retention_check        — row count vs threshold → PASS/WARN/BLOCK
+
+    Outcome 매핑 (Codex Round 5 Layer A):
+        PASS  — 모든 정상 path (query/summarize 항상 PASS)
+        WARN  — retention_check: total_rows > max_rows
+        BLOCK — retention_check: total_rows > max_rows * 1.5 (즉시 archive 필요)
+    """
+
+    name = "audit-ledger"
+    version = "0.1.0"
+    layer = Layer.A
+
+    VALID_ACTIONS: tuple[str, ...] = (
+        "query",
+        "summarize_by_outcome",
+        "summarize_by_actor",
+        "retention_check",
+    )
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        action = input_data.get("action")
+        if action not in self.VALID_ACTIONS:
+            return ActorResult(
+                output={"error": f"invalid action {action!r}, expected {self.VALID_ACTIONS}"},
+                outcome=Outcome.BLOCK,
+                input_summary=f"action={action}",
+            )
+
+        if action == "query":
+            return self._query(input_data)
+        if action == "summarize_by_outcome":
+            return self._summarize_by_outcome(input_data)
+        if action == "summarize_by_actor":
+            return self._summarize_by_actor(input_data)
+        # retention_check
+        return self._retention_check(input_data, ctx)
+
+    # ─── query ────────────────────────────────────────────────
+
+    @staticmethod
+    def _query(input_data: dict[str, Any]) -> ActorResult:
+        # filter parameter — 모두 optional
+        actor_name = input_data.get("actor_name")
+        layer = input_data.get("layer")
+        outcome = input_data.get("outcome")
+        since_iso = input_data.get("since_iso")
+        try:
+            limit = int(input_data.get("limit", 100))
+        except (TypeError, ValueError):
+            return ActorResult(
+                output={"error": "limit must be integer"},
+                outcome=Outcome.BLOCK,
+                input_summary="query invalid limit",
+            )
+
+        if layer is not None and layer not in ("A", "B", "C"):
+            return ActorResult(
+                output={"error": f"layer must be A/B/C, got {layer!r}"},
+                outcome=Outcome.BLOCK,
+                input_summary="query invalid layer",
+            )
+        if outcome is not None and outcome not in ("pass", "block", "warn", "error"):
+            return ActorResult(
+                output={"error": f"outcome must be pass/block/warn/error, got {outcome!r}"},
+                outcome=Outcome.BLOCK,
+                input_summary="query invalid outcome",
+            )
+
+        sql = "SELECT * FROM agent_audit_ledger"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if actor_name:
+            clauses.append("actor_name = ?")
+            params.append(actor_name)
+        if layer:
+            clauses.append("layer = ?")
+            params.append(layer)
+        if outcome:
+            clauses.append("outcome = ?")
+            params.append(outcome)
+        if since_iso:
+            clauses.append("timestamp >= ?")
+            params.append(since_iso)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY timestamp DESC, id DESC LIMIT ?"
+        params.append(limit)
+
+        rows = query(sql, tuple(params))
+        items = [dict(r) for r in rows]
+        return ActorResult(
+            output={"count": len(items), "rows": items},
+            outcome=Outcome.PASS,
+            sample_n=len(items),
+            input_summary=f"query (n={len(items)})",
+        )
+
+    # ─── summarize_by_outcome ─────────────────────────────────
+
+    @staticmethod
+    def _summarize_by_outcome(input_data: dict[str, Any]) -> ActorResult:
+        actor_name = input_data.get("actor_name")
+        since_iso = input_data.get("since_iso")
+
+        sql = "SELECT outcome, COUNT(*) as cnt FROM agent_audit_ledger"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if actor_name:
+            clauses.append("actor_name = ?")
+            params.append(actor_name)
+        if since_iso:
+            clauses.append("timestamp >= ?")
+            params.append(since_iso)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " GROUP BY outcome"
+
+        rows = query(sql, tuple(params))
+        # outcome 4종 + None (unset) — None 은 'unset' key 로 surface
+        totals: dict[str, int] = {"pass": 0, "block": 0, "warn": 0, "error": 0}
+        unset = 0
+        for r in rows:
+            key = r["outcome"]
+            cnt = int(r["cnt"])
+            if key is None:
+                unset += cnt
+            elif key in totals:
+                totals[key] = cnt
+        total_count = sum(totals.values()) + unset
+        output: dict[str, Any] = {"totals": totals, "total_count": total_count}
+        if unset:
+            output["unset"] = unset
+        return ActorResult(
+            output=output,
+            outcome=Outcome.PASS,
+            sample_n=total_count,
+            input_summary=f"summarize_by_outcome (total={total_count})",
+        )
+
+    # ─── summarize_by_actor ───────────────────────────────────
+
+    @staticmethod
+    def _summarize_by_actor(input_data: dict[str, Any]) -> ActorResult:
+        layer = input_data.get("layer")
+        since_iso = input_data.get("since_iso")
+
+        if layer is not None and layer not in ("A", "B", "C"):
+            return ActorResult(
+                output={"error": f"layer must be A/B/C, got {layer!r}"},
+                outcome=Outcome.BLOCK,
+                input_summary="summarize_by_actor invalid layer",
+            )
+
+        sql = "SELECT actor_name, outcome, COUNT(*) as cnt FROM agent_audit_ledger"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if layer:
+            clauses.append("layer = ?")
+            params.append(layer)
+        if since_iso:
+            clauses.append("timestamp >= ?")
+            params.append(since_iso)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " GROUP BY actor_name, outcome"
+
+        rows = query(sql, tuple(params))
+        actors: dict[str, dict[str, int]] = {}
+        for r in rows:
+            name = r["actor_name"]
+            slot = actors.setdefault(name, {"pass": 0, "block": 0, "warn": 0, "error": 0, "total": 0})
+            outcome_key = r["outcome"] or "unset"
+            cnt = int(r["cnt"])
+            if outcome_key in slot:
+                slot[outcome_key] = cnt
+            slot["total"] += cnt
+        return ActorResult(
+            output={"actors": actors, "total_actors": len(actors)},
+            outcome=Outcome.PASS,
+            sample_n=len(actors),
+            input_summary=f"summarize_by_actor (n={len(actors)})",
+        )
+
+    # ─── retention_check ──────────────────────────────────────
+
+    def _retention_check(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        try:
+            max_rows = int(input_data.get("max_rows", DEFAULT_MAX_ROWS))
+            since_days = int(input_data.get("since_days", DEFAULT_RETENTION_DAYS))
+        except (TypeError, ValueError):
+            return ActorResult(
+                output={"error": "max_rows / since_days must be integer"},
+                outcome=Outcome.BLOCK,
+                input_summary="retention_check invalid args",
+            )
+
+        if max_rows <= 0 or since_days <= 0:
+            return ActorResult(
+                output={"error": "max_rows / since_days must be positive"},
+                outcome=Outcome.BLOCK,
+                input_summary="retention_check invalid args",
+            )
+
+        # 총 row 개수 — sqlite COUNT(*) 는 full scan but ledger 1M 까지 OK
+        total_rows_result = query("SELECT COUNT(*) AS n FROM agent_audit_ledger")
+        total_rows = int(total_rows_result[0]["n"]) if total_rows_result else 0
+
+        # since_days 보다 오래된 row — sqlite julianday 기반 (datetime('now') 와 동일 격)
+        old_rows_result = query(
+            "SELECT COUNT(*) AS n FROM agent_audit_ledger "
+            "WHERE julianday('now') - julianday(timestamp) > ?",
+            (since_days,),
+        )
+        old_rows = int(old_rows_result[0]["n"]) if old_rows_result else 0
+
+        block_threshold = int(max_rows * BLOCK_MULTIPLIER)
+        if total_rows > block_threshold:
+            recommendation = (
+                f"BLOCK: total_rows {total_rows:,} > block threshold {block_threshold:,} "
+                f"(max_rows {max_rows:,} × {BLOCK_MULTIPLIER}). 즉시 archive 필요."
+            )
+            outcome = Outcome.BLOCK
+        elif total_rows > max_rows:
+            recommendation = (
+                f"WARN: total_rows {total_rows:,} > max_rows {max_rows:,}. "
+                f"cleanup (>{since_days}d {old_rows:,} rows) 권고."
+            )
+            outcome = Outcome.WARN
+        else:
+            recommendation = (
+                f"PASS: total_rows {total_rows:,} ≤ max_rows {max_rows:,} "
+                f"(>{since_days}d: {old_rows:,} rows)."
+            )
+            outcome = Outcome.PASS
+
+        output = {
+            "total_rows": total_rows,
+            "rows_older_than_n_days": old_rows,
+            "since_days": since_days,
+            "max_rows": max_rows,
+            "block_threshold": block_threshold,
+            "recommendation": recommendation,
+        }
+
+        # ─── Discord publish (BLOCK → INCIDENTS, WARN → OPS) ───
+        if outcome == Outcome.BLOCK:
+            self._publish_incidents(output, ctx.run_id)
+        elif outcome == Outcome.WARN:
+            self._publish_ops(output, ctx.run_id)
+
+        return ActorResult(
+            output=output,
+            outcome=outcome,
+            sample_n=total_rows,
+            input_summary=f"retention_check {outcome.value} (rows={total_rows:,})",
+        )
+
+    # ─── Discord publish (best-effort) ───────────────────────
+
+    @staticmethod
+    def _publish_incidents(output: dict[str, Any], run_id: str) -> None:
+        """retention_check BLOCK → INCIDENTS 채널 (RED)."""
+        try:
+            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+
+            embed = {
+                "title": "Audit-Ledger BLOCK — DB bloat 위험",
+                "description": (
+                    f"total_rows: **{output['total_rows']:,}**\n"
+                    f"block_threshold: {output['block_threshold']:,}\n"
+                    f"max_rows: {output['max_rows']:,}\n\n"
+                    f"{output['recommendation']}"
+                ),
+                "color": 0xE74C3C,
+                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • 즉시 archive 필요"},
+            }
+            DiscordPublisher().publish_embed(
+                Channel.INCIDENTS,
+                embed=embed,
+                actor_name="audit-ledger",
+                run_id=run_id,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    @staticmethod
+    def _publish_ops(output: dict[str, Any], run_id: str) -> None:
+        """retention_check WARN → OPS 채널 (AMBER)."""
+        try:
+            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+
+            embed = {
+                "title": "Audit-Ledger WARN — cleanup 권고",
+                "description": (
+                    f"total_rows: **{output['total_rows']:,}**\n"
+                    f"max_rows: {output['max_rows']:,}\n"
+                    f"older than {output['since_days']}d: {output['rows_older_than_n_days']:,}\n\n"
+                    f"{output['recommendation']}"
+                ),
+                "color": 0xF39C12,
+                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • cleanup 권고"},
+            }
+            DiscordPublisher().publish_embed(
+                Channel.OPS,
+                embed=embed,
+                actor_name="audit-ledger",
+                run_id=run_id,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI: python -m nuri.agents.actors.audit_ledger <action> [options]."""
+    import argparse
+    import json as _json
+
+    parser = argparse.ArgumentParser(prog="audit-ledger")
+    parser.add_argument(
+        "action",
+        choices=["query", "summarize_by_outcome", "summarize_by_actor", "retention_check"],
+    )
+    parser.add_argument("--actor-name", default=None)
+    parser.add_argument("--layer", default=None, choices=[None, "A", "B", "C"])
+    parser.add_argument("--outcome", default=None, choices=[None, "pass", "block", "warn", "error"])
+    parser.add_argument("--since-iso", default=None)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--max-rows", type=int, default=DEFAULT_MAX_ROWS)
+    parser.add_argument("--since-days", type=int, default=DEFAULT_RETENTION_DAYS)
+    args = parser.parse_args(argv)
+
+    payload: dict[str, Any] = {"action": args.action}
+    if args.actor_name:
+        payload["actor_name"] = args.actor_name
+    if args.layer:
+        payload["layer"] = args.layer
+    if args.outcome:
+        payload["outcome"] = args.outcome
+    if args.since_iso:
+        payload["since_iso"] = args.since_iso
+    if args.action == "query":
+        payload["limit"] = args.limit
+    if args.action == "retention_check":
+        payload["max_rows"] = args.max_rows
+        payload["since_days"] = args.since_days
+
+    result = AuditLedger().run(payload)
+    print(_json.dumps(result.output, indent=2, ensure_ascii=False, default=str))
+    return 0 if result.outcome == Outcome.PASS else 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/tests/agent_infra/test_audit_ledger.py
+++ b/tests/agent_infra/test_audit_ledger.py
@@ -1,0 +1,592 @@
+"""AuditLedger tests (#529 Phase 2 — actor #10, canonical Layer A).
+
+검증 (Codex Round 5 Layer A):
+- Layer A enforcement (outcome 필수, ZERO LLM)
+- 4 actions: query / summarize_by_outcome / summarize_by_actor / retention_check
+- query: filter + sort + limit
+- summarize_by_outcome: GROUP BY outcome → totals dict
+- summarize_by_actor: GROUP BY actor_name → counts dict
+- retention_check 3 paths: PASS / WARN / BLOCK
+- empty DB handling
+- Discord publish: BLOCK → INCIDENTS, WARN → OPS (mock)
+- CLI smoke
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nuri.agents.actors.audit_ledger import (
+    BLOCK_MULTIPLIER,
+    DEFAULT_MAX_ROWS,
+    DEFAULT_RETENTION_DAYS,
+    AuditLedger,
+    main,
+)
+from nuri.agents.base import Layer, Outcome
+from nuri.core.db import init_db, log_agent_audit
+
+# ═══════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "audit.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def patched_db(db_path):
+    """audit-ledger 의 모든 DB 호출 redirect."""
+    from nuri.core import db as db_module
+
+    def make_redirect(fn):
+        def wrapped(*args, **kwargs):
+            kwargs.setdefault("db_path", db_path)
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    patches = [
+        patch(
+            "nuri.agents.base.log_agent_audit",
+            side_effect=make_redirect(db_module.log_agent_audit),
+        ),
+        patch(
+            "nuri.agents.base.start_agent_run",
+            side_effect=make_redirect(db_module.start_agent_run),
+        ),
+        patch(
+            "nuri.agents.base.finish_agent_run",
+            side_effect=make_redirect(db_module.finish_agent_run),
+        ),
+        patch(
+            "nuri.agents.actors.audit_ledger.query",
+            side_effect=make_redirect(db_module.query),
+        ),
+    ]
+    for p in patches:
+        p.start()
+    yield db_path
+    for p in patches:
+        p.stop()
+
+
+def _seed_audit(
+    db_path,
+    decision_id: str,
+    actor_name: str,
+    layer: str = "A",
+    outcome: str = "pass",
+    *,
+    timestamp: str | None = None,
+):
+    """단일 audit row 삽입. timestamp override 시 sqlite raw INSERT 우회.
+
+    log_agent_audit 은 timestamp DEFAULT 사용 — 과거 timestamp 가 필요하면
+    별도 raw write 로 처리 (db.py 내부 sqlite3 import 만 sole importer 라
+    여기는 query 만 사용 가능 → log_agent_audit 으로 시드 후 timestamp 업데이트).
+    """
+    log_agent_audit(
+        decision_id=decision_id,
+        actor_name=actor_name,
+        actor_version="0.1.0",
+        layer=layer,
+        input_hash="hash" + decision_id,
+        output='{"x":1}',
+        outcome=outcome,
+        db_path=db_path,
+    )
+    if timestamp is not None:
+        # raw timestamp 업데이트 — sole importer 룰 준수 위해 query() 미사용 path X.
+        # Pattern: get_db() context manager 로 안전한 conn 확보.
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "UPDATE agent_audit_ledger SET timestamp = ? WHERE decision_id = ? AND actor_name = ?",
+                (timestamp, decision_id, actor_name),
+            )
+
+
+# ═══════════════════════════════════════════════════════
+# Layer A invariants
+# ═══════════════════════════════════════════════════════
+
+
+class TestActorRegistration:
+    def test_layer_is_a(self):
+        assert AuditLedger.layer == Layer.A
+
+    def test_no_llm_dependency(self):
+        assert getattr(AuditLedger, "_uses_llm", False) is False
+
+    def test_registered_in_canonical_15(self):
+        from nuri.agents.base import REGISTRY
+
+        assert REGISTRY.get("audit-ledger") is AuditLedger
+
+    def test_name_is_canonical(self):
+        assert AuditLedger.name == "audit-ledger"
+
+    def test_valid_actions(self):
+        assert set(AuditLedger.VALID_ACTIONS) == {
+            "query",
+            "summarize_by_outcome",
+            "summarize_by_actor",
+            "retention_check",
+        }
+
+
+# ═══════════════════════════════════════════════════════
+# Input validation
+# ═══════════════════════════════════════════════════════
+
+
+class TestInputValidation:
+    def test_invalid_action_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "weird"})
+        assert result.outcome == Outcome.BLOCK
+        assert "invalid action" in result.output["error"]
+
+    def test_missing_action_blocked(self, patched_db):
+        result = AuditLedger().run({})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_query_invalid_layer_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "query", "layer": "Z"})
+        assert result.outcome == Outcome.BLOCK
+        assert "layer" in result.output["error"]
+
+    def test_query_invalid_outcome_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "query", "outcome": "yolo"})
+        assert result.outcome == Outcome.BLOCK
+        assert "outcome" in result.output["error"]
+
+    def test_query_invalid_limit_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "query", "limit": "xx"})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_summarize_by_actor_invalid_layer_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "summarize_by_actor", "layer": "Z"})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_retention_invalid_args_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "retention_check", "max_rows": "bad"})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_retention_zero_max_rows_blocked(self, patched_db):
+        result = AuditLedger().run({"action": "retention_check", "max_rows": 0})
+        assert result.outcome == Outcome.BLOCK
+
+    def test_retention_negative_since_days_blocked(self, patched_db):
+        result = AuditLedger().run(
+            {"action": "retention_check", "max_rows": 100, "since_days": -1}
+        )
+        assert result.outcome == Outcome.BLOCK
+
+
+# ═══════════════════════════════════════════════════════
+# query action
+# ═══════════════════════════════════════════════════════
+
+
+class TestQuery:
+    def test_query_empty_db(self, patched_db):
+        result = AuditLedger().run({"action": "query"})
+        assert result.outcome == Outcome.PASS
+        assert result.output["count"] == 0
+        assert result.output["rows"] == []
+
+    def test_query_returns_all_when_no_filter(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall")
+        _seed_audit(patched_db, "d2", "freshness-gatekeeper")
+        result = AuditLedger().run({"action": "query"})
+        assert result.outcome == Outcome.PASS
+        assert result.output["count"] == 2
+
+    def test_query_filter_by_actor(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall")
+        _seed_audit(patched_db, "d2", "freshness-gatekeeper")
+        _seed_audit(patched_db, "d3", "execution-firewall")
+        result = AuditLedger().run(
+            {"action": "query", "actor_name": "execution-firewall"}
+        )
+        assert result.output["count"] == 2
+        for row in result.output["rows"]:
+            assert row["actor_name"] == "execution-firewall"
+
+    def test_query_filter_by_layer(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", layer="A")
+        _seed_audit(patched_db, "d2", "regime-posterior", layer="B")
+        result = AuditLedger().run({"action": "query", "layer": "A"})
+        assert result.output["count"] == 1
+        assert result.output["rows"][0]["layer"] == "A"
+
+    def test_query_filter_by_outcome(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="pass")
+        _seed_audit(patched_db, "d2", "execution-firewall", outcome="block")
+        _seed_audit(patched_db, "d3", "execution-firewall", outcome="block")
+        result = AuditLedger().run({"action": "query", "outcome": "block"})
+        assert result.output["count"] == 2
+        for row in result.output["rows"]:
+            assert row["outcome"] == "block"
+
+    def test_query_filter_combination(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="pass")
+        _seed_audit(patched_db, "d2", "execution-firewall", outcome="block")
+        _seed_audit(patched_db, "d3", "freshness-gatekeeper", outcome="block")
+        result = AuditLedger().run(
+            {
+                "action": "query",
+                "actor_name": "execution-firewall",
+                "outcome": "block",
+            }
+        )
+        assert result.output["count"] == 1
+        assert result.output["rows"][0]["actor_name"] == "execution-firewall"
+        assert result.output["rows"][0]["outcome"] == "block"
+
+    def test_query_filter_by_since_iso(self, patched_db):
+        _seed_audit(
+            patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00"
+        )
+        _seed_audit(
+            patched_db, "new", "execution-firewall", timestamp="2030-01-01 00:00:00"
+        )
+        result = AuditLedger().run(
+            {"action": "query", "since_iso": "2025-01-01 00:00:00"}
+        )
+        assert result.output["count"] == 1
+        assert result.output["rows"][0]["decision_id"] == "new"
+
+    def test_query_limit_respected(self, patched_db):
+        for i in range(5):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        result = AuditLedger().run({"action": "query", "limit": 3})
+        assert result.output["count"] == 3
+
+    def test_query_sorted_desc(self, patched_db):
+        _seed_audit(
+            patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00"
+        )
+        _seed_audit(
+            patched_db, "new", "execution-firewall", timestamp="2030-01-01 00:00:00"
+        )
+        result = AuditLedger().run({"action": "query"})
+        # Newest first
+        assert result.output["rows"][0]["decision_id"] == "new"
+
+
+# ═══════════════════════════════════════════════════════
+# summarize_by_outcome
+# ═══════════════════════════════════════════════════════
+
+
+class TestSummarizeByOutcome:
+    def test_empty_db_zero_totals(self, patched_db):
+        result = AuditLedger().run({"action": "summarize_by_outcome"})
+        assert result.outcome == Outcome.PASS
+        assert result.output["totals"] == {"pass": 0, "block": 0, "warn": 0, "error": 0}
+        assert result.output["total_count"] == 0
+
+    def test_groups_by_outcome(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="pass")
+        _seed_audit(patched_db, "d2", "execution-firewall", outcome="pass")
+        _seed_audit(patched_db, "d3", "execution-firewall", outcome="block")
+        _seed_audit(patched_db, "d4", "execution-firewall", outcome="warn")
+        _seed_audit(patched_db, "d5", "execution-firewall", outcome="error")
+        result = AuditLedger().run({"action": "summarize_by_outcome"})
+        assert result.output["totals"] == {
+            "pass": 2,
+            "block": 1,
+            "warn": 1,
+            "error": 1,
+        }
+        assert result.output["total_count"] == 5
+
+    def test_filter_by_actor(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="block")
+        _seed_audit(patched_db, "d2", "freshness-gatekeeper", outcome="block")
+        result = AuditLedger().run(
+            {"action": "summarize_by_outcome", "actor_name": "execution-firewall"}
+        )
+        assert result.output["totals"]["block"] == 1
+        assert result.output["total_count"] == 1
+
+    def test_filter_by_since_iso(self, patched_db):
+        _seed_audit(
+            patched_db,
+            "old",
+            "execution-firewall",
+            outcome="pass",
+            timestamp="2020-01-01 00:00:00",
+        )
+        _seed_audit(patched_db, "new", "execution-firewall", outcome="pass")
+        result = AuditLedger().run(
+            {"action": "summarize_by_outcome", "since_iso": "2025-01-01 00:00:00"}
+        )
+        assert result.output["totals"]["pass"] == 1
+        assert result.output["total_count"] == 1
+
+    def test_unset_outcome_surfaced(self, patched_db):
+        """Layer B/C 시 outcome=None 인 row 가 'unset' 으로 노출됨."""
+        # Layer B audit row with outcome=None
+        from nuri.core.db import log_agent_audit
+
+        log_agent_audit(
+            decision_id="db",
+            actor_name="regime-posterior",
+            actor_version="0.1.0",
+            layer="B",
+            input_hash="x",
+            output="{}",
+            outcome=None,  # Layer B optional
+            db_path=patched_db,
+        )
+        result = AuditLedger().run({"action": "summarize_by_outcome"})
+        assert result.output.get("unset") == 1
+        assert result.output["total_count"] == 1
+
+
+# ═══════════════════════════════════════════════════════
+# summarize_by_actor
+# ═══════════════════════════════════════════════════════
+
+
+class TestSummarizeByActor:
+    def test_empty_db(self, patched_db):
+        result = AuditLedger().run({"action": "summarize_by_actor"})
+        assert result.outcome == Outcome.PASS
+        assert result.output["actors"] == {}
+        assert result.output["total_actors"] == 0
+
+    def test_groups_by_actor(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="pass")
+        _seed_audit(patched_db, "d2", "execution-firewall", outcome="block")
+        _seed_audit(patched_db, "d3", "freshness-gatekeeper", outcome="pass")
+        result = AuditLedger().run({"action": "summarize_by_actor"})
+        actors = result.output["actors"]
+        assert "execution-firewall" in actors
+        assert "freshness-gatekeeper" in actors
+        assert actors["execution-firewall"]["pass"] == 1
+        assert actors["execution-firewall"]["block"] == 1
+        assert actors["execution-firewall"]["total"] == 2
+        assert actors["freshness-gatekeeper"]["pass"] == 1
+        assert actors["freshness-gatekeeper"]["total"] == 1
+        assert result.output["total_actors"] == 2
+
+    def test_filter_by_layer(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", layer="A", outcome="pass")
+        _seed_audit(patched_db, "d2", "regime-posterior", layer="B", outcome="pass")
+        result = AuditLedger().run({"action": "summarize_by_actor", "layer": "A"})
+        assert "execution-firewall" in result.output["actors"]
+        assert "regime-posterior" not in result.output["actors"]
+
+
+# ═══════════════════════════════════════════════════════
+# retention_check
+# ═══════════════════════════════════════════════════════
+
+
+class TestRetentionCheck:
+    def test_empty_db_passes(self, patched_db):
+        result = AuditLedger().run({"action": "retention_check"})
+        assert result.outcome == Outcome.PASS
+        assert result.output["total_rows"] == 0
+        assert result.output["rows_older_than_n_days"] == 0
+        assert "PASS" in result.output["recommendation"]
+
+    def test_within_threshold_passes(self, patched_db):
+        for i in range(3):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        result = AuditLedger().run({"action": "retention_check", "max_rows": 100})
+        assert result.outcome == Outcome.PASS
+        assert result.output["total_rows"] == 3
+        assert result.output["max_rows"] == 100
+
+    def test_above_max_warns(self, patched_db):
+        for i in range(15):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_ops"):
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
+        assert result.outcome == Outcome.WARN
+        assert result.output["total_rows"] == 15
+        assert "WARN" in result.output["recommendation"]
+
+    def test_far_above_threshold_blocks(self, patched_db):
+        # max_rows=10 → block_threshold=15 → 16 rows triggers BLOCK
+        for i in range(16):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_incidents"):
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
+        assert result.outcome == Outcome.BLOCK
+        assert result.output["total_rows"] == 16
+        assert result.output["block_threshold"] == int(10 * BLOCK_MULTIPLIER)
+        assert "BLOCK" in result.output["recommendation"]
+
+    def test_old_rows_counted(self, patched_db):
+        _seed_audit(
+            patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00"
+        )
+        _seed_audit(patched_db, "fresh", "execution-firewall")
+        result = AuditLedger().run(
+            {"action": "retention_check", "max_rows": 1000, "since_days": 30}
+        )
+        assert result.output["rows_older_than_n_days"] == 1
+        assert result.output["total_rows"] == 2
+
+    def test_default_thresholds(self):
+        assert DEFAULT_MAX_ROWS == 1_000_000
+        assert DEFAULT_RETENTION_DAYS == 90
+        assert BLOCK_MULTIPLIER == 1.5
+
+
+# ═══════════════════════════════════════════════════════
+# Discord publish (mock)
+# ═══════════════════════════════════════════════════════
+
+
+class TestDiscordPublish:
+    def test_block_publishes_incidents(self, patched_db):
+        # max_rows=2 → block_threshold=3 → 4 rows → BLOCK
+        for i in range(4):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_incidents") as m:
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 2})
+        assert result.outcome == Outcome.BLOCK
+        m.assert_called_once()
+
+    def test_warn_publishes_ops(self, patched_db):
+        for i in range(11):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_ops") as m:
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
+        assert result.outcome == Outcome.WARN
+        m.assert_called_once()
+
+    def test_pass_no_publish(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall")
+        with (
+            patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_incidents") as inc,
+            patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_ops") as ops,
+        ):
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 1000})
+        assert result.outcome == Outcome.PASS
+        inc.assert_not_called()
+        ops.assert_not_called()
+
+    def test_query_no_publish(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall")
+        with (
+            patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_incidents") as inc,
+            patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_ops") as ops,
+        ):
+            AuditLedger().run({"action": "query"})
+        inc.assert_not_called()
+        ops.assert_not_called()
+
+    def test_publish_failure_swallowed(self, patched_db):
+        """Discord webhook 실패가 actor 결정 차단해서는 안 됨 (best-effort)."""
+        for i in range(11):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch(
+            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
+            side_effect=Exception("network down"),
+        ):
+            # 예외 raise 하지 않아야 함
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
+        assert result.outcome == Outcome.WARN
+
+    def test_block_publish_real_path(self, patched_db):
+        """BLOCK path 가 실제 _publish_incidents body 를 실행 — coverage 보강."""
+        for i in range(4):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch(
+            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed"
+        ) as mock_pub:
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 2})
+        assert result.outcome == Outcome.BLOCK
+        # publish_embed 호출 — INCIDENTS channel 인지 확인
+        mock_pub.assert_called_once()
+        from nuri.agents.discord.publisher import Channel
+
+        kwargs = mock_pub.call_args
+        # positional: (channel,) ; kwargs: embed=..., actor_name=...
+        assert kwargs.args[0] == Channel.INCIDENTS
+
+    def test_warn_publish_real_path(self, patched_db):
+        """WARN path 가 실제 _publish_ops body 를 실행 — coverage 보강."""
+        for i in range(11):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch(
+            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed"
+        ) as mock_pub:
+            result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
+        assert result.outcome == Outcome.WARN
+        mock_pub.assert_called_once()
+        from nuri.agents.discord.publisher import Channel
+
+        kwargs = mock_pub.call_args
+        assert kwargs.args[0] == Channel.OPS
+
+
+# ═══════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════
+
+
+class TestCLI:
+    def test_cli_query_returns_zero_on_pass(self, patched_db, capsys):
+        rc = main(["query", "--limit", "5"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "count" in captured.out
+
+    def test_cli_summarize_by_outcome(self, patched_db, capsys):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="pass")
+        rc = main(["summarize_by_outcome"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "totals" in captured.out
+
+    def test_cli_summarize_by_actor(self, patched_db, capsys):
+        _seed_audit(patched_db, "d1", "execution-firewall", outcome="pass")
+        rc = main(["summarize_by_actor"])
+        assert rc == 0
+
+    def test_cli_retention_check_pass(self, patched_db, capsys):
+        rc = main(["retention_check", "--max-rows", "1000", "--since-days", "30"])
+        assert rc == 0
+
+    def test_cli_retention_check_warn_returns_nonzero(self, patched_db):
+        for i in range(11):
+            _seed_audit(patched_db, f"d{i}", "execution-firewall")
+        with patch("nuri.agents.actors.audit_ledger.AuditLedger._publish_ops"):
+            rc = main(["retention_check", "--max-rows", "10"])
+        # WARN → outcome != PASS → nonzero exit
+        assert rc == 1
+
+    def test_cli_query_with_all_optional_args(self, patched_db):
+        _seed_audit(patched_db, "d1", "execution-firewall", layer="A", outcome="pass")
+        rc = main(
+            [
+                "query",
+                "--actor-name",
+                "execution-firewall",
+                "--layer",
+                "A",
+                "--outcome",
+                "pass",
+                "--since-iso",
+                "2020-01-01 00:00:00",
+                "--limit",
+                "10",
+            ]
+        )
+        assert rc == 0


### PR DESCRIPTION
## Summary

#529 Phase 2 의 canonical actor #10 — `agent_audit_ledger` (#25 migration) 의
**read-only query interface + retention policy**.

- Schema 변동 X — 기존 ledger 의 consumer/측정 layer 만 채움
- 다른 wave 1 actor (#36/#37) 와 schema 충돌 zero
- Layer A 100% rule-based, ZERO LLM, outcome 필수

## Actions

| action | outcome path | publish |
|--------|-------------|---------|
| `query` | PASS (filter+sort+limit) | — |
| `summarize_by_outcome` | PASS (GROUP BY outcome) | — |
| `summarize_by_actor` | PASS (GROUP BY actor) | — |
| `retention_check` | PASS / WARN / BLOCK | WARN→OPS, BLOCK→INCIDENTS |

`retention_check` thresholds:
- `max_rows`        (default 1,000,000) — 초과 시 WARN (cleanup 권고)
- `max_rows × 1.5`  — 초과 시 BLOCK (즉시 archive)
- `since_days`      (default 90) — 오래된 row 개수 별도 보고

archive 로직 직접 구현 X (다음 phase) — 측정 + 권고만.

## Test plan

- [x] 50 tests pass, 97% coverage on `audit_ledger.py`
- [x] Layer A invariants (no LLM, outcome required, registered in canonical 15)
- [x] 4 actions × empty-DB / filter-combination / sort / limit
- [x] `retention_check` 3 paths (PASS / WARN / BLOCK) + Discord channel routing
- [x] Discord publish best-effort (network failure swallowed)
- [x] CLI smoke (`python -m nuri.agents.actors.audit_ledger <action>`)
- [x] Full `tests/agent_infra/` suite green (481 tests)
- [x] Ruff lint clean