### PR TITLE
fix(launchd): #557 stale paths — autopull/state-replicator/health-check plists

### DIFF
--- a/scripts/launchd/com.nuri-quant.autopull.plist
+++ b/scripts/launchd/com.nuri-quant.autopull.plist
@@ -5,7 +5,7 @@
 
   목적:
     MBP에서 git push → 5분 이내에 Mac mini가 origin/main을 ff-only merge.
-    실제 동작은 scripts/autopull_receiver.sh에 위임 — 거기서 dependency/schema
+    실제 동작은 scripts/deploy/autopull_receiver.sh에 위임 — 거기서 dependency/schema
     변경 감지, 서비스 재시작 hook 등을 처리.
 
   설치 (Mac mini에서 1회):
@@ -35,7 +35,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/ehbebe/workspace/nuri-quant/scripts/autopull_receiver.sh</string>
+        <string>/Users/ehbebe/workspace/nuri-quant/scripts/deploy/autopull_receiver.sh</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/scripts/launchd/com.nuri-quant.health-check.plist
+++ b/scripts/launchd/com.nuri-quant.health-check.plist
@@ -21,7 +21,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; bash scripts/health_check.sh</string>
+        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; bash scripts/ops/health_check.sh</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/scripts/launchd/com.nuri-quant.state-replicator.plist
+++ b/scripts/launchd/com.nuri-quant.state-replicator.plist
@@ -30,7 +30,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; source ~/.zshrc &amp;&amp; bash scripts/state_replicator.sh primary</string>
+        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; source ~/.zshrc &amp;&amp; bash scripts/deploy/state_replicator.sh primary</string>
     </array>
 
     <key>WorkingDirectory</key>


### PR DESCRIPTION
## Summary
- Mac mini autopull launchd 가 #557 (scripts/ modular refactor) 후 stale path 로 16 commits behind 정체
- 3 launchd plists 의 ProgramArguments 경로 갱신: `scripts/X.sh` → `scripts/{deploy,ops}/X.sh`
- Mac mini 에 fixed plist 동기화 + launchctl reload 완료 — 즉시 catch-up `8ab65b9`, schema_version=43, held_add_shadow 정상

## Why now
- runs=1890 누적 실패 (exit 127, "No such file or directory")
- #518 phase 2a shadow data 누적 블락 — 운영 차단 상태였음
- 사용자 직접 운영 검증 요청 (NEXT_SESSION P0-B)

## Test plan
- [x] Mac mini autopull log 정상 ("updated to 8ab65b9")
- [x] schema_version=43 + held_add_shadow 테이블 존재 확인
- [x] CI green (cosmetic plist 변경 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)