### PR TITLE
feat(collectors): activate _expected_count guard — technical (DataFrame 1-row/ticker)

### DIFF
--- a/nuri/collectors/technical.py
+++ b/nuri/collectors/technical.py
@@ -34,6 +34,11 @@ class TechnicalCollector(BaseCollector):
             self.logger.warning("계산할 종목 없음")
             return pd.DataFrame()
 
+        # MAX_FAILURE_RATE(10%) 가드 활성화 — prices 데이터 부족 누적 시 save 거부.
+        # technical.collect() 는 1 row/ticker 반환이라 len(df) == ticker count 매칭 가능.
+        # asymmetric data age 방지 (어제 signals 그대로 + 오늘 70% 결손 silent save 차단).
+        self._expected_count = len(tickers)
+
         from tqdm import tqdm
 
         self.logger.info(f"기술적 지표 대상: {len(tickers)}종목 (source={source})")

--- a/tests/collectors/test_technical.py
+++ b/tests/collectors/test_technical.py
@@ -196,3 +196,83 @@ class TestSaveEmpty:
         result = c.save(df)
         assert result == 1
         assert called["n"] == 1
+
+
+class TestTechnicalExpectedCountGuard:
+    """MAX_FAILURE_RATE 가드 활성화 lock-test (PR #590 후속).
+
+    Reason: 직전 audit 에서 _expected_count 가 25/26 collector 에 unset 인 상태로
+    base.py 의 'asymmetric data age 방지' 가드가 dead code 였음을 확인. PR #590 이
+    fundamental + estimates (list[dict] 반환) 활성화. technical 은 1 row/ticker 반환
+    DataFrame 이라 len(df) == ticker count 매칭 가능 — 본 PR 에서 활성화.
+    이 테스트가 회귀를 차단함.
+    """
+
+    def test_collect_sets_expected_count(self, monkeypatch):
+        """collect() 진입 시 self._expected_count 가 len(tickers) 로 설정됨."""
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        # initial state — 0 (불활성)
+        assert c._expected_count == 0
+
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["AAA", "BBB", "CCC"])
+        # _compute_for_ticker 결과는 가드 trigger 와 무관 (count 만 검증)
+        monkeypatch.setattr(
+            c,
+            "_compute_for_ticker",
+            lambda t: pd.DataFrame({"ticker": [t], "date": ["2024-01-01"], "rsi_14": [50.0]}),
+        )
+
+        c.collect()
+        assert c._expected_count == 3, "collect() 가 ticker 수로 _expected_count 설정 안 함"
+
+    def test_run_blocks_save_when_failure_rate_exceeds_threshold(self, monkeypatch):
+        """run() 이 80% 실패 시 CollectionFailureError 발생 + save() 미호출."""
+        from nuri.collectors.base import CollectionFailureError
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        # 10 ticker 중 2개만 성공 → failure_rate 80% > 10% threshold
+        tickers = [f"T{i}" for i in range(10)]
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: tickers)
+
+        def fake_compute(ticker):
+            # T0/T1 만 valid row, 나머지 8개는 None (데이터 부족 시뮬레이션)
+            if ticker in ("T0", "T1"):
+                return pd.DataFrame({"ticker": [ticker], "date": ["2024-01-01"], "rsi_14": [50.0]})
+            return None
+
+        monkeypatch.setattr(c, "_compute_for_ticker", fake_compute)
+
+        save_called = []
+        monkeypatch.setattr(c, "save", lambda data: save_called.append(len(data)) or len(data))
+
+        with pytest.raises(CollectionFailureError, match="실패율 80%"):
+            c.run()
+
+        assert save_called == [], "실패율 초과 시 save() 호출되면 안 됨 (asymmetric save 차단)"
+
+    def test_run_allows_save_when_failure_rate_below_threshold(self, monkeypatch):
+        """failure_rate 5% < 10% 면 save() 정상 호출."""
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        # 20 ticker 중 19개 성공 → failure_rate 5%
+        tickers = [f"T{i}" for i in range(20)]
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: tickers)
+
+        def fake_compute(ticker):
+            if ticker == "T0":
+                return None  # 1개만 결손
+            return pd.DataFrame({"ticker": [ticker], "date": ["2024-01-01"], "rsi_14": [50.0]})
+
+        monkeypatch.setattr(c, "_compute_for_ticker", fake_compute)
+
+        save_called = []
+        monkeypatch.setattr(c, "save", lambda data: save_called.append(len(data)) or len(data))
+
+        # 가드 통과 — retry 없이 첫 시도에서 save 호출
+        result = c.run()
+        assert result == 19, "save() 가 19 records 받아야 함"
+        assert save_called == [19], "save() 1회 호출"


### PR DESCRIPTION
## Summary

- **Follows PR #590** (fundamental + estimates) — DataFrame 반환 collector 활성화 라운드 1.
- `nuri/collectors/technical.py` 의 `collect()` 진입 시 `self._expected_count = len(tickers)` 설정 → `BaseCollector.run` 의 `MAX_FAILURE_RATE`(10%) 가드 활성화.
- `_compute_for_ticker()` 가 ticker 당 정확히 1 row 반환 → `len(df) == ticker count` 매칭 → `base.py` 가드 시그니처 변경 불필요 (옵션 A, 가장 보수적 길).

## Why now

직전 audit reproduce: `BaseCollector._expected_count` 가 26개 collector 중 25개 unset (default=0) + universe_sync 1개 opt-out → `asymmetric data age 방지` 가드가 26개 collector 모두에서 dead code. PR #590 이 list[dict] 반환 2개 활성화. 본 PR 이 DataFrame 반환 중 **1 row/ticker 보장** 1개 추가. 잔여 3개는 의미 미정 → 별 PR.

## Deferred — explicit blockers

| Collector | 반환 형식 | Blocker |
|-----------|-----------|---------|
| `stock.py` | `pd.DataFrame` (N tickers × M days rows) | 단순 `len(df)` ≠ ticker count. `_expected_count = len(tickers)` 두면 `actual >> expected` → false negative (가드 항상 통과). 옵션 D (unique-ticker 카운트) 적용 시 `base.py` 가드 시그니처 변경 필요 — 영향 범위 큼, 별 PR 설계. |
| `stock_kr.py` | `pd.DataFrame` (N tickers × M days rows, pykrx sequential) | 동일. |
| `wallstreet.py` | `dict` (4 streams) | `__len__` == 4 (key count) 의미 없음. 4 stream record 합산 vs ticker 수 정의 필요. 별 PR. |

## Changes

- `nuri/collectors/technical.py` — 4 line addition (가드 활성화 + 한국어 주석).
- `tests/collectors/test_technical.py` — `TestTechnicalExpectedCountGuard` 클래스 (3 lock-test).

## Test plan

- [x] `pytest tests/collectors/test_technical.py -v` — 13 pass (기존 10 + 신규 3)
- [x] `pytest tests/collectors/test_base.py tests/collectors/test_technical.py` — 25 pass
- [x] `ruff check` clean
- [x] Lock-test 무결성 — `self._expected_count = len(tickers)` 라인 제거 시 `test_collect_sets_expected_count` (assert ==3 fail) 와 `test_run_blocks_save_when_failure_rate_exceeds_threshold` (CollectionFailureError 미발생 fail) 양쪽 차단

## Note for #590 conflict

PR #590 와 본 PR 모두 `_expected_count` 가드 활성화 시리즈 — 파일 겹침 없음 (#590: `fundamental.py` + `estimates.py`, 본 PR: `technical.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)