### PR TITLE
fix(deploy): bounce scheduler around uv sync (#576)

### DIFF
--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -9,8 +9,8 @@
 #   1. SSH 연결 확인
 #   2. 원격 git pull (ff-only)
 #   3. config 동기화 (.env, portfolio.yaml, NEXT_SESSION.md — DB 제외)
-#   4. uv sync 확인 (lock 변경 시)
-#   5. scheduler plist 설치 (미설치 시) + reload (scheduler.py 변경 시)
+#   4. scheduler unload → uv sync --frozen (항상) → (5에서 load)
+#   5. scheduler load (fresh importlib — 신규 패키지 + 코드 변경 모두 반영)
 #   6. 최종 검증 (git HEAD, launchctl, scheduler --dry-run)
 #
 # 전제:
@@ -88,52 +88,107 @@ for f in .env config/portfolio.yaml NEXT_SESSION.md; do
 done
 echo "  ${SYNC_COUNT}개 파일 동기화"
 
-# ── 4. uv sync --frozen (항상 실행, #574) ──
-# 기존 로직: this-deploy 의 diff 에 uv.lock 이 있을 때만 sync — 누적 drift 미감지.
-# 예) 이전 deploy 에서 lock 변경이 `|| warn` 으로 silently fail → 다음 deploy 의
-# diff 엔 lock 없음 → 영영 미적용. hmmlearn 누락 사례 (2026-05-02).
-# 수정: 매 deploy 마다 `uv sync --frozen --extra dev` 강제. lock 일치 시 거의 no-op,
-# 불일치 시 명시 abort 해 silent drift 차단. transient 인프라 (네트워크) 흡수 위해
-# 1회 retry 추가 (Codex review #584 Round 1 blocker #1).
-#
-# TODO #576: scheduler 가 launchd 로 동작 중 .venv 가 변경되면 race condition
-# 가능성 — sync 전 launchctl unload, sync 후 launchctl load 로 보정 필요. 본 PR
-# scope 외, 별 PR 로 해결.
-step 4 "의존성 동기화 (uv sync --frozen, 항상 실행)"
+# ── 4. scheduler bounce + uv sync --frozen (#574 + #576) ──
+# 순서: scheduler stop → uv sync → scheduler start.
+# Why bounce around sync:
+#   1) launchd race (#576): sync 가 .venv 를 mutate 하는 동안 scheduler 가 import
+#      하면 partial 상태 노출 가능. unload 로 KeepAlive 잠시 정지.
+#   2) importlib stale cache (#576 본체): uv sync 로 신규 패키지 (예: hmmlearn)
+#      추가돼도 이미 떠 있는 process 는 못 봄 — restart 가 유일한 정석.
+#   3) 매 deploy 마다 fresh process 보장 → 코드 변경 reload 별도 trigger 불필요.
+# Why always sync (#574): lock 일치 시 거의 no-op, 불일치 시 명시 abort 해
+#   silent drift 차단. transient 인프라 (네트워크) 흡수 위해 1회 retry.
+# Verify launchctl 동작 (#576 Codex Round 1 #1 blocker): legacy `launchctl
+#   load/unload` 는 실제 stop/start 실패해도 0 반환할 수 있음. PID 확인 polling
+#   으로 race 보장 실현. unload 후 PID 사라짐 / load 후 PID 살아남 verify.
+# Trade-off (Codex Round 1 #2): 매 deploy 마다 ~수초 downtime. cron miss 가능성
+#   있으나 (a) deploy 는 사용자 수동 이벤트 (자동 cron 아님), (b) trading hour 외
+#   에 실행, (c) misfire_grace_time=300 가 부분 흡수. acceptable.
+PLIST_REMOTE="\$HOME/Library/LaunchAgents/${PLIST_NAME}"
+SCHEDULER_LABEL="${PLIST_NAME%.plist}"
+SCHEDULER_INSTALLED=$(ssh "${REMOTE}" "[ -f ${PLIST_REMOTE} ] && echo yes || echo no")
+
+# launchctl PID 조회 — running 시 숫자, 미실행/미등록 시 빈 문자열
+get_scheduler_pid() {
+    ssh "${REMOTE}" "launchctl list 2>/dev/null | awk -v label='${SCHEDULER_LABEL}' '\$3==label && \$1 ~ /^[0-9]+\$/ { print \$1; exit }'" || true
+}
+
+# polling: 20초 동안 0.5초 간격으로 condition (gone|alive) 체크.
+# Why 20s: launchd default ThrottleInterval=10s — KeepAlive bounce 시 첫 spawn
+# 까지 최대 10s 지연 가능 (Codex Round 2 #1). 안전 margin 포함 20s 채택.
+wait_scheduler() {
+    local want="$1"  # "gone" | "alive"
+    local elapsed=0
+    while (( elapsed < 40 )); do
+        local pid
+        pid=$(get_scheduler_pid)
+        if [[ "${want}" == "gone" && -z "${pid}" ]]; then return 0; fi
+        if [[ "${want}" == "alive" && -n "${pid}" ]]; then echo "${pid}"; return 0; fi
+        sleep 0.5
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+# health verify: PID 잡힌 후 3초 동안 같은 PID 유지하는지 재확인.
+# Why: scheduler 가 import 시 ModuleNotFoundError 로 즉시 die 하면 KeepAlive 가
+# 새 PID 로 respawn 반복 (crash-loop). 단일 PID 관찰만으로는 healthy 보장 안 됨
+# (Codex Round 2 #2). Stable PID for 3s = import + apscheduler.start() 까지 진행.
+verify_stable_pid() {
+    local first_pid="$1"
+    sleep 3
+    local now_pid
+    now_pid=$(get_scheduler_pid)
+    [[ "${now_pid}" == "${first_pid}" ]]
+}
+
+step 4 "scheduler bounce + 의존성 동기화"
+
+# 4a. scheduler unload + verify PID 사라짐
+if [[ "${SCHEDULER_INSTALLED}" == "yes" ]]; then
+    ssh "${REMOTE}" "launchctl unload ${PLIST_REMOTE} 2>/dev/null" || true
+    if wait_scheduler gone >/dev/null; then
+        ok "scheduler unloaded (PID 사라짐 verified)"
+    else
+        fail "scheduler unload 실패 — PID 가 20초 후에도 살아 있음. 'ssh ${REMOTE} launchctl list | grep ${SCHEDULER_LABEL}' 로 수동 확인 후 재시도"
+    fi
+else
+    warn "scheduler plist 미설치 → 4c 에서 초기 설치"
+fi
+
+# 4b. uv sync --frozen (항상 실행, 1회 retry)
 SYNC_CMD="cd ${REMOTE_PATH} && uv sync --extra dev --frozen --quiet"
 if ssh "${REMOTE}" "${SYNC_CMD}" 2>&1; then
     ok "uv sync --frozen 성공"
 elif sleep 5 && ssh "${REMOTE}" "${SYNC_CMD}" 2>&1; then
     ok "uv sync --frozen 성공 (retry 1회 후)"
 else
+    # sync 실패 시 scheduler 재가동 시도 (이전 .venv 상태로라도 복구) 후 abort.
+    # load + stable check — partial .venv 로 인한 crash-loop 도 감지.
+    if [[ "${SCHEDULER_INSTALLED}" == "yes" ]]; then
+        ssh "${REMOTE}" "launchctl load ${PLIST_REMOTE} 2>/dev/null" || true
+        if RECOVERY_PID=$(wait_scheduler alive) && verify_stable_pid "${RECOVERY_PID}"; then
+            warn "sync 실패 — 이전 .venv 상태로 scheduler 재가동 성공 (PID ${RECOVERY_PID} stable)"
+        else
+            warn "sync 실패 + scheduler 재가동 실패 또는 crash-loop — production downtime. SSH 로 'tail data/logs/scheduler.err' 확인 + 수동 복구 필요"
+        fi
+    fi
     fail "uv sync --frozen 실패 (1 retry 후) — uv.lock divergence 또는 transient 인프라 (네트워크/디스크). 로컬에서 'uv lock' 재생성 후 commit/push, 또는 Mac mini 에서 'rm -rf .venv && uv sync' 수동 복구"
 fi
 
-# ── 5. scheduler reload ──
-step 5 "scheduler 관리"
-PLIST_REMOTE="\$HOME/Library/LaunchAgents/${PLIST_NAME}"
-
-# 5a. plist 설치 여부 확인
-SCHEDULER_INSTALLED=$(ssh "${REMOTE}" "[ -f ${PLIST_REMOTE} ] && echo yes || echo no")
+# 4c. scheduler load + verify PID 살아남
+step 5 "scheduler 재기동"
 if [[ "${SCHEDULER_INSTALLED}" == "no" ]]; then
-    warn "scheduler plist 미설치 → 초기 설치"
     ssh "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && cp ${REMOTE_PATH}/scripts/${PLIST_NAME} ${PLIST_REMOTE}"
     ssh "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
-    ok "scheduler 초기 설치 + 로드 완료"
 else
-    # 5b. scheduler.py 변경 시에만 reload
-    NEED_RELOAD="no"
-    if [[ -n "${CHANGED_FILES:-}" ]] && echo "${CHANGED_FILES}" | grep -qE '^(nuri/scheduler\.py|config/agents\.yaml|config/rules\.yaml)$'; then
-        NEED_RELOAD="yes"
-    fi
+    ssh "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
+fi
 
-    if [[ "${NEED_RELOAD}" == "yes" ]]; then
-        ok "scheduler 관련 파일 변경 감지 → reload"
-        ssh "${REMOTE}" "launchctl unload ${PLIST_REMOTE} 2>/dev/null; sleep 2; launchctl load ${PLIST_REMOTE}"
-        ok "scheduler reloaded"
-    else
-        ok "scheduler 변경 없음 (reload skip)"
-    fi
+if NEW_PID=$(wait_scheduler alive) && verify_stable_pid "${NEW_PID}"; then
+    ok "scheduler reloaded (fresh importlib, PID ${NEW_PID} stable for 3s)"
+else
+    fail "scheduler load 실패 또는 crash-loop — 20초 안에 stable PID 못 찾음. import error 가능성. 'ssh ${REMOTE} tail data/logs/scheduler.err' 확인 + 'launchctl load ${PLIST_REMOTE}' 수동 실행"
 fi
 
 # ── 6. 최종 검증 ──


### PR DESCRIPTION
## Summary
- `scripts/deploy/deploy_to_mini.sh` step 4-5 reorder: scheduler **unload → uv sync → load**.
- Resolves importlib stale cache (#576 본체) + launchd race (#584 Codex Round 1 #3) in one structural change.
- 매 deploy 마다 fresh process 보장 → 기존 conditional reload trigger 제거 (단순화).
- launchctl 동작 verify (PID polling 20s timeout + 3s stable check) 로 silent failure 차단.

## Why now
이전 세션 (#574, #584) 에서 `uv sync --frozen` 항상 실행으로 누적 drift 는 차단했지만, sync 후 scheduler 재기동이 없으면:
- importlib 가 신규 패키지를 못 봄 → cron 마다 `ModuleNotFoundError` (hmmlearn 사례)
- sync 가 `.venv` mutate 중 scheduler import → partial state 가능 (race)

#584 Round 2 에서 `.venv` race 는 #576 로 명시 defer 했음 — 본 PR 이 이행.

## Behavior change
| 단계 | 기존 | 변경 |
|---|---|---|
| 4 | `uv sync` (항상, #584) | scheduler unload + verify gone → `uv sync` → (5에서 load) |
| 5 | scheduler.py 변경 시에만 reload | 항상 load + verify alive + verify stable PID (3s) |

Failure path: sync 실패 시 이전 `.venv` 상태로 scheduler 재가동 + stable check 후 abort — partial venv crash-loop 도 감지.

## Codex review history (3 rounds)
- **Round 1 FAIL** (3 findings): launchctl 성공 verify 부재 (blocking) + cron miss tradeoff (medium) + first-install plist path mismatch (medium, pre-existing)
- **Round 2 FAIL** (2 new blockers): 5s timeout < launchd ThrottleInterval 10s (false-fail) + 단일 PID 관찰 ≠ healthy (crash-loop 시 transient PID 캐치)
- **Round 3 PASS**: 20s timeout + 3s stable PID re-check 로 양쪽 blocker 해소

Cron miss tradeoff: 매 deploy 마다 ~수초 downtime 인정 — deploy 는 사용자 수동 이벤트, trading hour 외 실행, misfire_grace_time=300 부분 흡수.

First-install plist path mismatch (Round 1 #3): pre-existing, 본 PR worsen 안 함 → 별 issue **#586** 으로 분리.

## Test plan
- [x] `shellcheck scripts/deploy/deploy_to_mini.sh` clean
- [x] Codex Round 3 PASS (timeout 적정성, stable window 적정성, recovery chaining, bash 3.2 호환, first-install no regression 모두 confirm)
- [ ] (다음 단계, Mac mini 실측) `make deploy-mini` — unload PID-gone verify, sync no-op 케이스, load + stable PID 검증

## Notes
- Scope: 1 issue = 1 PR, 1 commit. PR Discipline 준수.
- Test: integration test 작성 시 SSH + launchctl mocking 비용 대비 가치 낮음 — 실측 검증으로 대체.
- 본 PR 머지 후 첫 deploy 에서 scheduler PID 갱신 + 20s 이내 stable confirm 필요.
- Follow-up: #586 (first-install plist path)

closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)