### PR TITLE
fix(deploy): correct PROJECT_ROOT path in deploy_to_mini.sh

### DIFF
--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -23,7 +23,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# scripts/deploy/.. = scripts/, .. 한 번 더 → repo root.
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${PROJECT_ROOT}"
 
 REMOTE="${DEV2_HOST:-}"


### PR DESCRIPTION
## Summary

\`scripts/deploy/deploy_to_mini.sh\` 의 PROJECT_ROOT 계산 버그 fix.

## Root cause

\`\`\`bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"  # scripts/deploy/
PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"               # ❌ scripts/  (한 단계만 올라감)
\`\`\`

스크립트가 \`scripts/deploy/\` 에 있으므로 \`..\` 한 번은 \`scripts/\` 까지만 올라감. config sync step 의 \`[[ -f \${PROJECT_ROOT}/.env ]]\` 가 \`scripts/.env\` 를 검사 → 항상 false → \`.env\` / \`config/portfolio.yaml\` / \`NEXT_SESSION.md\` 동기화 전혀 작동 안 함 ("0개 파일 동기화").

## Fix

\`\`\`bash
PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"  # ✅ repo root
\`\`\`

## Verification

\`\`\`
[3/6] config 동기화 (.env, portfolio.yaml, NEXT_SESSION.md)
  ✓ .env
  ✓ config/portfolio.yaml
  ✓ NEXT_SESSION.md
  3개 파일 동기화
\`\`\`

## Test plan

- [x] 로컬 \`make deploy-mini\` 실행 → 3 files 정상 동기화 확인
- [ ] CI green (shellcheck pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)