### PR TITLE
test(coverage): close llm/report.py 5 partials — Phase 3-D1 (#616)

### DIFF
--- a/nuri/llm/report.py
+++ b/nuri/llm/report.py
@@ -473,10 +473,8 @@ def validate_output(text: str, ctx: ReportContext) -> ValidationResult:
         "CVaR",
         "VaR",
     }
-    suspicious = mentioned_tickers - ctx.known_tickers - common_words
-    for t in suspicious:
-        if len(t) <= 5 and t.isalpha():
-            hallucinated.append(t)
+    # mentioned_tickers 는 regex `[A-Z]{2,5}` 매칭이라 len ≤ 5 + isalpha 보장 → 추가 guard 불필요.
+    hallucinated.extend(mentioned_tickers - ctx.known_tickers - common_words)
     if hallucinated:
         warnings.append(f"입력 데이터에 없는 티커 언급: {', '.join(hallucinated)}. LLM 환각 가능성.")
 

--- a/tests/llm/test_report_branch_coverage.py
+++ b/tests/llm/test_report_branch_coverage.py
@@ -558,3 +558,105 @@ class TestExceptionFallbackPaths:
         monkeypatch.setattr("nuri.trading.engine.memory.detect_drift", _boom)
         ctx = gather_context(db_path=db_path)
         assert ctx.drift_section == "성과 변화 데이터 없음"
+
+
+# ─── Phase 3-D #616: remaining 5 partials ─────────────────────────────
+
+
+class TestDriftAllStable:
+    def test_drift_no_critical_skips_warning_line(self, db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """281→283: drifts 존재하지만 status=stable 만 → if critical False → 경고 라인 skip."""
+        drifts = [
+            MagicMock(
+                signal_id="rsi_oversold",
+                all_time_wr=0.65,
+                recent_wr=0.62,
+                drift_pct=-3.0,
+                status="stable",
+            ),
+            MagicMock(
+                signal_id="macd_cross",
+                all_time_wr=0.55,
+                recent_wr=0.58,
+                drift_pct=5.5,
+                status="improving",
+            ),
+        ]
+        monkeypatch.setattr("nuri.trading.engine.memory.detect_drift", lambda **kw: drifts)
+        ctx = gather_context(db_path=db_path)
+        assert "rsi_oversold" in ctx.drift_section
+        # critical 없음 → ⚠ 라인 미렌더
+        assert "성과 급락 시그널" not in ctx.drift_section
+
+
+class TestConsensusNoDissent:
+    def test_consensus_dissent_empty_skips_inner_lines(self, db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """302→295: r.dissent=[] False → inner for skip → 다음 result iter."""
+        verdict = MagicMock(agent_name="agent1", action="HOLD")
+        result = MagicMock(
+            ticker="BBB",
+            final_action="HOLD",
+            final_confidence=70,
+            agreement_rate=1.0,
+            verdicts=[verdict],
+            dissent=[],  # 빈 list → if False
+        )
+        monkeypatch.setattr("nuri.trading.agents.consensus.analyze_portfolio", lambda **kw: [result])
+        ctx = gather_context(db_path=db_path)
+        assert "BBB" in ctx.known_tickers
+        # dissent 라인 미렌더
+        assert "반대:" not in ctx.consensus_section
+
+
+class TestOllamaNoMarker:
+    def test_response_without_marker_returns_as_is(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """615→620: response 에 '## 1.' / '# 1. ' 마커 없음 → for 자연 종료 → re.sub 진행."""
+        fake_resp = MagicMock(status_code=200)
+        fake_resp.json.return_value = {"response": "직접 분석 결과만 텍스트"}
+        fake_resp.raise_for_status = lambda: None
+
+        import sys
+
+        mock_requests = MagicMock()
+        mock_requests.post.return_value = fake_resp
+        mock_requests.ConnectionError = ConnectionError
+        monkeypatch.setitem(sys.modules, "requests", mock_requests)
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://fake-ollama")
+
+        result = _generate_ollama("test prompt")
+        # 마커 없음 → response 가 그대로 (re.sub 적용된 형태) 반환
+        assert "직접 분석 결과만 텍스트" in result
+
+    def test_thinking_path_when_response_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """622→632 inverse: response='' but thinking 존재 → elif True → thinking 처리."""
+        fake_resp = MagicMock(status_code=200)
+        fake_resp.json.return_value = {"response": "", "thinking": "## 1. thinking content"}
+        fake_resp.raise_for_status = lambda: None
+
+        import sys
+
+        mock_requests = MagicMock()
+        mock_requests.post.return_value = fake_resp
+        mock_requests.ConnectionError = ConnectionError
+        monkeypatch.setitem(sys.modules, "requests", mock_requests)
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://fake-ollama")
+
+        result = _generate_ollama("test prompt")
+        assert "thinking content" in result
+
+    def test_response_empty_no_thinking_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """622→632: response='' AND data.thinking 부재 → elif False → return '' (response 그대로)."""
+        fake_resp = MagicMock(status_code=200)
+        fake_resp.json.return_value = {"response": ""}  # thinking 없음
+        fake_resp.raise_for_status = lambda: None
+
+        import sys
+
+        mock_requests = MagicMock()
+        mock_requests.post.return_value = fake_resp
+        mock_requests.ConnectionError = ConnectionError
+        monkeypatch.setitem(sys.modules, "requests", mock_requests)
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://fake-ollama")
+
+        result = _generate_ollama("test prompt")
+        assert result == ""


### PR DESCRIPTION
## Summary

`nuri/llm/report.py` 5 branch partials closure:
- **281→283**: drift critical 라인 — drifts 모두 stable/improving 시 경고 라인 skip
- **302→295**: consensus dissent — `result.dissent=[]` 시 inner for skip
- **615→620**: ollama marker for-loop — response 에 마커 미포함 시 자연 종료
- **622→632**: ollama elif `data.thinking` False — response/thinking 모두 부재 path

## dead-by-design simplify

- **478→477**: `mentioned_tickers` 가 regex `[A-Z]{2,5}` 매칭 결과라 len ≤ 5 + isalpha 항상 True. 중복 guard 제거 + `set.extend()` 로 단순화.

## Test plan

- [x] `pytest tests/llm/test_report*.py` (147 passed)
- [x] `--cov-branch` BrPart 5 → 0
- [x] ruff clean
- [x] 도큐 카운트 변동 없음 (기존 file modification)

## Issue #616 진행률

#647 (auto-merge pending) + this = **19 PR** / ~90 partials closed. 잔존 ~98 partials / 55 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)