### PR TITLE
docs: strip leftover merge conflict markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,15 +145,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-<<<<<<< HEAD
 make test       # full suite — 5,482 backend (228 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
-=======
-<<<<<<< HEAD
-make test       # full suite — 5,482 backend (228 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
-=======
-make test       # full suite — 5,482 backend (228 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
->>>>>>> origin/main
->>>>>>> origin/main
 make test-fast  # backend only, slow tests excluded (~24s, what PR CI runs)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler integration)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,10 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-<<<<<<< HEAD
 5,482 backend tests across 228 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
-=======
->>>>>>> origin/main
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,10 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-<<<<<<< HEAD
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,482 tests, 228 files |
-=======
->>>>>>> origin/main
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |


### PR DESCRIPTION
PR #605 merge resolution awk dedup 누락 — 3 docs 의 conflict markers (<<<<<<<, =======, >>>>>>>) + README test 3중 중복 제거. verify-doc-counts 13/13.