### PR TITLE
fix(ci): codecov carryforward=false — eliminate stale per-flag merge (#613)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -35,22 +35,27 @@ coverage:
 # nuri/ 를 대상으로 하고, component_management 에서 'backend' component 로
 # 합쳐진다 (flag_regexes: backend.*).
 flags:
+  # carryforward: false (#613) — 직전 PR #612 가 per-shard unique flag 로 분리해도
+  # codecov 페이지에 nuri/ 8 files 46 false-positive misses 잔존. 가설 #2: backend-slow
+  # 가 다수 파일 (예: dashboard.py) 의 line 정보를 포함하지 않아 codecov 가 해당 flag
+  # 에 대해 carryforward 로 stale 데이터 머지 → 머지 결과에 가짜 miss 생성. carryforward
+  # 비활성화로 검증.
   backend-fast-1:
     paths:
       - nuri/
-    carryforward: true       # 미수정 파일 직전 커버리지 유지
+    carryforward: false
   backend-fast-2:
     paths:
       - nuri/
-    carryforward: true
+    carryforward: false
   backend-slow:
     paths:
       - nuri/
-    carryforward: true
+    carryforward: false
   frontend:
     paths:
       - frontend/src/
-    carryforward: true
+    carryforward: false
 
 # 커버리지 계산 제외 — 테스트 코드, 스크립트, 자동 생성
 ignore:


### PR DESCRIPTION
## Summary

Result of PR #612: same 8 files / 46 misses persist on commit `2e73966` despite per-shard unique flag (`backend-fast-1` / `backend-fast-2`) and 4 sessions uploading. Per-shard merge hypothesis disproved.

## Next hypothesis (#613)

`carryforward: true` brings in stale per-flag data on partial uploads. The backend-slow flag runs 23 slow tests (LLM/scheduler) that don't exercise web routes / market data / brief modules at all. So `coverage.xml` from the slow shard **omits those files entirely**. Codecov's merge for those files = `union(backend-fast-1, backend-fast-2, carryforward(backend-slow))` — and the carryforward pulls ancient data from prior commits where the file content / line numbers differ, producing phantom misses on lines that have since been removed or renumbered.

## Fix

Disable `carryforward` on all 4 flags. Each flag's coverage is now pinned to the current commit's actual upload only — files absent from a flag's XML are simply not contributed by that flag (no stale fill).

## Trade-off

- ✅ Ground-truth post-merge totals are deterministic.
- ⚠️ PR comments / carryforward-only commits will show 0% for files not covered by any uploaded flag. We don't have such commits today (push always uploads all 4 flags), and PR events upload backend-fast-1/-2 + frontend covering all relevant paths. Net behavior should be unchanged for typical commits.

## Verification

- [x] `python -c "import yaml; yaml.safe_load(open('codecov.yml'))"` valid
- [ ] CI Backend Tests + slow + frontend green
- [ ] After merge: codecov.io commit page reports **0 misses** for nuri/ across all 8 previously-flagged files: `dashboard.py`, `actions.py`, `premarket_brief.py`, `postmarket_brief.py`, `held_add.py`, `consensus/presentation.py`, `strategy_map.py`, `evidence_charts.py`, `market_data.py` (matches local `pytest --cov=nuri` 100%)

If this hypothesis also fails, the next probe is to remove `component_management.flag_regexes` to see whether the component aggregator (not the merge) is what introduces the misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)