### PR TITLE
fix(api): /pipeline/status returns frontend-shaped step array (live DAG, was hardcoded)

### DIFF
--- a/nuri/api/routes/pipeline.py
+++ b/nuri/api/routes/pipeline.py
@@ -1,4 +1,5 @@
 """Pipeline API — 파이프라인 상태 조회 + 스텝 실행."""
+
 import logging
 import time
 
@@ -12,6 +13,42 @@ _limiter = Limiter(key_func=get_remote_address)
 
 VALID_STEPS = ("collect", "validate", "classify", "diagnose", "recommend", "track")
 
+# Frontend PipelineStep presentation (frontend/src/app/pipeline/page.tsx expects this shape).
+_STEP_LABELS = {
+    "collect": "Collect",
+    "validate": "Validate",
+    "classify": "Classify",
+    "diagnose": "Diagnose",
+    "recommend": "Recommend",
+    "track": "Track",
+}
+_STEP_DESCRIPTIONS = {
+    "collect": "26 collectors + external sites",
+    "validate": "Signal backtest + scorecard",
+    "classify": "6-regime classifier",
+    "diagnose": "10 agents consensus",
+    "recommend": "Buy/sell + price targets",
+    "track": "30/60/90d outcomes",
+}
+# core event status -> frontend PipelineStep.status enum (idle|running|done|error).
+# Robust to both vocabularies: canonical EVENT_TYPES (step_completed/...) and the
+# legacy "step_success" emitted by run_pipeline_step + seeds (event-schema drift,
+# normalized at the emit site separately).
+_UI_STATUS = {
+    "step_started": "running",
+    "running": "running",
+    "step_completed": "done",
+    "completed": "done",
+    "step_success": "done",
+    "success": "done",
+    "step_failed": "error",
+    "failed": "error",
+    "step_blocked": "error",
+    "blocked": "error",
+    "unknown": "idle",
+    "idle": "idle",
+}
+
 _HEARTBEAT_PATH = None  # 테스트에서 monkeypatch 가능
 
 
@@ -19,6 +56,7 @@ def _get_heartbeat_path():
     if _HEARTBEAT_PATH:
         return _HEARTBEAT_PATH
     from pathlib import Path
+
     return Path(__file__).parent.parent.parent.parent / "data" / ".scheduler_heartbeat"
 
 
@@ -32,6 +70,7 @@ def get_scheduler_health():
     from datetime import datetime
 
     from nuri.core.timezone import kst_now
+
     try:
         last = datetime.fromisoformat(heartbeat_path.read_text().strip())
         age_seconds = (kst_now().replace(tzinfo=None) - last).total_seconds()
@@ -49,13 +88,33 @@ def get_scheduler_health():
 
 @router.get("/pipeline/status")
 def get_pipeline_status():
-    """6단계 파이프라인 최신 상태 + 신선도."""
-    from nuri.core.events import get_pipeline_status
+    """6단계 파이프라인 최신 상태 + 신선도.
+
+    `steps` 는 PIPELINE_STEPS 순서의 **배열** (프론트 PipelineStep[] 계약).
+    과거엔 dict {step: {...}} 를 반환 → 프론트가 array(`for...of`/`.length`)로
+    소비 못해 항상 하드코딩 DEFAULT_NODES 로 fallback → DAG 가 가짜 데이터였음.
+    """
+    from nuri.core.events import get_pipeline_status as _step_status_map
     from nuri.core.freshness import get_freshness_summary
 
-    steps = get_pipeline_status()
-    freshness = get_freshness_summary()
-    return {"steps": steps, "freshness": freshness}
+    status_map = _step_status_map()  # {step: {step, status, timestamp, payload, record_count}}
+    steps = []
+    for name, st in status_map.items():
+        raw = st.get("status", "unknown")
+        payload = st.get("payload")
+        steps.append(
+            {
+                "step": name,
+                "label": _STEP_LABELS.get(name, name.title()),
+                "description": _STEP_DESCRIPTIONS.get(name, ""),
+                "record_count": st.get("record_count", 0) or 0,
+                "last_updated": st.get("timestamp"),
+                "status": _UI_STATUS.get(raw, "idle"),
+                "started_at": st.get("timestamp") if raw == "running" else None,
+                "error": payload.get("error") if isinstance(payload, dict) else None,
+            }
+        )
+    return {"steps": steps, "freshness": get_freshness_summary()}
 
 
 @router.get("/pipeline/timeline")
@@ -103,6 +162,7 @@ def run_pipeline_step(step: str, request: Request):
 def get_freshness():
     """전체 데이터 신선도 조회."""
     from nuri.core.freshness import get_freshness_summary
+
     return get_freshness_summary()
 
 
@@ -112,24 +172,29 @@ def _execute_step(step: str) -> str:
         return "not_implemented: collect requires individual collector runs"
     elif step == "validate":
         from nuri.quant.validation.signal_backtest import backtest_signals
+
         result = backtest_signals()
         return f"signal_backtest: {len(result) if result else 0} signals"
     elif step == "classify":
         from nuri.quant.regime.classifier import classify_regime
+
         r = classify_regime()
         if r:
             return f"regime={r.regime}, trend={r.trend}, confidence={r.confidence:.0%}"
         return "regime=unknown (데이터 부족)"
     elif step == "diagnose":
         from nuri.trading.agents.consensus import analyze_portfolio
+
         results = analyze_portfolio()
         return f"consensus: {len(results)} tickers analyzed"
     elif step == "recommend":
         from nuri.trading.recommend.candidates import screen_candidates
+
         candidates = screen_candidates()
         return f"candidates: {len(candidates)} found"
     elif step == "track":
         from nuri.trading.recommend.tracker import track_outcomes
+
         tracked = track_outcomes()
         return f"tracked: {tracked} recommendations updated"
     return "unknown step"

--- a/nuri/core/events.py
+++ b/nuri/core/events.py
@@ -75,7 +75,7 @@ def get_step_status(step: str, db_path: Optional[Path] = None) -> dict:
     """특정 스텝의 최신 이벤트 조회 → {status, timestamp, payload}."""
     try:
         rows = query(
-            """SELECT event_type, timestamp, payload
+            """SELECT event_type, timestamp, payload, record_count
                FROM pipeline_events
                WHERE step = ?
                ORDER BY timestamp DESC, id DESC
@@ -88,9 +88,9 @@ def get_step_status(step: str, db_path: Optional[Path] = None) -> dict:
         import logging
 
         logging.getLogger(__name__).debug("pipeline_events 조회 실패: %s", e)
-        return {"step": step, "status": "unknown", "timestamp": None, "payload": None}
+        return {"step": step, "status": "unknown", "timestamp": None, "payload": None, "record_count": 0}
     if not rows:
-        return {"step": step, "status": "unknown", "timestamp": None, "payload": None}
+        return {"step": step, "status": "unknown", "timestamp": None, "payload": None, "record_count": 0}
 
     row = rows[0]
     # event_type → status 매핑
@@ -102,7 +102,13 @@ def get_step_status(step: str, db_path: Optional[Path] = None) -> dict:
     }
     status = status_map.get(row["event_type"], row["event_type"])
     payload = json.loads(row["payload"]) if row["payload"] else None
-    return {"step": step, "status": status, "timestamp": row["timestamp"], "payload": payload}
+    return {
+        "step": step,
+        "status": status,
+        "timestamp": row["timestamp"],
+        "payload": payload,
+        "record_count": row["record_count"] if row["record_count"] is not None else 0,
+    }
 
 
 def get_pipeline_status(db_path: Optional[Path] = None) -> dict:

--- a/tests/api/test_pipeline.py
+++ b/tests/api/test_pipeline.py
@@ -409,24 +409,30 @@ class TestPipelineStatus:
 
         assert "steps" in data
         assert "freshness" in data
-        # 6 steps 모두 존재
+        # steps 는 프론트 PipelineStep[] 계약: 배열, 각 원소에 step/label/status 등.
+        # (과거 dict 반환 → 프론트가 array 로 소비 못해 DAG 가 하드코딩 fallback 했던 버그의 회귀 가드.)
         steps = data["steps"]
+        assert isinstance(steps, list)
+        by_step = {s["step"]: s for s in steps}
         for step in ("collect", "validate", "classify", "diagnose", "recommend", "track"):
-            assert step in steps
-            assert "status" in steps[step]
+            assert step in by_step
+            s = by_step[step]
+            assert s["status"] in ("idle", "running", "done", "error")  # 프론트 enum
+            assert "label" in s and "description" in s and "record_count" in s
 
     def test_pipeline_status_with_events(self, client, db_path):
-        """이벤트 데이터 있을 때 상태 반영 확인."""
+        """이벤트 데이터 있을 때 상태가 프론트 enum 으로 매핑되어 반영되는지 확인."""
         _seed_pipeline_events_for_pipeline(db_path)
 
         r = client.get("/api/pipeline/status")
         assert r.status_code == 200
         data = r.json()
 
-        steps = data["steps"]
-        # events.py의 get_step_status()가 event_type을 status로 매핑
-        assert steps["collect"]["status"] in ("success", "step_success", "completed")
-        assert steps["diagnose"]["status"] in ("failed", "step_failed")
+        by_step = {s["step"]: s for s in data["steps"]}
+        # step_success(collect) -> done, step_failed(diagnose) -> error
+        assert by_step["collect"]["status"] == "done"
+        assert by_step["collect"]["record_count"] == 1500  # seed record_count 컬럼 반영
+        assert by_step["diagnose"]["status"] == "error"
 
 
 class TestPipelineTimeline:


### PR DESCRIPTION
## fix(api): `/pipeline/status` returns a frontend-shaped step array (was a dict)

The pipeline page's DAG showed **permanently hardcoded `DEFAULT_NODES`, never live data** — a "fake telemetry" bug surfaced by the frontend Palantir-maturity audit.

### Root cause (verified by code, not assumed)
- `/pipeline/status` returned `steps` as a **dict** `{step: {...}}` (`nuri.core.events.get_pipeline_status -> dict`).
- The frontend (`frontend/src/app/pipeline/page.tsx`) expects `PipelineStep[]` — it does `for (const s of data.steps)` (line 248), `steps.length` (329), `steps.map` (330).
- `for...of` on a plain object **throws** ("not iterable") → caught by the silent `.catch(() => {})` → and `steps.length` on an object is `undefined` → `> 0` is false → the page **always falls back to hardcoded `DEFAULT_NODES`** (stale labels like "15 collectors + 6 sites", recordCount 0).
- The backend test `test_pipeline_status_with_events` asserted the **dict** shape (`steps["collect"]`) — a test illusion: it passed green while the real UI silently rendered fake nodes.

### Fix (smallest blast radius — frontend already expects the correct contract)
- **Endpoint** transforms the dict into an ordered array of the full `PipelineStep` shape: `{step, label, description, record_count, last_updated, status, started_at, error}`, mapping core event status → the frontend enum (`idle | running | done | error`). The status map is robust to both the canonical `step_completed` and the legacy `step_success` vocabularies (the latter is emitted by `run_pipeline_step` + seeds — an event-schema drift to normalize separately).
- **`get_step_status()`** now also surfaces `record_count` (from the `pipeline_events.record_count` column). Status values are unchanged (core lock-tests still pass).
- **Backend test** rewritten to assert the **array** contract (FE-consumable) instead of the broken dict shape.
- **Frontend: unchanged** — it already expects this exact array (its own `mockSteps` fixture + the dashboard `steps: []` fallback confirm the intended contract).

### Verification
- `tests/api/test_pipeline.py` + `tests/core/test_pipeline_events.py`: **93 passed**.
- Live endpoint check: `/api/pipeline/status` now returns a **6-element array** with all 8 `PipelineStep` keys and statuses mapped to the FE enum (`['idle','done','done','done','done','error']`). The DAG will now render live step status instead of the hardcoded fallback.
- Full fast suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
