### PR TITLE
test(coverage): close 14 partial branches — codecov-flagged files (#611)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ make scan-extended  # Weekly scan (us_core + S&P 500, 543 tickers)
 ### Test commands
 
 ```bash
-make test       # full suite — 5,482 backend (228 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
+make test       # full suite — 5,684 backend (233 files) + 917 frontend (82 files) + 38 Playwright e2e (8 specs)
 make test-fast  # backend only, slow tests excluded (~24s, what PR CI runs)
 make test-slow  # backend slow tests only (LLM gather_context, scheduler integration)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,658 backend tests across 232 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,684 backend tests across 233 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,658 tests, 232 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,684 tests, 233 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -753,3 +753,48 @@ class TestLoad5dHelpers:
         # latest=20, five_back=10 → delta = 10
         result = _load_5d_macro_delta("BAR", db_path=path)
         assert result == pytest.approx(10.0)
+
+
+class TestWriteBriefBranchCoverage:
+    """postmarket_brief.py write_brief 분기 — codecov 갭 (#611)."""
+
+    def test_publish_discord_returns_id_skips_skip_log(self, seeded_db, portfolio_yaml, caplog):
+        """postmarket_brief.py 472->475: outbox_id 가 None 이 아니면 'skip' 로그 출력 안 함."""
+        from nuri.alerts.postmarket_brief import write_brief
+
+        # _publish_discord 가 outbox_id (str) 반환 → 472 분기 False → 475 로 스킵
+        with (
+            patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+            patch("nuri.agents.discord.outbox.stage_brief", return_value="outbox-uuid-1234"),
+            caplog.at_level("INFO"),
+        ):
+            path = write_brief("us", date="2026-05-01")
+        assert path.exists()
+        # 'skip' 또는 '미발행' 메시지가 로그에 없어야 함 (472 False 분기 확인)
+        assert not any("미발행" in rec.message for rec in caplog.records)
+
+    def test_holdings_no_pnl_match_continues_outer_loop(self):
+        """postmarket_brief.py 267->265: actionable row 가 pnl rows 와 매칭 안 되면 inner for 가
+        break 없이 종료 → flat_rows 누락 (외부 루프 다음 row 로 진행, #611)."""
+        from nuri.alerts.postmarket_brief import _format_markdown
+
+        # holdings 에 AAPL 있지만 pnl rows 에는 다른 ticker → 매칭 실패 시나리오
+        macro = {"vix": None, "fear_greed": None, "regime": None}
+        holdings = {
+            "acct_x": {
+                "label": "Acct X",
+                "rows": [{"ticker": "AAPL", "account": "acct_x", "qty": 1, "avg_price": 100, "current_price": 100}],
+            }
+        }
+        # pnl["rows"] 는 ZZZ 만 → AAPL 매칭 실패, 267 inner for break 없이 종료 → 265 로 점프
+        pnl = {
+            "rows": [{"ticker": "ZZZ", "account": "other", "pnl_pct": 1.0, "pnl_abs": 0.0}],
+            "total_abs": 0.0,
+            "total_pct": 0.0,
+        }
+        sectors = []
+        md = _format_markdown("us", "2026-05-01", macro, holdings, pnl, sectors)
+        # holdings flat_rows 가 비어있어 "데이터 없음" 출력 (267->265 분기 확인)
+        assert "데이터 없음" in md
+        # AAPL holdings 행은 표 안에 없음
+        assert "## Holdings" in md

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -770,6 +770,80 @@ class TestPremarketBriefExceptionFallbacks:
         names = [f.get("name", "") for f in embed.get("fields", [])]
         assert any("BUY" in n for n in names)
 
+    def test_format_brief_embed_buy_candidates_empty_list_skips_field(self):
+        """premarket_brief.py 400->417: bc.candidates 비어있으면 elif False → Opportunities 로 진행 (#611)."""
+        from dataclasses import dataclass, field
+
+        from nuri.alerts.premarket_brief import format_brief_embed
+
+        @dataclass
+        class FakeBC:
+            blocked_reason: str | None = None  # blocked_reason 없음 → 첫 if False
+            regime: str = "bull"
+            vix: float = 15.0
+            candidates: list = field(default_factory=list)  # 빈 list → elif False (400 분기)
+            total_deploy_pct: int = 0
+            skipped: list = field(default_factory=list)
+            timestamp_kst: str = "2026-05-04 08:00 KST"
+
+        embed = format_brief_embed({"buy_candidates": FakeBC()})
+        names = [f.get("name", "") for f in embed.get("fields", [])]
+        # 빈 candidates → BUY Candidates field 미생성
+        assert not any("BUY Candidates" in n for n in names)
+
+    def test_format_brief_markdown_buy_candidates_empty_skips_section(self):
+        """premarket_brief.py 540->553: bc.candidates 비어있으면 BUY Candidates section 출력 생략 (#611)."""
+        from dataclasses import dataclass, field
+
+        from nuri.alerts.premarket_brief import format_brief_markdown
+
+        @dataclass
+        class FakeBC:
+            blocked_reason: str | None = None
+            regime: str = "bull"
+            vix: float = 15.0
+            candidates: list = field(default_factory=list)  # 빈 → elif False
+            total_deploy_pct: int = 0
+            skipped: list = field(default_factory=list)
+            timestamp_kst: str = "2026-05-04 08:00 KST"
+
+        md = format_brief_markdown({"buy_candidates": FakeBC()})
+        # BUY Candidates 헤더 없어야 함 (540 False 분기)
+        assert "## BUY Candidates" not in md
+
+    def test_format_brief_markdown_buy_candidates_no_skipped(self):
+        """premarket_brief.py 549->551: bc.skipped 비어있으면 'skipped:' 줄 출력 생략 (#611)."""
+        from dataclasses import dataclass, field
+
+        from nuri.alerts.premarket_brief import format_brief_markdown
+
+        @dataclass
+        class FakeCand:
+            ticker: str = "AAPL"
+            score: int = 80
+            deploy_pct: int = 5
+            entry: float = 200.0
+            stop: float = 190.0
+            tp1: float = 220.0
+            tp2: float = 240.0
+            why_now: str = "test"
+            sources: dict = field(default_factory=lambda: {"a": 80.0})
+
+        @dataclass
+        class FakeBC:
+            blocked_reason: str | None = None
+            regime: str = "bull"
+            vix: float = 15.0
+            candidates: list = field(default_factory=lambda: [FakeCand()])
+            total_deploy_pct: int = 5
+            skipped: list = field(default_factory=list)  # 빈 → 549 False 분기
+            timestamp_kst: str = "2026-05-04 08:00 KST"
+
+        md = format_brief_markdown({"buy_candidates": FakeBC()})
+        assert "AAPL" in md
+        # skipped 비어있어 "skipped:" 라인 미출력 (549 False 확인)
+        assert "skipped:" not in md
+
     def test_send_brief_exception(self):
         """send_webhook raise → False (lines 601-603)."""
         from nuri.alerts.premarket_brief import send_brief

--- a/tests/analysis/test_evidence_charts_branches.py
+++ b/tests/analysis/test_evidence_charts_branches.py
@@ -298,3 +298,101 @@ class TestEvidenceChartsRunpy:
         runpy.run_module("nuri.analysis.evidence_charts", run_name="__main__")
         out = capsys.readouterr().out
         assert "증거 차트 생성 완료" in out
+
+
+class TestRegimeChartSMABranches:
+    """evidence_charts.py 89->101, 102->115: SMA50/SMA200 모두 NaN 시 add_trace 우회 (#611)."""
+
+    def test_sma50_sma200_all_nan_skips_traces(self, db_path, tmp_path):
+        """SMA50/SMA200 모두 NaN → 89 False / 102 False (trace 미추가).
+
+        rolling(50).mean() 은 row 수 < 50 시 전 NaN 반환. 30 row 삽입해
+        sma50_valid.empty / sma200_valid.empty 가 둘 다 True 가 되게 한다.
+        """
+        from nuri.core.db import upsert_prices
+
+        n = 30  # < 50 → SMA50/SMA200 모두 NaN
+        dates = pd.bdate_range("2025-01-01", periods=n).strftime("%Y-%m-%d").tolist()
+        rows = [
+            {
+                "ticker": "SPY",
+                "date": dates[i],
+                "open": 400.0,
+                "high": 401.0,
+                "low": 399.0,
+                "close": 400.0 + i * 0.1,
+                "volume": 1_000_000,
+                "adj_close": 400.0 + i * 0.1,
+            }
+            for i in range(n)
+        ]
+        upsert_prices(pd.DataFrame(rows), db_path)
+
+        out_dir = tmp_path / "evidence"
+        out_dir.mkdir()
+        with patch.object(ec, "classify_regime", return_value=None):
+            result = ec.generate_regime_chart(out_dir, db_path=db_path)
+        assert result.exists()
+        body = result.read_text()
+        # SMA 50 / 200 trace 미추가 (89 False / 102 False 분기 확인)
+        assert '"name":"SMA 50"' not in body
+        assert '"name":"SMA 200"' not in body
+
+
+class TestShadeRegimeZonesEarlyExit:
+    """evidence_charts.py 214->exit: _shade_regime_zones 에 row 1 개만 입력 시
+    prev_zone 이 None 인 채 루프 종료 → 마지막 vrect 추가 분기 미진입 (#611)."""
+
+    def test_single_row_no_zone_transitions(self):
+        from plotly.subplots import make_subplots
+
+        from nuri.analysis.evidence_charts import _shade_regime_zones
+
+        fig = make_subplots(rows=1, cols=1)
+        # SMA50/SMA200 모두 NaN → zone 결정 불가, prev_zone 영원히 None
+        df = pd.DataFrame(
+            [
+                {"date": "2025-01-01", "sma50": float("nan"), "sma200": float("nan")},
+                {"date": "2025-01-02", "sma50": float("nan"), "sma200": float("nan")},
+            ]
+        )
+        # 예외 raise 없이 통과 — 214 분기 False 진입
+        _shade_regime_zones(fig, df)
+        # zone 추가 안 됨 — fig.layout.shapes 가 비어 있어야 함 (vrect 미생성)
+        shapes = list(getattr(fig.layout, "shapes", None) or [])
+        assert shapes == [], f"zone vrect 가 추가되면 안 됨: {shapes}"
+
+
+class TestPortfolioHeatmapNoViolations:
+    """evidence_charts.py 312->324: violations 빈 list → annotation 미추가 (#611)."""
+
+    def test_no_violations_skips_annotation(self, tmp_path, monkeypatch):
+        """모든 종목이 stop_loss / max_single 정상 → violations 빈 list → 312 False → 324."""
+        # analyze_portfolio 가 정상 비중·정상 pnl 데이터 반환하도록 patch
+        df = pd.DataFrame(
+            [
+                {
+                    "ticker": "AAA",
+                    "current_value_usd": 1000,
+                    "pnl_pct": 5.0,
+                    "weight_pct": 8.0,  # max_single 15% 미만
+                    "sector": "Tech",
+                },
+                {
+                    "ticker": "BBB",
+                    "current_value_usd": 1000,
+                    "pnl_pct": -2.0,  # PORTFOLIO_STOP -10 보다 큼
+                    "weight_pct": 8.0,
+                    "sector": "Health",
+                },
+            ]
+        )
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda *a, **kw: df)
+
+        out_dir = tmp_path / "evidence"
+        out_dir.mkdir()
+        result = ec.generate_portfolio_heatmap(out_dir)
+        assert result.exists()
+        body = result.read_text()
+        # violations 비어 annotation 미추가 — "위반 종목" 텍스트 없음 (312 False 분기 확인)
+        assert "위반 종목" not in body

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -775,6 +775,37 @@ class TestGetSystemHealth:
             result = _get_system_health()
             assert result["siege"] == {"score": 0, "certified": False}
 
+    @patch("nuri.api.routes.actions.query", return_value=[])
+    def test_classify_regime_returns_none_skips_regime_dict(self, _):
+        """branch 774->785: classify_regime() 가 None 반환 시 health['regime'] 그대로 빈 dict (#611)."""
+        from types import SimpleNamespace
+
+        with (
+            patch(
+                "nuri.trading.engine.certification.certify",
+                return_value=SimpleNamespace(
+                    score=80,
+                    certified=True,
+                    passed=10,
+                    failed=0,
+                    warnings=1,
+                    total_conditions=11,
+                    conditions=[],
+                ),
+            ),
+            patch("nuri.quant.regime.classifier.classify_regime", return_value=None),
+            patch(
+                "nuri.quant.regime.macro_score.compute_macro_score",
+                return_value=SimpleNamespace(total_score=50, interpretation="Neutral"),
+            ),
+            patch("nuri.core.freshness.check_all_freshness", return_value=[]),
+        ):
+            from nuri.api.routes.actions import _get_system_health
+
+            result = _get_system_health()
+            # regime 은 초기값(빈 dict) 유지 — 774 False 분기 확인
+            assert result["regime"] == {}
+
 
 # ═══════════════════════════════════════════════════
 # Unit tests — _build_actions business logic

--- a/tests/api/test_ticker_search.py
+++ b/tests/api/test_ticker_search.py
@@ -1,4 +1,5 @@
 """Tests for /api/tickers/* endpoints (#133)."""
+
 import pytest
 
 from nuri.core.db import get_db, init_db
@@ -58,9 +59,14 @@ class TestMarketContext:
     def test_market_context_with_vix_data(self, seeded_client):
         """VIX 데이터가 있으면 값 반환."""
         from nuri.core.db import get_db
+
         with get_db() as conn:
-            conn.execute("INSERT OR REPLACE INTO macro (indicator, date, value, source) VALUES ('vix','2026-04-10',19.2,'test')")
-            conn.execute("INSERT OR REPLACE INTO macro (indicator, date, value, source) VALUES ('fear_greed','2026-04-10',37.7,'test')")
+            conn.execute(
+                "INSERT OR REPLACE INTO macro (indicator, date, value, source) VALUES ('vix','2026-04-10',19.2,'test')"
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO macro (indicator, date, value, source) VALUES ('fear_greed','2026-04-10',37.7,'test')"
+            )
         resp = seeded_client.get("/api/tickers/market-context")
         data = resp.json()
         assert data["vix"] == 19.2
@@ -73,10 +79,31 @@ class TestLatestPricesWithData:
         import pandas as pd
 
         from nuri.core.db import upsert_prices
-        df = pd.DataFrame([
-            {"ticker": "AAPL", "date": "2026-04-09", "open": 220, "high": 222, "low": 218, "close": 219, "volume": 1000, "adj_close": 219},
-            {"ticker": "AAPL", "date": "2026-04-10", "open": 219, "high": 225, "low": 219, "close": 223, "volume": 1200, "adj_close": 223},
-        ])
+
+        df = pd.DataFrame(
+            [
+                {
+                    "ticker": "AAPL",
+                    "date": "2026-04-09",
+                    "open": 220,
+                    "high": 222,
+                    "low": 218,
+                    "close": 219,
+                    "volume": 1000,
+                    "adj_close": 219,
+                },
+                {
+                    "ticker": "AAPL",
+                    "date": "2026-04-10",
+                    "open": 219,
+                    "high": 225,
+                    "low": 219,
+                    "close": 223,
+                    "volume": 1200,
+                    "adj_close": 223,
+                },
+            ]
+        )
         upsert_prices(df)
         resp = seeded_client.get("/api/tickers/latest-prices?tickers=AAPL")
         data = resp.json()
@@ -139,3 +166,55 @@ class TestTickerSearch:
             assert "date" in r
             assert "ticker" in r
             assert "name" in r
+
+
+class TestSearchTickersBranchCoverage:
+    """ticker.py 브랜치 커버 — universe.yaml 부재 / 비-dict 그룹 분기."""
+
+    def test_universe_missing_skips_loading(self, client, monkeypatch):
+        """universe.yaml 가 없으면 line 27 False → line 35 점프 (한글 매칭만 시도)."""
+        from pathlib import Path as _P
+
+        original_exists = _P.exists
+
+        def fake_exists(self):
+            # universe.yaml 만 False 로 가장. 다른 경로(예: 실제 fs lookup) 는 영향 없게.
+            if self.name == "universe.yaml":
+                return False
+            return original_exists(self)
+
+        monkeypatch.setattr(_P, "exists", fake_exists)
+        resp = client.get("/api/tickers/search?q=AAPL")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "results" in data
+        # universe.yaml 부재 → all_tickers 비어 ticker code 매칭 0
+        # 한글 매칭 path 도 all_tickers 비어 0 → results=[]
+        assert data["count"] == 0
+
+    def test_universe_group_non_dict_skipped(self, client, monkeypatch, tmp_path):
+        """universe.yaml 안에 list / 비-dict 그룹이 섞이면 line 31 False → 다음 그룹으로 진행."""
+        import yaml as _yaml
+
+        # 비-dict 값을 포함한 universe payload (실제 universe.yaml 와 같은 구조)
+        fake_universe = {
+            "us_growth": {"tickers": ["AAPL", "NVDA"]},  # dict + tickers (정상)
+            "deprecated_legacy": ["OLD1", "OLD2"],  # list (비-dict, 31->30 트리거)
+            "metadata_only": {"description": "no tickers key"},  # dict but no "tickers"
+        }
+
+        original_safe_load = _yaml.safe_load
+
+        def fake_safe_load(stream):
+            text = stream.read() if hasattr(stream, "read") else stream
+            if "us_growth" in str(text) or "tickers" in str(text):
+                return fake_universe
+            return original_safe_load(text)
+
+        monkeypatch.setattr(_yaml, "safe_load", fake_safe_load)
+        resp = client.get("/api/tickers/search?q=AAPL")
+        assert resp.status_code == 200
+        # AAPL 은 us_growth 그룹에 있어 매칭 성공해야 함 (다른 비-dict 그룹은 skip)
+        data = resp.json()
+        tickers = [r["ticker"] for r in data.get("results", [])]
+        assert "AAPL" in tickers

--- a/tests/quant/regime/test_strategy_map_branches.py
+++ b/tests/quant/regime/test_strategy_map_branches.py
@@ -1,0 +1,47 @@
+"""strategy_map.py 브랜치 커버 — codecov 갭 (#611).
+
+print_strategy 의 signal_regime_stats 빈 분기 (325->332).
+"""
+
+from __future__ import annotations
+
+from nuri.quant.regime.strategy_map import StrategyRecommendation, print_strategy
+
+
+class TestPrintStrategyEmptyStats:
+    def test_no_signal_stats_skips_performance_block(self, capsys):
+        """signal_regime_stats 가 비어있으면 'Signal Performance' 블록 출력 생략 (325 False → 332)."""
+        rec = StrategyRecommendation(
+            regime="sideways_high_vol",
+            macro_interpretation="Neutral",
+            position_sizing="defensive",
+            recommended_signals=["rsi_oversold"],
+            avoid_signals=["sma_dead"],
+            sector_preference=["XLP", "XLU"],
+            signal_regime_stats={},  # 핵심: 비어있어 325 분기 False 트리거
+            notes="테스트",
+        )
+        print_strategy(rec)
+        out = capsys.readouterr().out
+        assert "Strategy Recommendation" in out
+        # signal_regime_stats 비어있으면 헤더가 출력되지 않아야 함
+        assert "Signal Performance" not in out
+
+    def test_with_signal_stats_prints_performance_block(self, capsys):
+        """signal_regime_stats 가 있으면 'Signal Performance' 블록 출력 (325 True 분기, 회귀 lock)."""
+        rec = StrategyRecommendation(
+            regime="bull_low_vol",
+            macro_interpretation="Risk-on",
+            position_sizing="aggressive",
+            recommended_signals=["rsi_oversold"],
+            avoid_signals=[],
+            sector_preference=["XLK"],
+            signal_regime_stats={
+                "rsi_oversold": {"trades": 12, "win_rate": 0.66, "pf": 2.4, "avg_return": 3.5},
+            },
+            notes="ok",
+        )
+        print_strategy(rec)
+        out = capsys.readouterr().out
+        assert "Signal Performance" in out
+        assert "rsi_oversold" in out

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -774,6 +774,32 @@ class TestConsensus_R23:
         captured = capsys.readouterr()
         assert "합의 결과 없음" in captured.out
 
+    def test_print_consensus_no_buy_hold_skips_targets_block(self, capsys, monkeypatch):
+        """presentation.py 91->104: SELL only (BUY/HOLD 없음) → 'Price Targets' 블록 출력 생략 (#611)."""
+        from nuri.trading.agents.base import AgentVerdict
+        from nuri.trading.agents.consensus import ConsensusResult, print_consensus
+
+        results = [
+            ConsensusResult(
+                ticker="ZZZ",
+                final_action="SELL",  # BUY/HOLD 아님 → buy_hold 빈 리스트 → 91 False
+                final_confidence=70.0,
+                agreement_rate=0.7,
+                verdicts=[AgentVerdict("technical", "ZZZ", "SELL", 80, "sell signal")],
+                dissent=[],
+                reasoning="technical: sell",
+            )
+        ]
+        # external 호출 차단 (테스트 isolation)
+        monkeypatch.setattr(
+            "nuri.collectors.external.get_external", lambda *a: (_ for _ in ()).throw(ImportError("no module"))
+        )
+        print_consensus(results)
+        captured = capsys.readouterr()
+        assert "ZZZ" in captured.out
+        # buy_hold 비어있음 → 'Price Targets' 헤더 미출력 (91->104 분기 확인)
+        assert "Price Targets" not in captured.out
+
     def test_print_consensus_external_data(self, capsys, monkeypatch):
         """Print consensus with external data."""
         from nuri.trading.agents.base import AgentVerdict

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -330,6 +330,52 @@ class TestModeEvaluation:
         )
         assert mode is None
 
+    def test_average_down_macro_veto_disabled_passes_high_vix(
+        self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict
+    ) -> None:
+        """held_add.py 320->326: macro_veto=False 면 VIX/regime 무시하고 통과 (#611)."""
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_last_trim_age_days",
+            lambda ticker, max_days=60: None,
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_account_strategy_profile",
+            lambda account: {"stop_loss": -10, "tp1_pct": 21.0},
+        )
+        cfg_no_veto = {
+            "held_add_mode": {
+                **cfg_held_add["held_add_mode"],
+                "modes": {
+                    **cfg_held_add["held_add_mode"]["modes"],
+                    "average_down": {
+                        **cfg_held_add["held_add_mode"]["modes"].get("average_down", {}),
+                        "trigger": {
+                            **cfg_held_add["held_add_mode"]["modes"].get("average_down", {}).get("trigger", {}),
+                            "macro_veto": False,  # 분기 False 트리거
+                        },
+                    },
+                },
+            }
+        }
+        pos = {
+            "ticker": "MSFT",
+            "account": "acct_alpha",
+            "pnl_pct": -5.0,
+            "days_held": 20,
+        }
+        # bear + VIX>28 인데도 macro_veto=False 면 통과 (320 분기 False → 326 return)
+        mode = ha.select_held_mode(
+            pos,
+            cfg_no_veto["held_add_mode"],
+            score=85,
+            rsi=30,
+            regime="bear",
+            vix=35,
+            breakout_above_trim=False,
+            sector_mom=0,
+        )
+        assert mode == "average_down"
+
 
 # ─── 4. emit_held_add_shadow E2E (multi-account independent caps) ──
 
@@ -409,6 +455,56 @@ class TestEmitHeldAddShadow:
         rows = query("SELECT ticker, account, mode FROM held_add_shadow", db_path=db_path)
         assert len(rows) == 2
         assert {r["account"] for r in rows} == {"acct_alpha", "acct_beta"}
+
+    def test_shadow_mode_off_skips_persist(
+        self,
+        db_path: Path,
+        cfg_yaml_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        stub_strategy: None,
+    ) -> None:
+        """held_add.py 486->436: shadow_mode 종료 후 (오늘 > shadow_mode_until)
+        candidate 는 emit 하되 held_add_shadow 테이블 persist 는 skip (#611)."""
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_held_positions",
+            lambda: [
+                {
+                    "ticker": "NVDA",
+                    "account": "acct_alpha",
+                    "qty": 14.0,
+                    "avg_price": 100.0,
+                    "current_price": 160.0,
+                    "pnl_pct": 60.0,
+                    "days_held": 35,
+                },
+            ],
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_last_trim_age_days",
+            lambda ticker, max_days=60: None,
+        )
+
+        def _fetcher_factory(t: str) -> SimpleNamespace:
+            return SimpleNamespace(calendar={})
+
+        # shadow_mode_until=2026-05-15 cfg, today=2026-06-01 → shadow=False
+        result = ha.emit_held_add_shadow(
+            config_path=cfg_yaml_path,
+            today=date(2026, 6, 1),
+            earnings_fetcher_factory=_fetcher_factory,
+            score_provider=lambda t: 85.0,
+            rsi_provider=lambda t: 55.0,
+            regime_provider=lambda: ("neutral", 18.0),
+            sector_mom_provider=lambda t: 10.0,
+            db_path=db_path,
+        )
+
+        # shadow=False 분기: candidates 는 그대로 emit
+        assert result.shadow_mode is False
+        assert len(result.candidates) == 1
+        # 하지만 held_add_shadow 테이블 persist 는 skip (486->436 분기 확인)
+        rows = query("SELECT ticker FROM held_add_shadow", db_path=db_path)
+        assert len(rows) == 0
 
     def test_earnings_blackout_blocks_emit(
         self,


### PR DESCRIPTION
## Summary

- Close 14 partial branches in 8 codecov-flagged `nuri/` files using **real pytest tests** (zero new `# pragma: no cover`).
- 16 new tests across 8 files (1 new file: `tests/quant/regime/test_strategy_map_branches.py`).
- Doc count drift sync: 5,658/232 → 5,684/233 (verify-doc-counts 13/13).

### Branches closed (file → branches → trigger)

| File | Branch(es) | Trigger condition |
|---|---|---|
| `nuri/alerts/premarket_brief.py` | 400→417 / 540→553 / 549→551 | BUY candidate empty list / no skipped |
| `nuri/alerts/postmarket_brief.py` | 267→265 / 472→475 | holdings/pnl ticker mismatch / publish ok |
| `nuri/trading/recommend/held_add.py` | 320→326 / 486→436 | macro_veto disabled / shadow off |
| `nuri/trading/agents/consensus/presentation.py` | 91→104 | SELL-only consensus skips price targets |
| `nuri/quant/regime/strategy_map.py` | 325→332 | empty `signal_regime_stats` |
| `nuri/api/routes/actions.py` | 774→785 | `classify_regime()` returns None |
| `nuri/analysis/evidence_charts.py` | 89→101 + 102→115 / 214→exit / 312→324 | all-NaN SMA / single-zone / no violations |
| `nuri/api/routes/ticker.py` | 27→35 / 31→30 | universe.yaml missing / non-dict group |

### Why these specifically

User flagged the codecov.io view of `nuri/` showing 8 files with 46 statement misses despite local 100%. While diagnosing the codecov merge bug (see Test plan), I closed every partial branch in those 8 files locally so the file-level `--cov-branch` reports 100% on each.

### Codecov merge bug (unresolved, follow-up)

Local `pytest --cov=nuri --cov-branch` after this PR reports 100% statement / 99% branch (173 partials in **other** files). codecov.io for commit `c86de5e` still shows 46 misses across these 8 files even after CI rerun (sessions 4 → 8, totals unchanged). Investigation hypothesis: `carryforward: true` on shard flags causing stale data merge. Resolution deferred to a follow-up PR.

## Test plan

- [x] `make verify-doc-counts` (13/13 passed)
- [x] `pytest tests/ -m "not integration"` — 5,678 passed, 6 skipped, 9 deselected
- [x] `ruff check tests/` — clean
- [x] Each new test verified against `coverage report --include=<file> --show-missing` to confirm the cited branch left the Missing column
- [ ] CI Backend Tests Shard 1/2 + slow green
- [ ] Codecov fresh upload reduces nuri/ misses (verifies merge-bug hypothesis or escalates follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)