### PR TITLE
perf(ci): pytest-split 4-shard timing-aware split (#615)

### DIFF
--- a/.github/actions/setup-backend-env/action.yml
+++ b/.github/actions/setup-backend-env/action.yml
@@ -14,7 +14,27 @@ runs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ inputs.python-version }}
+        # setup-uv 의 auto-cache 비활성. 이유: setup-uv 의 cache key 가
+        # uv.lock 으로 묶여 있어 lockfile 1 줄 변경 시 venv + uv 캐시 모두 miss
+        # → 4 shards 각각 PyPI 에서 221 packages 재다운로드 (cold ~3min).
+        # 아래 별도 actions/cache 가 broad restore-keys 로 lockfile churn 에도
+        # uv 캐시 hit 보장 (codex consult uv-cache-pattern-2026-05-05 §codex).
         enable-cache: false
+
+    # uv tool 캐시 (wheel 다운로드 저장소). venv cache miss 시 uv sync 가
+    # 이 디렉토리에서 wheel 을 link → PyPI 다운로드 skip → 2:50 → ~30s.
+    # restore-keys 가 broad 매칭이라 lockfile 변경에도 가장 가까운 캐시 reuse.
+    - name: Cache uv tool dir
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/uv-cache
+        key: uv-tool-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          uv-tool-${{ runner.os }}-py${{ inputs.python-version }}-
+
+    - name: Set UV_CACHE_DIR
+      shell: bash
+      run: echo "UV_CACHE_DIR=${{ runner.temp }}/uv-cache" >> "$GITHUB_ENV"
 
     - name: Cache TA-Lib
       id: cache-talib
@@ -54,8 +74,15 @@ runs:
       with:
         path: .venv
         key: venv-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('uv.lock') }}
+        # uv.lock 이 살짝 바뀌어도 (예: pytest-shard → pytest-split, 1줄 diff)
+        # venv cache 가 완전 miss → 221 패키지 재설치를 막기 위한 fallback.
+        # 부분 hit 면 uv sync 가 변경된 패키지만 install (~수초).
+        restore-keys: |
+          venv-${{ runner.os }}-py${{ inputs.python-version }}-
 
     - name: Install deps
       if: steps.cache-venv.outputs.cache-hit != 'true'
       shell: bash
+      # restore-keys 로 일부 복원되었거나 빈 .venv 라면 uv sync 가 ① uv 캐시
+      # (~/.cache/uv) 에서 wheel 즉시 link → 다운로드 skip, ② 변경된 deps 만 추가.
       run: uv sync --frozen --extra dev

--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Skip notice (no backend changes)
         if: needs.changes.outputs.run_backend != 'true'
@@ -400,18 +400,17 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      # pytest-shard splits non-slow tests by hash(test_id) into 2 buckets.
-      # shard-id is 0-indexed but the matrix exposes 1-indexed values.
-      # Slow tests (23, LLM/scheduler) are ALWAYS excluded here and run
-      # separately in backend-tests-slow on push only.
+      # pytest-split (timing-aware) — `pytest-shard` (hash-based) 가 #320 처럼
+      # 테스트 런타임 분포가 치우치면 한 shard 가 전체 wall 을 결정. pytest-split
+      # 은 `.test-durations` (repo 동봉) 의 historical 시간을 읽어 4 shard 를
+      # 균등 분배. 파일 부재 시 test-count balance 로 graceful degrade.
+      # Slow tests (23, LLM/scheduler) 는 backend-tests-slow 에서 별도 push-only.
 
       - name: Run fast tests with coverage
         if: needs.changes.outputs.run_backend == 'true'
         # `--cov-report=` (empty) suppresses XML — backend-coverage-merge 가 모든
         # shard 의 `.coverage` 를 모아 단일 XML 을 만들고 codecov 에 한 번 업로드.
-        # 이전엔 shard 별 XML 을 각각 codecov 에 업로드해 multi-session merge 시
-        # phantom miss (8 files / 46) 가 잔존했음 (#611-#613 history).
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --shard-id=$((${{ matrix.shard }} - 1)) --num-shards=2 --cov=nuri --cov-report= --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --splits 4 --group ${{ matrix.shard }} --cov=nuri --cov-report= --cov-report=term
         timeout-minutes: 5
 
       - name: Upload .coverage artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,11 @@ dependencies = [
 dev = [
     "pytest>=9.0.3",  # security: CVE-2025-71176 tmpdir handling (Dependabot #16)
     "pytest-cov>=7.1.0",
-    "pytest-shard>=0.1.2",
+    # pytest-split: timing-aware test partitioning for CI 4-shard split.
+    # Replaces pytest-shard (hash-based) which produced unbalanced buckets when
+    # test runtimes varied — see #320 history. pytest-split reads `.test-durations`
+    # to balance shards by historical duration.
+    "pytest-split>=0.10.0",
     "pytest-xdist>=3.8.0",
     "ruff>=0.8.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-shard" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -2188,7 +2188,7 @@ requires-dist = [
     { name = "pykrx", specifier = ">=1.2.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
-    { name = "pytest-shard", marker = "extra == 'dev'", specifier = ">=0.1.2" },
+    { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.10.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -3378,15 +3378,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-shard"
-version = "0.1.2"
+name = "pytest-split"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ca/3efa6f3b84dab83220db45997e785be726684c2c2c4267bffb7d80101c7f/pytest-shard-0.1.2.tar.gz", hash = "sha256:b86a967fbfd1c8e50295095ccda031b7e890862ee06531d5142844f4c1d1cd67", size = 3579, upload-time = "2020-12-11T19:52:55.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/7a/dbeb4c54e9fc3b59622f410091365f354a69cda1af10c3b83ac0ca6e6f4f/pytest_shard-0.1.2-py3-none-any.whl", hash = "sha256:407a1df385cebe1feb9b4d2e7eeee8b044f8a24f0919421233159a17c59be2b9", size = 4608, upload-time = "2020-12-11T19:52:54.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #615

## Summary

- `pytest-shard` (hash-based) → `pytest-split` (timing-aware) 전환
- Fast lane matrix `[1, 2]` → `[1, 2, 3, 4]` (각 shard = 자체 4-core public ubuntu-latest)
- 예상 Fast lane wall: 2:55 → ~1:30 (4 buckets × 4-core 병렬, balanced by pytest-split)

## Why

Codex CI consult (`data/llm_consults/2026-05-05_ci-speedup-2026-05-05.md`) priority A. Public `ubuntu-latest` 가 이미 4-core (실측 `created: 4/4 workers`), larger runner 는 public OSS 유료 → 무료 가속 옵션은 shard 수 증가.

`pytest-shard` 는 hash 분배라 #320 처럼 runtime variance 시 효과 반감. `pytest-split` 은 `.test-durations` 의 historical duration 으로 균등.

## Coverage 영향

없음 — fast shard 4 개 모두 `.coverage` artifact 업로드, `backend-coverage-merge` 가 union (PR #614 의 단일 `backend` flag 그대로).

## Trade-off

- ✅ Free tier 만 사용 (larger runner 미사용)
- ✅ 4 shards 분배 더 안정 (hash → timing)
- 🟡 `.test-durations` 미동봉 — 첫 실행은 test-count balance fallback. 후속 commit 에서 generate + commit 가능 (별 소형 PR)

## Test plan

- [ ] PR CI 통과 (4 shards 모두 green)
- [ ] Wall clock 비교: 직전 main `8ae0937` vs 이 PR — fast shard wall < 2 분 확인
- [ ] backend-coverage-merge 동작 정상 (4 artifacts 합산 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)