### PR TITLE
perf(ci): split slow tests into 2 shards — drop critical path 2:16 → ~1:00

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -415,7 +415,7 @@ jobs:
 
       - name: Upload .coverage artifact
         if: needs.changes.outputs.run_backend == 'true' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-fast-${{ matrix.shard }}
           path: .coverage
@@ -459,7 +459,7 @@ jobs:
 
       - name: Upload .coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-slow-${{ matrix.shard }}
           path: .coverage
@@ -490,7 +490,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: coverage-*
           path: cov-artifacts

--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -431,13 +431,17 @@ jobs:
   # fast shards' flag `backend-fast` for full-suite coverage on main.
 
   backend-tests-slow:
-    name: Backend Slow Tests
+    name: Backend Slow Tests Shard ${{ matrix.shard }}
     needs: changes
     # Push-only (strict). workflow_dispatch and schedule won't run slow.
     # PR deliberately skips slow (matches pre-split behavior, STRATEGY §4.1).
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v6
 
@@ -447,14 +451,17 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run slow tests with coverage
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --cov=nuri --cov-report= --cov-report=term
+        # 23 slow tests (LLM/scheduler) → 2 shards × xdist 4 workers. 단일 shard
+        # 2:16 wall 의 critical path 를 절반 ~1:00-1:15 로 단축 — fast lane (shard
+        # 4 분할 후 ~2:11 wall) 과 같은 critical path 안에 들어옴.
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --splits 2 --group ${{ matrix.shard }} --cov=nuri --cov-report= --cov-report=term
         timeout-minutes: 5
 
       - name: Upload .coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-slow
+          name: coverage-slow-${{ matrix.shard }}
           path: .coverage
           if-no-files-found: ignore
           retention-days: 1

--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -378,7 +378,7 @@ jobs:
   # Only the aggregator name "Backend Tests" is protected.
 
   backend-tests-shard:
-    name: Backend Tests Shard ${{ matrix.shard }}
+    name: Backend Tests · Fast ${{ matrix.shard }}
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -431,7 +431,7 @@ jobs:
   # fast shards' flag `backend-fast` for full-suite coverage on main.
 
   backend-tests-slow:
-    name: Backend Slow Tests Shard ${{ matrix.shard }}
+    name: Backend Tests · Slow ${{ matrix.shard }}
     needs: changes
     # Push-only (strict). workflow_dispatch and schedule won't run slow.
     # PR deliberately skips slow (matches pre-split behavior, STRATEGY §4.1).
@@ -476,7 +476,7 @@ jobs:
   # push 에선 fast+slow 모두 합산.
 
   backend-coverage-merge:
-    name: Backend Coverage Aggregate
+    name: Backend Tests · Coverage Aggregate
     needs: [changes, backend-tests-shard, backend-tests-slow]
     if: ${{ !cancelled() && needs.changes.outputs.run_backend == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Slow tests (23 LLM/scheduler tests) 는 push-only 단일 job 으로 2:16 wall — 현재 main push CI 의 진짜 critical path. PR #617 의 4-shard fast 가속이 total CI 를 줄이지 못한 (3:24 → 3:44 +20s) 진짜 원인.

이 PR: slow 도 2-shard pytest-split 적용 → critical path 절반.

## Why

`gh run view` 토탈 비교:
- pre #614 (`2e73966`): **3:19**
- post #614 (`8ae0937`): 3:24
- post #617 (`3ac7475`): **3:44** ← 현 main, 오히려 19s 악화

원인: 4-shard fast 가속 (2:54 → 2:11) 했지만 slow 가 더 긴 critical leg 라 fast 단축이 total 에 반영 안 됨.

## Fix

```yaml
backend-tests-slow:
  strategy:
    matrix:
      shard: [1, 2]
  ...
  run: pytest -m "slow" --splits 2 --group ${{ matrix.shard }} ...
```

## Expected timings

- Slow shard wall: 2:16 → ~1:00 (12 tests × xdist 4 worker)
- Critical path = max(fast 2:11, slow ~1:00) = **2:11**
- Total CI: 2:11 + Aggregate (25s) + agg (2s) ≈ **2:38**
- 즉 3:44 → 2:38 = **66s 단축, 30%**

## Coverage

- artifact 이름 `coverage-slow-1` / `coverage-slow-2` 로 분리
- `backend-coverage-merge` 의 `coverage-*` glob 가 두 shard 매칭
- 결과 동일한 단일 backend flag

## Test plan

- [ ] PR CI 통과 (slow 는 push-only 라 PR 에선 skipping 표시)
- [ ] 머지 후 main push CI total 측정 — 목표 < 3:00
- [ ] backend coverage 정상 (187 files, 99.77%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)