### PR TITLE
test(coverage): close 3 single-partial files — Phase 3-C1 (#616)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,788 backend tests across 244 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,791 backend tests across 247 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,788 tests, 244 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,791 tests, 247 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/agents/test_causal_factor_auditor_branches.py
+++ b/tests/agents/test_causal_factor_auditor_branches.py
@@ -1,0 +1,21 @@
+"""causal_factor_auditor.py branch coverage — Issue #616 Phase 3-C1.
+
+147→149: `if rng is None:` False (호출자가 rng 주입) → 기본값 fallback skip.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class TestPlaceboFalsificationRngInjection:
+    def test_with_caller_supplied_rng(self):
+        """147→149: rng != None → 기본 default_rng(42) fallback skip."""
+        from nuri.agents.actors.causal_factor_auditor import _placebo_falsification
+
+        returns = np.array([0.01, -0.02, 0.03, -0.01, 0.02, 0.01, -0.01, 0.02])
+        factor = np.array([1.0, 2.0, 1.5, 0.5, 1.8, 1.2, 0.9, 1.6])
+        rng = np.random.default_rng(123)
+
+        result = _placebo_falsification(returns, factor, n_runs=10, rng=rng)
+        assert isinstance(result, dict)

--- a/tests/trading/recommend/test_price_targets_branches.py
+++ b/tests/trading/recommend/test_price_targets_branches.py
@@ -1,0 +1,23 @@
+"""price_targets.py branch coverage — Issue #616 Phase 3-C1.
+
+51→58: `if _STOCK_TYPES_PATH.exists():` False (yaml 부재) → 빈 mapping 반환.
+"""
+
+from __future__ import annotations
+
+
+class TestLoadStockTypesYamlMissing:
+    def test_returns_empty_when_yaml_path_missing(self, tmp_path, monkeypatch):
+        """51→58: _STOCK_TYPES_PATH 존재 안 함 → 빈 mapping."""
+        from nuri.trading.recommend import price_targets as pt_mod
+
+        # cache 무효화 후 존재하지 않는 path 주입.
+        monkeypatch.setattr(pt_mod, "_stock_types_cache", None)
+        monkeypatch.setattr(
+            pt_mod,
+            "_STOCK_TYPES_PATH",
+            tmp_path / "nonexistent" / "stock_types.yaml",
+        )
+
+        result = pt_mod._load_stock_types()
+        assert result == {}

--- a/tests/trading/recommend/test_tracker_branches.py
+++ b/tests/trading/recommend/test_tracker_branches.py
@@ -1,0 +1,37 @@
+"""tracker.py branch coverage — Issue #616 Phase 3-C1.
+
+353→364: `if report["by_action"]:` False (빈 list) → 표 출력 skip.
+"""
+
+from __future__ import annotations
+
+
+class TestTrackerEmptyByAction:
+    def test_print_report_with_zero_by_action_skips_table(self, tmp_path, capsys, monkeypatch):
+        """353→364: report['by_action']==[] → 표 출력 skip → recent 쿼리로 fall through."""
+        from nuri.core.db import init_db
+        from nuri.trading.recommend import tracker as tracker_mod
+
+        p = tmp_path / "tr.db"
+        init_db(p)
+
+        # tracked>0 이지만 by_action 빈 list 인 report 주입.
+        fake_report = {
+            "total_recommendations": 5,
+            "tracked": 3,
+            "hit_count": 2,
+            "hit_rate": 0.67,
+            "by_action": [],  # 빈 list → 353 False
+        }
+        monkeypatch.setattr(
+            tracker_mod,
+            "get_tracking_report",
+            lambda *a, **kw: fake_report,
+        )
+        monkeypatch.setattr(tracker_mod, "query", lambda *a, **kw: [])
+
+        tracker_mod.print_tracking_report(db_path=p)
+        out = capsys.readouterr().out
+        # tracked > 0 → "Hit rate" 출력. by_action 빈 → "Action" 헤더 미출력.
+        assert "Hit rate" in out
+        assert "Action" not in out


### PR DESCRIPTION
## Summary

#616 Phase 3-C 진입 — 작은 파일 묶음 (single-partial files) 첫 batch.

| file | partial | trigger | result |
|---|---|---|---|
| `nuri/trading/recommend/tracker.py` | 353→364 | `if report["by_action"]:` False (빈 list) | 99% (CLI 만 잔존) |
| `nuri/trading/recommend/price_targets.py` | 51→58 | `_STOCK_TYPES_PATH.exists()` False | **100%** |
| `nuri/agents/actors/causal_factor_auditor.py` | 147→149 | 호출자가 rng 주입 | **100%** |

## Changes

- 3 new test files (1 test each, properly co-located by module)
- Doc count sync: 244 → 247 backend test files, 5,788 → 5,791 tests

## Test plan

- [x] All 3 tests pass
- [x] Combined coverage: 2 files **100%**, 1 file 99% (CLI block 만)
- [x] `make verify-doc-counts` 13/13
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)