### PR TITLE
docs: sync stale frontend test counts to measured values

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,876 backend tests across 258 files + 1372 frontend vitest (124 files) + 38 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,876 backend tests across 258 files + 1372 frontend vitest (124 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -229,7 +229,7 @@ PR 전 확인.
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,876 tests, 258 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1372 tests, 124 files |
-| E2E | 핵심 flow | 38 Playwright (6 spec) |
+| E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |
 ### 4.2 코드

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (917 tests, 60 files)
+npm run test           # vitest run (1372 tests, 124 files)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,8 +7,8 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (876 tests, 58 files)
-npx playwright test    # E2E (39 tests, 6 specs)
+npm run test           # vitest (1372 tests, 124 files)
+npx playwright test    # E2E (57 tests, 8 specs)
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary
While resolving the open dependency/security PRs I noticed frontend test counts had drifted in several docs — in a number format `verify-doc-counts` doesn't capture, so they silently went stale (from coverage PRs #682/#683, not the dep work).

| File | Was | Now (measured) |
|---|---|---|
| frontend/README.md | 876 tests / 58 files · 39 E2E / 6 specs | 1372 / 124 · 57 / 8 |
| frontend/CLAUDE.md | 917 tests / 60 files | 1372 / 124 |
| docs/ARCHITECTURE.md | 38 Playwright E2E | 57 |
| docs/STRATEGY.md | 38 Playwright / 6 spec | 57 / 8 |

## Verification
- `npm test` → **1372 tests / 124 files**
- `npx playwright test --list` → **57 tests / 8 spec files**
- `make verify-doc-counts` → 13/13 pass
- Docs-only; no code touched.

Note: the dependency/security bumps themselves (PRs #684–#690) required no doc changes — all version badges are major-version (React 19 / Tailwind 4 / Next 16 / shadcn/ui), unaffected by minor/patch bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)