### PR TITLE
feat(scheduler): wire alpha tracking into scheduler + clarify decision_pnl job

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -140,11 +140,25 @@ def _run_collector(name: str, **kwargs):
 
             n = save_snapshot()
             logger.info(f"[memory_snapshot] {n}건 저장")
-        elif name == "decision_outcomes":
+        elif name == "decision_pnl":
+            # decisions 테이블의 7/30/60/90d raw P&L 갱신.
+            # NOTE: decision_outcomes(alpha) 테이블이 아님 — alpha 는 아래 alpha_tracking job.
             from nuri.trading.engine.decisions import track_decision_outcomes
 
             n = track_decision_outcomes()
-            logger.info(f"[decision_outcomes] {n}건 업데이트")
+            logger.info(f"[decision_pnl] {n}건 업데이트")
+        elif name == "alpha_tracking":
+            # ForwardOutcomeTracker: emit 된 추천 vs SPY benchmark → realized alpha 를
+            # decision_outcomes 테이블에 기록 (recommendations → agent_decisions 백필 포함).
+            # canonical scheduler 경로 — 과거 launchd track-forward.plist 를 흡수(이제 redundant).
+            from nuri.agents.actors.forward_outcome_tracker import ForwardOutcomeTracker
+
+            res = ForwardOutcomeTracker().run({"action": "scan", "max_decisions": 2000})
+            out = res.output if isinstance(res.output, dict) else {}
+            logger.info(
+                f"[alpha_tracking] synced={out.get('synced_from_recommendations', 0)} "
+                f"measured={out.get('n_measurements', 0)}"
+            )
         elif name == "agent_accuracy":
             from nuri.trading.engine.decisions import save_agent_accuracy_snapshot
 
@@ -402,8 +416,11 @@ SCHEDULES = [
     {"name": "wallstreet", "func": _run_collector, "args": ("wallstreet",), "cron": "30 3 * * 0"},
     # Learning Memory 스냅샷 (주 1회 일요일 04:00)
     {"name": "memory_snapshot", "func": _run_collector, "args": ("memory_snapshot",), "cron": "0 4 * * 0"},
-    # Decision outcome 추적 (매일 07:00 — 시장 개장 전)
-    {"name": "decision_outcomes", "func": _run_collector, "args": ("decision_outcomes",), "cron": "0 7 * * *"},
+    # decisions 테이블 raw P&L 갱신 (매일 07:00 — 시장 개장 전). NOT alpha (아래 alpha_tracking).
+    {"name": "decision_pnl", "func": _run_collector, "args": ("decision_pnl",), "cron": "0 7 * * *"},
+    # 실현 alpha 추적 (매일 17:00 — 한국장 마감 후). ForwardOutcomeTracker scan →
+    # decision_outcomes (realized vs SPY benchmark). 과거 launchd track-forward.plist 를 scheduler 로 흡수.
+    {"name": "alpha_tracking", "func": _run_collector, "args": ("alpha_tracking",), "cron": "0 17 * * *"},
     # 10-agent consensus (매일 07:05 — technical 07:00 완료 후, daily_report 08:00 전).
     # agent_verdicts 를 recommendations 테이블에 쌓아 Learning Memory 가 30 일 후 학습.
     # Phase 2 A-1a (PR #361) 의 read path fix 를 활용하려면 input 이 꾸준히 쌓여야 함.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -642,12 +642,13 @@ class TestWriteHeartbeat_PipelineApi:
 class TestSchedulerDecisions:
     """Tests for decision_outcomes and agent_accuracy schedule entries."""
 
-    def test_decision_outcomes_in_schedules(self):
-        """SCHEDULES에 decision_outcomes 엔트리 존재."""
+    def test_decision_pnl_and_alpha_in_schedules(self):
+        """SCHEDULES에 decision_pnl(raw P&L) + alpha_tracking(realized alpha) 엔트리 존재."""
         from nuri.scheduler import SCHEDULES
 
         names = [s["name"] for s in SCHEDULES]
-        assert "decision_outcomes" in names
+        assert "decision_pnl" in names
+        assert "alpha_tracking" in names  # ForwardOutcomeTracker → decision_outcomes 테이블
 
     def test_agent_accuracy_in_schedules(self):
         """SCHEDULES에 agent_accuracy 엔트리 존재."""
@@ -656,12 +657,19 @@ class TestSchedulerDecisions:
         names = [s["name"] for s in SCHEDULES]
         assert "agent_accuracy" in names
 
-    def test_decision_outcomes_cron(self):
-        """decision_outcomes: 매일 07:00 KST."""
+    def test_decision_pnl_cron(self):
+        """decision_pnl: 매일 07:00 KST."""
         from nuri.scheduler import SCHEDULES
 
-        entry = next(s for s in SCHEDULES if s["name"] == "decision_outcomes")
+        entry = next(s for s in SCHEDULES if s["name"] == "decision_pnl")
         assert entry["cron"] == "0 7 * * *"
+
+    def test_alpha_tracking_cron(self):
+        """alpha_tracking: 매일 17:00 KST (한국장 마감 후, 흡수된 launchd track-forward timing)."""
+        from nuri.scheduler import SCHEDULES
+
+        entry = next(s for s in SCHEDULES if s["name"] == "alpha_tracking")
+        assert entry["cron"] == "0 17 * * *"
 
     def test_agent_accuracy_cron(self):
         """agent_accuracy: 일요일 08:00 KST."""
@@ -670,13 +678,28 @@ class TestSchedulerDecisions:
         entry = next(s for s in SCHEDULES if s["name"] == "agent_accuracy")
         assert entry["cron"] == "0 8 * * 0"
 
-    def test_run_collector_decision_outcomes(self):
-        """_run_collector dispatches to track_decision_outcomes."""
+    def test_run_collector_decision_pnl(self):
+        """_run_collector('decision_pnl') dispatches to track_decision_outcomes (raw P&L)."""
         from nuri.scheduler import _run_collector
 
         with patch("nuri.trading.engine.decisions.track_decision_outcomes", return_value=3) as mock_fn:
-            _run_collector("decision_outcomes")
+            _run_collector("decision_pnl")
         mock_fn.assert_called_once()
+
+    def test_run_collector_alpha_tracking(self):
+        """_run_collector('alpha_tracking') dispatches to ForwardOutcomeTracker.scan (realized alpha)."""
+        from unittest.mock import MagicMock
+
+        from nuri.scheduler import _run_collector
+
+        with patch("nuri.agents.actors.forward_outcome_tracker.ForwardOutcomeTracker") as mock_cls:
+            mock_cls.return_value.run.return_value = MagicMock(
+                output={"synced_from_recommendations": 2, "n_measurements": 6}
+            )
+            _run_collector("alpha_tracking")
+        mock_cls.return_value.run.assert_called_once()
+        # scan action 으로 호출됐는지
+        assert mock_cls.return_value.run.call_args[0][0]["action"] == "scan"
 
     def test_run_collector_agent_accuracy(self):
         """_run_collector dispatches to save_agent_accuracy_snapshot."""


### PR DESCRIPTION
## T0b cleanup — operationalize alpha tracking in production

The frontend Palantir audit flagged the alpha pipeline as "wired but verify." Investigation (this session) found the real gap is **operational, not code**:

- `decision_outcomes` (realized alpha vs SPY) is written by `ForwardOutcomeTracker`, scheduled **only** via the launchd `track-forward.plist`.
- **Verified on the production Mac mini**: only `com.nuri-quant.scheduler` + `autopull` launchd agents are loaded — `track-forward` is **not installed/loaded**. So alpha was never auto-tracked in prod (this session's `decision_outcomes` rows came from a manual MBP run).

### Fix
- Add an **`alpha_tracking`** job to `scheduler.py SCHEDULES` (17:00 KST) → runs `ForwardOutcomeTracker.scan` via the already-running canonical scheduler. No launchd dependency; the launchd `track-forward.plist` is now redundant (absorbed).
- Rename the misleadingly-named **`decision_outcomes`** scheduler job → **`decision_pnl`** (it updates `decisions.pnl_*`, NOT the `decision_outcomes` alpha table the new job owns) + clarifying comments.

### Tests
- `test_scheduler.py`: dispatch + SCHEDULES + cron tests updated to `decision_pnl`; new `alpha_tracking` dispatch (asserts scan action) + cron (17:00) tests. **86 passed.**
- Full fast suite green (5844 passed; 1 unrelated numba/xdist flake, passes in isolation).

### Post-merge ops (flagged, not automated)
The Mac mini scheduler process must **restart** to load the new `alpha_tracking` SCHEDULES entry (autopull syncs code only; the running APScheduler holds stale SCHEDULES). `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)