### PR TITLE
fix(ci): codecov per-shard unique flag — merge bug fix (#612)

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -416,7 +416,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          flags: backend-fast
+          # Per-shard unique flag (#612). 직전엔 두 shard 가 동일 `backend-fast` 로 업로드 →
+          # codecov 가 같은 flag/commit 의 후속 upload 를 union 이 아닌 replace 로 처리해
+          # shard1-only 라인이 final view 에서 missed 로 나타나는 merge bug 발생. shard 별
+          # 별도 flag 로 분리 + component_management `backend.*` 정규식이 여전히 matches.
+          flags: backend-fast-${{ matrix.shard }}
           disable_search: true
           fail_ci_if_error: false
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The system rests on five enduring decisions. Recent feature additions and tuning
 
 | # | Principle | What it means in practice |
 |---|-----------|---------------------------|
-| 1 | **Sole SQLite gateway** | `nuri/core/db/` (package after #566 P2 refactor) is the only `sqlite3` importer (hook-enforced — every other module uses `query()` / `upsert_*()` / `get_db()` with optional `db_path=` for test isolation). 50 tables, WAL mode, 43 forward-only migrations. |
+| 1 | **Sole SQLite gateway** | `nuri/core/db/` (package after #566 P2 refactor) is the only `sqlite3` importer (hook-enforced — every other module uses `query()` / `upsert_*()` / `get_db()` with optional `db_path=` for test isolation). 51 tables, WAL mode, 44 forward-only migrations. |
 | 2 | **Config over code** | Stop-loss thresholds, agent weights, signal metadata, SIEGE gate policies — all in `config/*.yaml`. Changing a rule or adding a market means editing YAML, never Python. |
 | 3 | **Loose phase coupling** | Pipeline phases communicate via DB tables / CSV only. No cross-phase imports. Re-run any upstream phase and downstream consumers refresh. |
 | 4 | **3-D SIEGE certification** | Gates apply per `Account (strategy)` × `Asset Class (us_equity / kr_equity / kr_index / commodity / bond)` × `Execution Market`. 1 error-grade fail → REJECTED, no manual override. Inspired by [nutshells3/SIEGE](https://github.com/nutshells3/Swarm-Intelligence-Engine-with-Gated-Execution). |
@@ -77,7 +77,7 @@ The system rests on five enduring decisions. Recent feature additions and tuning
 |  | `nuri/trading/recommend/` | Candidates, price targets, rebalance advisor, outcome tracker (30 / 60 / 90d). |
 | **Serve** | `nuri/api/` | FastAPI REST + SSE on **:8001** (69 endpoints incl. `/actions`, `/opportunities`, `/market-context`, `/coverage`). Swagger at `/docs`. |
 |  | `frontend/` | Next.js 16 + React 19 + Tailwind 4 + shadcn/ui on **:3000** (17 routes, Action-First dashboard, dark theme). |
-| **Foundation** | `nuri/core/` | `db/` (sole SQLite gateway, 8 submodules incl. agent_runtime / discord_outbox_ops / market_data / portfolio / research_ops) · `events.py` (journal) · `freshness.py` (SLA) · `timezone.py` (KST) · `rules.py` · `signal_config.py` · `axis.py` (alpha/portfolio helpers) · `account_cap.py` (#518 per-account cap derivation). |
+| **Foundation** | `nuri/core/` | `db/` (sole SQLite gateway, 11 submodules incl. agent_runtime / discord_outbox_ops / execution_ops / market_data / portfolio / postmortem_ops / research_ops / trades) · `events.py` (journal) · `freshness.py` (SLA) · `timezone.py` (KST) · `rules.py` · `signal_config.py` · `axis.py` (alpha/portfolio helpers) · `account_cap.py` (#518 per-account cap derivation). |
 |  | `config/*.yaml` | `rules` · `agents` · `signals` · `universe` · `stock_types` · `portfolio` (gitignored) · `kis/` (gitignored credentials). |
 | **LLM gateway** | `nuri/llm/` | `openai_client.py` (sole external entry, audit-logged) · event classifier · LLM daily report (OpenAI primary, llama.cpp / Ollama fallback). |
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,12 +4,18 @@
 # Codecov가 PR마다 backend/frontend 커버리지를 별도 배지로 표시
 # 정책: 자동 임계값 + 1% 허용범위 (작은 변동 무시)
 
-# Uploads per event (after slow-split):
-#   - PR:   2 backend-fast shards + 1 frontend                    = 3 uploads
-#   - push: 2 backend-fast shards + 1 backend-slow + 1 frontend   = 4 uploads
+# Uploads per event (after slow-split + #612 per-shard unique flag):
+#   - PR:   backend-fast-1 + backend-fast-2 + frontend                  = 3 uploads
+#   - push: backend-fast-1 + backend-fast-2 + backend-slow + frontend   = 4 uploads
 # `after_n_builds` removed — a static value would either hang PRs (waiting
 # for a 4th upload that never comes) or report partial push coverage. Codecov
 # now processes uploads as they arrive; status settles on the final state.
+#
+# #612: shard 별 unique flag — 이전엔 두 shard 가 같은 `backend-fast` 로 업로드,
+# codecov 가 같은 flag/commit 의 후속 upload 를 union 이 아닌 replace 로 처리해
+# shard1-only 라인이 final view 에서 missed 로 나타나는 merge bug 가 발생. 분리하면
+# component_management `backend.*` regex 가 여전히 matches 해 backend component 합산
+# 결과는 동일.
 codecov:
   notify: {}
 
@@ -25,14 +31,18 @@ coverage:
         threshold: 5%        # 리팩토링(문자열 교체 등)에서 미커버 기존 라인 허용
 
 # Backend = Python (nuri/), Frontend = TypeScript (frontend/src/)
-# backend-fast / backend-slow: workflow 의 slow-split 대응. 두 flag 모두
+# backend-fast-{1,2} / backend-slow: workflow 의 shard-split 대응. 모두
 # nuri/ 를 대상으로 하고, component_management 에서 'backend' component 로
 # 합쳐진다 (flag_regexes: backend.*).
 flags:
-  backend-fast:
+  backend-fast-1:
     paths:
       - nuri/
     carryforward: true       # 미수정 파일 직전 커버리지 유지
+  backend-fast-2:
+    paths:
+      - nuri/
+    carryforward: true
   backend-slow:
     paths:
       - nuri/
@@ -64,7 +74,7 @@ component_management:
     - component_id: backend
       name: Backend (Python)
       flag_regexes:
-        - backend.*          # backend-fast + backend-slow 모두 매치
+        - backend.*          # backend-fast-1 / -2 / backend-slow 모두 매치
     - component_id: frontend
       name: Frontend (Next.js)
       flag_regexes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ Configured in `.env` (see `.env.example`):
 - `KIS_PROD_APP_KEY` / `KIS_PROD_APP_SECRET` — KIS Open API live (optional; falls back to `config/kis/kis_devlp.yaml`, gitignored)
 - `KIS_PAPER_APP_KEY` / `KIS_PAPER_APP_SECRET` — KIS Open API paper (optional)
 ## DB Schema (SQLite, WAL mode)
-48 tables total (40 migrations as of 2026-05-01). Key tables:
+51 tables total (44 migrations as of 2026-05-05). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |


### PR DESCRIPTION
## Summary

Fix the codecov merge bug observed in #611: codecov.io shows 46 false-positive misses across 8 nuri/ files at `c86de5e` / `907445c` despite local `pytest --cov=nuri` reporting 100% statement coverage.

## Root cause

Both backend test shards upload to codecov with the same flag `backend-fast`. Codecov treats multiple uploads to the same `(flag, commit)` pair as **replace**, not union — so lines covered by shard 1 but not shard 2 (or vice versa) show as missed in the final merged report.

Local verification (per-session XML union): 0 missed in `nuri/api/routes/dashboard.py`. Codecov reports 1 miss.

## Fix

Per-shard unique flag — `backend-fast-1` and `backend-fast-2` instead of single `backend-fast`. Each shard uploads to its own flag, codecov stores them as separate sessions, and the file-level merge unions them properly.

- **Workflow**: `flags: backend-fast-${{ matrix.shard }}`
- **codecov.yml**: replace `backend-fast` block with `backend-fast-1` + `backend-fast-2` (both `paths: [nuri/]`, `carryforward: true`)
- `component_management.flag_regexes: backend.*` still matches all three flags (`-1`, `-2`, `-slow`), so the aggregated `backend` component view is unchanged.

## Verification

- [x] `python -c "import yaml; yaml.safe_load(open('codecov.yml'))"` valid
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/main-ci-cd.yml'))"` valid
- [ ] CI Backend Tests Shard 1/2 + slow green
- [ ] After merge: codecov.io commit page reports 0 misses for `nuri/api/routes/dashboard.py`, `nuri/api/routes/actions.py`, `nuri/alerts/premarket_brief.py`, `nuri/alerts/postmarket_brief.py`, `nuri/trading/recommend/held_add.py`, `nuri/trading/agents/consensus/presentation.py`, `nuri/quant/regime/strategy_map.py`, `nuri/analysis/evidence_charts.py`, `nuri/core/db/market_data.py` (all 8 files local 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)