### PR TITLE
docs(claude-md): complete Load Triggers table for 4 trading subpackages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ This project's primary developer is an LLM (Claude Code). LLMs fail systematical
 | `nuri/collectors/` (data sources) | `nuri/collectors/CLAUDE.md` + `docs/STRATEGY.md §4.4` (privacy / external LLM egress) |
 | `nuri/trading/agents/` (consensus / veto) | `nuri/trading/agents/CLAUDE.md` + `docs/STRATEGY.md §3.2-§3.3, §3.9` |
 | `nuri/trading/engine/` (SIEGE) | `nuri/trading/engine/CLAUDE.md` + `docs/SIEGE_V2.md` + `docs/STRATEGY.md §6` |
+| `nuri/trading/recommend/` (BUY/SELL emitters, price targets, tracker) | `nuri/trading/recommend/CLAUDE.md` + `docs/STRATEGY.md §7.1` (recommend-only, never execute) |
+| `nuri/trading/swing/` (≤7d swing scanner / rules) | `nuri/trading/swing/CLAUDE.md` + `config/rules.yaml` swing ladder |
+| `nuri/trading/strategy/` (longshort, mean-rev, pairs, position) | `nuri/trading/strategy/CLAUDE.md` — `REGIME_ALLOCATION` lives in `longshort.py` (not config); changes require STRATEGY PR + backtest |
+| `nuri/trading/execution/` (broker adapter) | `nuri/trading/execution/CLAUDE.md` — paper-only (Alpaca paper endpoint), live execution out of scope per §7.1 |
 | `config/rules.yaml`, `config/agents.yaml`, `config/signals.yaml` | `config/CLAUDE.md` + `docs/STRATEGY.md §2.6, §3.4-§3.5` |
 | `frontend/` | `frontend/CLAUDE.md` (Next.js 16 breaking changes — read `node_modules/next/dist/docs/` first) |
 | `tests/` | `tests/CLAUDE.md` (DB isolation, mock pitfalls, privacy in fixtures) |


### PR DESCRIPTION
## Summary

Closes #572

루트 \`CLAUDE.md\` Load Triggers 표가 11개 scoped \`CLAUDE.md\` 중 7개만 매핑하던 gap fix. 4행 추가:

- \`nuri/trading/recommend/\` — recommend-only invariant (§7.1)
- \`nuri/trading/swing/\` — swing ladder
- \`nuri/trading/strategy/\` — \`REGIME_ALLOCATION\` 위치 규정 (config 아닌 longshort.py 인 이유)
- \`nuri/trading/execution/\` — paper-only invariant (live exec out of scope)

특히 \`strategy/CLAUDE.md\` 의 \`REGIME_ALLOCATION\` rule 이 매핑 안 돼 있어, future Claude 세션이 파일을 안 읽고 잘못된 리팩터 (예: config 로 옮기기) 를 시도할 위험이 있었음.

## Test plan

- [x] \`make verify-doc-counts\` pass — 13/13 checks
- [x] privacy-scan pass
- [x] PR Discipline: 1 commit
- [x] Conventional commit (English) + Korean commit body
- [ ] CI pre-merge checks pass (auto)