### PR TITLE
refactor(kis): extract retry helper — close dead-by-design partials (#616)

### DIFF
--- a/nuri/collectors/kis_realtime.py
+++ b/nuri/collectors/kis_realtime.py
@@ -291,6 +291,26 @@ def _is_token_cooldown(payload: dict, status_code: int) -> bool:
     return "1분당" in err_desc or err_code == "EGW00133"
 
 
+def _request_with_rate_limit_retry(url: str, headers: dict, params: dict, label: str) -> tuple[int | None, dict]:
+    """KIS API 요청 — rate limit 시 1회 재시도. 명시적 2-call (loop natural-exit 회피).
+
+    Returns:
+        (status_code, payload) — 정상 / non-200 / 두 번째 시도도 rate-limited 인 경우
+        (None, {}) — requests 예외 발생 시
+    """
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=10)
+        payload = resp.json() if resp.status_code == 200 else {}
+        if _is_rate_limit(payload):
+            time.sleep(KIS_RATE_LIMIT_RETRY_DELAY_SEC)
+            resp = requests.get(url, headers=headers, params=params, timeout=10)
+            payload = resp.json() if resp.status_code == 200 else {}
+        return resp.status_code, payload
+    except Exception as e:
+        logger.warning("KIS %s 요청 실패: %s", label, e)
+        return None, {}
+
+
 def inquire_price_kr(creds: KISCredentials, token: str, ticker: str) -> dict | None:
     """한국 종목 현재가 조회 (FHKST01010100).
 
@@ -307,35 +327,27 @@ def inquire_price_kr(creds: KISCredentials, token: str, ticker: str) -> dict | N
         "tr_id": "FHKST01010100",
     }
     params = {"FID_COND_MRKT_DIV_CODE": "J", "FID_INPUT_ISCD": code}
-    for attempt in range(2):
-        try:
-            resp = requests.get(url, headers=headers, params=params, timeout=10)
-            payload = resp.json() if resp.status_code == 200 else {}
-            if _is_rate_limit(payload) and attempt == 0:
-                time.sleep(KIS_RATE_LIMIT_RETRY_DELAY_SEC)
-                continue
-            if resp.status_code != 200:
-                logger.warning("KIS 한국 %s HTTP %d", ticker, resp.status_code)
-                return None
-            data = payload.get("output", {})
-            if not data or not data.get("stck_prpr"):
-                logger.debug("KIS 한국 %s 빈 응답: rt_cd=%s msg=%s", ticker, payload.get("rt_cd"), payload.get("msg1"))
-                return None
-            return {
-                "ticker": ticker,
-                "date": today_kst(),
-                "open": float(data.get("stck_oprc", 0) or 0),
-                "high": float(data.get("stck_hgpr", 0) or 0),
-                "low": float(data.get("stck_lwpr", 0) or 0),
-                "close": float(data.get("stck_prpr", 0)),
-                "volume": int(data.get("acml_vol", 0) or 0),
-                "adj_close": float(data.get("stck_prpr", 0)),
-            }
-        except Exception as e:
-            logger.warning("KIS 한국 시세 실패 %s: %s", ticker, e)
-            return None
-    # for attempt in range(2) 의 모든 가지가 return 으로 종료되므로
-    # 루프 후 fall-through 는 도달 불가 — 명시적 fallback 코드 제거.
+
+    status, payload = _request_with_rate_limit_retry(url, headers, params, f"한국 {ticker}")
+    if status is None:
+        return None
+    if status != 200:
+        logger.warning("KIS 한국 %s HTTP %d", ticker, status)
+        return None
+    data = payload.get("output", {})
+    if not data or not data.get("stck_prpr"):
+        logger.debug("KIS 한국 %s 빈 응답: rt_cd=%s msg=%s", ticker, payload.get("rt_cd"), payload.get("msg1"))
+        return None
+    return {
+        "ticker": ticker,
+        "date": today_kst(),
+        "open": float(data.get("stck_oprc", 0) or 0),
+        "high": float(data.get("stck_hgpr", 0) or 0),
+        "low": float(data.get("stck_lwpr", 0) or 0),
+        "close": float(data.get("stck_prpr", 0)),
+        "volume": int(data.get("acml_vol", 0) or 0),
+        "adj_close": float(data.get("stck_prpr", 0)),
+    }
 
 
 def inquire_price_us(creds: KISCredentials, token: str, ticker: str) -> dict | None:
@@ -356,31 +368,24 @@ def inquire_price_us(creds: KISCredentials, token: str, ticker: str) -> dict | N
         if excd_idx > 0:
             time.sleep(KIS_EXCD_RETRY_INTERVAL_SEC)  # EXCD 폴백 사이 rate limit 회피
         params = {"AUTH": "", "EXCD": excd, "SYMB": ticker}
-        for attempt in range(2):
-            try:
-                resp = requests.get(url, headers=headers, params=params, timeout=10)
-                if resp.status_code != 200:
-                    break
-                payload = resp.json()
-                if _is_rate_limit(payload) and attempt == 0:
-                    time.sleep(KIS_RATE_LIMIT_RETRY_DELAY_SEC)
-                    continue
-                data = payload.get("output", {})
-                last = data.get("last", "")
-                if last and float(last) > 0:
-                    return {
-                        "ticker": ticker,
-                        "date": today_kst(),
-                        "open": float(data.get("open", 0) or 0),
-                        "high": float(data.get("high", 0) or 0),
-                        "low": float(data.get("low", 0) or 0),
-                        "close": float(last),
-                        "volume": int(data.get("tvol", 0) or 0),
-                        "adj_close": float(last),
-                    }
-                break  # 빈 응답 → 다음 EXCD
-            except Exception:
-                break
+
+        status, payload = _request_with_rate_limit_retry(url, headers, params, f"해외 {ticker} {excd}")
+        if status is None or status != 200:
+            continue  # 예외 / non-200 → 다음 EXCD
+        data = payload.get("output", {})
+        last = data.get("last", "")
+        if last and float(last) > 0:
+            return {
+                "ticker": ticker,
+                "date": today_kst(),
+                "open": float(data.get("open", 0) or 0),
+                "high": float(data.get("high", 0) or 0),
+                "low": float(data.get("low", 0) or 0),
+                "close": float(last),
+                "volume": int(data.get("tvol", 0) or 0),
+                "adj_close": float(last),
+            }
+        # 빈 응답 → 다음 EXCD
     return None
 
 

--- a/tests/collectors/test_kis_realtime.py
+++ b/tests/collectors/test_kis_realtime.py
@@ -192,6 +192,24 @@ class TestInquirePriceKR:
         assert row is not None
         assert row["close"] == 100000.0
 
+    def test_http_500_returns_none(self):
+        """status_code != 200 → 재시도 없이 None (rate-limit 검증 후 status 분기)."""
+        creds = KISCredentials("k", "s", "", "", "prod")
+        err_resp = MagicMock(status_code=500)
+        err_resp.json.return_value = {}
+        with patch("nuri.collectors.kis_realtime.requests.get", return_value=err_resp):
+            with patch("nuri.collectors.kis_realtime.time.sleep"):
+                row = inquire_price_kr(creds, "token", "005930.KS")
+        assert row is None
+
+    def test_request_exception_returns_none(self):
+        """requests.get 예외 → helper 가 (None, {}) 반환 → caller None."""
+        creds = KISCredentials("k", "s", "", "", "prod")
+        with patch("nuri.collectors.kis_realtime.requests.get", side_effect=ConnectionError("boom")):
+            with patch("nuri.collectors.kis_realtime.time.sleep"):
+                row = inquire_price_kr(creds, "token", "005930.KS")
+        assert row is None
+
 
 class TestInquirePriceUS:
     def test_nas_first_success(self):
@@ -228,6 +246,33 @@ class TestInquirePriceUS:
             with patch("nuri.collectors.kis_realtime.time.sleep"):
                 row = inquire_price_us(creds, "token", "FAKE")
         assert row is None
+
+    def test_excd_http_error_skips_to_next(self):
+        """NAS HTTP 500 → continue 다음 EXCD (NYS) → 성공."""
+        creds = KISCredentials("k", "s", "", "", "prod")
+        nas_err = MagicMock(status_code=500)
+        nas_err.json.return_value = {}
+        nys_success = MagicMock(status_code=200)
+        nys_success.json.return_value = {"rt_cd": "0", "output": {"last": "100.0"}}
+        with patch("nuri.collectors.kis_realtime.requests.get", side_effect=[nas_err, nys_success]):
+            with patch("nuri.collectors.kis_realtime.time.sleep"):
+                row = inquire_price_us(creds, "token", "AAPL")
+        assert row is not None
+        assert row["close"] == 100.0
+
+    def test_excd_exception_skips_to_next(self):
+        """NAS 예외 → helper 가 (None, {}) → continue → NYS 시도."""
+        creds = KISCredentials("k", "s", "", "", "prod")
+        nys_success = MagicMock(status_code=200)
+        nys_success.json.return_value = {"rt_cd": "0", "output": {"last": "200.0"}}
+        with patch(
+            "nuri.collectors.kis_realtime.requests.get",
+            side_effect=[ConnectionError("nas down"), nys_success],
+        ):
+            with patch("nuri.collectors.kis_realtime.time.sleep"):
+                row = inquire_price_us(creds, "token", "AAPL")
+        assert row is not None
+        assert row["close"] == 200.0
 
 
 # ═══════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Codex review (Option B) 권고대로 `inquire_price_kr` / `inquire_price_us` 의 `for attempt in range(2)` retry loop 를 `_request_with_rate_limit_retry()` helper 로 대체. dead-by-design partials 제거 (자연 loop-exit 도달 불가, coverage tool 만 partial 로 표시):

- **310→exit** (`inquire_price_kr` for-loop 자연 종료)
- **359→355** (`inquire_price_us` inner attempt loop 자연 종료)

## Behavior preservation

기존 retry semantics 유지:
- rate-limit 응답 → 1초 대기 → 1회 재시도
- non-200 status → 즉시 None
- requests 예외 → helper 가 `(None, {})` 반환 → caller None

## Pinning regression tests (4)

helper extraction 의 동등성을 보장하기 위한 테스트 (Codex 권고):
- `test_http_500_returns_none` — KR non-200 즉시 None
- `test_request_exception_returns_none` — KR 예외 흡수
- `test_excd_http_error_skips_to_next` — US NAS HTTP 500 → continue NYS
- `test_excd_exception_skips_to_next` — US NAS 예외 → continue NYS

기존 33 테스트 (rate-limit 재시도 / EXCD fallback / all empty) 도 모두 통과.

## Issue #616 진행률

publisher.py 201→229, 259→287 dead-by-design 은 별 PR 후보 (동일 패턴, 별도 검증).

17 PR + this = **18 PR** / ~85 partials closed. 잔존 103 partials / 56 files.

## Test plan

- [x] `pytest tests/collectors/test_kis_realtime*.py` (37 passed)
- [x] `--cov-branch` BrPart 8 → 3 (310→exit / 359→355 제거)
- [x] ruff clean
- [x] 도큐 카운트 변동 없음 (기존 file modification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)