### PR TITLE
chore(ci): --cov-branch + artifact actions v6 + make ci-cov target

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -410,12 +410,12 @@ jobs:
         if: needs.changes.outputs.run_backend == 'true'
         # `--cov-report=` (empty) suppresses XML — backend-coverage-merge 가 모든
         # shard 의 `.coverage` 를 모아 단일 XML 을 만들고 codecov 에 한 번 업로드.
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --splits 4 --group ${{ matrix.shard }} --cov=nuri --cov-report= --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --splits 4 --group ${{ matrix.shard }} --cov=nuri --cov-branch --cov-report= --cov-report=term
         timeout-minutes: 5
 
       - name: Upload .coverage artifact
         if: needs.changes.outputs.run_backend == 'true' && always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-fast-${{ matrix.shard }}
           path: .coverage
@@ -454,12 +454,12 @@ jobs:
         # 23 slow tests (LLM/scheduler) → 2 shards × xdist 4 workers. 단일 shard
         # 2:16 wall 의 critical path 를 절반 ~1:00-1:15 로 단축 — fast lane (shard
         # 4 분할 후 ~2:11 wall) 과 같은 critical path 안에 들어옴.
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --splits 2 --group ${{ matrix.shard }} --cov=nuri --cov-report= --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --splits 2 --group ${{ matrix.shard }} --cov=nuri --cov-branch --cov-report= --cov-report=term
         timeout-minutes: 5
 
       - name: Upload .coverage artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-slow-${{ matrix.shard }}
           path: .coverage
@@ -490,7 +490,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           pattern: coverage-*
           path: cov-artifacts

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 PYTHON = .venv/bin/python
 
 .PHONY: help \
-        setup test test-fast test-slow lint lint-fix verify-quick verify-all verify verify-fast \
+        setup test test-fast test-slow ci-cov ci-cov-detail lint lint-fix verify-quick verify-all verify verify-fast \
         collect collect-kis collect-kis-check wallstreet filings \
         analyze report report-llm \
         validate regime recommend gate consensus certify remediate track-decisions \
@@ -84,6 +84,32 @@ test:
 
 test-fast:
 	$(PYTHON) -m pytest tests/ -v --cov=nuri -n auto --dist worksteal -m "not slow"
+
+# ─── CI artifact ground-truth coverage (Issue #616 verification protocol) ───
+# 직전 main CI run 의 6 shards (.coverage artifacts) 다운로드 + combine →
+# Codecov 와 동일한 측정값 산출. local pytest --cov 는 dev 환경 path 의존
+# (config/portfolio.yaml 등) 으로 결과 다를 수 있어 ground truth 아님.
+ci-cov:    ## Latest main CI artifact 6 shards combine → coverage report
+	@LATEST=$$(gh run list --branch main --workflow main-ci-cd.yml --limit 1 --json databaseId | jq -r '.[0].databaseId'); \
+	if [ -z "$$LATEST" ] || [ "$$LATEST" = "null" ]; then echo "❌ no recent main CI run"; exit 1; fi; \
+	echo "📥 Downloading shards from run $$LATEST"; \
+	rm -rf /tmp/ci-cov-shards && mkdir -p /tmp/ci-cov-shards; \
+	cd /tmp/ci-cov-shards && for s in fast-1 fast-2 fast-3 fast-4 slow-1 slow-2; do \
+	    gh run download "$$LATEST" --name "coverage-$$s" --dir ./$$s -R researcherhojin/nuri-quant 2>&1 | tail -1; \
+	done; \
+	cd $(CURDIR); \
+	rm -f .coverage.ci .coverage.ci.shard.*; \
+	for d in fast-1 fast-2 fast-3 fast-4 slow-1 slow-2; do \
+	    [ -f /tmp/ci-cov-shards/$$d/.coverage ] && cp /tmp/ci-cov-shards/$$d/.coverage .coverage.ci.shard.$$d; \
+	done; \
+	$(PYTHON) -m coverage combine --data-file=.coverage.ci .coverage.ci.shard.* 2>&1 | tail -3; \
+	echo ""; echo "═══ CI ground-truth coverage ═══"; \
+	$(PYTHON) -m coverage report --data-file=.coverage.ci --skip-covered; \
+	rm -f .coverage.ci.shard.*
+
+ci-cov-detail:    ## ci-cov + show-missing for files with gaps
+	@$(MAKE) --no-print-directory ci-cov 2>&1 | head -1
+	@$(PYTHON) -m coverage report --data-file=.coverage.ci --show-missing --skip-covered
 
 # ─── #529 Phase 2 production verification ────────────────
 phase2-chain:    ## Phase 2 4-actor chain end-to-end on real macro + ticker (default NVDA)


### PR DESCRIPTION
## Summary

3 CI 개선 동시 처리:

### B. CI workflow `--cov-branch` 추가
Backend Tests Fast/Slow pytest 모두 `--cov-branch` 추가 → Codecov UI 가 statement + branch 통합 표시. 직전 세션 #616 branch coverage 작업이 비로소 가시화 (이전엔 statement only).

### D. actions/{upload,download}-artifact v5 → v6
매 push 마다 7번 출력되던 Node.js 20 deprecation warning 제거. v6 = Node 24 native.

### E. `make ci-cov` / `make ci-cov-detail` target 추가
직전 main CI run 의 6 shards (`.coverage` artifacts) 자동 다운로드 + combine → Codecov 와 동일한 ground-truth 측정.

**Rationale**: local `pytest --cov` 는 dev 환경 path 의존 (`config/portfolio.yaml` 같은 gitignored file) 으로 결과 다를 수 있음. CI artifact = ground truth. 이번 세션 #654 → #655 로 22 stmts 잔존 발견한 것이 그 사례 (local 100% / CI 97%).

## 사용법

\`\`\`bash
make ci-cov         # summary (skip-covered)
make ci-cov-detail  # show-missing for files with gaps
\`\`\`

## Test plan

- [x] Workflow YAML 변경: pytest Fast (line 413) / Slow (line 457) 둘 다 `--cov-branch` 추가
- [x] artifact action 3곳 v6 bump (upload-fast, upload-slow, download-aggregate)
- [x] Makefile ci-cov target 추가 + .PHONY 등록
- [x] `make -n test-fast` syntax 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)