### PR TITLE
docs: refresh root doc counts + scope refactor + portfolio gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,9 @@ data/logs/
 data/llm_consults/
 # Thesis Q&A archive (#508) — DB context + LLM verdict 포함, portfolio holdings 노출
 data/thesis_query/
+# Portfolio recommendation backtracking archive (per-day .md) — broker holdings +
+# rebalance proposals 노출, public repo 절대 금지. STRATEGY §4.4.1 privacy.
+data/portfolio_recommendations/
 # API health check heartbeat (scheduler 가 매분 rewrite)
 data/.scheduler_heartbeat
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,10 +88,10 @@ make full-scan                      # 8-phase including SIEGE certify + report
 make consensus                      # 10-agent BUY/SELL/HOLD on holdings
 make certify / remediate            # SIEGE v2 gate
 
-# Issue #507/#508/#509 (2026-04-30)
-make buy-candidates                 # cash deploy candidate emit (#507)
-make thesis ticker=<T> [question=]  # ticker thesis Q&A (#508)
-make earnings-preview ticker=<T>    # consensus EPS + IV implied move (#509)
+# Reactive analysis (recommend-only, all 3 ship 2026-04-30)
+make buy-candidates                 # top-N cash deploy candidate emit
+make thesis ticker=<T> [question=]  # on-demand ticker thesis Q&A (codex+Qwen)
+make earnings-preview ticker=<T>    # consensus EPS + IV implied move
 
 # LLM consult (codex + Qwen3.5 dual archive)
 make llm-consult slug=<kebab> prompt=<file>
@@ -156,7 +156,7 @@ L1 CLAUDE.md (memory) → L2 Skills (auto-invoked) → L3 Hooks (deterministic) 
 
 | Layer | Where | Inventory |
 |-------|-------|-----------|
-| L1 Memory | 8 scoped `CLAUDE.md` (this file + 7 subdirs) + `~/.claude/CLAUDE.md` global | Subfolder appends, never overwrites parent |
+| L1 Memory | 12 scoped `CLAUDE.md` (this file + 11 subdirs) + `~/.claude/CLAUDE.md` global | Subfolder appends, never overwrites parent |
 | L2 Skills | `.claude/skills/nuri-{deploy,flow,harness-debug,review,siege-audit,verify}/SKILL.md` (6) | Auto-invoke via natural language. `nuri-flow` = 7-phase Flow recommend-only orchestrator (audit P1-1) |
 | L3 Hooks | `.claude/settings.json` PreToolUse + PostToolUse | sqlite3 / datetime.now / destructive-git / privacy ticker+PnL block; ruff advisory |
 | L4 Agents | `.claude/agents/nuri-{codex-second-opinion,thesis-batch}.md` (2) | Own context, parallel work |
@@ -181,7 +181,7 @@ For framework / test-mocking / data-source / pipeline-policy gotchas → see sco
 - `docs/SOURCE_OF_TRUTH.md` — file-ownership map. Consult before adding/de-duplicating any doc fact.
 - `docs/ARCHITECTURE.md` — detailed code/DB layout (env vars, CI/CD, schema)
 - `docs/OPERATIONS.md` — operator runbook (2-machine setup, deploy / scheduler / recovery)
-- `docs/TODO.md` (gitignored) — forward-only backlog. Tier 2 P0=#507 (BUY signal asymmetry) / P1 #0a-#0b (#508 thesis / #509 earnings preview) / P2 #0c (Gap B harness telemetry)
+- `docs/TODO.md` (gitignored) — forward-only backlog (Tier 2 next, Tier 3 research). Contents drift fast — read the file, never duplicate items here.
 - `docs/SIEGE_V2.md` — 3D certification spec
 - `docs/KIS_INTEGRATION.md` — KIS Open API integration details
 - `AGENTS.md` — **cross-tool** rules (Cursor / Copilot / Codex CLI), not auto-loaded by Claude Code. **`.claude/agents/` 와 별개 메커니즘** — `.claude/agents/nuri-*.md` 가 Claude Code 의 sub-agent 정의, `AGENTS.md` 는 비-Claude 도구용 contributor 가이드. 이름이 비슷해도 혼동 금지.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ flowchart TB
 
     subgraph Pipeline["5-phase decision pipeline (DB-only coupling)"]
         direction TB
-        A(["① Collect<br/>25 data collectors"]):::pipe
+        A(["① Collect<br/>26 data collectors"]):::pipe
         B(["② Analyze<br/>signals · regimes · factors"]):::pipe
         C(["③ Consensus<br/>10-agent weighted vote"]):::pipe
         D(["④ Certify<br/>SIEGE v2 (3-D gates)"]):::pipe
@@ -44,7 +44,7 @@ flowchart TB
 
 | Phase | What it does | Inputs → Outputs |
 |-------|--------------|------------------|
-| ① **Collect** | 25 collectors — US: yfinance / OpenBB · KR: pykrx · Macro: FRED · News: GoogleNews RSS · 13F: edgartools · KIS Open API | external APIs → `prices` · `fundamentals` · `macro` · `news` · `institutional_flows` |
+| ① **Collect** | 26 collectors — US: yfinance / OpenBB · KR: pykrx · Macro: FRED · News: GoogleNews RSS · 13F: edgartools · KIS Open API | external APIs → `prices` · `fundamentals` · `macro` · `news` · `institutional_flows` |
 | ② **Analyze** | 22 signals (20 actionable + 2 SHADOW crash precursors) · 10 regimes (6 base + 4 special) · 3 factor scorers + composite aggregator · 15 macro event categories | DB → `signals` · `factors` · `regime_transitions` · `macro_events` |
 | ③ **Consensus** | 10 specialist agents · weighted vote · risk-agent veto fires on `alpha_action==FLAT` only | DB → `recommendations` (incl. `agent_verdicts`, `scoring_detail` JSON columns) |
 | ④ **Certify** | SIEGE v2 — Account × Asset Class × Execution Market. 1 error-grade fail → REJECTED, no manual override | DB → `certifications` (incl. `conditions_json` evidence + `portfolio_hash`) |
@@ -58,7 +58,7 @@ The system rests on five enduring decisions. Recent feature additions and tuning
 
 | # | Principle | What it means in practice |
 |---|-----------|---------------------------|
-| 1 | **Sole SQLite gateway** | `nuri/core/db.py` is the only `sqlite3` importer (hook-enforced — every other module uses `query()` / `upsert_*()` / `get_db()` with optional `db_path=` for test isolation). 32 tables, WAL mode. |
+| 1 | **Sole SQLite gateway** | `nuri/core/db.py` is the only `sqlite3` importer (hook-enforced — every other module uses `query()` / `upsert_*()` / `get_db()` with optional `db_path=` for test isolation). 48 tables, WAL mode. |
 | 2 | **Config over code** | Stop-loss thresholds, agent weights, signal metadata, SIEGE gate policies — all in `config/*.yaml`. Changing a rule or adding a market means editing YAML, never Python. |
 | 3 | **Loose phase coupling** | Pipeline phases communicate via DB tables / CSV only. No cross-phase imports. Re-run any upstream phase and downstream consumers refresh. |
 | 4 | **3-D SIEGE certification** | Gates apply per `Account (strategy)` × `Asset Class (us_equity / kr_equity / kr_index / commodity / bond)` × `Execution Market`. 1 error-grade fail → REJECTED, no manual override. Inspired by [nutshells3/SIEGE](https://github.com/nutshells3/Swarm-Intelligence-Engine-with-Gated-Execution). |
@@ -145,7 +145,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite — 3,577 backend (158 files) + 989 frontend (67 files) + 8 Playwright e2e specs
+make test       # full suite — 4,485 backend (187 files) + 989 frontend (81 files) + 8 Playwright e2e specs
 make test-fast  # backend only, slow tests excluded (~24s, what PR CI runs)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler integration)
 ```


### PR DESCRIPTION
## Summary
사용자 요청 — 18개 repo-root 파일을 \"엄밀하게\" update + refactor. 코드 실측 대비 stale 한 숫자/참조 정리.

## Changes (3 files, +13/-10)

### README.md (4 sites — drift sweep)
- L23 mermaid diagram: \`25 → 26\` data collectors
- L47 phase table: \`25 → 26\` collectors (전체 표 일관성)
- L62 architectural principle: \`32 → 48\` tables (drift since 2025)
- L148 test command: \`3,577 (158 files) + 989 (67 files)\` → \`4,485 (187) + 989 (81)\`

### CLAUDE.md (3 spots — count + scope refactor)
- L91 reactive analysis section: 닫힌 issue 번호 (#507/#508/#509 모두 closed/merged) 제거, purpose-based comment 으로 refactor (Harness Principle #5: 숫자 grep 영향 면역)
- L159 .claude inventory: \`8 scoped → 12 scoped\` (this + 11 subdirs)
- L184 docs/TODO.md reference: stale Tier descriptor 제거, "read the file" 로 단순화

### .gitignore (사용자 요청)
- \`data/portfolio_recommendations/\` 추가 — broker holdings + rebalance proposals 노출, public repo 절대 금지 (STRATEGY §4.4.1 privacy)

## Skipped (의도적)
| 파일 | 이유 |
|---|---|
| LICENSE / uv.lock | Touch 금지. uv.lock 은 \`uv lock\` 만 재생성 |
| SESSION_PROMPT.md / NEXT_SESSION.md | gitignored, untracked |
| Makefile (684 lines) / .cspell.json (784 lines) | Bulk refactor 별도 PR scope, 본 PR 의 drift fix scope 초과 |
| pyproject.toml, pyrightconfig.json, codecov.yml, .mcp.json, .env.example, AGENTS.md, SECURITY.md, CONTRIBUTING.md | Drift 없음 (코드 실측과 일치), refactor 가치 X |

## Test plan
- [x] \`bash scripts/verify/verify_doc_counts.sh\` — 13/13 PASS
- [x] \`ruff check nuri/ tests/\` — All checks passed
- [x] \`git check-ignore data/portfolio_recommendations/2026-05-01.md\` — matches new rule

## 검증 출처 (live counts)
- \`find nuri/collectors -maxdepth 1 -name "*.py" ! -name "__init__.py" ! -name "base.py" | wc -l\` → 26
- \`init_db + sqlite_master COUNT(*)\` → 48 tables
- \`find tests -name "test_*.py" | wc -l\` → 187 files
- \`find frontend/src -name "*.test.ts" -o -name "*.test.tsx" | wc -l\` → 81 files
- \`find . -name CLAUDE.md\` → 12 scoped (root + 11 subdirs)
- \`gh issue view 507/508/509\` → CLOSED / MERGED / MERGED

🤖 Generated with [Claude Code](https://claude.com/claude-code)