### PR TITLE
fix(ci): merge .coverage files before codecov upload — phantom miss bug fix

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -407,22 +407,22 @@ jobs:
 
       - name: Run fast tests with coverage
         if: needs.changes.outputs.run_backend == 'true'
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=2 --cov=nuri --cov-report=xml --cov-report=term
+        # `--cov-report=` (empty) suppresses XML — backend-coverage-merge 가 모든
+        # shard 의 `.coverage` 를 모아 단일 XML 을 만들고 codecov 에 한 번 업로드.
+        # 이전엔 shard 별 XML 을 각각 codecov 에 업로드해 multi-session merge 시
+        # phantom miss (8 files / 46) 가 잔존했음 (#611-#613 history).
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=2 --cov=nuri --cov-report= --cov-report=term
         timeout-minutes: 5
 
-      - name: Upload coverage to Codecov
+      - name: Upload .coverage artifact
         if: needs.changes.outputs.run_backend == 'true' && always()
-        uses: codecov/codecov-action@v6
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          # Per-shard unique flag (#612). 직전엔 두 shard 가 동일 `backend-fast` 로 업로드 →
-          # codecov 가 같은 flag/commit 의 후속 upload 를 union 이 아닌 replace 로 처리해
-          # shard1-only 라인이 final view 에서 missed 로 나타나는 merge bug 발생. shard 별
-          # 별도 flag 로 분리 + component_management `backend.*` 정규식이 여전히 matches.
-          flags: backend-fast-${{ matrix.shard }}
-          disable_search: true
-          fail_ci_if_error: false
+          name: coverage-fast-${{ matrix.shard }}
+          path: .coverage
+          if-no-files-found: ignore
+          retention-days: 1
+          include-hidden-files: true
 
   # ── Backend Tests (slow) — isolated, push-only ──
   # Runs the 23 @pytest.mark.slow tests (mostly LLM/scheduler) in a single
@@ -448,16 +448,83 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run slow tests with coverage
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --cov=nuri --cov-report=xml --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --cov=nuri --cov-report= --cov-report=term
         timeout-minutes: 5
 
-      - name: Upload coverage to Codecov
+      - name: Upload .coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-slow
+          path: .coverage
+          if-no-files-found: ignore
+          retention-days: 1
+          include-hidden-files: true
+
+  # ── Backend Coverage merge ──
+  # Single source of truth for codecov: 모든 backend test job 의 `.coverage`
+  # artifact 를 다운로드 → `coverage combine` 으로 union → 단일 coverage.xml
+  # 을 codecov 에 한 번만 업로드 (flag=backend). 이전엔 shard/slow 가 각각
+  # 별도 flag 로 업로드 → codecov multi-session merge 가 phantom miss 생성
+  # (#611~#613 history). PR 에선 slow artifact 가 없어 fast 만 합산되며,
+  # push 에선 fast+slow 모두 합산.
+
+  backend-coverage-merge:
+    name: Backend Coverage Merge
+    needs: [changes, backend-tests-shard, backend-tests-slow]
+    if: ${{ !cancelled() && needs.changes.outputs.run_backend == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup backend env (uv + TA-Lib + venv)
+        uses: ./.github/actions/setup-backend-env
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: cov-artifacts
+
+      - name: Combine coverage data
+        run: |
+          set -e
+          mkdir -p cov-merge
+          # 각 artifact 디렉토리의 `.coverage` 파일을 unique suffix 로 복사
+          # (coverage combine 은 `.coverage.<suffix>` 형태를 union).
+          shopt -s nullglob
+          found=0
+          for d in cov-artifacts/coverage-*/; do
+            name=$(basename "$d")
+            suffix=${name#coverage-}
+            if [ -f "${d}.coverage" ]; then
+              cp "${d}.coverage" "cov-merge/.coverage.${suffix}"
+              found=$((found + 1))
+              echo "✓ ${name} → cov-merge/.coverage.${suffix}"
+            else
+              echo "⚠ ${name}: .coverage missing — skipped"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::no .coverage artifacts found"
+            exit 1
+          fi
+          # combine 은 positional arg 로 받은 디렉토리의 `.coverage*` 를 union 한 뒤
+          # cwd 의 `.coverage` 파일에 결과를 기록한다 (없으면 새로 생성).
+          .venv/bin/python -m coverage combine cov-merge
+          .venv/bin/python -m coverage xml -o coverage.xml
+          .venv/bin/python -m coverage report --skip-empty | tail -5
+
+      - name: Upload merged coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          flags: backend-slow
+          flags: backend
           disable_search: true
           fail_ci_if_error: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,6 +25,12 @@ coverage:
 
 # Backend = Python (nuri/), Frontend = TypeScript (frontend/src/)
 # 두 flag 모두 단일 upload — workflow 가 이미 합산 후 한 번만 업로드한다.
+#
+# 옛 flag (backend-fast / backend-fast-1 / backend-fast-2 / backend-slow) 는
+# 더 이상 워크플로우에서 업로드되지 않지만 codecov 측 stored 데이터에 남아 있다.
+# 명시적으로 `carryforward: false` 를 지정하지 않으면 codecov 가 default
+# carryforward=true 로 옛 commit 데이터를 새 commit 까지 끌고 와 stale 결과 (PR
+# #614 머지 전 main HEAD 의 8 files / 46 misses 가 PR 까지 따라옴) 를 보여준다.
 flags:
   backend:
     paths:
@@ -33,6 +39,15 @@ flags:
   frontend:
     paths:
       - frontend/src/
+    carryforward: false
+  # ── deprecated: explicit carryforward off so stale data does not bleed in ──
+  backend-fast:
+    carryforward: false
+  backend-fast-1:
+    carryforward: false
+  backend-fast-2:
+    carryforward: false
+  backend-slow:
     carryforward: false
 
 # 커버리지 계산 제외 — 테스트 코드, 스크립트, 자동 생성

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,18 +4,11 @@
 # Codecov가 PR마다 backend/frontend 커버리지를 별도 배지로 표시
 # 정책: 자동 임계값 + 1% 허용범위 (작은 변동 무시)
 
-# Uploads per event (after slow-split + #612 per-shard unique flag):
-#   - PR:   backend-fast-1 + backend-fast-2 + frontend                  = 3 uploads
-#   - push: backend-fast-1 + backend-fast-2 + backend-slow + frontend   = 4 uploads
-# `after_n_builds` removed — a static value would either hang PRs (waiting
-# for a 4th upload that never comes) or report partial push coverage. Codecov
-# now processes uploads as they arrive; status settles on the final state.
-#
-# #612: shard 별 unique flag — 이전엔 두 shard 가 같은 `backend-fast` 로 업로드,
-# codecov 가 같은 flag/commit 의 후속 upload 를 union 이 아닌 replace 로 처리해
-# shard1-only 라인이 final view 에서 missed 로 나타나는 merge bug 가 발생. 분리하면
-# component_management `backend.*` regex 가 여전히 matches 해 backend component 합산
-# 결과는 동일.
+# Single backend upload (workflow `backend-coverage-merge` job 이 fast shard +
+# slow `.coverage` 를 `coverage combine` 으로 union 한 뒤 단일 XML 을 codecov 에
+# 업로드). 이전엔 shard 별 / slow 별 multi-session upload + component_management
+# `backend.*` regex 머지가 phantom miss (8 files / 46) 를 만들어내는 merge bug
+# (#611~#613) 가 있었음. Pre-upload combine 으로 multi-session merge 자체를 제거.
 codecov:
   notify: {}
 
@@ -31,24 +24,9 @@ coverage:
         threshold: 5%        # 리팩토링(문자열 교체 등)에서 미커버 기존 라인 허용
 
 # Backend = Python (nuri/), Frontend = TypeScript (frontend/src/)
-# backend-fast-{1,2} / backend-slow: workflow 의 shard-split 대응. 모두
-# nuri/ 를 대상으로 하고, component_management 에서 'backend' component 로
-# 합쳐진다 (flag_regexes: backend.*).
+# 두 flag 모두 단일 upload — workflow 가 이미 합산 후 한 번만 업로드한다.
 flags:
-  # carryforward: false (#613) — 직전 PR #612 가 per-shard unique flag 로 분리해도
-  # codecov 페이지에 nuri/ 8 files 46 false-positive misses 잔존. 가설 #2: backend-slow
-  # 가 다수 파일 (예: dashboard.py) 의 line 정보를 포함하지 않아 codecov 가 해당 flag
-  # 에 대해 carryforward 로 stale 데이터 머지 → 머지 결과에 가짜 miss 생성. carryforward
-  # 비활성화로 검증.
-  backend-fast-1:
-    paths:
-      - nuri/
-    carryforward: false
-  backend-fast-2:
-    paths:
-      - nuri/
-    carryforward: false
-  backend-slow:
+  backend:
     paths:
       - nuri/
     carryforward: false
@@ -65,22 +43,6 @@ ignore:
 
 # PR comment 설정 — 변경 파일 + flag별 커버리지 표시
 comment:
-  layout: "diff, flags, components"
+  layout: "diff, flags"
   behavior: default               # 기존 comment 업데이트 (새 comment 생성 X)
   require_changes: true           # 커버리지 변동 없으면 comment 생략
-
-# Component 별 PR 배지
-component_management:
-  default_rules:
-    statuses:
-      - type: project
-        target: auto
-  individual_components:
-    - component_id: backend
-      name: Backend (Python)
-      flag_regexes:
-        - backend.*          # backend-fast-1 / -2 / backend-slow 모두 매치
-    - component_id: frontend
-      name: Frontend (Next.js)
-      flag_regexes:
-        - frontend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,22 @@ filterwarnings = [
 
 
 # ═══════════════════════════════════════════════════════════════
+# coverage.py
+# ═══════════════════════════════════════════════════════════════
+# `relative_files = true` 은 .coverage 에 절대 경로 대신 cwd 기준 상대 경로를
+# 저장한다. CI 의 multi-job `coverage combine` 워크플로우 (각 shard `.coverage`
+# artifact 다운로드 → 합산 → coverage xml) 에서 다음 효과:
+#   - 모든 shard 가 동일 상대 경로로 저장 → combine 이 같은 file 식별자로 union
+#   - `coverage xml` 이 source path 를 상대로 출력 → codecov 가 path 필터
+#     (`flags.backend.paths: [nuri/]`) 매칭 가능 (절대 경로면 매칭 실패)
+# 절대 경로 파일을 codecov 에 업로드하면 flag.backend coverage=0% 가 되며 PR
+# #614 가 정확히 그 증상이었음 (job log 는 통과처럼 보였음 — 82k XML 송신했지만
+# codecov 측에서 nuri/ 파일을 0개로 처리).
+[tool.coverage.run]
+relative_files = true
+
+
+# ═══════════════════════════════════════════════════════════════
 # ruff (lint + isort)
 # ═══════════════════════════════════════════════════════════════
 [tool.ruff]


### PR DESCRIPTION
## Summary

- #611~#613 의 codecov phantom miss (8 files / 46) 가 multi-session merge bug 임을 로컬 재현으로 확정
- 각 test job 이 `.coverage` artifact 만 업로드, 새 `backend-coverage-merge` job 이 `coverage combine` → 단일 XML → 단일 `backend` flag 로 codecov 업로드
- codecov.yml flags 단순화 + component_management 제거

## Why

직전 세션에서 가설 #1 (per-shard unique flag, #612), #2 (carryforward=false, #613) 모두 무효. 로컬 full pytest --cov=nuri 로 8 files 모두 100% statement coverage 확정.

```
Name                                            Stmts   Miss  Cover
nuri/alerts/premarket_brief.py                    342      0   100%
nuri/api/routes/dashboard.py                      267      0   100%
nuri/api/routes/actions.py                        384      0   100%
nuri/core/db/market_data.py                        51      0   100%
nuri/quant/regime/strategy_map.py                 183      0   100%
nuri/trading/agents/consensus/presentation.py      83      0   100%
nuri/analysis/evidence_charts.py                  287      0   100%
nuri/trading/recommend/held_add.py                237      0   100%
TOTAL                                            1834      0   100%
```

Codecov 측 multi-session merge 가 phantom miss 를 만들어내는 원인 — pre-upload combine 으로 multi-session merge 자체를 제거.

## Trade-off

- ✅ "엄밀": 로컬 pytest 결과와 1:1 일치하는 단일 XML 만 codecov 도달
- ✅ codecov.yml 단순화 (component_management 제거, flag 4 → 2)
- 🟡 push CI critical path: `backend-coverage-merge` 가 fast+slow 양쪽 대기 → max(fast, slow) + ~30s combine. 현재 max=2:55 → ~3:25 push only (PR 은 slow 없으니 영향 적음)
- ✅ 무료: `ubuntu-latest` (public repo 4-core) 그대로 사용, 유료 larger runner 미사용

## Verification

로컬 3-way `.coverage` combine 동작 확인:

```
.venv/bin/python -m coverage combine cov-merge-test
# → Combined data file cov-merge-test/.coverage.fast-1
# → Skipping duplicate data ... (3 동일 입력으로 테스트)
.venv/bin/python -m coverage xml -o coverage.xml  # → 785k XML
```

## Test plan

- [ ] PR CI 통과 (frontend + backend + 새 backend-coverage-merge 모두 green)
- [ ] PR comment 에 codecov flag = `backend` 단일 표시 확인
- [ ] push 후 codecov.io commit 페이지에서 nuri/ 8 files miss=0 검증
- [ ] 잔존 시 후속 PR (component_management probe 또는 다른 가설)

🤖 Generated with [Claude Code](https://claude.com/claude-code)