### PR TITLE
refactor(ci): unify job names to Title Case

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -31,7 +31,7 @@ jobs:
   # Push to main always runs everything (no PR context to filter on).
 
   changes:
-    name: Detect changes
+    name: Detect Changes
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -424,7 +424,7 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
-  # ── Backend Tests (slow) — isolated, push-only ──
+  # ── Backend Slow Tests — isolated, push-only ──
   # Runs the 23 @pytest.mark.slow tests (mostly LLM/scheduler) in a single
   # unsharded job. Push-only: PRs deliberately skip slow tests, matching
   # pre-split behavior (see STRATEGY §4.1 — slow excluded from PR CI).
@@ -432,7 +432,7 @@ jobs:
   # fast shards' flag `backend-fast` for full-suite coverage on main.
 
   backend-tests-slow:
-    name: Backend Tests (slow)
+    name: Backend Slow Tests
     needs: changes
     # Push-only (strict). workflow_dispatch and schedule won't run slow.
     # PR deliberately skips slow (matches pre-split behavior, STRATEGY §4.1).
@@ -470,7 +470,7 @@ jobs:
   # push 에선 fast+slow 모두 합산.
 
   backend-coverage-merge:
-    name: Backend Coverage Merge
+    name: Backend Coverage Aggregate
     needs: [changes, backend-tests-shard, backend-tests-slow]
     if: ${{ !cancelled() && needs.changes.outputs.run_backend == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

3 job name renames for consistency:
- `Detect changes` → `Detect Changes`
- `Backend Tests (slow)` → `Backend Slow Tests`
- `Backend Coverage Merge` → `Backend Coverage Aggregate`

## Why

CI check list 의 시각적 일관성 향상. 모든 job 가 Title Case + 단어 합성 패턴이었으나 위 3 개만 예외였음. \"Merge\" 는 git merge 와 어휘 충돌해 \"Aggregate\" 로 의미 명확화 (이 job 의 실제 동작 = 4 shards artifact aggregate).

## Safety check

\`required_status_checks\` 에 3 개 모두 포함 안 됨 (확인: \`gh api repos/.../branches/main/protection\`):
- 포함된 checks: Backend Tests, Backend Lint, Frontend Tests, Frontend Build, Security Scan, Universe Coverage Validation, Shell Lint, Doc Count Drift Check, Privacy Leak Scan, Frontend Lint
- 변경 대상: Detect Changes / Backend Slow Tests / Backend Coverage Aggregate (모두 비-required)

Job ID 는 그대로 유지 (\`backend-tests-slow\`, \`backend-coverage-merge\`) — 다른 job 의 \`needs:\` 참조 호환.

## Test plan

- [ ] CI pass (모든 job 정상)
- [ ] PR check list 에서 새 이름 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)