### PR TITLE
feat(discord): channel digest outbox — single-writer redesign (Codex Round 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flowchart TB
         E -. "agent weight drift (±30%)" .-> C
     end
 
-    DB[("SQLite WAL · 48 tables<br/>pipeline_events · certifications · audit trail")]:::sink
+    DB[("SQLite WAL · 49 tables<br/>pipeline_events · certifications · audit trail")]:::sink
 
     CFG -. policies .-> Pipeline
     Pipeline -. persist .-> DB

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,7 @@ data/
 
 ## Testing
 
-4,485 backend tests across 187 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+4,524 backend tests across 189 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,485 tests, 187 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,524 tests, 189 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/audit_ledger.py
+++ b/nuri/agents/actors/audit_ledger.py
@@ -250,8 +250,7 @@ class AuditLedger(Actor):
 
         # since_days 보다 오래된 row — sqlite julianday 기반 (datetime('now') 와 동일 격)
         old_rows_result = query(
-            "SELECT COUNT(*) AS n FROM agent_audit_ledger "
-            "WHERE julianday('now') - julianday(timestamp) > ?",
+            "SELECT COUNT(*) AS n FROM agent_audit_ledger WHERE julianday('now') - julianday(timestamp) > ?",
             (since_days,),
         )
         old_rows = int(old_rows_result[0]["n"]) if old_rows_result else 0
@@ -271,8 +270,7 @@ class AuditLedger(Actor):
             outcome = Outcome.WARN
         else:
             recommendation = (
-                f"PASS: total_rows {total_rows:,} ≤ max_rows {max_rows:,} "
-                f"(>{since_days}d: {old_rows:,} rows)."
+                f"PASS: total_rows {total_rows:,} ≤ max_rows {max_rows:,} (>{since_days}d: {old_rows:,} rows)."
             )
             outcome = Outcome.PASS
 
@@ -302,24 +300,24 @@ class AuditLedger(Actor):
 
     @staticmethod
     def _publish_incidents(output: dict[str, Any], run_id: str) -> None:
-        """retention_check BLOCK → INCIDENTS 채널 (RED)."""
+        """retention_check BLOCK → #incidents outbox stage (PR3 Codex Round 6)."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_incident
 
-            embed = {
-                "title": "Audit-Ledger BLOCK — DB bloat 위험",
-                "description": (
-                    f"total_rows: **{output['total_rows']:,}**\n"
-                    f"block_threshold: {output['block_threshold']:,}\n"
-                    f"max_rows: {output['max_rows']:,}\n\n"
-                    f"{output['recommendation']}"
-                ),
-                "color": 0xE74C3C,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • 즉시 archive 필요"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.INCIDENTS,
-                embed=embed,
+            stage_incident(
+                payload={
+                    "kind": "audit_ledger_block",
+                    "summary": (
+                        f"DB bloat BLOCK: total={output['total_rows']:,} > "
+                        f"threshold={output['block_threshold']:,}, immediate archive required"
+                    ),
+                    "total_rows": output["total_rows"],
+                    "block_threshold": output["block_threshold"],
+                    "max_rows": output["max_rows"],
+                    "recommendation": output["recommendation"],
+                },
+                priority="high",  # bloat block 은 즉시 surface
+                dedupe_key="audit_ledger_block",  # 1건만 (반복 alert 방지)
                 actor_name="audit-ledger",
                 run_id=run_id,
             )
@@ -328,24 +326,24 @@ class AuditLedger(Actor):
 
     @staticmethod
     def _publish_ops(output: dict[str, Any], run_id: str) -> None:
-        """retention_check WARN → OPS 채널 (AMBER)."""
+        """retention_check WARN → #ops outbox stage (PR3 Codex Round 6)."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_ops
 
-            embed = {
-                "title": "Audit-Ledger WARN — cleanup 권고",
-                "description": (
-                    f"total_rows: **{output['total_rows']:,}**\n"
-                    f"max_rows: {output['max_rows']:,}\n"
-                    f"older than {output['since_days']}d: {output['rows_older_than_n_days']:,}\n\n"
-                    f"{output['recommendation']}"
-                ),
-                "color": 0xF39C12,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • cleanup 권고"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.OPS,
-                embed=embed,
+            stage_ops(
+                payload={
+                    "kind": "audit_ledger_warn",
+                    "summary": (
+                        f"cleanup recommended: total={output['total_rows']:,}, "
+                        f"older than {output['since_days']}d = {output['rows_older_than_n_days']:,}"
+                    ),
+                    "total_rows": output["total_rows"],
+                    "max_rows": output["max_rows"],
+                    "since_days": output["since_days"],
+                    "rows_older_than_n_days": output["rows_older_than_n_days"],
+                    "recommendation": output["recommendation"],
+                },
+                dedupe_key="audit_ledger_warn",
                 actor_name="audit-ledger",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/brief_auditor.py
+++ b/nuri/agents/actors/brief_auditor.py
@@ -1,0 +1,301 @@
+"""BriefAuditor — Discord-as-dev-loop self-quality actor.
+
+Why this exists (2026-05-02 user escalation):
+사용자가 #brief 채널 screenshot 공유. NVDA 가 BUY → BUY → SELL 같은 conviction
+0.810 으로 같은 시간대 emit. 숫자만 dump 되고 가격/근거/충돌 surface 없음.
+사용자: "당신이 알아서 개발할 수 있는 형태로 디스코드를 활용해주세요."
+
+→ Discord 가 단순 출력 sink 가 아니라 **claude/codex 가 본인 emit 품질을
+self-audit 하고 개선 ticket 을 자동으로 #incidents 에 띄우는 dev loop** 가
+되게 함. 사용자는 #incidents 만 보면 다음 PR scope 가 추출됨.
+
+Phase 0 (이 모듈, deterministic only — ZERO LLM):
+    C1 conflict           — 같은 ticker BUY+SELL 24h 내 동시 emit
+    C2 noise              — 같은 ticker > 3 emit 24h 내
+    C3 identical_conv     — 최근 N emit 의 conviction 이 모두 동일 (broken scoring)
+
+Phase 1 (deferred):
+    C4 missing_price      — content_preview 에 $ 가 없음 (brief 포맷 결함)
+    LLM-based root cause  — codex 가 issue 의 의미 narrative
+    Auto-PR draft         — issue → PR scope yaml emit
+
+Hard constraint:
+    - 절대 매매 권고 X. 시스템 출력 quality 만 audit.
+    - 사용자 reaction (👍/👎) 학습 deferred — Discord bot read access 필요.
+    - 같은 issue_id 24h 내 1회만 emit (dedupe via incidents channel content_preview).
+
+Layer: B (deterministic computation on past audit data).
+
+Output gate:
+    PASS  — 0 issues found
+    WARN  — issues found and emitted (or already emitted within 24h)
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter, defaultdict
+from typing import Any, Optional
+
+from nuri.agents.base import Actor, ActorResult, Layer, Outcome, RunContext
+from nuri.core.db import query
+
+DEFAULT_AUDIT_HOURS = 24
+NOISE_THRESHOLD = 3  # 같은 ticker > 3 emit / 24h
+IDENTICAL_CONV_TOLERANCE = 1e-3  # conviction 차이 < 0.001 → identical
+IDENTICAL_CONV_MIN_SAMPLES = 5  # 최소 5 emit 이상에서만 검출
+
+# Issue type → suggested fix path (보고서에 surface)
+_SUGGESTED_FIX = {
+    "conflict": "nuri/agents/discord/brief_card.py — same-ticker BUY+SELL 합쳐서 CONFLICT card 1건만 emit",
+    "noise": "nuri/agents/actors/decision_compiler.py — 같은 ticker repeat-emit cooldown (last_emit_at + 6h 룰)",
+    "identical_conv": "nuri/agents/actors/decision_compiler.py:188 conviction 가중치 산출 검증 — 입력 변동성 부재 가능",
+}
+
+
+class BriefAuditor(Actor):
+    """Audit recent #brief decision emits and surface quality issues to #incidents.
+
+    Usage:
+        result = BriefAuditor().run({"hours": 24})
+        # → result.output["issues_emitted"] = N
+    """
+
+    name = "brief-auditor"
+    version = "0.1.0"
+    layer = Layer.B
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        hours = int(input_data.get("hours") or DEFAULT_AUDIT_HOURS)
+        db_path = input_data.get("db_path")
+
+        decisions = _fetch_recent_decisions(hours, db_path)
+
+        issues: list[dict[str, Any]] = []
+        issues.extend(_check_conflict(decisions))
+        issues.extend(_check_noise(decisions))
+        issues.extend(_check_identical_conv(decisions))
+
+        new_issues = _dedupe_recent(issues, hours, db_path)
+
+        emit_results = []
+        for issue in new_issues:
+            ok = _emit_incident(issue, ctx.run_id, db_path)
+            emit_results.append({"issue_id": issue["issue_id"], "ok": ok})
+
+        return ActorResult(
+            output={
+                "audit_hours": hours,
+                "decisions_audited": len(decisions),
+                "issues_found": len(issues),
+                "issues_emitted": len(new_issues),
+                "issues_dedupe_skipped": len(issues) - len(new_issues),
+                "issues": issues,
+                "emit_results": emit_results,
+            },
+            outcome=Outcome.WARN if new_issues else Outcome.PASS,
+            sample_n=len(decisions),
+            input_summary=f"audit {hours}h / {len(decisions)} decisions / {len(new_issues)} new issues",
+        )
+
+
+# ─── data layer ────────────────────────────────────────────────
+
+
+def _fetch_recent_decisions(hours: int, db_path: Optional[Any]) -> list[dict[str, Any]]:
+    """Read agent_decisions actually published to #brief within last N hours.
+
+    HOLD 는 #brief 발송 안 됨 — BUY/SELL 만 audit 대상.
+
+    status filter:
+        'emitted'    — 현재 활성
+        'superseded' — 이전에 발송 후 같은 ticker 의 새 emit 으로 덮어쓰여짐.
+                       발송 자체는 이미 일어났으므로 #brief 품질 audit 에 포함해야
+                       conflict / noise 가 정확히 잡힘.
+    """
+    rows = query(
+        """SELECT decision_id, ticker, action, conviction, created_at, run_id
+             FROM agent_decisions
+            WHERE status IN ('emitted','superseded')
+              AND action IN ('BUY','SELL')
+              AND created_at > datetime('now', ?)
+            ORDER BY created_at""",
+        (f"-{hours} hours",),
+        db_path=db_path,
+    )
+    return [dict(r) for r in rows]
+
+
+def _dedupe_recent(
+    issues: list[dict[str, Any]],
+    hours: int,
+    db_path: Optional[Any],
+) -> list[dict[str, Any]]:
+    """Drop issues whose dedupe_key was staged to outbox within last N hours.
+
+    Outbox dedupe_key 패턴 `brief_quality:<issue_id>` 로 조회. status 무관 (pending/sent/failed/dropped 모두) — 24h 내 1회만 surface.
+    """
+    if not issues:
+        return []
+    rows = query(
+        """SELECT dedupe_key FROM discord_outbox
+            WHERE channel = 'incidents'
+              AND dedupe_key IS NOT NULL
+              AND created_at > datetime('now', ?)""",
+        (f"-{hours} hours",),
+        db_path=db_path,
+    )
+    seen_keys = {r["dedupe_key"] for r in rows if r["dedupe_key"]}
+    return [i for i in issues if f"brief_quality:{i['issue_id']}" not in seen_keys]
+
+
+# ─── checks ───────────────────────────────────────────────────
+
+
+def _check_conflict(decisions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """C1: same ticker BUY + SELL within audit window."""
+    by_ticker: dict[str, set[str]] = defaultdict(set)
+    decisions_by_ticker: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for d in decisions:
+        by_ticker[d["ticker"]].add(d["action"])
+        decisions_by_ticker[d["ticker"]].append(d)
+
+    issues = []
+    for ticker, actions in by_ticker.items():
+        if "BUY" in actions and "SELL" in actions:
+            ticker_decisions = decisions_by_ticker[ticker]
+            issue_id = _make_issue_id("conflict", [ticker])
+            evidence_lines = [
+                f"  - {d['action']} {d['decision_id']} conv={d['conviction']:.3f} @ {d['created_at']}"
+                for d in ticker_decisions
+            ]
+            issues.append(
+                {
+                    "issue_id": issue_id,
+                    "type": "conflict",
+                    "affected": [ticker],
+                    "evidence": "\n".join(evidence_lines[:8]),  # 8개로 제한
+                    "n_decisions": len(ticker_decisions),
+                    "suggested_fix": _SUGGESTED_FIX["conflict"],
+                }
+            )
+    return issues
+
+
+def _check_noise(decisions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """C2: same ticker > NOISE_THRESHOLD emits in window."""
+    counts = Counter(d["ticker"] for d in decisions)
+    decisions_by_ticker: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for d in decisions:
+        decisions_by_ticker[d["ticker"]].append(d)
+
+    issues = []
+    for ticker, n in counts.items():
+        if n > NOISE_THRESHOLD:
+            issue_id = _make_issue_id("noise", [ticker])
+            ticker_decisions = decisions_by_ticker[ticker]
+            actions_seq = " → ".join(d["action"] for d in ticker_decisions[:8])
+            issues.append(
+                {
+                    "issue_id": issue_id,
+                    "type": "noise",
+                    "affected": [ticker],
+                    "evidence": f"  - {n} emits in window: {actions_seq}",
+                    "n_decisions": n,
+                    "suggested_fix": _SUGGESTED_FIX["noise"],
+                }
+            )
+    return issues
+
+
+def _check_identical_conv(decisions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """C3: all recent emits have identical conviction (broken scoring signal)."""
+    if len(decisions) < IDENTICAL_CONV_MIN_SAMPLES:
+        return []
+    convictions = [d["conviction"] for d in decisions]
+    spread = max(convictions) - min(convictions)
+    if spread >= IDENTICAL_CONV_TOLERANCE:
+        return []
+    affected_tickers = sorted({d["ticker"] for d in decisions})
+    issue_id = _make_issue_id("identical_conv", affected_tickers)
+    return [
+        {
+            "issue_id": issue_id,
+            "type": "identical_conv",
+            "affected": affected_tickers,
+            "evidence": (
+                f"  - {len(decisions)} emits, conviction spread={spread:.6f} "
+                f"(tolerance {IDENTICAL_CONV_TOLERANCE})\n"
+                f"  - sample: {convictions[0]:.6f} on tickers {affected_tickers[:6]}"
+            ),
+            "n_decisions": len(decisions),
+            "suggested_fix": _SUGGESTED_FIX["identical_conv"],
+        }
+    ]
+
+
+# ─── emit ─────────────────────────────────────────────────────
+
+
+def _make_issue_id(issue_type: str, affected: list[str]) -> str:
+    """Deterministic 12-char hash so dedupe survives re-runs.
+
+    Same issue_type + same affected ticker set → same id.
+    """
+    key = f"{issue_type}:{','.join(sorted(affected))}"
+    return hashlib.sha1(key.encode()).hexdigest()[:12]
+
+
+def _emit_incident(issue: dict[str, Any], run_id: str, db_path: Optional[Any]) -> bool:
+    """Stage incident to #incidents outbox (PR3 Codex Round 6).
+
+    Dispatcher 가 6h cron 마다 종합. dedupe_key 로 24h 내 중복 방지 (outbox 자체).
+    Legacy round-trip dedupe (agent_messages 의 `[issue=...]` prefix) 는 outbox
+    dedupe_key 로 대체.
+    """
+    try:
+        from nuri.agents.discord.outbox import stage_incident
+
+        stage_incident(
+            payload={
+                "kind": f"brief_quality_{issue['type']}",
+                "summary": (f"{issue['type'].upper()} on {','.join(issue['affected'][:3])}: n={issue['n_decisions']}"),
+                "issue_id": issue["issue_id"],
+                "affected": issue["affected"],
+                "evidence": issue["evidence"],
+                "suggested_fix": issue["suggested_fix"],
+            },
+            dedupe_key=f"brief_quality:{issue['issue_id']}",
+            actor_name="brief-auditor",
+            run_id=run_id,
+            db_path=db_path,
+        )
+        return True
+    except Exception:  # noqa: BLE001 — stage must not break audit
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.agents.actors.brief_auditor [--hours N]"""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="brief-auditor")
+    parser.add_argument("--hours", type=int, default=DEFAULT_AUDIT_HOURS)
+    args = parser.parse_args(argv)
+
+    result = BriefAuditor().run({"hours": args.hours})
+    print(
+        f"audited={result.output['decisions_audited']} "
+        f"found={result.output['issues_found']} "
+        f"emitted={result.output['issues_emitted']} "
+        f"deduped={result.output['issues_dedupe_skipped']}"
+    )
+    for i in result.output["issues"]:
+        print(f"  [{i['issue_id']}] {i['type']}: {','.join(i['affected'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/agents/actors/causal_factor_auditor.py
+++ b/nuri/agents/actors/causal_factor_auditor.py
@@ -492,24 +492,22 @@ class CausalFactorAuditor(Actor):
         run_id: str,
     ) -> None:
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_rollout
 
-            embed = {
-                "title": f"Factor MIRAGE detected — {factor_id}",
-                "description": (
-                    f"as_of_date: `{as_of_date}`\n"
-                    f"causal_certainty: **{certainty:.3f}**\n"
-                    f"placebo_t_ratio: **{placebo.get('placebo_t_ratio', 0):.3f}** "
-                    f"(cutoff {PLACEBO_T_RATIO_MIRAGE_CUTOFF})\n"
-                    f"origin_t_stat: {placebo.get('origin_t_stat', 0):.3f}, "
-                    f"placebo_p95: {placebo.get('placebo_p95_t_stat', 0):.3f}"
-                ),
-                "color": 0xE74C3C,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]}"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.ROLLOUT,
-                embed=embed,
+            stage_rollout(
+                payload={
+                    "kind": "factor_mirage",
+                    "summary": (
+                        f"MIRAGE {factor_id} @ {as_of_date}: "
+                        f"certainty={certainty:.2f}, "
+                        f"placebo_t_ratio={placebo.get('placebo_t_ratio', 0):.2f}"
+                    ),
+                    "factor_id": factor_id,
+                    "as_of_date": as_of_date,
+                    "certainty": certainty,
+                    "placebo_t_ratio": placebo.get("placebo_t_ratio"),
+                },
+                dedupe_key=f"mirage:{factor_id}:{as_of_date}",
                 actor_name="causal-factor-auditor",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/channel_dispatcher.py
+++ b/nuri/agents/actors/channel_dispatcher.py
@@ -1,0 +1,204 @@
+"""ChannelDispatcher — single-writer Discord dispatcher (Codex Round 6, 2026-05-02).
+
+Why this exists (사용자 통증 2026-05-02):
+#brief 채널에 NVDA BUY/BUY/SELL 같은 conviction 으로 따로 발송 → 노이즈 폭발.
+Codex 권고: per-event publish 패턴 폐기, dispatcher 가 outbox 의 pending event 들을
+종합해서 1 embed 만 발송 (single-writer 패턴).
+
+Layer: B (deterministic aggregation, ZERO LLM).
+
+흐름:
+    1. claim_pending_outbox(channel) — lease + claim_token 으로 atomically pending 픽업
+    2. quiet-period gate (#brief 만): 마지막 stage 이후 60s 미경과 면 skip ("아직 더 올 수 있음")
+    3. payload list → bucket_brief_digest() / bucket_generic_digest() 로 1 embed
+    4. DiscordPublisher.publish_embed → success → mark_outbox_sent
+                                       failure → mark_outbox_failed (재시도 가능)
+
+Quiet-period (Codex 권고):
+    daily cron 이 아니라 run-scoped flush. 마지막 #brief stage 이후 QUIET_PERIOD_SECONDS
+    (60s) 동안 새 stage 가 없으면 "사용자가 받아도 되는 시점" 으로 판단해 dispatch.
+    cron 은 단지 polling — 1분마다 깨어나서 quiet-period 체크.
+
+#ops / #incidents / #rollout 은 quiet-period 무시하고 cron 주기마다 무조건 dispatch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from nuri.agents.base import Actor, ActorResult, Layer, Outcome, RunContext
+from nuri.agents.discord.outbox import bucket_brief_digest, bucket_generic_digest
+from nuri.core.db import (
+    claim_pending_outbox,
+    mark_outbox_failed,
+    mark_outbox_sent,
+    query,
+)
+
+# #brief 의 quiet-period — 마지막 stage 이후 N초 동안 새 stage 없을 때만 dispatch.
+QUIET_PERIOD_SECONDS = 60
+
+# 1회 dispatch 당 최대 events. embed 가 너무 커지지 않게.
+MAX_EVENTS_PER_DIGEST = 50
+
+_CHANNEL_LABELS = {
+    "brief": "Brief",
+    "ops": "Ops",
+    "incidents": "Incidents",
+    "rollout": "Research Rollout",
+}
+
+
+def _last_stage_age_seconds(channel: str, db_path: Optional[Any]) -> Optional[int]:
+    """가장 최근 pending row 의 created_at 으로부터 경과 초. row 없으면 None."""
+    rows = query(
+        """SELECT CAST((julianday('now') - julianday(MAX(created_at))) * 86400 AS INTEGER) AS age_s
+             FROM discord_outbox
+            WHERE channel = ? AND status = 'pending'""",
+        (channel,),
+        db_path=db_path,
+    )
+    if not rows:
+        return None
+    val = rows[0]["age_s"]
+    return int(val) if val is not None else None
+
+
+def _has_high_priority_pending(channel: str, db_path: Optional[Any]) -> bool:
+    """high priority pending 이 1건이라도 있으면 quiet-period bypass."""
+    rows = query(
+        """SELECT 1 FROM discord_outbox
+            WHERE channel = ? AND status = 'pending' AND priority = 'high'
+            LIMIT 1""",
+        (channel,),
+        db_path=db_path,
+    )
+    return bool(rows)
+
+
+class ChannelDispatcher(Actor):
+    """Dispatch one channel's pending outbox to Discord as ONE digest embed.
+
+    Usage:
+        ChannelDispatcher().run({"channel": "brief"})
+    """
+
+    name = "channel-dispatcher"
+    version = "0.1.0"
+    layer = Layer.B
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        channel = input_data.get("channel")
+        if channel not in ("brief", "ops", "incidents", "rollout"):
+            raise ValueError(f"channel must be brief/ops/incidents/rollout, got {channel!r}")
+        db_path = input_data.get("db_path")
+        force = bool(input_data.get("force", False))
+
+        # Quiet-period gate (#brief only)
+        if channel == "brief" and not force:
+            if not _has_high_priority_pending(channel, db_path):
+                age = _last_stage_age_seconds(channel, db_path)
+                if age is not None and age < QUIET_PERIOD_SECONDS:
+                    return ActorResult(
+                        output={
+                            "channel": channel,
+                            "skipped": "quiet-period",
+                            "last_stage_age_seconds": age,
+                            "threshold": QUIET_PERIOD_SECONDS,
+                        },
+                        outcome=Outcome.PASS,
+                        input_summary=f"dispatch {channel} skipped quiet-period age={age}s",
+                    )
+
+        # Claim
+        claim_token, claimed = claim_pending_outbox(channel, limit=MAX_EVENTS_PER_DIGEST, db_path=db_path)
+        if not claimed:
+            return ActorResult(
+                output={"channel": channel, "skipped": "no-pending"},
+                outcome=Outcome.PASS,
+                input_summary=f"dispatch {channel} nothing pending",
+            )
+
+        ids = [r["id"] for r in claimed]
+        payloads = [r["payload"] for r in claimed]
+
+        # Compose 1 embed
+        if channel == "brief":
+            embed = bucket_brief_digest(payloads)
+        else:
+            embed = bucket_generic_digest(payloads, channel_label=_CHANNEL_LABELS[channel])
+
+        # Send
+        try:
+            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+
+            result = DiscordPublisher().publish_embed(
+                Channel(channel),
+                embed=embed,
+                actor_name=self.name,
+                run_id=ctx.run_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — webhook missing / module load
+            mark_outbox_failed(ids, claim_token, error=f"publish exception: {exc!r}", db_path=db_path)
+            return ActorResult(
+                output={
+                    "channel": channel,
+                    "claimed_n": len(ids),
+                    "error": str(exc)[:200],
+                },
+                outcome=Outcome.ERROR,
+                sample_n=len(ids),
+                input_summary=f"dispatch {channel} failed exc",
+            )
+
+        if result.ok:
+            n_sent = mark_outbox_sent(ids, claim_token, db_path=db_path)
+            return ActorResult(
+                output={
+                    "channel": channel,
+                    "claimed_n": len(ids),
+                    "marked_sent_n": n_sent,
+                    "http_status": result.http_status,
+                },
+                outcome=Outcome.PASS,
+                sample_n=len(ids),
+                input_summary=f"dispatch {channel} sent={n_sent}",
+            )
+        else:
+            mark_outbox_failed(
+                ids,
+                claim_token,
+                error=result.error or f"HTTP {result.http_status}",
+                db_path=db_path,
+            )
+            return ActorResult(
+                output={
+                    "channel": channel,
+                    "claimed_n": len(ids),
+                    "http_status": result.http_status,
+                    "error": result.error,
+                },
+                outcome=Outcome.WARN,
+                sample_n=len(ids),
+                input_summary=f"dispatch {channel} failed http={result.http_status}",
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.agents.actors.channel_dispatcher <channel> [--force]"""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="channel-dispatcher")
+    parser.add_argument("channel", choices=["brief", "ops", "incidents", "rollout"])
+    parser.add_argument("--force", action="store_true", help="bypass quiet-period gate")
+    args = parser.parse_args(argv)
+
+    result = ChannelDispatcher().run({"channel": args.channel, "force": args.force})
+    print(f"{args.channel}: {result.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/agents/actors/collector_orchestrator.py
+++ b/nuri/agents/actors/collector_orchestrator.py
@@ -246,11 +246,7 @@ class CollectorOrchestrator(Actor):
     ) -> ActorResult:
         """orchestrate finished 케이스 — under-fetch 판정 + Outcome 결정."""
         # under-fetch: expected_rows 가 주어지면 90% threshold.
-        warn_under_fetch = (
-            expected_rows is not None
-            and expected_rows > 0
-            and rows_collected < expected_rows * 0.9
-        )
+        warn_under_fetch = expected_rows is not None and expected_rows > 0 and rows_collected < expected_rows * 0.9
         if warn_under_fetch:
             outcome = Outcome.WARN
             self._publish_orchestrate_failure(
@@ -454,30 +450,23 @@ class CollectorOrchestrator(Actor):
         attempts: int,
         run_id: str,
     ) -> None:
-        """Final orchestrate failure → OPS 채널. 예외 발생해도 audit 영향 없음."""
+        """Final orchestrate failure → #ops outbox stage (PR3 Codex Round 6)."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_ops
 
-            description = (
-                f"collector: **{collector_name}**\n"
-                f"attempts: {attempts}\n"
-                f"error: ```\n{error[:300]}\n```"
-            )
-            embed = {
-                "title": "Collector orchestrate failed",
-                "description": description,
-                "color": 0xF39C12,  # AMBER
-                "footer": {
-                    "text": f"nuri-quant • run_id={run_id[:8]} • Collector-Orchestrator"
+            stage_ops(
+                payload={
+                    "kind": "collector_failure",
+                    "summary": (f"{collector_name} failed after {attempts} attempts: {error[:120]}"),
+                    "collector_name": collector_name,
+                    "attempts": attempts,
+                    "error": error[:300],
                 },
-            }
-            DiscordPublisher().publish_embed(
-                Channel.OPS,
-                embed=embed,
+                dedupe_key=f"collector_failure:{collector_name}",
                 actor_name="collector-orchestrator",
                 run_id=run_id,
             )
-        except Exception:  # noqa: BLE001 — publish 실패는 audit 무관.
+        except Exception:  # noqa: BLE001
             pass
 
     @staticmethod
@@ -487,55 +476,48 @@ class CollectorOrchestrator(Actor):
         hours: int,
         run_id: str,
     ) -> None:
-        """scan_health WARN → OPS, BLOCK → INCIDENTS. info 는 publish X."""
+        """scan_health WARN → #ops, BLOCK → #incidents (PR3 Codex Round 6). info 는 publish X."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_incident, stage_ops
 
             unhealthy = [s for s in summaries if s["health_status"] == "unhealthy"]
             if outcome == Outcome.BLOCK:
-                channel = Channel.INCIDENTS
-                color = 0xE74C3C
-                title = f"Collector health CATASTROPHIC ({len(unhealthy)}/{len(summaries)} unhealthy)"
+                stage_fn = stage_incident
+                kind = "collector_health_catastrophic"
             elif outcome == Outcome.WARN:
-                channel = Channel.OPS
-                color = 0xF39C12
-                title = f"Collector health WARN ({len(unhealthy)}/{len(summaries)} unhealthy)"
+                stage_fn = stage_ops
+                kind = "collector_health_warn"
             else:
                 return
 
-            unhealthy_lines = "\n".join(
-                f"- **{s['collector_name']}** pass_rate={s['pass_rate']:.1%} "
-                f"runs={s['total_runs']} last={s['last_status']}"
-                for s in unhealthy[:10]
-            )
-            description = (
-                f"window: last **{hours}h**\n"
-                f"unhealthy collectors:\n{unhealthy_lines or '(none)'}"
-            )
-            embed = {
-                "title": title,
-                "description": description,
-                "color": color,
-                "footer": {
-                    "text": f"nuri-quant • run_id={run_id[:8]} • Collector-Orchestrator"
+            unhealthy_names = ",".join(s["collector_name"] for s in unhealthy[:5])
+            stage_fn(
+                payload={
+                    "kind": kind,
+                    "summary": (f"{len(unhealthy)}/{len(summaries)} unhealthy in {hours}h: {unhealthy_names}"),
+                    "hours": hours,
+                    "unhealthy": [
+                        {
+                            "name": s["collector_name"],
+                            "pass_rate": s["pass_rate"],
+                            "runs": s["total_runs"],
+                            "last_status": s["last_status"],
+                        }
+                        for s in unhealthy[:10]
+                    ],
                 },
-            }
-            DiscordPublisher().publish_embed(
-                channel,
-                embed=embed,
+                dedupe_key=f"collector_health:{kind}",
                 actor_name="collector-orchestrator",
                 run_id=run_id,
             )
-        except Exception:  # noqa: BLE001 — best-effort.
+        except Exception:  # noqa: BLE001
             pass
 
 
 # ─── helpers ───────────────────────────────────────────────
 
 
-def make_collector_fn(
-    fn: Callable[..., Any], *args: Any, **kwargs: Any
-) -> Callable[[], Any]:
+def make_collector_fn(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Callable[[], Any]:
     """편의 wrapper — 기존 collector 함수를 zero-arg 형태로 변환.
 
     e.g. `make_collector_fn(fetch_prices, tickers=['AAPL'])`.

--- a/nuri/agents/actors/decision_compiler.py
+++ b/nuri/agents/actors/decision_compiler.py
@@ -393,47 +393,47 @@ class DecisionCompiler(Actor):
         rationale: dict,
         run_id: str,
     ) -> None:
-        """emit 된 decision → BRIEF 채널 (사용자 추천)."""
-        try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+        """emit 된 decision → #brief outbox stage (Codex Round 6, 2026-05-02).
 
-            color = 0x2ECC71 if action == "BUY" else 0xE74C3C if action == "SELL" else 0x95A5A6
-            embed = {
-                "title": f"{action} — {ticker}",
-                "description": (
-                    f"decision_id: `{decision_id}`\n"
-                    f"conviction: **{conviction:.3f}**\n"
-                    f"causal: {rationale.get('causal_certainty', 0):.3f} · "
-                    f"regime_top: {rationale.get('regime_top_prob', 0):.3f} · "
-                    f"margin: {rationale.get('top2_margin', 0):.3f}"
-                ),
-                "color": color,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • emit only, manual execute"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.BRIEF,
-                embed=embed,
+        ChannelDispatcher 가 quiet-period (60s) 후 종합 1 embed 발송.
+        per-event direct publish 패턴 폐기 — 사용자 통증 (NVDA BUY/BUY/SELL noise).
+        """
+        try:
+            from nuri.agents.discord.outbox import stage_brief
+
+            stage_brief(
+                payload={
+                    "kind": action,
+                    "ticker": ticker,
+                    "conviction": conviction,
+                    "regime": f"top {rationale.get('regime_top_prob', 0):.2f}",
+                    "causal": f"{rationale.get('causal_certainty', 0):.2f}",
+                    "decision_id": decision_id,
+                    "margin": f"{rationale.get('top2_margin', 0):.2f}",
+                },
+                # 같은 decision 이 retry 로 두 번 stage 되어도 1건만 — decision_id 가 dedupe key
+                dedupe_key=f"decision:{decision_id}",
                 actor_name="decision-compiler",
                 run_id=run_id,
             )
-        except Exception:  # noqa: BLE001 — best-effort
+        except Exception:  # noqa: BLE001 — outbox stage failure must not break decision pipeline
             pass
 
     @staticmethod
     def _publish_block(decision_id: str, ticker: str, reason: str, run_id: str) -> None:
-        """blocked decision → OPS 채널 (operator alert)."""
+        """blocked decision → #ops outbox stage (PR3 Codex Round 6)."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_ops
 
-            embed = {
-                "title": f"Decision BLOCKED — {ticker}",
-                "description": (f"decision_id: `{decision_id}`\nreason: {reason}"),
-                "color": 0xF39C12,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]}"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.OPS,
-                embed=embed,
+            stage_ops(
+                payload={
+                    "kind": "decision_blocked",
+                    "ticker": ticker,
+                    "summary": f"{ticker} BLOCKED — {reason} (decision_id={decision_id})",
+                    "decision_id": decision_id,
+                    "reason": reason,
+                },
+                dedupe_key=f"block:{decision_id}",
                 actor_name="decision-compiler",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/drift_sentinel.py
+++ b/nuri/agents/actors/drift_sentinel.py
@@ -125,7 +125,7 @@ def _compute_ks(baseline: np.ndarray, current: np.ndarray) -> float:
         from scipy.stats import ks_2samp
 
         result = ks_2samp(baseline, current)
-        return float(result.statistic)
+        return float(result.statistic)  # type: ignore[union-attr]
     except Exception:  # noqa: BLE001 — scipy 부재 또는 numerical issue
         # fallback: empirical CDF 비교 (numpy only)
         combined = np.sort(np.concatenate([baseline, current]))
@@ -308,10 +308,7 @@ class DriftSentinel(Actor):
 
         if baseline.ndim != 1 or current.ndim != 1:
             return ActorResult(
-                output={
-                    "error": f"baseline/current must be 1-D, got shapes "
-                    f"{baseline.shape} / {current.shape}"
-                },
+                output={"error": f"baseline/current must be 1-D, got shapes {baseline.shape} / {current.shape}"},
                 outcome=Outcome.BLOCK,
                 input_summary=f"check {feature_name}",
             )
@@ -493,34 +490,34 @@ class DriftSentinel(Actor):
         actor_name: Optional[str],
         run_id: str,
     ) -> None:
-        """critical → INCIDENTS (RED), major → OPS (AMBER). minor/stable publish X."""
+        """critical → #incidents, major → #ops outbox (PR3 Codex Round 6). minor/stable X."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_incident, stage_ops
 
             if severity == "critical":
-                channel = Channel.INCIDENTS
-                color = 0xE74C3C  # RED
+                stage_fn = stage_incident
+                priority = "high"
             elif severity == "major":
-                channel = Channel.OPS
-                color = 0xF39C12  # AMBER
+                stage_fn = stage_ops
+                priority = "normal"
             else:
                 return
 
-            embed = {
-                "title": f"Drift detected — {feature_name} ({test_type.upper()})",
-                "description": (
-                    f"feature: **{feature_name}**\n"
-                    f"actor: **{actor_name or 'n/a'}**\n"
-                    f"test: **{test_type.upper()}**\n"
-                    f"statistic: **{statistic:.4f}** (threshold {threshold:.4f})\n"
-                    f"severity: **{severity}**"
-                ),
-                "color": color,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • Drift-Sentinel"},
-            }
-            DiscordPublisher().publish_embed(
-                channel,
-                embed=embed,
+            stage_fn(
+                payload={
+                    "kind": f"drift_{severity}",
+                    "summary": (
+                        f"{feature_name} ({test_type.upper()}) stat={statistic:.4f} > {threshold:.4f} ({severity})"
+                    ),
+                    "feature": feature_name,
+                    "actor": actor_name,
+                    "test_type": test_type,
+                    "statistic": statistic,
+                    "threshold": threshold,
+                    "severity": severity,
+                },
+                priority=priority,
+                dedupe_key=f"drift:{feature_name}:{test_type}:{severity}",
                 actor_name="drift-sentinel",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/execution_firewall.py
+++ b/nuri/agents/actors/execution_firewall.py
@@ -403,22 +403,22 @@ class ExecutionFirewall(Actor):
         blocks: list[dict[str, Any]],
         run_id: str,
     ) -> None:
+        """Hard-veto execution block → #incidents outbox stage (PR3 Codex Round 6)."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_incident
 
-            block_types = ", ".join(b["type"] for b in blocks)
-            description = f"decision_id: `{decision_id}`\nblocks: **{block_types}**\n"
-            for b in blocks[:5]:
-                description += f"\n• {b['reason']}"
-            embed = {
-                "title": f"Execution BLOCK — {ticker}",
-                "description": description,
-                "color": 0xE74C3C,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • emit 차단됨"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.INCIDENTS,
-                embed=embed,
+            block_types = ",".join(b["type"] for b in blocks)
+            stage_incident(
+                payload={
+                    "kind": "execution_block",
+                    "ticker": ticker,
+                    "summary": f"{ticker} EXEC BLOCK [{block_types}] decision_id={decision_id}",
+                    "decision_id": decision_id,
+                    "blocks": blocks[:5],
+                    "block_types": block_types,
+                },
+                priority="high",  # hard-veto = 즉시 surface
+                dedupe_key=f"exec_block:{decision_id}",
                 actor_name="execution-firewall",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/forward_outcome_tracker.py
+++ b/nuri/agents/actors/forward_outcome_tracker.py
@@ -429,22 +429,21 @@ class ForwardOutcomeTracker(Actor):
         run_id: str,
     ) -> None:
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_rollout
 
-            color = 0x2ECC71 if new_status == "validated" else 0xE74C3C
-            embed = {
-                "title": f"Hypothesis auto-{new_status} — {hypothesis_id}",
-                "description": (
-                    f"trigger: forward-outcome-tracker\n"
-                    f"realized_return: **{realized:.4f}**\n"
-                    f"alpha: {alpha if alpha is not None else 'N/A'}"
-                ),
-                "color": color,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]}"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.ROLLOUT,
-                embed=embed,
+            stage_rollout(
+                payload={
+                    "kind": f"hypothesis_{new_status}",
+                    "summary": (
+                        f"{hypothesis_id} → {new_status} "
+                        f"realized={realized:+.4f} alpha={alpha if alpha is not None else 'N/A'}"
+                    ),
+                    "hypothesis_id": hypothesis_id,
+                    "new_status": new_status,
+                    "realized": realized,
+                    "alpha": alpha,
+                },
+                dedupe_key=f"hyp_validation:{hypothesis_id}:{new_status}",
                 actor_name="forward-outcome-tracker",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/foundation_benchmark.py
+++ b/nuri/agents/actors/foundation_benchmark.py
@@ -73,7 +73,12 @@ class FoundationBenchmark(Actor):
     VALID_ACTIONS: tuple[str, ...] = ("benchmark", "compare", "list_runs")
     VALID_KINDS: tuple[str, ...] = ("baseline", "foundation", "traditional")
     VALID_METRICS: tuple[str, ...] = (
-        "brier", "logloss", "sharpe", "mse", "mae", "hit_rate",
+        "brier",
+        "logloss",
+        "sharpe",
+        "mse",
+        "mae",
+        "hit_rate",
     )
 
     def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
@@ -140,9 +145,7 @@ class FoundationBenchmark(Actor):
             )
 
         # higher_is_better 기본값 (caller override 가능)
-        higher_is_better = bool(
-            input_data.get("higher_is_better", _DEFAULT_HIGHER_IS_BETTER[metric_name])
-        )
+        higher_is_better = bool(input_data.get("higher_is_better", _DEFAULT_HIGHER_IS_BETTER[metric_name]))
 
         try:
             benchmark_id = log_foundation_benchmark(
@@ -239,12 +242,14 @@ class FoundationBenchmark(Actor):
         any_significant_foundation_win = False
         for metric_name, group in per_metric.items():
             if len(group) < 2:
-                comparisons.append({
-                    "metric_name": metric_name,
-                    "n_models": len(group),
-                    "verdict": "insufficient_models",
-                    "models": group,
-                })
+                comparisons.append(
+                    {
+                        "metric_name": metric_name,
+                        "n_models": len(group),
+                        "verdict": "insufficient_models",
+                        "models": group,
+                    }
+                )
                 continue
             higher_is_better = bool(group[0]["higher_is_better"])
             ranked = sorted(
@@ -255,26 +260,26 @@ class FoundationBenchmark(Actor):
             winner = ranked[0]
             runner = ranked[1]
             # baseline vs foundation 비교 — foundation 이 winner 이고 baseline runner 면 delta 산출
-            delta = self._relative_improvement(
-                winner["metric_value"], runner["metric_value"], higher_is_better
-            )
+            delta = self._relative_improvement(winner["metric_value"], runner["metric_value"], higher_is_better)
             verdict = self._verdict(winner, runner, delta)
             if verdict == "foundation_wins_significantly":
                 any_significant_foundation_win = True
-            comparisons.append({
-                "metric_name": metric_name,
-                "n_models": len(group),
-                "winner_model_id": winner["model_id"],
-                "winner_kind": winner["model_kind"],
-                "winner_value": winner["metric_value"],
-                "runner_model_id": runner["model_id"],
-                "runner_kind": runner["model_kind"],
-                "runner_value": runner["metric_value"],
-                "delta_relative": delta,
-                "higher_is_better": higher_is_better,
-                "verdict": verdict,
-                "ranked_models": ranked,
-            })
+            comparisons.append(
+                {
+                    "metric_name": metric_name,
+                    "n_models": len(group),
+                    "winner_model_id": winner["model_id"],
+                    "winner_kind": winner["model_kind"],
+                    "winner_value": winner["metric_value"],
+                    "runner_model_id": runner["model_id"],
+                    "runner_kind": runner["model_kind"],
+                    "runner_value": runner["metric_value"],
+                    "delta_relative": delta,
+                    "higher_is_better": higher_is_better,
+                    "verdict": verdict,
+                    "ranked_models": ranked,
+                }
+            )
 
         # 단 1개 model 만 등록된 경우 (모든 metric 그룹이 insufficient_models) → WARN
         all_insufficient = all(c["verdict"] == "insufficient_models" for c in comparisons)
@@ -298,9 +303,7 @@ class FoundationBenchmark(Actor):
         )
 
     @staticmethod
-    def _relative_improvement(
-        winner_val: float, runner_val: float, higher_is_better: bool
-    ) -> float:
+    def _relative_improvement(winner_val: float, runner_val: float, higher_is_better: bool) -> float:
         """winner 가 runner 대비 얼마나 우수한가 — relative pct (0.10 = 10% 개선).
 
         higher_is_better=True 일 때: (winner - runner) / |runner|
@@ -380,28 +383,18 @@ class FoundationBenchmark(Actor):
     ) -> None:
         """foundation 우수 시 ROLLOUT 채널에 promotion 권고. 실패해도 actor outcome 영향 X."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_rollout
 
             wins = [c for c in comparisons if c.get("verdict") == "foundation_wins_significantly"]
-            lines = []
-            for c in wins:
-                lines.append(
-                    f"- **{c['metric_name']}**: {c['winner_model_id']} "
-                    f"({c['winner_value']:.4f}) > {c['runner_model_id']} "
-                    f"({c['runner_value']:.4f}) — Δ {c['delta_relative'] * 100:.1f}%"
-                )
-            embed = {
-                "title": f"Foundation model win — {benchmark_run}",
-                "description": (
-                    "Consider promotion — foundation model significantly outperforms baseline "
-                    f"on {len(wins)} metric(s):\n" + "\n".join(lines)
-                ),
-                "color": 0x2ECC71,
-                "footer": {"text": f"nuri-quant • foundation-benchmark • run_id={run_id[:8]}"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.ROLLOUT,
-                embed=embed,
+            metrics = ",".join(c["metric_name"] for c in wins)
+            stage_rollout(
+                payload={
+                    "kind": "foundation_promotion",
+                    "summary": (f"foundation wins {len(wins)} metric(s) on {benchmark_run}: {metrics}"),
+                    "benchmark_run": benchmark_run,
+                    "wins": wins,
+                },
+                dedupe_key=f"foundation_promotion:{benchmark_run}",
                 actor_name="foundation-benchmark",
                 run_id=run_id,
             )
@@ -418,9 +411,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("action", choices=["benchmark", "compare", "list_runs"])
     parser.add_argument("--benchmark-run", default=None)
     parser.add_argument("--model-id", default=None)
-    parser.add_argument(
-        "--model-kind", default="baseline", choices=["baseline", "foundation", "traditional"]
-    )
+    parser.add_argument("--model-kind", default="baseline", choices=["baseline", "foundation", "traditional"])
     parser.add_argument(
         "--metric-name",
         default="brier",

--- a/nuri/agents/actors/hypothesis_registry.py
+++ b/nuri/agents/actors/hypothesis_registry.py
@@ -284,30 +284,28 @@ class HypothesisRegistry(Actor):
         publish 실패해도 actor outcome 영향 X (best-effort).
         """
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_rollout
 
-            color = 0x2ECC71 if new_status == "validated" else 0xE74C3C
-            description_parts = [
-                f"hypothesis_id: `{hypothesis_id}`",
-                f"status: **{new_status}**",
-            ]
+            metrics_str = ""
             if "metrics" in extra:
-                metrics_preview = ", ".join(
+                metrics_str = ", ".join(
                     f"{k}={v:.4f}" if isinstance(v, float) else f"{k}={v}"
                     for k, v in list(extra["metrics"].items())[:5]
                 )
-                description_parts.append(f"metrics: `{metrics_preview}`")
-            if "reason" in extra:
-                description_parts.append(f"reason: {extra['reason']}")
-            embed = {
-                "title": f"Hypothesis {new_status} — {hypothesis_id}",
-                "description": "\n".join(description_parts),
-                "color": color,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]}"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.ROLLOUT,
-                embed=embed,
+            stage_rollout(
+                payload={
+                    "kind": f"hypothesis_{new_status}",
+                    "summary": (
+                        f"{hypothesis_id} → {new_status}"
+                        + (f" [{metrics_str}]" if metrics_str else "")
+                        + (f" reason={extra['reason']}" if extra.get("reason") else "")
+                    ),
+                    "hypothesis_id": hypothesis_id,
+                    "new_status": new_status,
+                    "metrics": extra.get("metrics"),
+                    "reason": extra.get("reason"),
+                },
+                dedupe_key=f"hyp_status:{hypothesis_id}:{new_status}",
                 actor_name="hypothesis-registry",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/outbox_watchdog.py
+++ b/nuri/agents/actors/outbox_watchdog.py
@@ -1,0 +1,134 @@
+"""OutboxWatchdog — alerts when discord_outbox health degrades (Codex Round 6).
+
+Why this exists:
+`scheduler.py` 의 `_run_*` 함수들은 모두 exception 흡수 (silent failure 패턴) →
+ChannelDispatcher 가 죽어도 사용자가 모름. Watchdog 이 outbox 의 backlog /
+oldest_pending_age 를 측정해서 threshold 넘으면 #ops 직접 발송 (recursion 방지
+위해 outbox 안 쓰고 webhook 직접).
+
+Layer: A (enforcement-style threshold check, ZERO LLM).
+
+Thresholds (config 가능, 일단 conservative 로 시작):
+    OLDEST_PENDING_ALERT_SECONDS = 30 * 60   # 30분
+    PENDING_COUNT_ALERT_THRESHOLD = 100      # 한 채널에 100건 이상 backlog
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nuri.agents.base import Actor, ActorResult, Layer, Outcome, RunContext
+from nuri.core.db import outbox_health
+from nuri.core.timezone import kst_now, today_kst
+
+OLDEST_PENDING_ALERT_SECONDS = 30 * 60  # 30분
+PENDING_COUNT_ALERT_THRESHOLD = 100  # backlog 한도
+
+# Watchdog 자체 alert 의 dedupe — 같은 issue 가 30분 안에 반복 emit 되지 않게
+# (DB 안 거치고 caller 가 cron 빈도 조절. 여기는 1회 직접 발송만)
+
+
+def _direct_publish_ops(embed: dict[str, Any]) -> dict[str, Any]:
+    """Watchdog 전용 직접 발송 — outbox 안 거침 (recursion 방지).
+
+    DiscordPublisher 가 webhook 미설정 시 graceful skip.
+    """
+    try:
+        from nuri.agents.discord.publisher import Channel, DiscordPublisher
+
+        result = DiscordPublisher().publish_embed(
+            Channel.OPS,
+            embed=embed,
+            actor_name="outbox-watchdog",
+        )
+        return {"ok": result.ok, "http_status": result.http_status, "error": result.error}
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "http_status": None, "error": f"{type(exc).__name__}: {exc}"}
+
+
+class OutboxWatchdog(Actor):
+    """Read outbox_health(); alert #ops directly if thresholds breached.
+
+    Output:
+        breaches: list of {channel, kind, value, threshold}
+        published: {ok, http_status, error} or None
+    """
+
+    name = "outbox-watchdog"
+    version = "0.1.0"
+    layer = Layer.A
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        db_path = input_data.get("db_path")
+        health = outbox_health(db_path=db_path)
+
+        breaches: list[dict[str, Any]] = []
+
+        # Check 1 — oldest_pending_age across channels
+        age = health.get("oldest_pending_age_seconds")
+        if age is not None and age > OLDEST_PENDING_ALERT_SECONDS:
+            breaches.append(
+                {
+                    "channel": health.get("oldest_pending_channel"),
+                    "kind": "oldest_pending_age",
+                    "value": age,
+                    "threshold": OLDEST_PENDING_ALERT_SECONDS,
+                }
+            )
+
+        # Check 2 — per-channel pending count
+        for channel, statuses in health.get("by_channel", {}).items():
+            pending = int(statuses.get("pending", 0))
+            if pending > PENDING_COUNT_ALERT_THRESHOLD:
+                breaches.append(
+                    {
+                        "channel": channel,
+                        "kind": "pending_count",
+                        "value": pending,
+                        "threshold": PENDING_COUNT_ALERT_THRESHOLD,
+                    }
+                )
+
+        if not breaches:
+            return ActorResult(
+                output={"health": health, "breaches": [], "published": None},
+                outcome=Outcome.PASS,
+                input_summary="outbox watchdog clean",
+            )
+
+        # Compose alert embed (직접 #ops 발송)
+        lines = [f"  - {b['channel']}: {b['kind']}={b['value']} > {b['threshold']}" for b in breaches]
+        embed = {
+            "title": f"Outbox Watchdog — {len(breaches)} breach(es)",
+            "description": (
+                f"Discord outbox health degraded ({today_kst()} {kst_now().strftime('%H:%M')} KST):\n"
+                + "\n".join(lines)
+                + "\n\nDispatcher 가 멈췄거나 webhook 발송이 반복 실패 중일 가능성. "
+                + "`make scheduler-status` 또는 `python -m nuri.agents.actors.channel_dispatcher <channel> --force` 확인."
+            ),
+            "color": 0xE74C3C,
+            "footer": {"text": "outbox-watchdog • direct emit (bypasses outbox)"},
+        }
+        published = _direct_publish_ops(embed)
+
+        return ActorResult(
+            output={"health": health, "breaches": breaches, "published": published},
+            outcome=Outcome.WARN,
+            sample_n=len(breaches),
+            input_summary=f"watchdog {len(breaches)} breach published={published.get('ok')}",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.agents.actors.outbox_watchdog"""
+    result = OutboxWatchdog().run({})
+    print(f"breaches={len(result.output['breaches'])} health={result.output['health']}")
+    if result.output.get("published"):
+        print(f"published: {result.output['published']}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/agents/actors/regime_posterior.py
+++ b/nuri/agents/actors/regime_posterior.py
@@ -440,25 +440,25 @@ class RegimePosterior(Actor):
         실패도 actor decision 자체를 fail 시키지 않음 (best-effort notification).
         """
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_rollout
 
-            posterior_str = ", ".join(f"{p:.3f}" for p in summary.posterior)
-            embed = {
-                "title": f"Regime change — {model_version}",
-                "description": (
-                    f"as_of_date: `{as_of_date}`\n"
-                    f"argmax: **{prev_argmax}** → **{summary.argmax_state}**\n"
-                    f"top2_margin: {summary.top2_margin:.3f} · entropy: {summary.entropy:.3f}"
-                ),
-                "color": 0x3498DB,
-                "fields": [
-                    {"name": "posterior", "value": f"`[{posterior_str}]`", "inline": False},
-                ],
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]}"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.ROLLOUT,
-                embed=embed,
+            stage_rollout(
+                payload={
+                    "kind": "regime_change",
+                    "summary": (
+                        f"{model_version} @ {as_of_date}: "
+                        f"{prev_argmax} → {summary.argmax_state} "
+                        f"(margin {summary.top2_margin:.2f}, entropy {summary.entropy:.2f})"
+                    ),
+                    "model_version": model_version,
+                    "as_of_date": as_of_date,
+                    "prev_argmax": prev_argmax,
+                    "new_argmax": summary.argmax_state,
+                    "top2_margin": summary.top2_margin,
+                    "entropy": summary.entropy,
+                    "posterior": list(summary.posterior),
+                },
+                dedupe_key=f"regime_change:{model_version}:{as_of_date}",
                 actor_name="regime-posterior",
                 run_id=run_id,
             )

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -283,9 +283,7 @@ class SREIncidentAgent(Actor):
             if len(statuses) >= FAILURE_STREAK_CRIT and all(s == "failed" for s in statuses):
                 severity = "critical"
                 streak = FAILURE_STREAK_CRIT
-            elif len(statuses) >= FAILURE_STREAK_WARN and all(
-                s == "failed" for s in statuses[:FAILURE_STREAK_WARN]
-            ):
+            elif len(statuses) >= FAILURE_STREAK_WARN and all(s == "failed" for s in statuses[:FAILURE_STREAK_WARN]):
                 severity = "warning"
                 streak = FAILURE_STREAK_WARN
             else:
@@ -463,38 +461,35 @@ class SREIncidentAgent(Actor):
         evidence: dict[str, Any],
         run_id: str,
     ) -> None:
-        """critical → INCIDENTS, warning → OPS. info 는 publish X."""
+        """critical → #incidents, warning → #ops outbox (PR3 Codex Round 6). info X."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_incident, stage_ops
 
             if severity == "critical":
-                channel = Channel.INCIDENTS
-                color = 0xE74C3C  # RED
+                stage_fn = stage_incident
+                priority = "high"
             elif severity == "warning":
-                channel = Channel.OPS
-                color = 0xF39C12  # AMBER
+                stage_fn = stage_ops
+                priority = "normal"
             else:
-                return  # info — publish 안 함
+                return
 
-            description = (
-                f"target: **{target}**\n"
-                f"incident_id: `{incident_id}`\n"
-                f"severity: **{severity}**\n"
-                f"\nevidence:\n```json\n{_short_json(evidence)}\n```"
-            )
-            embed = {
-                "title": f"SRE Incident — {incident_type}",
-                "description": description,
-                "color": color,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • SRE-Incident-Agent"},
-            }
-            DiscordPublisher().publish_embed(
-                channel,
-                embed=embed,
+            stage_fn(
+                payload={
+                    "kind": f"sre_{incident_type}",
+                    "summary": (f"{incident_type} {severity} on {target} (incident_id={incident_id})"),
+                    "incident_id": incident_id,
+                    "incident_type": incident_type,
+                    "severity": severity,
+                    "target": target,
+                    "evidence": evidence,
+                },
+                priority=priority,
+                dedupe_key=f"sre_incident:{incident_id}",
                 actor_name="sre-incident-agent",
                 run_id=run_id,
             )
-        except Exception:  # noqa: BLE001 — publish 실패는 incident 기록 자체에 영향 X
+        except Exception:  # noqa: BLE001
             pass
 
 

--- a/nuri/agents/actors/state_replicator_dr.py
+++ b/nuri/agents/actors/state_replicator_dr.py
@@ -39,8 +39,8 @@ from nuri.core.timezone import kst_now
 HEARTBEAT_PATH = Path("data/.autopull_heartbeat")
 
 # status 임계값 (사용자 룰 명세)
-HEALTHY_LAG_SECONDS = 600       # 10분 이내 = healthy
-STALE_LAG_SECONDS = 3600        # 10분 ~ 1시간 = stale, 그 이상 = unreachable
+HEALTHY_LAG_SECONDS = 600  # 10분 이내 = healthy
+STALE_LAG_SECONDS = 3600  # 10분 ~ 1시간 = stale, 그 이상 = unreachable
 
 
 @REGISTRY.register
@@ -115,9 +115,7 @@ class StateReplicatorDR(Actor):
             status = "healthy"
             notes = "primary writer — last_sync_at=now"
         else:
-            last_sync_at, sync_lag_seconds, status, notes = self._probe_replica_heartbeat(
-                now_kst
-            )
+            last_sync_at, sync_lag_seconds, status, notes = self._probe_replica_heartbeat(now_kst)
 
         upsert_dr_replica(
             replica_id=replica_id,
@@ -228,10 +226,7 @@ class StateReplicatorDR(Actor):
 
             # schema mismatch 검증: replica 만 (primary 는 자기 자신 기준)
             schema_mismatch = (
-                role == "replica"
-                and primary_schema is not None
-                and schema_v is not None
-                and schema_v != primary_schema
+                role == "replica" and primary_schema is not None and schema_v is not None and schema_v != primary_schema
             )
             if schema_mismatch:
                 # status 를 out_of_sync 로 update (idempotent)
@@ -246,29 +241,35 @@ class StateReplicatorDR(Actor):
                     notes=f"schema mismatch: replica={schema_v} vs primary={primary_schema}",
                     run_id=ctx.run_id,
                 )
-                unhealthy_blocks.append({
-                    "replica_id": replica_id,
-                    "role": role,
-                    "status": "out_of_sync",
-                    "reason": f"schema mismatch: replica={schema_v} vs primary={primary_schema}",
-                })
+                unhealthy_blocks.append(
+                    {
+                        "replica_id": replica_id,
+                        "role": role,
+                        "status": "out_of_sync",
+                        "reason": f"schema mismatch: replica={schema_v} vs primary={primary_schema}",
+                    }
+                )
                 continue
 
             # lag 기반 분류
             if status in ("unreachable", "out_of_sync"):
-                unhealthy_blocks.append({
-                    "replica_id": replica_id,
-                    "role": role,
-                    "status": status,
-                    "reason": f"status={status}, lag={lag}s",
-                })
+                unhealthy_blocks.append(
+                    {
+                        "replica_id": replica_id,
+                        "role": role,
+                        "status": status,
+                        "reason": f"status={status}, lag={lag}s",
+                    }
+                )
             elif status == "stale" or (lag is not None and lag > max_lag):
-                stale_warns.append({
-                    "replica_id": replica_id,
-                    "role": role,
-                    "status": status,
-                    "reason": f"lag {lag}s exceeds max_lag {max_lag}s",
-                })
+                stale_warns.append(
+                    {
+                        "replica_id": replica_id,
+                        "role": role,
+                        "status": status,
+                        "reason": f"lag {lag}s exceeds max_lag {max_lag}s",
+                    }
+                )
 
         # outcome 결정 — worst-case enforcement
         if unhealthy_blocks:
@@ -316,9 +317,7 @@ class StateReplicatorDR(Actor):
 
     @staticmethod
     def _list_replicas() -> ActorResult:
-        rows = query(
-            "SELECT * FROM dr_replicas ORDER BY role, replica_id"
-        )
+        rows = query("SELECT * FROM dr_replicas ORDER BY role, replica_id")
         items = [dict(r) for r in rows]
         return ActorResult(
             output={"count": len(items), "replicas": items},
@@ -331,22 +330,20 @@ class StateReplicatorDR(Actor):
 
     @staticmethod
     def _publish_incidents(blocks: list[dict[str, Any]], run_id: str) -> None:
+        """DR replica BLOCK → #incidents outbox stage (PR3 Codex Round 6)."""
         try:
-            from nuri.agents.discord.publisher import Channel, DiscordPublisher
+            from nuri.agents.discord.outbox import stage_incident
 
-            block_lines = "\n".join(
-                f"• `{b['replica_id']}` ({b['role']}): {b['reason']}"
-                for b in blocks[:5]
-            )
-            embed = {
-                "title": "DR Replica BLOCK — readiness compromised",
-                "description": f"unhealthy replicas: **{len(blocks)}**\n{block_lines}",
-                "color": 0xE74C3C,
-                "footer": {"text": f"nuri-quant • run_id={run_id[:8]} • DR readiness fail"},
-            }
-            DiscordPublisher().publish_embed(
-                Channel.INCIDENTS,
-                embed=embed,
+            replica_ids = ",".join(b["replica_id"] for b in blocks[:5])
+            stage_incident(
+                payload={
+                    "kind": "dr_replica_block",
+                    "summary": f"DR readiness compromised: {len(blocks)} unhealthy [{replica_ids}]",
+                    "n_unhealthy": len(blocks),
+                    "blocks": blocks[:5],
+                },
+                priority="high",  # DR readiness 위반 = 즉시 surface
+                dedupe_key="dr_replica_block",
                 actor_name="state-replicator-dr",
                 run_id=run_id,
             )

--- a/nuri/agents/discord/outbox.py
+++ b/nuri/agents/discord/outbox.py
@@ -1,0 +1,318 @@
+"""Discord outbox public API + digest layout helpers (Codex Round 6, 2026-05-02).
+
+Caller-facing convenience wrapping `nuri.core.db.discord_outbox_ops`. 모든 actor 가
+`stage_brief()` / `stage_ops()` / `stage_incident()` / `stage_rollout()` 4개 helper
+하나만 호출하면 됨 — channel string 실수 / payload 형식 mismatch 방지.
+
+**중요 invariant (Codex 단호한 권고)**:
+모든 channel emit 은 **이 모듈** 또는 watchdog (recursion 방지) 만 직접 publish.
+actor 가 `DiscordPublisher` 를 직접 호출하면 single-writer 깨짐 → CI 검사 추가
+(future) + code review 차단.
+
+Layout helpers:
+    bucket_brief_digest(events) — Codex 권장 actionability bucket layout 으로
+    여러 BUY/SELL/HOLD/BLOCK event 를 1 embed dict 로 합친다. dispatcher 가 호출.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from nuri.core.db import stage_outbox
+from nuri.core.timezone import kst_now, today_kst
+
+# Discord embed limits — agents/discord/embeds.py 와 동일 (Single source of truth
+# 아니지만 import 순환 회피 위해 중복 정의)
+_TITLE_MAX = 256
+_DESC_MAX = 4000
+_FIELD_NAME_MAX = 256
+_FIELD_VALUE_MAX = 1024
+_MAX_FIELDS = 25
+
+_PRIORITY_BY_ACTION = {
+    "BUY": 0,
+    "SELL": 0,
+    "BLOCK": 1,
+    "CONFLICT": 1,
+    "HOLD": 2,
+    "INFO": 2,
+}
+
+# 사용자가 본 통증의 색상 단서 — bucket 별 색
+_BUCKET_COLORS = {
+    "Action Now": 0x2ECC71,  # green
+    "Blocked / Conflict": 0xE74C3C,  # red
+    "Lower Priority": 0x95A5A6,  # gray
+}
+
+
+def _truncate(text: str, limit: int) -> str:
+    if text is None:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)] + "…"
+
+
+def stage_brief(
+    payload: dict[str, Any],
+    dedupe_key: Optional[str] = None,
+    priority: str = "normal",
+    actor_name: Optional[str] = None,
+    run_id: Optional[str] = None,
+    db_path: Optional[Any] = None,
+) -> Optional[int]:
+    """Stage one event into #brief outbox. Dispatcher 가 종합해서 발송."""
+    return stage_outbox(
+        "brief",
+        payload,
+        priority=priority,
+        dedupe_key=dedupe_key,
+        actor_name=actor_name,
+        run_id=run_id,
+        db_path=db_path,
+    )
+
+
+def stage_ops(
+    payload: dict[str, Any],
+    dedupe_key: Optional[str] = None,
+    priority: str = "normal",
+    actor_name: Optional[str] = None,
+    run_id: Optional[str] = None,
+    db_path: Optional[Any] = None,
+) -> Optional[int]:
+    """Stage one event into #ops outbox."""
+    return stage_outbox(
+        "ops",
+        payload,
+        priority=priority,
+        dedupe_key=dedupe_key,
+        actor_name=actor_name,
+        run_id=run_id,
+        db_path=db_path,
+    )
+
+
+def stage_incident(
+    payload: dict[str, Any],
+    dedupe_key: Optional[str] = None,
+    priority: str = "normal",
+    actor_name: Optional[str] = None,
+    run_id: Optional[str] = None,
+    db_path: Optional[Any] = None,
+) -> Optional[int]:
+    """Stage one event into #incidents outbox."""
+    return stage_outbox(
+        "incidents",
+        payload,
+        priority=priority,
+        dedupe_key=dedupe_key,
+        actor_name=actor_name,
+        run_id=run_id,
+        db_path=db_path,
+    )
+
+
+def stage_rollout(
+    payload: dict[str, Any],
+    dedupe_key: Optional[str] = None,
+    priority: str = "normal",
+    actor_name: Optional[str] = None,
+    run_id: Optional[str] = None,
+    db_path: Optional[Any] = None,
+) -> Optional[int]:
+    """Stage one event into #research-rollout outbox."""
+    return stage_outbox(
+        "rollout",
+        payload,
+        priority=priority,
+        dedupe_key=dedupe_key,
+        actor_name=actor_name,
+        run_id=run_id,
+        db_path=db_path,
+    )
+
+
+# ─── digest layout (Codex Round 6 actionability bucket pattern) ──────────
+
+
+def _classify_event(payload: dict[str, Any]) -> str:
+    """Map event payload → bucket name.
+
+    payload['kind']: BUY/SELL/HOLD/BLOCK/CONFLICT/INFO
+    """
+    kind = (payload.get("kind") or "").upper()
+    pri = _PRIORITY_BY_ACTION.get(kind, 2)
+    if pri == 0:
+        return "Action Now"
+    if pri == 1:
+        return "Blocked / Conflict"
+    return "Lower Priority"
+
+
+def _format_event_line(payload: dict[str, Any]) -> str:
+    """Compact one-line per event (Codex format).
+
+    `NVDA | SELL | conv 0.81 | regime bear 0.72 | causal 0.68 | reason: stop-loss`
+    """
+    kind = (payload.get("kind") or "?").upper()
+    ticker = payload.get("ticker", "?")
+    parts = [str(ticker), kind]
+    if "conviction" in payload:
+        parts.append(f"conv {float(payload['conviction']):.2f}")
+    for opt in ("regime", "causal", "horizon", "reason", "note"):
+        if opt in payload and payload[opt] is not None:
+            parts.append(f"{opt}: {payload[opt]}")
+    return " | ".join(parts)
+
+
+def bucket_brief_digest(
+    events: list[dict[str, Any]],
+    title_prefix: str = "Nuri Brief Digest",
+) -> dict[str, Any]:
+    """Compose multiple stage_brief() payloads into ONE digest embed.
+
+    Codex layout:
+        Title:       "Nuri Brief Digest | YYYY-MM-DD HH:MM KST | N opinions"
+        Description: "BUY 2 | SELL 1 | BLOCK 2 | manual execute only"
+        Fields:      Action Now / Blocked|Conflict / Lower Priority
+                     each = compact one-line list, hard cap to fit Discord limits
+
+    Returns Discord embed dict — caller passes to DiscordPublisher.publish_embed.
+    """
+    if not events:
+        return {
+            "title": _truncate(
+                f"{title_prefix} | {today_kst()} {kst_now().strftime('%H:%M')} KST | 0 opinions", _TITLE_MAX
+            ),
+            "description": "(no pending events)",
+            "color": _BUCKET_COLORS["Lower Priority"],
+            "fields": [],
+            "footer": {"text": "manual execute only"},
+        }
+
+    counts = {"BUY": 0, "SELL": 0, "BLOCK": 0, "CONFLICT": 0, "HOLD": 0, "INFO": 0}
+    buckets: dict[str, list[str]] = {
+        "Action Now": [],
+        "Blocked / Conflict": [],
+        "Lower Priority": [],
+    }
+    for ev in events:
+        kind = (ev.get("kind") or "").upper()
+        if kind in counts:
+            counts[kind] += 1
+        bucket = _classify_event(ev)
+        buckets[bucket].append(_format_event_line(ev))
+
+    n = len(events)
+    title = f"{title_prefix} | {today_kst()} {kst_now().strftime('%H:%M')} KST | {n} opinions"
+
+    desc_parts = []
+    for kind in ("BUY", "SELL", "BLOCK", "CONFLICT", "HOLD"):
+        if counts[kind]:
+            desc_parts.append(f"{kind} {counts[kind]}")
+    desc = " | ".join(desc_parts) + " | manual execute only" if desc_parts else "manual execute only"
+
+    fields = []
+    for bucket_name in ("Action Now", "Blocked / Conflict", "Lower Priority"):
+        lines = buckets[bucket_name]
+        if not lines:
+            continue
+        # Truncate per-line to keep value < 1024
+        body_lines: list[str] = []
+        running = 0
+        for ln in lines:
+            ln_trunc = _truncate(ln, 200)
+            if running + len(ln_trunc) + 1 > _FIELD_VALUE_MAX:
+                hidden = len(lines) - len(body_lines)
+                body_lines.append(f"… (+{hidden} more)")
+                break
+            body_lines.append(ln_trunc)
+            running += len(ln_trunc) + 1
+        fields.append(
+            {
+                "name": _truncate(f"{bucket_name} ({len(lines)})", _FIELD_NAME_MAX),
+                "value": _truncate("\n".join(body_lines), _FIELD_VALUE_MAX),
+                "inline": False,
+            }
+        )
+        if len(fields) >= _MAX_FIELDS:
+            break
+
+    color = (
+        _BUCKET_COLORS["Action Now"]
+        if buckets["Action Now"]
+        else (
+            _BUCKET_COLORS["Blocked / Conflict"] if buckets["Blocked / Conflict"] else _BUCKET_COLORS["Lower Priority"]
+        )
+    )
+
+    return {
+        "title": _truncate(title, _TITLE_MAX),
+        "description": _truncate(desc, _DESC_MAX),
+        "color": color,
+        "fields": fields,
+        "footer": {"text": "manual execute only — STRATEGY §7.1"},
+    }
+
+
+def bucket_generic_digest(
+    events: list[dict[str, Any]],
+    channel_label: str,
+    color: int = 0x3498DB,
+) -> dict[str, Any]:
+    """Generic digest for #ops / #incidents / #rollout.
+
+    No actionability bucketing — group by 'kind' or 'category' if present,
+    otherwise flat list.
+    """
+    if not events:
+        return {
+            "title": _truncate(
+                f"{channel_label} Digest | {today_kst()} {kst_now().strftime('%H:%M')} KST | 0 events", _TITLE_MAX
+            ),
+            "description": "(no pending events)",
+            "color": color,
+            "fields": [],
+            "footer": {"text": "auto digest"},
+        }
+
+    n = len(events)
+    title = f"{channel_label} Digest | {today_kst()} {kst_now().strftime('%H:%M')} KST | {n} events"
+
+    by_group: dict[str, list[str]] = {}
+    for ev in events:
+        group = str(ev.get("kind") or ev.get("category") or "general")
+        line = ev.get("summary") or _format_event_line(ev)
+        by_group.setdefault(group, []).append(str(line))
+
+    fields = []
+    for group, lines in by_group.items():
+        body_lines: list[str] = []
+        running = 0
+        for ln in lines:
+            ln_trunc = _truncate(ln, 200)
+            if running + len(ln_trunc) + 1 > _FIELD_VALUE_MAX:
+                hidden = len(lines) - len(body_lines)
+                body_lines.append(f"… (+{hidden} more)")
+                break
+            body_lines.append(ln_trunc)
+            running += len(ln_trunc) + 1
+        fields.append(
+            {
+                "name": _truncate(f"{group} ({len(lines)})", _FIELD_NAME_MAX),
+                "value": _truncate("\n".join(body_lines), _FIELD_VALUE_MAX),
+                "inline": False,
+            }
+        )
+        if len(fields) >= _MAX_FIELDS:
+            break
+
+    return {
+        "title": _truncate(title, _TITLE_MAX),
+        "description": _truncate(f"{n} aggregated events", _DESC_MAX),
+        "color": color,
+        "fields": fields,
+        "footer": {"text": "auto digest"},
+    }

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -42,6 +42,12 @@ from .decisions import (  # noqa: F401, E402
     upsert_decision,
     upsert_decision_evidence,
 )
+from .discord_outbox_ops import CLAIM_LEASE_SECONDS as CLAIM_LEASE_SECONDS  # noqa: E402
+from .discord_outbox_ops import claim_pending_outbox as claim_pending_outbox  # noqa: E402
+from .discord_outbox_ops import mark_outbox_failed as mark_outbox_failed  # noqa: E402
+from .discord_outbox_ops import mark_outbox_sent as mark_outbox_sent  # noqa: E402
+from .discord_outbox_ops import outbox_health as outbox_health  # noqa: E402
+from .discord_outbox_ops import stage_outbox as stage_outbox  # noqa: E402
 from .execution_ops import (  # noqa: F401, E402
     acknowledge_incident,
     log_decision,

--- a/nuri/core/db/discord_outbox_ops.py
+++ b/nuri/core/db/discord_outbox_ops.py
@@ -1,0 +1,267 @@
+"""Discord outbox writes — single-writer outbox for channel digests (Codex Round 6, 2026-05-02).
+
+Why this exists (사용자 통증 2026-05-02):
+#brief 채널에 NVDA BUY/BUY/SELL 같은 conviction 으로 따로 발송 → 노이즈 폭발.
+Codex 권고: per-event publish 패턴 폐기, outbox stage → cron/quiet-period dispatcher
+가 종합 1 embed 발송. 본 모듈은 outbox 의 storage layer.
+
+State machine:
+    pending → claim_pending() → claimed (claim_token + claimed_at)
+                              → mark_sent() → sent
+                              → mark_failed() → failed (재시도 또는 dropped)
+
+Lease semantics:
+    dispatcher crash 시 claimed_at 이 stale (> CLAIM_LEASE_SECONDS) 이면 다른
+    dispatcher 가 다시 claim 가능 → at-least-once 발송. 멱등성은 caller (digest
+    dedupe_key) 책임.
+
+Layer: 데이터 레이어 (액터 호출 X). caller = `nuri/agents/discord/outbox.py` (stage)
++ `nuri/agents/actors/channel_dispatcher.py` (claim/mark).
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from pathlib import Path
+from typing import Any, Optional
+
+from .connection import get_db
+
+_CHANNELS = ("brief", "ops", "incidents", "rollout")
+_PRIORITIES = ("high", "normal", "low")
+_STATUSES = ("pending", "claimed", "sent", "failed", "dropped")
+
+# Lease 만료 — claimed 상태에서 이 시간 지나면 다른 dispatcher 가 재claim
+CLAIM_LEASE_SECONDS = 300  # 5분
+
+
+def stage_outbox(
+    channel: str,
+    payload: dict[str, Any],
+    priority: str = "normal",
+    dedupe_key: Optional[str] = None,
+    scheduled_for: Optional[str] = None,
+    actor_name: Optional[str] = None,
+    run_id: Optional[str] = None,
+    dedupe_strategy: str = "skip",
+    db_path: Optional[Path] = None,
+) -> Optional[int]:
+    """Stage one Discord embed/text payload for later digest dispatch.
+
+    payload: dict — Discord embed dict or {"content": "..."}. JSON-serialized 저장.
+    priority:
+        high   — scheduled_for=now (즉시 dispatcher 픽업)
+        normal — 다음 cron 주기
+        low    — 후순위
+    dedupe_key: caller 의 멱등성 키. 같은 key 의 pending row 가 있으면:
+        dedupe_strategy='skip'    — return None (이미 stage 됨)
+        dedupe_strategy='replace' — 기존 pending payload 를 새 것으로 덮음
+    scheduled_for: 'YYYY-MM-DD HH:MM:SS' or None (now). future timestamp 면 그
+        시점 이후 dispatcher 가 픽업.
+    """
+    if channel not in _CHANNELS:
+        raise ValueError(f"channel must be {_CHANNELS}, got {channel!r}")
+    if priority not in _PRIORITIES:
+        raise ValueError(f"priority must be {_PRIORITIES}, got {priority!r}")
+    if dedupe_strategy not in ("skip", "replace"):
+        raise ValueError(f"dedupe_strategy must be skip|replace, got {dedupe_strategy!r}")
+
+    payload_json = json.dumps(payload, default=str)
+    sched = scheduled_for  # None → DB default datetime('now')
+
+    with get_db(db_path) as conn:
+        if dedupe_key:
+            existing = conn.execute(
+                """SELECT id FROM discord_outbox
+                    WHERE channel = ? AND dedupe_key = ? AND status = 'pending'
+                    LIMIT 1""",
+                (channel, dedupe_key),
+            ).fetchone()
+            if existing is not None:
+                if dedupe_strategy == "skip":
+                    return None
+                conn.execute(
+                    """UPDATE discord_outbox
+                          SET payload_json = ?, priority = ?,
+                              scheduled_for = COALESCE(?, scheduled_for),
+                              actor_name = COALESCE(?, actor_name),
+                              run_id = COALESCE(?, run_id)
+                        WHERE id = ?""",
+                    (payload_json, priority, sched, actor_name, run_id, existing["id"]),
+                )
+                return int(existing["id"])
+
+        if sched is None:
+            cursor = conn.execute(
+                """INSERT INTO discord_outbox
+                       (channel, payload_json, priority, dedupe_key,
+                        actor_name, run_id)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (channel, payload_json, priority, dedupe_key, actor_name, run_id),
+            )
+        else:
+            cursor = conn.execute(
+                """INSERT INTO discord_outbox
+                       (channel, payload_json, priority, dedupe_key,
+                        scheduled_for, actor_name, run_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (channel, payload_json, priority, dedupe_key, sched, actor_name, run_id),
+            )
+        return int(cursor.lastrowid or 0)
+
+
+def claim_pending_outbox(
+    channel: str,
+    limit: int = 100,
+    db_path: Optional[Path] = None,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Atomically claim up to `limit` ready pending rows for `channel`.
+
+    Returns (claim_token, rows). 빈 배열 = 처리할 것 없음.
+
+    "Ready" = status='pending' AND scheduled_for <= now()
+        OR  status='claimed' AND claimed_at < now() - CLAIM_LEASE_SECONDS
+                                                    (lease 만료 → 재claim).
+    Priority order: high > normal > low, scheduled_for 오름차순 (오래된 것 먼저).
+    Same claim_token 으로 mark_sent / mark_failed 호출 → 다른 dispatcher 침범 방지.
+    """
+    if channel not in _CHANNELS:
+        raise ValueError(f"channel must be {_CHANNELS}, got {channel!r}")
+    claim_token = secrets.token_hex(8)
+
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """SELECT id FROM discord_outbox
+                WHERE channel = ?
+                  AND (
+                       (status = 'pending' AND scheduled_for <= datetime('now'))
+                    OR (status = 'claimed' AND claimed_at < datetime('now', ?))
+                  )
+                ORDER BY
+                    CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+                    scheduled_for ASC,
+                    id ASC
+                LIMIT ?""",
+            (channel, f"-{CLAIM_LEASE_SECONDS} seconds", limit),
+        ).fetchall()
+        if not rows:
+            return claim_token, []
+
+        ids = [r["id"] for r in rows]
+        placeholders = ",".join("?" for _ in ids)
+        conn.execute(
+            f"""UPDATE discord_outbox
+                   SET status = 'claimed',
+                       claim_token = ?,
+                       claimed_at = datetime('now'),
+                       attempt_count = attempt_count + 1
+                 WHERE id IN ({placeholders})""",
+            (claim_token, *ids),
+        )
+
+        claimed = conn.execute(
+            f"""SELECT id, channel, payload_json, priority, dedupe_key,
+                       scheduled_for, attempt_count, actor_name, run_id, created_at
+                  FROM discord_outbox
+                 WHERE id IN ({placeholders})
+                 ORDER BY
+                     CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+                     scheduled_for ASC,
+                     id ASC""",
+            ids,
+        ).fetchall()
+
+    result = []
+    for r in claimed:
+        d = dict(r)
+        try:
+            d["payload"] = json.loads(d.pop("payload_json"))
+        except json.JSONDecodeError:
+            d["payload"] = {}
+        result.append(d)
+    return claim_token, result
+
+
+def mark_outbox_sent(
+    ids: list[int],
+    claim_token: str,
+    db_path: Optional[Path] = None,
+) -> int:
+    """Mark claimed rows as sent. claim_token 일치하는 row 만 업데이트 (lease 보호).
+
+    Returns updated row count.
+    """
+    if not ids:
+        return 0
+    placeholders = ",".join("?" for _ in ids)
+    with get_db(db_path) as conn:
+        cursor = conn.execute(
+            f"""UPDATE discord_outbox
+                   SET status = 'sent', sent_at = datetime('now'), last_error = NULL
+                 WHERE id IN ({placeholders}) AND claim_token = ?""",
+            (*ids, claim_token),
+        )
+        return int(cursor.rowcount or 0)
+
+
+def mark_outbox_failed(
+    ids: list[int],
+    claim_token: str,
+    error: str,
+    drop: bool = False,
+    db_path: Optional[Path] = None,
+) -> int:
+    """Mark claimed rows as failed (or dropped if drop=True).
+
+    failed → 후속 claim 가능 (재시도). dropped → terminal.
+    claim_token 일치하는 row 만 업데이트.
+    """
+    if not ids:
+        return 0
+    new_status = "dropped" if drop else "failed"
+    placeholders = ",".join("?" for _ in ids)
+    with get_db(db_path) as conn:
+        cursor = conn.execute(
+            f"""UPDATE discord_outbox
+                   SET status = ?, last_error = ?, claim_token = NULL, claimed_at = NULL
+                 WHERE id IN ({placeholders}) AND claim_token = ?""",
+            (new_status, error[:500], *ids, claim_token),
+        )
+        return int(cursor.rowcount or 0)
+
+
+def outbox_health(db_path: Optional[Path] = None) -> dict[str, Any]:
+    """Watchdog metrics — channel × status 별 count + oldest pending age.
+
+    Returns:
+        {
+          'by_channel': {channel: {status: count, ...}, ...},
+          'oldest_pending_age_seconds': int (across all channels) or None,
+          'oldest_pending_channel': str or None,
+        }
+    """
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            """SELECT channel, status, COUNT(*) AS n
+                 FROM discord_outbox
+                GROUP BY channel, status"""
+        ).fetchall()
+        by_channel: dict[str, dict[str, int]] = {c: {} for c in _CHANNELS}
+        for r in rows:
+            by_channel[r["channel"]][r["status"]] = int(r["n"])
+
+        oldest = conn.execute(
+            """SELECT channel,
+                      CAST((julianday('now') - julianday(scheduled_for)) * 86400 AS INTEGER) AS age_s
+                 FROM discord_outbox
+                WHERE status = 'pending'
+                ORDER BY scheduled_for ASC
+                LIMIT 1"""
+        ).fetchone()
+
+    return {
+        "by_channel": by_channel,
+        "oldest_pending_age_seconds": int(oldest["age_s"]) if oldest else None,
+        "oldest_pending_channel": oldest["channel"] if oldest else None,
+    }

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1237,4 +1237,44 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_fbench_metric ON foundation_benchmarks(metric_name, created_at);
     """,
     ),
+    (
+        41,
+        "discord_outbox — single-writer outbox for Discord channel digests (Codex Round 6, 2026-05-02)",
+        # 사용자 통증 (2026-05-02): #brief 채널에 NVDA BUY/BUY/SELL 같은 conviction 으로
+        # 따로 따로 emit 되어 노이즈 폭발. Codex 권고: per-event publish → outbox stage →
+        # cron/quiet-period dispatcher 가 종합 1 embed 발송 (single-writer 패턴).
+        #
+        # status lifecycle:
+        #   pending  → claim_pending() → claimed (claim_token + claimed_at) → mark_sent → sent
+        #                                                                  → mark_failed → failed (재시도 또는 dropped)
+        # lease semantics: dispatcher crash 시 claimed_at 이 stale (>5min) 이면 다른 dispatcher 가
+        # 다시 claim 가능 → at-least-once 발송 (멱등성은 dedupe_key 로 caller 책임).
+        #
+        # priority: high → scheduled_for=now (즉시), normal → cron 주기, low → 다음 digest 까지 대기
+        # dedupe_key: 같은 key 의 pending 이 있으면 stage() 가 skip 또는 update (caller 선택)
+        # scheduled_for: now() default, future timestamp 면 그 시점 이후 dispatcher 픽업
+        """
+        CREATE TABLE IF NOT EXISTS discord_outbox (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            channel TEXT NOT NULL CHECK(channel IN ('brief','ops','incidents','rollout')),
+            payload_json TEXT NOT NULL,
+            priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('high','normal','low')),
+            dedupe_key TEXT,
+            scheduled_for TEXT NOT NULL DEFAULT (datetime('now')),
+            status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','claimed','sent','failed','dropped')),
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            claim_token TEXT,
+            claimed_at TEXT,
+            sent_at TEXT,
+            last_error TEXT,
+            actor_name TEXT,
+            run_id TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_outbox_pending ON discord_outbox(channel, status, scheduled_for);
+        CREATE INDEX IF NOT EXISTS idx_outbox_claim ON discord_outbox(status, claimed_at);
+        CREATE INDEX IF NOT EXISTS idx_outbox_dedupe ON discord_outbox(channel, dedupe_key, status);
+        CREATE INDEX IF NOT EXISTS idx_outbox_run ON discord_outbox(run_id);
+    """,
+    ),
 ]

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -215,6 +215,62 @@ def _run_db_maintenance():
         logger.error(f"[db_maintenance] 실행 실패: {e}", exc_info=True)
 
 
+def _run_brief_audit():
+    """BriefAuditor — Discord-as-dev-loop self-quality check.
+
+    매 6시간마다 #brief 채널 emit 24h windowing audit. quality issue 발견 시
+    deterministic check (C1-C3) 결과를 #incidents 로 surface. dedupe 24h.
+    실행 실패가 다음 job 영향 없게 exception 흡수 (다른 _run_* 와 동일).
+    """
+    try:
+        from nuri.agents.actors.brief_auditor import BriefAuditor
+
+        result = BriefAuditor().run({"hours": 24})
+        logger.info(
+            f"[brief_audit] decisions={result.output['decisions_audited']} "
+            f"found={result.output['issues_found']} "
+            f"emitted={result.output['issues_emitted']}"
+        )
+    except Exception as e:
+        logger.error(f"[brief_audit] 실행 실패: {e}", exc_info=True)
+
+
+def _run_channel_dispatcher(channel: str):
+    """ChannelDispatcher — single-writer Discord outbox flush (Codex Round 6).
+
+    pending events 종합 → 1 embed → webhook. #brief 만 quiet-period (60s) gate.
+    """
+    try:
+        from nuri.agents.actors.channel_dispatcher import ChannelDispatcher
+
+        result = ChannelDispatcher().run({"channel": channel})
+        out = result.output
+        if "skipped" in out:
+            logger.info(f"[dispatcher:{channel}] skipped={out['skipped']}")
+        else:
+            logger.info(
+                f"[dispatcher:{channel}] claimed={out.get('claimed_n')} "
+                f"sent={out.get('marked_sent_n')} http={out.get('http_status')}"
+            )
+    except Exception as e:
+        logger.error(f"[dispatcher:{channel}] 실행 실패: {e}", exc_info=True)
+
+
+def _run_outbox_watchdog():
+    """OutboxWatchdog — 직접 #ops 발송 (recursion 방지). 10분 마다."""
+    try:
+        from nuri.agents.actors.outbox_watchdog import OutboxWatchdog
+
+        result = OutboxWatchdog().run({})
+        n = len(result.output.get("breaches", []))
+        if n > 0:
+            logger.warning(f"[outbox_watchdog] {n} breach(es) — alert sent")
+        else:
+            logger.info("[outbox_watchdog] healthy")
+    except Exception as e:
+        logger.error(f"[outbox_watchdog] 실행 실패: {e}", exc_info=True)
+
+
 # ═══════════════════════════════════════════════════════
 # 스케줄 정의
 # ═══════════════════════════════════════════════════════
@@ -283,6 +339,20 @@ SCHEDULES = [
     # 사용자 명령 없이도 매일 판단 trigger — session-start 에서 Claude 가
     # 이 brief 를 pick up 해 qualitative 뉴스와 cross-ref.
     {"name": "premarket_brief", "func": _run_premarket_brief, "args": (), "cron": "0 9 * * 1-5", "tz": "US/Eastern"},
+    # Brief auditor (Discord-as-dev-loop) — 매 6시간 #brief 품질 self-audit.
+    # decision_compiler emit 의 conflict / noise / identical-conviction 검출 →
+    # #incidents 로 ticket 자동 emit. dedupe 24h. recommend-only, ZERO LLM.
+    {"name": "brief_audit", "func": _run_brief_audit, "args": (), "cron": "0 */6 * * *"},
+    # Discord channel dispatcher (Codex Round 6, 2026-05-02) — single-writer outbox flush.
+    # PR1 shadow mode: outbox 는 비어있으므로 발송 없음. 실제 사용자 화면 변화는 PR2/PR3 channel-migration 시.
+    # #brief: 1분 polling + quiet-period gate (60s no-new-event)
+    # #ops: 10분, #incidents: 10분, #rollout: 일요일 06:00 KST
+    {"name": "dispatcher_brief", "func": _run_channel_dispatcher, "args": ("brief",), "cron": "* * * * *"},
+    {"name": "dispatcher_ops", "func": _run_channel_dispatcher, "args": ("ops",), "cron": "*/10 * * * *"},
+    {"name": "dispatcher_incidents", "func": _run_channel_dispatcher, "args": ("incidents",), "cron": "*/10 * * * *"},
+    {"name": "dispatcher_rollout", "func": _run_channel_dispatcher, "args": ("rollout",), "cron": "0 6 * * 0"},
+    # Watchdog — outbox backlog / oldest-pending-age threshold breach 시 #ops 직접 발송 (recursion 방지).
+    {"name": "outbox_watchdog", "func": _run_outbox_watchdog, "args": (), "cron": "*/10 * * * *"},
     # DB 백업 (매일 자정)
     {"name": "backup", "func": _run_backup, "args": (), "cron": "0 0 * * *"},
     # DB 유지보수 (일요일 새벽 3시)

--- a/tests/agents/test_audit_ledger.py
+++ b/tests/agents/test_audit_ledger.py
@@ -185,9 +185,7 @@ class TestInputValidation:
         assert result.outcome == Outcome.BLOCK
 
     def test_retention_negative_since_days_blocked(self, patched_db):
-        result = AuditLedger().run(
-            {"action": "retention_check", "max_rows": 100, "since_days": -1}
-        )
+        result = AuditLedger().run({"action": "retention_check", "max_rows": 100, "since_days": -1})
         assert result.outcome == Outcome.BLOCK
 
 
@@ -214,9 +212,7 @@ class TestQuery:
         _seed_audit(patched_db, "d1", "execution-firewall")
         _seed_audit(patched_db, "d2", "freshness-gatekeeper")
         _seed_audit(patched_db, "d3", "execution-firewall")
-        result = AuditLedger().run(
-            {"action": "query", "actor_name": "execution-firewall"}
-        )
+        result = AuditLedger().run({"action": "query", "actor_name": "execution-firewall"})
         assert result.output["count"] == 2
         for row in result.output["rows"]:
             assert row["actor_name"] == "execution-firewall"
@@ -253,15 +249,9 @@ class TestQuery:
         assert result.output["rows"][0]["outcome"] == "block"
 
     def test_query_filter_by_since_iso(self, patched_db):
-        _seed_audit(
-            patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00"
-        )
-        _seed_audit(
-            patched_db, "new", "execution-firewall", timestamp="2030-01-01 00:00:00"
-        )
-        result = AuditLedger().run(
-            {"action": "query", "since_iso": "2025-01-01 00:00:00"}
-        )
+        _seed_audit(patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00")
+        _seed_audit(patched_db, "new", "execution-firewall", timestamp="2030-01-01 00:00:00")
+        result = AuditLedger().run({"action": "query", "since_iso": "2025-01-01 00:00:00"})
         assert result.output["count"] == 1
         assert result.output["rows"][0]["decision_id"] == "new"
 
@@ -272,12 +262,8 @@ class TestQuery:
         assert result.output["count"] == 3
 
     def test_query_sorted_desc(self, patched_db):
-        _seed_audit(
-            patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00"
-        )
-        _seed_audit(
-            patched_db, "new", "execution-firewall", timestamp="2030-01-01 00:00:00"
-        )
+        _seed_audit(patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00")
+        _seed_audit(patched_db, "new", "execution-firewall", timestamp="2030-01-01 00:00:00")
         result = AuditLedger().run({"action": "query"})
         # Newest first
         assert result.output["rows"][0]["decision_id"] == "new"
@@ -313,9 +299,7 @@ class TestSummarizeByOutcome:
     def test_filter_by_actor(self, patched_db):
         _seed_audit(patched_db, "d1", "execution-firewall", outcome="block")
         _seed_audit(patched_db, "d2", "freshness-gatekeeper", outcome="block")
-        result = AuditLedger().run(
-            {"action": "summarize_by_outcome", "actor_name": "execution-firewall"}
-        )
+        result = AuditLedger().run({"action": "summarize_by_outcome", "actor_name": "execution-firewall"})
         assert result.output["totals"]["block"] == 1
         assert result.output["total_count"] == 1
 
@@ -328,9 +312,7 @@ class TestSummarizeByOutcome:
             timestamp="2020-01-01 00:00:00",
         )
         _seed_audit(patched_db, "new", "execution-firewall", outcome="pass")
-        result = AuditLedger().run(
-            {"action": "summarize_by_outcome", "since_iso": "2025-01-01 00:00:00"}
-        )
+        result = AuditLedger().run({"action": "summarize_by_outcome", "since_iso": "2025-01-01 00:00:00"})
         assert result.output["totals"]["pass"] == 1
         assert result.output["total_count"] == 1
 
@@ -431,13 +413,9 @@ class TestRetentionCheck:
         assert "BLOCK" in result.output["recommendation"]
 
     def test_old_rows_counted(self, patched_db):
-        _seed_audit(
-            patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00"
-        )
+        _seed_audit(patched_db, "old", "execution-firewall", timestamp="2020-01-01 00:00:00")
         _seed_audit(patched_db, "fresh", "execution-firewall")
-        result = AuditLedger().run(
-            {"action": "retention_check", "max_rows": 1000, "since_days": 30}
-        )
+        result = AuditLedger().run({"action": "retention_check", "max_rows": 1000, "since_days": 30})
         assert result.output["rows_older_than_n_days"] == 1
         assert result.output["total_rows"] == 2
 
@@ -503,37 +481,27 @@ class TestDiscordPublish:
             result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
         assert result.outcome == Outcome.WARN
 
-    def test_block_publish_real_path(self, patched_db):
-        """BLOCK path 가 실제 _publish_incidents body 를 실행 — coverage 보강."""
+    def test_block_stages_to_incidents(self, patched_db):
+        """BLOCK path → outbox stage_incident (PR3 Codex Round 6)."""
         for i in range(4):
             _seed_audit(patched_db, f"d{i}", "execution-firewall")
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed"
-        ) as mock_pub:
+        with patch("nuri.agents.discord.outbox.stage_incident") as mock_stage:
             result = AuditLedger().run({"action": "retention_check", "max_rows": 2})
         assert result.outcome == Outcome.BLOCK
-        # publish_embed 호출 — INCIDENTS channel 인지 확인
-        mock_pub.assert_called_once()
-        from nuri.agents.discord.publisher import Channel
+        mock_stage.assert_called_once()
+        kw = mock_stage.call_args.kwargs
+        assert kw["actor_name"] == "audit-ledger"
+        assert kw["payload"]["kind"] == "audit_ledger_block"
 
-        kwargs = mock_pub.call_args
-        # positional: (channel,) ; kwargs: embed=..., actor_name=...
-        assert kwargs.args[0] == Channel.INCIDENTS
-
-    def test_warn_publish_real_path(self, patched_db):
-        """WARN path 가 실제 _publish_ops body 를 실행 — coverage 보강."""
+    def test_warn_stages_to_ops(self, patched_db):
+        """WARN path → outbox stage_ops (PR3 Codex Round 6)."""
         for i in range(11):
             _seed_audit(patched_db, f"d{i}", "execution-firewall")
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed"
-        ) as mock_pub:
+        with patch("nuri.agents.discord.outbox.stage_ops") as mock_stage:
             result = AuditLedger().run({"action": "retention_check", "max_rows": 10})
         assert result.outcome == Outcome.WARN
-        mock_pub.assert_called_once()
-        from nuri.agents.discord.publisher import Channel
-
-        kwargs = mock_pub.call_args
-        assert kwargs.args[0] == Channel.OPS
+        mock_stage.assert_called_once()
+        assert mock_stage.call_args.kwargs["payload"]["kind"] == "audit_ledger_warn"
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/agents/test_brief_auditor.py
+++ b/tests/agents/test_brief_auditor.py
@@ -1,0 +1,242 @@
+"""BriefAuditor tests — Discord-as-dev-loop self-quality actor.
+
+Each check (C1 conflict / C2 noise / C3 identical_conv) tested with synthetic
+agent_decisions rows. Dedupe verified with pre-existing #incidents content_preview.
+
+Privacy: synthetic tickers TST_A/TST_B (never real holdings).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nuri.agents.actors.brief_auditor import (
+    BriefAuditor,
+    _check_conflict,
+    _check_identical_conv,
+    _check_noise,
+    _make_issue_id,
+)
+from nuri.agents.base import Outcome
+from nuri.core.db import init_db, log_agent_message, log_decision
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "ba.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def patched_db(db_path):
+    """Redirect every DB call in brief_auditor + base to the test DB."""
+    from nuri.core import db as db_module
+
+    def make_redirect(fn):
+        def wrapped(*args, **kwargs):
+            kwargs.setdefault("db_path", db_path)
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    patches = [
+        patch("nuri.agents.base.log_agent_audit", side_effect=make_redirect(db_module.log_agent_audit)),
+        patch("nuri.agents.base.start_agent_run", side_effect=make_redirect(db_module.start_agent_run)),
+        patch("nuri.agents.base.finish_agent_run", side_effect=make_redirect(db_module.finish_agent_run)),
+        patch("nuri.agents.actors.brief_auditor.query", side_effect=make_redirect(db_module.query)),
+    ]
+    for p in patches:
+        p.start()
+    yield db_path
+    for p in patches:
+        p.stop()
+
+
+def _seed_decision(
+    db_path,
+    *,
+    decision_id: str,
+    ticker: str,
+    action: str,
+    conviction: float,
+    status: str = "emitted",
+):
+    """Insert a minimal agent_decisions row."""
+    log_decision(
+        decision_id=decision_id,
+        ticker=ticker,
+        as_of_date="2026-05-02",
+        action=action,
+        conviction=conviction,
+        inputs={
+            "regime_run_id": "r1",
+            "hypothesis_id": "h1",
+            "causal_audit_id": "c1",
+        },
+        rationale={"causal_certainty": 0.8, "regime_top_prob": 0.8, "top2_margin": 0.6},
+        status=status,
+        run_id="run-test",
+        db_path=db_path,
+    )
+
+
+# ─── pure check functions (no DB) ─────────────────────────
+
+
+def test_check_conflict_detects_buy_and_sell_same_ticker():
+    decisions = [
+        {"ticker": "TST_A", "action": "BUY", "decision_id": "d1", "conviction": 0.81, "created_at": "2026-05-02 00:00"},
+        {
+            "ticker": "TST_A",
+            "action": "SELL",
+            "decision_id": "d2",
+            "conviction": 0.81,
+            "created_at": "2026-05-02 06:00",
+        },
+    ]
+    issues = _check_conflict(decisions)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "conflict"
+    assert issues[0]["affected"] == ["TST_A"]
+    assert "d1" in issues[0]["evidence"]
+    assert "d2" in issues[0]["evidence"]
+
+
+def test_check_conflict_no_issue_when_only_buy():
+    decisions = [
+        {"ticker": "TST_A", "action": "BUY", "decision_id": "d1", "conviction": 0.81, "created_at": "2026-05-02 00:00"},
+        {"ticker": "TST_A", "action": "BUY", "decision_id": "d2", "conviction": 0.82, "created_at": "2026-05-02 06:00"},
+    ]
+    assert _check_conflict(decisions) == []
+
+
+def test_check_noise_above_threshold():
+    decisions = [
+        {"ticker": "TST_A", "action": "BUY", "decision_id": f"d{i}", "conviction": 0.81, "created_at": "2026-05-02"}
+        for i in range(5)
+    ]
+    issues = _check_noise(decisions)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "noise"
+    assert issues[0]["n_decisions"] == 5
+
+
+def test_check_noise_at_threshold_no_issue():
+    decisions = [
+        {"ticker": "TST_A", "action": "BUY", "decision_id": f"d{i}", "conviction": 0.81, "created_at": "2026-05-02"}
+        for i in range(3)
+    ]
+    assert _check_noise(decisions) == []
+
+
+def test_check_identical_conv_detects_broken_scoring():
+    decisions = [
+        {"ticker": f"TST_{i}", "action": "BUY", "decision_id": f"d{i}", "conviction": 0.810, "created_at": "2026-05-02"}
+        for i in range(6)
+    ]
+    issues = _check_identical_conv(decisions)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "identical_conv"
+    assert issues[0]["n_decisions"] == 6
+
+
+def test_check_identical_conv_skips_with_spread():
+    decisions = [
+        {
+            "ticker": f"TST_{i}",
+            "action": "BUY",
+            "decision_id": f"d{i}",
+            "conviction": 0.81 + i * 0.01,
+            "created_at": "2026-05-02",
+        }
+        for i in range(6)
+    ]
+    assert _check_identical_conv(decisions) == []
+
+
+def test_check_identical_conv_skips_below_min_samples():
+    decisions = [
+        {"ticker": f"TST_{i}", "action": "BUY", "decision_id": f"d{i}", "conviction": 0.810, "created_at": "2026-05-02"}
+        for i in range(3)
+    ]
+    assert _check_identical_conv(decisions) == []
+
+
+def test_make_issue_id_deterministic():
+    a = _make_issue_id("conflict", ["TST_B", "TST_A"])
+    b = _make_issue_id("conflict", ["TST_A", "TST_B"])
+    assert a == b == _make_issue_id("conflict", ["TST_A", "TST_B"])
+
+
+def test_make_issue_id_differs_by_type():
+    a = _make_issue_id("conflict", ["TST_A"])
+    b = _make_issue_id("noise", ["TST_A"])
+    assert a != b
+
+
+# ─── full actor run with patched DB ─────────────────────────
+
+
+def test_audit_finds_conflict_and_emits_warn(patched_db):
+    _seed_decision(patched_db, decision_id="dc-1", ticker="TST_A", action="BUY", conviction=0.81)
+    _seed_decision(patched_db, decision_id="dc-2", ticker="TST_A", action="SELL", conviction=0.82)
+
+    with patch("nuri.agents.actors.brief_auditor._emit_incident", return_value=True) as emit:
+        result = BriefAuditor().run({"hours": 24, "db_path": patched_db})
+
+    assert result.outcome == Outcome.WARN
+    assert result.output["decisions_audited"] == 2
+    assert result.output["issues_found"] == 1
+    assert result.output["issues_emitted"] == 1
+    assert emit.called
+
+
+def test_audit_passes_when_no_issues(patched_db):
+    _seed_decision(patched_db, decision_id="dc-1", ticker="TST_A", action="BUY", conviction=0.81)
+    _seed_decision(patched_db, decision_id="dc-2", ticker="TST_B", action="SELL", conviction=0.85)
+
+    with patch("nuri.agents.actors.brief_auditor._emit_incident", return_value=True):
+        result = BriefAuditor().run({"hours": 24, "db_path": patched_db})
+
+    assert result.outcome == Outcome.PASS
+    assert result.output["issues_found"] == 0
+    assert result.output["issues_emitted"] == 0
+
+
+def test_audit_skips_hold_status_only_emitted_buy_sell(patched_db):
+    _seed_decision(patched_db, decision_id="dc-1", ticker="TST_A", action="HOLD", conviction=0.81)
+    _seed_decision(patched_db, decision_id="dc-2", ticker="TST_A", action="HOLD", conviction=0.81)
+
+    with patch("nuri.agents.actors.brief_auditor._emit_incident", return_value=True):
+        result = BriefAuditor().run({"hours": 24, "db_path": patched_db})
+
+    assert result.output["decisions_audited"] == 0
+    assert result.outcome == Outcome.PASS
+
+
+def test_audit_dedupes_against_recent_outbox_stage(patched_db):
+    """Codex Round 6: dedupe via outbox dedupe_key (no longer agent_messages)."""
+    from nuri.core.db import stage_outbox
+
+    _seed_decision(patched_db, decision_id="dc-1", ticker="TST_A", action="BUY", conviction=0.81)
+    _seed_decision(patched_db, decision_id="dc-2", ticker="TST_A", action="SELL", conviction=0.82)
+
+    issue_id = _make_issue_id("conflict", ["TST_A"])
+    stage_outbox(
+        channel="incidents",
+        payload={"summary": "prior brief_quality issue"},
+        dedupe_key=f"brief_quality:{issue_id}",
+        actor_name="brief-auditor",
+        db_path=patched_db,
+    )
+
+    with patch("nuri.agents.actors.brief_auditor._emit_incident", return_value=True) as emit:
+        result = BriefAuditor().run({"hours": 24, "db_path": patched_db})
+
+    assert result.output["issues_found"] == 1
+    assert result.output["issues_emitted"] == 0
+    assert result.output["issues_dedupe_skipped"] == 1
+    assert not emit.called

--- a/tests/agents/test_causal_factor_auditor.py
+++ b/tests/agents/test_causal_factor_auditor.py
@@ -589,9 +589,10 @@ class TestLastAudit:
 
 
 class TestDiscordPublish:
-    def test_mirage_publishes_to_rollout(self, patched_db, random_factor):
+    def test_mirage_stages_to_rollout(self, patched_db, random_factor):
+        """MIRAGE → outbox stage_rollout (PR3 Codex Round 6)."""
         f, r = random_factor
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             CausalFactorAuditor().run(
                 {
                     "action": "audit",
@@ -603,14 +604,14 @@ class TestDiscordPublish:
                     "n_placebo_runs": 100,
                 }
             )
-            mock_publish.assert_called_once()
-            call_kwargs = mock_publish.call_args.kwargs
-            assert call_kwargs["actor_name"] == "causal-factor-auditor"
-            assert "MIRAGE" in call_kwargs["embed"]["title"]
+            mock_stage.assert_called_once()
+            kw = mock_stage.call_args.kwargs
+            assert kw["actor_name"] == "causal-factor-auditor"
+            assert kw["payload"]["kind"] == "factor_mirage"
 
-    def test_robust_does_not_publish(self, patched_db, genuine_factor):
+    def test_robust_does_not_stage(self, patched_db, genuine_factor):
         f, r = genuine_factor
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             CausalFactorAuditor().run(
                 {
                     "action": "audit",
@@ -622,13 +623,13 @@ class TestDiscordPublish:
                     "n_placebo_runs": 30,
                 }
             )
-            mock_publish.assert_not_called()
+            mock_stage.assert_not_called()
 
     def test_publish_failure_does_not_block_actor(self, patched_db, random_factor):
         f, r = random_factor
         with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            side_effect=RuntimeError("network"),
+            "nuri.agents.discord.outbox.stage_rollout",
+            side_effect=RuntimeError("outbox down"),
         ):
             result = CausalFactorAuditor().run(
                 {

--- a/tests/agents/test_collector_orchestrator.py
+++ b/tests/agents/test_collector_orchestrator.py
@@ -398,9 +398,7 @@ class TestOrchestrateInputValidation:
 class TestScanHealth:
     def _seed(self, db_path, name, statuses):
         for s in statuses:
-            log_collector_run(
-                collector_name=name, status=s, db_path=db_path
-            )
+            log_collector_run(collector_name=name, status=s, db_path=db_path)
 
     def test_no_data_returns_pass(self, patched_db):
         actor = CollectorOrchestrator()
@@ -425,9 +423,7 @@ class TestScanHealth:
         result = actor.run({"action": "scan_health", "hours": 24})
         assert result.outcome == Outcome.WARN
         assert result.output["unhealthy_count"] == 1
-        unhealthy = [
-            s for s in result.output["summaries"] if s["health_status"] == "unhealthy"
-        ]
+        unhealthy = [s for s in result.output["summaries"] if s["health_status"] == "unhealthy"]
         assert unhealthy[0]["collector_name"] == "yfinance"
 
     def test_all_unhealthy_block(self, patched_db):
@@ -460,25 +456,17 @@ class TestScanHealth:
 class TestListRecent:
     def test_lists_all_when_no_filter(self, patched_db):
         for name in ("kis_prices", "yfinance", "fred"):
-            log_collector_run(
-                collector_name=name, status="finished", db_path=patched_db
-            )
+            log_collector_run(collector_name=name, status="finished", db_path=patched_db)
         actor = CollectorOrchestrator()
         result = actor.run({"action": "list_recent", "limit": 10})
         assert result.outcome == Outcome.PASS
         assert result.output["count"] == 3
 
     def test_filters_by_collector_name(self, patched_db):
-        log_collector_run(
-            collector_name="kis_prices", status="finished", db_path=patched_db
-        )
-        log_collector_run(
-            collector_name="yfinance", status="finished", db_path=patched_db
-        )
+        log_collector_run(collector_name="kis_prices", status="finished", db_path=patched_db)
+        log_collector_run(collector_name="yfinance", status="finished", db_path=patched_db)
         actor = CollectorOrchestrator()
-        result = actor.run(
-            {"action": "list_recent", "collector_name": "yfinance", "limit": 10}
-        )
+        result = actor.run({"action": "list_recent", "collector_name": "yfinance", "limit": 10})
         assert result.output["count"] == 1
         assert result.output["runs"][0]["collector_name"] == "yfinance"
 
@@ -505,80 +493,51 @@ class TestListRecent:
 
 
 class TestDiscordPublish:
-    def test_orchestrate_failure_publishes_to_ops(self, patched_db):
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher"
-        ) as MockPub:
+    def test_orchestrate_failure_stages_to_ops(self, patched_db):
+        """orchestrate failure → outbox stage_ops (PR3 Codex Round 6)."""
+        with patch("nuri.agents.discord.outbox.stage_ops") as mock_stage:
             actor = CollectorOrchestrator()
             actor.run(
                 {
                     "action": "orchestrate",
                     "collector_name": "kis_prices",
-                    "collector_fn": lambda: (_ for _ in ()).throw(
-                        RuntimeError("boom")
-                    ),
+                    "collector_fn": lambda: (_ for _ in ()).throw(RuntimeError("boom")),
                     "max_retries": 0,
                 }
             )
-            assert MockPub.return_value.publish_embed.called
-            args, kwargs = MockPub.return_value.publish_embed.call_args
-            from nuri.agents.discord.publisher import Channel
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "collector_failure"
 
-            assert args[0] == Channel.OPS
-
-    def test_scan_health_block_publishes_to_incidents(self, patched_db):
-        # 모두 unhealthy → BLOCK → INCIDENTS
+    def test_scan_health_block_stages_to_incidents(self, patched_db):
         for name in ("kis_prices", "yfinance"):
             for _ in range(5):
-                log_collector_run(
-                    collector_name=name, status="failed", db_path=patched_db
-                )
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher"
-        ) as MockPub:
+                log_collector_run(collector_name=name, status="failed", db_path=patched_db)
+        with patch("nuri.agents.discord.outbox.stage_incident") as mock_stage:
             actor = CollectorOrchestrator()
             actor.run({"action": "scan_health", "hours": 24})
-            assert MockPub.return_value.publish_embed.called
-            args, kwargs = MockPub.return_value.publish_embed.call_args
-            from nuri.agents.discord.publisher import Channel
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "collector_health_catastrophic"
 
-            assert args[0] == Channel.INCIDENTS
-
-    def test_scan_health_warn_publishes_to_ops(self, patched_db):
-        log_collector_run(
-            collector_name="kis_prices", status="finished", db_path=patched_db
-        )
+    def test_scan_health_warn_stages_to_ops(self, patched_db):
+        log_collector_run(collector_name="kis_prices", status="finished", db_path=patched_db)
         for _ in range(5):
-            log_collector_run(
-                collector_name="yfinance", status="failed", db_path=patched_db
-            )
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher"
-        ) as MockPub:
+            log_collector_run(collector_name="yfinance", status="failed", db_path=patched_db)
+        with patch("nuri.agents.discord.outbox.stage_ops") as mock_stage:
             actor = CollectorOrchestrator()
             actor.run({"action": "scan_health", "hours": 24})
-            assert MockPub.return_value.publish_embed.called
-            args, kwargs = MockPub.return_value.publish_embed.call_args
-            from nuri.agents.discord.publisher import Channel
-
-            assert args[0] == Channel.OPS
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "collector_health_warn"
 
     def test_publish_failure_does_not_break_actor(self, patched_db):
         """Discord 가 raise 해도 actor outcome 영향 없음 — best-effort 보장."""
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher"
-        ) as MockPub:
-            MockPub.return_value.publish_embed.side_effect = RuntimeError(
-                "discord down"
-            )
+        with patch("nuri.agents.discord.publisher.DiscordPublisher") as MockPub:
+            MockPub.return_value.publish_embed.side_effect = RuntimeError("discord down")
             actor = CollectorOrchestrator()
             result = actor.run(
                 {
                     "action": "orchestrate",
                     "collector_name": "kis_prices",
-                    "collector_fn": lambda: (_ for _ in ()).throw(
-                        RuntimeError("boom")
-                    ),
+                    "collector_fn": lambda: (_ for _ in ()).throw(RuntimeError("boom")),
                     "max_retries": 0,
                 }
             )
@@ -679,22 +638,16 @@ class TestCli:
 
     def test_cli_warn_returns_1(self, patched_db, capsys):
         # 1 healthy + 1 unhealthy → WARN → rc=1
-        log_collector_run(
-            collector_name="kis_prices", status="finished", db_path=patched_db
-        )
+        log_collector_run(collector_name="kis_prices", status="finished", db_path=patched_db)
         for _ in range(5):
-            log_collector_run(
-                collector_name="yfinance", status="failed", db_path=patched_db
-            )
+            log_collector_run(collector_name="yfinance", status="failed", db_path=patched_db)
         rc = main(["scan_health", "--hours", "24"])
         assert rc == 1
 
     def test_cli_block_returns_2(self, patched_db, capsys):
         # 모두 unhealthy → BLOCK → rc=2
         for _ in range(5):
-            log_collector_run(
-                collector_name="kis_prices", status="failed", db_path=patched_db
-            )
+            log_collector_run(collector_name="kis_prices", status="failed", db_path=patched_db)
         rc = main(["scan_health", "--hours", "24"])
         assert rc == 2
 

--- a/tests/agents/test_decision_compiler.py
+++ b/tests/agents/test_decision_compiler.py
@@ -57,7 +57,10 @@ def patched_db(db_path):
 
     def make_redirect(fn):
         def wrapped(*args, **kwargs):
-            kwargs.setdefault("db_path", db_path)
+            # setdefault 가 아니라 None 도 override — outbox stage_brief 처럼
+            # caller 가 db_path=None 명시 전달하는 경로 대응 (PR channel-migration).
+            if kwargs.get("db_path") is None:
+                kwargs["db_path"] = db_path
             return fn(*args, **kwargs)
 
         return wrapped
@@ -110,6 +113,11 @@ def patched_db(db_path):
         patch(
             "nuri.agents.actors.causal_factor_auditor.query",
             side_effect=make_redirect(db_module.query),
+        ),
+        # PR #brief outbox channel-migration (Codex Round 6, 2026-05-02)
+        patch(
+            "nuri.agents.discord.outbox.stage_outbox",
+            side_effect=make_redirect(db_module.stage_outbox),
         ),
     ]
     for p in patches:
@@ -503,16 +511,23 @@ class TestLastDecision:
 
 
 class TestDiscordPublish:
-    def test_emit_publishes_to_brief(self, patched_db):
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
-            DecisionCompiler().run(_compile_payload())
-            mock_publish.assert_called_once()
-            kw = mock_publish.call_args.kwargs
-            assert kw["actor_name"] == "decision-compiler"
-            assert "BUY" in kw["embed"]["title"]
+    """#brief channel-migration (Codex Round 6): decision_compiler._publish_brief 가 outbox stage 로 전환.
+    #ops (block path) 는 PR3 에서 별도 channel-migration. 본 클래스의 emit 검사는 outbox 기준."""
 
-    def test_blocked_publishes_to_ops(self, patched_db):
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+    def test_emit_stages_to_brief_outbox(self, patched_db):
+        from nuri.core.db import claim_pending_outbox
+
+        DecisionCompiler().run(_compile_payload())
+        _, rows = claim_pending_outbox("brief", db_path=patched_db)
+        assert len(rows) == 1
+        payload = rows[0]["payload"]
+        assert payload["kind"] == "BUY"
+        assert payload["ticker"]
+        assert "decision_id" in payload
+
+    def test_blocked_stages_to_ops(self, patched_db):
+        """Block path → outbox stage_ops (PR3 Codex Round 6)."""
+        with patch("nuri.agents.discord.outbox.stage_ops") as mock_stage:
             DecisionCompiler().run(
                 _compile_payload(
                     causal_evidence={
@@ -523,40 +538,41 @@ class TestDiscordPublish:
                     }
                 )
             )
-            mock_publish.assert_called_once()
-            assert "BLOCKED" in mock_publish.call_args.kwargs["embed"]["title"]
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "decision_blocked"
 
     def test_publish_failure_does_not_block_actor(self, patched_db):
+        # outbox stage 가 어떤 이유로든 raise 해도 actor pipeline 죽지 않아야 함.
         with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            side_effect=RuntimeError("network"),
+            "nuri.agents.discord.outbox.stage_brief",
+            side_effect=RuntimeError("outbox down"),
         ):
             result = DecisionCompiler().run(_compile_payload())
-            assert result.outcome == Outcome.PASS  # publish 실패해도 emit 유지
+            assert result.outcome == Outcome.PASS
             assert result.output["status"] == "emitted"
 
-    def test_hold_emit_does_not_publish_brief(self, patched_db):
-        """HOLD (low conviction emit) 은 BRIEF publish X (사용자 noise)."""
-        # 조건: low conviction → HOLD blocked path (publish_block 호출됨)
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
-            DecisionCompiler().run(
-                _compile_payload(
-                    causal_evidence={
-                        "factor_id": "weak",
-                        "as_of_date": "2026-05-01",
-                        "verdict": "WEAK",
-                        "causal_certainty": 0.3,
-                    },
-                    regime_evidence={
-                        "regime_run_id": "r-weak",
-                        "posterior": [0.4, 0.35, 0.25],
-                        "argmax_state": 0,
-                        "top2_margin": 0.05,
-                    },
-                )
+    def test_hold_emit_does_not_stage_brief(self, patched_db):
+        """HOLD (low conviction) 은 BRIEF outbox stage X — 사용자 noise 방지."""
+        from nuri.core.db import claim_pending_outbox
+
+        DecisionCompiler().run(
+            _compile_payload(
+                causal_evidence={
+                    "factor_id": "weak",
+                    "as_of_date": "2026-05-01",
+                    "verdict": "WEAK",
+                    "causal_certainty": 0.3,
+                },
+                regime_evidence={
+                    "regime_run_id": "r-weak",
+                    "posterior": [0.4, 0.35, 0.25],
+                    "argmax_state": 0,
+                    "top2_margin": 0.05,
+                },
             )
-            # Block path → OPS publish, not BRIEF
-            assert mock_publish.call_args.kwargs["actor_name"] == "decision-compiler"
+        )
+        _, rows = claim_pending_outbox("brief", db_path=patched_db)
+        assert rows == []
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/agents/test_discord_outbox.py
+++ b/tests/agents/test_discord_outbox.py
@@ -1,0 +1,334 @@
+"""Discord outbox tests — single-writer pattern (Codex Round 6, 2026-05-02).
+
+Coverage:
+    - stage_outbox / dedupe skip vs replace
+    - claim_pending_outbox lease + priority + scheduled_for ordering
+    - mark_outbox_sent / mark_outbox_failed claim_token isolation
+    - Lease expiry → re-claim by another dispatcher
+    - bucket_brief_digest / bucket_generic_digest layout
+    - ChannelDispatcher quiet-period gate (#brief)
+    - ChannelDispatcher publish path (mock webhook)
+    - OutboxWatchdog threshold breach → direct ops alert (mock webhook)
+
+Privacy: synthetic tickers TST_A/TST_B (never real holdings).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nuri.agents.actors.channel_dispatcher import ChannelDispatcher
+from nuri.agents.actors.outbox_watchdog import OutboxWatchdog
+from nuri.agents.base import Outcome
+from nuri.agents.discord.outbox import (
+    bucket_brief_digest,
+    bucket_generic_digest,
+    stage_brief,
+    stage_incident,
+)
+from nuri.core.db import (
+    claim_pending_outbox,
+    init_db,
+    mark_outbox_failed,
+    mark_outbox_sent,
+    outbox_health,
+    stage_outbox,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "outbox.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def patched_db(db_path):
+    """Redirect DB calls in dispatcher / watchdog to test DB."""
+    from nuri.core import db as db_module
+
+    def make_redirect(fn):
+        def wrapped(*args, **kwargs):
+            kwargs.setdefault("db_path", db_path)
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    patches = [
+        patch("nuri.agents.base.log_agent_audit", side_effect=make_redirect(db_module.log_agent_audit)),
+        patch("nuri.agents.base.start_agent_run", side_effect=make_redirect(db_module.start_agent_run)),
+        patch("nuri.agents.base.finish_agent_run", side_effect=make_redirect(db_module.finish_agent_run)),
+        patch(
+            "nuri.agents.actors.channel_dispatcher.claim_pending_outbox",
+            side_effect=make_redirect(db_module.claim_pending_outbox),
+        ),
+        patch(
+            "nuri.agents.actors.channel_dispatcher.mark_outbox_sent",
+            side_effect=make_redirect(db_module.mark_outbox_sent),
+        ),
+        patch(
+            "nuri.agents.actors.channel_dispatcher.mark_outbox_failed",
+            side_effect=make_redirect(db_module.mark_outbox_failed),
+        ),
+        patch("nuri.agents.actors.channel_dispatcher.query", side_effect=make_redirect(db_module.query)),
+        patch("nuri.agents.actors.outbox_watchdog.outbox_health", side_effect=make_redirect(db_module.outbox_health)),
+    ]
+    for p in patches:
+        p.start()
+    yield db_path
+    for p in patches:
+        p.stop()
+
+
+# ─── stage / dedupe ──────────────────────────────────────
+
+
+def test_stage_dedupe_skip_returns_none_for_duplicate(db_path):
+    i1 = stage_outbox("brief", {"kind": "BUY", "ticker": "TST_A"}, dedupe_key="key1", db_path=db_path)
+    i2 = stage_outbox("brief", {"kind": "BUY", "ticker": "TST_A"}, dedupe_key="key1", db_path=db_path)
+    assert i1 is not None
+    assert i2 is None
+
+
+def test_stage_dedupe_replace_updates_payload(db_path):
+    i1 = stage_outbox("brief", {"v": 1}, dedupe_key="k", db_path=db_path)
+    i2 = stage_outbox("brief", {"v": 2}, dedupe_key="k", db_path=db_path, dedupe_strategy="replace")
+    assert i1 == i2
+
+    _, rows = claim_pending_outbox("brief", db_path=db_path)
+    assert rows[0]["payload"]["v"] == 2
+
+
+def test_stage_invalid_channel_raises(db_path):
+    with pytest.raises(ValueError):
+        stage_outbox("nope", {}, db_path=db_path)
+
+
+def test_stage_brief_helper_routes_to_brief_channel(db_path):
+    stage_brief({"kind": "BUY", "ticker": "TST_A"}, db_path=db_path)
+    _, rows = claim_pending_outbox("brief", db_path=db_path)
+    assert len(rows) == 1
+    _, ops_rows = claim_pending_outbox("ops", db_path=db_path)
+    assert ops_rows == []
+
+
+# ─── claim / priority / lease ────────────────────────────
+
+
+def test_claim_priority_high_first(db_path):
+    stage_outbox("ops", {"x": "normal"}, priority="normal", db_path=db_path)
+    stage_outbox("ops", {"x": "high"}, priority="high", db_path=db_path)
+    stage_outbox("ops", {"x": "low"}, priority="low", db_path=db_path)
+    _, rows = claim_pending_outbox("ops", db_path=db_path)
+    assert [r["payload"]["x"] for r in rows] == ["high", "normal", "low"]
+
+
+def test_mark_sent_only_with_correct_token(db_path):
+    stage_outbox("ops", {"x": 1}, db_path=db_path)
+    token1, rows = claim_pending_outbox("ops", db_path=db_path)
+    assert mark_outbox_sent([rows[0]["id"]], "wrong-token", db_path=db_path) == 0
+    assert mark_outbox_sent([rows[0]["id"]], token1, db_path=db_path) == 1
+
+
+def test_lease_expiry_allows_reclaim(db_path):
+    # stage + claim
+    stage_outbox("ops", {"x": 1}, db_path=db_path)
+    token1, rows1 = claim_pending_outbox("ops", db_path=db_path)
+    assert len(rows1) == 1
+
+    # 두 번째 claim 즉시 = 빈 결과 (lease 유효)
+    _, rows2 = claim_pending_outbox("ops", db_path=db_path)
+    assert rows2 == []
+
+    # claimed_at 을 6분 전으로 강제 backdate 해서 lease 만료 시뮬레이션
+    from nuri.core.db import get_db
+
+    with get_db(db_path) as conn:
+        conn.execute(
+            "UPDATE discord_outbox SET claimed_at = datetime('now','-6 minutes') WHERE id = ?",
+            (rows1[0]["id"],),
+        )
+    _, rows3 = claim_pending_outbox("ops", db_path=db_path)
+    assert len(rows3) == 1
+
+
+def test_scheduled_for_future_not_claimed_yet(db_path):
+    from nuri.core.db import get_db
+
+    stage_outbox("ops", {"x": 1}, db_path=db_path)
+    # backdate scheduled_for to future
+    with get_db(db_path) as conn:
+        conn.execute("UPDATE discord_outbox SET scheduled_for = datetime('now','+1 hour')")
+    _, rows = claim_pending_outbox("ops", db_path=db_path)
+    assert rows == []
+
+
+def test_mark_failed_clears_claim_token_for_retry(db_path):
+    stage_outbox("ops", {"x": 1}, db_path=db_path)
+    token1, rows1 = claim_pending_outbox("ops", db_path=db_path)
+    assert mark_outbox_failed([rows1[0]["id"]], token1, error="boom", db_path=db_path) == 1
+    # status='failed' 인 row 는 다음 claim 안 잡힘 (현재 정책: failed terminal until manual requeue)
+    _, rows2 = claim_pending_outbox("ops", db_path=db_path)
+    assert rows2 == []
+
+
+# ─── digest layout ───────────────────────────────────────
+
+
+def test_bucket_brief_digest_groups_by_actionability():
+    events = [
+        {"kind": "BUY", "ticker": "TST_A", "conviction": 0.81},
+        {"kind": "SELL", "ticker": "TST_B", "conviction": 0.77},
+        {"kind": "BLOCK", "ticker": "TST_A", "reason": "vix"},
+        {"kind": "HOLD", "ticker": "TST_C", "conviction": 0.45},
+    ]
+    embed = bucket_brief_digest(events)
+    field_names = [f["name"] for f in embed["fields"]]
+    assert any("Action Now" in n for n in field_names)
+    assert any("Blocked / Conflict" in n for n in field_names)
+    assert any("Lower Priority" in n for n in field_names)
+    assert "BUY 1" in embed["description"]
+    assert "SELL 1" in embed["description"]
+    assert "BLOCK 1" in embed["description"]
+
+
+def test_bucket_brief_digest_empty_returns_no_op_embed():
+    embed = bucket_brief_digest([])
+    assert embed["fields"] == []
+    assert "0 opinions" in embed["title"]
+
+
+def test_bucket_generic_digest_groups_by_kind():
+    events = [
+        {"kind": "freshness_warn", "summary": "prices stale 25h"},
+        {"kind": "freshness_warn", "summary": "vix stale 26h"},
+        {"kind": "rate_limit", "summary": "kis 429"},
+    ]
+    embed = bucket_generic_digest(events, channel_label="Ops")
+    field_names = [f["name"] for f in embed["fields"]]
+    assert any("freshness_warn (2)" in n for n in field_names)
+    assert any("rate_limit (1)" in n for n in field_names)
+
+
+# ─── dispatcher ──────────────────────────────────────────
+
+
+def test_dispatcher_brief_quiet_period_skips_recent_stage(patched_db):
+    stage_brief({"kind": "BUY", "ticker": "TST_A", "conviction": 0.8}, db_path=patched_db)
+    result = ChannelDispatcher().run({"channel": "brief", "db_path": patched_db})
+    assert result.outcome == Outcome.PASS
+    assert result.output["skipped"] == "quiet-period"
+
+
+def test_dispatcher_brief_high_priority_bypasses_quiet_period(patched_db):
+    stage_brief(
+        {"kind": "SELL", "ticker": "TST_A", "conviction": 0.9, "reason": "stop-loss"},
+        priority="high",
+        db_path=patched_db,
+    )
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=True, http_status=204, error=None)
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = ChannelDispatcher().run({"channel": "brief", "db_path": patched_db})
+    assert result.outcome == Outcome.PASS
+    assert result.output.get("marked_sent_n") == 1
+
+
+def test_dispatcher_force_bypass(patched_db):
+    stage_brief({"kind": "BUY", "ticker": "TST_A", "conviction": 0.8}, db_path=patched_db)
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=True, http_status=204, error=None)
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = ChannelDispatcher().run({"channel": "brief", "force": True, "db_path": patched_db})
+    assert result.output.get("marked_sent_n") == 1
+
+
+def test_dispatcher_no_pending_passes(patched_db):
+    result = ChannelDispatcher().run({"channel": "ops", "db_path": patched_db})
+    assert result.outcome == Outcome.PASS
+    assert result.output["skipped"] == "no-pending"
+
+
+def test_dispatcher_ops_does_not_quiet_period(patched_db):
+    stage_outbox("ops", {"kind": "freshness_warn", "summary": "x"}, db_path=patched_db)
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=True, http_status=204, error=None)
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = ChannelDispatcher().run({"channel": "ops", "db_path": patched_db})
+    assert result.output.get("marked_sent_n") == 1
+
+
+def test_dispatcher_publish_failure_marks_failed(patched_db):
+    stage_outbox("ops", {"kind": "x", "summary": "y"}, db_path=patched_db)
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=False, http_status=500, error="server error")
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = ChannelDispatcher().run({"channel": "ops", "db_path": patched_db})
+    assert result.outcome == Outcome.WARN
+    health = outbox_health(db_path=patched_db)
+    assert health["by_channel"]["ops"].get("failed", 0) == 1
+
+
+def test_dispatcher_quiet_period_dispatches_after_age(patched_db):
+    stage_brief({"kind": "BUY", "ticker": "TST_A", "conviction": 0.8}, db_path=patched_db)
+    # backdate created_at past quiet-period
+    from nuri.core.db import get_db
+
+    with get_db(patched_db) as conn:
+        conn.execute("UPDATE discord_outbox SET created_at = datetime('now','-2 minutes')")
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=True, http_status=204, error=None)
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = ChannelDispatcher().run({"channel": "brief", "db_path": patched_db})
+    assert result.output.get("marked_sent_n") == 1
+
+
+# ─── watchdog ────────────────────────────────────────────
+
+
+def test_watchdog_clean_when_no_backlog(patched_db):
+    result = OutboxWatchdog().run({"db_path": patched_db})
+    assert result.outcome == Outcome.PASS
+    assert result.output["breaches"] == []
+
+
+def test_watchdog_breach_on_old_pending(patched_db):
+    stage_outbox("ops", {"x": 1}, db_path=patched_db)
+    from nuri.core.db import get_db
+
+    with get_db(patched_db) as conn:
+        conn.execute("UPDATE discord_outbox SET scheduled_for = datetime('now','-45 minutes')")
+
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=True, http_status=204, error=None)
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = OutboxWatchdog().run({"db_path": patched_db})
+    assert result.outcome == Outcome.WARN
+    assert any(b["kind"] == "oldest_pending_age" for b in result.output["breaches"])
+
+
+def test_watchdog_breach_on_pending_count(patched_db):
+    for i in range(120):
+        stage_outbox("ops", {"i": i}, db_path=patched_db)
+    mock_pub = MagicMock()
+    mock_pub.publish_embed.return_value = MagicMock(ok=True, http_status=204, error=None)
+    with patch("nuri.agents.discord.publisher.DiscordPublisher", return_value=mock_pub):
+        result = OutboxWatchdog().run({"db_path": patched_db})
+    assert any(b["kind"] == "pending_count" for b in result.output["breaches"])
+
+
+# ─── outbox_health ──────────────────────────────────────
+
+
+def test_outbox_health_shows_per_channel_counts(db_path):
+    stage_outbox("brief", {"x": 1}, db_path=db_path)
+    stage_outbox("brief", {"x": 2}, db_path=db_path)
+    stage_outbox("ops", {"x": 3}, db_path=db_path)
+    h = outbox_health(db_path=db_path)
+    assert h["by_channel"]["brief"]["pending"] == 2
+    assert h["by_channel"]["ops"]["pending"] == 1
+    assert h["oldest_pending_age_seconds"] is not None

--- a/tests/agents/test_drift_sentinel.py
+++ b/tests/agents/test_drift_sentinel.py
@@ -305,16 +305,12 @@ class TestInvalidAction:
 class TestCheckInputValidation:
     def test_missing_feature_name_blocks(self, patched_db, no_publish):
         actor = DriftSentinel()
-        result = actor.run(
-            {"action": "check", "baseline": [1.0, 2.0], "current": [1.0], "test_type": "psi"}
-        )
+        result = actor.run({"action": "check", "baseline": [1.0, 2.0], "current": [1.0], "test_type": "psi"})
         assert result.outcome == Outcome.BLOCK
 
     def test_missing_baseline_blocks(self, patched_db, no_publish):
         actor = DriftSentinel()
-        result = actor.run(
-            {"action": "check", "feature_name": "x", "current": [1.0], "test_type": "psi"}
-        )
+        result = actor.run({"action": "check", "feature_name": "x", "current": [1.0], "test_type": "psi"})
         assert result.outcome == Outcome.BLOCK
 
     def test_invalid_test_type_blocks(self, patched_db, no_publish):
@@ -647,9 +643,7 @@ class TestListAlerts:
         self._seed_alerts(patched_db)
         actor = DriftSentinel()
         # 미래 시점 → 0 hits
-        result = actor.run(
-            {"action": "list_alerts", "since_iso": "2099-01-01 00:00:00"}
-        )
+        result = actor.run({"action": "list_alerts", "since_iso": "2099-01-01 00:00:00"})
         assert result.outcome == Outcome.PASS
         assert result.output["count"] == 0
 
@@ -660,14 +654,13 @@ class TestListAlerts:
 
 
 class TestDiscordPublishRouting:
-    def test_critical_publishes_to_incidents(self, patched_db):
+    """PR3 Codex Round 6: drift critical → outbox stage_incident, major → stage_ops."""
+
+    def test_critical_stages_to_incidents(self, patched_db):
         rng = np.random.default_rng(42)
         baseline = rng.normal(0, 1, 1000).tolist()
         current = rng.normal(5, 1, 1000).tolist()
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            return_value=MagicMock(ok=True, channel="incidents", http_status=204, retry_count=0),
-        ) as pub_embed:
+        with patch("nuri.agents.discord.outbox.stage_incident") as mock_stage:
             actor = DriftSentinel()
             actor.run(
                 {
@@ -679,22 +672,17 @@ class TestDiscordPublishRouting:
                     "actor_name": "regime-posterior",
                 }
             )
-        from nuri.agents.discord.publisher import Channel
+        assert mock_stage.called
+        assert mock_stage.call_args.kwargs["payload"]["kind"] == "drift_critical"
 
-        assert pub_embed.called
-        call = pub_embed.call_args
-        channel_arg = call.args[0] if call.args else call.kwargs.get("channel")
-        assert channel_arg == Channel.INCIDENTS
-
-    def test_major_publishes_to_ops(self, patched_db):
-        # PSI major (0.25-0.50) 강제
+    def test_major_stages_to_ops(self, patched_db):
         rng = np.random.default_rng(42)
         baseline = rng.normal(0, 1, 5000).tolist()
         current = rng.normal(0.7, 1, 5000).tolist()
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            return_value=MagicMock(ok=True, channel="ops", http_status=204, retry_count=0),
-        ) as pub_embed:
+        with (
+            patch("nuri.agents.discord.outbox.stage_ops") as mock_ops,
+            patch("nuri.agents.discord.outbox.stage_incident") as mock_inc,
+        ):
             actor = DriftSentinel()
             result = actor.run(
                 {
@@ -705,28 +693,22 @@ class TestDiscordPublishRouting:
                     "test_type": "psi",
                 }
             )
-        # severity major 가 나와야 publish 호출됨
         if result.output["severity"] == "major":
-            from nuri.agents.discord.publisher import Channel
-
-            assert pub_embed.called
-            channel_arg = pub_embed.call_args.args[0] if pub_embed.call_args.args else pub_embed.call_args.kwargs.get(
-                "channel"
-            )
-            assert channel_arg == Channel.OPS
+            assert mock_ops.called
+            assert mock_ops.call_args.kwargs["payload"]["kind"] == "drift_major"
+        elif result.output["severity"] == "critical":
+            assert mock_inc.called
         else:
-            # severity 가 critical 이라면 INCIDENTS 로 가야 — 본 테스트 invariant 미충족
-            # 하지만 publish 자체는 호출되어야 함 (defensive)
-            assert pub_embed.called
+            assert not mock_ops.called and not mock_inc.called
 
-    def test_stable_does_not_publish(self, patched_db):
+    def test_stable_does_not_stage(self, patched_db):
         rng = np.random.default_rng(42)
         baseline = rng.normal(0, 1, 1000).tolist()
         current = rng.normal(0, 1, 1000).tolist()
-        with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            return_value=MagicMock(ok=True, channel="ops", http_status=204, retry_count=0),
-        ) as pub_embed:
+        with (
+            patch("nuri.agents.discord.outbox.stage_ops") as mock_ops,
+            patch("nuri.agents.discord.outbox.stage_incident") as mock_inc,
+        ):
             actor = DriftSentinel()
             actor.run(
                 {
@@ -737,15 +719,16 @@ class TestDiscordPublishRouting:
                     "test_type": "psi",
                 }
             )
-        assert not pub_embed.called
+        assert not mock_ops.called
+        assert not mock_inc.called
 
     def test_publish_failure_does_not_break_check(self, patched_db):
         rng = np.random.default_rng(42)
         baseline = rng.normal(0, 1, 1000).tolist()
         current = rng.normal(5, 1, 1000).tolist()
         with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            side_effect=RuntimeError("webhook 500"),
+            "nuri.agents.discord.outbox.stage_incident",
+            side_effect=RuntimeError("outbox down"),
         ):
             actor = DriftSentinel()
             result = actor.run(
@@ -906,12 +889,7 @@ class TestAuditTrail:
             "SELECT actor_name, layer, outcome FROM agent_audit_ledger",
             db_path=patched_db,
         )
-        assert any(
-            r["actor_name"] == "drift-sentinel"
-            and r["layer"] == "B"
-            and r["outcome"] == "pass"
-            for r in rows
-        )
+        assert any(r["actor_name"] == "drift-sentinel" and r["layer"] == "B" and r["outcome"] == "pass" for r in rows)
 
     def test_invalid_action_block_audited(self, patched_db, no_publish):
         actor = DriftSentinel()

--- a/tests/agents/test_execution_firewall.py
+++ b/tests/agents/test_execution_firewall.py
@@ -523,29 +523,31 @@ class TestListBlocks:
 
 
 class TestDiscordPublish:
-    def test_hard_block_publishes_to_incidents(self, patched_db):
-        _seed_decision(patched_db, "dc-pub", ticker="TQQQ")
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
-            ExecutionFirewall().run(_check_payload("dc-pub", "TQQQ"))
-            mock_publish.assert_called_once()
-            kw = mock_publish.call_args.kwargs
-            assert kw["actor_name"] == "execution-firewall"
-            assert "BLOCK" in kw["embed"]["title"]
+    """PR3 Codex Round 6: hard-block → outbox stage_incident."""
 
-    def test_pass_does_not_publish(self, patched_db):
+    def test_hard_block_stages_to_incidents(self, patched_db):
+        _seed_decision(patched_db, "dc-pub", ticker="TQQQ")
+        with patch("nuri.agents.discord.outbox.stage_incident") as mock_stage:
+            ExecutionFirewall().run(_check_payload("dc-pub", "TQQQ"))
+            mock_stage.assert_called_once()
+            kw = mock_stage.call_args.kwargs
+            assert kw["actor_name"] == "execution-firewall"
+            assert kw["payload"]["kind"] == "execution_block"
+            assert kw["priority"] == "high"
+
+    def test_pass_does_not_stage(self, patched_db):
         _seed_decision(patched_db, "dc-pubp")
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_incident") as mock_stage:
             ExecutionFirewall().run(_check_payload("dc-pubp", "AMD", sector="tech"))
-            mock_publish.assert_not_called()
+            mock_stage.assert_not_called()
 
     def test_publish_failure_does_not_block_actor(self, patched_db):
         _seed_decision(patched_db, "dc-pubf", ticker="TQQQ")
         with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            side_effect=RuntimeError("network"),
+            "nuri.agents.discord.outbox.stage_incident",
+            side_effect=RuntimeError("outbox down"),
         ):
             result = ExecutionFirewall().run(_check_payload("dc-pubf", "TQQQ"))
-            # publish 실패해도 BLOCK outcome 유지
             assert result.outcome == Outcome.BLOCK
 
 

--- a/tests/agents/test_forward_outcome_tracker.py
+++ b/tests/agents/test_forward_outcome_tracker.py
@@ -490,38 +490,40 @@ class TestLastOutcome:
 
 
 class TestDiscordPublish:
-    def test_validate_publishes_to_rollout(self, patched_db):
+    """PR3 Codex Round 6: validate/reject → outbox stage_rollout."""
+
+    def test_validate_stages_to_rollout(self, patched_db):
         _seed_hypothesis(patched_db, "h-pub", "pub-claim")
         _seed_decision(patched_db, decision_id="dc-pub", ticker="TESTPB", hypothesis_id="h-pub")
         _seed_prices(
             patched_db,
             [("TESTPB", "2026-04-20", 100.0), ("TESTPB", "2026-04-27", 110.0)],
         )
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-pub", "observation_window": 7})
-            mock_publish.assert_called_once()
-            kw = mock_publish.call_args.kwargs
+            mock_stage.assert_called_once()
+            kw = mock_stage.call_args.kwargs
             assert kw["actor_name"] == "forward-outcome-tracker"
-            assert "validated" in kw["embed"]["title"]
+            assert kw["payload"]["kind"] == "hypothesis_validated"
 
-    def test_reject_publishes_to_rollout(self, patched_db):
+    def test_reject_stages_to_rollout(self, patched_db):
         _seed_hypothesis(patched_db, "h-pub2", "pub2-claim")
         _seed_decision(patched_db, decision_id="dc-pub2", ticker="TESTPC", hypothesis_id="h-pub2")
         _seed_prices(
             patched_db,
             [("TESTPC", "2026-04-20", 100.0), ("TESTPC", "2026-04-27", 90.0)],
         )
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-pub2", "observation_window": 7})
-            mock_publish.assert_called_once()
-            assert "rejected" in mock_publish.call_args.kwargs["embed"]["title"]
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "hypothesis_rejected"
 
-    def test_insufficient_does_not_publish(self, patched_db):
+    def test_insufficient_does_not_stage(self, patched_db):
         _seed_hypothesis(patched_db, "h-np", "np-claim")
         _seed_decision(patched_db, decision_id="dc-np", ticker="MISSING2", hypothesis_id="h-np")
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-np", "observation_window": 7})
-            mock_publish.assert_not_called()
+            mock_stage.assert_not_called()
 
     def test_publish_failure_does_not_block_actor(self, patched_db):
         _seed_hypothesis(patched_db, "h-pf", "pf-claim")
@@ -531,8 +533,8 @@ class TestDiscordPublish:
             [("TESTPF", "2026-04-20", 100.0), ("TESTPF", "2026-04-27", 110.0)],
         )
         with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            side_effect=RuntimeError("network"),
+            "nuri.agents.discord.outbox.stage_rollout",
+            side_effect=RuntimeError("outbox down"),
         ):
             result = ForwardOutcomeTracker().run(
                 {"action": "track_one", "decision_id": "dc-pf", "observation_window": 7}

--- a/tests/agents/test_foundation_benchmark.py
+++ b/tests/agents/test_foundation_benchmark.py
@@ -139,32 +139,52 @@ class TestHelperLockTests:
     def test_unknown_model_kind_rejected(self, db_path):
         with pytest.raises(ValueError, match="model_kind"):
             log_foundation_benchmark(
-                benchmark_run="r", model_id="m", model_kind="weird",
-                metric_name="brier", metric_value=0.1, higher_is_better=False,
-                sample_n=10, db_path=db_path,
+                benchmark_run="r",
+                model_id="m",
+                model_kind="weird",
+                metric_name="brier",
+                metric_value=0.1,
+                higher_is_better=False,
+                sample_n=10,
+                db_path=db_path,
             )
 
     def test_unknown_metric_name_rejected(self, db_path):
         with pytest.raises(ValueError, match="metric_name"):
             log_foundation_benchmark(
-                benchmark_run="r", model_id="m", model_kind="baseline",
-                metric_name="unknown", metric_value=0.1, higher_is_better=False,
-                sample_n=10, db_path=db_path,
+                benchmark_run="r",
+                model_id="m",
+                model_kind="baseline",
+                metric_name="unknown",
+                metric_value=0.1,
+                higher_is_better=False,
+                sample_n=10,
+                db_path=db_path,
             )
 
     def test_negative_sample_n_rejected(self, db_path):
         with pytest.raises(ValueError, match="sample_n"):
             log_foundation_benchmark(
-                benchmark_run="r", model_id="m", model_kind="baseline",
-                metric_name="brier", metric_value=0.1, higher_is_better=False,
-                sample_n=-1, db_path=db_path,
+                benchmark_run="r",
+                model_id="m",
+                model_kind="baseline",
+                metric_name="brier",
+                metric_value=0.1,
+                higher_is_better=False,
+                sample_n=-1,
+                db_path=db_path,
             )
 
     def test_returns_lastrowid(self, db_path):
         bid = log_foundation_benchmark(
-            benchmark_run="r", model_id="m", model_kind="baseline",
-            metric_name="brier", metric_value=0.1, higher_is_better=False,
-            sample_n=10, db_path=db_path,
+            benchmark_run="r",
+            model_id="m",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.1,
+            higher_is_better=False,
+            sample_n=10,
+            db_path=db_path,
         )
         assert bid >= 1
 
@@ -177,15 +197,17 @@ class TestHelperLockTests:
 class TestBenchmarkAction:
     def test_benchmark_inserts_row(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "2026-05-01-pilot",
-            "model_id": "sticky-hmm-v1",
-            "model_kind": "baseline",
-            "metric_name": "brier",
-            "metric_value": 0.18,
-            "sample_n": 252,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "2026-05-01-pilot",
+                "model_id": "sticky-hmm-v1",
+                "model_kind": "baseline",
+                "metric_name": "brier",
+                "metric_value": 0.18,
+                "sample_n": 252,
+            }
+        )
         assert result.outcome == Outcome.PASS
         assert result.output["benchmark_id"] >= 1
         assert result.output["model_kind"] == "baseline"
@@ -196,60 +218,68 @@ class TestBenchmarkAction:
 
     def test_benchmark_higher_is_better_default_for_sharpe(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m1",
-            "model_kind": "baseline",
-            "metric_name": "sharpe",
-            "metric_value": 1.2,
-            "sample_n": 100,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m1",
+                "model_kind": "baseline",
+                "metric_name": "sharpe",
+                "metric_value": 1.2,
+                "sample_n": 100,
+            }
+        )
         assert result.outcome == Outcome.PASS
         assert result.output["higher_is_better"] is True
 
     def test_benchmark_higher_is_better_default_for_brier(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m1",
-            "model_kind": "baseline",
-            "metric_name": "brier",
-            "metric_value": 0.15,
-            "sample_n": 100,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m1",
+                "model_kind": "baseline",
+                "metric_name": "brier",
+                "metric_value": 0.15,
+                "sample_n": 100,
+            }
+        )
         assert result.outcome == Outcome.PASS
         assert result.output["higher_is_better"] is False
 
     def test_benchmark_caller_can_override_higher_is_better(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m1",
-            "model_kind": "foundation",
-            "metric_name": "sharpe",
-            "metric_value": 1.5,
-            "sample_n": 100,
-            "higher_is_better": False,  # override (의도적)
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m1",
+                "model_kind": "foundation",
+                "metric_name": "sharpe",
+                "metric_value": 1.5,
+                "sample_n": 100,
+                "higher_is_better": False,  # override (의도적)
+            }
+        )
         assert result.output["higher_is_better"] is False
 
     def test_benchmark_persists_walkforward_link(self, patched_db):
         actor = FoundationBenchmark()
-        actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m1",
-            "model_kind": "baseline",
-            "metric_name": "brier",
-            "metric_value": 0.2,
-            "sample_n": 50,
-            "pit_hash": "abc123",
-            "walkforward_run_id": "wf-uuid-1",
-            "notes": "fold spec rolling/252/21/21",
-        })
+        actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m1",
+                "model_kind": "baseline",
+                "metric_name": "brier",
+                "metric_value": 0.2,
+                "sample_n": 50,
+                "pit_hash": "abc123",
+                "walkforward_run_id": "wf-uuid-1",
+                "notes": "fold spec rolling/252/21/21",
+            }
+        )
         rows = query("SELECT * FROM foundation_benchmarks", db_path=patched_db)
         assert rows[0]["pit_hash"] == "abc123"
         assert rows[0]["walkforward_run_id"] == "wf-uuid-1"
@@ -257,15 +287,17 @@ class TestBenchmarkAction:
 
     def test_benchmark_records_actor_run_id(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m1",
-            "model_kind": "baseline",
-            "metric_name": "brier",
-            "metric_value": 0.2,
-            "sample_n": 50,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m1",
+                "model_kind": "baseline",
+                "metric_name": "brier",
+                "metric_value": 0.2,
+                "sample_n": 50,
+            }
+        )
         rows = query("SELECT * FROM foundation_benchmarks", db_path=patched_db)
         # actor_run_id is set by actor (RunContext.run_id)
         assert rows[0]["actor_run_id"] is not None
@@ -283,57 +315,65 @@ class TestBenchmarkValidation:
 
     def test_invalid_model_kind_blocked(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m",
-            "model_kind": "not_a_kind",
-            "metric_name": "brier",
-            "metric_value": 0.1,
-            "sample_n": 10,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m",
+                "model_kind": "not_a_kind",
+                "metric_name": "brier",
+                "metric_value": 0.1,
+                "sample_n": 10,
+            }
+        )
         assert result.outcome == Outcome.BLOCK
         assert "model_kind" in result.output["error"]
 
     def test_invalid_metric_name_blocked(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m",
-            "model_kind": "baseline",
-            "metric_name": "not_a_metric",
-            "metric_value": 0.1,
-            "sample_n": 10,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m",
+                "model_kind": "baseline",
+                "metric_name": "not_a_metric",
+                "metric_value": 0.1,
+                "sample_n": 10,
+            }
+        )
         assert result.outcome == Outcome.BLOCK
         assert "metric_name" in result.output["error"]
 
     def test_negative_sample_n_blocked(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m",
-            "model_kind": "baseline",
-            "metric_name": "brier",
-            "metric_value": 0.1,
-            "sample_n": -5,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m",
+                "model_kind": "baseline",
+                "metric_name": "brier",
+                "metric_value": 0.1,
+                "sample_n": -5,
+            }
+        )
         assert result.outcome == Outcome.BLOCK
         assert "sample_n" in result.output["error"]
 
     def test_uncastable_metric_value_blocked(self, patched_db):
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "benchmark",
-            "benchmark_run": "r1",
-            "model_id": "m",
-            "model_kind": "baseline",
-            "metric_name": "brier",
-            "metric_value": "not_a_number",
-            "sample_n": 10,
-        })
+        result = actor.run(
+            {
+                "action": "benchmark",
+                "benchmark_run": "r1",
+                "model_id": "m",
+                "model_kind": "baseline",
+                "metric_name": "brier",
+                "metric_value": "not_a_number",
+                "sample_n": 10,
+            }
+        )
         assert result.outcome == Outcome.BLOCK
 
 
@@ -363,10 +403,22 @@ class TestCompareAction:
 
     def test_foundation_wins_significantly_pass(self, patched_db):
         # baseline brier 0.20, foundation brier 0.15 → foundation 25% 우수 (lower better)
-        _seed(patched_db, benchmark_run="rcmp", model_id="hmm-base",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rcmp", model_id="timesfm-2.5",
-              model_kind="foundation", metric_name="brier", metric_value=0.15)
+        _seed(
+            patched_db,
+            benchmark_run="rcmp",
+            model_id="hmm-base",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rcmp",
+            model_id="timesfm-2.5",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.15,
+        )
         actor = FoundationBenchmark()
         result = actor.run({"action": "compare", "benchmark_run": "rcmp"})
         assert result.outcome == Outcome.PASS
@@ -377,10 +429,22 @@ class TestCompareAction:
 
     def test_baseline_wins_pass(self, patched_db):
         # baseline brier 0.10 < foundation brier 0.30 → baseline winner
-        _seed(patched_db, benchmark_run="rb", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.10)
-        _seed(patched_db, benchmark_run="rb", model_id="big-foundation",
-              model_kind="foundation", metric_name="brier", metric_value=0.30)
+        _seed(
+            patched_db,
+            benchmark_run="rb",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.10,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rb",
+            model_id="big-foundation",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.30,
+        )
         actor = FoundationBenchmark()
         result = actor.run({"action": "compare", "benchmark_run": "rb"})
         assert result.outcome == Outcome.PASS
@@ -391,10 +455,22 @@ class TestCompareAction:
 
     def test_foundation_wins_marginal(self, patched_db):
         # baseline 0.20, foundation 0.198 → 1% improvement (< SIGNIFICANT 10%)
-        _seed(patched_db, benchmark_run="rm", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rm", model_id="found-light",
-              model_kind="foundation", metric_name="brier", metric_value=0.198)
+        _seed(
+            patched_db,
+            benchmark_run="rm",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rm",
+            model_id="found-light",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.198,
+        )
         actor = FoundationBenchmark()
         result = actor.run({"action": "compare", "benchmark_run": "rm"})
         assert result.outcome == Outcome.PASS
@@ -404,10 +480,22 @@ class TestCompareAction:
 
     def test_tie_verdict(self, patched_db):
         # 둘 다 0.200 ≈ 동일 → tie (delta < 1%)
-        _seed(patched_db, benchmark_run="rt", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.200)
-        _seed(patched_db, benchmark_run="rt", model_id="found-tie",
-              model_kind="foundation", metric_name="brier", metric_value=0.2005)
+        _seed(
+            patched_db,
+            benchmark_run="rt",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.200,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rt",
+            model_id="found-tie",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.2005,
+        )
         actor = FoundationBenchmark()
         result = actor.run({"action": "compare", "benchmark_run": "rt"})
         cmp = result.output["comparisons"][0]
@@ -415,12 +503,24 @@ class TestCompareAction:
 
     def test_higher_is_better_direction_sharpe(self, patched_db):
         # sharpe higher better — baseline 0.8 vs foundation 1.5 → foundation winner (87% improvement)
-        _seed(patched_db, benchmark_run="rs", model_id="hmm",
-              model_kind="baseline", metric_name="sharpe", metric_value=0.8,
-              higher_is_better=True)
-        _seed(patched_db, benchmark_run="rs", model_id="found",
-              model_kind="foundation", metric_name="sharpe", metric_value=1.5,
-              higher_is_better=True)
+        _seed(
+            patched_db,
+            benchmark_run="rs",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="sharpe",
+            metric_value=0.8,
+            higher_is_better=True,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rs",
+            model_id="found",
+            model_kind="foundation",
+            metric_name="sharpe",
+            metric_value=1.5,
+            higher_is_better=True,
+        )
         actor = FoundationBenchmark()
         result = actor.run({"action": "compare", "benchmark_run": "rs"})
         cmp = result.output["comparisons"][0]
@@ -430,20 +530,42 @@ class TestCompareAction:
         assert cmp["delta_relative"] > SIGNIFICANT_IMPROVEMENT_PCT
 
     def test_metric_name_filter(self, patched_db):
-        _seed(patched_db, benchmark_run="rfilt", model_id="m1",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rfilt", model_id="m2",
-              model_kind="foundation", metric_name="brier", metric_value=0.10)
-        _seed(patched_db, benchmark_run="rfilt", model_id="m1",
-              model_kind="baseline", metric_name="sharpe", metric_value=0.5,
-              higher_is_better=True)
-        _seed(patched_db, benchmark_run="rfilt", model_id="m2",
-              model_kind="foundation", metric_name="sharpe", metric_value=1.0,
-              higher_is_better=True)
+        _seed(
+            patched_db,
+            benchmark_run="rfilt",
+            model_id="m1",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rfilt",
+            model_id="m2",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.10,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rfilt",
+            model_id="m1",
+            model_kind="baseline",
+            metric_name="sharpe",
+            metric_value=0.5,
+            higher_is_better=True,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rfilt",
+            model_id="m2",
+            model_kind="foundation",
+            metric_name="sharpe",
+            metric_value=1.0,
+            higher_is_better=True,
+        )
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "compare", "benchmark_run": "rfilt", "metric_name": "brier"
-        })
+        result = actor.run({"action": "compare", "benchmark_run": "rfilt", "metric_name": "brier"})
         assert result.outcome == Outcome.PASS
         # only brier compared
         assert result.output["n_metrics"] == 1
@@ -452,24 +574,21 @@ class TestCompareAction:
     def test_invalid_metric_filter_blocked(self, patched_db):
         _seed(patched_db, benchmark_run="rx")
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "compare", "benchmark_run": "rx", "metric_name": "garbage"
-        })
+        result = actor.run({"action": "compare", "benchmark_run": "rx", "metric_name": "garbage"})
         assert result.outcome == Outcome.BLOCK
 
     def test_model_ids_filter(self, patched_db):
-        _seed(patched_db, benchmark_run="rmid", model_id="a",
-              model_kind="baseline", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rmid", model_id="b",
-              model_kind="foundation", metric_value=0.10)
-        _seed(patched_db, benchmark_run="rmid", model_id="c",
-              model_kind="traditional", metric_value=0.30)
+        _seed(patched_db, benchmark_run="rmid", model_id="a", model_kind="baseline", metric_value=0.20)
+        _seed(patched_db, benchmark_run="rmid", model_id="b", model_kind="foundation", metric_value=0.10)
+        _seed(patched_db, benchmark_run="rmid", model_id="c", model_kind="traditional", metric_value=0.30)
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "compare",
-            "benchmark_run": "rmid",
-            "model_ids": ["a", "b"],
-        })
+        result = actor.run(
+            {
+                "action": "compare",
+                "benchmark_run": "rmid",
+                "model_ids": ["a", "b"],
+            }
+        )
         assert result.outcome == Outcome.PASS
         cmp = result.output["comparisons"][0]
         # winner among {a, b} should be b (foundation 0.10 < baseline 0.20)
@@ -479,18 +598,32 @@ class TestCompareAction:
     def test_invalid_model_ids_filter_blocked(self, patched_db):
         _seed(patched_db, benchmark_run="rmid2")
         actor = FoundationBenchmark()
-        result = actor.run({
-            "action": "compare",
-            "benchmark_run": "rmid2",
-            "model_ids": "not_a_list",
-        })
+        result = actor.run(
+            {
+                "action": "compare",
+                "benchmark_run": "rmid2",
+                "model_ids": "not_a_list",
+            }
+        )
         assert result.outcome == Outcome.BLOCK
 
     def test_traditional_winner_verdict(self, patched_db):
-        _seed(patched_db, benchmark_run="rtr", model_id="naive",
-              model_kind="traditional", metric_name="brier", metric_value=0.10)
-        _seed(patched_db, benchmark_run="rtr", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
+        _seed(
+            patched_db,
+            benchmark_run="rtr",
+            model_id="naive",
+            model_kind="traditional",
+            metric_name="brier",
+            metric_value=0.10,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rtr",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
         actor = FoundationBenchmark()
         result = actor.run({"action": "compare", "benchmark_run": "rtr"})
         cmp = result.output["comparisons"][0]
@@ -522,8 +655,9 @@ class TestListRuns:
     def test_n_models_aggregation(self, patched_db):
         _seed(patched_db, benchmark_run="rN", model_id="m1")
         _seed(patched_db, benchmark_run="rN", model_id="m2")
-        _seed(patched_db, benchmark_run="rN", model_id="m1", metric_name="sharpe",
-              metric_value=1.0, higher_is_better=True)  # 같은 model_id 다른 metric
+        _seed(
+            patched_db, benchmark_run="rN", model_id="m1", metric_name="sharpe", metric_value=1.0, higher_is_better=True
+        )  # 같은 model_id 다른 metric
         actor = FoundationBenchmark()
         result = actor.run({"action": "list_runs"})
         runs = {r["benchmark_run"]: r for r in result.output["runs"]}
@@ -572,73 +706,116 @@ class TestInvalidAction:
 
 
 class TestDiscordPublish:
-    def test_significant_foundation_win_publishes(self, patched_db):
-        _seed(patched_db, benchmark_run="rpub", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rpub", model_id="found",
-              model_kind="foundation", metric_name="brier", metric_value=0.10)
-        with patch("nuri.agents.discord.publisher.DiscordPublisher") as mock_pub:
-            mock_instance = MagicMock()
-            mock_pub.return_value = mock_instance
+    """PR3 Codex Round 6: foundation win → outbox stage_rollout."""
+
+    def test_significant_foundation_win_stages(self, patched_db):
+        _seed(
+            patched_db,
+            benchmark_run="rpub",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rpub",
+            model_id="found",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.10,
+        )
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             actor = FoundationBenchmark()
             result = actor.run({"action": "compare", "benchmark_run": "rpub"})
             assert result.outcome == Outcome.PASS
-            assert mock_instance.publish_embed.called
-            call_kwargs = mock_instance.publish_embed.call_args
-            embed = call_kwargs.kwargs.get("embed") or call_kwargs.args[1]
-            assert "Foundation model win" in embed["title"]
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "foundation_promotion"
 
-    def test_baseline_winner_does_not_publish(self, patched_db):
-        _seed(patched_db, benchmark_run="rnopub", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.10)
-        _seed(patched_db, benchmark_run="rnopub", model_id="found",
-              model_kind="foundation", metric_name="brier", metric_value=0.30)
-        with patch("nuri.agents.discord.publisher.DiscordPublisher") as mock_pub:
-            mock_instance = MagicMock()
-            mock_pub.return_value = mock_instance
+    def test_baseline_winner_does_not_stage(self, patched_db):
+        _seed(
+            patched_db,
+            benchmark_run="rnopub",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.10,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rnopub",
+            model_id="found",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.30,
+        )
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             actor = FoundationBenchmark()
             actor.run({"action": "compare", "benchmark_run": "rnopub"})
-            assert not mock_instance.publish_embed.called
+            assert not mock_stage.called
 
-    def test_marginal_foundation_win_does_not_publish(self, patched_db):
-        _seed(patched_db, benchmark_run="rmar", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rmar", model_id="found",
-              model_kind="foundation", metric_name="brier", metric_value=0.198)
-        with patch("nuri.agents.discord.publisher.DiscordPublisher") as mock_pub:
-            mock_instance = MagicMock()
-            mock_pub.return_value = mock_instance
+    def test_marginal_foundation_win_does_not_stage(self, patched_db):
+        _seed(
+            patched_db,
+            benchmark_run="rmar",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rmar",
+            model_id="found",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.198,
+        )
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             actor = FoundationBenchmark()
             actor.run({"action": "compare", "benchmark_run": "rmar"})
-            assert not mock_instance.publish_embed.called
+            assert not mock_stage.called
 
     def test_publish_failure_does_not_block_actor(self, patched_db):
-        _seed(patched_db, benchmark_run="rfail", model_id="hmm",
-              model_kind="baseline", metric_name="brier", metric_value=0.20)
-        _seed(patched_db, benchmark_run="rfail", model_id="found",
-              model_kind="foundation", metric_name="brier", metric_value=0.10)
-        with patch("nuri.agents.discord.publisher.DiscordPublisher") as mock_pub:
-            mock_pub.side_effect = RuntimeError("network down")
+        _seed(
+            patched_db,
+            benchmark_run="rfail",
+            model_id="hmm",
+            model_kind="baseline",
+            metric_name="brier",
+            metric_value=0.20,
+        )
+        _seed(
+            patched_db,
+            benchmark_run="rfail",
+            model_id="found",
+            model_kind="foundation",
+            metric_name="brier",
+            metric_value=0.10,
+        )
+        with patch(
+            "nuri.agents.discord.outbox.stage_rollout",
+            side_effect=RuntimeError("outbox down"),
+        ):
             actor = FoundationBenchmark()
             result = actor.run({"action": "compare", "benchmark_run": "rfail"})
-            # actor 는 PASS 유지 — Discord 실패는 best-effort
             assert result.outcome == Outcome.PASS
 
     def test_benchmark_action_does_not_publish(self, patched_db):
-        with patch("nuri.agents.discord.publisher.DiscordPublisher") as mock_pub:
-            mock_instance = MagicMock()
-            mock_pub.return_value = mock_instance
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             actor = FoundationBenchmark()
-            actor.run({
-                "action": "benchmark",
-                "benchmark_run": "r1",
-                "model_id": "m1",
-                "model_kind": "foundation",
-                "metric_name": "brier",
-                "metric_value": 0.05,
-                "sample_n": 100,
-            })
-            assert not mock_instance.publish_embed.called
+            actor.run(
+                {
+                    "action": "benchmark",
+                    "benchmark_run": "r1",
+                    "model_id": "m1",
+                    "model_kind": "foundation",
+                    "metric_name": "brier",
+                    "metric_value": 0.05,
+                    "sample_n": 100,
+                }
+            )
+            assert not mock_stage.called
 
 
 # ═══════════════════════════════════════════════════════
@@ -662,15 +839,23 @@ class TestCLI:
         assert rc == 2
 
     def test_cli_benchmark_happy_path(self, patched_db, capsys):
-        rc = main([
-            "benchmark",
-            "--benchmark-run", "cli-test",
-            "--model-id", "m-cli",
-            "--model-kind", "baseline",
-            "--metric-name", "brier",
-            "--metric-value", "0.15",
-            "--sample-n", "50",
-        ])
+        rc = main(
+            [
+                "benchmark",
+                "--benchmark-run",
+                "cli-test",
+                "--model-id",
+                "m-cli",
+                "--model-kind",
+                "baseline",
+                "--metric-name",
+                "brier",
+                "--metric-value",
+                "0.15",
+                "--sample-n",
+                "50",
+            ]
+        )
         assert rc == 0
         out = capsys.readouterr().out
         assert "benchmark_id" in out

--- a/tests/agents/test_hypothesis_registry.py
+++ b/tests/agents/test_hypothesis_registry.py
@@ -404,21 +404,23 @@ class TestAuditLedger:
 
 
 class TestDiscordPublish:
-    def test_validate_publishes_to_rollout(self, patched_db):
+    """PR3 Codex Round 6: validate/reject → outbox stage_rollout."""
+
+    def test_validate_stages_to_rollout(self, patched_db):
         actor = HypothesisRegistry()
         actor.run(_register_payload())
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             result = actor.run({"action": "validate", "hypothesis_id": "h-1", "validation_metrics": {"brier": 0.2}})
             assert result.outcome == Outcome.PASS
-            mock_publish.assert_called_once()
-            call_kwargs = mock_publish.call_args.kwargs
-            assert call_kwargs["actor_name"] == "hypothesis-registry"
-            assert "validated" in call_kwargs["embed"]["title"]
+            mock_stage.assert_called_once()
+            kw = mock_stage.call_args.kwargs
+            assert kw["actor_name"] == "hypothesis-registry"
+            assert kw["payload"]["kind"] == "hypothesis_validated"
 
-    def test_reject_publishes_to_rollout(self, patched_db):
+    def test_reject_stages_to_rollout(self, patched_db):
         actor = HypothesisRegistry()
         actor.run(_register_payload())
-        with patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish:
+        with patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage:
             actor.run(
                 {
                     "action": "reject",
@@ -426,18 +428,18 @@ class TestDiscordPublish:
                     "rejection_reason": "Brier > 0.4",
                 }
             )
-            mock_publish.assert_called_once()
-            assert "rejected" in mock_publish.call_args.kwargs["embed"]["title"]
+            mock_stage.assert_called_once()
+            assert mock_stage.call_args.kwargs["payload"]["kind"] == "hypothesis_rejected"
 
     def test_publish_failure_does_not_block_actor(self, patched_db):
         actor = HypothesisRegistry()
         actor.run(_register_payload())
         with patch(
-            "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-            side_effect=RuntimeError("network down"),
+            "nuri.agents.discord.outbox.stage_rollout",
+            side_effect=RuntimeError("outbox down"),
         ):
             result = actor.run({"action": "validate", "hypothesis_id": "h-1", "validation_metrics": {"x": 1}})
-            assert result.outcome == Outcome.PASS  # publish 실패해도 PASS
+            assert result.outcome == Outcome.PASS
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/agents/test_regime_posterior.py
+++ b/tests/agents/test_regime_posterior.py
@@ -671,7 +671,7 @@ class TestRegimeChangeDetection:
 
         with (
             patch.object(rp_module, "_summarize_last_step", side_effect=flip_summary),
-            patch("nuri.agents.discord.publisher.DiscordPublisher.publish_embed") as mock_publish,
+            patch("nuri.agents.discord.outbox.stage_rollout") as mock_stage,
         ):
             result = actor.run(
                 {
@@ -684,11 +684,10 @@ class TestRegimeChangeDetection:
             )
             assert result.output["regime_changed"] is True
             assert result.output["prev_argmax"] is not None
-            mock_publish.assert_called_once()
-            # ROLLOUT channel + embed
-            call_kwargs = mock_publish.call_args.kwargs
-            assert call_kwargs["actor_name"] == "regime-posterior"
-            assert "title" in call_kwargs["embed"]
+            mock_stage.assert_called_once()
+            kw = mock_stage.call_args.kwargs
+            assert kw["actor_name"] == "regime-posterior"
+            assert kw["payload"]["kind"] == "regime_change"
 
     def test_publish_failure_does_not_block_actor(self, patched_db, two_regime_data):
         """ROLLOUT publish 실패 시에도 actor outcome 은 PASS 유지 (best-effort)."""
@@ -721,7 +720,7 @@ class TestRegimeChangeDetection:
 
         with (
             patch.object(rp_module, "_summarize_last_step", side_effect=flip),
-            patch("nuri.agents.discord.publisher.publish", side_effect=RuntimeError("network")),
+            patch("nuri.agents.discord.outbox.stage_rollout", side_effect=RuntimeError("outbox down")),
         ):
             result = actor.run(
                 {

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -651,12 +651,11 @@ class TestListOpenAction:
 
 
 class TestDiscordPublishRouting:
-    def test_critical_publishes_to_incidents(self, patched_db):
+    """PR3 Codex Round 6: critical → outbox stage_incident, warning → stage_ops."""
+
+    def test_critical_stages_to_incidents(self, patched_db):
         with (
-            patch(
-                "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-                return_value=MagicMock(ok=True, channel="incidents", http_status=204, retry_count=0),
-            ) as pub_embed,
+            patch("nuri.agents.discord.outbox.stage_incident") as mock_inc,
             patch(
                 "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
                 return_value=MagicMock(total=1000, used=950, free=50),
@@ -665,21 +664,14 @@ class TestDiscordPublishRouting:
         ):
             actor = SREIncidentAgent()
             actor.run({"action": "scan"})
-        # 최소 1번 호출 — channel 인자 검증
-        from nuri.agents.discord.publisher import Channel
+        assert mock_inc.called
+        kw = mock_inc.call_args.kwargs
+        assert kw["actor_name"] == "sre-incident-agent"
+        assert kw["priority"] == "high"
 
-        assert pub_embed.called
-        call_kwargs = pub_embed.call_args
-        # 첫 positional arg 가 channel (publish_embed signature)
-        channel_arg = call_kwargs.args[0] if call_kwargs.args else call_kwargs.kwargs.get("channel")
-        assert channel_arg == Channel.INCIDENTS
-
-    def test_warning_publishes_to_ops(self, patched_db):
+    def test_warning_stages_to_ops(self, patched_db):
         with (
-            patch(
-                "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-                return_value=MagicMock(ok=True, channel="ops", http_status=204, retry_count=0),
-            ) as pub_embed,
+            patch("nuri.agents.discord.outbox.stage_ops") as mock_ops,
             patch(
                 "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
                 return_value=MagicMock(total=1000, used=850, free=150),
@@ -688,21 +680,12 @@ class TestDiscordPublishRouting:
         ):
             actor = SREIncidentAgent()
             actor.run({"action": "scan"})
-        from nuri.agents.discord.publisher import Channel
+        assert mock_ops.called
 
-        assert pub_embed.called
-        channel_arg = pub_embed.call_args.args[0] if pub_embed.call_args.args else pub_embed.call_args.kwargs.get(
-            "channel"
-        )
-        assert channel_arg == Channel.OPS
-
-    def test_repeat_detection_does_not_republish(self, patched_db):
-        """재detection 시 동일 incident → publish 차단 (UNIQUE update)."""
+    def test_repeat_detection_does_not_restage(self, patched_db):
+        """재detection 시 동일 incident → stage 차단 (UNIQUE update)."""
         with (
-            patch(
-                "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-                return_value=MagicMock(ok=True, channel="incidents", http_status=204, retry_count=0),
-            ) as pub_embed,
+            patch("nuri.agents.discord.outbox.stage_incident") as mock_inc,
             patch(
                 "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
                 return_value=MagicMock(total=1000, used=950, free=50),
@@ -711,16 +694,16 @@ class TestDiscordPublishRouting:
         ):
             actor = SREIncidentAgent()
             actor.run({"action": "scan"})
-            first_count = pub_embed.call_count
+            first_count = mock_inc.call_count
             actor.run({"action": "scan"})
-            assert pub_embed.call_count == first_count, "재detection 은 publish 안 해야 함"
+            assert mock_inc.call_count == first_count, "재detection 은 stage 안 해야 함"
 
     def test_publish_failure_does_not_break_scan(self, patched_db):
-        """Discord publish 실패해도 scan 자체는 PASS."""
+        """outbox stage 실패해도 scan 자체는 PASS."""
         with (
             patch(
-                "nuri.agents.discord.publisher.DiscordPublisher.publish_embed",
-                side_effect=RuntimeError("webhook 500"),
+                "nuri.agents.discord.outbox.stage_incident",
+                side_effect=RuntimeError("outbox down"),
             ),
             patch(
                 "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
@@ -807,8 +790,7 @@ class TestAuditTrail:
             db_path=patched_db,
         )
         assert any(
-            r["actor_name"] == "sre-incident-agent" and r["layer"] == "A" and r["outcome"] == "pass"
-            for r in rows
+            r["actor_name"] == "sre-incident-agent" and r["layer"] == "A" and r["outcome"] == "pass" for r in rows
         )
 
     def test_acknowledge_block_audited(self, patched_db, no_publish):

--- a/tests/agents/test_state_replicator_dr.py
+++ b/tests/agents/test_state_replicator_dr.py
@@ -104,9 +104,7 @@ class TestStateReplicatorDRLayer:
 class TestSnapshotAction:
     def test_snapshot_primary(self, patched_db):
         actor = StateReplicatorDR()
-        result = actor.run(
-            {"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"}
-        )
+        result = actor.run({"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"})
         assert result.outcome == Outcome.PASS
         assert result.output["role"] == "primary"
         assert result.output["status"] == "healthy"
@@ -121,14 +119,10 @@ class TestSnapshotAction:
 
     def test_snapshot_replica_no_heartbeat_unreachable(self, patched_db):
         """heartbeat 파일 없을 때 → unreachable 처리 (Docker 이전 placeholder)."""
-        with patch(
-            "nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH"
-        ) as mock_path:
+        with patch("nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH") as mock_path:
             mock_path.exists.return_value = False
             actor = StateReplicatorDR()
-            result = actor.run(
-                {"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"}
-            )
+            result = actor.run({"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"})
         assert result.outcome == Outcome.PASS  # snapshot 자체는 성공
         assert result.output["status"] == "unreachable"
         assert result.output["sync_lag_seconds"] is None
@@ -138,13 +132,9 @@ class TestSnapshotAction:
         """heartbeat 파일 mtime 이 최근 (< 600s) → healthy."""
         hb = tmp_path / ".autopull_heartbeat"
         hb.touch()  # mtime = now
-        with patch(
-            "nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH", hb
-        ):
+        with patch("nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH", hb):
             actor = StateReplicatorDR()
-            result = actor.run(
-                {"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"}
-            )
+            result = actor.run({"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"})
         assert result.outcome == Outcome.PASS
         assert result.output["status"] == "healthy"
         assert result.output["sync_lag_seconds"] is not None
@@ -159,13 +149,9 @@ class TestSnapshotAction:
         hb.touch()
         old_ts = _time.time() - 1200  # 20분 전
         os.utime(hb, (old_ts, old_ts))
-        with patch(
-            "nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH", hb
-        ):
+        with patch("nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH", hb):
             actor = StateReplicatorDR()
-            result = actor.run(
-                {"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"}
-            )
+            result = actor.run({"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"})
         assert result.output["status"] == "stale"
         assert 600 <= result.output["sync_lag_seconds"] < 3600
 
@@ -178,13 +164,9 @@ class TestSnapshotAction:
         hb.touch()
         old_ts = _time.time() - 7200  # 2시간 전
         os.utime(hb, (old_ts, old_ts))
-        with patch(
-            "nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH", hb
-        ):
+        with patch("nuri.agents.actors.state_replicator_dr.HEARTBEAT_PATH", hb):
             actor = StateReplicatorDR()
-            result = actor.run(
-                {"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"}
-            )
+            result = actor.run({"action": "snapshot", "replica_id": "mbp-replica", "role": "replica"})
         assert result.output["status"] == "unreachable"
         assert result.output["sync_lag_seconds"] >= 3600
 
@@ -202,9 +184,7 @@ class TestSnapshotAction:
 
     def test_snapshot_invalid_role_blocks(self, patched_db):
         actor = StateReplicatorDR()
-        result = actor.run(
-            {"action": "snapshot", "replica_id": "x", "role": "tertiary"}
-        )
+        result = actor.run({"action": "snapshot", "replica_id": "x", "role": "tertiary"})
         assert result.outcome == Outcome.BLOCK
         rows = query("SELECT COUNT(*) AS c FROM dr_replicas", db_path=patched_db)
         assert rows[0]["c"] == 0  # state 변경 X
@@ -212,12 +192,8 @@ class TestSnapshotAction:
     def test_snapshot_idempotent_upsert(self, patched_db):
         """동일 replica_id 두 번 snapshot → row 1개 (upsert)."""
         actor = StateReplicatorDR()
-        actor.run(
-            {"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"}
-        )
-        actor.run(
-            {"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"}
-        )
+        actor.run({"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"})
+        actor.run({"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"})
         rows = query("SELECT * FROM dr_replicas", db_path=patched_db)
         assert len(rows) == 1
 
@@ -235,16 +211,14 @@ class TestVerifyAction:
 
     def test_verify_all_healthy_passes(self, patched_db):
         actor = StateReplicatorDR()
-        actor.run(
-            {"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"}
-        )
+        actor.run({"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"})
         # replica 도 healthy 로 직접 등록 (heartbeat probe 우회)
         upsert_dr_replica(
             replica_id="mbp-replica",
             role="replica",
             hostname="mbp-test",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=120,
             status="healthy",
             db_path=patched_db,
@@ -259,7 +233,7 @@ class TestVerifyAction:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
@@ -269,7 +243,7 @@ class TestVerifyAction:
             role="replica",
             hostname="mbp",
             last_sync_at="2026-05-01 11:30:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=1800,
             status="stale",
             db_path=patched_db,
@@ -286,7 +260,7 @@ class TestVerifyAction:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
@@ -296,7 +270,7 @@ class TestVerifyAction:
             role="replica",
             hostname="mbp",
             last_sync_at="2026-05-01 09:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=10800,
             status="unreachable",
             db_path=patched_db,
@@ -314,7 +288,7 @@ class TestVerifyAction:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
@@ -340,9 +314,7 @@ class TestVerifyAction:
         )
         assert rows[0]["status"] == "out_of_sync"
         # blocks 에 mismatch 정보 포함
-        assert any(
-            "schema mismatch" in b["reason"] for b in result.output["blocks"]
-        )
+        assert any("schema mismatch" in b["reason"] for b in result.output["blocks"])
 
     def test_verify_invalid_max_lag_blocks(self, patched_db):
         actor = StateReplicatorDR()
@@ -356,7 +328,7 @@ class TestVerifyAction:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
@@ -366,7 +338,7 @@ class TestVerifyAction:
             role="replica",
             hostname="mbp",
             last_sync_at="2026-05-01 11:55:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=300,
             status="healthy",
             db_path=patched_db,
@@ -393,7 +365,7 @@ class TestListReplicasAction:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
@@ -403,7 +375,7 @@ class TestListReplicasAction:
             role="replica",
             hostname="mbp",
             last_sync_at="2026-05-01 11:55:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=300,
             status="healthy",
             db_path=patched_db,
@@ -433,9 +405,7 @@ class TestAuditTrail:
 
     def test_snapshot_recorded_in_audit_ledger(self, patched_db):
         actor = StateReplicatorDR()
-        actor.run(
-            {"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"}
-        )
+        actor.run({"action": "snapshot", "replica_id": "macmini-primary", "role": "primary"})
         rows = query(
             "SELECT actor_name, layer, outcome FROM agent_audit_ledger",
             db_path=patched_db,
@@ -518,7 +488,7 @@ class TestDiscordPublish:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
@@ -528,14 +498,12 @@ class TestDiscordPublish:
             role="replica",
             hostname="mbp",
             last_sync_at="2026-05-01 09:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=10800,
             status="unreachable",
             db_path=patched_db,
         )
-        with patch(
-            "nuri.agents.actors.state_replicator_dr.StateReplicatorDR._publish_incidents"
-        ) as mock_publish:
+        with patch("nuri.agents.actors.state_replicator_dr.StateReplicatorDR._publish_incidents") as mock_publish:
             actor = StateReplicatorDR()
             result = actor.run({"action": "verify"})
             assert result.outcome == Outcome.BLOCK
@@ -547,14 +515,12 @@ class TestDiscordPublish:
             role="primary",
             hostname="macmini",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=40,
+            last_sync_schema_version=41,
             sync_lag_seconds=0,
             status="healthy",
             db_path=patched_db,
         )
-        with patch(
-            "nuri.agents.actors.state_replicator_dr.StateReplicatorDR._publish_incidents"
-        ) as mock_publish:
+        with patch("nuri.agents.actors.state_replicator_dr.StateReplicatorDR._publish_incidents") as mock_publish:
             actor = StateReplicatorDR()
             actor.run({"action": "verify"})
             assert not mock_publish.called

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,9 +29,9 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_40(self, db_path):
-        """Phase 1+2 migrations 모두 적용 → schema version 40 (#38 + #39 + #40 모두 포함)."""
-        assert get_schema_version(db_path) == 40
+    def test_schema_version_at_41(self, db_path):
+        """Phase 1+2 + discord_outbox (PR3 Codex Round 6) → schema version 41."""
+        assert get_schema_version(db_path) == 41
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
## Summary
사용자 통증 (2026-05-02): #brief 채널에 NVDA BUY/BUY/SELL 같은 conviction 으로 따로 발송 → 노이즈 폭발. Codex Round 6 권고에 따라 per-event direct publish 패턴 폐기, **single-writer outbox + dispatcher** 패턴으로 재설계.

3 commits = 3 phases (Codex 권장 channel-by-channel migration):
1. **Phase 1** — outbox infra + brief_auditor + scheduler crons (shadow mode, 사용자 화면 변화 0)
2. **Phase 2** — decision_compiler `#brief` + `#ops` cutover (사용자 화면이 단일 digest 로 전환되는 시점)
3. **Phase 3** — 11 actor 의 `#ops` / `#incidents` / `#rollout` cutover

User-facing 효과:
- 매 emit 마다 따로 발송되던 카드 → dispatcher 가 60s quiet-period 후 1 embed 종합 (Codex actionability bucket: Action Now / Blocked&Conflict / Lower Priority)
- HIGH priority (stop-loss / hard-veto / DR readiness) 는 즉시 픽업
- watchdog 가 outbox 정체 시 #ops 알림 (recursion 방지 직접 발송)

Architecture (Codex Round 6 단호한 권고 반영):
- **New table** `discord_outbox` (migration #41) — lease columns (status / claim_token / claimed_at / attempt_count / last_error / sent_at) → at-least-once 보장, dispatcher crash mid-flush 안전
- **Single-writer invariant** — actor 가 webhook 직접 호출 X, outbox stage 만 (watchdog 만 recursion 방지로 직접 #ops)
- **Quiet-period flush** (#brief) — 마지막 stage 이후 60s no-event 면 dispatch (daily cron 거부)
- **Dedupe via dedupe_key** (decision_id / factor_id+date / replica_id 등) — retry 중복 stage 방지

## Files changed (35 file)
- 신규: \`discord_outbox_ops.py\`, \`outbox.py\`, \`channel_dispatcher.py\`, \`outbox_watchdog.py\`, \`brief_auditor.py\` + 2 test files
- 변경: 12 actor (decision_compiler / audit_ledger / causal_factor_auditor / collector_orchestrator / drift_sentinel / execution_firewall / forward_outcome_tracker / foundation_benchmark / hypothesis_registry / regime_posterior / sre_incident_agent / state_replicator_dr) + 11 test files
- migration #41, scheduler 5 cron 추가 (dispatcher 4채널 + watchdog), test_state_replicator_dr / test_agent_infra schema bump 40→41

## Test plan
- [x] \`pytest tests/agents/\` — 769 passed (+ 36 new tests: outbox 23 + brief_auditor 13)
- [x] \`ruff check\` — clean
- [x] \`python -m nuri.scheduler --dry-run\` — 33 jobs 등록 확인
- [ ] **Production deploy 후 #brief 화면 직접 확인** — 60s quiet-period 후 1 embed 만 발송되는지
- [ ] **Watchdog 알림 trigger** — 임의로 dispatcher 멈추고 30분 oldest_pending 대기 → #ops 알림 발생 확인
- [ ] **STRATEGY §7.1 invariant** — 자동 매매 X, dispatcher publish only

## Codex archive
\`data/llm_consults/2026-05-02_discord-outbox-redesign.md\` (Round 6 대화 전문)

## Codex 권고 vs 채택 매트릭스
| 항목 | Codex | 채택 |
|---|---|---|
| outbox 분리 vs agent_messages 재활용 | 분리 | ✅ |
| HIGH priority bypass | outbox 통과, scheduled_for=now | ✅ |
| #brief flush 시점 | run-scoped + quiet-period (60-90s) | ✅ (60s) |
| 디지털 layout | actionability bucket | ✅ |
| Phase 분할 | channel-by-channel | ✅ (3 commits) |
| Lease semantics | 의무 | ✅ (claim_token + claimed_at) |
| Watchdog | 의무 | ✅ (oldest_age 30min / pending_count 100) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)