### PR TITLE
feat(core): record first_buy_date on first portfolio sync (first-seen)

### DIFF
--- a/nuri/core/db/portfolio.py
+++ b/nuri/core/db/portfolio.py
@@ -9,23 +9,45 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from nuri.core.timezone import today_kst
+
 from .connection import get_db
 
 
 def upsert_portfolio(records: list[dict], db_path: Optional[Path] = None) -> int:
-    """포트폴리오 보유 종목 upsert."""
+    """포트폴리오 보유 종목 upsert.
+
+    first_buy_date 는 (account, ticker) 가 처음 등장할 때 today_kst() 로 기록되고,
+    이후 재upsert(수량/평단 변경) 시에는 보존된다 (first-seen 시맨틱). 이 진입일이
+    트레일링 스톱 HWM 의 앵커로 쓰인다 (price_targets.check_trailing_stop_signals).
+    """
     if not records:
         return 0
-    # metadata 필드 없는 레코드에 기본값 추가
+    today = today_kst()
+    # 호출자 dict 변형 방지(재사용 객체 stale anchor 방지) — 복사본으로 파라미터 구성.
+    params = []
     for r in records:
-        r.setdefault("metadata", None)
+        p = dict(r)
+        p.setdefault("metadata", None)
+        p.setdefault("first_buy_date", today)
+        params.append(p)
     with get_db(db_path) as conn:
+        # 충돌 시 first_buy_date 는 COALESCE: 기존 비-NULL 보존 + 기존 NULL(레거시 행) backfill.
         conn.executemany(
-            """INSERT OR REPLACE INTO portfolio
-               (account, ticker, quantity, avg_price, currency, sector, metadata, updated_at)
+            """INSERT INTO portfolio
+               (account, ticker, quantity, avg_price, currency, sector, metadata,
+                updated_at, first_buy_date)
                VALUES (:account, :ticker, :quantity, :avg_price, :currency, :sector,
-                       :metadata, datetime('now'))""",
-            records,
+                       :metadata, datetime('now'), :first_buy_date)
+               ON CONFLICT(account, ticker) DO UPDATE SET
+                   quantity=excluded.quantity,
+                   avg_price=excluded.avg_price,
+                   currency=excluded.currency,
+                   sector=excluded.sector,
+                   metadata=excluded.metadata,
+                   updated_at=excluded.updated_at,
+                   first_buy_date=COALESCE(portfolio.first_buy_date, excluded.first_buy_date)""",
+            params,
         )
         return len(records)
 
@@ -54,17 +76,31 @@ def replace_portfolio_account(
     for r in records:
         if r.get("account") != account:
             raise ValueError(f"record account mismatch: expected {account!r}, got {r.get('account')!r}")
-        r.setdefault("metadata", None)
 
     with get_db(db_path) as conn:
+        # first_buy_date 보존(first-seen): DELETE+INSERT 라 진입일을 미리 조회해 둔다.
+        existing = {
+            row["ticker"]: row["first_buy_date"]
+            for row in conn.execute(
+                "SELECT ticker, first_buy_date FROM portfolio WHERE account = ?",
+                (account,),
+            ).fetchall()
+        }
         cur = conn.execute("DELETE FROM portfolio WHERE account = ?", (account,))
         deleted = cur.rowcount
         if records:
+            today = today_kst()
+            # 기존 보유면 진입일 보존, 신규면 today (first-seen). 복사본만 변형 — 호출자 dict 불변.
+            params = [
+                {**r, "metadata": r.get("metadata"), "first_buy_date": existing.get(r["ticker"]) or today}
+                for r in records
+            ]
             conn.executemany(
                 """INSERT INTO portfolio
-                   (account, ticker, quantity, avg_price, currency, sector, metadata, updated_at)
+                   (account, ticker, quantity, avg_price, currency, sector, metadata,
+                    updated_at, first_buy_date)
                    VALUES (:account, :ticker, :quantity, :avg_price, :currency, :sector,
-                           :metadata, datetime('now'))""",
-                records,
+                           :metadata, datetime('now'), :first_buy_date)""",
+                params,
             )
         return (deleted, len(records))

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -578,8 +578,8 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
         # first_buy_date 미기록(NULL) 시에는 전체 이력 폴백 — over-trigger(노이즈)이나
         # under-trigger(미발동)보다 drawdown-first 에 안전. updated_at 은 upsert 마다 now() 로
         # 리셋되어(portfolio.py) 앵커로 부적합하므로 폴백에서 제외한다.
-        # NOTE: 현 write-path(upsert_portfolio/replace_portfolio_account)는 first_buy_date 를
-        # 채우지 않는다 → 실제 진입일 앵커는 후속(포지션 sync) 에서 채워야 본 필터가 활성화된다.
+        # NOTE: write-path(upsert_portfolio/replace_portfolio_account)가 first_buy_date 를
+        # first-seen(최초 sync 일)으로 채운다. 실제 매입일 단위 앵커는 후속(브로커 포지션 sync)에서.
         entry_anchor = row["entry_anchor"]
         if isinstance(entry_anchor, str) and entry_anchor:
             hwm_rows = query(

--- a/tests/core/test_portfolio_sync.py
+++ b/tests/core/test_portfolio_sync.py
@@ -1063,7 +1063,7 @@ class TestPortfolioSyncBranches:
         with get_db(db) as conn:
             conn.execute(
                 "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) "
-                "VALUES ('emptycur', 'AAA', 10, 100, NULL)"
+                "VALUES ('demo', 'AAA', 10, 100, NULL)"
             )
 
         config_path = tmp_path / "portfolio.yaml"
@@ -1123,3 +1123,189 @@ class TestPortfolioSyncBranches:
         config_path.write_text("accounts:\n  main:\n    strategy: core\n    holdings:\n      AAA: 10\n")
         sync_portfolio_to_yaml(config_path=config_path, db_path=db)
         assert config_path.exists()
+
+
+class TestFirstBuyDate:
+    """first_buy_date first-seen 기록 + 보존 (트레일링 스톱 HWM 진입 앵커, #694 후속)."""
+
+    def _db(self, tmp_path, name="test.db"):
+        from nuri.core.db import init_db
+
+        db = tmp_path / name
+        init_db(db)
+        return db
+
+    def test_upsert_sets_first_buy_date_today(self, tmp_path):
+        """신규 종목 upsert → first_buy_date = today_kst() (first-seen)."""
+        from nuri.core.db import query, upsert_portfolio
+        from nuri.core.timezone import today_kst
+
+        db = self._db(tmp_path)
+        upsert_portfolio(
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "quantity": 10,
+                    "avg_price": 300.0,
+                    "currency": "USD",
+                    "sector": "EV",
+                }
+            ],
+            db_path=db,
+        )
+        rows = query("SELECT first_buy_date FROM portfolio WHERE ticker='TSLA'", db_path=db)
+        assert rows[0]["first_buy_date"] == today_kst()
+
+    def test_upsert_preserves_first_buy_date(self, tmp_path):
+        """재upsert(수량 변경) 시 기존 first_buy_date 보존."""
+        from nuri.core.db import get_db, query, upsert_portfolio
+
+        db = self._db(tmp_path)
+        upsert_portfolio(
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "quantity": 10,
+                    "avg_price": 300.0,
+                    "currency": "USD",
+                    "sector": "EV",
+                }
+            ],
+            db_path=db,
+        )
+        # 진입일을 과거로 강제 (이전 진입 시뮬레이션)
+        with get_db(db) as conn:
+            conn.execute("UPDATE portfolio SET first_buy_date='2026-01-02' WHERE ticker='TSLA'")
+        # 수량 변경 재upsert
+        upsert_portfolio(
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "quantity": 25,
+                    "avg_price": 310.0,
+                    "currency": "USD",
+                    "sector": "EV",
+                }
+            ],
+            db_path=db,
+        )
+        rows = query("SELECT quantity, first_buy_date FROM portfolio WHERE ticker='TSLA'", db_path=db)
+        assert rows[0]["quantity"] == 25  # 갱신됨
+        assert rows[0]["first_buy_date"] == "2026-01-02"  # 보존됨
+
+    def test_replace_account_preserves_existing_and_seeds_new(self, tmp_path):
+        """yaml→DB sync(DELETE+INSERT): 유지 종목은 진입일 보존, 신규는 today."""
+        from nuri.core.db import get_db, query, replace_portfolio_account
+        from nuri.core.timezone import today_kst
+
+        db = self._db(tmp_path)
+        replace_portfolio_account(
+            "test",
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "quantity": 10,
+                    "avg_price": 300.0,
+                    "currency": "USD",
+                    "sector": "EV",
+                }
+            ],
+            db_path=db,
+        )
+        with get_db(db) as conn:
+            conn.execute("UPDATE portfolio SET first_buy_date='2026-01-02' WHERE ticker='TSLA'")
+        # 재sync: TSLA 유지(수량 변경) + NVDA 신규
+        replace_portfolio_account(
+            "test",
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "quantity": 33,
+                    "avg_price": 320.0,
+                    "currency": "USD",
+                    "sector": "EV",
+                },
+                {
+                    "account": "test",
+                    "ticker": "NVDA",
+                    "quantity": 5,
+                    "avg_price": 130.0,
+                    "currency": "USD",
+                    "sector": "Semiconductor",
+                },
+            ],
+            db_path=db,
+        )
+        rows = {
+            r["ticker"]: r["first_buy_date"]
+            for r in query("SELECT ticker, first_buy_date FROM portfolio WHERE account='test'", db_path=db)
+        }
+        assert rows["TSLA"] == "2026-01-02"  # DELETE+INSERT 거쳐도 보존
+        assert rows["NVDA"] == today_kst()  # 신규 = first-seen today
+
+    def test_upsert_backfills_legacy_null(self, tmp_path):
+        """레거시 NULL first_buy_date 행을 재upsert 시 COALESCE 로 backfill (codex P1)."""
+        from nuri.core.db import get_db, query, upsert_portfolio
+        from nuri.core.timezone import today_kst
+
+        db = self._db(tmp_path)
+        # 컬럼 추가 전 만들어진 행 시뮬레이션 (first_buy_date NULL)
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) "
+                "VALUES ('test', 'TSLA', 10, 300, 'USD')"
+            )
+        # 정상 upsert → NULL 이 today 로 backfill (전체 보유 활성화)
+        upsert_portfolio(
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "quantity": 12,
+                    "avg_price": 305.0,
+                    "currency": "USD",
+                    "sector": "EV",
+                }
+            ],
+            db_path=db,
+        )
+        rows = query("SELECT first_buy_date FROM portfolio WHERE ticker='TSLA'", db_path=db)
+        assert rows[0]["first_buy_date"] == today_kst()
+
+    def test_upsert_does_not_mutate_caller_dict(self, tmp_path):
+        """upsert 가 호출자 record dict 에 first_buy_date 를 박지 않음 (codex P2 — 모듈전역 재사용)."""
+        from nuri.core.db import upsert_portfolio
+
+        db = self._db(tmp_path)
+        record = {
+            "account": "test",
+            "ticker": "TSLA",
+            "quantity": 10,
+            "avg_price": 300.0,
+            "currency": "USD",
+            "sector": "EV",
+        }
+        upsert_portfolio([record], db_path=db)
+        assert "first_buy_date" not in record  # 호출자 객체 불변
+
+    def test_replace_account_does_not_mutate_caller_dict(self, tmp_path):
+        """replace_portfolio_account 가 호출자 record dict 를 변형하지 않음 (codex round2 cleanup)."""
+        from nuri.core.db import replace_portfolio_account
+
+        db = self._db(tmp_path)
+        record = {
+            "account": "test",
+            "ticker": "TSLA",
+            "quantity": 10,
+            "avg_price": 300.0,
+            "currency": "USD",
+            "sector": "EV",
+        }
+        replace_portfolio_account("test", [record], db_path=db)
+        assert "first_buy_date" not in record  # 진입일 미주입
+        assert "metadata" not in record  # metadata 도 호출자 dict 에 안 박힘


### PR DESCRIPTION
## Summary

Activates the since-entry trailing-stop filter from #694. Portfolio write paths never populated `first_buy_date`, so the HWM anchor fell back to all-time high in production. Now both write paths record `first_buy_date` on a position's first appearance and preserve it across re-syncs (first-seen semantics):

- `upsert_portfolio` — `INSERT ... ON CONFLICT(account,ticker) DO UPDATE` with `first_buy_date=COALESCE(portfolio.first_buy_date, excluded.first_buy_date)`: preserves a real entry date, backfills legacy `NULL` rows with `today_kst()`.
- `replace_portfolio_account` (yaml→DB sync, DELETE+INSERT) — pre-fetches existing `first_buy_date` before DELETE, preserves it for surviving tickers, seeds `today_kst()` for new ones.

Broker-agnostic: works for Toss/KakaoPay holdings via the existing manual `portfolio.yaml` import. No broker API required (Toss OpenAPI pending; KIS Open API cannot read other brokers' accounts). Real per-lot purchase dates remain a future enhancement once a broker position-sync exists.

Also fixes the now-stale comment in `price_targets.py` and removes caller-dict mutation (both write paths build copied param dicts — no stale anchors for reused record objects like the module-global sample portfolio).

## Test Coverage

New `TestFirstBuyDate` (5 tests): first-seen set, preserve on re-upsert, preserve+seed through DELETE+INSERT, legacy-NULL backfill, caller-dict immutability for both functions. Full module 71 passed + price_targets 73 passed. test-fast: 5869 passed (1 pre-existing unrelated numba/vectorbt flake in test_engine.py — passes in isolation, no relation to this diff).

## Review

Codex adversarial review, 2 rounds:
- R1: [P1] ON CONFLICT preserved even NULL (legacy rows never activated) → fixed with COALESCE backfill. [P2] caller-dict mutation via setdefault (stale anchor for reused records) → fixed with copy pattern.
- R2: GATE PASS — both resolved; round-2 cleanup (full caller immutability + stale comment) applied.

## Follow-up

Real per-lot entry dates from a broker position-sync (e.g. Toss OpenAPI once issued) can populate `first_buy_date` precisely; the first-seen value is the interim until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)