### PR TITLE
feat(api): honest /api/alpha tracking-completeness endpoint

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,7 +2,7 @@
 
 ## Code layout
 
-`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (26 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (69 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
+`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (26 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (70 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
 
 ## Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ README shows the high-level flow. Per-phase orientation table — each row point
 | 3 | **Consensus** | Phase 2 outputs + `portfolio` + `macro_events` | `recommendations` table rows with per-agent verdicts + weighted final action | `nuri/trading/agents/` (10 specialists + consensus engine, risk veto) | `nuri/trading/agents/CLAUDE.md` |
 | 4 | **Certify** | Phase 3 recommendations + `config/rules.yaml siege_gates` | `Certificate` → CERTIFIED / REJECTED + evidence trace via `pipeline_events` | `nuri/trading/engine/certification.py` | "SIEGE Engine" below + [CERTIFICATION_SPEC.md](CERTIFICATION_SPEC.md) |
 | 5 | **Track** | Phase 3 `recommendations.action` + actual prices after N days | `outcome_30d` / `outcome_60d` / `outcome_90d` + `agent_accuracy_snapshots` (feeds Learning Memory back to Phase 3 weights) | `nuri/trading/recommend/tracker.py` + `nuri/trading/engine/learning_memory.py` | "C→D→E Data Flow" below |
-The **Serve** layer (FastAPI `:8001` + Next.js `:3000` + Discord/Telegram) is a read-only projection from the DB — not a pipeline phase. See "API (69 endpoints)" and "Dashboard API" sections below.
+The **Serve** layer (FastAPI `:8001` + Next.js `:3000` + Discord/Telegram) is a read-only projection from the DB — not a pipeline phase. See "API (70 endpoints)" and "Dashboard API" sections below.
 ## DB as the Sole Integration Point
 `nuri/core/db/` is the **only** module that imports `sqlite3`. DB file: `data/portfolio.db` (WAL mode). All upsert functions accept optional `db_path` — tests inject `tmp_path` for isolation. Schema versioning via `schema_version` table + `_MIGRATIONS` list.
 Key DB access patterns:
@@ -57,8 +57,8 @@ Trade execution API (`nuri/api/routes/trades.py`):
 - `PUT /api/trades/{id}` — Update exit info
 ## Dashboard API (Projection-based, <5s)
 `/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display.
-## API (69 endpoints)
-`nuri/api/routes/` — 69 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 18 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
+## API (70 endpoints)
+`nuri/api/routes/` — 70 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 18 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
 ### Action-First Dashboard APIs (PR #264-#266)
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 258 files + 1372 frontend vitest (124 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 259 files + 1372 frontend vitest (124 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 258 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 259 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1372 tests, 124 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/main.py
+++ b/nuri/api/main.py
@@ -28,6 +28,7 @@ from slowapi.util import get_remote_address
 from nuri.api.routes import (
     actions,
     agents,
+    alpha,
     coverage,
     dashboard,
     decisions,
@@ -124,6 +125,7 @@ app.include_router(external.router, prefix="/api")
 app.include_router(targets.router, prefix="/api")
 app.include_router(trades.router, prefix="/api")
 app.include_router(decisions.router, prefix="/api")
+app.include_router(alpha.router, prefix="/api")
 app.include_router(learning_memory.router, prefix="/api")
 
 

--- a/nuri/api/routes/alpha.py
+++ b/nuri/api/routes/alpha.py
@@ -1,0 +1,107 @@
+"""정직한 alpha 추적 — tracking-completeness + 데이터 품질. 검증된 edge 가 아님.
+
+decision_outcomes 의 각 행은 (decision, observation_window) 단위다. 생산자
+(ForwardOutcomeTracker)는 윈도우(as_of + window 영업일)가 도래하기 전이면
+lookahead guard 로 realized_return=NULL 을 기록한다. 따라서 realized_return 유무가
+완료/열림의 신뢰 가능한 신호이며, 이 엔드포인트는 자체 날짜 재계산 없이 이를 그대로
+사용한다. realized_return 절대값이 임계값 초과인 행은 price-measurement 오류 의심으로
+별도 카운트한다.
+
+P0c (Lean MVP). edge 증명은 멀티레짐 walk-forward(P1/P7) 통과 후에만 가능 →
+이 엔드포인트는 항상 edge_status=NOT_MEASURABLE 로 신뢰도를 명시한다.
+"""
+
+import logging
+
+from fastapi import APIRouter
+
+from nuri.core.db import query
+from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["alpha"])
+
+# 추적 호라이즌 (영업일)
+WINDOWS = (7, 14, 30)
+# |realized_return| 이 초과면 측정 오류 의심 (해당 호라이즌에서 물리적으로 비현실적)
+SUSPECT_ABS_RETURN = 0.5
+
+
+def _median(values: list[float]) -> float | None:
+    n = len(values)
+    if n == 0:
+        return None
+    s = sorted(values)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2
+
+
+@router.get("/alpha")
+def alpha_summary() -> dict:
+    """결정 추적 완성도 + alpha 데이터 품질 요약 (검증된 edge 아님)."""
+    rows = query(
+        "SELECT decision_id AS did, observation_window AS w, "
+        "realized_return AS rr, alpha AS a, notes "
+        "FROM decision_outcomes WHERE observation_window IN (7, 14, 30)"
+    )
+
+    buckets: dict[int, dict] = {w: {"completed": [], "pending": 0, "unmeasured": 0} for w in WINDOWS}
+    clean_decisions: set[str] = set()
+    suspect = 0
+    unmeasured_total = 0
+
+    for r in rows:
+        w = r["w"]
+        if w not in buckets:
+            continue
+        rr = r["rr"]
+        if rr is None:
+            # 생산자가 realized_return=NULL 을 쓰는 두 경우 구분:
+            # lookahead(윈도우 미도래) vs price-missing(도래했으나 가격 없음=데이터 갭).
+            # 생산자 notes 자유텍스트 매칭이라 대소문자 무시 (tracker 테스트도 case-insensitive 잠금).
+            if "lookahead" in (r["notes"] or "").lower():
+                buckets[w]["pending"] += 1
+            else:
+                buckets[w]["unmeasured"] += 1
+                unmeasured_total += 1
+            continue
+        buckets[w]["completed"].append(r)
+        if abs(rr) > SUSPECT_ABS_RETURN:
+            suspect += 1
+        elif r["a"] is not None:
+            clean_decisions.add(r["did"])
+
+    windows_out = []
+    for w in WINDOWS:
+        completed = buckets[w]["completed"]
+        # clean = 오염 아님 + alpha 측정됨 (벤치마크 가용)
+        clean = [c for c in completed if abs(c["rr"]) <= SUSPECT_ABS_RETURN and c["a"] is not None]
+        med = _median([c["a"] for c in clean])
+        windows_out.append(
+            {
+                "window": w,
+                "n_completed": len(completed),
+                "n_pending": buckets[w]["pending"],  # 윈도우 미도래
+                "n_unmeasured": buckets[w]["unmeasured"],  # 도래했으나 가격 없음 (데이터 갭)
+                "n_clean": len(clean),
+                # outlier-robust median, clean 부분집합만. edge 아님 (NOT_MEASURABLE).
+                "median_alpha_pct": round(med * 100, 2) if med is not None else None,
+            }
+        )
+
+    return {
+        "as_of": today_kst(),
+        "windows": windows_out,
+        # clean alpha 의 distinct 결정 수 — median 의 실제 표본 크기 (coverage 아님).
+        "effective_bets": len(clean_decisions),
+        "data_quality": {
+            "suspect_rows": suspect,
+            "suspect_threshold_pct": int(SUSPECT_ABS_RETURN * 100),
+            "unmeasured_rows": unmeasured_total,
+            "note": "suspect=|realized_return|>임계값(측정오류 의심). unmeasured=윈도우 도래했으나 가격 없음(데이터 갭). 둘 다 alpha 헤드라인 비신뢰.",
+        },
+        # 멀티레짐 walk-forward(P1) 통과 전엔 항상 미측정. 단기·강세장 표본 + 오염 가능.
+        "edge_status": "NOT_MEASURABLE",
+        "caveat": "추적 완성도(tracking-completeness)이며 검증된 edge 가 아님. 표본은 단기·강세장 편향 + 오염 가능. 멀티레짐 walk-forward 통과 전 edge 미측정.",
+    }

--- a/nuri/api/routes/alpha.py
+++ b/nuri/api/routes/alpha.py
@@ -53,7 +53,7 @@ def alpha_summary() -> dict:
 
     for r in rows:
         w = r["w"]
-        if w not in buckets:
+        if w not in buckets:  # pragma: no cover — SQL 이 IN (7,14,30) 으로 이미 필터, 방어용
             continue
         rr = r["rr"]
         if rr is None:

--- a/tests/api/test_alpha.py
+++ b/tests/api/test_alpha.py
@@ -1,0 +1,73 @@
+"""GET /api/alpha — 정직한 alpha 추적 (P0c).
+
+완료/미완료 신호는 생산자(ForwardOutcomeTracker)와 동일하게 realized_return 유무.
+realized_return=NULL 은 두 경우: lookahead(미도래) vs price-missing(데이터 갭) — notes 로 구분.
+"""
+
+from nuri.core.db import get_db
+
+
+def _seed(conn, *, rec_id, window, alpha, rr, notes="action=BUY", decided="2026-04-01"):
+    """agent_decisions(FK) + decision_outcomes 한 쌍. rr=None 이면 미완료."""
+    did = f"rec_{rec_id}"
+    conn.execute(
+        "INSERT INTO agent_decisions "
+        "(decision_id, ticker, as_of_date, action, conviction, inputs_json, rationale_json, status) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (did, f"TK{rec_id}", decided, "BUY", 0.7, "{}", "{}", "emitted"),
+    )
+    bench = (rr - alpha) if (rr is not None and alpha is not None) else None
+    conn.execute(
+        "INSERT INTO decision_outcomes "
+        "(decision_id, observation_window, tracked_as_of_date, realized_return, benchmark_return, alpha, "
+        "hypothesis_validation, notes) VALUES (?,?,?,?,?,?,?,?)",
+        (did, window, "2026-06-04", rr, bench, alpha, "insufficient_data", notes),
+    )
+
+
+def test_alpha_completeness_and_quality(client):
+    with get_db() as conn:
+        # 완료 + clean
+        _seed(conn, rec_id=100, window=7, alpha=0.05, rr=0.06)
+        # 미도래 (lookahead) — notes 대문자여도 case-insensitive 분류 (codex round3 P1 잠금)
+        _seed(conn, rec_id=101, window=30, alpha=None, rr=None, notes="target_date 2026-07 > today (LOOKAHEAD guard)")
+        # 완료지만 suspect (|rr|>0.5 = 측정 오류 의심)
+        _seed(conn, rec_id=102, window=30, alpha=0.9, rr=0.9)
+        # 데이터 갭 (price missing) — rr NULL 이지만 lookahead 아님
+        _seed(conn, rec_id=103, window=14, alpha=None, rr=None, notes="price missing — entry=None, exit=None")
+
+    r = client.get("/api/alpha")
+    assert r.status_code == 200
+    data = r.json()
+
+    assert data["edge_status"] == "NOT_MEASURABLE"
+    assert data["data_quality"]["suspect_rows"] == 1
+    assert data["data_quality"]["unmeasured_rows"] == 1  # rec_103
+    # effective_bets = clean distinct 결정만 = rec_100 (suspect/미측정 제외)
+    assert data["effective_bets"] == 1
+
+    by_w = {w["window"]: w for w in data["windows"]}
+    # window 7: rec_100 완료 clean
+    assert by_w[7]["n_completed"] == 1
+    assert by_w[7]["n_pending"] == 0
+    assert by_w[7]["n_clean"] == 1
+    assert by_w[7]["median_alpha_pct"] == 5.0
+    # window 14: rec_103 데이터 갭
+    assert by_w[14]["n_completed"] == 0
+    assert by_w[14]["n_unmeasured"] == 1
+    # window 30: rec_102 완료(suspect) + rec_101 미도래
+    assert by_w[30]["n_completed"] == 1
+    assert by_w[30]["n_pending"] == 1
+    assert by_w[30]["n_unmeasured"] == 0
+    assert by_w[30]["n_clean"] == 0
+    assert by_w[30]["median_alpha_pct"] is None
+
+
+def test_alpha_empty(client):
+    """데이터 없으면 0 카운트 + NOT_MEASURABLE."""
+    r = client.get("/api/alpha")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["effective_bets"] == 0
+    assert data["edge_status"] == "NOT_MEASURABLE"
+    assert all(w["n_completed"] == 0 and w["n_pending"] == 0 for w in data["windows"])


### PR DESCRIPTION
## Summary

P0c (Lean MVP). Surfaces `decision_outcomes` as **tracking-completeness, not proven edge** — directly avoids the phantom "+5.4% alpha" disposition trap the roadmap review flagged.

`GET /api/alpha` returns, per window (7/14/30d):
- `n_completed` (producer measured a `realized_return`), `n_pending` (window not yet due — lookahead), `n_unmeasured` (window due but price missing — a real coverage gap), `n_clean` (non-suspect + benchmark-available).
- `median_alpha_pct` — outlier-robust median on the **clean subset only**.
- `effective_bets` = distinct decisions behind the clean alpha (the real sample size, not coverage).
- `data_quality.suspect_rows` (`|realized_return| > 50%` = likely price-measurement errors) + `unmeasured_rows`.
- `edge_status` hardcoded **NOT_MEASURABLE** — a multi-regime walk-forward (P1) is required before any edge claim.

Completion uses the producer's own signal (`ForwardOutcomeTracker` writes `realized_return=NULL` on its lookahead guard), not a re-derived date calc.

On live data: 119/118/103 completed, 7/11/23 pending, 21/18/21 unmeasured, median +1.09%/+1.72%/+1.4%, 21 suspect, 60 unmeasured total — the honest picture, not a headline edge.

## Review

Codex adversarial review, 3 rounds:
- R1: 3×[P1] — n_open undercounted (alpha-IS-NOT-NULL filter), busday_count semantics mismatched producer, unsafe rec_N substr/CAST join. → resolved by dropping the JOIN/busday and using the producer's `realized_return IS NULL` signal.
- R2: [P1] n_open conflated lookahead vs price-missing; [P2] effective_bets overstated the alpha sample. → split `n_pending`/`n_unmeasured`; `effective_bets` = clean distinct decisions.
- R3: [P1] case-sensitive notes match fragile. → case-insensitive + uppercase test lock. [P2] confirmed correct.

## Test Coverage

`tests/api/test_alpha.py` (2 tests): completeness + quality across completed/pending/unmeasured/suspect/clean, case-insensitive lookahead classification, empty. Full `tests/api` 536 passed, ruff clean.

## Follow-up

Frontend alpha panel (labeled "tracking-completeness", consuming this endpoint) folds into P6 (/decisions UI). The 60 unmeasured rows + 21 suspect rows are a tracker data-quality issue to fix before edge can be measured (P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)