### PR TITLE
docs: sync stale backend/frontend test counts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every BUY / SELL recommendation runs through a 5-phase pipeline — **collect �
 - 🔁 **Self-correcting** — agent weights adjust based on actual prediction accuracy, not hand-tuning.
 - 🛡️ **3-D certification** — gates apply per `Account × Asset Class × Market`. One error-grade fail → REJECTED, no manual override.
 - 🔓 **Open data flow** — phases coupled only via SQLite tables. Re-run any phase, downstream consumers refresh automatically.
-- ✅ **Tested rigorously** — 5,865 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
+- ✅ **Tested rigorously** — 5,892 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
 
 ## Quick Start
 
@@ -157,8 +157,8 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 
 | Metric | Value |
 |--------|-------|
-| **Backend tests** | 5,865 (255 files) — **100% statement coverage** |
-| **Frontend tests** | 1,014 (82 files) |
+| **Backend tests** | 5,892 (258 files) — **100% statement coverage** |
+| **Frontend tests** | 1,372 (124 files) |
 | **E2E tests** | 57 (Playwright, 8 specs) |
 | **Pipeline phases** | 5 (collect / analyze / consensus / certify / track) |
 | **Data collectors** | 26 collectors (BaseCollector pattern) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,876 backend tests across 258 files + 1372 frontend vitest (124 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 258 files + 1372 frontend vitest (124 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,876 tests, 258 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 258 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1372 tests, 124 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |


### PR DESCRIPTION
## Summary
Follow-up to #691. The main `README.md` "Project Stats" still had stale test counts that also **conflicted** with `docs/ARCHITECTURE.md` / `docs/STRATEGY.md` — `verify-doc-counts` only enforces *file* counts, not *test* counts, so these drifted silently.

| Metric | README was | ARCH/STRATEGY was | Now (measured) |
|---|---|---|---|
| Backend tests | 5,865 (255 files) | 5,876 (258 files) | **5,892 (258 files)** |
| Frontend tests | 1,014 (82 files) | 1,372 (124 files) ✓ | **1,372 (124 files)** |

## Measurement
- `pytest tests/ --collect-only` → **5892 items** across **258 files** (9 integration deselected by default → 5,883 selected)
- `npm test` → **1372 tests / 124 files**

## Audited accurate (no change needed)
collectors 26 · agents 10 · regimes 10 · signals 22 · endpoints 69 · routes 17 · DB tables 51 · DB submodules 11 · migrations 44 · pipeline phases 5 · E2E 57/8 → all verified against code. `make verify-doc-counts` → 13/13.

Docs-only; no code touched.

> Note: backend/frontend test counts aren't CI-enforced (they shift every test PR). If you want them gate-protected, I can extend `verify-doc-counts` to grep these phrases — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)