### PR TITLE
test(coverage): cover #679 leader-exit gap + enforce patch gate 100%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,8 +20,8 @@ coverage:
         threshold: 1%        # ±1% 이내 변동은 통과
     patch:
       default:
-        target: auto         # 신규 코드 기준
-        threshold: 5%        # 리팩토링(문자열 교체 등)에서 미커버 기존 라인 허용
+        target: 100%         # 신규 코드는 전량 테스트 (엄밀 enforce — 미커버 diff 라인 0 허용)
+        threshold: 0%        # 허용범위 없음. 진짜 방어용(트리거 불가) 라인만 `# pragma: no cover`
 
 # Backend = Python (nuri/), Frontend = TypeScript (frontend/src/)
 # 두 flag 모두 단일 upload — workflow 가 이미 합산 후 한 번만 업로드한다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,876 backend tests across 256 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,876 backend tests across 258 files + 917 frontend vitest (82 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,876 tests, 256 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,876 tests, 258 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 917 tests, 82 files |
 | E2E | 핵심 flow | 38 Playwright (6 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/api/test_actions_leader_trail.py
+++ b/tests/api/test_actions_leader_trail.py
@@ -1,0 +1,76 @@
+"""Lock-tests for leader-trail wiring in /api/actions (#679 → codecov patch 100%).
+
+- `_build_actions`: leader_trail_triggered 종목에 '⭐ 리더 N일선 이탈' reason 부여.
+- `_get_targets_status`: check_leader_trail_signals 예외 시 안전 폴백 (빈 set).
+"""
+
+from unittest.mock import patch
+
+
+def _invoke_build_actions(*, recommendations, siege_violations, portfolio_map, targets_status=None):
+    """_build_actions 를 mock 된 helper 로 실행 (TestPRABucketRouting 패턴 재사용)."""
+    from nuri.api.routes import actions as actions_mod
+
+    with (
+        patch.object(actions_mod, "_get_recommendations", return_value=recommendations),
+        patch.object(actions_mod, "_get_siege_violations", return_value=siege_violations),
+        patch.object(actions_mod, "_get_targets_status", return_value=targets_status or {}),
+        patch.object(actions_mod, "_get_portfolio_map", return_value=portfolio_map),
+        patch.object(actions_mod, "_get_short_interest", return_value=None),
+        patch.object(actions_mod, "has_recent_catalyst", return_value=(False, "no data")),
+        patch.object(actions_mod, "check_divergence", return_value=(False, 0.0, None)),
+    ):
+        return actions_mod._build_actions()
+
+
+class TestLeaderTrailWiring:
+    def test_leader_trail_triggered_adds_reason(self):
+        """리더 50일선 이탈 종목은 '리더 … 이탈' reason 으로 청산 검토 surface."""
+        result = _invoke_build_actions(
+            recommendations=[
+                {
+                    "ticker": "GRW",
+                    "action": "HOLD",
+                    "confidence": 62,
+                    "agreement": 90,
+                    "scoring_detail": None,
+                    "agent_verdicts": None,
+                    "alpha_action": None,
+                    "portfolio_action": None,
+                }
+            ],
+            siege_violations=[],
+            portfolio_map={
+                "GRW": {
+                    "current_price": 130.0,
+                    "avg_price": 100.0,
+                    "quantity": 10,
+                    "pnl_pct": 30.0,
+                    "position_pct": 5.0,
+                    "account": "Main",
+                }
+            },
+            targets_status={
+                "GRW": {
+                    "is_leader": True,
+                    "leader_trail_triggered": True,
+                    "target_1": None,
+                    "target_2": None,
+                    "stop_loss": 93.0,
+                    "trailing_stop_pct": -15,
+                }
+            },
+        )
+        all_items = result["urgent"] + result["check"] + result["hold"] + result["portfolio"]
+        grw = next(i for i in all_items if i["ticker"] == "GRW")
+        assert any("리더" in r and "이탈" in r for r in grw["reasons"])
+
+
+class TestGetTargetsStatusLeaderTrailException:
+    @patch("nuri.trading.recommend.price_targets.calculate_portfolio_targets", return_value=[])
+    @patch("nuri.trading.recommend.price_targets.check_leader_trail_signals", side_effect=Exception("boom"))
+    def test_leader_trail_exception_falls_back(self, _mock_lt, _mock_cpt):
+        """check_leader_trail_signals 가 터져도 _get_targets_status 는 폴백 (크래시 없음)."""
+        from nuri.api.routes.actions import _get_targets_status
+
+        assert _get_targets_status() == {}

--- a/tests/api/test_targets_leader_trail.py
+++ b/tests/api/test_targets_leader_trail.py
@@ -1,0 +1,18 @@
+"""Lock-test for /api/targets leader-trail exception fallback (#679 → codecov patch 100%).
+
+check_leader_trail_signals 가 예외를 던져도 get_portfolio_targets 는 빈 시그널로 폴백.
+"""
+
+from unittest.mock import patch
+
+
+@patch("nuri.trading.recommend.price_targets.calculate_portfolio_targets", return_value=[])
+@patch("nuri.trading.recommend.price_targets.check_trailing_stop_signals", return_value=[])
+@patch("nuri.trading.recommend.price_targets.check_take_profit_signals", return_value=[])
+@patch("nuri.trading.recommend.price_targets.check_leader_trail_signals", side_effect=Exception("boom"))
+def test_leader_trail_exception_falls_back(_mock_lt, _mock_tp, _mock_ts, _mock_cpt):
+    from nuri.api.routes.targets import get_portfolio_targets
+
+    result = get_portfolio_targets()
+    assert result["targets"] == []
+    assert result["count"] == 0

--- a/tests/trading/recommend/test_leader_exit.py
+++ b/tests/trading/recommend/test_leader_exit.py
@@ -16,6 +16,7 @@ from nuri.trading.recommend.price_targets import (
     calculate_targets,
     check_leader_trail_signals,
     check_take_profit_signals,
+    format_target_tree,
     is_leader,
 )
 
@@ -99,6 +100,27 @@ class TestLeaderTrail:
         _seed(db_path, "VLO", 100.0, closes, sector="Financials")
         assert "VLO" not in {s["ticker"] for s in check_leader_trail_signals(db_path=db_path)}
 
+    def test_disabled_returns_empty(self, db_path, monkeypatch):
+        """take_profit.leader.enabled=False → 리더-트레일 비활성 (빈 리스트)."""
+        import nuri.trading.recommend.price_targets as pt
+
+        monkeypatch.setattr(pt, "TAKE_PROFIT_LEADER", {"enabled": False, "trail_ma": 50})
+        _seed(db_path, "GRW", 100.0, [140.0] * 49 + [125.0], sector="AI")
+        assert check_leader_trail_signals(db_path=db_path) == []
+
+    def test_skips_zero_entry_price(self, db_path):
+        """avg_price=0 보유는 손익 계산 불가 → skip (크래시 없음)."""
+        _seed(db_path, "ZERO", 0.0, [140.0] * 49 + [125.0], sector="AI")
+        assert "ZERO" not in {s["ticker"] for s in check_leader_trail_signals(db_path=db_path)}
+
+    def test_skips_when_current_price_missing(self, db_path, monkeypatch):
+        """리더여도 현재가 조회 실패 시 시그널 침묵 (방어)."""
+        import nuri.trading.recommend.price_targets as pt
+
+        _seed(db_path, "GRW", 100.0, [140.0] * 49 + [125.0], sector="AI")
+        monkeypatch.setattr(pt, "_get_current_price", lambda *a, **k: None)
+        assert "GRW" not in {s["ticker"] for s in check_leader_trail_signals(db_path=db_path)}
+
 
 class TestLeaderTargets:
     def test_leader_targets_numeric_kept_with_flag(self, db_path):
@@ -108,3 +130,11 @@ class TestLeaderTargets:
         assert t["is_leader"] is True
         assert t["target_1"] is not None and t["target_2"] is not None  # price-level 의무 유지 (참고용)
         assert t["leader_ma"] is not None
+
+    def test_format_target_tree_shows_leader_line(self, db_path):
+        """리더 target 트리는 '⭐ 리더 (성장주) … N일선 … 이탈 시 청산' 줄을 포함."""
+        _seed(db_path, "GRW", 100.0, [130.0] * 50, sector="AI")
+        t = calculate_targets("GRW", entry_price=100.0, db_path=db_path)
+        tree = format_target_tree(t)
+        assert "리더" in tree
+        assert "일선" in tree


### PR DESCRIPTION
## Summary
Coverage fix for #679 leader-exit gap + codecov patch gate → 100%. 3 files to 100% coverage, 554 tests pass.
