### PR TITLE
fix(thesis-query): scripts/llm_consult.py path drift after #557

### DIFF
--- a/nuri/llm/thesis_query.py
+++ b/nuri/llm/thesis_query.py
@@ -40,7 +40,7 @@ from nuri.core.timezone import today_kst
 logger = logging.getLogger(__name__)
 
 OUT_DIR = Path("data/thesis_query")
-LLM_CONSULT_SCRIPT = Path("scripts/llm_consult.py")
+LLM_CONSULT_SCRIPT = Path("scripts/dev/llm_consult.py")
 
 DEFAULT_QUESTION = "investment thesis (long/short/avoid) + portfolio implications"
 


### PR DESCRIPTION
## Summary
- \`nuri/llm/thesis_query.py:LLM_CONSULT_SCRIPT\` 가 \`scripts/llm_consult.py\` 를 참조했으나 #557 에서 \`scripts/dev/\` 로 이동됨
- \`make thesis ticker=X\` silent fail 하던 issue
- 1-line path fix

## Test plan
- [ ] \`make thesis ticker=NVDA question="test"\` 실제 실행 확인
- [ ] 기존 \`tests/llm/\` 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)