### PR TITLE
refactor(db): #566 P2 Stage 2 PR-A — db/ package + connection.py extract

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,13 +81,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // \"\"'); if [[ \"$FILE\" == */nuri/*.py && \"$FILE\" != */core/db.py ]]; then CONTENT=$(echo \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); if echo \"$CONTENT\" | grep -q 'import sqlite3'; then echo '{\"decision\":\"block\",\"reason\":\"sqlite3는 nuri/core/db.py만 import 가능. query()/query_df()/upsert_*() 사용.\"}'; exit 2; fi; fi",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // \"\"'); if [[ \"$FILE\" == */nuri/*.py && \"$FILE\" != */core/db.py && \"$FILE\" != */core/db/connection.py ]]; then CONTENT=$(echo \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); if echo \"$CONTENT\" | grep -q 'import sqlite3'; then echo '{\"decision\":\"block\",\"reason\":\"sqlite3는 nuri/core/db/connection.py만 import 가능 (PR #566 stage 2). query()/query_df()/upsert_*() 사용.\"}'; exit 2; fi; fi",
             "timeout": 5,
             "statusMessage": "sqlite3 import guard..."
           },
           {
             "type": "command",
-            "command": "INPUT=$(cat); [ -x .venv/bin/python ] && [ -f scripts/check_privacy_leak.py ] || exit 0; CONTENT=$(echo \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); [ -z \"$CONTENT\" ] && exit 0; OUT=$(echo \"$CONTENT\" | .venv/bin/python scripts/check_privacy_leak.py --message --quiet 2>&1); if [ $? -ne 0 ]; then printf '{\"decision\":\"block\",\"reason\":\"Privacy ticker+PnL leak detected (PR #202 signature). Findings: %s. See scripts/check_privacy_leak.py + STRATEGY §4.4.1. Use placeholders or round values.\"}' \"$(echo \"$OUT\" | head -3 | tr '\\n' ' ' | sed 's/\"/\\\\\"/g')\"; exit 2; fi",
+            "command": "INPUT=$(cat); [ -x .venv/bin/python ] && [ -f scripts/verify/check_privacy_leak.py ] || exit 0; CONTENT=$(echo \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); [ -z \"$CONTENT\" ] && exit 0; OUT=$(echo \"$CONTENT\" | .venv/bin/python scripts/verify/check_privacy_leak.py --message --quiet 2>&1); if [ $? -ne 0 ]; then printf '{\"decision\":\"block\",\"reason\":\"Privacy ticker+PnL leak detected (PR #202 signature). Findings: %s. See scripts/verify/check_privacy_leak.py + STRATEGY §4.4.1. Use placeholders or round values.\"}' \"$(echo \"$OUT\" | head -3 | tr '\\n' ' ' | sed 's/\"/\\\\\"/g')\"; exit 2; fi",
             "timeout": 5,
             "statusMessage": "privacy ticker+pnl check..."
           }

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -1,77 +1,30 @@
 """
 Nuri-Quant 데이터베이스 모듈 — 모든 DB 접근의 단일 진입점.
 
-다른 모듈에서 sqlite3를 직접 import하지 않는다.
+다른 모듈에서 sqlite3를 직접 import하지 않는다 (PreToolUse hook 차단).
 모든 DB 작업은 이 모듈의 함수를 통해서만 수행한다.
+
+Package layout (P2 Stage 2 — PR #566):
+    connection.py — sole sqlite3 importer + lifecycle (get_db, init_db, DB_PATH)
+    __init__.py   — facade: query/query_df/get_tickers + all writer functions
+                    (behavior modules to be extracted in follow-up commits)
 """
 
 import json
-import sqlite3
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
 import pandas as pd
 
-from nuri.core.db_migrations import _MIGRATIONS, _SCHEMA, _SCHEMA_VERSION_TABLE
+from nuri.core.db_migrations import _MIGRATIONS, _SCHEMA, _SCHEMA_VERSION_TABLE  # noqa: F401 — back-compat re-export
 
-DB_PATH = Path(__file__).parent.parent.parent.parent / "data" / "portfolio.db"
-
-# ═══════════════════════════════════════════════════════
-# 연결 관리
-# ═══════════════════════════════════════════════════════
-
-
-def get_connection(db_path: Optional[Path] = None) -> sqlite3.Connection:
-    """DB 연결 반환. WAL 모드, foreign keys 활성화."""
-    path = db_path or DB_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(path))
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA foreign_keys=ON")
-    conn.execute("PRAGMA busy_timeout=5000")
-    return conn
-
-
-@contextmanager
-def get_db(db_path: Optional[Path] = None):
-    """DB 컨텍스트 매니저. 성공 시 자동 commit, 실패 시 rollback."""
-    conn = get_connection(db_path)
-    try:
-        yield conn
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-    finally:
-        conn.close()
-
-
-# ═══════════════════════════════════════════════════════
-# 스키마 초기화
-# ═══════════════════════════════════════════════════════
-
-
-def init_db(db_path: Optional[Path] = None) -> None:
-    """전체 테이블 스키마 생성 + 증분 마이그레이션 적용."""
-    with get_db(db_path) as conn:
-        conn.executescript(_SCHEMA)
-        conn.executescript(_SCHEMA_VERSION_TABLE)
-        _apply_migrations(conn)
-
-
-def _apply_migrations(conn: sqlite3.Connection) -> None:
-    """미적용 마이그레이션을 순서대로 실행."""
-    applied = {row[0] for row in conn.execute("SELECT version FROM schema_version").fetchall()}
-    for version, desc, sql in _MIGRATIONS:
-        if version not in applied:
-            conn.executescript(sql)
-            conn.execute(
-                "INSERT INTO schema_version (version, description) VALUES (?, ?)",
-                (version, desc),
-            )
-            conn.commit()
+from .connection import (  # noqa: F401 — facade re-exports for back-compat
+    DB_PATH,
+    _apply_migrations,
+    get_connection,
+    get_db,
+    init_db,
+)
 
 
 def get_schema_version(db_path: Optional[Path] = None) -> int:

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from nuri.core.db_migrations import _MIGRATIONS, _SCHEMA, _SCHEMA_VERSION_TABLE
 
-DB_PATH = Path(__file__).parent.parent.parent / "data" / "portfolio.db"
+DB_PATH = Path(__file__).parent.parent.parent.parent / "data" / "portfolio.db"
 
 # ═══════════════════════════════════════════════════════
 # 연결 관리

--- a/nuri/core/db/connection.py
+++ b/nuri/core/db/connection.py
@@ -1,0 +1,89 @@
+"""sqlite3 connection lifecycle — sole sqlite3 importer in the codebase.
+
+PreToolUse hook (.claude/settings.json) blocks `import sqlite3` outside this
+file. All other modules must use `query()` / `query_df()` / `upsert_*()` /
+`get_db()` from `nuri.core.db` (the package facade re-exports these).
+
+Schema migrations live in `nuri/core/db_migrations.py` (PR #553 P2 Stage 1).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+from nuri.core.db_migrations import _MIGRATIONS, _SCHEMA, _SCHEMA_VERSION_TABLE
+
+# Repo root: nuri/core/db/connection.py → parents[3] = repo root
+DB_PATH = Path(__file__).parent.parent.parent.parent / "data" / "portfolio.db"
+
+
+def _resolve_db_path(db_path: Optional[Path]) -> Path:
+    """Lookup default DB_PATH from facade (nuri.core.db) so test monkeypatch
+    on `nuri.core.db.DB_PATH` continues to work post-Stage-2 split.
+
+    Tests do `monkeypatch.setattr(db_mod, "DB_PATH", tmp_path)`. Without this
+    indirection, get_connection would use connection.py's local DB_PATH and
+    bypass the patch. Cost: 1 attribute lookup per connection (~negligible).
+    """
+    if db_path is not None:
+        return db_path
+    from nuri.core import db as _facade
+
+    return _facade.DB_PATH
+
+
+def get_connection(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    """DB 연결 반환. WAL 모드, foreign keys 활성화."""
+    path = _resolve_db_path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+@contextmanager
+def get_db(db_path: Optional[Path] = None):
+    """DB 컨텍스트 매니저. 성공 시 자동 commit, 실패 시 rollback.
+
+    Resolves `get_connection` via the facade module so test conftest
+    `monkeypatch.setattr(db_mod, "get_connection", ...)` (e.g. tmpfs MEMORY
+    journal patch in tests/conftest.py) is honored post-Stage-2 split.
+    """
+    from nuri.core import db as _facade
+
+    conn = _facade.get_connection(db_path)
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def init_db(db_path: Optional[Path] = None) -> None:
+    """전체 테이블 스키마 생성 + 증분 마이그레이션 적용."""
+    with get_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+        conn.executescript(_SCHEMA_VERSION_TABLE)
+        _apply_migrations(conn)
+
+
+def _apply_migrations(conn: sqlite3.Connection) -> None:
+    """미적용 마이그레이션을 순서대로 실행."""
+    applied = {row[0] for row in conn.execute("SELECT version FROM schema_version").fetchall()}
+    for version, desc, sql in _MIGRATIONS:
+        if version not in applied:
+            conn.executescript(sql)
+            conn.execute(
+                "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+                (version, desc),
+            )
+            conn.commit()

--- a/tests/agents/test_discord_bot.py
+++ b/tests/agents/test_discord_bot.py
@@ -118,7 +118,7 @@ class TestRepoRoot:
         from nuri.agents.discord.bot import REPO_ROOT
 
         assert (REPO_ROOT / "Makefile").exists()
-        assert (REPO_ROOT / "nuri" / "core" / "db.py").exists()
+        assert (REPO_ROOT / "nuri" / "core" / "db" / "__init__.py").exists()  # Stage 2 package
 
 
 class TestMainRuntime:


### PR DESCRIPTION
## Summary

P2 Stage 2 PR-A: file→package transition + sqlite3 importer narrowed to `connection.py`. Stage 1 (PR #553) extracted `_MIGRATIONS` data; this PR extracts the connection lifecycle. Behavior module split (writers / queries / lookups) deferred to PR-B follow-up to keep commit count low and review surface small.

Codex consult: `data/llm_consults/2026-05-01_p2-db-split-stage2.md` (codex Round 1 layout, qwen agreement on facade strategy).

### What changed

| Path | Before | After |
|---|---|---|
| `nuri/core/db.py` | 1634 LOC monolith, sole sqlite3 importer | Removed |
| `nuri/core/db/__init__.py` | (new) | 1587 LOC facade — re-exports from connection + still owns 45 writer/lookup functions (next PR) |
| `nuri/core/db/connection.py` | (new) | 90 LOC — **sole sqlite3 importer**, DB_PATH, get_connection, get_db, init_db, _apply_migrations |
| `.claude/settings.json` sqlite3 hook | allowlist `*/core/db.py` | allowlist `*/core/db.py` + `*/core/db/connection.py` |
| `.claude/settings.json` privacy hook | `scripts/check_privacy_leak.py` | `scripts/verify/check_privacy_leak.py` (PR #557 drift) |

### Critical compat shims (test monkeypatch preservation)

Pre-split, `monkeypatch.setattr(db_mod, "DB_PATH", path)` and `setattr(db_mod, "get_connection", _test_connect)` worked because `get_connection()` read these from the same module scope. Post-split, the facade re-export is a separate binding from `connection.py`'s local. **Without shims: 99 tests failed.** Shims:
- `_resolve_db_path(db_path)` in `connection.py`: deferred lookup of `nuri.core.db.DB_PATH` via facade attribute access when `db_path` is None.
- `get_db()` body: resolves `get_connection` via `nuri.core.db.get_connection` (facade) instead of local — honors `tests/conftest.py::_force_no_wal` autouse MEMORY-journal patch.

### Performance

| Metric | Before | After |
|---|---|---|
| `import nuri.core.db` cold | 202ms | 208ms (+6ms, well under codex 230ms threshold) |
| Test count | 4464 | **4465** |

## Test plan
- [x] `make test-fast` — 4465/4465 pass
- [x] `make lint` — clean
- [x] `make typecheck` — 0 errors
- [x] Cold import time within budget
- [x] DB_PATH absolute resolves correctly
- [ ] CI: lint + tests + privacy-scan + codecov

## Follow-up (PR-B)

Codex commit 3 — extract 8 behavior submodules:
- `market_data.py` (upsert_prices/macro/signals/ark/news/macro_events + insert_events)
- `portfolio.py` (upsert_portfolio, replace_portfolio_account)
- `trades.py` (upsert_trade)
- `decisions.py` (upsert_decision/_evidence + insert_certification — #178)
- `audit.py` (log_external_llm_call + audit_log)
- `agent_runtime.py` (start/finish_agent_run, log_agent_audit, set_feature_flag, upsert_dr_replica, log_collector_run, log_agent_message)
- `research_ops.py` (Phase 2 actors — walkforward/regime/hypothesis/causal/foundation)
- `execution_ops.py` (Phase 2 — log_decision, log_decision_outcome, log_execution_block, incidents, drift_alert)

Keep at `__init__.py` root: `query`, `query_df`, `get_schema_version`, `get_tickers`, `get_latest_price`, `get_trades`, `get_decisions`, `get_decision_with_evidence`, `is_feature_enabled` (patch-sensitive read helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)