### PR TITLE
test(coverage): close partials in finviz/stock/portfolio_sync — Phase 3-D6 (#616)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,818 backend tests across 255 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
+5,846 backend tests across 255 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate.
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,818 tests, 255 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,846 tests, 255 files |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/collectors/test_finviz.py
+++ b/tests/collectors/test_finviz.py
@@ -2,6 +2,7 @@
 
 Split from tests/test_collectors_all.py for module-level isolation.
 """
+
 from unittest.mock import MagicMock, patch
 
 
@@ -22,11 +23,9 @@ class TestFINVIZCollector:
         from nuri.collectors.finviz import FINVIZCollector
 
         c = FINVIZCollector()
-        records = [{"date": "2026-03-30", "ticker": "AAPL",
-                     "signal": "new_high", "source": "FINVIZ"}]
+        records = [{"date": "2026-03-30", "ticker": "AAPL", "signal": "new_high", "source": "FINVIZ"}]
         count = c.save(records, db_path=db_path)
         assert count == 1
-
 
 
 class TestFINVIZCollector_Phase2:
@@ -47,7 +46,12 @@ class TestFINVIZCollector_Phase2:
 
         mock_tickers.return_value = ["TSLA", "NVDA", "AAPL"]
         mock_fetch.side_effect = [
-            {"TSLA", "MSFT", "GME"}, set(), {"NVDA"}, set(), set(), {"TSLA", "AAPL"},
+            {"TSLA", "MSFT", "GME"},
+            set(),
+            {"NVDA"},
+            set(),
+            set(),
+            {"TSLA", "AAPL"},
         ]
         collector = FINVIZCollector()
         records = collector.collect()
@@ -73,7 +77,6 @@ class TestFINVIZCollector_Phase2:
         mock_tickers.return_value = []
         collector = FINVIZCollector()
         assert collector.collect() == []
-
 
 
 class TestFINVIZCollectorMockedScreener:
@@ -112,8 +115,14 @@ class TestFINVIZCollectorMockedScreener:
         with patch("nuri.collectors.finviz.Ticker", mock_ticker_cls, create=True):
             mock_mod = MagicMock()
             mock_mod.screener.ticker.Ticker = mock_ticker_cls
-            with patch.dict("sys.modules", {"finvizfinance": mock_mod, "finvizfinance.screener": mock_mod.screener,
-                                            "finvizfinance.screener.ticker": mock_mod.screener.ticker}):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "finvizfinance": mock_mod,
+                    "finvizfinance.screener": mock_mod.screener,
+                    "finvizfinance.screener.ticker": mock_mod.screener.ticker,
+                },
+            ):
                 result = collector._fetch_signal_tickers("Oversold")
                 assert isinstance(result, set)
 
@@ -125,9 +134,12 @@ class TestFINVIZCollectorMockedScreener:
     def test_save_records(self, rich_db):
         from nuri.collectors.finviz import FINVIZCollector
 
-        count = FINVIZCollector().save([
-            {"date": "2025-01-01", "ticker": "AAPL", "signal": "oversold_rsi", "source": "FINVIZ"},
-        ], db_path=rich_db)
+        count = FINVIZCollector().save(
+            [
+                {"date": "2025-01-01", "ticker": "AAPL", "signal": "oversold_rsi", "source": "FINVIZ"},
+            ],
+            db_path=rich_db,
+        )
         assert count == 1
 
     def test_scrape_signal_fallback_mocked(self, monkeypatch):
@@ -151,3 +163,68 @@ class TestFINVIZCollectorMockedScreener:
 # ##############################################################################
 # Source: test_coverage_round24.py -- comprehensive collector tests
 # ##############################################################################
+
+
+# ─── Phase 3-D #616: branch coverage ──────────────────────────────────
+
+
+class TestFinvizFallbackBranches:
+    def test_finvizfinance_empty_list_falls_to_scrape(self, monkeypatch):
+        """94→100: finvizfinance result 빈 list → if False → 직접 스크래핑 호출."""
+        from nuri.collectors.finviz import FINVIZCollector
+
+        # finvizfinance Ticker 가 빈 list 반환 (signal 없음 케이스)
+        class _FakeTicker:
+            def set_filter(self, signal):
+                pass
+
+            def screener_view(self, **kw):
+                return []  # 빈 list → if 블록 skip
+
+        import sys
+
+        fake_mod = type(sys)("finvizfinance.screener.ticker")
+        fake_mod.Ticker = _FakeTicker
+        # finvizfinance 모듈 트리 stub
+        monkeypatch.setitem(sys.modules, "finvizfinance.screener.ticker", fake_mod)
+
+        c = FINVIZCollector()
+        scrape_called = []
+        monkeypatch.setattr(c, "_scrape_signal_fallback", lambda s: scrape_called.append(s) or set())
+        result = c._fetch_signal_tickers("Oversold")
+        assert scrape_called == ["Oversold"]
+        assert result == set()
+
+    def test_scrape_skips_non_quote_links(self, monkeypatch):
+        """133→131: href 에 quote.ashx 미포함 → 다음 link iter."""
+        import requests
+
+        from nuri.collectors.finviz import FINVIZCollector
+
+        # quote.ashx 없는 링크만 있는 HTML
+        fake_html = '<a href="/news.ashx">News</a><a href="/about">About</a>'
+        fake_resp = type("R", (), {"text": fake_html, "raise_for_status": lambda self: None, "status_code": 200})()
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: fake_resp)
+
+        c = FINVIZCollector()
+        result = c._scrape_signal_fallback("Oversold")
+        assert result == set()
+
+    def test_scrape_skips_invalid_ticker_text(self, monkeypatch):
+        """135→131: ticker 가 non-alpha or len>5 → 다음 iter."""
+        import requests
+
+        from nuri.collectors.finviz import FINVIZCollector
+
+        # quote.ashx 링크는 있지만 텍스트가 invalid (숫자 / 너무 김)
+        fake_html = (
+            '<a href="/quote.ashx?t=AAA">123</a>'  # non-alpha
+            '<a href="/quote.ashx?t=BBB">VERYLONGTICKER</a>'  # len > 5
+            '<a href="/quote.ashx?t=CCC"></a>'  # 빈 텍스트
+        )
+        fake_resp = type("R", (), {"text": fake_html, "raise_for_status": lambda self: None, "status_code": 200})()
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: fake_resp)
+
+        c = FINVIZCollector()
+        result = c._scrape_signal_fallback("Oversold")
+        assert result == set()  # 모두 invalid → empty

--- a/tests/collectors/test_stock.py
+++ b/tests/collectors/test_stock.py
@@ -379,3 +379,57 @@ class TestFreshnessSource:
         src = inspect.getsource(stock_mod)
         # choices 리스트에 'freshness' 포함 확인
         assert "'freshness'" in src or '"freshness"' in src
+
+
+# ─── Phase 3-D6 #616: branch coverage ──────────────────────────────────
+
+
+class TestStockBranches:
+    def test_freshness_tickers_skips_empty_secondary(self, monkeypatch):
+        """51→50: secondary list 빈 dict → for 자연 종료 → primary 만 추가."""
+        from nuri.collectors import stock as stock_mod
+
+        fake_rules = {
+            "siege_gates": {
+                "asset_classes": {
+                    "us": {"freshness_primary": "SPY", "freshness_secondary": []},
+                    "kr": {"freshness_primary": "TLT"},  # secondary 없음 (None)
+                }
+            }
+        }
+        monkeypatch.setattr("nuri.core.rules.RULES", fake_rules)
+        result = stock_mod._load_freshness_tickers()
+        assert "SPY" in result and "TLT" in result
+
+    def test_standardize_single_index_df(self):
+        """179→181: df.columns 가 MultiIndex 아님 → MultiIndex 변환 분기 skip."""
+        import pandas as pd
+
+        from nuri.collectors.stock import StockCollector
+
+        df = pd.DataFrame(
+            {
+                "date": ["2026-05-06"],
+                "open": [100],
+                "high": [101],
+                "low": [99],
+                "close": [100.5],
+                "volume": [1000],
+                "adj_close": [100.5],
+            }
+        )
+        result = StockCollector()._standardize(df, "AAPL")
+        assert "ticker" in result.columns
+
+    def test_standardize_no_date_column(self):
+        """203→206: 'date' 컬럼 없음 → datetime 변환 skip."""
+        import pandas as pd
+
+        from nuri.collectors.stock import StockCollector
+
+        # date 없이 다른 칼럼만
+        df = pd.DataFrame(
+            {"open": [100.0], "high": [101.0], "low": [99.0], "close": [100.5], "volume": [1000], "adj_close": [100.5]}
+        )
+        result = StockCollector()._standardize(df, "AAPL")
+        assert "ticker" in result.columns

--- a/tests/core/test_portfolio_sync.py
+++ b/tests/core/test_portfolio_sync.py
@@ -1041,3 +1041,85 @@ class TestImportScriptSync:
 
         rows = query("SELECT * FROM portfolio WHERE account='test'", db_path=db_path)
         assert rows == []
+
+
+# ─── Phase 3-D6 #616: branch coverage ──────────────────────────────────
+
+
+class TestPortfolioSyncBranches:
+    def test_empty_currency_rows_skips_currency_set(self, tmp_path, monkeypatch):
+        """104→106: account 의 currency rows 빈 → if False → currency set skip."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+        from nuri.core.portfolio_sync import sync_portfolio_to_yaml
+
+        db = tmp_path / "sync.db"
+        init_db(db)
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+        # portfolio 에 NULL currency 만 있는 row
+        from nuri.core.db import get_db
+
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) "
+                "VALUES ('emptycur', 'AAA', 10, 100, NULL)"
+            )
+
+        config_path = tmp_path / "portfolio.yaml"
+        config_path.write_text("accounts: {}\n")
+        sync_portfolio_to_yaml(config_path=config_path, db_path=db)
+        # 실패 없이 완료 — currency 미설정도 graceful
+        assert config_path.exists()
+
+    def test_account_meta_only_no_holdings_key_skip(self, tmp_path, monkeypatch):
+        """111→109: account 가 meta 만 있고 holdings 키 없음 → if False → 다음 iter."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import init_db
+        from nuri.core.portfolio_sync import sync_portfolio_to_yaml
+
+        db = tmp_path / "meta.db"
+        init_db(db)
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+        # DB 에 한 계좌만 있음. yaml 에 다른 계좌가 holdings 없이 존재 → 그 계좌에 대해 holdings 키 없는 path.
+        from nuri.core.db import get_db
+
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) "
+                "VALUES ('main', 'AAA', 10, 100, 'USD')"
+            )
+
+        config_path = tmp_path / "portfolio.yaml"
+        config_path.write_text(
+            "accounts:\n"
+            "  main:\n"
+            "    strategy: core\n"
+            "  legacy:\n"
+            "    strategy: long_term\n"  # holdings 키 없음 + DB 에 row 없음
+        )
+        sync_portfolio_to_yaml(config_path=config_path, db_path=db)
+        assert config_path.exists()
+
+    def test_account_with_db_rows_keeps_holdings(self, tmp_path, monkeypatch):
+        """117→109: db_count > 0 → del 안 됨 → holdings 유지."""
+        import nuri.core.db as db_mod
+        from nuri.core.db import get_db, init_db
+        from nuri.core.portfolio_sync import sync_portfolio_to_yaml
+
+        db = tmp_path / "keep.db"
+        init_db(db)
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) "
+                "VALUES ('main', 'AAA', 10, 100, 'USD')"
+            )
+
+        # yaml 에 main 계좌 + holdings 키 (lower scope 의 path 진입을 위해)
+        config_path = tmp_path / "portfolio.yaml"
+        config_path.write_text("accounts:\n  main:\n    strategy: core\n    holdings:\n      AAA: 10\n")
+        sync_portfolio_to_yaml(config_path=config_path, db_path=db)
+        assert config_path.exists()


### PR DESCRIPTION
## Summary

3 collectors / core 파일의 branch partials closure (기존 test 파일 append, doc drift 없음):

| file | partials |
|---|---|
| `collectors/finviz.py` | 94→100 (finvizfinance empty list → scrape fallback), 133→131 / 135→131 (link href / ticker filter) |
| `collectors/stock.py` | 179→181 (df.columns single-index path), 203→206 (no date column) |
| `core/portfolio_sync.py` | account meta-only path, holdings retain path |

## Test plan

- [x] 105 passed (finviz 17 + stock + portfolio_sync 88)
- [x] ruff clean
- [x] `make verify-doc-counts` 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)