### PR TITLE
fix(docker): COPY README.md + nuri/ for hatchling editable build (#621)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -47,7 +47,11 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /usr/local/bin/
 
 # ── Python deps (project sync) ────────────────────────────────
 WORKDIR /workspace
-COPY pyproject.toml uv.lock ./
+# pyproject.toml 의 `readme = "README.md"` 를 hatchling build_editable 이
+# 검증 → README.md 누락 시 OSError. editable install 모드라 nuri/ 패키지
+# 코드도 필요 (단, CI 사용 시 mount 로 덮여 무관).
+COPY pyproject.toml uv.lock README.md ./
+COPY nuri/ ./nuri/
 # UV_CACHE_DIR persistent so subsequent uv sync (in CI) reuses wheels.
 ENV UV_CACHE_DIR=/root/.cache/uv
 RUN uv sync --frozen --extra dev


### PR DESCRIPTION
PR #623 의 첫 image build (run #1) 가 \`OSError: Readme file does not exist: README.md\` 로 실패. hatchling 이 \`pyproject.toml\` 의 \`readme = \"README.md\"\` 검증.

## Fix

- COPY README.md (hatchling readme 검증 통과)
- COPY nuri/ (editable install 시 패키지 코드 필요)

CI 사용 시 actions/checkout 가 mount 하므로 image 내 nuri/ 는 덮여 무관 — build-time validation 통과만 보장.

## Test plan

- [ ] PR CI 통과 (Dockerfile.ci 변경 → build-ci-image workflow 자동 트리거)
- [ ] image 가 GHCR 에 push 됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)