### PR TITLE
fix: reconcile decision-param single-source-of-truth (TP 20/40, firewall, held_add)

### DIFF
--- a/config/buy_signals.yaml
+++ b/config/buy_signals.yaml
@@ -58,12 +58,14 @@ allocation:
   per_candidate_method: score_weighted    # score 비중에 따라 분할 (vs equal_split)
 
 # ─── Risk per candidate (entry/stop/TP from rules.yaml) ─────────────
-# Stop -7% / TP1 +21% (3:1 R/R, growth ladder rules.yaml 와 align)
+# Stop -7% / TP1 +20% / TP2 +40% — canonical O'Neil growth ladder.
+# rules.yaml take_profit.growth (20/40) 와 단일 출처 일치 (SSoT).
+# 변경 시 rules.yaml 와 함께. test_buy_emitter_tp_ladder_matches_canonical_growth 가 lock.
 # Phase 1 = growth ladder 만 적용. Phase 2: ticker 별 growth/value 분기.
 risk:
   stop_pct: -7.0
-  tp1_pct: 21.0
-  tp2_pct: 42.0
+  tp1_pct: 20.0
+  tp2_pct: 40.0
 
 # ─── Exclude (held tickers + ETFs not eligible) ─────────────────────
 exclude_held: true            # 보유 종목은 BUY 추천 X (held_add_mode 가 Phase 2a 부터 별도 처리)
@@ -96,7 +98,7 @@ held_add_mode:
     # precedence=2 — winner momentum add (cap headroom 활용)
     ride_winner:
       trigger:
-        unrealized_pnl_min_factor: 2.5    # core: tp1=+21 → trigger ≥ +52.5
+        unrealized_pnl_min_factor: 2.5    # core: tp1=+20 → trigger ≥ +50 (canonical growth TP1)
         days_held_min: 30
         composite_score_min: 75
         sector_momentum_min: 5

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -128,6 +128,7 @@ leverage:
     - UPRO
     - SPXU
   max_holding_days: 5           # 레버리지 ETF 최대 보유일 (스윙만 허용)
+  max_leverage: 1.5             # long_exposure / cash 최대 배수 (ExecutionFirewall leverage_cap)
 
 # ─── 실행 우선순위 ──────────────────────────────────────
 # 근거: 하락 모멘텀 종목의 1시간 지연 = 추가 손실 확정.

--- a/nuri/agents/actors/execution_firewall.py
+++ b/nuri/agents/actors/execution_firewall.py
@@ -36,11 +36,14 @@ from typing import Any
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_execution_block, query
-from nuri.core.rules import RULES
+from nuri.core.rules import RULES, VIX_BLOCK_ABOVE, VIX_CAUTION_ABOVE
 
 # ─── 룰 임계값 (config/rules.yaml override 가능) ─────────────
-VIX_HARD_BLOCK = float(RULES.get("buy_checklist", {}).get("vix_gate", {}).get("block_above", 30))
-VIX_SOFT_CAUTION = float(RULES.get("buy_checklist", {}).get("vix_gate", {}).get("caution_above", 25))
+# VIX 게이트는 canonical entry_rules.vix_gate (nuri.core.rules 로더) 단일 출처를 import.
+# (과거: buy_checklist.vix_gate 를 읽었으나 그 키는 rules.yaml 에 부재 → 항상 dead literal
+#  fallback 이라 운영자의 VIX 게이트 config 편집이 firewall 에서 무시됐음.)
+VIX_HARD_BLOCK = float(VIX_BLOCK_ABOVE)
+VIX_SOFT_CAUTION = float(VIX_CAUTION_ABOVE)
 MAX_SINGLE_POSITION = float(RULES["position_limits"]["max_single_position"])
 MAX_SECTOR_EXPOSURE = float(RULES["position_limits"]["max_sector_exposure"])
 MIN_CASH_RESERVE = float(RULES.get("position_limits", {}).get("min_cash_reserve", 0.20))

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -446,8 +446,8 @@ def emit_buy_candidates(
                 deploy_pct=round(per_pct * 100.0, 2),
                 entry=round(entry, 2),
                 stop=round(entry * (1 + risk.get("stop_pct", -7.0) / 100.0), 2),
-                tp1=round(entry * (1 + risk.get("tp1_pct", 21.0) / 100.0), 2),
-                tp2=round(entry * (1 + risk.get("tp2_pct", 42.0) / 100.0), 2),
+                tp1=round(entry * (1 + risk.get("tp1_pct", 20.0) / 100.0), 2),
+                tp2=round(entry * (1 + risk.get("tp2_pct", 40.0) / 100.0), 2),
                 why_now=_build_why_now(sources, price, _rsi),
                 sources=sources,
             )
@@ -474,7 +474,11 @@ def render_markdown(result: EmitResult) -> str:
         lines.append("")
         lines.append(f"{i}. **{c.ticker}** — score {c.score}/100, deploy {c.deploy_pct}%")
         lines.append(f"   - Why now: {c.why_now}")
-        lines.append(f"   - Entry ${c.entry} / Stop ${c.stop} (-7%) / TP1 ${c.tp1} (+21%) / TP2 ${c.tp2} (+42%)")
+        lines.append(
+            f"   - Entry ${c.entry} / Stop ${c.stop} ({(c.stop / c.entry - 1) * 100:+.0f}%) / "
+            f"TP1 ${c.tp1} ({(c.tp1 / c.entry - 1) * 100:+.0f}%) / "
+            f"TP2 ${c.tp2} ({(c.tp2 / c.entry - 1) * 100:+.0f}%)"
+        )
         src = " · ".join(f"{k}={v:.0f}" for k, v in c.sources.items())
         lines.append(f"   - Sources: {src}")
 

--- a/nuri/trading/recommend/held_add.py
+++ b/nuri/trading/recommend/held_add.py
@@ -29,6 +29,7 @@ import yaml
 
 from nuri.core.account_cap import derive_position_cap
 from nuri.core.db import get_db, query_df
+from nuri.core.rules import TAKE_PROFIT_GROWTH
 from nuri.core.timezone import kst_now, today_kst
 
 logger = logging.getLogger(__name__)
@@ -246,7 +247,7 @@ def _evaluate_tp1_residual_add(
         return None
 
     profile = _get_account_strategy_profile(pos["account"])
-    tp1_pct = abs(float(profile.get("tp1_pct", 21.0)))
+    tp1_pct = abs(float(profile.get("tp1_pct", TAKE_PROFIT_GROWTH["target_1"])))
     pnl_threshold = tp1_pct * float(trig.get("unrealized_pnl_min_factor", 1.2))
     if pos["pnl_pct"] < pnl_threshold:
         return None
@@ -267,7 +268,7 @@ def _evaluate_ride_winner(pos: dict[str, Any], cfg: dict, score: float, sector_m
         return None
 
     profile = _get_account_strategy_profile(pos["account"])
-    tp1_pct = abs(float(profile.get("tp1_pct", 21.0)))
+    tp1_pct = abs(float(profile.get("tp1_pct", TAKE_PROFIT_GROWTH["target_1"])))
     pnl_threshold = tp1_pct * float(trig.get("unrealized_pnl_min_factor", 2.5))
     if pos["pnl_pct"] < pnl_threshold:
         return None

--- a/tests/agents/test_execution_firewall.py
+++ b/tests/agents/test_execution_firewall.py
@@ -631,3 +631,38 @@ class TestCli:
 
         rc = main(["list_blocks", "--severity", "hard"])
         assert rc == 0
+
+
+def test_firewall_constants_track_canonical_config():
+    """SSoT lock for the firewall wrong-key bug.
+
+    firewall 은 과거 buy_checklist.vix_gate (rules.yaml 에 부재한 키) 를 읽어
+    항상 dead literal 30/25 로 fallback → 운영자의 entry_rules.vix_gate config
+    편집이 무시됐다. leverage.max_leverage 도 부재해 항상 1.5 fallback. 이 테스트는
+    rules.yaml 을 직접 로드해 firewall 이 canonical 키를 읽는지 lock 한다.
+    """
+    from pathlib import Path
+
+    import yaml
+
+    from nuri.agents.actors.execution_firewall import (
+        MAX_LEVERAGE,
+        VIX_HARD_BLOCK,
+        VIX_SOFT_CAUTION,
+    )
+    from nuri.core.rules import VIX_BLOCK_ABOVE, VIX_CAUTION_ABOVE
+
+    rules = yaml.safe_load((Path(__file__).parents[2] / "config" / "rules.yaml").read_text(encoding="utf-8"))
+
+    # 구조적 사실: buy_checklist 에는 vix_gate 가 없다 (옛 버그의 dead path).
+    # canonical 은 entry_rules.vix_gate. 이 단언이 깨지면 wrong-key 재도입 신호.
+    assert "vix_gate" not in rules.get("buy_checklist", {})
+    assert "vix_gate" in rules["entry_rules"]
+
+    # firewall 상수 == canonical 로더(rules.py) == rules.yaml entry_rules.
+    assert VIX_HARD_BLOCK == float(VIX_BLOCK_ABOVE) == float(rules["entry_rules"]["vix_gate"]["block_above"])
+    assert VIX_SOFT_CAUTION == float(VIX_CAUTION_ABOVE) == float(rules["entry_rules"]["vix_gate"]["caution_above"])
+
+    # leverage cap 은 config 에 존재해야 함 (없으면 firewall 이 dead literal 1.5 fallback).
+    assert "max_leverage" in rules["leverage"], "rules.yaml leverage.max_leverage 누락 — firewall dead-literal fallback"
+    assert MAX_LEVERAGE == float(rules["leverage"]["max_leverage"])

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -57,6 +57,9 @@ def cfg_path(tmp_path):
         "allocation": {
             "total_pct_by_regime": {"neutral": 0.30, "bull": 0.50},
         },
+        # 의도적 non-canonical (21/42): emitter 가 config 를 읽음(하드코딩 아님)을 증명.
+        # 실제 출하 config 의 canonical(20/40) 정합은
+        # test_buy_emitter_tp_ladder_matches_canonical_growth 가 별도로 lock.
         "risk": {"stop_pct": -7.0, "tp1_pct": 21.0, "tp2_pct": 42.0},
     }
     p = tmp_path / "buy_signals.yaml"
@@ -377,6 +380,40 @@ def test_render_with_candidates():
     assert "Multi-factor 상위" in md
 
 
+def test_render_markdown_tp_label_derived_from_price():
+    """라벨의 %는 가격에서 파생되어야 한다 (하드코딩 literal 금지).
+
+    과거 render_markdown 이 (-7%)/(+21%)/(+42%) 를 하드코딩해, 값을 20/40 으로
+    바꾼 뒤에도 brief 라벨은 +21/+42 로 표시되는 모순이 있었다 (codex P2).
+    entry=100, stop=93, tp1=120, tp2=140 → 라벨 -7% / +20% / +40%.
+    """
+    r = EmitResult(
+        candidates=[
+            BuyCandidate(
+                ticker="ZZZ",
+                score=80,
+                deploy_pct=10.0,
+                entry=100.0,
+                stop=93.0,
+                tp1=120.0,
+                tp2=140.0,
+                why_now="x",
+                sources={"factor": 90},
+            )
+        ],
+        regime="neutral",
+        vix=20.0,
+        total_deploy_pct=10.0,
+        timestamp_kst="2026-04-30 02:00:00 KST",
+    )
+    md = render_markdown(r)
+    assert "(-7%)" in md
+    assert "(+20%)" in md
+    assert "(+40%)" in md
+    # 옛 하드코딩 회귀 방지
+    assert "(+21%)" not in md and "(+42%)" not in md
+
+
 # --- Config load -----------------------------------------------------------
 
 
@@ -419,3 +456,24 @@ def test_brief_surfaces_buy_candidates(db, cfg_path):
     assert bc is not None, "buy_candidates ctx key missing — brief integration broken"
     # 1 emitted (STRONG only) — others non-existent in fresh DB
     assert any(c.ticker == "STRONG" for c in bc.candidates) or bc.blocked_reason
+
+
+def test_buy_emitter_tp_ladder_matches_canonical_growth():
+    """SSoT lock: BUY emitter 출하 config 의 TP 사다리는 rules.yaml
+    take_profit.growth (canonical 20/40) 와 일치해야 한다.
+
+    buy_signals.yaml 가 canonical 에서 다시 fork (예: 21/42) 하면 실패한다.
+    근거: brief(+21%) vs /targets(+20%) 운영자-facing 모순 회귀 방지
+    (recommend/CLAUDE.md "price_targets.py canonical — caller 재유도 금지").
+    """
+    from nuri.core.rules import TAKE_PROFIT_GROWTH
+
+    risk = _load_config().get("risk", {})  # 실제 config/buy_signals.yaml 로드
+    assert risk["tp1_pct"] == TAKE_PROFIT_GROWTH["target_1"], (
+        f"buy_signals tp1_pct={risk.get('tp1_pct')} != canonical "
+        f"{TAKE_PROFIT_GROWTH['target_1']} (rules.yaml take_profit.growth)"
+    )
+    assert risk["tp2_pct"] == TAKE_PROFIT_GROWTH["target_2"], (
+        f"buy_signals tp2_pct={risk.get('tp2_pct')} != canonical "
+        f"{TAKE_PROFIT_GROWTH['target_2']} (rules.yaml take_profit.growth)"
+    )

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -216,6 +216,48 @@ class TestModeEvaluation:
         )
         assert mode == "ride_winner"
 
+    def test_ride_winner_default_tp1_uses_canonical_growth_not_phantom(
+        self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict
+    ) -> None:
+        """SSoT lock: account_strategies 에 tp1_pct 가 없을 때(실제 모든 계좌)
+        held_add 는 canonical growth TP1 (rules.yaml take_profit.growth = 20) 을
+        default 로 써야 한다. 과거엔 phantom 21.0 하드코딩이라 ride_winner 임계가
+        21×2.5=52.5 였다. 이제 20×2.5=50.
+
+        변별 입력 pnl_pct=51.0 (gap [50, 52.5)): 20-기준이면 trigger, 21-기준이면 skip.
+        phantom 21 회귀 시 mode != 'ride_winner' 로 실패한다.
+        """
+        from nuri.core.rules import TAKE_PROFIT_GROWTH
+
+        assert TAKE_PROFIT_GROWTH["target_1"] == 20  # canonical premise
+
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_last_trim_age_days",
+            lambda ticker, max_days=60: None,  # trim 없음 → tp1_residual skip
+        )
+        # 실제 account_strategies 모양: tp1_pct 키 없음 → canonical default 경로
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_account_strategy_profile",
+            lambda account: {"stop_loss": -7, "max_single_position": 0.15},
+        )
+        pos = {
+            "ticker": "NVDA",
+            "account": "acct_alpha",
+            "pnl_pct": 51.0,  # 20×2.5=50 충족, 21×2.5=52.5 미충족 (변별)
+            "days_held": 35,
+        }
+        mode = ha.select_held_mode(
+            pos,
+            cfg_held_add["held_add_mode"],
+            score=80,
+            rsi=55,
+            regime="neutral",
+            vix=18,
+            breakout_above_trim=False,
+            sector_mom=8,
+        )
+        assert mode == "ride_winner"
+
     def test_tp1_residual_takes_precedence_over_ride_winner(
         self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict
     ) -> None:


### PR DESCRIPTION
## Decision-parameter single-source-of-truth fixes

Three SSoT/wrong-key drifts surfaced by a full-codebase workflow audit + overhaul tribunal. All three were the "declared config-driven, but a code literal is the effective value" class — the silent-corruption failure mode this project is built to prevent. Each fix ships with a Gotcha-Test Pair (§5.3.1) verified to fail if the fix is reverted.

### Commits
1. **`fix(config)`: growth BUY TP ladder → canonical 20/40**
   `buy_candidate_emitter` re-derived TP1/TP2 from `buy_signals.yaml` (21/42) while `price_targets` used `rules.yaml take_profit.growth` (20/40, O'Neil). Same ticker showed **+21/+42 in the morning brief but +20/+40 in `/targets`, Discord, and the engine** — violating the `recommend/CLAUDE.md` "price_targets.py canonical" invariant.
   - `buy_signals.yaml` + emitter fallback → 20/40
   - `render_markdown()` TP labels now **derived from price** (were hardcoded `+21%/+42%`, which contradicted the new values — caught by codex review, not the first pass)
   - Gotcha-Tests: config ladder == `rules.yaml take_profit.growth`; markdown label == price-derived

2. **`fix(actor)`: firewall reads canonical VIX gate + leverage cap**
   `ExecutionFirewall` read `buy_checklist.vix_gate` (a key absent from `rules.yaml`) and `leverage.max_leverage` (also absent) → silently used dead literals 30/25/1.5, **ignoring the operator's `entry_rules.vix_gate` config**. Now imports `VIX_BLOCK_ABOVE`/`VIX_CAUTION_ABOVE` from the canonical `nuri.core.rules` loader; `max_leverage` added to `rules.yaml` (value unchanged 1.5). No behavior change — closes the silent config-ignore path.

3. **`fix(recommend)`: held_add tp1_pct → canonical growth TP1, not phantom 21**
   `held_add` read `profile.get("tp1_pct", 21.0)` but `account_strategies` has no `tp1_pct` key → every account's add-gate was frozen at 21. Defaults to canonical `TAKE_PROFIT_GROWTH.target_1` (20) while preserving per-account override. **Intended behavior delta** (follows the 20/40 decision): ride_winner trigger 52.5%→50%, tp1_residual 25.2%→24%. Discriminating Gotcha-Test (pnl 51%, gap [50,52.5)) fails if the phantom 21 returns.

### Verification
- Full fast suite: **5839 passed, 6 skipped** (pre-label-fix run); affected-file run **107 passed** post-fix.
- Each Gotcha-Test confirmed to fail on regression (21 returns) and pass on fix.
- Independent codex (gpt-5.4) review: **GATE PASS** (no P1); the one P2 it found (hardcoded markdown label) is fixed in commit 1.
- Permanent invariants respected: recommend-only, alpha/portfolio axis, config-as-source-of-truth (now actually enforced), no privacy data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
