### PR TITLE
fix(recommend): anchor trailing-stop HWM to since-entry not all-time

### DIFF
--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -554,7 +554,7 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
         list[dict]: 트레일링 스톱 시그널 리스트
     """
     df = query_df(
-        "SELECT ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
+        "SELECT ticker, avg_price, quantity, DATE(first_buy_date) AS entry_anchor FROM portfolio WHERE quantity > 0",
         db_path=db_path,
     )
     if df.empty:
@@ -572,12 +572,27 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
             logger.debug("No price data for %s, skipping trailing stop check", ticker)
             continue
 
-        # 고점(HWM) 계산: prices 테이블에서 진입 이후 최고가
-        hwm_rows = query(
-            "SELECT MAX(high) as max_high FROM prices WHERE ticker = ?",
-            (ticker,),
-            db_path=db_path,
-        )
+        # 고점(HWM) 계산: 진입 이후 최고가만 집계한다. 앵커는 first_buy_date(SELECT 에서 DATE 정규화).
+        # 날짜 필터 없이 MAX(high) 를 쓰면 진입 전 수년 전 꼭지가 HWM 으로 잡혀
+        # 트레일링 스톱(-15%)이 진입 후 고점 대비로 작동하지 못한다 (drawdown 방어 무력화).
+        # first_buy_date 미기록(NULL) 시에는 전체 이력 폴백 — over-trigger(노이즈)이나
+        # under-trigger(미발동)보다 drawdown-first 에 안전. updated_at 은 upsert 마다 now() 로
+        # 리셋되어(portfolio.py) 앵커로 부적합하므로 폴백에서 제외한다.
+        # NOTE: 현 write-path(upsert_portfolio/replace_portfolio_account)는 first_buy_date 를
+        # 채우지 않는다 → 실제 진입일 앵커는 후속(포지션 sync) 에서 채워야 본 필터가 활성화된다.
+        entry_anchor = row["entry_anchor"]
+        if isinstance(entry_anchor, str) and entry_anchor:
+            hwm_rows = query(
+                "SELECT MAX(high) as max_high FROM prices WHERE ticker = ? AND date >= ?",
+                (ticker, entry_anchor),
+                db_path=db_path,
+            )
+        else:
+            hwm_rows = query(
+                "SELECT MAX(high) as max_high FROM prices WHERE ticker = ?",
+                (ticker,),
+                db_path=db_path,
+            )
         hwm = hwm_rows[0]["max_high"] if hwm_rows and hwm_rows[0]["max_high"] else None
         if hwm is None or hwm <= 0:
             continue

--- a/tests/trading/recommend/test_price_targets.py
+++ b/tests/trading/recommend/test_price_targets.py
@@ -931,6 +931,41 @@ class TestPriceTargets_R27:
         signals = check_trailing_stop_signals(db_path=db_path)
         assert len(signals) >= 1
 
+    def test_trailing_stop_hwm_since_entry_not_all_time(self, db_path, monkeypatch):
+        """Gotcha-Test: 트레일링 HWM 은 진입 이후(first_buy_date) 최고가만 집계해야 한다.
+
+        진입 전 역대 최고가가 HWM 으로 잡히면 트레일링 스톱이 거짓 발동한다.
+        price_targets.py HWM 쿼리에서 `date >= entry_anchor` 필터를 제거(revert)하면
+        HWM=300(진입 전 꼭지) → -38% → 거짓 발동 → 이 테스트가 실패한다.
+        """
+        import nuri.trading.recommend.price_targets as pt_mod
+        from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
+        monkeypatch.setattr(pt_mod, "_stock_types_cache", {"ZETA": "growth"})
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, sector, currency, first_buy_date) "
+                "VALUES (?,?,?,?,?,?,?)",
+                ("test", "ZETA", 10, 190.0, "Technology", "USD", "2025-03-01"),
+            )
+            # 진입 전(2025-03-01 이전) 역대 최고가 = 300 (트랩: 날짜 필터 없으면 HWM 으로 잡힘)
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                ("ZETA", "2025-01-01", 290, 300, 285, 295, 500000),
+            )
+            # 진입 이후 실제 고점 = 200
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                ("ZETA", "2025-03-05", 195, 200, 192, 198, 500000),
+            )
+            # 현재가 184 → 진입후 HWM(200) 대비 -8% → 트레일 -15% 미달, 발동 안 함
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                ("ZETA", "2025-03-28", 186, 188, 183, 184, 500000),
+            )
+        signals = check_trailing_stop_signals(db_path=db_path)
+        assert signals == []
+
     def test_check_portfolio_mdd_no_violation(self, db_path):
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
 


### PR DESCRIPTION
## Summary

`check_trailing_stop_signals()` computed the high-water mark from all-time `MAX(high)` with no date filter. For a held growth name (e.g. TSLA/NVDA), a years-old **pre-entry** peak inflated the HWM, so the -15% trailing stop never measured drawdown from the actual entry — a silent survival bug for a drawdown-first account.

**Fix:** anchor the HWM query to `DATE(first_buy_date)`; the trailing stop now measures the drop from the since-entry peak. When `first_buy_date` is NULL, fall back to all-time `MAX(high)` (over-trigger is drawdown-safe and == prior behavior, so no regression). `updated_at` is deliberately **excluded** from the anchor because `upsert_portfolio`/`replace_portfolio_account` reset it to `now()` on every sync (that would shrink the window to last-sync-time and *miss* warranted stops — flagged by Codex review).

## Test Coverage

- New Gotcha-Test `test_trailing_stop_hwm_since_entry_not_all_time`: a pre-entry peak of 300 + post-entry peak of 200 + current 184 → no false trigger (since-entry HWM=200, -8%). Reverting the `date >= entry_anchor` filter makes HWM=300 (-38.7%) fire falsely → the test fails. Verified the revert direction empirically.
- The NULL→all-time fallback branch is covered by the existing `test_check_trailing_stop_signals`.
- Full suite: 5864 passed, 6 skipped, 100% coverage. ruff clean.

## Review

Codex adversarial review, 2 rounds:
- **R1 [P1]**: original `COALESCE(first_buy_date, updated_at)` anchor tracked last-sync-time (under-trigger). Resolved by dropping `updated_at`.
- **R2 GATE: PASS** — no new P1/P2; fallback confirmed drawdown-safe, no regression.

## Follow-up (separate issue)

`first_buy_date` is **not yet populated** by the portfolio write paths, so production rows currently use the all-time fallback. A position-sync follow-up (e.g. Toss OpenAPI position import) must populate `first_buy_date` to activate the since-entry filter in production. Tracking separately per PR discipline — not in this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)