### PR TITLE
test(coverage): close kis_realtime 173→184 — Phase 3-C5 (#616)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,810 backend tests across 252 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,811 backend tests across 253 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,810 tests, 252 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,811 tests, 253 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/collectors/test_kis_realtime_branches.py
+++ b/tests/collectors/test_kis_realtime_branches.py
@@ -1,0 +1,46 @@
+"""kis_realtime.py branch coverage — Issue #616 Phase 3-C5.
+
+| line | branch / stmt | trigger |
+|---|---|---|
+| 173→184 | `if creds.is_valid():` False (YAML loaded but blank fields) | YAML 존재 + 모든 키 빈 문자열 |
+
+Note: 310→exit / 359→355 dead-by-design (retry-loop 자연 종료 불가) — publisher.py
+follow-up 과 묶어 별도 refactor PR + Codex review 처리.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import yaml
+
+
+class TestYamlLoadedButCredsInvalid:
+    def test_yaml_present_but_blank_fields_returns_none(self, monkeypatch, tmp_path):
+        """173→184: YAML 파일 존재 + 파싱 성공 → 빈 키 → is_valid()=False → fall-through return None."""
+        # env 우선순위 차단
+        monkeypatch.delenv("KIS_PROD_APP_KEY", raising=False)
+        monkeypatch.delenv("KIS_PROD_APP_SECRET", raising=False)
+        monkeypatch.delenv("KIS_PROD_ACCOUNT", raising=False)
+        monkeypatch.delenv("KIS_HTS_ID", raising=False)
+
+        # YAML 파일은 존재하지만 모든 KIS 키가 빈 문자열
+        yaml_path = tmp_path / "kis_devlp.yaml"
+        yaml_path.write_text(
+            yaml.safe_dump(
+                {
+                    "my_app": "",
+                    "my_sec": "",
+                    "my_acct_stock": "",
+                    "my_htsid": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        from nuri.collectors.kis_realtime import load_credentials
+
+        with patch("nuri.collectors.kis_realtime.KIS_YAML_PATH", yaml_path):
+            creds = load_credentials("prod")
+
+        assert creds is None


### PR DESCRIPTION
## Summary

- `tests/collectors/test_kis_realtime_branches.py` — close `173→184` partial in `nuri/collectors/kis_realtime.py::load_credentials()` (YAML 로드 성공 + 빈 필드 → `creds.is_valid()=False` → `return None` fall-through)
- BrPart 9 → 8, coverage 57% (statement gap 은 websocket runtime — 별 spec)

## Out of scope (분리)

`310→exit` / `359→355` partials 은 KIS retry-loop 의 자연 종료 fall-through — 모든 inner path 가 `return`/`break`/`continue` 로 종료되어 실측상 unreachable (dead-by-design). publisher.py 의 `for+break` retry 패턴과 묶어 별 refactor PR + Codex review 로 분리. `# pragma: no cover` 추가는 invariant 위반.

## Issue #616 진행률

15 PR + this = **16 PR** / ~80 partials closed (직전 세션 phase 3-A/B/C 완료, 이번이 3-C5 단일).

## Test plan

- [x] `pytest tests/collectors/test_kis_realtime.py tests/collectors/test_kis_realtime_branches.py` (33 passed)
- [x] coverage `--cov-branch` 173→184 닫힘 확인
- [x] `make verify-doc-counts` 13/13 (5,811/253)
- [x] full fast suite 5,773 passed (총 5,811)

🤖 Generated with [Claude Code](https://claude.com/claude-code)