### PR TITLE
fix(scheduler): call init_db() on bootstrap to prevent migration drift

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -473,7 +473,8 @@ def main():
 
     # 부트스트랩 시 DB 스키마 / 마이그레이션 멱등 적용 — 신규 deploy 후 첫 부팅에서
     # `_MIGRATIONS` 누적 drift 가 자동 catch-up 되도록 한다 (#575).
-    # init_db() 는 멱등이라 재실행 비용은 schema_version SELECT 한 번뿐.
+    # init_db() 는 functionally idempotent: `_SCHEMA` / `_SCHEMA_VERSION_TABLE` 는
+    # `IF NOT EXISTS` 기반이라 재실행해도 결과 동일. 미적용 마이그레이션만 새로 INSERT.
     init_db()
     logger.info("DB schema initialized (idempotent)")
 

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from nuri.core.db import init_db
+
 
 def _configure_logging() -> None:
     """Set up scheduler logging with optional file rotation.
@@ -468,6 +470,12 @@ def main():
     if args.dry_run:
         print_schedule()
         return
+
+    # 부트스트랩 시 DB 스키마 / 마이그레이션 멱등 적용 — 신규 deploy 후 첫 부팅에서
+    # `_MIGRATIONS` 누적 drift 가 자동 catch-up 되도록 한다 (#575).
+    # init_db() 는 멱등이라 재실행 비용은 schema_version SELECT 한 번뿐.
+    init_db()
+    logger.info("DB schema initialized (idempotent)")
 
     scheduler = create_scheduler()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -931,3 +931,55 @@ class TestSchedulerLogRotation:
         finally:
             # Restore default for downstream tests that might assert on it.
             _logging.getLogger("yfinance").setLevel(_logging.NOTSET)
+
+
+# ═══════════════════════════════════════════════════════
+# TestSchedulerBootstrap — #575 init_db on startup
+# ═══════════════════════════════════════════════════════
+
+
+class TestSchedulerBootstrap:
+    """`main()` 진입 시 `init_db()` 가 `create_scheduler()` 보다 먼저 호출되어야 함.
+
+    배경: 신규 머신 / migration drift 누적 상태에서 scheduler 가 init_db() 없이
+    부팅하면 첫 cron job 이 미적용 schema 로 실행되어 IntegrityError. #575 의 root
+    cause 였고 직전 세션 (2026-05-02) 에 22→41 수동 catch-up 으로 워크어라운드.
+
+    Gotcha-Test Pair (STRATEGY §5.3.1) — 본 테스트는 fix revert 시 fail.
+    """
+
+    def test_main_calls_init_db_before_scheduler_start(self, monkeypatch):
+        """main() 이 init_db() → create_scheduler().start() 순서로 동작."""
+        from nuri import scheduler as sched_mod
+
+        call_order: list[str] = []
+
+        mock_init_db = MagicMock(side_effect=lambda *a, **kw: call_order.append("init_db"))
+        mock_scheduler = MagicMock()
+        mock_scheduler.start.side_effect = lambda: call_order.append("start")
+        mock_create = MagicMock(side_effect=lambda: (call_order.append("create_scheduler"), mock_scheduler)[1])
+
+        monkeypatch.setattr(sched_mod, "init_db", mock_init_db)
+        monkeypatch.setattr(sched_mod, "create_scheduler", mock_create)
+        # signal.signal 은 main 스레드 외에서 호출 시 ValueError — 우회.
+        monkeypatch.setattr(sched_mod.signal, "signal", lambda *_a, **_kw: None)
+        monkeypatch.setattr(sys, "argv", ["nuri.scheduler"])
+
+        sched_mod.main()
+
+        mock_init_db.assert_called_once()
+        assert call_order == ["init_db", "create_scheduler", "start"], (
+            f"순서 어긋남: {call_order} — init_db 가 create_scheduler 이전이어야 함 (#575)"
+        )
+
+    def test_dry_run_does_not_call_init_db(self, monkeypatch):
+        """--dry-run 은 schedule 출력만 — DB 쓰기 회피 (CI / 검증용)."""
+        from nuri import scheduler as sched_mod
+
+        mock_init_db = MagicMock()
+        monkeypatch.setattr(sched_mod, "init_db", mock_init_db)
+        monkeypatch.setattr(sys, "argv", ["nuri.scheduler", "--dry-run"])
+
+        sched_mod.main()
+
+        mock_init_db.assert_not_called()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -949,7 +949,12 @@ class TestSchedulerBootstrap:
     """
 
     def test_main_calls_init_db_before_scheduler_start(self, monkeypatch):
-        """main() 이 init_db() → create_scheduler().start() 순서로 동작."""
+        """main() 이 scheduler.start() 이전에 init_db() 를 호출.
+
+        실제 correctness boundary 는 "start() 이전" — create_scheduler() 는 job
+        등록만 하므로 그 이전/이후는 무관. Codex review (PR #583) 후 의도적으로
+        order assertion 을 완화 (init_db.index < start.index).
+        """
         from nuri import scheduler as sched_mod
 
         call_order: list[str] = []
@@ -957,10 +962,9 @@ class TestSchedulerBootstrap:
         mock_init_db = MagicMock(side_effect=lambda *a, **kw: call_order.append("init_db"))
         mock_scheduler = MagicMock()
         mock_scheduler.start.side_effect = lambda: call_order.append("start")
-        mock_create = MagicMock(side_effect=lambda: (call_order.append("create_scheduler"), mock_scheduler)[1])
 
         monkeypatch.setattr(sched_mod, "init_db", mock_init_db)
-        monkeypatch.setattr(sched_mod, "create_scheduler", mock_create)
+        monkeypatch.setattr(sched_mod, "create_scheduler", MagicMock(return_value=mock_scheduler))
         # signal.signal 은 main 스레드 외에서 호출 시 ValueError — 우회.
         monkeypatch.setattr(sched_mod.signal, "signal", lambda *_a, **_kw: None)
         monkeypatch.setattr(sys, "argv", ["nuri.scheduler"])
@@ -968,8 +972,9 @@ class TestSchedulerBootstrap:
         sched_mod.main()
 
         mock_init_db.assert_called_once()
-        assert call_order == ["init_db", "create_scheduler", "start"], (
-            f"순서 어긋남: {call_order} — init_db 가 create_scheduler 이전이어야 함 (#575)"
+        assert "init_db" in call_order and "start" in call_order, call_order
+        assert call_order.index("init_db") < call_order.index("start"), (
+            f"순서 어긋남: {call_order} — init_db 가 scheduler.start() 이전이어야 함 (#575)"
         )
 
     def test_dry_run_does_not_call_init_db(self, monkeypatch):


### PR DESCRIPTION
## Summary

- `nuri/scheduler.py::main()` now invokes `init_db()` before `scheduler.start()` so freshly-deployed Mac mini hosts auto-apply pending migrations on first boot
- `--dry-run` path skips `init_db()` (CI / inspection only)
- `init_db()` is functionally idempotent: `_SCHEMA` / `_SCHEMA_VERSION_TABLE` use `IF NOT EXISTS`; `_apply_migrations()` filters via `schema_version` SELECT and only INSERTs un-applied versions

## Motivation

Closes #575. Direct lineage of the manual migration-22→41 catch-up the user performed on 2026-05-02 23:55 KST after the #569 deploy.

## Test plan

- [x] `tests/test_scheduler.py::TestSchedulerBootstrap::test_main_calls_init_db_before_scheduler_start` — Gotcha-Test Pair: asserts `init_db` index < `start` index (relaxed from full sequence per Codex review — `create_scheduler` ordering is incidental)
- [x] `TestSchedulerBootstrap::test_dry_run_does_not_call_init_db` — guards against unintended DB write on `--dry-run`
- [x] Full `test_scheduler.py` — 84 passed
- [x] `ruff check` — clean
- [x] `python -m nuri.scheduler --dry-run` — schedule list still printed

## Codex review iteration

`gpt-5.4` flagged inaccurate idempotency cost claim in the original commit (claimed "single SELECT"; actually opens a connection + executes IF-NOT-EXISTS schema + version SELECT). Comment + PR body now state functional idempotency without the false cost shortcut. Test order assertion relaxed to the real correctness boundary.

## Out of scope

- #574 (lock-diff `--frozen`) and #576 (post-sync importlib reload) ship in a sibling PR. Codex+Qwen consult (`data/llm_consults/2026-05-03_session-priority-2026-05-03.md`) recommended bundling those two; #575 is intentionally split per PR Discipline (1 issue = 1 PR).
- `init_db()` reliance on `DB_PATH` env / default path resolution (env-load ordering) — separate issue if it ever surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)