### PR TITLE
chore(tests): batch 2 — Pylance Optional/Argument fixes + cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -720,7 +720,12 @@
     "Brok",
     "BRKR",
     "SCRY",
-    "aopay"
+    "aopay",
+    "CBOEY",
+    "CBOEDB",
+    "prdy",
+    "clpr",
+    "EHTC"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/tests/collectors/test_cboe.py
+++ b/tests/collectors/test_cboe.py
@@ -2,6 +2,7 @@
 
 Split from tests/test_collectors_all.py for module-level isolation.
 """
+
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,7 +37,7 @@ class TestCBOECollector:
 
         c = CBOECollector()
         result = c._extract_pcr({"TOTAL_PUT_VOLUME": 1000, "TOTAL_CALL_VOLUME": 2000})
-        assert abs(result - 0.5) < 0.01
+        assert result is not None and abs(result - 0.5) < 0.01
 
     def test_extract_pcr_missing(self):
         from nuri.collectors.cboe import CBOECollector
@@ -48,11 +49,9 @@ class TestCBOECollector:
         from nuri.collectors.cboe import CBOECollector
 
         c = CBOECollector()
-        records = [{"indicator": "put_call_ratio", "date": "2026-03-30",
-                     "value": 0.85, "source": "cboe"}]
+        records = [{"indicator": "put_call_ratio", "date": "2026-03-30", "value": 0.85, "source": "cboe"}]
         count = c.save(records)
         assert count == 1
-
 
 
 class TestCBOECollector_Phase2:
@@ -65,10 +64,12 @@ class TestCBOECollector_Phase2:
     def test_extract_pcr_volume_calc(self):
         from nuri.collectors.cboe import CBOECollector
 
-        result = CBOECollector._extract_pcr({
-            "TOTAL_PUT_VOLUME": 1500000,
-            "TOTAL_CALL_VOLUME": 2000000,
-        })
+        result = CBOECollector._extract_pcr(
+            {
+                "TOTAL_PUT_VOLUME": 1500000,
+                "TOTAL_CALL_VOLUME": 2000000,
+            }
+        )
         assert result == pytest.approx(0.75)
 
     def test_extract_pcr_missing(self):
@@ -80,10 +81,15 @@ class TestCBOECollector_Phase2:
     def test_extract_pcr_zero_call(self):
         from nuri.collectors.cboe import CBOECollector
 
-        assert CBOECollector._extract_pcr({
-            "TOTAL_PUT_VOLUME": 100,
-            "TOTAL_CALL_VOLUME": 0,
-        }) is None
+        assert (
+            CBOECollector._extract_pcr(
+                {
+                    "TOTAL_PUT_VOLUME": 100,
+                    "TOTAL_CALL_VOLUME": 0,
+                }
+            )
+            is None
+        )
 
     @patch("nuri.collectors.cboe.requests.get")
     def test_collect_daily_json(self, mock_get):
@@ -91,9 +97,7 @@ class TestCBOECollector_Phase2:
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            "data": [{"TRADE_DATE": "2026-03-28", "TOTAL_PUT_CALL_RATIO": 0.92}]
-        }
+        mock_resp.json.return_value = {"data": [{"TRADE_DATE": "2026-03-28", "TOTAL_PUT_CALL_RATIO": 0.92}]}
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
@@ -109,9 +113,7 @@ class TestCBOECollector_Phase2:
         from nuri.collectors.cboe import CBOECollector
 
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "data": [{"TRADE_DATE": "2026-03-28", "TOTAL_PUT_CALL_RATIO": 0.88}]
-        }
+        mock_resp.json.return_value = {"data": [{"TRADE_DATE": "2026-03-28", "TOTAL_PUT_CALL_RATIO": 0.88}]}
         mock_resp.raise_for_status = MagicMock()
         mock_get.return_value = mock_resp
 
@@ -134,16 +136,13 @@ class TestCBOECollector_Phase2:
         assert parse_date("2026-03-28T12:00:00") == "2026-03-28"
 
 
-
 class TestCBOEDeepFromHistorical:
     def test_collect_daily_mock(self):
         from nuri.collectors.cboe import CBOECollector
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            "data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]
-        }
+        mock_resp.json.return_value = {"data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]}
         c = CBOECollector()
         with patch("nuri.collectors.cboe.requests") as mock_req:
             mock_req.get.return_value = mock_resp
@@ -165,16 +164,13 @@ class TestCBOEDeepFromHistorical:
 # ##############################################################################
 
 
-
 class TestCBOEDeepCalculations:
     def test_collect_daily_success(self):
         from nuri.collectors.cboe import CBOECollector
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            "data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]
-        }
+        mock_resp.json.return_value = {"data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]}
         c = CBOECollector()
         with patch("nuri.collectors.cboe.requests.get", return_value=mock_resp):
             result = c._collect_daily()
@@ -204,9 +200,7 @@ class TestCBOEDeepCalculations:
         c = CBOECollector()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            "data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]
-        }
+        mock_resp.json.return_value = {"data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]}
         with patch("nuri.collectors.cboe.requests.get", return_value=mock_resp):
             result = c.collect()
         assert isinstance(result, list)
@@ -217,27 +211,22 @@ class TestCBOEDeepCalculations:
 # ##############################################################################
 
 
-
 class TestCBOEFull:
     def test_collect_with_fallback(self):
         from nuri.collectors.cboe import CBOECollector
 
         mock_daily = MagicMock()
         mock_daily.status_code = 200
-        mock_daily.json.return_value = {
-            "data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]
-        }
+        mock_daily.json.return_value = {"data": [{"TRADE_DATE": "2026-03-30", "TOTAL_PUT_CALL_RATIO": 0.85}]}
         mock_fail = MagicMock()
         mock_fail.status_code = 500
 
         c = CBOECollector()
-        with patch("nuri.collectors.cboe.requests.get",
-                    side_effect=[mock_daily, mock_fail]):
+        with patch("nuri.collectors.cboe.requests.get", side_effect=[mock_daily, mock_fail]):
             daily = c._collect_daily()
             totalpc = c._collect_totalpc()
         assert len(daily) > 0
         assert len(totalpc) == 0
-
 
 
 class TestCBOEExtractPCR:
@@ -254,7 +243,7 @@ class TestCBOEExtractPCR:
         from nuri.collectors.cboe import CBOECollector
 
         result = CBOECollector._extract_pcr({"TOTAL_PUT_VOLUME": 1000, "TOTAL_CALL_VOLUME": 2000})
-        assert abs(result - 0.5) < 0.01
+        assert result is not None and abs(result - 0.5) < 0.01
 
     def test_extract_pcr_none(self):
         from nuri.collectors.cboe import CBOECollector
@@ -326,9 +315,13 @@ class TestCBOEExtractPCR:
         c.fred_key = "test_key"
         with patch.object(c, "_collect_daily", side_effect=RuntimeError("fail")):
             with patch.object(c, "_collect_totalpc", side_effect=RuntimeError("fail")):
-                with patch.object(c, "_collect_fred_pcr", return_value=[
-                    {"indicator": "put_call_ratio", "date": "2025-03-15", "value": 0.9, "source": "FRED"}
-                ]):
+                with patch.object(
+                    c,
+                    "_collect_fred_pcr",
+                    return_value=[
+                        {"indicator": "put_call_ratio", "date": "2025-03-15", "value": 0.9, "source": "FRED"}
+                    ],
+                ):
                     result = c.collect()
         assert len(result) == 1
 
@@ -350,9 +343,11 @@ class TestCBOEExtractPCR:
         c = CBOECollector()
         c.fred_key = ""
         with patch.object(c, "_collect_daily", return_value=[]):
-            with patch.object(c, "_collect_totalpc", return_value=[
-                {"indicator": "put_call_ratio", "date": "2025-03-15", "value": 0.8, "source": "CBOE"}
-            ]):
+            with patch.object(
+                c,
+                "_collect_totalpc",
+                return_value=[{"indicator": "put_call_ratio", "date": "2025-03-15", "value": 0.8, "source": "CBOE"}],
+            ):
                 result = c.collect()
         assert len(result) == 1
 

--- a/tests/collectors/test_kis_token_cache.py
+++ b/tests/collectors/test_kis_token_cache.py
@@ -9,6 +9,7 @@
 
 Issue: https://github.com/researcherhojin/nuri-quant/issues/532
 """
+
 from __future__ import annotations
 
 import json
@@ -58,9 +59,7 @@ def legacy_cache_dir(tmp_path):
 class TestCacheLocationDeterminism:
     """Cache 는 항상 project-local 이어야 한다 (yaml 존재 여부 무관)."""
 
-    def test_cache_dir_is_project_local_when_yaml_absent(
-        self, project_cache_dir, legacy_cache_dir
-    ):
+    def test_cache_dir_is_project_local_when_yaml_absent(self, project_cache_dir, legacy_cache_dir):
         """`.env` only 셋업 (yaml 없음) → cache 가 project-local 로 결정됨.
 
         이 테스트가 실패하면 Issue #532 재발: cache 가 legacy `~/KIS/cache/` 로
@@ -77,9 +76,7 @@ class TestCacheLocationDeterminism:
             f"(expected: {project_cache_dir}). Issue #532 회귀."
         )
 
-    def test_cache_dir_is_project_local_when_yaml_present(
-        self, project_cache_dir, legacy_cache_dir
-    ):
+    def test_cache_dir_is_project_local_when_yaml_present(self, project_cache_dir, legacy_cache_dir):
         """yaml 있을 때도 동일하게 project-local cache. 결정성 보장."""
         project_kis_dir = project_cache_dir.parent
         project_kis_dir.mkdir(parents=True, exist_ok=True)
@@ -97,9 +94,7 @@ class TestCacheLocationDeterminism:
 class TestTokenCacheTTL:
     """TTL 이내 두 번째 호출은 캐시된 token 반환 (HTTP 0회)."""
 
-    def test_two_calls_within_ttl_only_one_http_request(
-        self, fake_creds, project_cache_dir
-    ):
+    def test_two_calls_within_ttl_only_one_http_request(self, fake_creds, project_cache_dir):
         """24h cache 의 핵심: 2번 호출 → HTTP 1번만 발생."""
         project_cache_dir.mkdir(parents=True, exist_ok=True)
         cache_file = project_cache_dir / "token_prod.json"
@@ -112,9 +107,7 @@ class TestTokenCacheTTL:
         }
 
         with (
-            patch(
-                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
-            ),
+            patch("nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir),
             patch("nuri.collectors.kis_realtime.requests.post", return_value=mock_response) as mock_post,
         ):
             # 1차: HTTP 호출 → cache 작성
@@ -125,8 +118,7 @@ class TestTokenCacheTTL:
         assert tok1 == "TOKEN_FROM_HTTP"
         assert tok2 == "TOKEN_FROM_HTTP", "Cache hit 시 같은 token 반환해야 함"
         assert mock_post.call_count == 1, (
-            f"TTL 이내 2회 호출이 HTTP {mock_post.call_count}회 발생 — "
-            "Issue #532 회귀 (cache 미작동)"
+            f"TTL 이내 2회 호출이 HTTP {mock_post.call_count}회 발생 — Issue #532 회귀 (cache 미작동)"
         )
         assert cache_file.exists(), "Cache 파일이 작성되어야 함"
 
@@ -136,11 +128,13 @@ class TestTokenCacheTTL:
         cache_file = project_cache_dir / "token_prod.json"
         # 25시간 전 issued (TTL 23h 초과)
         cache_file.write_text(
-            json.dumps({
-                "access_token": "STALE_TOKEN",
-                "issued_at": time.time() - 25 * 3600,
-                "expires_in": 86400,
-            })
+            json.dumps(
+                {
+                    "access_token": "STALE_TOKEN",
+                    "issued_at": time.time() - 25 * 3600,
+                    "expires_in": 86400,
+                }
+            )
         )
 
         mock_response = MagicMock()
@@ -151,9 +145,7 @@ class TestTokenCacheTTL:
         }
 
         with (
-            patch(
-                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
-            ),
+            patch("nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir),
             patch("nuri.collectors.kis_realtime.requests.post", return_value=mock_response) as mock_post,
         ):
             tok = get_access_token(fake_creds)
@@ -161,9 +153,7 @@ class TestTokenCacheTTL:
         assert tok == "FRESH_TOKEN"
         assert mock_post.call_count == 1
 
-    def test_corrupted_cache_falls_back_to_new_issue(
-        self, fake_creds, project_cache_dir
-    ):
+    def test_corrupted_cache_falls_back_to_new_issue(self, fake_creds, project_cache_dir):
         """깨진 JSON cache → silently 무시 + 새로 발급."""
         project_cache_dir.mkdir(parents=True, exist_ok=True)
         cache_file = project_cache_dir / "token_prod.json"
@@ -177,9 +167,7 @@ class TestTokenCacheTTL:
         }
 
         with (
-            patch(
-                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
-            ),
+            patch("nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir),
             patch("nuri.collectors.kis_realtime.requests.post", return_value=mock_response),
         ):
             tok = get_access_token(fake_creds)
@@ -201,15 +189,14 @@ class TestModeSeparation:
         prod_creds = KISCredentials("k", "s", "1", "h", "prod")
         paper_creds = KISCredentials("k", "s", "1", "h", "paper")
 
-        responses = [
-            MagicMock(status_code=200, **{"json.return_value": {"access_token": "PROD_TOK", "expires_in": 86400}}),
-            MagicMock(status_code=200, **{"json.return_value": {"access_token": "PAPER_TOK", "expires_in": 86400}}),
-        ]
+        prod_resp = MagicMock(status_code=200)
+        prod_resp.json.return_value = {"access_token": "PROD_TOK", "expires_in": 86400}
+        paper_resp = MagicMock(status_code=200)
+        paper_resp.json.return_value = {"access_token": "PAPER_TOK", "expires_in": 86400}
+        responses = [prod_resp, paper_resp]
 
         with (
-            patch(
-                "nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir
-            ),
+            patch("nuri.collectors.kis_realtime.TOKEN_CACHE_DIR", project_cache_dir),
             patch("nuri.collectors.kis_realtime.requests.post", side_effect=responses),
         ):
             assert get_access_token(prod_creds) == "PROD_TOK"

--- a/tests/core/test_pipeline_events.py
+++ b/tests/core/test_pipeline_events.py
@@ -38,13 +38,13 @@ class TestEmitEvent:
     def test_emit_returns_id(self, db_path):
         """emit_event가 양수 event ID를 반환."""
         event_id = emit_event("step_started", "collect", db_path=db_path)
-        assert event_id > 0
+        assert event_id is not None and event_id > 0
 
     def test_emit_multiple_sequential_ids(self, db_path):
         """여러 이벤트의 ID가 순차 증가."""
         id1 = emit_event("step_started", "collect", db_path=db_path)
         id2 = emit_event("step_completed", "collect", duration_ms=100, db_path=db_path)
-        assert id2 > id1
+        assert id1 is not None and id2 is not None and id2 > id1
 
     def test_emit_with_payload(self, db_path):
         """payload가 JSON으로 저장/조회."""

--- a/tests/quant/test_factors_quality.py
+++ b/tests/quant/test_factors_quality.py
@@ -1,4 +1,6 @@
+# pyright: reportArgumentType=false
 """Tests for factors_quality — split from test_quant_all.py."""
+
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -23,12 +25,12 @@ class TestQuality:
 
     def test_empty_when_no_data(self, db_path_mp):
         from nuri.quant.factors.quality import compute_quality
+
         result = compute_quality(tickers=["FAKE"])
         assert result.empty
 
     def test_normalization_logic(self):
-        scores = {"AAPL": {"roe": 0.30, "operating_margin": 0.25},
-                  "MSFT": {"roe": 0.15, "operating_margin": 0.10}}
+        scores = {"AAPL": {"roe": 0.30, "operating_margin": 0.25}, "MSFT": {"roe": 0.15, "operating_margin": 0.10}}
         df = pd.DataFrame(scores).T
         for col in ["roe", "operating_margin"]:
             valid = df[col].dropna()
@@ -57,8 +59,7 @@ class TestQualityDbRead:
         with get_db(db_path) as conn:
             for ticker, date, roe, margin in rows:
                 conn.execute(
-                    "INSERT OR REPLACE INTO fundamentals (ticker, date, roe, operating_margin)"
-                    " VALUES (?, ?, ?, ?)",
+                    "INSERT OR REPLACE INTO fundamentals (ticker, date, roe, operating_margin) VALUES (?, ?, ?, ?)",
                     (ticker, date, roe, margin),
                 )
 
@@ -79,8 +80,7 @@ class TestQualityDbRead:
         assert "quality_score" in df.columns
         # 핵심 회귀 방어: score 가 상수화되면 이 assert 가 깨진다
         assert df["quality_score"].nunique() > 1, (
-            "quality_score 가 상수 (이전 0.5 버그 재발) — "
-            "fundamentals read 로 source 가 되었는지 확인"
+            "quality_score 가 상수 (이전 0.5 버그 재발) — fundamentals read 로 source 가 되었는지 확인"
         )
         # NVDA (최고 ROE + margin) > AAPL > MSFT 순서 검증
         assert float(df.loc["NVDA", "quality_score"]) > float(df.loc["AAPL", "quality_score"])
@@ -120,6 +120,4 @@ class TestQualityDbRead:
                 )
             elif isinstance(node, ast.Import):
                 for alias in node.names:
-                    assert "openbb" not in alias.name.lower(), (
-                        f"quality.py `import {alias.name}` 재도입됨 (§2.3 위배)"
-                    )
+                    assert "openbb" not in alias.name.lower(), f"quality.py `import {alias.name}` 재도입됨 (§2.3 위배)"

--- a/tests/quant/test_factors_value.py
+++ b/tests/quant/test_factors_value.py
@@ -1,4 +1,6 @@
+# pyright: reportArgumentType=false
 """Tests for factors_value — split from test_quant_all.py."""
+
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -23,12 +25,12 @@ class TestValue:
 
     def test_empty_when_no_data(self, db_path_mp):
         from nuri.quant.factors.value import compute_value
+
         result = compute_value(tickers=["FAKE"])
         assert result.empty
 
     def test_normalization_logic(self):
-        scores = {"AAPL": {"pe_ratio": 15.0, "pb_ratio": 2.0},
-                  "MSFT": {"pe_ratio": 30.0, "pb_ratio": 5.0}}
+        scores = {"AAPL": {"pe_ratio": 15.0, "pb_ratio": 2.0}, "MSFT": {"pe_ratio": 30.0, "pb_ratio": 5.0}}
         df = pd.DataFrame(scores).T
         for col in ["pe_ratio", "pb_ratio"]:
             valid = df[col].dropna()
@@ -56,8 +58,7 @@ class TestValueDbRead:
         with get_db(db_path) as conn:
             for ticker, date, pe, pb in rows:
                 conn.execute(
-                    "INSERT OR REPLACE INTO fundamentals (ticker, date, pe_ratio, price_to_book)"
-                    " VALUES (?, ?, ?, ?)",
+                    "INSERT OR REPLACE INTO fundamentals (ticker, date, pe_ratio, price_to_book) VALUES (?, ?, ?, ?)",
                     (ticker, date, pe, pb),
                 )
 
@@ -68,8 +69,8 @@ class TestValueDbRead:
         self._seed_fundamentals(
             db_path_mp,
             [
-                ("AAPL", "2026-04-15", 15.0, 2.0),   # 저평가
-                ("MSFT", "2026-04-15", 30.0, 5.0),   # 중간
+                ("AAPL", "2026-04-15", 15.0, 2.0),  # 저평가
+                ("MSFT", "2026-04-15", 30.0, 5.0),  # 중간
                 ("NVDA", "2026-04-15", 60.0, 10.0),  # 고평가
             ],
         )
@@ -78,8 +79,7 @@ class TestValueDbRead:
         assert "value_score" in df.columns
         # 핵심 회귀 방어: score 가 상수화되면 이 assert 가 깨진다
         assert df["value_score"].nunique() > 1, (
-            "value_score 가 상수 (이전 0.5 버그 재발) — "
-            "fundamentals read 로 source 가 되었는지 확인"
+            "value_score 가 상수 (이전 0.5 버그 재발) — fundamentals read 로 source 가 되었는지 확인"
         )
         # 낮은 PE/PB = 높은 가치 스코어 (역수 정규화)
         assert float(df.loc["AAPL", "value_score"]) > float(df.loc["MSFT", "value_score"])
@@ -93,7 +93,7 @@ class TestValueDbRead:
             db_path_mp,
             [
                 ("AAPL", "2026-04-10", 100.0, 20.0),  # old (should be ignored)
-                ("AAPL", "2026-04-15", 15.0, 2.0),    # latest — 저평가
+                ("AAPL", "2026-04-15", 15.0, 2.0),  # latest — 저평가
                 ("MSFT", "2026-04-15", 30.0, 5.0),
             ],
         )
@@ -119,6 +119,4 @@ class TestValueDbRead:
                 )
             elif isinstance(node, ast.Import):
                 for alias in node.names:
-                    assert "openbb" not in alias.name.lower(), (
-                        f"value.py `import {alias.name}` 재도입됨 (§2.3 위배)"
-                    )
+                    assert "openbb" not in alias.name.lower(), f"value.py `import {alias.name}` 재도입됨 (§2.3 위배)"


### PR DESCRIPTION
## Summary

Continues #561 IDE diagnostic cleanup. New batch surfaced after the first landed.

### Pylance fixes (severity 8)
- `tests/core/test_pipeline_events.py`: `emit_event` returns `int | None` (sqlite3 lastrowid type) — guard with `is not None and >`.
- `tests/collectors/test_cboe.py`: `_extract_pcr` returns `float | None` — guard before arithmetic in 2 places.
- `tests/quant/test_factors_quality.py` + `test_factors_value.py`: pandas `.loc` returns `Scalar` (includes complex) — file-level `# pyright: reportArgumentType=false` (matches `nuri/trading/strategy/*` pragma pattern).
- `tests/collectors/test_kis_token_cache.py`: `MagicMock(**{"json.return_value": ...})` confuses Pylance — split into explicit `mock.json.return_value = ...` assignment.

### cspell additions (severity 2)
Test fixture identifiers (placeholder tickers + KIS API field names): CBOEY, CBOEDB, prdy, clpr, EHTC.

## Test plan
- [x] 87 / 87 affected tests pass
- [x] `make lint` — clean
- [ ] CI: lint + tests + privacy-scan + codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)