### PR TITLE
fix(ci): exclude merge commits from PR discipline gate count

### DIFF
--- a/.github/workflows/pr-discipline.yml
+++ b/.github/workflows/pr-discipline.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin "$BASE_SHA" --depth=50 --quiet || true
-          COUNT=$(git rev-list --count "$BASE_SHA..$HEAD_SHA")
+          COUNT=$(git rev-list --count --no-merges "$BASE_SHA..$HEAD_SHA")
           echo "PR has $COUNT commit(s) since base"
           if [ "$COUNT" -gt 3 ]; then
             echo "::error::PR has $COUNT commits (limit: 3 per STRATEGY §5.8 #4 / PR Discipline)."


### PR DESCRIPTION
## Summary
- `git rev-list --count` 에 `--no-merges` 추가 → rebase-induced merge commit 을 제외하고 content 변경 commit 만 카운트
- Dependabot PR 가 여러 번 update-branch (main 으로 rebase) 시 merge commit 누적 → false positive 로 ≤ 3 gate 실패하던 문제 해결

## Root cause
`gh pr update-branch` 는 main 을 PR 브랜치로 merge 함 (rebase 아님). 매번 merge commit 1개 추가. 3회 rebase = 1 (원본) + 3 (merge) = 4 commits → gate fail.

룰 의도 ("1 issue = 1 PR, scope ≤ 3 logical changes")는 content commit 기준이지 git ref 개수 기준 아님. Squash-merge 가 어차피 모든 commit 을 1개로 collapse 하므로 main 의 commit count 는 영향 없음.

## 검증
- #664 (shadcn 4.6→4.7): 4 commits (1 dependabot + 3 update-branch merges) → gate FAIL → soft check 라 머지 통과했지만 false positive
- After fix: merge commit 제외 → 1 actual commit → gate PASS

## Test plan
- [x] 1-line surgical change, 의도 명확
- [ ] CI 의 discipline gate 자체 통과 확인 (이 PR 자체 — 1 commit only)
- [ ] 이후 dependabot PR rebase 후 gate false positive 미발생 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)