### PR TITLE
fix(deps): force ip-address >=10.1.1 via override (#21)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7198,9 +7198,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
   },
   "overrides": {
     "hono": ">=4.12.14",
-    "postcss": ">=8.5.10"
+    "postcss": ">=8.5.10",
+    "ip-address": ">=10.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Closes the last open Dependabot alert, **#21** (medium, ip-address XSS — GHSA-v2v4-37r5-5v8g).

`express-rate-limit@8.3.1` (transitive via `@modelcontextprotocol/sdk`) pins `ip-address` to exactly `10.1.0`, so a plain `npm update` can't lift it. Added an npm `overrides` entry (`"ip-address": ">=10.1.1"`) — matching the existing `hono`/`postcss` override pattern — which resolves to `10.2.0`.

### Correction
PR #689 claimed #21 was resolved via dedupe, but that was measured against a stray `frontend/frontend/` lockfile created by a bad `--prefix`; the real lockfile kept `ip-address 10.1.0`. This PR actually fixes it.

## Verification
- `npm audit` → **0 vulnerabilities**
- `ip-address` resolves to `10.2.0` in lockfile
- `npm run build` ✓, `npm test` → 1372 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)