### PR TITLE
test(coverage): close longshort.py 4 partials — Phase 3-D2 (#616)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,814 backend tests across 254 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,818 backend tests across 255 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,814 tests, 254 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,818 tests, 255 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/trading/strategy/test_longshort_branches.py
+++ b/tests/trading/strategy/test_longshort_branches.py
@@ -1,0 +1,111 @@
+"""longshort.py branch coverage — Issue #616 Phase 3-D2.
+
+| line | branch | trigger |
+|---|---|---|
+| 314→306 | `if pos:` False (close 시 포지션 부재) | actions 에 close 인데 DB 에 매칭 포지션 없음 |
+| 325→306 | `elif a.action in ('open_long','open_short')` False | action 이 close/open_* 외 |
+| 347→306 | `if success:` False (open_position 실패) | open_position → False |
+| 378→384 | `if opens:` False (close 만 있는 actions) | print_strategy with close-only |
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nuri.trading.strategy.longshort import StrategyAction, execute_strategy, print_strategy
+
+
+def _action(act: str = "close", ticker: str = "AAA", direction: str = "long") -> StrategyAction:
+    return StrategyAction(act, ticker, direction, "tactical", "test", "bull_low_vol", 80)
+
+
+class TestExecuteStrategyClosePathNoPosition:
+    def test_close_action_no_matching_position_skipped(self, tmp_path, monkeypatch):
+        """314→306: close action 인데 DB 에 포지션 없음 → close_position 미호출 → next iter."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+
+        p = tmp_path / "no_pos.db"
+        init_db(p)
+        monkeypatch.setattr(db_mod, "DB_PATH", p)
+
+        # update_prices / close_position / open_position 호출 차단
+        with (
+            patch("nuri.trading.strategy.position.update_prices") as up_prices,
+            patch("nuri.trading.strategy.position.close_position") as cp,
+            patch("nuri.trading.strategy.position.open_position"),
+        ):
+            executed = execute_strategy([_action("close")], db_path=p)
+
+        assert executed == 0
+        cp.assert_not_called()
+        up_prices.assert_called_once()
+
+
+class TestExecuteStrategyUnknownAction:
+    def test_unknown_action_falls_through(self, tmp_path, monkeypatch):
+        """325→306: action='hold' 등 close/open_* 외 → if/elif 모두 False → next iter."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+
+        p = tmp_path / "unknown.db"
+        init_db(p)
+        monkeypatch.setattr(db_mod, "DB_PATH", p)
+
+        unknown = StrategyAction("hold", "AAA", "long", "tactical", "wait", "bull_low_vol", 50)
+
+        with (
+            patch("nuri.trading.strategy.position.update_prices"),
+            patch("nuri.trading.strategy.position.close_position") as cp,
+            patch("nuri.trading.strategy.position.open_position") as op,
+        ):
+            executed = execute_strategy([unknown], db_path=p)
+
+        assert executed == 0
+        cp.assert_not_called()
+        op.assert_not_called()
+
+
+class TestExecuteStrategyOpenFailure:
+    def test_open_position_returns_false_no_increment(self, tmp_path, monkeypatch):
+        """347→306: open_position → False (SIEGE reject 등) → executed 증가 없음."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+
+        p = tmp_path / "open_fail.db"
+        init_db(p)
+        monkeypatch.setattr(db_mod, "DB_PATH", p)
+
+        # yfinance.download mock — 정상 가격 반환
+        import pandas as pd
+
+        fake_df = pd.DataFrame({"Close": [100.0, 102.0, 105.0, 107.0, 110.0]})
+
+        class _FakeYf:
+            @staticmethod
+            def download(*a, **kw):
+                return fake_df
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "yfinance", _FakeYf)
+
+        with (
+            patch("nuri.trading.strategy.position.update_prices"),
+            patch("nuri.trading.strategy.position.close_position"),
+            patch("nuri.trading.strategy.position.open_position", return_value=False) as op,
+        ):
+            executed = execute_strategy([_action("open_long")], db_path=p)
+
+        assert executed == 0
+        op.assert_called_once()
+
+
+class TestPrintStrategyClosesOnly:
+    def test_close_only_skips_opens_section(self, capsys):
+        """378→384: opens=[] 빈 리스트 → if False → OPEN section skip → final print()."""
+        actions = [_action("close", "AAA"), _action("close", "BBB")]
+        print_strategy(actions)
+        captured = capsys.readouterr().out
+        assert "CLOSE" in captured
+        assert "OPEN" not in captured  # opens section 미렌더


### PR DESCRIPTION
## Summary

`nuri/trading/strategy/longshort.py` 4 partials closure:
- **314→306**: `execute_strategy` close path 에서 매칭 포지션 부재
- **325→306**: action 이 `close`/`open_*` 외 (unknown action) → 양분기 모두 False
- **347→306**: `open_position` → False (SIEGE reject 등) → executed 미증가
- **378→384**: `print_strategy` opens 빈 리스트 → OPEN section skip

100% coverage / BrPart 4 → 0.

## Test plan

- [x] `pytest tests/trading/strategy/test_longshort_branches.py` (4 passed)
- [x] full strategy suite — 290 passed
- [x] `make verify-doc-counts` 13/13 (5,818/255)

🤖 Generated with [Claude Code](https://claude.com/claude-code)