### PR TITLE
feat(agent-loop): orchestrator skeleton — Codex+Claude+Qwen pipeline (#578)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,10 @@ data/logs/
 # carry portfolio context, verdicts may quote it. Decision audit trail kept
 # locally, not committed. Mirror policy of codex-reviews/.
 data/llm_consults/
+# Agent loop transcripts (#578) — issue spec + patch + adversarial review.
+# Codex/Qwen 가 issue body 를 스니펫으로 인용할 수 있어 portfolio context 노출
+# 가능. local audit trail 만 보존, public repo 절대 금지.
+data/agent_loop/
 # Thesis Q&A archive (#508) — DB context + LLM verdict 포함, portfolio holdings 노출
 data/thesis_query/
 # Portfolio recommendation backtracking archive (per-day .md) — broker holdings +

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,7 @@ data/
 
 ## Testing
 
-4,524 backend tests across 189 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+4,539 backend tests across 190 files + 917 frontend vitest (81 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -285,7 +285,7 @@ PR 전 확인.
 
 | 항목 | 기준 | 현재 |
 |------|------|------|
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,524 tests, 189 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 4,539 tests, 190 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 81 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/dev/agent_loop.py
+++ b/scripts/dev/agent_loop.py
@@ -1,0 +1,257 @@
+"""Agent loop orchestrator skeleton — Codex (spec) → Claude (patch, stub) → Qwen (review).
+
+epic #577 / E2 (#578). Discord 미연결, file-based transcript. Claude builder
+는 본 PR 에서 stub — 별 issue 에서 backend 결정 (API 직접 vs Claude Code subprocess).
+
+Usage:
+    .venv/bin/python scripts/dev/agent_loop.py --issue 575
+    .venv/bin/python scripts/dev/agent_loop.py --issue 575 --budget-tokens 50000 --budget-usd 0.50
+
+산출물:
+    data/agent_loop/<issue>/
+      spec.md       # Codex 의 spec breakdown (Step 1)
+      patch.diff    # Claude 자리 (Step 2 stub — TODO 주석만)
+      review.md     # Qwen adversarial review (Step 3)
+      cost.json     # 누적 token + USD / 단계별 사용량
+
+Cost budget: token (Codex char-proxy + Qwen server usage) 와 USD 동시 추적.
+어느 한쪽이라도 budget 초과 시 다음 단계 abort.
+
+Exit codes:
+  0 success / 1 LLM ok=False / 2 budget exceeded
+  3 dependency error — I/O 또는 subprocess 의존성 (network/filesystem/external CLI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# llm_consult.py 의 헬퍼 재사용. scripts/dev/ 자체 모듈이라 sys.path 조작 불필요.
+# requests 는 직접 import 하지 않음 — RequestException 은 OSError 상속이므로
+# main() 의 except 가 자동 포착.
+sys.path.insert(0, str(Path(__file__).parent))
+from llm_consult import consult_codex, consult_qwen  # noqa: E402
+
+DEFAULT_BUDGET_TOKENS = 100_000
+DEFAULT_BUDGET_USD = 1.00
+
+# Pricing (USD per 1M tokens). Codex CLI 는 gpt-5.4 기준.
+# Source: https://openai.com/api/pricing/ (2026-05-03 confirmed).
+# 가격 정책 변경 시 본 상수만 갱신. Qwen 은 local LLM 이라 비용 0.
+CODEX_INPUT_USD_PER_M = 2.50
+CODEX_OUTPUT_USD_PER_M = 15.00
+QWEN_USD_PER_M = 0.0
+
+
+class BudgetExceeded(RuntimeError):
+    pass
+
+
+@dataclass
+class CostTracker:
+    """누적 토큰 + USD 추적. 어느 한쪽이라도 초과 시 raise BudgetExceeded."""
+
+    budget_tokens: int
+    budget_usd: float
+    used_tokens: int = 0
+    used_usd: float = 0.0
+    by_step_tokens: dict[str, int] = field(default_factory=dict)
+    by_step_usd: dict[str, float] = field(default_factory=dict)
+
+    def charge(self, step: str, tokens: int, usd_per_m: float) -> None:
+        usd = tokens * usd_per_m / 1_000_000
+        self.used_tokens += tokens
+        self.used_usd += usd
+        self.by_step_tokens[step] = self.by_step_tokens.get(step, 0) + tokens
+        self.by_step_usd[step] = round(self.by_step_usd.get(step, 0.0) + usd, 6)
+        if self.used_tokens > self.budget_tokens:
+            raise BudgetExceeded(f"누적 {self.used_tokens} tokens > budget {self.budget_tokens} (마지막: {step})")
+        if self.used_usd > self.budget_usd:
+            raise BudgetExceeded(f"누적 ${self.used_usd:.4f} > budget ${self.budget_usd:.2f} (마지막: {step})")
+
+    def to_dict(self) -> dict:
+        return {
+            "budget_tokens": self.budget_tokens,
+            "budget_usd": self.budget_usd,
+            "used_tokens": self.used_tokens,
+            "used_usd": round(self.used_usd, 6),
+            "by_step_tokens": self.by_step_tokens,
+            "by_step_usd": self.by_step_usd,
+        }
+
+
+def estimate_tokens(text: str) -> int:
+    """Mitigation char-proxy: 2 char ≈ 1 token. NOT a hard upper bound.
+
+    Heuristic: Korean (Hangul) tokenizers (Qwen/Claude/GPT-style BPE) typically
+    emit ~1.5-2 chars/token; English ~4. Mixed Korean + Markdown 가정해 2 채택.
+    Codex usage API 미반환 — 본 proxy 가 step1 budget 의 유일 근거.
+
+    한계: code-fence / 짙은 punctuation / 비-ASCII symbol 이 많은 prompt 에서
+    real token count 가 len//2 를 초과할 수 있음. budget 가 발화하지 않는
+    case 에서도 실제 cost 가 약간 더 들 수 있다는 점을 caller 가 인지해야 함.
+    Mitigation 강화 방안 (별 issue): tiktoken / Qwen tokenizer 직접 사용.
+    """
+    return max(1, len(text) // 2)
+
+
+def fetch_issue_body(issue_num: int) -> tuple[str, str]:
+    """gh issue view 로 title + body 조회. (title, body) 반환."""
+    proc = subprocess.run(
+        ["gh", "issue", "view", str(issue_num), "--json", "title,body"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(proc.stdout)
+    return data["title"], data["body"]
+
+
+def build_spec_prompt(issue_num: int, title: str, body: str) -> str:
+    return f"""# Issue #{issue_num} — spec breakdown
+
+본 task 를 patch-ready spec 으로 분해. 구현은 다음 단계 (Claude builder) 가
+담당하므로 본 응답은 **명세** 만 작성 — 코드 직접 작성 금지.
+
+## Issue
+**Title:** {title}
+
+**Body:**
+{body}
+
+## Output 형식
+1. **Goal** (1 sentence)
+2. **Touched files** (예상, 경로만)
+3. **Acceptance criteria** (bullet, ≤5)
+4. **Risks / open questions** (bullet, ≤3)
+5. **Out-of-scope** — 의도적 제외 항목
+
+## 제약
+- PR Discipline: 1 issue = 1 PR ≤ 3 commits
+- nuri-quant CLAUDE.md invariants 준수 (sole-importer DB, kst_now, etc.)
+- spec 자체는 ≤300 줄
+"""
+
+
+def build_review_prompt(issue_num: int, spec: str, patch_diff: str) -> str:
+    return f"""# Issue #{issue_num} — adversarial review
+
+본 task 의 spec 과 patch (stub 가능) 를 adversarial 관점으로 review.
+
+## Spec
+{spec}
+
+## Patch
+```diff
+{patch_diff if patch_diff.strip() else "(stub — patch 미작성, spec 만 검토)"}
+```
+
+## Review 형식
+1. **Spec gaps** — 누락된 acceptance criteria / edge case
+2. **Hidden risk** — Codex 가 안 짚은 functional / security / privacy 위험
+3. **PR scope sanity** — 1 PR 로 적정한가? 분리 권고?
+4. **Verdict**: PASS / NEEDS_REWORK / ABSTAIN (이유 1 sentence)
+
+ruthlessly honest. PASS 남발 금지.
+"""
+
+
+def write_outputs(out_dir: Path, name: str, content: str) -> Path:
+    path = out_dir / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def run_loop(issue_num: int, budget_tokens: int, budget_usd: float, out_root: Path) -> int:
+    out_dir = out_root / str(issue_num)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cost = CostTracker(budget_tokens=budget_tokens, budget_usd=budget_usd)
+
+    # Step 0: 이슈 fetch
+    title, body = fetch_issue_body(issue_num)
+    print(f"[step 0] issue #{issue_num}: {title}")
+
+    # Step 1: Codex spec
+    print("[step 1] Codex spec ...")
+    spec_prompt = build_spec_prompt(issue_num, title, body)
+    cost.charge("step1_codex_in", estimate_tokens(spec_prompt), CODEX_INPUT_USD_PER_M)
+    codex_result = consult_codex(spec_prompt)
+    if not codex_result["ok"]:
+        print(f"  codex failed: {codex_result.get('stderr', '')[:200]}")
+        return 1
+    spec = codex_result["verdict"]
+    cost.charge("step1_codex_out", estimate_tokens(spec), CODEX_OUTPUT_USD_PER_M)
+    spec_path = write_outputs(out_dir, "spec.md", spec)
+    print(f"  saved {spec_path} ({len(spec)} chars)")
+
+    # Step 2: Claude builder = stub
+    patch_diff = (
+        "# TODO E2 #578: Claude builder 자리.\n"
+        "# 별 issue 에서 backend 결정 (Anthropic API 직접 vs Claude Code subprocess).\n"
+        "# 현재는 사용자 수동으로 채움.\n"
+    )
+    patch_path = write_outputs(out_dir, "patch.diff", patch_diff)
+    print(f"[step 2] Claude builder (stub) → {patch_path}")
+
+    # Step 3: Qwen review
+    print("[step 3] Qwen review ...")
+    review_prompt = build_review_prompt(issue_num, spec, patch_diff)
+    cost.charge("step3_qwen_in", estimate_tokens(review_prompt), QWEN_USD_PER_M)
+    qwen_result = consult_qwen(review_prompt)
+    if not qwen_result["ok"]:
+        print(f"  qwen failed: {qwen_result['verdict'][:200]}")
+        return 1
+    review = qwen_result["verdict"]
+    # Qwen 은 server side usage 반환 — 정확 값 우선 사용
+    qwen_out_tokens = qwen_result.get("tokens_out") or estimate_tokens(review)
+    cost.charge("step3_qwen_out", qwen_out_tokens, QWEN_USD_PER_M)
+    review_path = write_outputs(out_dir, "review.md", review)
+    print(f"  saved {review_path} ({len(review)} chars)")
+
+    # cost.json
+    cost_path = write_outputs(out_dir, "cost.json", json.dumps(cost.to_dict(), indent=2))
+    print(
+        f"\n총 사용: {cost.used_tokens} tokens / ${cost.used_usd:.4f} "
+        f"(budget {budget_tokens} / ${budget_usd:.2f}) → {cost_path}"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--issue", type=int, required=True, help="GitHub issue 번호")
+    parser.add_argument("--budget-tokens", type=int, default=DEFAULT_BUDGET_TOKENS)
+    parser.add_argument("--budget-usd", type=float, default=DEFAULT_BUDGET_USD)
+    parser.add_argument("--out-dir", type=Path, default=Path("data/agent_loop"))
+    args = parser.parse_args(argv)
+
+    try:
+        return run_loop(args.issue, args.budget_tokens, args.budget_usd, args.out_dir)
+    except BudgetExceeded as e:
+        print(f"BUDGET_EXCEEDED: {e}", file=sys.stderr)
+        return 2
+    except (
+        # OSError 상속: FileNotFoundError (gh missing), PermissionError (out_dir
+        # write 실패), ConnectionError, TimeoutError (built-in), requests.
+        # RequestException (Connection/Timeout/HTTPError 등 — IOError 상속).
+        OSError,
+        # SubprocessError 상속: CalledProcessError (non-zero exit), TimeoutExpired
+        # (codex hang — built-in TimeoutError 상속 안 하므로 별도 필요).
+        subprocess.SubprocessError,
+        # ValueError 상속: gh stdout malformed JSON.
+        json.JSONDecodeError,
+    ) as e:
+        # Narrow tuple — I/O / subprocess / parse 의존성 오류만 rc=3 으로 표면화.
+        # KeyError/TypeError/AttributeError 등 programmer bug 는 의도적으로
+        # propagate (traceback 으로 디버깅).
+        print(f"DEPENDENCY_ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_agent_loop.py
+++ b/tests/scripts/test_agent_loop.py
@@ -1,0 +1,234 @@
+"""Tests for scripts/dev/agent_loop.py — orchestrator skeleton (#578).
+
+Network-free: subprocess (gh issue view) + LLM consult helpers 모두 mock.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# scripts/dev/ 는 패키지가 아니라 직접 import.
+SCRIPT_DIR = Path(__file__).parent.parent.parent / "scripts" / "dev"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+spec = importlib.util.spec_from_file_location("agent_loop", SCRIPT_DIR / "agent_loop.py")
+assert spec is not None and spec.loader is not None
+agent_loop = importlib.util.module_from_spec(spec)
+sys.modules["agent_loop"] = agent_loop  # @dataclass 가 cls.__module__ lookup 함 — 사전 등록 필요
+spec.loader.exec_module(agent_loop)
+
+
+@pytest.fixture
+def out_dir(tmp_path):
+    return tmp_path / "agent_loop"
+
+
+def _mock_subprocess_gh(title="Test issue", body="Fix the foo when bar."):
+    """gh issue view --json mock — agent_loop.fetch_issue_body 가 호출."""
+    proc = MagicMock()
+    proc.stdout = json.dumps({"title": title, "body": body})
+    return proc
+
+
+def test_run_loop_writes_artifacts_with_token_and_usd(out_dir):
+    """정상 path: spec/patch/review/cost.json 생성, cost.json 에 token + USD 모두 기록."""
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            return_value={"ok": True, "verdict": "spec contents", "stderr": ""},
+        ),
+        patch(
+            "agent_loop.consult_qwen",
+            return_value={
+                "ok": True,
+                "verdict": "review verdict: PASS",
+                "tokens_out": 200,
+            },
+        ),
+    ):
+        rc = agent_loop.run_loop(issue_num=999, budget_tokens=100_000, budget_usd=1.0, out_root=out_dir)
+
+    assert rc == 0
+    issue_dir = out_dir / "999"
+    assert (issue_dir / "spec.md").read_text() == "spec contents"
+    assert "TODO E2 #578" in (issue_dir / "patch.diff").read_text()
+    assert "PASS" in (issue_dir / "review.md").read_text()
+    cost = json.loads((issue_dir / "cost.json").read_text())
+    assert cost["used_tokens"] > 0
+    assert cost["used_usd"] >= 0  # local Qwen 만이면 0 가능; Codex out 은 비용 발생
+    assert "step1_codex_in" in cost["by_step_tokens"]
+    assert "step1_codex_out" in cost["by_step_usd"]
+    # Codex output 가격 적용 확인 ($15.00/M tokens — agent_loop.CODEX_OUTPUT_USD_PER_M 와 동기)
+    assert cost["by_step_usd"]["step1_codex_out"] > 0
+
+
+def test_budget_tokens_exceeded_aborts_before_qwen(out_dir):
+    """token budget 초과 시 step3 skip, rc=2."""
+    huge_spec = "x" * 200_000
+
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            return_value={"ok": True, "verdict": huge_spec, "stderr": ""},
+        ),
+        patch("agent_loop.consult_qwen") as mock_qwen,
+    ):
+        rc = agent_loop.main(
+            ["--issue", "999", "--budget-tokens", "5000", "--budget-usd", "100", "--out-dir", str(out_dir)]
+        )
+
+    mock_qwen.assert_not_called()
+    assert rc == 2
+
+
+def test_budget_usd_exceeded_aborts(out_dir):
+    """USD budget 가 token 보다 먼저 초과될 때도 rc=2."""
+    big_codex_out = "x" * 50_000  # ~25k tokens proxy → step1_codex_out 비용 ~$0.25
+
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            return_value={"ok": True, "verdict": big_codex_out, "stderr": ""},
+        ),
+        patch("agent_loop.consult_qwen") as mock_qwen,
+    ):
+        rc = agent_loop.main(
+            [
+                "--issue",
+                "999",
+                "--budget-tokens",
+                "10_000_000",
+                "--budget-usd",
+                "0.05",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+
+    mock_qwen.assert_not_called()
+    assert rc == 2
+
+
+def test_codex_failure_returns_rc_1(out_dir):
+    """Codex 가 ok=False 반환하면 step3 skip, rc=1."""
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            return_value={"ok": False, "verdict": "", "stderr": "auth error"},
+        ),
+        patch("agent_loop.consult_qwen") as mock_qwen,
+    ):
+        rc = agent_loop.run_loop(issue_num=999, budget_tokens=100_000, budget_usd=1.0, out_root=out_dir)
+
+    mock_qwen.assert_not_called()
+    assert rc == 1
+
+
+def test_dependency_error_returns_rc_3(out_dir):
+    """gh issue view CalledProcessError → rc=3, traceback 노출 안 됨."""
+    with patch(
+        "agent_loop.subprocess.run",
+        side_effect=subprocess.CalledProcessError(returncode=1, cmd=["gh"], stderr="not found"),
+    ):
+        rc = agent_loop.main(["--issue", "999", "--out-dir", str(out_dir)])
+    assert rc == 3
+
+
+def test_qwen_transport_error_returns_rc_3(out_dir):
+    """consult_qwen 이 RequestException raise → rc=3."""
+    import requests
+
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            return_value={"ok": True, "verdict": "spec ok", "stderr": ""},
+        ),
+        patch("agent_loop.consult_qwen", side_effect=requests.ConnectionError("server down")),
+    ):
+        rc = agent_loop.main(["--issue", "999", "--budget-usd", "10", "--out-dir", str(out_dir)])
+    assert rc == 3
+
+
+def test_gh_binary_missing_returns_rc_3(out_dir):
+    """gh CLI 미설치 시 FileNotFoundError → rc=3 (Codex Round 3)."""
+    with patch("agent_loop.subprocess.run", side_effect=FileNotFoundError("gh: not found")):
+        rc = agent_loop.main(["--issue", "999", "--out-dir", str(out_dir)])
+    assert rc == 3
+
+
+def test_codex_subprocess_timeout_returns_rc_3(out_dir):
+    """consult_codex 가 subprocess.TimeoutExpired raise → rc=3 (Codex Round 3).
+
+    subprocess.TimeoutExpired 는 built-in TimeoutError 상속 안 함 — 별도 catch 필요."""
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            side_effect=subprocess.TimeoutExpired(cmd=["codex"], timeout=600),
+        ),
+    ):
+        rc = agent_loop.main(["--issue", "999", "--out-dir", str(out_dir)])
+    assert rc == 3
+
+
+def test_filesystem_write_permission_error_returns_rc_3(out_dir):
+    """out_dir write 가 PermissionError raise → rc=3 (Codex Round 4).
+
+    --out-dir 가 public CLI input 이라 unwritable 케이스 cover 필요."""
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch(
+            "agent_loop.consult_codex",
+            return_value={"ok": True, "verdict": "spec ok", "stderr": ""},
+        ),
+        patch.object(Path, "write_text", side_effect=PermissionError("denied")),
+    ):
+        rc = agent_loop.main(["--issue", "999", "--out-dir", str(out_dir)])
+    assert rc == 3
+
+
+def test_estimate_tokens_proxy_basic():
+    # 2 char ≈ 1 token mitigation proxy. Mitigation 이지 hard upper bound 아님.
+    assert agent_loop.estimate_tokens("") == 1
+    assert agent_loop.estimate_tokens("x" * 2) == 1
+    assert agent_loop.estimate_tokens("x" * 200) == 100
+
+
+def test_estimate_tokens_korean_input():
+    # 한국어 + Markdown 혼합 sample 이 nonzero + len/2 에 일치하는지.
+    # 실제 tokenizer 와는 다를 수 있어 정확도 보장 안 함 — proxy 동작만 검증.
+    sample = "## 한국어 prompt 예시\n- 항목 하나\n- 항목 둘"
+    estimated = agent_loop.estimate_tokens(sample)
+    assert estimated == max(1, len(sample) // 2)
+    assert estimated > 1
+
+
+def test_programmer_bug_propagates_not_swallowed(out_dir):
+    """rc=3 catch tuple 이 narrow — KeyError 같은 programmer bug 는 propagate.
+    swallow 하면 디버깅이 어려워짐 (Codex Round 2 #2)."""
+    with (
+        patch("agent_loop.subprocess.run", return_value=_mock_subprocess_gh()),
+        patch("agent_loop.consult_codex", side_effect=KeyError("missing_field")),
+    ):
+        with pytest.raises(KeyError):
+            agent_loop.main(["--issue", "999", "--out-dir", str(out_dir)])
+
+
+def test_codex_pricing_constants_match_openai_2026_05():
+    """Pricing constant 가 GPT-5.4 공식가 (2026-05-03) 와 일치.
+    가격 변경 시 본 테스트 + 상수 + 주석 동기 갱신 (Codex Round 2 #1)."""
+    assert agent_loop.CODEX_INPUT_USD_PER_M == 2.50
+    assert agent_loop.CODEX_OUTPUT_USD_PER_M == 15.00
+    assert agent_loop.QWEN_USD_PER_M == 0.0


### PR DESCRIPTION
## Summary
- `scripts/dev/agent_loop.py` 추가 — Codex(spec) → Claude(stub) → Qwen(review) sequential pipeline
- Discord/HITL 의존 없이 핵심 로직 file-based 검증
- `scripts/dev/llm_consult.py` 의 `consult_codex` / `consult_qwen` 재사용
- Cost tracker: 누적 토큰 + USD 동시 추적 (Codex char-proxy + Qwen server usage), 어느 한쪽 초과 시 abort
- 13 tests (network-free) — happy path, dual budget, codex fail, 5가지 dependency error, programmer-bug propagation, pricing constants, token proxy

## Why now
epic #577 / E2 (#578). E1 Discord bot 은 사용자 token 발급 선행 필요라 병렬 진행. 본 PR 이 agent loop dogfood 의 발판.

## Architecture
```
Codex (spec)  ─→  Claude (stub)  ─→  Qwen (review)
gpt-5.4           TODO E2            122B-A10B
   │                  │                  │
   ▼                  ▼                  ▼
spec.md           patch.diff         review.md
                                   ▼
                              cost.json (tokens + USD)
```

산출물: `data/agent_loop/<issue>/` (gitignored — issue body + LLM verdict portfolio context 노출 가능).

## Cost tracker
- `CODEX_INPUT_USD_PER_M=2.50`, `CODEX_OUTPUT_USD_PER_M=15.00` (GPT-5.4 공식가, 2026-05-03 확인)
- `QWEN_USD_PER_M=0.0` (local LLM)
- `estimate_tokens(text) = max(1, len(text)//2)` — Korean+Markdown mitigation proxy (NOT hard upper bound)
- CLI: `--budget-tokens 100000 --budget-usd 1.00` (defaults)

## Exit codes
- `0` success
- `1` LLM ok=False (Codex / Qwen verdict empty)
- `2` budget exceeded (tokens OR USD)
- `3` dependency error — I/O / subprocess / parse 의존성 (gh missing, codex timeout, qwen ConnectionError, filesystem PermissionError, malformed JSON 등)

KeyError/TypeError 등 programmer bug 는 의도적으로 propagate (traceback 으로 디버깅).

## Codex review history (5 rounds)
- **R1 NEEDS_REWORK** (3): Korean token undercount, inconsistent failure handling, USD missing (scope miss)
- **R2 NEEDS_REWORK** (3): GPT-5.4 pricing wrong, `except Exception` swallows bugs, token proxy claim overstated
- **R3 NEEDS_REWORK** (1): dependency tuple misses FileNotFoundError + subprocess.TimeoutExpired
- **R4 NEEDS_REWORK** (1): filesystem write failures (PermissionError) bypass rc=3
- **R5 PASS**: tuple 재구조화 (`OSError` + `subprocess.SubprocessError` + `json.JSONDecodeError`) — narrow enough to preserve programmer-bug propagation, broad enough to cover orchestrator's external dependency surface. requests.RequestException 도 OSError 상속 → import 제거.

## Out-of-scope (별 issue, epic E3-E5)
- Claude builder backend 선택 (Anthropic API 직접 vs Claude Code subprocess vs SDK) — E2 merged 후 issue 신설
- tiktoken/Qwen tokenizer 직접 사용 (estimate_tokens 강화)
- Discord publish (#580 E4)
- Privacy scanner stream gate (#579 E3)
- Self-dogfood — agent_loop 으로 issue ship (#581 E5)

## Test plan
- [x] `pytest tests/scripts/test_agent_loop.py -v` (13/13 pass, network-free)
- [x] `ruff check` clean
- [x] Codex Round 5 PASS
- [ ] (선택, 후속) live dry-run on real issue with Codex + Qwen

## Notes
- PR Discipline: 1 issue = 1 PR, 1 commit (5 round amend → squash)
- Test mock 패턴: `subprocess.run` (gh) + `consult_codex` / `consult_qwen` 모두 patch
- Import 패턴: scripts/dev/ 가 패키지 아니라 sys.path insert + importlib spec_from_file_location

closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)