### PR TITLE
test(coverage): close 4 print_candidates partials — Phase 3-B4 (#616)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,785 backend tests across 243 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,788 backend tests across 244 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,785 tests, 243 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,788 tests, 244 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/trading/recommend/test_candidates_3b2.py
+++ b/tests/trading/recommend/test_candidates_3b2.py
@@ -66,7 +66,8 @@ class TestLoadScorecardMissingBranches:
         if not SELL_SIGNALS:
             pytest.skip("SELL_SIGNALS 비어있음 — 회귀 시 skip")
 
-        sell_sig = next(iter(SELL_SIGNALS))
+        # 결정적 선택 (PYTHONHASHSEED 영향 회피).
+        sell_sig = sorted(SELL_SIGNALS)[0]
         report_dir = tmp_path / "reports_stale_sell"
         day_dir = report_dir / "2026-04-30"
         day_dir.mkdir(parents=True)

--- a/tests/trading/recommend/test_candidates_3b3.py
+++ b/tests/trading/recommend/test_candidates_3b3.py
@@ -1,3 +1,4 @@
+# cspell:ignore noact LOWTR SELLT SELLOK nondir lowsev
 """screen_candidates main flow — Issue #616 Phase 3-B3.
 
 candidates.py 의 main loop / drift / catalyst / conflict / scorecard-stale 분기 닫음.
@@ -198,7 +199,9 @@ class TestScreenCandidatesNotesAndScoring:
         rsi_cands = [c for c in result if c.signal_id == "rsi_oversold"]
         assert rsi_cands
         c = rsi_cands[0]
-        assert c.scoring_detail["drift_multiplier"] == 0.3
+        sd = c.scoring_detail
+        assert sd is not None
+        assert sd["drift_multiplier"] == 0.3
         assert "critical" in c.notes
 
     def test_scorecard_stale_appends_warning(self, tmp_path):
@@ -241,13 +244,15 @@ class TestSellCatalystDowngrade:
         """277-283, 368: SELL ACTIONABLE + no catalyst → tier=ADVISORY, note '근거 없음'."""
         import pytest
 
-        from nuri.quant.validation.signal_backtest import SELL_SIGNALS
+        from nuri.quant.validation.signal_backtest import SELL_SIGNALS, SIGNAL_DEFINITIONS
         from nuri.trading.recommend.candidates import screen_candidates
 
-        if not SELL_SIGNALS:
-            pytest.skip("SELL_SIGNALS 비어있음")
+        # SHADOW signal 제외 — SIGNAL_DEFINITIONS (active) ∩ SELL_SIGNALS, 정렬해서 결정적.
+        active_sells = sorted(set(SELL_SIGNALS) & set(SIGNAL_DEFINITIONS.keys()))
+        if not active_sells:
+            pytest.skip("active SELL signal 없음")
 
-        sell_sig = next(iter(SELL_SIGNALS))
+        sell_sig = active_sells[0]
 
         p = tmp_path / "sell.db"
         init_db(p)
@@ -291,13 +296,14 @@ class TestSellCatalystDowngrade:
         """282-283: SELL ACTIONABLE + catalyst 있음 → tier 유지, catalyst_note 기록."""
         import pytest
 
-        from nuri.quant.validation.signal_backtest import SELL_SIGNALS
+        from nuri.quant.validation.signal_backtest import SELL_SIGNALS, SIGNAL_DEFINITIONS
         from nuri.trading.recommend.candidates import screen_candidates
 
-        if not SELL_SIGNALS:
-            pytest.skip("SELL_SIGNALS 비어있음")
+        active_sells = sorted(set(SELL_SIGNALS) & set(SIGNAL_DEFINITIONS.keys()))
+        if not active_sells:
+            pytest.skip("active SELL signal 없음")
 
-        sell_sig = next(iter(SELL_SIGNALS))
+        sell_sig = active_sells[0]
 
         p = tmp_path / "sell_cat.db"
         init_db(p)
@@ -333,7 +339,9 @@ class TestSellCatalystDowngrade:
         c = sell_cands[0]
         # ACTIONABLE 유지 (catalyst 존재) + scoring_detail catalyst_note 기록
         assert c.tier == "actionable"
-        assert c.scoring_detail["catalyst_note"].startswith("catalyst:")
+        sd = c.scoring_detail
+        assert sd is not None
+        assert sd["catalyst_note"].startswith("catalyst:")
 
 
 # ═══════════════════════════════════════════════════════
@@ -416,7 +424,9 @@ class TestConflictDetectionBranches:
         # high 할인 없음 → notes 에 충돌 텍스트 없음.
         assert "충돌" not in c.notes
         # 418 False → 419-422 skip. conflict_penalty 는 1.0 으로 기록 (424 block 은 항상 실행).
-        assert c.scoring_detail["conflict_penalty"] == 1.0
+        sd = c.scoring_detail
+        assert sd is not None
+        assert sd["conflict_penalty"] == 1.0
 
     def test_detect_conflicts_exception_is_swallowed(self, tmp_path):
         """427-428: detect_conflicts raise → except 흡수 → 후보 정상 반환."""

--- a/tests/trading/recommend/test_candidates_3b4.py
+++ b/tests/trading/recommend/test_candidates_3b4.py
@@ -1,0 +1,129 @@
+"""print_candidates branch coverage — Issue #616 Phase 3-B4.
+
+candidates.py 의 print 분기 닫음. CLI block (525-532) 은 관행상 제외.
+
+| line | branch / stmt | trigger |
+|---|---|---|
+| 477 | `elif vix_gate=="caution":` | vix_gate caution |
+| 492 | `flags.append("UNSCORED")` | unscored=True |
+| 496 | `flags.append("CONF")` | conflict 표시 + tier 가 _print_table 대상 |
+| 500-501 | unscored 시 wr/pf 를 "—" 로 표시 | unscored=True |
+| 512 | advisory _print_table | advisory + regime_fit=True |
+| 514 | avoid _print_table | avoid + regime_fit=True |
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def _make_candidate(**overrides):
+    """기본 ACTIONABLE BUY candidate. overrides 로 필드 변경."""
+    from nuri.trading.recommend.candidates import TIER_ACTIONABLE, Candidate
+
+    base = {
+        "ticker": "TEST",
+        "signal_id": "rsi_oversold",
+        "signal_date": "2026-03-30",
+        "direction": "BUY",
+        "confidence": 50.0,
+        "win_rate": 0.6,
+        "profit_factor": 1.5,
+        "regime_fit": True,
+        "price": 100.0,
+        "notes": "test",
+        "drift_status": "",
+        "conflict": "",
+        "scoring_detail": None,
+        "unscored": False,
+        "tier": TIER_ACTIONABLE,
+    }
+    base.update(overrides)
+    return Candidate(**base)
+
+
+# ═══════════════════════════════════════════════════════
+# 477: VIX caution 분기
+# ═══════════════════════════════════════════════════════
+
+
+class TestPrintVixCaution:
+    def test_vix_caution_prints_warning(self, capsys):
+        """477: vix_gate=='caution' → 경고 print."""
+        from nuri.trading.recommend.candidates import print_candidates
+
+        candidates = [_make_candidate()]
+        with patch(
+            "nuri.trading.recommend.candidates._check_vix_gate",
+            return_value={"vix": 27.0, "gate": "caution", "msg": "VIX 27.0 caution"},
+        ):
+            print_candidates(candidates)
+
+        out = capsys.readouterr().out
+        assert "27.0 caution" in out  # 477 line 의 print 출력 확인
+
+
+# ═══════════════════════════════════════════════════════
+# 492, 496, 500-501: unscored + conflict flags / unscored wr/pf 표시
+# ═══════════════════════════════════════════════════════
+
+
+class TestPrintFlags:
+    def test_unscored_and_conflict_flags_printed(self, capsys):
+        """492 + 496 + 500-501: unscored=True + conflict 표시 → flags + '—' 표시."""
+        from nuri.trading.recommend.candidates import print_candidates
+
+        # ACTIONABLE + regime_fit=True → _print_table 대상이 되도록.
+        candidates = [
+            _make_candidate(
+                unscored=True,
+                conflict="direction_conflict",
+                drift_status="critical",
+            ),
+        ]
+        with patch(
+            "nuri.trading.recommend.candidates._check_vix_gate",
+            return_value={"vix": 15, "gate": "normal", "msg": ""},
+        ):
+            print_candidates(candidates)
+
+        out = capsys.readouterr().out
+        # 492: UNSCORED flag 출력
+        assert "UNSCORED" in out
+        # 496: CONF flag 출력
+        assert "CONF" in out
+        # 500-501: unscored 시 wr/pf 자리에 "—" 표시
+        assert "—" in out  # em-dash for missing stats
+
+
+# ═══════════════════════════════════════════════════════
+# 512, 514: advisory / avoid _print_table
+# ═══════════════════════════════════════════════════════
+
+
+class TestPrintTierTables:
+    def test_advisory_and_avoid_tables_printed(self, capsys):
+        """512 + 514: regime_fit=True + tier ADVISORY/AVOID → 별도 table 출력."""
+        from nuri.trading.recommend.candidates import (
+            TIER_ADVISORY,
+            TIER_AVOID,
+            print_candidates,
+        )
+
+        candidates = [
+            _make_candidate(ticker="ADV", tier=TIER_ADVISORY, notes="low-sample"),
+            _make_candidate(ticker="AVD", tier=TIER_AVOID, notes="negative-edge"),
+        ]
+        with patch(
+            "nuri.trading.recommend.candidates._check_vix_gate",
+            return_value={"vix": 15, "gate": "normal", "msg": ""},
+        ):
+            print_candidates(candidates)
+
+        out = capsys.readouterr().out
+        # 512: Advisory table title
+        assert "Advisory" in out
+        assert "ADV" in out
+        # 514: Avoid table title
+        assert "Avoid" in out
+        assert "AVD" in out


### PR DESCRIPTION
## Summary

#616 Phase 3-B4 — `nuri/trading/recommend/candidates.py` 의 `print_candidates` 분기 닫음.

| line | branch / stmt | trigger |
|---|---|---|
| 477 | `elif vix_gate == "caution":` | vix_gate caution |
| 492 | `flags.append("UNSCORED")` | `unscored=True` |
| 496 | `flags.append("CONF")` | `conflict` 표시 + tier 가 `_print_table` 대상 |
| 500-501 | unscored 시 wr/pf 자리에 `"—"` | `unscored=True` |
| 512 | advisory `_print_table` | `tier=ADVISORY` + `regime_fit=True` |
| 514 | avoid `_print_table` | `tier=AVOID` + `regime_fit=True` |

Coverage: **95% → 97%**, BrPart 11 → 5, Stmt miss 13 → 6 on `nuri/trading/recommend/candidates.py`.

## Phase 3-B 완료 요약

| sub | file | partials closed | coverage |
|---|---|---|---|
| 3-B1 | `ls_backtest.py` | 5/6 | 99% 유지 |
| 3-B2 | `candidates.py` helpers | 4 | 85→88% |
| 3-B3 | `candidates.py` main flow | 11 | 88→95% |
| 3-B4 | `candidates.py` print | 6 | 95→97% |

## 잔존 (별도 처리)

**dead-by-design 누적** (별도 simplify issue 후보 — 등록 시기 도래):
- `candidates.py`: 421→424, 424→413, 439→435, 447→443
- `ls_backtest.py`: 604→591
- `publisher.py`: 3 partials (NEXT_SESSION L43-49)
- `recovery_detector.py`: 2 partials (PR #624 잔존)

**제외**: `candidates.py` 525-532 `if __name__ == "__main__"` (관행)

## Changes

- `tests/trading/recommend/test_candidates_3b4.py` (new file, 3 tests)
- Doc count sync: 243 → 244 backend test files, 5,785 → 5,788 tests

## Test plan

- [x] `pytest tests/trading/recommend/test_candidates_3b4.py` — 3 pass
- [x] Combined coverage 97%, BrPart 5
- [x] `make verify-doc-counts` 13/13
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)