### PR TITLE
refactor(coverage): remove dead-by-design conditional branches (#638)

### DIFF
--- a/nuri/agents/discord/publisher.py
+++ b/nuri/agents/discord/publisher.py
@@ -339,8 +339,8 @@ def publish(
     global _singleton
     if _singleton is None:
         _singleton = DiscordPublisher()
-    if isinstance(channel, str):
-        channel = Channel(channel)
+    # Channel(str, Enum) — str 도 받아 Enum 반환 (재호출도 안전).
+    channel = Channel(channel)
     return _singleton.publish_text(channel, content, actor_name, run_id, decision_id)
 
 

--- a/nuri/trading/recommend/candidates.py
+++ b/nuri/trading/recommend/candidates.py
@@ -8,6 +8,7 @@ E-1: 시그널 기반 후보 스크리너.
     python -m nuri.trading.recommend.candidates
     python -m nuri.trading.recommend.candidates --days 3
 """
+
 import argparse
 import logging
 from dataclasses import dataclass
@@ -33,35 +34,36 @@ REPORT_DIR = Path(__file__).parent.parent.parent.parent / "data" / "reports"
 
 # Evidence tier thresholds — B-2-ext per codex mid-review (2026-04-17)
 # 증거 품질로 3분류해서 scoring 이 약한 근거를 legitimize 하지 못하도록 차단.
-MIN_TRADES_FOR_VALIDATION = 30   # 30+ trades = statistically validated sample
+MIN_TRADES_FOR_VALIDATION = 30  # 30+ trades = statistically validated sample
 NEGATIVE_EDGE_PF_THRESHOLD = 1.0  # PF < 1.0 = losses > gains = avoid
 
 TIER_ACTIONABLE = "actionable"  # validated + adequate sample + positive edge
-TIER_ADVISORY = "advisory"      # unscored OR low-sample (disclosure only)
-TIER_AVOID = "avoid"            # validated negative edge (do NOT act on signal alone)
+TIER_ADVISORY = "advisory"  # unscored OR low-sample (disclosure only)
+TIER_AVOID = "avoid"  # validated negative edge (do NOT act on signal alone)
 
 
 @dataclass
 class Candidate:
     """매매 후보."""
+
     ticker: str
     signal_id: str
     signal_date: str
-    direction: str          # "BUY" or "SELL"
-    confidence: float       # 0~100
+    direction: str  # "BUY" or "SELL"
+    confidence: float  # 0~100
     win_rate: float
     profit_factor: float
     regime_fit: bool
     price: float
     notes: str
-    drift_status: str = ""          # "stable", "degrading", "critical" (from Learning Memory)
-    conflict: str = ""              # "" or "direction_conflict" (from Conflict Detection)
+    drift_status: str = ""  # "stable", "degrading", "critical" (from Learning Memory)
+    conflict: str = ""  # "" or "direction_conflict" (from Conflict Detection)
     scoring_detail: dict | None = None  # confidence 계산 요인 기록
-    unscored: bool = False          # True = signal 이 scorecard 에 없음 → 통계 미검증
-                                    # (이전 폴백 win_rate=0.5/pf=1.0 제거, B-2 honesty fix)
-    tier: str = TIER_ACTIONABLE     # "actionable" | "advisory" | "avoid"
-                                    # codex B-2-ext: 증거 품질 bucket split. advisory/avoid
-                                    # 는 normal recommendation 에 섞이지 않음 (개별 섹션).
+    unscored: bool = False  # True = signal 이 scorecard 에 없음 → 통계 미검증
+    # (이전 폴백 win_rate=0.5/pf=1.0 제거, B-2 honesty fix)
+    tier: str = TIER_ACTIONABLE  # "actionable" | "advisory" | "avoid"
+    # codex B-2-ext: 증거 품질 bucket split. advisory/avoid
+    # 는 normal recommendation 에 섞이지 않음 (개별 섹션).
 
 
 def _load_scorecard() -> tuple[dict[str, dict], int | None]:
@@ -85,6 +87,7 @@ def _load_scorecard() -> tuple[dict[str, dict], int | None]:
                 age_days = None
                 try:
                     from nuri.core.timezone import kst_now
+
                     dir_date = datetime.strptime(d.name, "%Y-%m-%d")
                     age_days = (kst_now().replace(tzinfo=None) - dir_date).days
                 except ValueError:
@@ -106,8 +109,7 @@ def _load_scorecard() -> tuple[dict[str, dict], int | None]:
                 }
                 # Pre-B-1 cache detection: post-fix SELL 는 전부 PF<1 여야 함.
                 # SELL 중 PF>1 가 있으면 옛 측정 → 해당 시그널만 drop (unscored 로 fallback).
-                stale_sells = [sid for sid in _SELL_SIGNALS
-                               if sid in data and data[sid]["profit_factor"] > 1.0]
+                stale_sells = [sid for sid in _SELL_SIGNALS if sid in data and data[sid]["profit_factor"] > 1.0]
                 if stale_sells:
                     logger.warning(
                         "scorecard pre-B-1 (buy-perspective SELL) 데이터 감지: %s. "
@@ -124,6 +126,7 @@ def _get_drift_map(db_path=None) -> dict[str, dict]:
     """Learning Memory에서 시그널별 성과 변화(drift) 로드."""
     try:
         from nuri.trading.engine.memory import detect_drift
+
         drifts = detect_drift(db_path=db_path)
         return {d.signal_id: {"status": d.status, "drift_pct": d.drift_pct} for d in drifts}
     except Exception:
@@ -132,9 +135,9 @@ def _get_drift_map(db_path=None) -> dict[str, dict]:
 
 # drift 상태별 confidence 배수
 DRIFT_MULTIPLIERS = {
-    "critical": 0.3,    # 성과 급락 → 70% 할인
-    "degrading": 0.6,   # 성과 하락 → 40% 할인
-    "improving": 1.1,   # 성과 개선 → 10% 가점
+    "critical": 0.3,  # 성과 급락 → 70% 할인
+    "degrading": 0.6,  # 성과 하락 → 40% 할인
+    "improving": 1.1,  # 성과 개선 → 10% 가점
     "stable": 1.0,
 }
 
@@ -144,6 +147,7 @@ def _get_regime_context(db_path=None) -> dict | None:
     try:
         from nuri.quant.regime.classifier import classify_regime
         from nuri.quant.regime.strategy_map import map_regime_to_strategy
+
         regime = classify_regime(db_path=db_path)
         if regime is None:
             return None
@@ -212,7 +216,8 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
     for ticker in tickers:
         df = query_df(
             "SELECT date, open, high, low, close, volume FROM prices WHERE ticker = ? ORDER BY date",
-            (ticker,), db_path=db_path,
+            (ticker,),
+            db_path=db_path,
         )
         if df.empty or len(df) < 50:
             continue
@@ -235,6 +240,7 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
             # 섞어 confidence/tier 에 간접 반영하지 않도록 분리". surface 는 별도
             # market_signals.detect_all() 로 UI 노출.
             from nuri.core.signal_config import is_actionable
+
             if not is_actionable(signal_id):
                 continue
 
@@ -275,6 +281,7 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
                 catalyst_note = ""
                 if direction == "SELL" and tier == TIER_ACTIONABLE:
                     from nuri.core.catalyst import has_recent_catalyst
+
                     has_catalyst, catalyst_reason = has_recent_catalyst(ticker, db_path=db_path)
                     if not has_catalyst:
                         tier = TIER_ADVISORY
@@ -333,7 +340,7 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
                     # 전체 승률 기반 (레짐 무관). win_rate/pf 는 scorecard 실측.
                     pf_normalized = min(pf / 5.0, 1.0)
                     regime_bonus = 1.0 if regime_fit else 0.3
-                    confidence = (win_rate * 40 + pf_normalized * 30 + regime_bonus * 30)
+                    confidence = win_rate * 40 + pf_normalized * 30 + regime_bonus * 30
                     scoring["base_confidence"] = round(confidence, 2)
 
                 # 레짐 비적합 시 할인
@@ -382,26 +389,29 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
                 # 최종 confidence 기록
                 scoring["final_confidence"] = round(confidence, 2)
 
-                candidates.append(Candidate(
-                    ticker=ticker,
-                    signal_id=signal_id,
-                    signal_date=df["date"].iloc[entry_idx].strftime("%Y-%m-%d"),
-                    direction=direction,
-                    confidence=round(confidence, 1),
-                    win_rate=round(win_rate, 3),
-                    profit_factor=round(pf, 2),
-                    regime_fit=regime_fit,
-                    price=round(float(df["close"].iloc[entry_idx]), 2),
-                    notes="; ".join(notes_parts),
-                    drift_status=drift_status,
-                    scoring_detail=scoring,
-                    unscored=unscored,
-                    tier=tier,
-                ))
+                candidates.append(
+                    Candidate(
+                        ticker=ticker,
+                        signal_id=signal_id,
+                        signal_date=df["date"].iloc[entry_idx].strftime("%Y-%m-%d"),
+                        direction=direction,
+                        confidence=round(confidence, 1),
+                        win_rate=round(win_rate, 3),
+                        profit_factor=round(pf, 2),
+                        regime_fit=regime_fit,
+                        price=round(float(df["close"].iloc[entry_idx]), 2),
+                        notes="; ".join(notes_parts),
+                        drift_status=drift_status,
+                        scoring_detail=scoring,
+                        unscored=unscored,
+                        tier=tier,
+                    )
+                )
 
     # ── Conflict Detection: 방향 충돌 감지 + annotate ──
     try:
         from nuri.trading.engine.conflicts import detect_conflicts
+
         conflicts = detect_conflicts(candidates)
         # 충돌 종목 세트
         conflict_tickers = {}
@@ -410,6 +420,8 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
                 conflict_tickers[cf.ticker] = cf.severity
 
         # 충돌 종목의 후보에 표시 + high severity면 confidence 할인
+        # screen_candidates 가 생성한 candidate 는 항상 fresh (notes 에 "충돌" 사전 부재)
+        # 하고 scoring_detail dict 가 항상 set 되므로 None 가드 불필요.
         for c in candidates:
             if c.ticker in conflict_tickers:
                 c.conflict = "direction_conflict"
@@ -418,12 +430,9 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
                 if sev == "high":
                     conflict_penalty = 0.5
                     c.confidence *= conflict_penalty
-                    if "충돌" not in c.notes:
-                        c.notes += "; BUY/SELL 충돌(관망 권장)" if c.notes else "BUY/SELL 충돌(관망 권장)"
-                # scoring_detail에 충돌 페널티 기록
-                if c.scoring_detail is not None:
-                    c.scoring_detail["conflict_penalty"] = conflict_penalty
-                    c.scoring_detail["final_confidence"] = round(c.confidence, 2)
+                    c.notes += "; BUY/SELL 충돌(관망 권장)" if c.notes else "BUY/SELL 충돌(관망 권장)"
+                c.scoring_detail["conflict_penalty"] = conflict_penalty
+                c.scoring_detail["final_confidence"] = round(c.confidence, 2)
     except Exception as e:
         logger.debug(f"Conflict detection 실패: {e}")
 
@@ -431,22 +440,21 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
     # A-2b-pre: scoring_detail["final_confidence"] 도 함께 업데이트해야 A-2b
     # audit trail 이 stale 하지 않음 (codex A-2b-pre review Medium finding).
     # `vix_penalty` 필드 기록해 어느 경로로 discount 됐는지 surface.
+    # screen_candidates 가 생성한 candidate 는 항상 scoring_detail dict 보유 → None 가드 불필요.
     if vix_gate["gate"] == "blocked":
         for c in candidates:
             if c.direction == "BUY":
                 c.confidence = 0  # VIX > 30: BUY 후보 전부 차단
                 c.notes = (c.notes + "; " if c.notes else "") + vix_gate["msg"]
-                if c.scoring_detail is not None:
-                    c.scoring_detail["vix_penalty"] = 0.0
-                    c.scoring_detail["final_confidence"] = 0.0
+                c.scoring_detail["vix_penalty"] = 0.0
+                c.scoring_detail["final_confidence"] = 0.0
     elif vix_gate["gate"] == "caution":
         for c in candidates:
             if c.direction == "BUY":
                 c.confidence *= 0.5  # VIX 25~30: 절반 포지션
                 c.notes = (c.notes + "; " if c.notes else "") + vix_gate["msg"]
-                if c.scoring_detail is not None:
-                    c.scoring_detail["vix_penalty"] = 0.5
-                    c.scoring_detail["final_confidence"] = round(c.confidence, 2)
+                c.scoring_detail["vix_penalty"] = 0.5
+                c.scoring_detail["final_confidence"] = round(c.confidence, 2)
 
     # confidence 내림차순
     candidates.sort(key=lambda c: c.confidence, reverse=True)
@@ -475,16 +483,20 @@ def print_candidates(candidates: list[Candidate]) -> None:
         print(f"  ⚠ {vix_gate['msg']}")
     elif vix_gate["gate"] == "caution":
         print(f"  ⚠ {vix_gate['msg']}")
-    print(f"  Signal-Based Candidates — tier split ({len(actionable)} actionable / "
-          f"{len(advisory)} advisory / {len(avoid)} avoid, 충돌 "
-          f"{len(set(c.ticker for c in conflicted))}종목)")
+    print(
+        f"  Signal-Based Candidates — tier split ({len(actionable)} actionable / "
+        f"{len(advisory)} advisory / {len(avoid)} avoid, 충돌 "
+        f"{len(set(c.ticker for c in conflicted))}종목)"
+    )
     print(f"{'=' * 85}")
 
     def _print_table(title, items, limit=15):
         if not items:
             return
         print(f"\n  {title} ({len(items)}건)")
-        print(f"  {'Ticker':<8} {'Signal':<18} {'Date':<12} {'Conf':>5} {'WR':>6} {'PF':>6} {'Price':>10} {'Flags':<12}")
+        print(
+            f"  {'Ticker':<8} {'Signal':<18} {'Date':<12} {'Conf':>5} {'WR':>6} {'PF':>6} {'Price':>10} {'Flags':<12}"
+        )
         print(f"  {'-' * 80}")
         for c in items[:limit]:
             flags = []
@@ -502,8 +514,10 @@ def print_candidates(candidates: list[Candidate]) -> None:
             else:
                 wr_str = f"{c.win_rate:>5.0%}"
                 pf_str = f"{c.profit_factor:>5.1f}"
-            print(f"  {c.ticker:<8} {c.signal_id:<18} {c.signal_date:<12} "
-                  f"{c.confidence:>4.0f} {wr_str:>6} {pf_str:>6} ${c.price:>9,.2f} {flag_str:<12}")
+            print(
+                f"  {c.ticker:<8} {c.signal_id:<18} {c.signal_date:<12} "
+                f"{c.confidence:>4.0f} {wr_str:>6} {pf_str:>6} ${c.price:>9,.2f} {flag_str:<12}"
+            )
 
     # B-2-ext: tier 분리 표시 — actionable → advisory → avoid
     _print_table("✅ Actionable BUY", buys)

--- a/nuri/trading/strategy/ls_backtest.py
+++ b/nuri/trading/strategy/ls_backtest.py
@@ -9,6 +9,7 @@ Long/Short Strategy Backtest — 과거 5년 검증.
     python -m nuri.trading.strategy.ls_backtest
     python -m nuri.trading.strategy.ls_backtest --stress    # 위기 구간 분석
 """
+
 import argparse
 import logging
 from dataclasses import dataclass
@@ -25,26 +26,27 @@ REPORT_DIR = Path(__file__).parent.parent.parent.parent / "data" / "reports"
 
 # 레짐 → 배분 (longshort.py와 동일)
 REGIME_ALLOCATION = {
-    "bull_low_vol":     {"long": 0.90, "short": 0.00, "cash": 0.10},
-    "bull_high_vol":    {"long": 0.70, "short": 0.00, "cash": 0.30},
+    "bull_low_vol": {"long": 0.90, "short": 0.00, "cash": 0.10},
+    "bull_high_vol": {"long": 0.70, "short": 0.00, "cash": 0.30},
     "sideways_low_vol": {"long": 0.50, "short": 0.00, "cash": 0.50},
-    "sideways_high_vol":{"long": 0.25, "short": 0.15, "cash": 0.60},
-    "bear_low_vol":     {"long": 0.10, "short": 0.40, "cash": 0.50},
-    "bear_high_vol":    {"long": 0.00, "short": 0.50, "cash": 0.50},
+    "sideways_high_vol": {"long": 0.25, "short": 0.15, "cash": 0.60},
+    "bear_low_vol": {"long": 0.10, "short": 0.40, "cash": 0.50},
+    "bear_high_vol": {"long": 0.00, "short": 0.50, "cash": 0.50},
 }
 
 TRANSACTION_COST = 0.001  # 편도 0.1%
-SLIPPAGE = 0.0005         # 편도 0.05% 슬리피지
+SLIPPAGE = 0.0005  # 편도 0.05% 슬리피지
 
 
 @dataclass
 class BacktestResult:
     """백테스트 결과."""
+
     total_return: float
     annual_return: float
     sharpe: float
     max_drawdown: float
-    win_rate: float             # 양수 수익 일수 비율
+    win_rate: float  # 양수 수익 일수 비율
     total_days: int
     regime_changes: int
     transaction_costs: float
@@ -61,19 +63,21 @@ class BacktestResult:
 @dataclass
 class RegimePerformance:
     """레짐별 성과."""
+
     regime: str
     days: int
     pct_of_total: float
     avg_daily_return: float
     total_return: float
     win_rate: float
-    avg_duration: float         # 평균 지속 일수
-    transitions_to: dict        # 다음 레짐 확률
+    avg_duration: float  # 평균 지속 일수
+    transitions_to: dict  # 다음 레짐 확률
 
 
 @dataclass
 class TimingAnalysis:
     """현재 레짐에서의 향후 수익률 분석."""
+
     current_regime: str
     occurrences: int
     avg_forward_30d: float
@@ -131,7 +135,6 @@ def classify_historical_regimes(db_path=None, sma_period: int = 50) -> pd.DataFr
     # 레짐 분류
     regimes = []
     for idx, row in spy.iterrows():
-
         close = row["close"]
         sma_fast = row["sma_fast"]
         sma200 = row["sma200"]
@@ -439,10 +442,7 @@ def run_backtest(regimes_df: pd.DataFrame, db_path=None) -> BacktestResult:
             short_ret = -spy_ret  # SH 데이터 없으면 이론값
 
         # 전략 수익률
-        strat_ret = (alloc["long"] * spy_ret
-                     + alloc["short"] * short_ret
-                     + alloc["cash"] * 0
-                     - cost)
+        strat_ret = alloc["long"] * spy_ret + alloc["short"] * short_ret + alloc["cash"] * 0 - cost
 
         strategy_returns.append(strat_ret)
         spy_returns.append(spy_ret)
@@ -536,22 +536,24 @@ def analyze_per_regime(regimes_df: pd.DataFrame) -> list[RegimePerformance]:
         # 다음 레짐 전환 확률
         transitions = {}
         for i in range(len(df) - 1):
-            if df.iloc[i]["regime"] == regime and df.iloc[i+1]["regime"] != regime:
-                next_r = df.iloc[i+1]["regime"]
+            if df.iloc[i]["regime"] == regime and df.iloc[i + 1]["regime"] != regime:
+                next_r = df.iloc[i + 1]["regime"]
                 transitions[next_r] = transitions.get(next_r, 0) + 1
         total_trans = sum(transitions.values()) or 1
-        transitions = {k: round(v/total_trans, 2) for k, v in transitions.items()}
+        transitions = {k: round(v / total_trans, 2) for k, v in transitions.items()}
 
-        results.append(RegimePerformance(
-            regime=regime,
-            days=days,
-            pct_of_total=round(days / total_days * 100, 1),
-            avg_daily_return=round(float(strat_rets.mean()) * 100, 4),
-            total_return=round(float((1 + strat_rets).prod() - 1) * 100, 2),
-            win_rate=round(float((strat_rets > 0).mean()), 3),
-            avg_duration=round(np.mean(durations), 1) if durations else 0,
-            transitions_to=transitions,
-        ))
+        results.append(
+            RegimePerformance(
+                regime=regime,
+                days=days,
+                pct_of_total=round(days / total_days * 100, 1),
+                avg_daily_return=round(float(strat_rets.mean()) * 100, 4),
+                total_return=round(float((1 + strat_rets).prod() - 1) * 100, 2),
+                win_rate=round(float((strat_rets > 0).mean()), 3),
+                avg_duration=round(np.mean(durations), 1) if durations else 0,
+                transitions_to=transitions,
+            )
+        )
 
     return sorted(results, key=lambda r: r.total_return, reverse=True)
 
@@ -566,6 +568,7 @@ def analyze_entry_timing(regimes_df: pd.DataFrame, current_regime: str = None) -
     if current_regime is None:
         try:
             from nuri.quant.regime.classifier import classify_regime
+
             r = classify_regime()
             current_regime = r.regime if r else None
         except Exception:
@@ -579,7 +582,7 @@ def analyze_entry_timing(regimes_df: pd.DataFrame, current_regime: str = None) -
     # 현재 레짐이 시작된 모든 시점 찾기
     entries = []
     for i in range(1, len(df)):
-        if df.iloc[i]["regime"] == current_regime and df.iloc[i-1]["regime"] != current_regime:
+        if df.iloc[i]["regime"] == current_regime and df.iloc[i - 1]["regime"] != current_regime:
             entries.append(df.iloc[i]["date"])
 
     if not entries:
@@ -599,19 +602,19 @@ def analyze_entry_timing(regimes_df: pd.DataFrame, current_regime: str = None) -
                 ret = (spy_close.iloc[future_idx] - entry_price) / entry_price * 100
                 lst.append(ret)
 
-        # 30일 후 레짐
+        # 30일 후 레짐 — `min` cap 으로 future_idx <= len(df)-1 < len(df) 항상 성립.
         future_idx = min(entry_idx + 30, len(df) - 1)
-        if future_idx < len(df):
-            future_regime = df.iloc[future_idx]["regime"]
-            from nuri.trading.strategy.longshort import REGIME_ALLOCATION
-            alloc = REGIME_ALLOCATION.get(future_regime, {})
-            future_dir = alloc.get("direction", "")
-            if future_dir == "long":
-                to_bull += 1
-            elif future_dir == "short":
-                to_bear += 1
-            else:
-                stay += 1
+        future_regime = df.iloc[future_idx]["regime"]
+        from nuri.trading.strategy.longshort import REGIME_ALLOCATION
+
+        alloc = REGIME_ALLOCATION.get(future_regime, {})
+        future_dir = alloc.get("direction", "")
+        if future_dir == "long":
+            to_bull += 1
+        elif future_dir == "short":
+            to_bear += 1
+        else:
+            stay += 1
 
     total = to_bull + to_bear + stay or 1
 
@@ -672,16 +675,18 @@ def stress_test(regimes_df: pd.DataFrame) -> list[dict]:
         # 감지된 레짐
         regime_counts = period["regime"].value_counts().to_dict()
 
-        results.append({
-            "name": crisis["name"],
-            "period": f"{crisis['start']} ~ {crisis['end']}",
-            "days": len(period),
-            "spy_return": round(spy_ret, 2),
-            "strategy_return": round(strat_total, 2),
-            "excess": round(strat_total - spy_ret, 2),
-            "regimes": regime_counts,
-            "protected": strat_total > spy_ret,
-        })
+        results.append(
+            {
+                "name": crisis["name"],
+                "period": f"{crisis['start']} ~ {crisis['end']}",
+                "days": len(period),
+                "spy_return": round(spy_ret, 2),
+                "strategy_return": round(strat_total, 2),
+                "excess": round(strat_total - spy_ret, 2),
+                "regimes": regime_counts,
+                "protected": strat_total > spy_ret,
+            }
+        )
 
     return results
 
@@ -795,7 +800,9 @@ def print_backtest(result: BacktestResult) -> None:
     print(f"{'=' * 65}")
     print(f"  {'':>25} {'Strategy':>12} {'SPY B&H':>12} {'Excess':>10}")
     print(f"  {'-' * 52}")
-    print(f"  {'Total Return':>25} {result.total_return:>+11.1f}% {result.spy_total_return:>+11.1f}% {result.excess_return:>+9.1f}%")
+    print(
+        f"  {'Total Return':>25} {result.total_return:>+11.1f}% {result.spy_total_return:>+11.1f}% {result.excess_return:>+9.1f}%"
+    )
     print(f"  {'Annual Return':>25} {result.annual_return:>+11.1f}% {result.spy_annual_return:>+11.1f}%")
     print(f"  {'Sharpe Ratio':>25} {result.sharpe:>12.2f} {result.spy_sharpe:>12.2f}")
     print(f"  {'Max Drawdown':>25} {result.max_drawdown:>11.1f}% {result.spy_max_drawdown:>11.1f}%")
@@ -812,8 +819,10 @@ def print_regime_performance(perfs: list[RegimePerformance]) -> None:
     print(f"  {'Regime':<22} {'Days':>6} {'%Time':>6} {'Return':>8} {'Daily':>8} {'WR':>6} {'AvgDur':>6}")
     print(f"  {'-' * 66}")
     for p in perfs:
-        print(f"  {p.regime:<22} {p.days:>6} {p.pct_of_total:>5.1f}% {p.total_return:>+7.1f}% "
-              f"{p.avg_daily_return:>+7.3f}% {p.win_rate:>5.0%} {p.avg_duration:>5.0f}d")
+        print(
+            f"  {p.regime:<22} {p.days:>6} {p.pct_of_total:>5.1f}% {p.total_return:>+7.1f}% "
+            f"{p.avg_daily_return:>+7.3f}% {p.win_rate:>5.0%} {p.avg_duration:>5.0f}d"
+        )
     print()
 
 
@@ -822,7 +831,7 @@ def print_timing(timing: TimingAnalysis | None) -> None:
         print("  투입 적기 분석 불가")
         return
     print(f"\n{'=' * 60}")
-    print(f"  Entry Timing — \"{timing.current_regime}\" 진입 후 향후 수익률")
+    print(f'  Entry Timing — "{timing.current_regime}" 진입 후 향후 수익률')
     print(f"{'=' * 60}")
     print(f"  과거 발생: {timing.occurrences}회")
     print(f"  30일 후 평균: {timing.avg_forward_30d:+.1f}%")
@@ -840,8 +849,10 @@ def print_stress(results: list[dict]) -> None:
     print(f"  {'-' * 66}")
     for r in results:
         prot = "YES" if r["protected"] else "NO"
-        print(f"  {r['name']:<25} {r['days']:>5} {r['spy_return']:>+7.1f}% "
-              f"{r['strategy_return']:>+7.1f}% {r['excess']:>+7.1f}% {prot:>9}")
+        print(
+            f"  {r['name']:<25} {r['days']:>5} {r['spy_return']:>+7.1f}% "
+            f"{r['strategy_return']:>+7.1f}% {r['excess']:>+7.1f}% {prot:>9}"
+        )
     print()
 
 
@@ -867,7 +878,7 @@ def run_backtest_with_rules(regimes_df: pd.DataFrame, db_path=None) -> dict:
         TRAILING_STOP_GROWTH,
     )
 
-    stop_pct = STOCK_STOP_LOSS / 100          # -0.07
+    stop_pct = STOCK_STOP_LOSS / 100  # -0.07
     tp1_pct = TAKE_PROFIT_GROWTH["target_1"] / 100  # 0.20
     tp2_pct = TAKE_PROFIT_GROWTH["target_2"] / 100  # 0.40
     trailing_pct = TRAILING_STOP_GROWTH / 100  # -0.15
@@ -886,7 +897,7 @@ def run_backtest_with_rules(regimes_df: pd.DataFrame, db_path=None) -> dict:
     # 시뮬레이션: 롱 포지션에 손절/익절/트레일링 적용
     cum_return = 0.0
     high_water = 0.0
-    position_size = 1.0      # 1.0 = 100%
+    position_size = 1.0  # 1.0 = 100%
     tp1_triggered = False
     tp2_triggered = False
     ruled_returns = []
@@ -946,9 +957,9 @@ def run_backtest_with_rules(regimes_df: pd.DataFrame, db_path=None) -> dict:
                 continue
 
             # 일반 수익률
-            ruled_returns.append(daily_ret * long_pct * position_size
-                                + alloc["short"] * (-daily_ret)
-                                + alloc["cash"] * 0)
+            ruled_returns.append(
+                daily_ret * long_pct * position_size + alloc["short"] * (-daily_ret) + alloc["cash"] * 0
+            )
         else:
             # 포지션 없거나 long=0
             ruled_returns.append(alloc["short"] * (-daily_ret) if alloc["short"] > 0 else 0)
@@ -1018,15 +1029,21 @@ def print_rules_comparison(result: dict) -> None:
     print(f"\n{'═' * 70}")
     print("  Rules-Applied Backtest Comparison")
     print(f"{'═' * 70}")
-    print(f"  Rules: SL {config['stop_loss']} | TP1 {config['target_1']} | "
-          f"TP2 {config['target_2']} | Trail {config['trailing_stop']}")
+    print(
+        f"  Rules: SL {config['stop_loss']} | TP1 {config['target_1']} | "
+        f"TP2 {config['target_2']} | Trail {config['trailing_stop']}"
+    )
     print(f"{'─' * 70}")
     print(f"  {'Metric':<20} {'Base':>12} {'With Rules':>12} {'Diff':>10}")
     print(f"  {'─' * 54}")
-    print(f"  {'Total Return':<20} {base['total_return']:>+11.1f}% {ruled['total_return']:>+11.1f}% {impact['return_diff']:>+9.1f}%")
+    print(
+        f"  {'Total Return':<20} {base['total_return']:>+11.1f}% {ruled['total_return']:>+11.1f}% {impact['return_diff']:>+9.1f}%"
+    )
     print(f"  {'Annual Return':<20} {base['annual_return']:>+11.1f}% {ruled['annual_return']:>+11.1f}%")
     print(f"  {'Sharpe Ratio':<20} {base['sharpe']:>12.2f} {ruled['sharpe']:>12.2f} {impact['sharpe_diff']:>+9.2f}")
-    print(f"  {'Max Drawdown':<20} {base['max_drawdown']:>+11.1f}% {ruled['max_drawdown']:>+11.1f}% {impact['mdd_diff']:>+9.1f}%")
+    print(
+        f"  {'Max Drawdown':<20} {base['max_drawdown']:>+11.1f}% {ruled['max_drawdown']:>+11.1f}% {impact['mdd_diff']:>+9.1f}%"
+    )
     print(f"{'─' * 70}")
     print(f"  Stop losses hit:     {impact['stops_hit']}")
     print(f"  Take profit 1 (+20%): {impact['tp1_count']}")


### PR DESCRIPTION
## Summary

#638 — 6 unreachable False branch 코드 단순화로 제거. `# pragma: no cover` 미사용.

## Changes

### `publisher.py` (1 partial closed)
- `_publish` global wrapper: `if isinstance(channel, str)` 가드 제거.
  `class Channel(str, Enum)` 이라 모든 channel 인스턴스가 str 서브클래스 → 항상 True.
  `Channel(channel)` 직접 호출은 str/Enum 양쪽 받음 (재호출도 안전).
- **유지**: retry-loop natural-exit branches (201→229, 259→287). 리스크 큼 — 별도 followup.

### `ls_backtest.py` (1 partial closed → 100%)
- `analyze_entry_timing`: `if future_idx < len(df):` 가드 제거.
  `future_idx = min(entry_idx + 30, len(df) - 1)` 의 cap 으로 ≤ len(df)-1 < len(df) 항상 성립.

### `candidates.py` (4 partials closed → 98%)
- conflict path: `if "충돌" not in c.notes:` 제거 (single-pass fresh candidate).
- conflict + VIX (blocked/caution) path 모두: `if c.scoring_detail is not None:` 제거.
  `screen_candidates` 가 항상 dict 보장.

## Coverage 변화

| file | before | after | partials |
|---|---|---|---|
| `ls_backtest.py` | 99% | **100%** | 1 → 0 |
| `candidates.py` | 97% | **98%** | 5 → 1 (CLI 만) |
| `publisher.py` | 99% | 99% (1/3 closed) | 3 → 2 |

## Test plan

- [x] `pytest tests/ -m "not slow and not integration"` — 5,750 pass / 6 skip / 32 deselect (no regression)
- [x] `ruff check` clean
- [x] `make verify-doc-counts` 13/13

## Notes

- publisher.py retry-loop natural-exit branches (201→229, 259→287) 잔존 — for+break pattern 의 unreachable natural-exit. 리팩터링하려면 while True restructure 필요. retry logic 자체는 battle-tested 라 별도 followup 권고.

Closes #638 (partial — publisher retry 잔존 2 partials 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)