### PR TITLE
fix(deploy): always run uv sync --frozen to catch cumulative drift

### DIFF
--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -93,12 +93,20 @@ echo "  ${SYNC_COUNT}개 파일 동기화"
 # 예) 이전 deploy 에서 lock 변경이 `|| warn` 으로 silently fail → 다음 deploy 의
 # diff 엔 lock 없음 → 영영 미적용. hmmlearn 누락 사례 (2026-05-02).
 # 수정: 매 deploy 마다 `uv sync --frozen --extra dev` 강제. lock 일치 시 거의 no-op,
-# 불일치 시 명시 abort 해 silent drift 차단.
+# 불일치 시 명시 abort 해 silent drift 차단. transient 인프라 (네트워크) 흡수 위해
+# 1회 retry 추가 (Codex review #584 Round 1 blocker #1).
+#
+# TODO #576: scheduler 가 launchd 로 동작 중 .venv 가 변경되면 race condition
+# 가능성 — sync 전 launchctl unload, sync 후 launchctl load 로 보정 필요. 본 PR
+# scope 외, 별 PR 로 해결.
 step 4 "의존성 동기화 (uv sync --frozen, 항상 실행)"
-if ssh "${REMOTE}" "cd ${REMOTE_PATH} && uv sync --extra dev --frozen --quiet"; then
+SYNC_CMD="cd ${REMOTE_PATH} && uv sync --extra dev --frozen --quiet"
+if ssh "${REMOTE}" "${SYNC_CMD}" 2>&1; then
     ok "uv sync --frozen 성공"
+elif sleep 5 && ssh "${REMOTE}" "${SYNC_CMD}" 2>&1; then
+    ok "uv sync --frozen 성공 (retry 1회 후)"
 else
-    fail "uv sync --frozen 실패 — uv.lock 과 pyproject.toml / .venv 불일치. 로컬에서 'uv lock' 후 commit/push, 또는 Mac mini 에 .venv 재생성 필요"
+    fail "uv sync --frozen 실패 (1 retry 후) — uv.lock divergence 또는 transient 인프라 (네트워크/디스크). 로컬에서 'uv lock' 재생성 후 commit/push, 또는 Mac mini 에서 'rm -rf .venv && uv sync' 수동 복구"
 fi
 
 # ── 5. scheduler reload ──

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -88,13 +88,17 @@ for f in .env config/portfolio.yaml NEXT_SESSION.md; do
 done
 echo "  ${SYNC_COUNT}개 파일 동기화"
 
-# ── 4. uv sync (lock 변경 시) ──
-step 4 "의존성 확인"
-if [[ -n "${CHANGED_FILES:-}" ]] && echo "${CHANGED_FILES}" | grep -qE '^(uv\.lock|pyproject\.toml)$'; then
-    ok "lock/pyproject 변경 감지 → uv sync 실행"
-    ssh "${REMOTE}" "cd ${REMOTE_PATH} && .venv/bin/python -m pip --version >/dev/null 2>&1 && uv sync --extra dev --quiet" || warn "uv sync 실패 — 수동 확인 필요"
+# ── 4. uv sync --frozen (항상 실행, #574) ──
+# 기존 로직: this-deploy 의 diff 에 uv.lock 이 있을 때만 sync — 누적 drift 미감지.
+# 예) 이전 deploy 에서 lock 변경이 `|| warn` 으로 silently fail → 다음 deploy 의
+# diff 엔 lock 없음 → 영영 미적용. hmmlearn 누락 사례 (2026-05-02).
+# 수정: 매 deploy 마다 `uv sync --frozen --extra dev` 강제. lock 일치 시 거의 no-op,
+# 불일치 시 명시 abort 해 silent drift 차단.
+step 4 "의존성 동기화 (uv sync --frozen, 항상 실행)"
+if ssh "${REMOTE}" "cd ${REMOTE_PATH} && uv sync --extra dev --frozen --quiet"; then
+    ok "uv sync --frozen 성공"
 else
-    ok "lock 변경 없음 (skip)"
+    fail "uv sync --frozen 실패 — uv.lock 과 pyproject.toml / .venv 불일치. 로컬에서 'uv lock' 후 commit/push, 또는 Mac mini 에 .venv 재생성 필요"
 fi
 
 # ── 5. scheduler reload ──


### PR DESCRIPTION
## Summary

- `scripts/deploy/deploy_to_mini.sh` step 4 now runs `uv sync --extra dev --frozen` on every deploy instead of gating on `uv.lock` / `pyproject.toml` appearing in this-deploy's diff
- Failure aborts the deploy with a remediation hint (was: \`|| warn\`)
- Commentary added explaining the cumulative-drift failure mode the previous logic enabled

## Motivation

Closes #574. The hmmlearn drift on 2026-05-02 surfaced after the prior deploy's \`|| warn\` fallback masked a sync failure; the next deploy's narrower diff did not include \`uv.lock\` and so the script skipped the sync forever. Forcing \`--frozen\` makes that class of silent drift impossible — lock-vs-venv divergence becomes a hard abort with an explicit remediation step.

## Test plan

- [x] \`shellcheck\` clean
- [x] Privacy scanner clean
- [ ] **Real \`make deploy-mini\` execution** — must run after merge and confirm \`uv sync --frozen\` passes on Mac mini (planned in this session)

## Out of scope

- #576 (importlib cache stale after sync) ships in a sibling PR. Both touch \`deploy_to_mini.sh\` but on disjoint sections (step 4 vs step 5b reload trigger), so PR Discipline (1 issue = 1 PR) keeps them separate.
- Daemon lifecycle via shell vs systemd/launchd (Qwen consult smell, archive 2026-05-03) — separate epic if pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)