### PR TITLE
feat(collectors): activate _expected_count guard — fundamental + estimates

### DIFF
--- a/nuri/collectors/estimates.py
+++ b/nuri/collectors/estimates.py
@@ -50,6 +50,10 @@ class EstimatesCollector(BaseCollector):
             self.logger.warning("US 종목이 없습니다 (yfinance 컨센서스는 .KS 미지원)")
             return []
 
+        # MAX_FAILURE_RATE 가드 활성화 — yfinance consensus 1 record/ticker. KR 제외 후
+        # us_tickers 수와 결과 list 길이 직접 비교 가능 → asymmetric save 차단.
+        self._expected_count = len(us_tickers)
+
         self.logger.info(f"애널리스트 컨센서스 수집: {len(us_tickers)}종목 (source={source})")
         from nuri.core.timezone import today_kst
 

--- a/nuri/collectors/fundamental.py
+++ b/nuri/collectors/fundamental.py
@@ -172,6 +172,10 @@ class FundamentalCollector(BaseCollector):
             self.logger.warning("수집할 종목이 없습니다")
             return []
 
+        # MAX_FAILURE_RATE(10%) 가드 활성화 — yfinance/KIS fail 누적 시 save 거부.
+        # asymmetric data age 방지 (어제 row 그대로 + 오늘 70% 결손 silent save 차단).
+        self._expected_count = len(tickers)
+
         self.logger.info(f"펀더멘탈 수집 대상: {len(tickers)}종목 (source={source})")
         from nuri.core.timezone import today_kst
 

--- a/tests/collectors/test_estimates.py
+++ b/tests/collectors/test_estimates.py
@@ -5,6 +5,8 @@ Split from tests/test_collectors_all.py for module-level isolation.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from nuri.core.db import (
     init_db,
 )
@@ -312,14 +314,20 @@ class TestEstimatesCli:
 
         fake_rows = [
             {
-                "ticker": "AAPL", "recommendation": "buy",
-                "target_mean": 250.0, "target_median": 245.0,
-                "current_price": 230.0, "num_analysts": 30,
+                "ticker": "AAPL",
+                "recommendation": "buy",
+                "target_mean": 250.0,
+                "target_median": 245.0,
+                "current_price": 230.0,
+                "num_analysts": 30,
             },
             {
-                "ticker": "X", "recommendation": None,
-                "target_mean": None, "target_median": None,
-                "current_price": None, "num_analysts": None,
+                "ticker": "X",
+                "recommendation": None,
+                "target_mean": None,
+                "target_median": None,
+                "current_price": None,
+                "num_analysts": None,
             },
         ]
         monkeypatch.setattr(mod, "EstimatesCollector", _FakeCollector)
@@ -335,9 +343,7 @@ class TestEstimatesCli:
 class TestEstimatesCoverageExtra:
     """Lines 65 / 116-117 cover — source!=portfolio 분기 + bulk log summary."""
 
-    def test_collect_universe_mode_triggers_yfinance_log_suppression(
-        self, rich_db, monkeypatch
-    ):
+    def test_collect_universe_mode_triggers_yfinance_log_suppression(self, rich_db, monkeypatch):
         """line 65 — source != 'portfolio' 분기: yfinance logger 레벨 CRITICAL 로 변경.
 
         실제 change 여부를 로거 level 로 검증 (universe 모드 종료 후 원복).
@@ -350,7 +356,8 @@ class TestEstimatesCoverageExtra:
         # 21개 ticker — len(us_tickers) >= 20 분기도 같이 커버 (line 116-117)
         tickers = [f"T{i:02d}" for i in range(21)]
         monkeypatch.setattr(
-            collector, "_get_tickers",
+            collector,
+            "_get_tickers",
             lambda market=None, source="portfolio": tickers,
         )
 
@@ -381,7 +388,8 @@ class TestEstimatesCoverageExtra:
         collector = EstimatesCollector()
         tickers = [f"F{i:02d}" for i in range(20)]
         monkeypatch.setattr(
-            collector, "_get_tickers",
+            collector,
+            "_get_tickers",
             lambda market=None, source="portfolio": tickers,
         )
 
@@ -405,3 +413,70 @@ class TestEstimatesCoverageExtra:
         assert summary, "bulk summary log 가 emit 되지 않음"
         # 20개 전부 failed + '외 N개' truncation branch 확인 (15 remaining)
         assert "외 15개" in summary[0].message
+
+
+class TestEstimatesExpectedCountGuard:
+    """MAX_FAILURE_RATE 가드 활성화 lock-test.
+
+    Reason: estimates.collect() 가 us_tickers 수로 _expected_count 동적 설정 →
+    asymmetric data age 방지 가드 활성화. 회귀 차단.
+    """
+
+    def test_collect_sets_expected_count(self, monkeypatch):
+        """collect() 가 KR 제외 후 us_tickers 수로 _expected_count 설정."""
+        from nuri.collectors.estimates import EstimatesCollector
+
+        c = EstimatesCollector()
+        assert c._expected_count == 0
+
+        mock_yf = MagicMock()
+        mock_ticker = MagicMock()
+        mock_ticker.info = {
+            "regularMarketPrice": 100.0,
+            "recommendationKey": "buy",
+            "numberOfAnalystOpinions": 30,
+            "targetMeanPrice": 120.0,
+        }
+        mock_yf.Ticker.return_value = mock_ticker
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["AAPL", "MSFT", "GOOGL", "TSLA", "005930.KS"])
+
+        c.collect()
+        assert c._expected_count == 4, "KR 제외 후 us_tickers 수로 _expected_count 설정 안 함"
+
+    def test_run_blocks_when_failure_rate_exceeds_threshold(self, monkeypatch):
+        """run() 이 us_tickers 80% 실패 시 CollectionFailureError 발생."""
+        from nuri.collectors.base import CollectionFailureError
+        from nuri.collectors.estimates import EstimatesCollector
+
+        c = EstimatesCollector()
+        # 10 us_tickers 중 2개만 valid (T0/T1) → 80% 실패
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: [f"T{i}" for i in range(10)])
+
+        def make_ticker(t):
+            mock = MagicMock()
+            if t in ("T0", "T1"):
+                mock.info = {
+                    "regularMarketPrice": 100.0,
+                    "recommendationKey": "buy",
+                    "numberOfAnalystOpinions": 30,
+                    "targetMeanPrice": 120.0,
+                }
+            else:
+                mock.info = {}
+            return mock
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.side_effect = make_ticker
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        save_called = []
+        monkeypatch.setattr(c, "save", lambda data: save_called.append(len(data)) or len(data))
+
+        with pytest.raises(CollectionFailureError, match="실패율 80%"):
+            c.run()
+        assert save_called == [], "실패율 초과 시 save() 호출되면 안 됨"

--- a/tests/collectors/test_fundamental.py
+++ b/tests/collectors/test_fundamental.py
@@ -646,3 +646,96 @@ class TestKISFundamentalBranch:
         assert len(results) == 1
         assert results[0]["ticker"] == "005930.KS"
         assert results[0]["pe_ratio"] == 33.94
+
+
+class TestFundamentalExpectedCountGuard:
+    """MAX_FAILURE_RATE 가드 활성화 lock-test (PR #588 후속).
+
+    Reason: 직전 audit 에서 _expected_count 가 25/26 collector 에 unset 인 상태로
+    base.py 의 'asymmetric data age 방지' 가드가 dead code 였음을 확인.
+    fundamental.collect() 가 _expected_count 를 ticker 수로 동적 설정하도록 변경했고,
+    이 테스트가 회귀를 차단함.
+    """
+
+    def test_collect_sets_expected_count(self, monkeypatch, db_with_portfolio):
+        """collect() 진입 시 self._expected_count 가 len(tickers) 로 설정됨."""
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        # initial state — 0 (불활성)
+        assert c._expected_count == 0
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"regularMarketPrice": 100.0, "trailingPE": 20.0}
+        mock_yf = MagicMock()
+        mock_yf.Ticker.return_value = mock_ticker
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["AAPL", "MSFT", "GOOGL"])
+
+        c.collect()
+        assert c._expected_count == 3, "collect() 가 ticker 수로 _expected_count 설정 안 함"
+
+    def test_run_blocks_save_when_failure_rate_exceeds_threshold(self, monkeypatch, db_with_portfolio):
+        """run() 이 70% 실패 시 CollectionFailureError 발생 + save() 미호출."""
+        from nuri.collectors.base import CollectionFailureError
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        # 10 ticker 중 2개만 성공 → failure_rate 80% > 10% threshold
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: [f"T{i}" for i in range(10)])
+
+        # yfinance — T0/T1 만 valid info, 나머지 8개는 빈 info (skipped)
+        def make_ticker(t):
+            mock = MagicMock()
+            if t in ("T0", "T1"):
+                mock.info = {"regularMarketPrice": 100.0, "trailingPE": 20.0}
+            else:
+                mock.info = {}
+            return mock
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.side_effect = make_ticker
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        save_called = []
+        monkeypatch.setattr(c, "save", lambda data: save_called.append(len(data)) or len(data))
+
+        with pytest.raises(CollectionFailureError, match="실패율 80%"):
+            c.run()
+
+        assert save_called == [], "실패율 초과 시 save() 호출되면 안 됨 (asymmetric save 차단)"
+
+    def test_run_allows_save_when_failure_rate_below_threshold(self, monkeypatch, db_with_portfolio):
+        """failure_rate 5% < 10% 면 save() 정상 호출."""
+        from nuri.collectors.fundamental import FundamentalCollector
+
+        c = FundamentalCollector()
+        # 20 ticker 중 19개 성공 → failure_rate 5%
+        tickers = [f"T{i}" for i in range(20)]
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: tickers)
+
+        def make_ticker(t):
+            mock = MagicMock()
+            if t == "T0":
+                mock.info = {}
+            else:
+                mock.info = {"regularMarketPrice": 100.0, "trailingPE": 20.0}
+            return mock
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.side_effect = make_ticker
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", mock_yf)
+
+        save_called = []
+        monkeypatch.setattr(c, "save", lambda data: save_called.append(len(data)) or len(data))
+
+        # 가드 통과 — retry 없이 첫 시도에서 save 호출
+        result = c.run()
+        assert result == 19, "save() 가 19 records 받아야 함"
+        assert save_called == [19], "save() 1회 호출"


### PR DESCRIPTION
## Summary

직전 audit 에서 발견한 결함 — `BaseCollector._expected_count` 가 26개 collector 중 25개에서 unset (default=0) 이고 universe_sync 1개도 명시적 0=opt-out. 결과: `base.py` 의 'asymmetric data age 방지' 가드 (`MAX_FAILURE_RATE=10%`) 가 **사실상 0/26 active dead code** 상태.

이 PR 은 가장 영향 큰 2 collector (`fundamental` + `estimates` — 둘 다 `list[dict]` 반환, 1 record/ticker) 에서 가드 활성화. 보수적 첫걸음 — DataFrame 반환 collector (stock/stock_kr/technical) 는 row × day 다중 row 라 단순 `expected_count = ticker count` 매칭 안 됨, 후속 PR.

## What

- `nuri/collectors/fundamental.py:174` — `collect()` 진입 시 `self._expected_count = len(tickers)` 동적 설정
- `nuri/collectors/estimates.py:55` — `collect()` 진입 시 `self._expected_count = len(us_tickers)` 동적 설정 (KR 제외 후)

## Why

- 직전 audit reproduce 결과 `grep _expected_count` 가 universe_sync 1건 (=0) 만 매칭 → "수집 실패율 >10% 시 save 거부" docstring 미실현
- fundamentals universe 모드 (746 ticker) 에서 700개 fail 해도 silent save → 어제 row + 오늘 30% partial 로 freshness gate 통과 + 다운스트림 stale 의사결정 위험
- 2 collector 활성화로 즉시 차단

## Test plan (Gotcha-Test Pair §5.3.1)

3 lock-test in `TestFundamentalExpectedCountGuard` + 2 in `TestEstimatesExpectedCountGuard`:

- `test_collect_sets_expected_count` — collect() 진입 시 `_expected_count == len(tickers)` 검증 (회귀 차단)
- `test_run_blocks_save_when_failure_rate_exceeds_threshold` — 10 ticker 중 2 성공 → `CollectionFailureError("실패율 80%")` raise + save 미호출 검증
- `test_run_allows_save_when_failure_rate_below_threshold` (fundamental만) — 19/20 성공 (5%) → save 정상 호출

5 새 테스트 모두 PASS. 기존 56→61 fundamental + 27→29 estimates.

## Out of scope (후속 PR)

- DataFrame 반환 4 collector (stock/stock_kr/technical/wallstreet) — row count semantics 별도 설계
- 비-Collector 모듈 (external/filings/earnings_preview/news 자유함수) — base contract 일관성 PR
- `_send_failure_alert` → `nuri.agents.discord.outbox.stage_ops()` 통과 (Single-writer Discord 룰 준수) — 별 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)