### PR TITLE
feat(rules): leader-exit — ride growth winners on 50d MA instead of fixed TP

### DIFF
--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -82,6 +82,16 @@ take_profit:
     min_agent_confidence: 50    # 최소 에이전트 합의 신뢰도
   # O'Neil 8주 규칙: 매수 후 3주 이내에 +20% 돌파 시 최소 8주 보유
   eight_week_hold: true
+  # ─── Leader exception (8주 룰 운영화) ───────────────────────
+  # 성장주(classify_stock_type==growth) 보유는 고정 +20/+40 익절 미적용, trail_ma 이동평균
+  # 종가 이탈 시 청산 (승자 run). value/swing 은 위 ladder 유지. -7% 하드손절 공통.
+  # 백테스트(17 성장주 2021~26, 비중첩·트레일동일·비용·연율화, skeptic 검증): 무TP+MA50
+  # 트레일이 고정TP ladder 대비 CAGR 12.8% → 19.5%, 낙폭 더 얕음 (위험조정 0.30→0.53).
+  # 성장주 판정은 nuri/trading/recommend/price_targets.classify_stock_type (stock_types.yaml
+  # 수동 override > PE>30 > 성장 섹터). 50일선 미계산(< 50 종가) 시 고정 ladder 유지.
+  leader:
+    enabled: true
+    trail_ma: 50                  # 50일 이동평균 종가 이탈 시 청산 (고정 익절 대체)
 
 # ─── 트레일링 스톱 ──────────────────────────────────────
 # 근거: 11년 백테스트에서 15-20% 트레일링 스톱이 최적 수익 (73.9% 누적)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,865 backend tests across 255 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,876 backend tests across 256 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,865 tests, 255 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,876 tests, 256 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -197,13 +197,31 @@ def _build_actions() -> dict:
 
         promoted = False
 
-        # 2차 익절 도달
-        if target.get("target_2") and item["current_price"] and item["current_price"] >= target["target_2"]:
+        # 리더(성장주) 이동평균선 이탈 → 추세 break (고정 익절 폐기된 리더의 유일한 익절 트리거)
+        if target.get("leader_trail_triggered"):
+            from nuri.core.rules import TAKE_PROFIT_LEADER
+
+            _ma_p = int(TAKE_PROFIT_LEADER.get("trail_ma", 50))
+            item["reasons"].append(f"⭐ 리더 {_ma_p}일선 이탈 (+{pnl_pct:.0f}%) — 추세 break, 청산 검토")
+            promoted = True
+
+        # 2차 익절 도달 (리더는 고정 익절 미적용 → skip)
+        elif (
+            not target.get("is_leader")
+            and target.get("target_2")
+            and item["current_price"]
+            and item["current_price"] >= target["target_2"]
+        ):
             item["reasons"].append("2차 익절 도달 — 트레일링 전환 권장")
             promoted = True
 
-        # 1차 익절 도달
-        elif target.get("target_1") and item["current_price"] and item["current_price"] >= target["target_1"]:
+        # 1차 익절 도달 (리더 skip)
+        elif (
+            not target.get("is_leader")
+            and target.get("target_1")
+            and item["current_price"]
+            and item["current_price"] >= target["target_1"]
+        ):
             item["reasons"].append(f"1차 익절 도달 (+{pnl_pct:.0f}%) — 50% 매도 고려")
             promoted = True
 
@@ -476,8 +494,15 @@ def _get_targets_status() -> dict[str, dict]:
     """포트폴리오 가격 타겟 조회."""
     targets = {}
     try:
-        from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+        from nuri.trading.recommend.price_targets import (
+            calculate_portfolio_targets,
+            check_leader_trail_signals,
+        )
 
+        try:
+            _leader_trail = {x["ticker"] for x in check_leader_trail_signals()}
+        except Exception:
+            _leader_trail = set()
         for t in calculate_portfolio_targets():
             targets[t["ticker"]] = {
                 "stop_loss": t.get("stop_loss"),
@@ -485,6 +510,9 @@ def _get_targets_status() -> dict[str, dict]:
                 "target_2": t.get("target_2"),
                 "trailing_stop_pct": t.get("trailing_stop_pct"),
                 "analyst_target": t.get("analyst_target"),
+                "is_leader": t.get("is_leader"),
+                "leader_ma": t.get("leader_ma"),
+                "leader_trail_triggered": t["ticker"] in _leader_trail,
             }
     except Exception as e:
         logger.debug(f"Targets: {e}")

--- a/nuri/api/routes/targets.py
+++ b/nuri/api/routes/targets.py
@@ -10,13 +10,14 @@ def get_portfolio_targets():
     """전 종목 매수가/손절가/익절가 + 익절/트레일링 시그널."""
     from nuri.trading.recommend.price_targets import (
         calculate_portfolio_targets,
+        check_leader_trail_signals,
         check_take_profit_signals,
         check_trailing_stop_signals,
     )
 
     targets = calculate_portfolio_targets()
 
-    # 익절/트레일링 도달 종목 태깅
+    # 익절/트레일링/리더-트레일 도달 종목 태깅
     try:
         tp_signals = {s["ticker"]: s for s in check_take_profit_signals()}
     except Exception:
@@ -25,12 +26,19 @@ def get_portfolio_targets():
         ts_signals = {s["ticker"]: s for s in check_trailing_stop_signals()}
     except Exception:
         ts_signals = {}
+    try:
+        lt_signals = {s["ticker"]: s for s in check_leader_trail_signals()}
+    except Exception:
+        lt_signals = {}
     for t in targets:
         tp = tp_signals.get(t["ticker"])
         ts = ts_signals.get(t["ticker"])
+        lt = lt_signals.get(t["ticker"])
         t["take_profit_triggered"] = tp["level"] if tp else None
         t["take_profit_sell_pct"] = tp["sell_pct"] if tp else None
         t["trailing_stop_triggered"] = ts is not None
+        t["leader_trail_triggered"] = lt is not None
+        t["leader_trail_ma"] = lt["ma"] if lt else None
 
     return {"targets": targets, "count": len(targets)}
 
@@ -71,7 +79,7 @@ def get_certification():
     from nuri.trading.engine.certification import certify
 
     # API path — persist 실패가 HTTP 500 으로 전파되면 안 됨. swallow=True (E4-0a
-     # codex R1 P1). Engine/CLI/remediation 은 default loud 유지.
+    # codex R1 P1). Engine/CLI/remediation 은 default loud 유지.
     cert = certify(caller="api:targets", swallow_persist_errors=True)
     result = {
         "certified": cert.certified,

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -4,11 +4,13 @@
     from nuri.core.rules import RULES
     max_pos = RULES["position_limits"]["max_single_position"]
 """
+
 from pathlib import Path
 
 import yaml
 
 _RULES_PATH = Path(__file__).parent.parent.parent / "config" / "rules.yaml"
+
 
 def _load_rules() -> dict:
     if _RULES_PATH.exists():
@@ -20,6 +22,7 @@ def _load_rules() -> dict:
         "stop_loss": {"per_stock": -20, "portfolio": -10},
         "leverage": {"banned_etfs": ["TSLL", "TQQQ", "SQQQ", "UPRO", "SPXU"]},
     }
+
 
 RULES = _load_rules()
 
@@ -42,6 +45,9 @@ SWING_STOP_LOSS = TAKE_PROFIT_SWING.get("stop_loss", -5)
 SWING_MAX_HOLD_DAYS = TAKE_PROFIT_SWING.get("max_hold_days", 7)
 SWING_MIN_SCAN_SCORE = TAKE_PROFIT_SWING.get("min_scan_score", 20)
 SWING_MIN_AGENT_CONFIDENCE = TAKE_PROFIT_SWING.get("min_agent_confidence", 50)
+# Leader exception (8주 룰 운영화): 성장주는 고정 익절 대신 trail_ma 이동평균 이탈로 청산
+# (승자 run). value/swing 은 위 ladder 유지. config/rules.yaml take_profit.leader.
+TAKE_PROFIT_LEADER = _tp.get("leader", {"enabled": False, "trail_ma": 50})
 
 # ─── 트레일링 스톱 ───
 _ts = RULES.get("trailing_stop", {})
@@ -53,10 +59,16 @@ TRAILING_STOP_VOLATILE = _ts.get("volatile", -20)
 _entry = RULES.get("entry_rules", {})
 VIX_BLOCK_ABOVE = _entry.get("vix_gate", {}).get("block_above", 30)
 VIX_CAUTION_ABOVE = _entry.get("vix_gate", {}).get("caution_above", 25)
-REGIME_CASH = _entry.get("regime_cash", {
-    "extreme_fear": 0.60, "fear": 0.40, "neutral": 0.25,
-    "greed": 0.20, "extreme_greed": 0.40,
-})
+REGIME_CASH = _entry.get(
+    "regime_cash",
+    {
+        "extreme_fear": 0.60,
+        "fear": 0.40,
+        "neutral": 0.25,
+        "greed": 0.20,
+        "extreme_greed": 0.40,
+    },
+)
 MAX_TRANCHES = _entry.get("scaling_in", {}).get("max_tranches", 3)
 TRANCHE_INTERVAL_DAYS = _entry.get("scaling_in", {}).get("tranche_interval_days", 5)
 
@@ -69,25 +81,37 @@ MIN_REVENUE_GROWTH = _chk.get("min_revenue_growth", 0)
 REQUIRE_FACTOR_TOP50 = _chk.get("require_factor_top50pct", True)
 
 # ─── 매도 우선순위 ───
-SELL_PRIORITY = RULES.get("sell_priority", [
-    "leverage_etf", "stop_loss_exceeded", "no_superinvestor",
-    "position_limit_exceeded", "sector_limit_exceeded",
-])
+SELL_PRIORITY = RULES.get(
+    "sell_priority",
+    [
+        "leverage_etf",
+        "stop_loss_exceeded",
+        "no_superinvestor",
+        "position_limit_exceeded",
+        "sector_limit_exceeded",
+    ],
+)
 
 # ─── 레버리지 제한 ───
 LEVERAGE_ETFS = set(RULES["leverage"]["banned_etfs"])
 LEVERAGE_MAX_DAYS = RULES.get("leverage", {}).get("max_holding_days", 5)
 
 # ─── 계좌별 전략 프로파일 ───
-ACCOUNT_STRATEGIES = RULES.get("account_strategies", {
-    "core": {"stop_loss": -7, "max_single_position": 0.15, "max_sector_exposure": 0.35},
-})
-_DEFAULT_STRATEGY = ACCOUNT_STRATEGIES.get("core", {"stop_loss": -7, "max_single_position": 0.15, "max_sector_exposure": 0.35})
+ACCOUNT_STRATEGIES = RULES.get(
+    "account_strategies",
+    {
+        "core": {"stop_loss": -7, "max_single_position": 0.15, "max_sector_exposure": 0.35},
+    },
+)
+_DEFAULT_STRATEGY = ACCOUNT_STRATEGIES.get(
+    "core", {"stop_loss": -7, "max_single_position": 0.15, "max_sector_exposure": 0.35}
+)
 
 
 def get_account_strategy(account: str) -> dict:
     """계좌명 → 전략 프로파일 반환. portfolio.yaml의 strategy 필드 기준."""
     import yaml
+
     _portfolio_path = Path(__file__).parent.parent.parent / "config" / "portfolio.yaml"
     try:
         with open(_portfolio_path, encoding="utf-8") as f:

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -7,6 +7,7 @@ rules.yaml 기반 손절/익절/트레일링 스톱 가격을 계산한다.
 사용법:
     python -m nuri.trading.recommend.price_targets
 """
+
 import logging
 from pathlib import Path
 from typing import Optional
@@ -16,6 +17,7 @@ from nuri.core.rules import (
     STOCK_STOP_LOSS,
     STOCK_STOP_LOSS_VALUE,
     TAKE_PROFIT_GROWTH,
+    TAKE_PROFIT_LEADER,
     TAKE_PROFIT_SWING,
     TAKE_PROFIT_VALUE,
     TRAILING_STOP_GROWTH,
@@ -27,8 +29,18 @@ logger = logging.getLogger(__name__)
 
 # ─── 성장주 판별 섹터 (자동 분류 폴백용) ──────────────────────
 GROWTH_SECTORS = {
-    "EV", "AI", "Semiconductor", "Quantum", "Energy", "Fintech",
-    "전기차", "반도체", "양자컴퓨터", "원자력", "핀테크", "인공지능",
+    "EV",
+    "AI",
+    "Semiconductor",
+    "Quantum",
+    "Energy",
+    "Fintech",
+    "전기차",
+    "반도체",
+    "양자컴퓨터",
+    "원자력",
+    "핀테크",
+    "인공지능",
 }
 
 # 성장주 판별 PE 임계값 (자동 분류 폴백용)
@@ -131,6 +143,34 @@ def _get_analyst_target(
     return None
 
 
+def _get_sma(ticker: str, period: int, db_path: Optional[Path] = None) -> Optional[float]:
+    """최근 `period` 일 종가의 단순이동평균(SMA). 데이터 부족 시 None."""
+    rows = query(
+        "SELECT close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT ?",
+        (ticker, period),
+        db_path=db_path,
+    )
+    closes = [float(r["close"]) for r in rows if r["close"] is not None]
+    if len(closes) < period:
+        return None
+    return sum(closes) / len(closes)
+
+
+def is_leader(ticker: str, db_path: Optional[Path] = None) -> bool:
+    """리더 = 성장주(classify_stock_type==growth) + 50일선 계산 가능.
+
+    리더는 고정 익절(+20/+40) 대상에서 제외되고 `check_leader_trail_signals`
+    (trail_ma 이동평균 이탈)로 관리된다 — 승자 run. value/swing 은 고정 ladder.
+    `config/rules.yaml take_profit.leader` 가 source of truth (백테스트는 성장주 universe 검증).
+    50일선 미계산(< trail_ma 종가) 시엔 트레일 불가하므로 리더 아님 (고정 ladder 유지).
+    """
+    if not TAKE_PROFIT_LEADER.get("enabled", False):
+        return False
+    if _get_sma(ticker, int(TAKE_PROFIT_LEADER.get("trail_ma", 50)), db_path=db_path) is None:
+        return False
+    return classify_stock_type(ticker, db_path=db_path) == "growth"
+
+
 def calculate_targets(
     ticker: str,
     entry_price: Optional[float] = None,
@@ -164,17 +204,17 @@ def calculate_targets(
 
     # 유형별 규칙 적용
     if stock_type == "growth":
-        stop_loss_pct = STOCK_STOP_LOSS          # -7%
+        stop_loss_pct = STOCK_STOP_LOSS  # -7%
         tp_config = TAKE_PROFIT_GROWTH
         trailing_stop_pct = TRAILING_STOP_GROWTH  # -15%
     elif stock_type == "swing":
-        stop_loss_pct = STOCK_STOP_LOSS          # -7%
+        stop_loss_pct = STOCK_STOP_LOSS  # -7%
         tp_config = TAKE_PROFIT_SWING
-        trailing_stop_pct = TRAILING_STOP_VOLATILE      # -20% (스윙은 변동성 높음)
+        trailing_stop_pct = TRAILING_STOP_VOLATILE  # -20% (스윙은 변동성 높음)
     else:  # value
-        stop_loss_pct = STOCK_STOP_LOSS_VALUE    # -10%
+        stop_loss_pct = STOCK_STOP_LOSS_VALUE  # -10%
         tp_config = TAKE_PROFIT_VALUE
-        trailing_stop_pct = TRAILING_STOP_VALUE   # -15%
+        trailing_stop_pct = TRAILING_STOP_VALUE  # -15%
 
     target_1_pct = tp_config["target_1"]
     target_2_pct = tp_config["target_2"]
@@ -189,6 +229,13 @@ def calculate_targets(
     analyst_upside_pct = None
     if analyst_target is not None and entry_price > 0:
         analyst_upside_pct = round((analyst_target / entry_price - 1) * 100, 1)
+
+    # 리더(성장주) 판별. 리더는 고정 익절 폐기 → target_1/2 = None (canonical source:
+    # actions/decision_compiler 등 target_1/2 비교 caller 가 일괄 자동 skip — codex R4/R7-P2).
+    # 50일선 트레일(check_leader_trail_signals)이 유일한 exit. MA 미계산 시엔 ladder 유지.
+    leader = is_leader(ticker, db_path=db_path)
+    leader_ma_period = int(TAKE_PROFIT_LEADER.get("trail_ma", 50))
+    leader_ma = _get_sma(ticker, leader_ma_period, db_path=db_path) if leader else None
 
     return {
         "ticker": ticker,
@@ -206,6 +253,9 @@ def calculate_targets(
         "trailing_stop_pct": trailing_stop_pct,
         "analyst_target": analyst_target,
         "analyst_upside_pct": analyst_upside_pct,
+        "is_leader": leader,
+        "leader_ma": round(leader_ma, 2) if leader_ma is not None else None,
+        "leader_ma_period": leader_ma_period,
     }
 
 
@@ -291,16 +341,29 @@ def format_target_tree(target: dict) -> str:
         f"현재가: {fp(target['current_price'])}",
         f"├── 매수가 (진입): {fp(target['entry_price'])}",
         f"├── 손절가: {fp(target['stop_loss'])} ({target['stop_loss_pct']:+.1f}%)",
-        f"├── 1차 익절: {fp(target['target_1'])} (+{target['target_1_pct']:.1f}%) → {target['target_1_sell_pct']}% 매도",
-        f"├── 2차 익절: {fp(target['target_2'])} (+{target['target_2_pct']:.1f}%) → {target['target_2_sell_pct']}% 매도",
-        f"├── 트레일링 스톱: 고점 대비 {target['trailing_stop_pct']:+.1f}% (나머지 {100 - target['target_1_sell_pct'] - target['target_2_sell_pct']}%)",
     ]
+    # 비-리더만 고정 익절 ladder 표시 (리더는 target_1/2 = None → 50일선 트레일로 청산)
+    if target.get("target_1") is not None:
+        lines.append(
+            f"├── 1차 익절: {fp(target['target_1'])} (+{target['target_1_pct']:.1f}%) → {target['target_1_sell_pct']}% 매도"
+        )
+        lines.append(
+            f"├── 2차 익절: {fp(target['target_2'])} (+{target['target_2_pct']:.1f}%) → {target['target_2_sell_pct']}% 매도"
+        )
+        lines.append(
+            f"├── 트레일링 스톱: 고점 대비 {target['trailing_stop_pct']:+.1f}% (나머지 {100 - target['target_1_sell_pct'] - target['target_2_sell_pct']}%)"
+        )
+
+    # 리더(성장주): 고정 익절 미적용 — 50일선 이탈로만 청산 (위 TP는 참고용)
+    if target.get("is_leader") and target.get("leader_ma") is not None:
+        lines.append(
+            f"├── ⭐ 리더 (성장주): 고정 익절 미적용 — {target['leader_ma_period']}일선 "
+            f"{fp(target['leader_ma'])} 종가 이탈 시 청산"
+        )
 
     # 애널리스트 목표가 (있을 때만)
     if target["analyst_target"] is not None:
-        lines.append(
-            f"└── 애널리스트 목표가: {fp(target['analyst_target'])} ({target['analyst_upside_pct']:+.1f}%)"
-        )
+        lines.append(f"└── 애널리스트 목표가: {fp(target['analyst_target'])} ({target['analyst_upside_pct']:+.1f}%)")
     else:
         # 마지막 줄 교체: ├ → └
         lines[-1] = lines[-1].replace("├──", "└──")
@@ -363,6 +426,10 @@ def check_take_profit_signals(db_path: Optional[Path] = None) -> list[dict]:
             logger.debug("No price data for %s, skipping take-profit check", ticker)
             continue
 
+        # 리더(성장주)는 고정 익절 미적용 — 50일선 트레일(check_leader_trail_signals)로 관리
+        if is_leader(ticker, db_path=db_path):
+            continue
+
         stock_type = classify_stock_type(ticker, db_path=db_path)
         targets = calculate_targets(ticker, entry_price, stock_type, db_path=db_path)
         if "error" in targets:
@@ -372,28 +439,102 @@ def check_take_profit_signals(db_path: Optional[Path] = None) -> list[dict]:
 
         # 2차 익절 도달 (우선)
         if current_price >= targets["target_2"]:
-            sell_pct = TAKE_PROFIT_GROWTH.get("target_2_sell_pct", 25) if stock_type == "growth" else \
-                       TAKE_PROFIT_SWING.get("target_2_sell_pct", 100) if stock_type == "swing" else \
-                       TAKE_PROFIT_VALUE.get("target_2_sell_pct", 25)
-            signals.append({
-                "ticker": ticker, "stock_type": stock_type,
-                "entry_price": entry_price, "current_price": current_price,
-                "return_pct": round(return_pct, 1),
-                "level": "target_2", "target_price": targets["target_2"],
-                "sell_pct": sell_pct, "quantity": row["quantity"],
-            })
+            sell_pct = (
+                TAKE_PROFIT_GROWTH.get("target_2_sell_pct", 25)
+                if stock_type == "growth"
+                else TAKE_PROFIT_SWING.get("target_2_sell_pct", 100)
+                if stock_type == "swing"
+                else TAKE_PROFIT_VALUE.get("target_2_sell_pct", 25)
+            )
+            signals.append(
+                {
+                    "ticker": ticker,
+                    "stock_type": stock_type,
+                    "entry_price": entry_price,
+                    "current_price": current_price,
+                    "return_pct": round(return_pct, 1),
+                    "level": "target_2",
+                    "target_price": targets["target_2"],
+                    "sell_pct": sell_pct,
+                    "quantity": row["quantity"],
+                }
+            )
         # 1차 익절 도달
         elif current_price >= targets["target_1"]:
-            sell_pct = TAKE_PROFIT_GROWTH.get("target_1_sell_pct", 50) if stock_type == "growth" else \
-                       TAKE_PROFIT_SWING.get("target_1_sell_pct", 50) if stock_type == "swing" else \
-                       TAKE_PROFIT_VALUE.get("target_1_sell_pct", 50)
-            signals.append({
-                "ticker": ticker, "stock_type": stock_type,
-                "entry_price": entry_price, "current_price": current_price,
-                "return_pct": round(return_pct, 1),
-                "level": "target_1", "target_price": targets["target_1"],
-                "sell_pct": sell_pct, "quantity": row["quantity"],
-            })
+            sell_pct = (
+                TAKE_PROFIT_GROWTH.get("target_1_sell_pct", 50)
+                if stock_type == "growth"
+                else TAKE_PROFIT_SWING.get("target_1_sell_pct", 50)
+                if stock_type == "swing"
+                else TAKE_PROFIT_VALUE.get("target_1_sell_pct", 50)
+            )
+            signals.append(
+                {
+                    "ticker": ticker,
+                    "stock_type": stock_type,
+                    "entry_price": entry_price,
+                    "current_price": current_price,
+                    "return_pct": round(return_pct, 1),
+                    "level": "target_1",
+                    "target_price": targets["target_1"],
+                    "sell_pct": sell_pct,
+                    "quantity": row["quantity"],
+                }
+            )
+
+    return sorted(signals, key=lambda s: s["return_pct"], reverse=True)
+
+
+# ═══════════════════════════════════════════════════════
+# 리더 트레일 (50일선 이탈) 감지 — 8주 룰 운영화
+# ═══════════════════════════════════════════════════════
+
+
+def check_leader_trail_signals(db_path: Optional[Path] = None) -> list[dict]:
+    """리더(성장주) 종목이 trail_ma 이동평균 종가를 이탈하면 청산 시그널.
+
+    고정 익절을 폐기한 리더의 유일한 익절 트리거 — 추세(이동평균)가 깨질 때만
+    매도하여 승자를 끝까지 run. `config/rules.yaml take_profit.leader` source of truth.
+    """
+    if not TAKE_PROFIT_LEADER.get("enabled", False):
+        return []
+
+    df = query_df(
+        "SELECT ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
+        db_path=db_path,
+    )
+    if df.empty:
+        return []
+
+    ma_period = int(TAKE_PROFIT_LEADER.get("trail_ma", 50))
+    signals = []
+    for _, row in df.iterrows():
+        ticker = row["ticker"]
+        entry_price = row["avg_price"]
+        if not entry_price or entry_price <= 0:
+            continue
+        if not is_leader(ticker, db_path=db_path):
+            continue
+
+        current_price = _get_current_price(ticker, db_path=db_path)
+        ma = _get_sma(ticker, ma_period, db_path=db_path)
+        if current_price is None or ma is None:
+            continue
+
+        # 리더인데 종가가 이동평균 아래 → 추세 break, 청산
+        if current_price < ma:
+            signals.append(
+                {
+                    "ticker": ticker,
+                    "entry_price": entry_price,
+                    "current_price": current_price,
+                    "ma": round(ma, 2),
+                    "ma_period": ma_period,
+                    "return_pct": round((current_price / entry_price - 1) * 100, 1),
+                    "status": "TREND_BREAK",
+                    "quantity": row["quantity"],
+                }
+            )
 
     return sorted(signals, key=lambda s: s["return_pct"], reverse=True)
 
@@ -434,7 +575,8 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
         # 고점(HWM) 계산: prices 테이블에서 진입 이후 최고가
         hwm_rows = query(
             "SELECT MAX(high) as max_high FROM prices WHERE ticker = ?",
-            (ticker,), db_path=db_path,
+            (ticker,),
+            db_path=db_path,
         )
         hwm = hwm_rows[0]["max_high"] if hwm_rows and hwm_rows[0]["max_high"] else None
         if hwm is None or hwm <= 0:
@@ -448,22 +590,29 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
         if stock_type == "swing":
             threshold = TRAILING_STOP_VOLATILE  # -20%
         elif stock_type == "growth":
-            threshold = TRAILING_STOP_GROWTH    # -15%
+            threshold = TRAILING_STOP_GROWTH  # -15%
         else:
-            threshold = TRAILING_STOP_VALUE     # -15%
+            threshold = TRAILING_STOP_VALUE  # -15%
 
         # 하락률 계산
         drop_pct = (current_price / hwm - 1) * 100
         stop_price = round(hwm * (1 + threshold / 100), 2)
 
         if drop_pct <= threshold:
-            signals.append({
-                "ticker": ticker, "stock_type": stock_type,
-                "entry_price": entry_price, "current_price": current_price,
-                "high_water_mark": hwm, "stop_price": stop_price,
-                "drop_pct": round(drop_pct, 1), "threshold": threshold,
-                "status": "TRIGGERED", "quantity": row["quantity"],
-            })
+            signals.append(
+                {
+                    "ticker": ticker,
+                    "stock_type": stock_type,
+                    "entry_price": entry_price,
+                    "current_price": current_price,
+                    "high_water_mark": hwm,
+                    "stop_price": stop_price,
+                    "drop_pct": round(drop_pct, 1),
+                    "threshold": threshold,
+                    "status": "TRIGGERED",
+                    "quantity": row["quantity"],
+                }
+            )
 
     return sorted(signals, key=lambda s: s["drop_pct"])
 
@@ -484,6 +633,7 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
     # 환율 조회 (KRW → USD 변환용)
     from nuri.core.db import query as _q
     from nuri.core.rules import PORTFOLIO_STOP
+
     usd_krw = 1400.0  # 폴백
     try:
         fx_rows = _q("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1", db_path=db_path)

--- a/tests/trading/recommend/test_leader_exit.py
+++ b/tests/trading/recommend/test_leader_exit.py
@@ -1,0 +1,110 @@
+"""Lock-tests for the leader-exit rule (8주 룰 운영화) — growth-type 기준.
+
+Source of truth: `config/rules.yaml take_profit.leader` -> `nuri.core.rules.TAKE_PROFIT_LEADER`.
+리더 = 성장주(classify_stock_type==growth) + 50일선 계산가능. 고정 익절 대신 50일선 트레일.
+Reverting is_leader / TP skip / check_leader_trail_signals / actions wiring fails these.
+
+근거: 백테스트(17 성장주 2021~26, 비중첩·트레일동일·비용·연율화, skeptic 검증) —
+무TP+MA50 트레일이 고정TP ladder 대비 CAGR 12.8% → 19.5%, 낙폭 더 얕음.
+설계(codex 4-round review): growth-type 기준 (gain-threshold stickiness 문제 회피).
+"""
+
+from datetime import date, timedelta
+
+from nuri.core.db import get_db
+from nuri.trading.recommend.price_targets import (
+    calculate_targets,
+    check_leader_trail_signals,
+    check_take_profit_signals,
+    is_leader,
+)
+
+
+def _seed(db_path, ticker, avg_price, closes, sector="AI"):
+    """portfolio 1종 + len(closes)일 가격 시드. sector 로 growth/value 제어."""
+    d0 = date(2026, 1, 1)
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO portfolio "
+            "(account, ticker, quantity, avg_price, currency, sector) VALUES (?, ?, ?, ?, ?, ?)",
+            ("test", ticker, 10, avg_price, "USD", sector),
+        )
+        rows = [
+            ((d0 + timedelta(days=i)).isoformat(), ticker, c, c * 1.01, c * 0.99, c, 1_000_000)
+            for i, c in enumerate(closes)
+        ]
+        conn.executemany(
+            "INSERT OR REPLACE INTO prices (date, ticker, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+class TestIsLeader:
+    def test_growth_with_ma_is_leader(self, db_path):
+        _seed(db_path, "GRW", 100.0, [130.0] * 50, sector="AI")
+        assert is_leader("GRW", db_path=db_path) is True
+
+    def test_value_not_leader(self, db_path):
+        _seed(db_path, "VAL", 100.0, [130.0] * 50, sector="Financials")
+        assert is_leader("VAL", db_path=db_path) is False
+
+    def test_growth_without_ma_not_leader(self, db_path):
+        """codex R2-P2: 50일선 미계산(< trail_ma 종가) → 리더 아님 (고정 ladder 유지)."""
+        _seed(db_path, "NEW", 100.0, [130.0] * 10, sector="AI")
+        assert is_leader("NEW", db_path=db_path) is False
+
+    def test_disabled(self, db_path, monkeypatch):
+        import nuri.trading.recommend.price_targets as pt
+
+        monkeypatch.setattr(pt, "TAKE_PROFIT_LEADER", {"enabled": False, "trail_ma": 50})
+        _seed(db_path, "GRW", 100.0, [130.0] * 50, sector="AI")
+        assert is_leader("GRW", db_path=db_path) is False
+
+
+class TestTakeProfitSkipsLeader:
+    def test_growth_leader_excluded_from_fixed_tp(self, db_path):
+        _seed(db_path, "GRW", 100.0, [130.0] * 50, sector="AI")  # +30% 성장주
+        assert "GRW" not in {s["ticker"] for s in check_take_profit_signals(db_path=db_path)}
+
+    def test_value_still_fires_tp1(self, db_path):
+        """가치주 +16% (>= value target_1 +15%) → 비리더 → 고정 익절 유지."""
+        _seed(db_path, "VAL", 100.0, [116.0] * 50, sector="Financials")
+        sigs = {s["ticker"]: s for s in check_take_profit_signals(db_path=db_path)}
+        assert "VAL" in sigs
+        assert sigs["VAL"]["level"] == "target_1"
+
+    def test_growth_no_ma_keeps_fixed_tp(self, db_path):
+        """codex R2-P2: 성장주여도 MA 미계산이면 고정 익절 유지 (트리거 공백 방지)."""
+        _seed(db_path, "NEW", 100.0, [130.0] * 10, sector="AI")  # 성장주 +30% but 종가 10개
+        assert "NEW" in {s["ticker"] for s in check_take_profit_signals(db_path=db_path)}
+
+
+class TestLeaderTrail:
+    def test_fires_when_growth_below_ma(self, db_path):
+        closes = [140.0] * 49 + [125.0]  # MA50 ~= 139.7, current 125 < MA
+        _seed(db_path, "BRK", 100.0, closes, sector="AI")
+        sigs = {s["ticker"]: s for s in check_leader_trail_signals(db_path=db_path)}
+        assert "BRK" in sigs
+        assert sigs["BRK"]["status"] == "TREND_BREAK"
+        assert sigs["BRK"]["ma_period"] == 50
+
+    def test_silent_when_above_ma(self, db_path):
+        closes = [125.0] * 49 + [130.0]  # MA50 ~= 125.1, current 130 > MA
+        _seed(db_path, "RUN", 100.0, closes, sector="AI")
+        assert "RUN" not in {s["ticker"] for s in check_leader_trail_signals(db_path=db_path)}
+
+    def test_silent_for_value(self, db_path):
+        """가치주는 50일선 아래여도 리더 아님 → 리더-트레일 침묵 (고정 ladder/일반 트레일 적용)."""
+        closes = [140.0] * 49 + [125.0]
+        _seed(db_path, "VLO", 100.0, closes, sector="Financials")
+        assert "VLO" not in {s["ticker"] for s in check_leader_trail_signals(db_path=db_path)}
+
+
+class TestLeaderTargets:
+    def test_leader_targets_numeric_kept_with_flag(self, db_path):
+        """codex R4-P2: 리더라도 target_1/2 numeric 유지 (참고용) + is_leader/leader_ma 플래그."""
+        _seed(db_path, "GRW", 100.0, [130.0] * 50, sector="AI")
+        t = calculate_targets("GRW", entry_price=100.0, db_path=db_path)
+        assert t["is_leader"] is True
+        assert t["target_1"] is not None and t["target_2"] is not None  # price-level 의무 유지 (참고용)
+        assert t["leader_ma"] is not None

--- a/tests/trading/recommend/test_price_targets.py
+++ b/tests/trading/recommend/test_price_targets.py
@@ -1,4 +1,5 @@
 """Tests for price_targets — split from test_trading_recommend_all.py."""
+
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -31,6 +32,7 @@ class TestClassifyStockType:
         _seed_portfolio_nm(db_path)
         _seed_fundamentals_nm(db_path, [("2026-03-27", "TSLA", 327.0)])
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         result = classify_stock_type("TSLA", db_path=db_path)
         assert result == "growth"
 
@@ -38,6 +40,7 @@ class TestClassifyStockType:
         """섹터가 성장 섹터이면 PE 없어도 성장주."""
         _seed_portfolio_nm(db_path, [("test", "XYZ", 10, 100.0, "USD", "AI/Cloud")])
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         result = classify_stock_type("XYZ", db_path=db_path)
         assert result == "growth"
 
@@ -46,12 +49,14 @@ class TestClassifyStockType:
         _seed_portfolio_nm(db_path, [("test", "GOOGL", 5, 270.0, "USD", "BigTech")])
         _seed_fundamentals_nm(db_path, [("2026-03-27", "GOOGL", 22.0)])
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         result = classify_stock_type("GOOGL", db_path=db_path)
         assert result == "value"
 
     def test_value_when_no_data(self, db_path):
         """데이터 없으면 기본 가치주."""
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         result = classify_stock_type("UNKNOWN", db_path=db_path)
         assert result == "value"
 
@@ -65,6 +70,7 @@ class TestCalculateTargets:
         _seed_prices_nm(db_path)
         _seed_fundamentals_nm(db_path)
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("TSLA", entry_price=360.0, stock_type="growth", db_path=db_path)
         assert result["stock_type"] == "growth"
         assert result["stop_loss"] == pytest.approx(360.0 * 0.93, rel=0.01)
@@ -79,6 +85,7 @@ class TestCalculateTargets:
         _seed_portfolio_nm(db_path)
         _seed_prices_nm(db_path)
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("GOOGL", entry_price=270.0, stock_type="value", db_path=db_path)
         assert result["stock_type"] == "value"
         assert result["stop_loss"] == pytest.approx(270.0 * 0.90, rel=0.01)
@@ -89,6 +96,7 @@ class TestCalculateTargets:
         """스윙 타겟: -7% 손절, +5%/+10% 익절."""
         _seed_prices_nm(db_path)
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("NVDA", entry_price=168.0, stock_type="swing", db_path=db_path)
         assert result["stock_type"] == "swing"
         assert result["target_1"] == pytest.approx(168.0 * 1.05, rel=0.01)
@@ -99,6 +107,7 @@ class TestCalculateTargets:
         _seed_prices_nm(db_path)
         _seed_estimates_nm(db_path)
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("NVDA", entry_price=168.0, stock_type="growth", db_path=db_path)
         assert result["analyst_target"] == pytest.approx(273.61, rel=0.01)
         assert result["analyst_upside_pct"] is not None
@@ -107,6 +116,7 @@ class TestCalculateTargets:
     def test_no_price_returns_error(self, db_path):
         """가격 데이터 없으면 에러 반환."""
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("NOPRICE", db_path=db_path)
         assert "error" in result
 
@@ -114,6 +124,7 @@ class TestCalculateTargets:
         """entry_price 미지정 시 현재가 사용."""
         _seed_prices_nm(db_path)
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("TSLA", stock_type="growth", db_path=db_path)
         assert result["entry_price"] == result["current_price"]
 
@@ -127,6 +138,7 @@ class TestPortfolioTargets:
         _seed_prices_nm(db_path)
         _seed_fundamentals_nm(db_path)
         from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+
         targets = calculate_portfolio_targets(db_path=db_path)
         assert len(targets) > 0
         tickers = {t["ticker"] for t in targets if "error" not in t}
@@ -136,6 +148,7 @@ class TestPortfolioTargets:
     def test_empty_portfolio(self, db_path):
         """빈 포트폴리오면 빈 리스트."""
         from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+
         targets = calculate_portfolio_targets(db_path=db_path)
         assert targets == []
 
@@ -146,14 +159,23 @@ class TestFormatTargetTree:
     def test_usd_format(self):
         """USD 종목 포맷."""
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "NVDA", "stock_type": "growth",
-            "current_price": 168.0, "entry_price": 165.0,
-            "stop_loss": 153.45, "stop_loss_pct": -7.0,
-            "target_1": 198.0, "target_1_pct": 20.0, "target_1_sell_pct": 50,
-            "target_2": 231.0, "target_2_pct": 40.0, "target_2_sell_pct": 25,
+            "ticker": "NVDA",
+            "stock_type": "growth",
+            "current_price": 168.0,
+            "entry_price": 165.0,
+            "stop_loss": 153.45,
+            "stop_loss_pct": -7.0,
+            "target_1": 198.0,
+            "target_1_pct": 20.0,
+            "target_1_sell_pct": 50,
+            "target_2": 231.0,
+            "target_2_pct": 40.0,
+            "target_2_sell_pct": 25,
             "trailing_stop_pct": -15.0,
-            "analyst_target": 273.61, "analyst_upside_pct": 63.4,
+            "analyst_target": 273.61,
+            "analyst_upside_pct": 63.4,
         }
         output = format_target_tree(target)
         assert "NVDA" in output
@@ -166,14 +188,23 @@ class TestFormatTargetTree:
     def test_krw_format(self):
         """KRW 종목 포맷."""
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "005930.KS", "stock_type": "growth",
-            "current_price": 179700.0, "entry_price": 55000.0,
-            "stop_loss": 55521.0, "stop_loss_pct": -7.0,
-            "target_1": 71640.0, "target_1_pct": 20.0, "target_1_sell_pct": 50,
-            "target_2": 83580.0, "target_2_pct": 40.0, "target_2_sell_pct": 25,
+            "ticker": "005930.KS",
+            "stock_type": "growth",
+            "current_price": 179700.0,
+            "entry_price": 55000.0,
+            "stop_loss": 55521.0,
+            "stop_loss_pct": -7.0,
+            "target_1": 71640.0,
+            "target_1_pct": 20.0,
+            "target_1_sell_pct": 50,
+            "target_2": 83580.0,
+            "target_2_pct": 40.0,
+            "target_2_sell_pct": 25,
             "trailing_stop_pct": -15.0,
-            "analyst_target": None, "analyst_upside_pct": None,
+            "analyst_target": None,
+            "analyst_upside_pct": None,
         }
         output = format_target_tree(target)
         assert "005930.KS" in output
@@ -185,16 +216,19 @@ class TestPriceTargets_R9:
 
     def test_calculate_targets(self, rich_db):
         from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+
         results = calculate_portfolio_targets()
         assert isinstance(results, list)
 
     def test_check_take_profit(self, rich_db):
         from nuri.trading.recommend.price_targets import check_take_profit_signals
+
         signals = check_take_profit_signals()
         assert isinstance(signals, list)
 
     def test_check_trailing_stop(self, rich_db):
         from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
         signals = check_trailing_stop_signals()
         assert isinstance(signals, list)
 
@@ -205,6 +239,7 @@ class TestPriceTargets_R20:
     def test_calculate_targets_growth(self, rich_db_full, monkeypatch):
         """NVDA has PE=55 (>30), should be classified as growth."""
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         result = pt.calculate_targets("NVDA", entry_price=250.0, db_path=rich_db_full)
         assert "error" not in result
@@ -219,6 +254,7 @@ class TestPriceTargets_R20:
     def test_calculate_targets_value(self, rich_db_full, monkeypatch):
         """AAPL has PE=28 (<30), should be classified as value."""
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         result = pt.calculate_targets("AAPL", entry_price=200.0, db_path=rich_db_full)
         assert "error" not in result
@@ -229,12 +265,14 @@ class TestPriceTargets_R20:
 
     def test_calculate_targets_no_price(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         result = pt.calculate_targets("ZZZZ", db_path=rich_db_full)
         assert "error" in result
 
     def test_calculate_targets_uses_current_price_as_entry(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         result = pt.calculate_targets("AAPL", db_path=rich_db_full)
         assert "error" not in result
@@ -242,12 +280,14 @@ class TestPriceTargets_R20:
 
     def test_classify_stock_type_manual_override(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", {"AAPL": "swing"})
         assert pt.classify_stock_type("AAPL", db_path=rich_db_full) == "swing"
 
     def test_classify_stock_type_sector_growth(self, rich_db_full, monkeypatch):
         """Portfolio sector 'Semiconductor' should match GROWTH_SECTORS."""
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", {})
         with get_db(rich_db_full) as conn:
             conn.execute(
@@ -264,6 +304,7 @@ class TestPortfolioTargets_R20:
 
     def test_calculate_portfolio_targets(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         targets = pt.calculate_portfolio_targets(db_path=rich_db_full)
         assert len(targets) >= 2
@@ -277,6 +318,7 @@ class TestTakeProfitSignals:
 
     def test_check_take_profit_signals_triggered(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         signals = pt.check_take_profit_signals(db_path=rich_db_full)
         assert isinstance(signals, list)
@@ -290,6 +332,7 @@ class TestTakeProfitSignals:
         path = tmp_path / "empty.db"
         init_db(path)
         from nuri.trading.recommend.price_targets import check_take_profit_signals
+
         result = check_take_profit_signals(db_path=path)
         assert result == []
 
@@ -299,6 +342,7 @@ class TestTrailingStopSignals:
 
     def test_check_trailing_stop_no_trigger(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         signals = pt.check_trailing_stop_signals(db_path=rich_db_full)
         assert isinstance(signals, list)
@@ -307,6 +351,7 @@ class TestTrailingStopSignals:
         path = tmp_path / "empty.db"
         init_db(path)
         from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
         result = check_trailing_stop_signals(db_path=path)
         assert result == []
 
@@ -316,26 +361,47 @@ class TestPortfolioMDD:
 
     def test_check_portfolio_mdd_no_violation(self, rich_db_full, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
         result = pt.check_portfolio_mdd(db_path=rich_db_full)
         assert result is None
 
     def test_check_portfolio_mdd_violation(self, tmp_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt
+
         monkeypatch.setattr(pt, "_stock_types_cache", None)
 
         path = tmp_path / "mdd.db"
         init_db(path)
-        upsert_portfolio([
-            {"account": "test", "ticker": "LOSS", "quantity": 100,
-             "avg_price": 200.0, "currency": "USD", "sector": "Tech"},
-        ], path)
-        rows = [{"ticker": "LOSS", "date": "2025-01-01",
-                 "open": 170, "high": 172, "low": 168,
-                 "close": 170, "volume": 100000, "adj_close": 170}]
+        upsert_portfolio(
+            [
+                {
+                    "account": "test",
+                    "ticker": "LOSS",
+                    "quantity": 100,
+                    "avg_price": 200.0,
+                    "currency": "USD",
+                    "sector": "Tech",
+                },
+            ],
+            path,
+        )
+        rows = [
+            {
+                "ticker": "LOSS",
+                "date": "2025-01-01",
+                "open": 170,
+                "high": 172,
+                "low": 168,
+                "close": 170,
+                "volume": 100000,
+                "adj_close": 170,
+            }
+        ]
         upsert_prices(pd.DataFrame(rows), path)
 
         import nuri.core.db as db_mod
+
         monkeypatch.setattr(db_mod, "DB_PATH", path)
 
         result = pt.check_portfolio_mdd(db_path=path)
@@ -347,6 +413,7 @@ class TestPortfolioMDD:
         path = tmp_path / "empty.db"
         init_db(path)
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
         result = check_portfolio_mdd(db_path=path)
         assert result is None
 
@@ -356,14 +423,23 @@ class TestFormatTargetTree_R20:
 
     def test_format_target_tree_growth(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "NVDA", "stock_type": "growth",
-            "current_price": 250.0, "entry_price": 200.0,
-            "stop_loss": 186.0, "stop_loss_pct": -7.0,
-            "target_1": 240.0, "target_1_pct": 20.0, "target_1_sell_pct": 50,
-            "target_2": 280.0, "target_2_pct": 40.0, "target_2_sell_pct": 25,
+            "ticker": "NVDA",
+            "stock_type": "growth",
+            "current_price": 250.0,
+            "entry_price": 200.0,
+            "stop_loss": 186.0,
+            "stop_loss_pct": -7.0,
+            "target_1": 240.0,
+            "target_1_pct": 20.0,
+            "target_1_sell_pct": 50,
+            "target_2": 280.0,
+            "target_2_pct": 40.0,
+            "target_2_sell_pct": 25,
             "trailing_stop_pct": -15.0,
-            "analyst_target": 270.0, "analyst_upside_pct": 35.0,
+            "analyst_target": 270.0,
+            "analyst_upside_pct": 35.0,
         }
         result = format_target_tree(target)
         assert "NVDA" in result
@@ -374,20 +450,30 @@ class TestFormatTargetTree_R20:
 
     def test_format_target_tree_error(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         result = format_target_tree({"ticker": "BAD", "error": "no data"})
         assert "BAD" in result
         assert "no data" in result
 
     def test_format_target_tree_no_analyst(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "TEST", "stock_type": "value",
-            "current_price": 100.0, "entry_price": 100.0,
-            "stop_loss": 90.0, "stop_loss_pct": -10.0,
-            "target_1": 115.0, "target_1_pct": 15.0, "target_1_sell_pct": 50,
-            "target_2": 130.0, "target_2_pct": 30.0, "target_2_sell_pct": 25,
+            "ticker": "TEST",
+            "stock_type": "value",
+            "current_price": 100.0,
+            "entry_price": 100.0,
+            "stop_loss": 90.0,
+            "stop_loss_pct": -10.0,
+            "target_1": 115.0,
+            "target_1_pct": 15.0,
+            "target_1_sell_pct": 50,
+            "target_2": 130.0,
+            "target_2_pct": 30.0,
+            "target_2_sell_pct": 25,
             "trailing_stop_pct": -15.0,
-            "analyst_target": None, "analyst_upside_pct": None,
+            "analyst_target": None,
+            "analyst_upside_pct": None,
         }
         result = format_target_tree(target)
         assert "TEST" in result
@@ -396,11 +482,13 @@ class TestFormatTargetTree_R20:
 
     def test_format_price_krw(self):
         from nuri.trading.recommend.price_targets import _format_price
+
         result = _format_price(70000, "005930.KS")
         assert "₩" in result
 
     def test_format_price_usd(self):
         from nuri.trading.recommend.price_targets import _format_price
+
         result = _format_price(150.50, "AAPL")
         assert "$" in result
 
@@ -412,16 +500,19 @@ class TestPriceTargets_R23:
         """PE > 30 -> growth."""
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         pt_mod._stock_types_cache = None
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?, ?, ?)",
-                         ("NEWCO", "2026-03-31", 50.0))
+            conn.execute(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?, ?, ?)", ("NEWCO", "2026-03-31", 50.0)
+            )
         result = classify_stock_type("NEWCO", db_path=db_path)
         assert result == "growth"
 
     def test_classify_stock_type_sector_growth(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         pt_mod._stock_types_cache = None
         _seed_portfolio_r23(db_path, [("test", "SEMCO", 10, 100.0, "USD", "Semiconductor")])
         result = classify_stock_type("SEMCO", db_path=db_path)
@@ -430,18 +521,21 @@ class TestPriceTargets_R23:
     def test_classify_stock_type_value(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         pt_mod._stock_types_cache = None
         result = classify_stock_type("UNKNOWN", db_path=db_path)
         assert result == "value"
 
     def test_calculate_targets_no_price(self, db_path):
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("NOPRICE", db_path=db_path)
         assert "error" in result
 
     def test_calculate_targets_swing(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import calculate_targets
+
         pt_mod._stock_types_cache = None
         _seed_prices_r23(db_path, "SWING", 100.0)
         result = calculate_targets("SWING", entry_price=100.0, stock_type="swing", db_path=db_path)
@@ -450,6 +544,7 @@ class TestPriceTargets_R23:
 
     def test_calculate_targets_value(self, db_path):
         from nuri.trading.recommend.price_targets import calculate_targets
+
         _seed_prices_r23(db_path, "VALUE", 100.0)
         result = calculate_targets("VALUE", entry_price=100.0, stock_type="value", db_path=db_path)
         assert result["stock_type"] == "value"
@@ -457,31 +552,61 @@ class TestPriceTargets_R23:
 
     def test_calculate_targets_with_analyst(self, db_path):
         from nuri.trading.recommend.price_targets import calculate_targets
+
         _seed_prices_r23(db_path, "AAPL", 170.0)
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO estimates (ticker, date, target_mean) VALUES (?, ?, ?)",
-                         ("AAPL", "2026-03-31", 220.0))
+            conn.execute(
+                "INSERT INTO estimates (ticker, date, target_mean) VALUES (?, ?, ?)", ("AAPL", "2026-03-31", 220.0)
+            )
         result = calculate_targets("AAPL", db_path=db_path)
         assert result["analyst_target"] == 220.0
         assert result["analyst_upside_pct"] is not None
 
     def test_print_portfolio_targets_empty(self, capsys):
         from nuri.trading.recommend.price_targets import print_portfolio_targets
+
         print_portfolio_targets([])
         captured = capsys.readouterr()
         assert "종목 없음" in captured.out
 
     def test_print_portfolio_targets(self, capsys, db_path):
         from nuri.trading.recommend.price_targets import print_portfolio_targets
+
         targets = [
-            {"ticker": "AAPL", "stock_type": "growth", "current_price": 170.0, "entry_price": 150.0,
-             "stop_loss": 139.5, "stop_loss_pct": -7.0, "target_1": 180.0, "target_1_pct": 20.0,
-             "target_1_sell_pct": 50, "target_2": 210.0, "target_2_pct": 40.0, "target_2_sell_pct": 25,
-             "trailing_stop_pct": -15.0, "analyst_target": 220.0, "analyst_upside_pct": 29.4},
-            {"ticker": "MSFT", "stock_type": "value", "current_price": 400.0, "entry_price": 380.0,
-             "stop_loss": 342.0, "stop_loss_pct": -10.0, "target_1": 437.0, "target_1_pct": 15.0,
-             "target_1_sell_pct": 50, "target_2": 494.0, "target_2_pct": 30.0, "target_2_sell_pct": 25,
-             "trailing_stop_pct": -15.0, "analyst_target": None, "analyst_upside_pct": None},
+            {
+                "ticker": "AAPL",
+                "stock_type": "growth",
+                "current_price": 170.0,
+                "entry_price": 150.0,
+                "stop_loss": 139.5,
+                "stop_loss_pct": -7.0,
+                "target_1": 180.0,
+                "target_1_pct": 20.0,
+                "target_1_sell_pct": 50,
+                "target_2": 210.0,
+                "target_2_pct": 40.0,
+                "target_2_sell_pct": 25,
+                "trailing_stop_pct": -15.0,
+                "analyst_target": 220.0,
+                "analyst_upside_pct": 29.4,
+            },
+            {
+                "ticker": "MSFT",
+                "stock_type": "value",
+                "current_price": 400.0,
+                "entry_price": 380.0,
+                "stop_loss": 342.0,
+                "stop_loss_pct": -10.0,
+                "target_1": 437.0,
+                "target_1_pct": 15.0,
+                "target_1_sell_pct": 50,
+                "target_2": 494.0,
+                "target_2_pct": 30.0,
+                "target_2_sell_pct": 25,
+                "trailing_stop_pct": -15.0,
+                "analyst_target": None,
+                "analyst_upside_pct": None,
+            },
         ]
         print_portfolio_targets(targets)
         captured = capsys.readouterr()
@@ -489,10 +614,13 @@ class TestPriceTargets_R23:
         assert "MSFT" in captured.out
         assert "포트폴리오 가격 목표" in captured.out
 
-    def test_check_take_profit_target2(self, db_path):
+    def test_check_take_profit_target2(self, db_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import check_take_profit_signals
+
         pt_mod._stock_types_cache = None
+        # leader off -> 고정 ladder 경로 검증 (성장주여도 target_2 발화)
+        monkeypatch.setattr(pt_mod, "TAKE_PROFIT_LEADER", {"enabled": False, "trail_ma": 50})
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 100.0, "USD", "Technology")])
         _seed_prices_r23(db_path, "AAPL", 145.0)
         signals = check_take_profit_signals(db_path=db_path)
@@ -502,15 +630,18 @@ class TestPriceTargets_R23:
     def test_check_take_profit_target1(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import check_take_profit_signals
+
         pt_mod._stock_types_cache = None
+        # 가치주(Technology=비성장) +17% -> 비리더 -> 고정 TP1(+15%) 유지
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 100.0, "USD", "Technology")])
-        _seed_prices_r23(db_path, "AAPL", 122.0)
+        _seed_prices_r23(db_path, "AAPL", 117.0)
         signals = check_take_profit_signals(db_path=db_path)
         assert len(signals) >= 1
         assert signals[0]["level"] == "target_1"
 
     def test_check_take_profit_no_entry(self, db_path):
         from nuri.trading.recommend.price_targets import check_take_profit_signals
+
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 0, "USD", "Technology")])
         _seed_prices_r23(db_path, "AAPL", 200.0)
         signals = check_take_profit_signals(db_path=db_path)
@@ -519,13 +650,18 @@ class TestPriceTargets_R23:
     def test_check_trailing_stop(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
         pt_mod._stock_types_cache = None
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 100.0, "USD", "Technology")])
         with get_db(db_path) as conn:
-            conn.execute("INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                         ("AAPL", "2026-03-01", 195, 200, 190, 195, 1000000))
-            conn.execute("INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                         ("AAPL", "2026-03-31", 162, 165, 158, 160, 1000000))
+            conn.execute(
+                "INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("AAPL", "2026-03-01", 195, 200, 190, 195, 1000000),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("AAPL", "2026-03-31", 162, 165, 158, 160, 1000000),
+            )
         signals = check_trailing_stop_signals(db_path=db_path)
         assert len(signals) >= 1
         assert signals[0]["status"] == "TRIGGERED"
@@ -533,6 +669,7 @@ class TestPriceTargets_R23:
     def test_check_trailing_stop_not_triggered(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
         pt_mod._stock_types_cache = None
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 100.0, "USD", "Technology")])
         _seed_prices_r23(db_path, "AAPL", 180.0, high=185.0)
@@ -541,6 +678,7 @@ class TestPriceTargets_R23:
 
     def test_check_portfolio_mdd_no_violation(self, db_path):
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 150.0, "USD", "Technology")])
         _seed_prices_r23(db_path, "AAPL", 155.0)
         result = check_portfolio_mdd(db_path=db_path)
@@ -548,6 +686,7 @@ class TestPriceTargets_R23:
 
     def test_check_portfolio_mdd_violation(self, db_path):
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
         _seed_portfolio_r23(db_path, [("test", "AAPL", 100, 200.0, "USD", "Technology")])
         _seed_prices_r23(db_path, "AAPL", 170.0)
         result = check_portfolio_mdd(db_path=db_path)
@@ -556,6 +695,7 @@ class TestPriceTargets_R23:
 
     def test_check_portfolio_mdd_with_krw(self, db_path):
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
         _seed_portfolio_r23(db_path, [("test", "005930.KS", 10, 70000.0, "KRW", "Semiconductor")])
         _seed_prices_r23(db_path, "005930.KS", 72000.0, high=73000.0)
         _seed_macro_r23(db_path, "usd_krw", 1350.0)
@@ -564,39 +704,56 @@ class TestPriceTargets_R23:
 
     def test_check_portfolio_mdd_empty(self, db_path):
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
         result = check_portfolio_mdd(db_path=db_path)
         assert result is None
 
     def test_format_target_tree_error(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         result = format_target_tree({"ticker": "AAPL", "error": "no data"})
         assert "AAPL" in result
         assert "no data" in result
 
     def test_format_target_tree_no_analyst(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "AAPL", "stock_type": "growth", "current_price": 170.0, "entry_price": 150.0,
-            "stop_loss": 139.5, "stop_loss_pct": -7.0, "target_1": 180.0, "target_1_pct": 20.0,
-            "target_1_sell_pct": 50, "target_2": 210.0, "target_2_pct": 40.0, "target_2_sell_pct": 25,
-            "trailing_stop_pct": -15.0, "analyst_target": None, "analyst_upside_pct": None,
+            "ticker": "AAPL",
+            "stock_type": "growth",
+            "current_price": 170.0,
+            "entry_price": 150.0,
+            "stop_loss": 139.5,
+            "stop_loss_pct": -7.0,
+            "target_1": 180.0,
+            "target_1_pct": 20.0,
+            "target_1_sell_pct": 50,
+            "target_2": 210.0,
+            "target_2_pct": 40.0,
+            "target_2_sell_pct": 25,
+            "trailing_stop_pct": -15.0,
+            "analyst_target": None,
+            "analyst_upside_pct": None,
         }
         result = format_target_tree(target)
         assert "└──" in result
 
     def test_format_price_krw(self):
         from nuri.trading.recommend.price_targets import _format_price
+
         assert "₩" in _format_price(70000, "005930.KS")
         assert "$" in _format_price(170.0, "AAPL")
 
     def test_calculate_portfolio_targets_empty(self, db_path):
         from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+
         result = calculate_portfolio_targets(db_path=db_path)
         assert result == []
 
     def test_calculate_portfolio_targets(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+
         pt_mod._stock_types_cache = None
         _seed_portfolio_r23(db_path, [("test", "AAPL", 10, 150.0, "USD", "Technology")])
         _seed_prices_r23(db_path, "AAPL", 170.0)
@@ -607,11 +764,15 @@ class TestPriceTargets_R23:
     def test_calculate_portfolio_targets_skip_no_price(self, db_path):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import calculate_portfolio_targets
+
         pt_mod._stock_types_cache = None
-        _seed_portfolio_r23(db_path, [
-            ("test", "AAPL", 10, 150.0, "USD", "Technology"),
-            ("test", "NOPRICE", 5, 100.0, "USD", "Tech"),
-        ])
+        _seed_portfolio_r23(
+            db_path,
+            [
+                ("test", "AAPL", 10, 150.0, "USD", "Technology"),
+                ("test", "NOPRICE", 5, 100.0, "USD", "Tech"),
+            ],
+        )
         _seed_prices_r23(db_path, "AAPL", 170.0)
         targets = calculate_portfolio_targets(db_path=db_path)
         tickers = [t["ticker"] for t in targets]
@@ -625,62 +786,81 @@ class TestPriceTargets_R27:
     def test_classify_stock_type_manual(self, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         monkeypatch.setattr(pt_mod, "_stock_types_cache", {"TSLA": "growth"})
         assert classify_stock_type("TSLA") == "growth"
 
     def test_classify_stock_type_high_pe(self, db_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         monkeypatch.setattr(pt_mod, "_stock_types_cache", {})
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?,?,?)",
-                         ("TEST", "2025-03-28", 50.0))
+            conn.execute(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?,?,?)", ("TEST", "2025-03-28", 50.0)
+            )
         assert classify_stock_type("TEST", db_path=db_path) == "growth"
 
     def test_classify_stock_type_value_default(self, db_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import classify_stock_type
+
         monkeypatch.setattr(pt_mod, "_stock_types_cache", {})
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?,?,?)",
-                         ("TEST", "2025-03-28", 12.0))
+            conn.execute(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?,?,?)", ("TEST", "2025-03-28", 12.0)
+            )
         assert classify_stock_type("TEST", db_path=db_path) == "value"
 
     def test_calculate_targets_no_price(self, db_path):
         from nuri.trading.recommend.price_targets import calculate_targets
+
         result = calculate_targets("NOPRICE", db_path=db_path)
         assert "error" in result
 
     def test_calculate_targets_swing(self, db_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import calculate_targets
+
         monkeypatch.setattr(pt_mod, "_stock_types_cache", {"TEST": "swing"})
         with get_db(db_path) as conn:
             dates = pd.bdate_range(end="2025-03-28", periods=5)
             for i, d in enumerate(dates):
                 price = 100 + np.sin(i / 10) * 10
-                conn.execute("INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
-                             ("TEST", d.strftime("%Y-%m-%d"), price - 1, price + 2, price - 2, price, 500000 + i * 10000))
+                conn.execute(
+                    "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                    ("TEST", d.strftime("%Y-%m-%d"), price - 1, price + 2, price - 2, price, 500000 + i * 10000),
+                )
         result = calculate_targets("TEST", stock_type="swing", db_path=db_path)
         assert result["stock_type"] == "swing"
         assert result["trailing_stop_pct"] == -20
 
     def test_format_target_tree_error(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         result = format_target_tree({"ticker": "TEST", "error": "no data"})
         assert "TEST" in result
         assert "no data" in result
 
     def test_format_target_tree_kr_ticker(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "005930.KS", "stock_type": "value",
-            "current_price": 70000, "entry_price": 68000,
-            "stop_loss": 61200, "stop_loss_pct": -10.0,
-            "target_1": 78200, "target_1_pct": 15.0, "target_1_sell_pct": 50,
-            "target_2": 88400, "target_2_pct": 30.0, "target_2_sell_pct": 25,
+            "ticker": "005930.KS",
+            "stock_type": "value",
+            "current_price": 70000,
+            "entry_price": 68000,
+            "stop_loss": 61200,
+            "stop_loss_pct": -10.0,
+            "target_1": 78200,
+            "target_1_pct": 15.0,
+            "target_1_sell_pct": 50,
+            "target_2": 88400,
+            "target_2_pct": 30.0,
+            "target_2_sell_pct": 25,
             "trailing_stop_pct": -15.0,
-            "analyst_target": None, "analyst_upside_pct": None,
+            "analyst_target": None,
+            "analyst_upside_pct": None,
         }
         result = format_target_tree(target)
         assert "₩" in result
@@ -688,14 +868,23 @@ class TestPriceTargets_R27:
 
     def test_format_target_tree_with_analyst(self):
         from nuri.trading.recommend.price_targets import format_target_tree
+
         target = {
-            "ticker": "AAPL", "stock_type": "growth",
-            "current_price": 200, "entry_price": 195,
-            "stop_loss": 181.35, "stop_loss_pct": -7.0,
-            "target_1": 234, "target_1_pct": 20.0, "target_1_sell_pct": 50,
-            "target_2": 273, "target_2_pct": 40.0, "target_2_sell_pct": 25,
+            "ticker": "AAPL",
+            "stock_type": "growth",
+            "current_price": 200,
+            "entry_price": 195,
+            "stop_loss": 181.35,
+            "stop_loss_pct": -7.0,
+            "target_1": 234,
+            "target_1_pct": 20.0,
+            "target_1_sell_pct": 50,
+            "target_2": 273,
+            "target_2_pct": 40.0,
+            "target_2_sell_pct": 25,
             "trailing_stop_pct": -15.0,
-            "analyst_target": 250, "analyst_upside_pct": 28.2,
+            "analyst_target": 250,
+            "analyst_upside_pct": 28.2,
         }
         result = format_target_tree(target)
         assert "애널리스트" in result
@@ -704,12 +893,19 @@ class TestPriceTargets_R27:
     def test_check_take_profit_signals(self, db_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import check_take_profit_signals
+
         monkeypatch.setattr(pt_mod, "_stock_types_cache", {"AAPL": "growth"})
+        # 성장주 강제 -> leader off 해야 고정 TP1 검증 (on이면 리더로 skip)
+        monkeypatch.setattr(pt_mod, "TAKE_PROFIT_LEADER", {"enabled": False, "trail_ma": 50})
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency) VALUES (?,?,?,?,?,?)",
-                         ("test", "AAPL", 10, 100.0, "Technology", "USD"))
-            conn.execute("INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
-                         ("AAPL", "2025-03-28", 124, 126, 123, 125, 500000))
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency) VALUES (?,?,?,?,?,?)",
+                ("test", "AAPL", 10, 100.0, "Technology", "USD"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                ("AAPL", "2025-03-28", 124, 126, 123, 125, 500000),
+            )
         signals = check_take_profit_signals(db_path=db_path)
         assert len(signals) >= 1
         assert signals[0]["level"] == "target_1"
@@ -717,27 +913,39 @@ class TestPriceTargets_R27:
     def test_check_trailing_stop_signals(self, db_path, monkeypatch):
         import nuri.trading.recommend.price_targets as pt_mod
         from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
         monkeypatch.setattr(pt_mod, "_stock_types_cache", {"AAPL": "growth"})
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency) VALUES (?,?,?,?,?,?)",
-                         ("test", "AAPL", 10, 100.0, "Technology", "USD"))
-            conn.execute("INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
-                         ("AAPL", "2025-03-20", 195, 200, 190, 198, 500000))
-            conn.execute("INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
-                         ("AAPL", "2025-03-28", 162, 165, 158, 160, 500000))
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency) VALUES (?,?,?,?,?,?)",
+                ("test", "AAPL", 10, 100.0, "Technology", "USD"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                ("AAPL", "2025-03-20", 195, 200, 190, 198, 500000),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                ("AAPL", "2025-03-28", 162, 165, 158, 160, 500000),
+            )
         signals = check_trailing_stop_signals(db_path=db_path)
         assert len(signals) >= 1
 
     def test_check_portfolio_mdd_no_violation(self, db_path):
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
         with get_db(db_path) as conn:
-            conn.execute("INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency) VALUES (?,?,?,?,?,?)",
-                         ("test", "AAPL", 10, 100.0, "Technology", "USD"))
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency) VALUES (?,?,?,?,?,?)",
+                ("test", "AAPL", 10, 100.0, "Technology", "USD"),
+            )
         with get_db(db_path) as conn:
             dates = pd.bdate_range(end="2025-03-28", periods=5)
             for i, d in enumerate(dates):
-                conn.execute("INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
-                             ("AAPL", d.strftime("%Y-%m-%d"), 109, 112, 108, 110, 500000))
+                conn.execute(
+                    "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                    ("AAPL", d.strftime("%Y-%m-%d"), 109, 112, 108, 110, 500000),
+                )
         with get_db(db_path) as conn:
             conn.execute("INSERT INTO macro (indicator, date, value) VALUES (?,?,?)", ("usd_krw", "2025-03-28", 1400.0))
         result = check_portfolio_mdd(db_path=db_path)
@@ -745,6 +953,7 @@ class TestPriceTargets_R27:
 
     def test_print_portfolio_targets_empty(self, capsys):
         from nuri.trading.recommend.price_targets import print_portfolio_targets
+
         print_portfolio_targets([])
         captured = capsys.readouterr()
         assert "가격 목표 대상 종목 없음" in captured.out


### PR DESCRIPTION
## Summary
8주 룰 운영화: **성장주**(classify_stock_type==growth) 보유는 고정 +20/+40 익절 미적용, **50일 이동평균(trail_ma) 종가 이탈 시 청산** (승자 run). value/swing 은 기존 ladder 유지. -7% 하드손절 공통. `target_1/2` numeric 은 유지(price-level 의무) — 익절 *promotion* 만 `is_leader` 로 skip.

## 근거 (backtest, skeptic-verified)
17 성장주 2021~26 (비중첩·트레일동일·거래비용·연율화, 독립 skeptic 검증): 무TP+MA50 트레일이 고정TP ladder 대비 **CAGR +12.8%→+19.5%, 낙폭 더 얕음 (위험조정 0.30→0.53)**. 사용자 5월 실거래 root cause: 승자 조기매도(NVDA +48%)로 복리 손실.

## 구현
- `config/rules.yaml`: `take_profit.leader {enabled, trail_ma: 50}`
- `nuri/core/rules.py`: `TAKE_PROFIT_LEADER`
- `price_targets.py`: `is_leader`(성장주+MA계산가능) / `_get_sma` / `check_take_profit_signals` 리더 skip / `check_leader_trail_signals`(MA break exit) / `calculate_targets`+tree 리더 필드
- `api/routes/{targets,actions}.py`: leader-trail 배선 — `/api/actions` promotion(check bucket, MA period config 반영) + `/targets` `leader_trail_triggered` 필드
- tests: `test_leader_exit.py` (11 lock-tests) + obsolete fixed-TP 3 테스트 갱신

## Review — codex 8-round iteration
**P1 전부 해결.** 설계 수렴: gain-qualifier(+20%) → **growth-type**. gain-threshold stickiness 는 신뢰가능한 trade-date(first_buy_date, 미backfill) 없이 robust 구현 불가 (codex R1-R4: pullback flip / pre-entry 오염 / 멀티계좌 누수). growth-type 은 per-ticker classify 라 그 문제들이 구조적으로 없고 백테스트(성장주 universe)와 정합.

## Follow-up (UX process — 별도 PR)
`/targets` 페이지·ticker 상세·`client-table`·`holding-row` 가 `leader_trail_triggered` 를 읽어 소프트 'check' 로 표시 (현재 **`/api/actions` 메인 액션 surface 에는 배선됨**). frontend badge 는 PM→wireframe→approve.

## Test plan
- [x] 1,396 backend tests pass (recommend+api+core)
- [x] 11 leader-exit lock-tests + ruff clean
- [x] live smoke: NVDA(+63%)/TSLA(+29%) → leader, 50일선 위 riding (sell 신호 없음); value/pension → 고정 ladder 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)