### PR TITLE
feat(ops): O2+O3 #529 Phase 2 cron registration (track-forward + sre-scan)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -679,6 +679,7 @@
     "falsification",
     "spurious",
     "insuf",
+    "PYTHONPATH",
     "Hamilton",
     "MOIRAI",
     "Chronos",

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,24 @@ phase2-chain:    ## Phase 2 4-actor chain end-to-end on real macro + ticker (def
 phase2-chain-dry:    ## Phase 2 chain dry-run (no DB write, validation only)
 	$(PYTHON) scripts/run_phase2_chain.py --ticker $(or $(ticker),NVDA) --dry-run
 
+# ─── #529 Phase 2 운영 cron (O2 + O3) ────────────────────
+track-forward:    ## ForwardOutcomeTracker scan — emit decision outcome 측정 (closed loop)
+	$(PYTHON) -m nuri.agents.actors.forward_outcome_tracker scan
+
+sre-scan:    ## SREIncidentAgent scan — 6 detector (orphan/disk/heartbeat/freshness/...)
+	$(PYTHON) -m nuri.agents.actors.sre_incident_agent scan
+
+phase2-crons-install:    ## launchd cron 설치 (track-forward daily, sre-scan hourly)
+	bash scripts/launchd/install_phase2_crons.sh
+
+phase2-crons-uninstall:    ## launchd cron 제거
+	bash scripts/launchd/uninstall_phase2_crons.sh
+
+phase2-crons-status:    ## 설치된 cron 상태 + 로그 위치 표시
+	@launchctl list | grep -E "(track-forward|sre-scan)" || echo "  (none installed)"
+	@echo ""
+	@echo "  로그: data/logs/{track_forward,sre_scan}.log"
+
 test-slow:
 	$(PYTHON) -m pytest tests/ -v -n auto --dist worksteal -m "slow"
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flowchart TB
         E -. "agent weight drift (±30%)" .-> C
     end
 
-    DB[("SQLite WAL · 43 tables<br/>pipeline_events · certifications · audit trail")]:::sink
+    DB[("SQLite WAL · 48 tables<br/>pipeline_events · certifications · audit trail")]:::sink
 
     CFG -. policies .-> Pipeline
     Pipeline -. persist .-> DB

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,7 +194,7 @@ data/
 
 ## Testing
 
-4,183 backend tests across 187 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+4,485 backend tests across 187 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,183 tests, 187 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,485 tests, 187 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/launchd/com.nuri-quant.sre-scan.plist
+++ b/scripts/launchd/com.nuri-quant.sre-scan.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  com.nuri-quant.sre-scan (#529 Phase 2 — O3 SREIncidentAgent hourly cron)
+
+  매시간 SREIncidentAgent.scan 실행 — 6 detector (orphan_run / disk_full / db_lock /
+  scheduler_heartbeat / actor_failure_streak / data_freshness_critical) 일괄 검사.
+  critical 발견 시 Discord INCIDENTS 자동 publish, warning 시 OPS publish.
+
+  health_check.sh 와 보완 관계 — health_check 는 schema/table 검증 (build-time),
+  sre-scan 은 runtime incident 추적 (operation-time).
+
+  설치:
+    cp scripts/launchd/com.nuri-quant.sre-scan.plist ~/Library/LaunchAgents/
+    sed -i '' "s|/Users/USER|$HOME|g" ~/Library/LaunchAgents/com.nuri-quant.sre-scan.plist
+    launchctl load ~/Library/LaunchAgents/com.nuri-quant.sre-scan.plist
+-->
+<dict>
+    <key>Label</key>
+    <string>com.nuri-quant.sre-scan</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; .venv/bin/python -m nuri.agents.actors.sre_incident_agent scan</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/USER/workspace/nuri-quant</string>
+
+    <!-- 매시간 (3600초) -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/sre_scan.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/sre_scan.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/launchd/com.nuri-quant.track-forward.plist
+++ b/scripts/launchd/com.nuri-quant.track-forward.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  com.nuri-quant.track-forward (#529 Phase 2 — O2 ForwardOutcomeTracker daily cron)
+
+  매일 KST 17:00 (한국장 마감 후) ForwardOutcomeTracker.scan 실행 — agent_decisions
+  의 emit 결과를 7d/14d/30d window 후 측정하여 HypothesisRegistry validate/reject
+  자동 trigger. closed-loop 자동화의 핵심.
+
+  설치:
+    cp scripts/launchd/com.nuri-quant.track-forward.plist ~/Library/LaunchAgents/
+    sed -i '' "s|/Users/USER|$HOME|g" ~/Library/LaunchAgents/com.nuri-quant.track-forward.plist
+    launchctl load ~/Library/LaunchAgents/com.nuri-quant.track-forward.plist
+
+  주의: PROGRAM_PATH 는 사용자 환경에 맞게 수정 필요 (USER 자리).
+-->
+<dict>
+    <key>Label</key>
+    <string>com.nuri-quant.track-forward</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; .venv/bin/python -m nuri.agents.actors.forward_outcome_tracker scan</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/USER/workspace/nuri-quant</string>
+
+    <!-- 매일 KST 17:00 (한국장 마감 후, 한국 사용자 기준) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>17</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/track_forward.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/track_forward.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/launchd/install_phase2_crons.sh
+++ b/scripts/launchd/install_phase2_crons.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/launchd/install_phase2_crons.sh — #529 Phase 2 운영 cron 설치 (O2 + O3).
+#
+# 설치 대상 (HOME 자동 substitute):
+#   com.nuri-quant.track-forward — 매일 KST 17:00 ForwardOutcomeTracker.scan
+#   com.nuri-quant.sre-scan      — 매시간 SREIncidentAgent.scan
+#
+# 사용:
+#   bash scripts/launchd/install_phase2_crons.sh        # 설치 + load
+#   bash scripts/launchd/install_phase2_crons.sh --dry  # 무엇이 설치될지만 표시
+#
+# Uninstall:
+#   bash scripts/launchd/uninstall_phase2_crons.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+LAUNCHD_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$PWD/data/logs"
+
+PLISTS=(
+    "com.nuri-quant.track-forward.plist"
+    "com.nuri-quant.sre-scan.plist"
+)
+
+DRY=0
+[ "${1:-}" = "--dry" ] && DRY=1
+
+echo "═══ #529 Phase 2 cron install ═══"
+echo " HOME:       $HOME"
+echo " LAUNCHD:    $LAUNCHD_DIR"
+echo " LOG_DIR:    $LOG_DIR"
+echo " DRY-RUN:    $DRY"
+echo "──────────────────────────────────"
+
+mkdir -p "$LAUNCHD_DIR" "$LOG_DIR"
+
+for plist in "${PLISTS[@]}"; do
+    src="scripts/launchd/$plist"
+    dst="$LAUNCHD_DIR/$plist"
+
+    if [ ! -f "$src" ]; then
+        echo " ❌ source missing: $src"
+        exit 2
+    fi
+
+    if [ "$DRY" = "1" ]; then
+        echo " [DRY] would copy: $src → $dst"
+        echo " [DRY] would substitute /Users/USER → $HOME"
+        echo " [DRY] would launchctl load $dst"
+        continue
+    fi
+
+    # 기존 load 해제 (idempotent)
+    if launchctl list | grep -q "${plist%.plist}"; then
+        echo " ⏸  unloading existing: $plist"
+        launchctl unload "$dst" 2>/dev/null || true
+    fi
+
+    # 복사 + USER substitute
+    cp "$src" "$dst"
+    sed -i '' "s|/Users/USER|$HOME|g" "$dst"
+
+    # load
+    launchctl load "$dst"
+    echo " ✅ installed: $plist"
+done
+
+if [ "$DRY" = "0" ]; then
+    echo "──────────────────────────────────"
+    echo " 확인:"
+    for plist in "${PLISTS[@]}"; do
+        label="${plist%.plist}"
+        status=$(launchctl list | awk -v l="$label" '$3==l {print $1}')
+        echo "   $label → PID/exit: ${status:-not loaded}"
+    done
+    echo ""
+    echo " 로그 확인:"
+    echo "   tail -f $LOG_DIR/track_forward.log"
+    echo "   tail -f $LOG_DIR/sre_scan.log"
+fi

--- a/scripts/launchd/uninstall_phase2_crons.sh
+++ b/scripts/launchd/uninstall_phase2_crons.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# scripts/launchd/uninstall_phase2_crons.sh — #529 Phase 2 운영 cron 제거.
+set -euo pipefail
+
+LAUNCHD_DIR="$HOME/Library/LaunchAgents"
+PLISTS=(
+    "com.nuri-quant.track-forward.plist"
+    "com.nuri-quant.sre-scan.plist"
+)
+
+echo "═══ #529 Phase 2 cron uninstall ═══"
+
+for plist in "${PLISTS[@]}"; do
+    dst="$LAUNCHD_DIR/$plist"
+    label="${plist%.plist}"
+
+    if [ -f "$dst" ]; then
+        if launchctl list | grep -q "$label"; then
+            launchctl unload "$dst" 2>/dev/null || true
+            echo " ⏸  unloaded: $label"
+        fi
+        rm -f "$dst"
+        echo " 🗑  removed: $dst"
+    else
+        echo " ℹ  not installed: $plist"
+    fi
+done


### PR DESCRIPTION
## Summary

**O2 + O3 from NEXT_SESSION** — Phase 2 의 closed-loop 자동화 (ForwardOutcomeTracker daily) + 운영 self-monitoring (SREIncidentAgent hourly) launchd cron 등록. 두 작업이 동일 인프라 (launchd plist + Make + install script) 라 1 PR 로 묶음.

## Why

- **O2**: emit 된 decision 의 outcome 측정 → HypothesisRegistry validate/reject 자동 → *학습 시스템* 작동 시작. 매뉴얼로 매일 호출 X
- **O3**: orphan run / disk full / heartbeat / freshness 자동 감지 → Discord INCIDENTS/OPS publish → operator 가 수동 health check 안 해도 됨

## Changes

| File | Purpose |
|---|---|
| `scripts/launchd/com.nuri-quant.track-forward.plist` | StartCalendarInterval Hour=17 Min=0 (KST 한국장 마감 후) |
| `scripts/launchd/com.nuri-quant.sre-scan.plist` | StartInterval=3600 (hourly) + RunAtLoad=true |
| `scripts/launchd/install_phase2_crons.sh` | idempotent install (USER substitute, dry-run support) |
| `scripts/launchd/uninstall_phase2_crons.sh` | clean removal |
| `Makefile` | `track-forward` / `sre-scan` / `phase2-crons-{install,uninstall,status}` |
| `.cspell.json` | PYTHONPATH (pre-existing) |

## 검증 (live install on dev MBP)

- `bash scripts/launchd/install_phase2_crons.sh` — 둘 다 `launchctl load` 성공
- sre-scan `RunAtLoad=true` 즉시 실행 → `data/logs/sre_scan.log` 정상 출력 (0 incident, system healthy)
- `make track-forward` — 0 emit (현재 모든 emit blocked at MIRAGE per O1) → empty scan, 정상
- `make sre-scan` — 0 incident
- `make phase2-crons-status` — 등록 여부 + 로그 위치 표시

## 사용

```bash
# 설치 (개발자 / Mac mini)
make phase2-crons-install

# 상태 확인
make phase2-crons-status

# 수동 1회 실행
make track-forward
make sre-scan

# 제거
make phase2-crons-uninstall
```

## 운영 효과

- 매일 17:00 KST: emit 된 decision 의 7d/14d/30d outcome 측정 → hypothesis 자동 종결
- 매시간: 6 detector 가 incident scan → critical 시 Discord INCIDENTS alert (operator urgent)
- O1 의 `make phase2-chain` 으로 emit 된 decision 들이 자동으로 추적됨

## 후속 작업 (next sessions)

- O4: Mac mini 배포 + StateReplicatorDR replica 등록 (post-pull hook)
- O5: SIEGE 10-gate ↔ DecisionCompiler 통합 architecture decision
- 이번 PR 의 cron 들 Mac mini 에도 install (Mac mini 가 production primary)

## Test plan

- [x] `make phase2-crons-install` — live install on dev MBP 성공
- [x] sre-scan RunAtLoad 즉시 실행 → log 정상
- [x] `make track-forward` / `make sre-scan` 둘 다 정상 exit 0
- [x] `make phase2-crons-status` — launchctl list 표시
- [x] `make phase2-crons-uninstall` 후 재설치 가능 (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)