### PR TITLE
fix(tests): runpy RuntimeWarnings — sys.modules.pop + filterwarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,9 @@ filterwarnings = [
     "ignore::DeprecationWarning:openbb_intrinio.*:",
     "ignore::pydantic.warnings.PydanticDeprecatedSince211:",
     "ignore::pydantic.warnings.PydanticDeprecatedSince212:",
+    # runpy.run_module() — 부모 패키지의 transitive import 가 target 을 재등록하면
+    # sys.modules.pop 으로도 회피 불가. 실제 source 실행에 영향 없는 cosmetic warning.
+    "ignore::RuntimeWarning:runpy",
 ]
 
 


### PR DESCRIPTION
## Summary
- 65건 누적 `'X found in sys.modules after import of package Y'` runtime warning 제거
- 9 test 파일에 `sys.modules.pop(module_name, None)` 사전 호출 + pyproject.toml filterwarnings RuntimeWarning:runpy

## Why
- 직전 세션에서 사용자가 5,300 tests 의 65 warnings 를 CI 로그에서 식별
- runpy.run_module() 동작에 영향 없는 cosmetic 경고지만 신호 노이즈 큼

## Test plan
- [x] tests/agents/quant/analysis/collectors/llm/test_main_runpy.py 45 passed, 0 warnings
- [x] 전체 -m "not slow" suite 5300 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)