### PR TITLE
test(coverage): bucket E2 engine + strategy — 98 missed → 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,11 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite — 5,370 backend (223 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
+<<<<<<< HEAD
+make test       # full suite — 5,456 backend (227 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
+=======
+make test       # full suite — 5,456 backend (227 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
+>>>>>>> origin/main
 make test-fast  # backend only, slow tests excluded (~24s, what PR CI runs)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler integration)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ data/
 └── exports/          # Ad-hoc exports
 ## Testing
 <<<<<<< HEAD
-5,422 backend tests across 224 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,456 backend tests across 227 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 =======
 >>>>>>> origin/main
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -228,7 +228,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 <<<<<<< HEAD
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,422 tests, 224 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,456 tests, 227 files |
 =======
 >>>>>>> origin/main
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -949,7 +949,7 @@ def print_certificate(cert: Certificate) -> None:
     print()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover  # invariant: 3-line 표준 CLI invocation
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     cert = certify(caller="cli")
     print_certificate(cert)

--- a/nuri/trading/engine/conflicts.py
+++ b/nuri/trading/engine/conflicts.py
@@ -195,7 +195,7 @@ def print_conflicts(conflicts: list[SignalConflict]) -> None:
     print()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover  # invariant: 3-line 표준 CLI invocation
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     conflicts = detect_conflicts()
     print_conflicts(conflicts)

--- a/nuri/trading/engine/gate.py
+++ b/nuri/trading/engine/gate.py
@@ -269,18 +269,24 @@ def print_gate(result: GateResult) -> None:
     print()
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry — argparse + 오케스트레이션 (testable)."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     parser = argparse.ArgumentParser(description="Nuri-Quant Pipeline Gate")
     parser.add_argument("--phase", choices=["collect", "validate", "regime", "recommend"],
                         help="특정 단계만 확인")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.phase:
         result = check_gate(args.phase)
         print_gate(result)
     else:
         gates = check_all_gates()
-        for phase, result in gates.items():
+        for _phase, result in gates.items():
             print_gate(result)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover  # invariant: 표준 entry idiom — main() 이 testable
+    raise SystemExit(main())

--- a/nuri/trading/engine/memory.py
+++ b/nuri/trading/engine/memory.py
@@ -110,7 +110,7 @@ def save_snapshot(db_path=None) -> int:
                 "avg_return": row["avg_return"],
             })
 
-    if not records:
+    if not records:  # pragma: no cover  # invariant: trades non-empty 일 때 all_time groupby 가 반드시 1+ record 생성 — 도달 X (line 50 trades.empty check 가 선행)
         return 0
 
     with get_db(db_path) as conn:
@@ -237,12 +237,13 @@ def print_memory_status(drifts: list[PerformanceDrift]) -> None:
         print()
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry — argparse + 오케스트레이션 (testable)."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     parser = argparse.ArgumentParser(description="Nuri-Quant Strategy Learning Memory")
     parser.add_argument("--snapshot", action="store_true", help="오늘 스냅샷 저장")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.snapshot:
         from nuri.core.db import init_db
@@ -252,3 +253,8 @@ if __name__ == "__main__":
 
     drifts = detect_drift()
     print_memory_status(drifts)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover  # invariant: 표준 entry idiom — main() 이 testable
+    raise SystemExit(main())

--- a/nuri/trading/engine/remediation.py
+++ b/nuri/trading/engine/remediation.py
@@ -189,7 +189,7 @@ def print_remediation(plan: RemediationPlan) -> None:
     print(f"{'═' * 60}\n")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover  # invariant: 3-line 표준 CLI invocation
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     plan = generate_remediation()
     print_remediation(plan)

--- a/nuri/trading/strategy/longshort.py
+++ b/nuri/trading/strategy/longshort.py
@@ -267,13 +267,14 @@ def print_strategy(actions: list[StrategyAction]) -> None:
     print()
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry — argparse + 오케스트레이션 (testable)."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     init_db()
 
     parser = argparse.ArgumentParser(description="Nuri-Quant Long/Short Strategy")
     parser.add_argument("--execute", action="store_true", help="전략 실행 (포지션 오픈/클로즈)")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     actions = generate_strategy()
     print_strategy(actions)
@@ -284,3 +285,8 @@ if __name__ == "__main__":
 
         from nuri.trading.strategy.position import print_positions
         print_positions()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover  # invariant: 표준 entry idiom — main() 이 testable
+    raise SystemExit(main())

--- a/nuri/trading/strategy/mean_reversion.py
+++ b/nuri/trading/strategy/mean_reversion.py
@@ -156,7 +156,8 @@ def backtest_mean_reversion(
     }
 
 
-if __name__ == "__main__":
+def main() -> int:
+    """CLI entry — Mean-Reversion 스캔 + 백테스트 출력 (testable, no argparse)."""
     logging.basicConfig(level=logging.INFO)
 
     print("=== Mean-Reversion Scan ===")
@@ -169,3 +170,8 @@ if __name__ == "__main__":
     result = backtest_mean_reversion()
     for k, v in result.items():
         print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover  # invariant: 표준 entry idiom — main() 이 testable
+    raise SystemExit(main())

--- a/nuri/trading/strategy/monitor.py
+++ b/nuri/trading/strategy/monitor.py
@@ -157,7 +157,7 @@ def print_monitor(db_path=None) -> None:
         print()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover  # invariant: 4-line 표준 CLI invocation
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     from nuri.core.db import init_db
     init_db()

--- a/nuri/trading/strategy/position.py
+++ b/nuri/trading/strategy/position.py
@@ -303,7 +303,7 @@ def print_positions(db_path=None) -> None:
     print()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover  # invariant: 4-line 표준 CLI invocation
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     from nuri.core.db import init_db
     init_db()

--- a/nuri/trading/strategy/strategic_allocation.py
+++ b/nuri/trading/strategy/strategic_allocation.py
@@ -171,7 +171,7 @@ def main(argv: list[str] | None = None) -> int:
     return 0 if result.get("action") == "OK" else 1
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover  # invariant: 표준 entry idiom — main() 이 testable
     import sys
 
     sys.exit(main())

--- a/nuri/trading/swing/scanner.py
+++ b/nuri/trading/swing/scanner.py
@@ -269,7 +269,8 @@ def print_scan(results: list[ScanResult]) -> None:
     print()
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry — argparse + 오케스트레이션 (testable)."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     parser = argparse.ArgumentParser(description="Nuri-Quant Market Scanner")
@@ -277,7 +278,12 @@ if __name__ == "__main__":
     parser.add_argument("--top", type=int, default=20)
     parser.add_argument("--extended", action="store_true",
                         help="us_sp500_extended 포함 (us만 적용)")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     results = scan_market(market=args.market, top_n=args.top, extended=args.extended)
     print_scan(results)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover  # invariant: 표준 entry idiom — main() 이 testable
+    raise SystemExit(main())

--- a/tests/trading/engine/test_engine_e2_branch_coverage.py
+++ b/tests/trading/engine/test_engine_e2_branch_coverage.py
@@ -1,0 +1,587 @@
+"""Bucket E2 branch coverage — engine/certification, gate, memory, conflicts, remediation.
+
+Targets specific missed lines from coverage audit 2026-05-04.
+Each test = behavioral lock (not smoke).
+"""
+# cspell:ignore SPYY KOSP siege
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "test.db"
+    init_db(p)
+    return p
+
+
+# ════════════════════════ certification.py ════════════════════════════
+
+
+class TestCertificationClassifyAssetClass:
+    def test_safety_net_no_default_rule(self):
+        """Line 326: rules without `default` match → fallback 'us_equity'."""
+        from nuri.trading.engine.certification import _classify_asset_class
+
+        # Rules that won't match — no default rule
+        rules = [
+            {"match": {"ticker_suffix": ".KS"}, "asset_class": "kr_equity"},
+        ]
+        # AAPL has no .KS suffix — no rule matches → safety net
+        assert _classify_asset_class("AAPL", "Technology", rules) == "us_equity"
+
+
+class TestCertificationCompute3dChange:
+    def test_zero_past_value_returns_none(self, db_path):
+        """Line 383: past value == 0 → ZeroDivisionError 회피, None 반환."""
+        from nuri.trading.engine.certification import _compute_3d_change
+
+        with get_db(db_path) as conn:
+            for d, v in [
+                ("2025-03-22", 0.0),  # oldest in window
+                ("2025-03-23", 1.0),
+                ("2025-03-24", 1.5),
+                ("2025-03-25", 2.0),  # latest
+            ]:
+                conn.execute(
+                    "INSERT INTO macro (date, indicator, value) VALUES (?, ?, ?)",
+                    (d, "vix", v),
+                )
+        # 4 rows fetched (DESC LIMIT 4); past = oldest (0.0) → None
+        result = _compute_3d_change("vix", db_path=db_path)
+        assert result is None
+
+
+class TestCertificationVolatilityClass:
+    def test_secondary_indicator_missing_silent_skip(self, db_path):
+        """Line 422: secondary indicator data 없으면 continue (silent)."""
+        from nuri.trading.engine.certification import _check_volatility_for_class
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO macro (date, indicator, value) VALUES (?, ?, ?)",
+                ("2025-03-25", "vix", 18.0),
+            )
+        policy = {
+            "volatility_primary": "vix",
+            "volatility_primary_threshold": 30,
+            "volatility_secondary": ["nonexistent_indicator"],
+            "volatility_secondary_threshold": 25,
+        }
+        out = _check_volatility_for_class("us_equity", policy, db_path=db_path)
+        # 1 condition only — primary pass; secondary silently skipped
+        assert len(out) == 1
+        assert out[0].id == "volatility_gate_us_equity"
+        assert out[0].passed is True
+
+
+class TestCertificationVolatilityGates:
+    def test_class_without_policy_skipped(self, db_path, monkeypatch):
+        """Line 460: asset_classes 에 매칭 policy 없으면 continue."""
+        from nuri.trading.engine import certification as cert_mod
+
+        # Seed portfolio with kr_equity ticker
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) VALUES (?, ?, ?, ?, ?)",
+                ("test", "005930.KS", 10, 70000.0, "Semiconductor"),
+            )
+
+        # Mock RULES so siege_gates has classes but no kr_equity policy
+        fake_rules = {
+            "siege_gates": {
+                "asset_class_rules": [
+                    {"match": {"ticker_suffix": ".KS"}, "asset_class": "kr_equity"},
+                    {"match": {"default": True}, "asset_class": "us_equity"},
+                ],
+                "asset_classes": {
+                    # kr_equity policy 없음 → skip
+                    "us_equity": {"volatility_primary": "vix", "volatility_primary_threshold": 30},
+                },
+            }
+        }
+        monkeypatch.setattr(cert_mod, "RULES", fake_rules)
+
+        out = cert_mod._check_volatility_gates(db_path=db_path)
+        # kr_equity 매칭하지만 policy 없어서 결과는 0건 (continue)
+        assert all("kr_equity" not in c.id for c in out)
+
+
+class TestCertificationFreshnessClass:
+    def test_secondary_freshness_missing_silent(self, db_path):
+        """Line 556: secondary freshness 데이터 없으면 silent skip."""
+        from nuri.trading.engine.certification import _check_freshness_for_class
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("SPY", "2025-03-25", 500.0),
+            )
+        policy = {
+            "freshness_primary": "SPY",
+            "freshness_max_hours": 9999,  # always ok
+            "freshness_secondary": ["NONEXISTENT_TICKER"],
+        }
+        out = _check_freshness_for_class("us_equity", policy, db_path=db_path)
+        # primary 1건만, secondary silent skip
+        assert len(out) == 1
+        assert out[0].id == "data_fresh_us_equity"
+
+
+class TestCertificationDataFreshness:
+    def test_class_without_policy_skipped(self, db_path, monkeypatch):
+        """Line 590: data_freshness 에서도 policy 없는 class 는 continue."""
+        from nuri.trading.engine import certification as cert_mod
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) VALUES (?, ?, ?, ?, ?)",
+                ("test", "005930.KS", 10, 70000.0, "Semiconductor"),
+            )
+
+        fake_rules = {
+            "siege_gates": {
+                "asset_class_rules": [
+                    {"match": {"ticker_suffix": ".KS"}, "asset_class": "kr_equity"},
+                    {"match": {"default": True}, "asset_class": "us_equity"},
+                ],
+                "asset_classes": {
+                    "us_equity": {"freshness_primary": "SPY", "freshness_max_hours": 72},
+                },
+            }
+        }
+        monkeypatch.setattr(cert_mod, "RULES", fake_rules)
+
+        out = cert_mod._check_data_freshness(db_path=db_path)
+        # kr_equity: policy missing → continue (no data_fresh_kr_equity emitted)
+        assert all("kr_equity" not in c.id for c in out)
+
+
+class TestCertificationCountExternalForClass:
+    def test_empty_tickers_fallback_global(self, db_path):
+        """Lines 603-607: tickers=[] → global SELECT COUNT(*) fallback."""
+        from nuri.trading.engine.certification import _count_external_for_class
+
+        with get_db(db_path) as conn:
+            for src in ["a", "b", "c"]:
+                conn.execute(
+                    "INSERT INTO external_analysis (date, source, ticker, data_type, value) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    ("2025-03-25", src, "AAPL", "rating", "BUY"),
+                )
+        records, sources = _count_external_for_class("us_equity", [], db_path=db_path)
+        assert records == 3
+        assert sources == 3
+
+
+class TestCertificationExternalForClassException:
+    def test_count_exception_returns_warning(self, db_path):
+        """Lines 625-626: _count_external_for_class throws → warning 반환."""
+        from nuri.trading.engine.certification import _check_external_for_class
+
+        # Patch the helper to raise — verifies except branch
+        with patch(
+            "nuri.trading.engine.certification._count_external_for_class",
+            side_effect=RuntimeError("synthetic"),
+        ):
+            cond = _check_external_for_class(
+                "us_equity",
+                ["AAPL"],
+                {"external_min_records": 10, "external_min_sources": 3},
+                db_path=db_path,
+            )
+        assert cond.passed is False
+        assert cond.severity == "warning"
+        assert "external_analysis 조회 실패" in cond.detail
+
+
+class TestCertificationCheckExternalDataNoPolicy:
+    def test_external_class_without_policy_skipped(self, db_path, monkeypatch):
+        """Line 668: _check_external_data 에서도 policy 없는 class 는 continue."""
+        from nuri.trading.engine import certification as cert_mod
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) VALUES (?, ?, ?, ?, ?)",
+                ("test", "005930.KS", 10, 70000.0, "Semiconductor"),
+            )
+
+        fake_rules = {
+            "siege_gates": {
+                "asset_class_rules": [
+                    {"match": {"ticker_suffix": ".KS"}, "asset_class": "kr_equity"},
+                    {"match": {"default": True}, "asset_class": "us_equity"},
+                ],
+                "asset_classes": {
+                    "us_equity": {"external_min_records": 10, "external_min_sources": 3},
+                },
+            }
+        }
+        monkeypatch.setattr(cert_mod, "RULES", fake_rules)
+
+        out = cert_mod._check_external_data(db_path=db_path)
+        # kr_equity policy missing → continue (no external_data_kr_equity emitted)
+        assert all("kr_equity" not in c.id for c in out)
+
+
+# ════════════════════════ memory.py ════════════════════════════════════
+
+
+class TestConflictsBullSellRegimeFit:
+    def test_bull_with_regime_fit_sell_skipped(self, db_path, monkeypatch):
+        """Line 163: bull regime 에서 SELL 이 regime_fit 이면 모순으로 분류 X (continue)."""
+        from unittest.mock import MagicMock
+
+        from nuri.trading.engine.conflicts import detect_conflicts
+        from nuri.trading.recommend.candidates import TIER_ACTIONABLE
+
+        # Single SELL candidate, regime_fit=True
+        sell_cand = MagicMock(
+            ticker="AAPL",
+            tier=TIER_ACTIONABLE,
+            direction="SELL",
+            signal_id="sell1",
+            regime_fit=True,
+            profit_factor=2.0,
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.candidates.screen_candidates",
+            lambda **kw: [sell_cand],
+        )
+
+        # Force regime = bull
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeRegime:
+            regime: str = "bull_low_vol"
+            trend: str = "bull"
+            volatility: str = "low"
+            confidence: float = 0.8
+
+        monkeypatch.setattr(
+            "nuri.quant.regime.classifier.classify_regime",
+            lambda **kw: FakeRegime(),
+        )
+
+        conflicts = detect_conflicts(db_path=db_path)
+        # regime_fit → continue (no regime_contradiction emitted)
+        regime_conflicts = [c for c in conflicts if c.conflict_type == "regime_contradiction"]
+        assert regime_conflicts == []
+
+
+class TestMemoryDriftZeroWinrate:
+    def test_zero_all_time_winrate_skipped(self, db_path):
+        """Line 155 (continue): all_time win_rate=0 → drift skip."""
+        from nuri.trading.engine.memory import detect_drift
+
+        with get_db(db_path) as conn:
+            # all_time win_rate = 0 → drift 계산 스킵 (분모 0 회피)
+            conn.execute(
+                "INSERT INTO strategy_memory (snapshot_date, signal_id, regime, period, "
+                "trades, win_rate, profit_factor, avg_return) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2025-03-25", "loser_signal", None, "all_time", 50, 0.0, 0.5, -2.0),
+            )
+            conn.execute(
+                "INSERT INTO strategy_memory (snapshot_date, signal_id, regime, period, "
+                "trades, win_rate, profit_factor, avg_return) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2025-03-25", "loser_signal", None, "recent_90d", 10, 0.1, 0.6, -1.0),
+            )
+
+        drifts = detect_drift(db_path=db_path)
+        # zero-winrate 시그널은 skip — drift 결과 0건
+        assert drifts == []
+
+    def test_no_recent_match_skipped(self, db_path):
+        """Line 155 (continue): recent map 에 sig_id 없으면 drift skip."""
+        from nuri.trading.engine.memory import detect_drift
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO strategy_memory (snapshot_date, signal_id, regime, period, "
+                "trades, win_rate, profit_factor, avg_return) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2025-03-25", "orphan_signal", None, "all_time", 100, 0.6, 2.0, 3.0),
+            )
+            # recent_90d 에 동일 signal_id 없음 → continue branch
+        drifts = detect_drift(db_path=db_path)
+        assert drifts == []
+
+
+class TestMemorySaveSnapshotEmpty:
+    def test_save_snapshot_empty_trades_returns_zero(self, db_path, tmp_path, monkeypatch):
+        """Line 50-51: trades.empty (header-only csv) → return 0 early.
+
+        Line 114 (`if not records`) 는 unreachable 한 defensive guard 이므로 pragma 처리.
+        trades non-empty 이면 all_time groupby 가 반드시 1+ record 생성하기 때문.
+        """
+        from nuri.trading.engine import memory as mem_mod
+
+        # _find_latest_csv 가 헤더만 있는 빈 CSV 반환
+        empty_csv = tmp_path / "signal_results.csv"
+        empty_csv.write_text("signal_id,return_pct,entry_date\n")  # header only — no rows
+
+        monkeypatch.setattr(mem_mod, "_find_latest_csv", lambda fname: empty_csv)
+        # trades.empty → line 51 early return — DB write 없음
+        result = mem_mod.save_snapshot(db_path=db_path)
+        assert result == 0
+
+
+class TestRemediationGateNoMapping:
+    def test_failed_gate_without_violation_mapping_skipped(self, db_path, monkeypatch):
+        """Line 90: _GATE_TO_VIOLATION 매핑 없는 failed gate 는 continue (skip)."""
+        from unittest.mock import MagicMock
+
+        from nuri.trading.engine import remediation as rem
+
+        # cert with a failed gate that has NO mapping (e.g. 'unknown_gate')
+        unknown_failed = MagicMock(
+            id="unknown_gate", passed=False, severity="error", detail="x"
+        )
+        ok_passed = MagicMock(
+            id="position_limit", passed=True, severity="error", detail="ok"
+        )
+
+        cert_mock = MagicMock(
+            certified=False,
+            score=50.0,
+            conditions=[unknown_failed, ok_passed],
+            passed=1,
+            total_conditions=2,
+        )
+        # certify / advisor 모두 함수 내부 import — 'source.module.function' patching
+        monkeypatch.setattr(
+            "nuri.trading.engine.certification.certify",
+            lambda **kw: cert_mock,
+        )
+        monkeypatch.setattr(
+            "nuri.analysis.rebalance_advisor.generate_advisor_report",
+            lambda **kw: {"actions": []},
+        )
+
+        plan = rem.generate_remediation(db_path=db_path)
+        # unknown_gate has no mapping → no actions, ends in unresolvable (or unmapped)
+        assert plan.actions == []
+
+
+class TestMemoryMain:
+    def test_main_no_args_prints_status(self, monkeypatch, capsys):
+        """Lines 241-254 (refactored to main): default invocation calls detect_drift + print."""
+        from nuri.trading.engine import memory as mem_mod
+
+        called = {"snapshot": False, "detect": False, "print": False}
+
+        def fake_detect(db_path=None):
+            called["detect"] = True
+            return []
+
+        def fake_print(drifts):
+            called["print"] = True
+
+        monkeypatch.setattr(mem_mod, "detect_drift", fake_detect)
+        monkeypatch.setattr(mem_mod, "print_memory_status", fake_print)
+        rc = mem_mod.main([])
+        assert rc == 0
+        assert called["detect"] is True
+        assert called["print"] is True
+
+    def test_main_snapshot_flag_invokes_save(self, monkeypatch):
+        """--snapshot: save_snapshot 호출."""
+        from nuri.trading.engine import memory as mem_mod
+
+        called = {"save": False, "init": False}
+
+        def fake_save():
+            called["save"] = True
+            return 5
+
+        def fake_init():
+            called["init"] = True
+
+        monkeypatch.setattr(mem_mod, "save_snapshot", fake_save)
+        monkeypatch.setattr("nuri.core.db.init_db", fake_init)
+        monkeypatch.setattr(mem_mod, "detect_drift", lambda db_path=None: [])
+        monkeypatch.setattr(mem_mod, "print_memory_status", lambda d: None)
+
+        rc = mem_mod.main(["--snapshot"])
+        assert rc == 0
+        assert called["save"] is True
+        assert called["init"] is True
+
+
+# ════════════════════════ gate.py ════════════════════════════════════
+
+
+class TestGateScorecardFound:
+    def test_signal_scorecard_csv_found(self, db_path, tmp_path, monkeypatch):
+        """Lines 117-120: scorecard CSV 발견 → found=True branch.
+
+        gate.py 내부에서 `from pathlib import Path` 후 `Path(__file__).parent...` 로
+        report_dir 결정 — Path 자체를 monkeypatch 하여 우리의 tmp_path 가리키게 함.
+        """
+        from pathlib import Path as RealPath
+
+        # Set up: tmp_path/data/reports/2025-03-25/signal_scorecard.csv
+        snap_dir = tmp_path / "data" / "reports" / "2025-03-25"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "signal_scorecard.csv").write_text("dummy\n")
+
+        # Path(__file__).parent.parent.parent.parent — 4번 parent.
+        # gate.py 위치: nuri/trading/engine/gate.py → 4 parents = 프로젝트 루트.
+        # tmp_path 가 프로젝트 루트인 것처럼 보이게 하려면, 그 자리에 파일이 있는 것처럼
+        # 'fake __file__' 을 4-deep 으로 만들어준다.
+        fake_file = tmp_path / "nuri" / "trading" / "engine" / "gate.py"
+        fake_file.parent.mkdir(parents=True)
+        fake_file.write_text("")
+
+        import nuri.trading.engine.gate as gate_mod
+        monkeypatch.setattr(gate_mod, "__file__", str(fake_file))
+
+        cond = gate_mod._check_signal_scorecard(db_path=db_path)
+        assert cond.passed is True
+        assert cond.detail == "존재"
+
+
+class TestCertificationClassifyAssetClassSectorMatch:
+    def test_sector_exact_match(self):
+        """Line 325: `sector == m['sector']` exact match branch."""
+        from nuri.trading.engine.certification import _classify_asset_class
+
+        rules = [
+            {"match": {"sector": "Treasury"}, "asset_class": "bond"},
+            {"match": {"default": True}, "asset_class": "us_equity"},
+        ]
+        assert _classify_asset_class("TLT", "Treasury", rules) == "bond"
+
+
+class TestCertificationGroupHoldingsDup:
+    def test_duplicate_ticker_sector_skipped(self, db_path):
+        """Line 352: 같은 (ticker, sector) 가 여러 계좌에 있으면 두번째 row continue."""
+        from nuri.trading.engine import certification as cert_mod
+
+        with get_db(db_path) as conn:
+            # 두 계좌에서 같은 (AAPL, Technology) 보유 — DISTINCT
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("acct1", "AAPL", 10, 150.0, "Technology"),
+            )
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("acct2", "AAPL", 5, 160.0, "Technology"),
+            )
+        groups = cert_mod._group_holdings_by_asset_class(db_path=db_path)
+        # AAPL 만 1번 등장 (DISTINCT 효과)
+        all_tickers = [h["ticker"] for v in groups.values() for h in v]
+        assert all_tickers.count("AAPL") == 1
+
+
+class TestCertificationFreshnessClassThresholds:
+    def test_primary_stale_emits_warning(self, db_path):
+        """Line 548: primary age > max_hours → warning emit."""
+        from nuri.trading.engine.certification import _check_freshness_for_class
+
+        # Insert SPY price from 10 days ago — age > 1h
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("SPY", "2020-01-01", 300.0),
+            )
+        policy = {
+            "freshness_primary": "SPY",
+            "freshness_max_hours": 1,  # impossible — 항상 stale
+        }
+        out = _check_freshness_for_class("us_equity", policy, db_path=db_path)
+        # primary stale → warning
+        assert len(out) == 1
+        assert out[0].passed is False
+        assert out[0].severity == "warning"
+        assert "초과" in out[0].detail
+
+    def test_secondary_stale_emits_warning(self, db_path):
+        """Line 560: secondary age > max_hours → cross-market warning."""
+        from nuri.trading.engine.certification import _check_freshness_for_class
+
+        with get_db(db_path) as conn:
+            # primary fresh enough
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("SPY", "2099-01-01", 300.0),
+            )
+            # secondary stale (10 years ago)
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                ("KOSPI", "2015-01-01", 2000.0),
+            )
+        policy = {
+            "freshness_primary": "SPY",
+            "freshness_max_hours": 999999,  # primary always fresh
+            "freshness_secondary": ["KOSPI"],
+        }
+        # use threshold 1h so secondary stale
+        # Policy 위 max_hours 가 secondary 에도 사용됨 (freshness_max_hours)
+        # 그러므로 둘 다 같은 threshold — KOSPI 가 SPY 보다 더 stale 이지만 999999 면 둘 다 ok
+        # 다른 방식: max_hours 작게
+        policy["freshness_max_hours"] = 1
+        # 이제 SPY (2099 = 미래) 는 age 음수 → ok, KOSPI (2015) age > 1
+        # 다만 _ticker_age_hours 가 (now - date) 이므로 SPY 미래 → 음수 → 음수 <= 1 ok
+        out = _check_freshness_for_class("us_equity", policy, db_path=db_path)
+        # primary ok + secondary stale (warning)
+        secondary = [c for c in out if "KOSPI" in c.id]
+        assert len(secondary) == 1
+        assert secondary[0].passed is False
+        assert "교차 시장 stale" in secondary[0].detail
+
+
+class TestGateMain:
+    def test_main_phase_flag_invokes_check_gate(self, monkeypatch, capsys):
+        """Lines 273-286 (refactored): --phase=collect path."""
+        from nuri.trading.engine import gate as gate_mod
+
+        called = {"check": False, "all": False}
+
+        def fake_check(phase, db_path=None):
+            called["check"] = True
+            return gate_mod.GateResult(phase=phase, total=0, passed=0, score=0.0, ready=True, conditions=[])
+
+        def fake_all(db_path=None):
+            called["all"] = True
+            return {}
+
+        monkeypatch.setattr(gate_mod, "check_gate", fake_check)
+        monkeypatch.setattr(gate_mod, "check_all_gates", fake_all)
+        monkeypatch.setattr(gate_mod, "print_gate", lambda r: None)
+        rc = gate_mod.main(["--phase", "collect"])
+        assert rc == 0
+        assert called["check"] is True
+        assert called["all"] is False  # all-gates path NOT taken
+
+    def test_main_no_phase_invokes_check_all(self, monkeypatch):
+        """No --phase: check_all_gates branch."""
+        from nuri.trading.engine import gate as gate_mod
+
+        called = {"check": False, "all": False}
+
+        def fake_check(phase, db_path=None):
+            called["check"] = True
+            return gate_mod.GateResult(phase=phase, total=0, passed=0, score=0.0, ready=True, conditions=[])
+
+        def fake_all(db_path=None):
+            called["all"] = True
+            return {
+                "collect": gate_mod.GateResult("collect", 0, 0, 0.0, True, []),
+            }
+
+        monkeypatch.setattr(gate_mod, "check_gate", fake_check)
+        monkeypatch.setattr(gate_mod, "check_all_gates", fake_all)
+        monkeypatch.setattr(gate_mod, "print_gate", lambda r: None)
+        rc = gate_mod.main([])
+        assert rc == 0
+        assert called["all"] is True
+        assert called["check"] is False

--- a/tests/trading/strategy/test_strategy_e2_branch_coverage.py
+++ b/tests/trading/strategy/test_strategy_e2_branch_coverage.py
@@ -1,0 +1,247 @@
+"""Bucket E2 branch coverage — strategy/longshort, mean_reversion, strategic_allocation.
+
+Targets specific missed lines from coverage audit 2026-05-04.
+Each test = behavioral lock. Refactored CLI mains tested via main(argv).
+"""
+# cspell:ignore SPYY siege longshort
+
+from __future__ import annotations
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    import nuri.core.db as db_mod
+    p = tmp_path / "test.db"
+    init_db(p)
+    monkeypatch.setattr(db_mod, "DB_PATH", p)
+    return p
+
+
+# ════════════════════════ longshort.py main(argv) ═════════════════════
+
+
+class TestLongshortMainCLI:
+    """`__main__` block (lines 271-286) refactored to main(argv) — testable."""
+
+    def test_main_no_actions_prints_strategy(self, db_path, monkeypatch, capsys):
+        """No-args: generate_strategy + print_strategy, execute branch skipped."""
+        from nuri.trading.strategy import longshort as ls
+
+        called = {"generate": False, "print": False, "execute": False}
+
+        def fake_gen():
+            called["generate"] = True
+            return []
+
+        def fake_print(actions):
+            called["print"] = True
+
+        def fake_exec(actions):
+            called["execute"] = True
+            return 0
+
+        monkeypatch.setattr(ls, "generate_strategy", fake_gen)
+        monkeypatch.setattr(ls, "print_strategy", fake_print)
+        monkeypatch.setattr(ls, "execute_strategy", fake_exec)
+        monkeypatch.setattr(ls, "init_db", lambda: None)
+
+        rc = ls.main([])
+        assert rc == 0
+        assert called["generate"] is True
+        assert called["print"] is True
+        assert called["execute"] is False  # no --execute flag
+
+    def test_main_execute_flag_with_actions_invokes_executor(self, db_path, monkeypatch):
+        """--execute + actions present → execute_strategy + print_positions."""
+        from nuri.trading.strategy import longshort as ls
+
+        called = {"execute": False, "print_pos": False}
+        fake_actions = [
+            ls.StrategyAction(
+                action="open_long", ticker="QQQ", direction="long",
+                portfolio_type="tactical", reason="r", regime="bull_low_vol", confidence=80,
+            )
+        ]
+
+        monkeypatch.setattr(ls, "init_db", lambda: None)
+        monkeypatch.setattr(ls, "generate_strategy", lambda: fake_actions)
+        monkeypatch.setattr(ls, "print_strategy", lambda actions: None)
+
+        def fake_exec(actions):
+            called["execute"] = True
+            return 1
+
+        monkeypatch.setattr(ls, "execute_strategy", fake_exec)
+
+        # patch print_positions used in --execute branch
+        import nuri.trading.strategy.position as pos_mod
+
+        def fake_pp():
+            called["print_pos"] = True
+
+        monkeypatch.setattr(pos_mod, "print_positions", fake_pp)
+
+        rc = ls.main(["--execute"])
+        assert rc == 0
+        assert called["execute"] is True
+        assert called["print_pos"] is True
+
+    def test_main_execute_flag_no_actions_skips_executor(self, db_path, monkeypatch):
+        """--execute but actions empty → execute_strategy NOT invoked."""
+        from nuri.trading.strategy import longshort as ls
+
+        called = {"execute": False}
+        monkeypatch.setattr(ls, "init_db", lambda: None)
+        monkeypatch.setattr(ls, "generate_strategy", lambda: [])
+        monkeypatch.setattr(ls, "print_strategy", lambda actions: None)
+
+        def fake_exec(actions):
+            called["execute"] = True
+            return 0
+
+        monkeypatch.setattr(ls, "execute_strategy", fake_exec)
+        rc = ls.main(["--execute"])
+        assert rc == 0
+        # `args.execute and actions` short-circuits — execute NOT called
+        assert called["execute"] is False
+
+
+# ════════════════════════ mean_reversion.py main() ═════════════════════
+
+
+class TestMeanReversionMainCLI:
+    """`__main__` (lines 160-171) refactored to main() — testable."""
+
+    def test_main_invokes_scan_and_backtest(self, monkeypatch, capsys):
+        """main() prints scan results + backtest report."""
+        from nuri.trading.strategy import mean_reversion as mr
+
+        called = {"scan": False, "bt": False}
+
+        def fake_scan():
+            called["scan"] = True
+            return []
+
+        def fake_bt():
+            called["bt"] = True
+            return {"strategy": "mean_reversion", "total_trades": 0}
+
+        monkeypatch.setattr(mr, "scan_mean_reversion", fake_scan)
+        monkeypatch.setattr(mr, "backtest_mean_reversion", fake_bt)
+
+        rc = mr.main()
+        assert rc == 0
+        assert called["scan"] is True
+        assert called["bt"] is True
+
+        captured = capsys.readouterr()
+        # 두 헤더 모두 출력 — 분기 진입 lock
+        assert "Mean-Reversion Scan" in captured.out
+        assert "Mean-Reversion Backtest" in captured.out
+
+    def test_main_prints_signal_loop(self, monkeypatch, capsys):
+        """signals 가 있으면 ticker/RSI/Z line emit (signals[:10] loop)."""
+        from nuri.trading.strategy import mean_reversion as mr
+
+        sig = mr.MeanRevSignal(
+            ticker="AAPL", date="2025-03-25", entry_price=170.0,
+            bb_lower=168.0, rsi=25.0, z_score=-2.5, expected_target=175.0,
+        )
+        monkeypatch.setattr(mr, "scan_mean_reversion", lambda: [sig])
+        monkeypatch.setattr(
+            mr, "backtest_mean_reversion",
+            lambda: {"strategy": "mean_reversion", "total_trades": 0},
+        )
+        rc = mr.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "AAPL" in out
+
+
+# ════════════════════════ strategic_allocation.py ═════════════════════
+
+
+class TestStrategicAllocationDriftEdges:
+    def test_non_numeric_quantity_skipped(self, db_path):
+        """Lines 51-52: non-numeric quantity/avg_price → ValueError → continue."""
+        from nuri.trading.strategy.strategic_allocation import compute_current_allocation
+
+        # quantity is a string non-convertible value
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "BAD", "not_a_number", 100.0, "Technology"),
+            )
+            # Add one valid row so we don't hit the `total_value <= 0` branch
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "AAPL", 10, 150.0, "Technology"),
+            )
+        result = compute_current_allocation(db_path=db_path)
+        # Bad row skipped, only AAPL counted → 100% us_equity
+        assert result.get("us_equity", 0) == 100.0
+
+    def test_zero_value_position_skipped(self, db_path):
+        """Lines 53-54 (value <= 0 skip) and effectively non-zero AAPL classifies."""
+        from nuri.trading.strategy.strategic_allocation import compute_current_allocation
+
+        with get_db(db_path) as conn:
+            # quantity 0 → value 0 → skip
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "ZERO", 0, 100.0, "Technology"),
+            )
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "AAPL", 5, 200.0, "Technology"),
+            )
+        result = compute_current_allocation(db_path=db_path)
+        # ZERO skipped. AAPL accounts for 100%
+        assert result.get("us_equity", 0) == 100.0
+
+    def test_total_value_zero_returns_empty(self, db_path):
+        """Line 60: 모든 row skip 되어 total_value <= 0 → {}.
+
+        ValueError 가 발생하는 텍스트 quantity 와 0 quantity 만 사용 — NaN 회피.
+        """
+        from nuri.trading.strategy.strategic_allocation import compute_current_allocation
+
+        with get_db(db_path) as conn:
+            # 텍스트 quantity → ValueError → continue
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "BAD1", "abc", 100.0, "Technology"),
+            )
+            # quantity = 0 → value <= 0 → continue
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "BAD2", 0, 100.0, "Technology"),
+            )
+        result = compute_current_allocation(db_path=db_path)
+        assert result == {}
+
+    def test_no_asset_class_rules_returns_empty(self, db_path, monkeypatch):
+        """Line 44: rules_cfg empty → return {} (asset_class_rules 없음)."""
+        from nuri.trading.strategy import strategic_allocation as sa
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("test", "AAPL", 10, 150.0, "Technology"),
+            )
+        # Remove asset_class_rules
+        fake_rules = {"siege_gates": {}}
+        monkeypatch.setattr(sa, "RULES", fake_rules)
+        result = sa.compute_current_allocation(db_path=db_path)
+        assert result == {}

--- a/tests/trading/swing/test_scanner_e2_branch_coverage.py
+++ b/tests/trading/swing/test_scanner_e2_branch_coverage.py
@@ -1,0 +1,44 @@
+"""Bucket E2 branch coverage — swing/scanner.
+
+Targets `__main__` block (273-283) refactored to main(argv).
+"""
+
+from __future__ import annotations
+
+
+class TestScannerMainCLI:
+    def test_main_default_market_us(self, monkeypatch, capsys):
+        """main([]) — default market=us, top=20."""
+        from nuri.trading.swing import scanner as sc
+
+        captured_args = {}
+
+        def fake_scan(market, top_n, extended):
+            captured_args.update({"market": market, "top_n": top_n, "extended": extended})
+            return []
+
+        monkeypatch.setattr(sc, "scan_market", fake_scan)
+        monkeypatch.setattr(sc, "print_scan", lambda r: None)
+
+        rc = sc.main([])
+        assert rc == 0
+        assert captured_args == {"market": "us", "top_n": 20, "extended": False}
+
+    def test_main_kr_extended_top10(self, monkeypatch):
+        """main(['--market', 'kr', '--top', '10', '--extended'])."""
+        from nuri.trading.swing import scanner as sc
+
+        captured = {}
+
+        def fake_scan(market, top_n, extended):
+            captured.update({"market": market, "top_n": top_n, "extended": extended})
+            return []
+
+        monkeypatch.setattr(sc, "scan_market", fake_scan)
+        monkeypatch.setattr(sc, "print_scan", lambda r: None)
+
+        rc = sc.main(["--market", "kr", "--top", "10", "--extended"])
+        assert rc == 0
+        assert captured["market"] == "kr"
+        assert captured["top_n"] == 10
+        assert captured["extended"] is True


### PR DESCRIPTION
## Summary

Drives 11 files in `nuri/trading/engine/`, `nuri/trading/strategy/`, and `nuri/trading/swing/scanner.py` to **100% line coverage** (98 missed → 0).

## Before / After

| File | Before | After |
|---|---:|---:|
| `engine/certification.py` | 96.9% (14 missed) | **100%** |
| `engine/memory.py` | 90.8% (12 missed) | **100%** |
| `strategy/longshort.py` | 90.4% (12 missed) | **100%** |
| `engine/gate.py` | 91.9% (10 missed) | **100%** |
| `strategy/mean_reversion.py` | 90.2% (9 missed) | **100%** |
| `swing/scanner.py` | 94.9% (8 missed) | **100%** |
| `strategy/strategic_allocation.py` | 92.8% (6 missed) | **100%** |
| `engine/conflicts.py` | 95.9% (4 missed) | **100%** |
| `engine/remediation.py` | 96.0% (4 missed) | **100%** |
| `strategy/monitor.py` | 95.3% (4 missed) | **100%** |
| `strategy/position.py` | 97.6% (4 missed) | **100%** |
| **TOTAL** | **96% (98 missed)** | **100%** |

Fast suite: 5372 passed, 3 skipped, 0 failures (228s).

## Approach

**Type 1 (testable behaviors)** — 27 new lock-tests covering:
- `certification.py`: primary/secondary freshness staleness, asset-class classify safety net, group dedupe, external_data exception path, no-policy class skip (4 gate fns)
- `memory.py`: zero-winrate skip, no-recent-match skip, snapshot empty trades early-return
- `conflicts.py`: bull+SELL+regime_fit continue branch
- `remediation.py`: unmapped failed gate continue
- `strategic_allocation.py`: non-numeric quantity, zero-value, total<=0, no-rules

**`__main__` refactor** (PR #595 pattern) — 6 files: extract `def main(argv) -> int`, single-line `raise SystemExit(main())` with pragma:
- `engine/memory.py`, `engine/gate.py`
- `strategy/longshort.py`, `strategy/mean_reversion.py`
- `swing/scanner.py`

## Pragma Justifications

- `memory.py:114` `if not records: return 0` — defensive guard. Line 51 (`trades.empty`) catches header-only/empty CSV before reaching line 114. When `trades` is non-empty, the all-time `groupby` loop guarantees `records` is non-empty. Mathematically unreachable.
- `monitor.py`, `position.py`, `conflicts.py`, `remediation.py`, `certification.py`: pure 3-4 line `__main__` blocks (`logging.basicConfig` + `init_db` + 1-2 print fn calls) — pragma + invariant comment instead of refactor (per task rule: refactor only 30+ line `__main__` blocks).
- `strategic_allocation.py`: existing `main()` already extracted; only `__main__` 3-line entry pragma'd.

## Rigor

- No `isinstance`/`None`/smoke tests. Each test = behavioral lock with explicit assertion.
- No patching the function under test (e.g., `_count_external_for_class` in exception test patches the helper, not `_check_external_for_class`).
- No `runpy + target-level patch`. CLI main(argv) tests use module-level monkeypatch (`monkeypatch.setattr(module, fn_name, stub)`).
- DB tests use `tmp_path` + `init_db(path)` per `tests/CLAUDE.md`.
- Korean 주석 / English names / `kst_now()` invariant preserved (no `datetime.now()`).

## Test plan

- [x] Per-file coverage verified: all 11 targets at 100%
- [x] Full fast suite: 5372 passed, 3 skipped (`-m "not slow"`)
- [x] Ruff check passed (no fixes needed)
- [ ] CI (`Backend Tests`, `Backend Lint`, `privacy-scan`, `pr-discipline`, `Doc Count Drift`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)