### PR TITLE
feat(frontend): per-decision provenance page /decisions/[id]

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 259 files + 1372 frontend vitest (124 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 259 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -228,7 +228,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 259 files (statement coverage **100%**, 2026-05-06) |
-| Frontend tests | 목표 ≥ 90% | 1372 tests, 124 files |
+| Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+vi.mock("next/navigation", () => ({ notFound: () => notFoundMock() }));
+
+let mockFetchAPI: Mock;
+vi.mock("@/lib/api", () => ({
+  fetchAPI: (...args: unknown[]) => mockFetchAPI(...args),
+  API_BASE: "http://localhost:8001",
+}));
+
+const mockDetail = {
+  id: 531,
+  date: "2026-04-13",
+  ticker: "AAA",
+  action: "BUY",
+  confidence: 75,
+  regime: "bull_low_vol",
+  macro_score: 72,
+  vix: 15,
+  fear_greed: 65,
+  agreement_rate: 0.8,
+  // 생산자처럼 JSON 문자열로 저장
+  agent_verdicts: JSON.stringify([
+    { agent_name: "technical", action: "BUY", confidence: 80, reasoning: "MACD>Signal" },
+  ]),
+  entry_price: 120,
+  stop_loss: 111.6,
+  target_1: 144,
+  target_2: 168,
+  pnl_7d: 5.2,
+  pnl_30d: -3.1,
+  pnl_60d: null,
+  pnl_90d: null,
+  outcome: "pending",
+  reasoning: "Consensus reached",
+  evidence: [
+    { id: 1, decision_id: 531, source_type: "agent", source_key: "technical", action: "BUY", confidence: 80, detail: '{"rsi": 49}' },
+  ],
+};
+
+describe("DecisionProvenance", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockFetchAPI = vi.fn().mockResolvedValue(mockDetail);
+    notFoundMock.mockClear();
+  });
+
+  it("renders frozen context + price ladder + outcome", async () => {
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText("AAA")).toBeInTheDocument();
+    expect(screen.getByText(/결정 시점 컨텍스트/)).toBeInTheDocument();
+    expect(screen.getByText("Entry")).toBeInTheDocument();
+    expect(screen.getByText("Stop")).toBeInTheDocument();
+    expect(screen.getByText(/실현 결과/)).toBeInTheDocument();
+    expect(screen.getByText("#531 · 2026-04-13")).toBeInTheDocument();
+  });
+
+  it("renders parsed agent verdicts and evidence chain", async () => {
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText("technical")).toBeInTheDocument();
+    expect(screen.getByText(/증거 체인/)).toBeInTheDocument();
+    expect(screen.getByText("agent/technical")).toBeInTheDocument();
+  });
+
+  it("calls notFound when the decision fetch fails (404)", async () => {
+    mockFetchAPI = vi.fn().mockRejectedValue(new Error("API /api/decisions/999: 404"));
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await expect(DecisionProvenance({ id: "999" })).rejects.toThrow();
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  it("calls notFound when the API returns null", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(null);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await expect(DecisionProvenance({ id: "0" })).rejects.toThrow();
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  it("handles minimal decision: null fields, empty evidence, array verdicts, zero pnl", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      id: 1, date: "2026-04-01", ticker: "BBB", action: "HOLD", confidence: 50,
+      regime: null, macro_score: null, vix: null, fear_greed: null, agreement_rate: null,
+      agent_verdicts: [], // 직접 배열 (parse 분기 우회)
+      entry_price: null, stop_loss: null, target_1: null, target_2: null,
+      pnl_7d: 0, pnl_30d: null, pnl_60d: null, pnl_90d: null,
+      outcome: "", reasoning: null, evidence: [],
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "1" }));
+    });
+    expect(screen.getByText("BBB")).toBeInTheDocument();
+    expect(screen.getByText("증거 없음")).toBeInTheDocument();
+    // reasoning null → 근거 카드 없음, verdicts 빈 배열 → 에이전트 카드 없음
+    expect(screen.queryByText(/에이전트 판정/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to empty verdicts on malformed JSON + renders evidence with null fields", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      agent_verdicts: "not-json{", // parse 실패 → []
+      reasoning: null,
+      evidence: [
+        { id: 9, decision_id: 531, source_type: "data", source_key: "vix", action: null, confidence: null, detail: null },
+      ],
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText("data/vix")).toBeInTheDocument();
+    expect(screen.queryByText(/에이전트 판정/)).not.toBeInTheDocument();
+  });
+
+  it("parseVerdicts handles null and non-array JSON gracefully", async () => {
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    for (const av of [null, "{}"]) {
+      mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, agent_verdicts: av, evidence: [] });
+      await act(async () => {
+        render(await DecisionProvenance({ id: "531" }));
+      });
+    }
+    expect(mockFetchAPI).toHaveBeenCalled();
+  });
+
+  it("filters malformed verdict entries and guards missing confidence/reasoning", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      agent_verdicts: JSON.stringify([
+        null,
+        {},
+        { agent_name: "risk", action: "HOLD" }, // confidence/reasoning 누락
+        { agent_name: "macro", action: "BUY", confidence: 70, reasoning: "neutral" },
+      ]),
+      evidence: [],
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    // null/{} 제거 → valid 2개만
+    expect(screen.getByText("에이전트 판정 (2)")).toBeInTheDocument();
+    expect(screen.getByText("risk")).toBeInTheDocument();
+    expect(screen.getByText("macro")).toBeInTheDocument();
+  });
+
+  it("default export awaits params; Loading skeleton shows while child suspends", async () => {
+    mockFetchAPI = vi.fn(() => new Promise(() => {})); // never resolve → child suspends → fallback
+    const mod = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await mod.default({ params: Promise.resolve({ id: "531" }) }));
+    });
+    expect(document.querySelector(".animate-pulse")).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/decisions.test.tsx
+++ b/frontend/src/__tests__/pages/decisions.test.tsx
@@ -83,11 +83,11 @@ describe("DecisionsPage", () => {
     expect(screen.getByText("-8.5%")).toBeInTheDocument();
   });
 
-  it("renders ticker links to detail page", async () => {
+  it("renders ticker links to the frozen decision provenance page", async () => {
     const { default: DecisionsPage } = await import("@/app/decisions/page");
     await act(async () => { render(await DecisionsPage()); });
     const link = screen.getByRole("link", { name: "AAA" });
-    expect(link).toHaveAttribute("href", "/ticker/AAA");
+    expect(link).toHaveAttribute("href", "/decisions/1");
   });
 
   it("renders action badges", async () => {

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -1,0 +1,229 @@
+export const dynamic = "force-dynamic";
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchAPI } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { Metric } from "@/components/ui/metric";
+
+// === Types ===
+interface Evidence {
+  id: number;
+  decision_id: number;
+  source_type: string;
+  source_key: string;
+  action: string | null;
+  confidence: number | null;
+  detail: string | null;
+}
+
+interface AgentVerdict {
+  agent_name: string;
+  action: string;
+  confidence: number;
+  reasoning?: string;
+  [key: string]: unknown;
+}
+
+interface DecisionDetail {
+  id: number;
+  date: string;
+  ticker: string;
+  action: string;
+  confidence: number;
+  regime: string | null;
+  macro_score: number | null;
+  vix: number | null;
+  fear_greed: number | null;
+  agreement_rate: number | null;
+  agent_verdicts: AgentVerdict[] | string | null;
+  entry_price: number | null;
+  stop_loss: number | null;
+  target_1: number | null;
+  target_2: number | null;
+  pnl_7d: number | null;
+  pnl_30d: number | null;
+  pnl_60d: number | null;
+  pnl_90d: number | null;
+  outcome: string;
+  reasoning: string | null;
+  evidence: Evidence[];
+}
+
+// agent_verdicts 는 JSON 문자열로 저장됨 — 안전 파싱 + per-item 검증.
+function parseVerdicts(raw: AgentVerdict[] | string | null): AgentVerdict[] {
+  let arr: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      arr = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(arr)) return [];
+  // 불량 항목(null/[{}]/타입 불일치) 제거 — agent_name·action 문자열만 통과.
+  return arr.filter(
+    (v): v is AgentVerdict =>
+      v != null &&
+      typeof v === "object" &&
+      typeof (v as AgentVerdict).agent_name === "string" &&
+      typeof (v as AgentVerdict).action === "string",
+  );
+}
+
+function pnlColor(v: number | null): "green" | "red" | "default" {
+  if (v === null) return "default";
+  return v > 0 ? "green" : v < 0 ? "red" : "default";
+}
+
+function fmt(v: number | null, suffix = ""): string {
+  return v === null ? "—" : `${v}${suffix}`;
+}
+
+// === Provenance (exported for test coverage of async children — frontend RSC gotcha) ===
+export async function DecisionProvenance({ id }: { id: string }) {
+  let d: DecisionDetail | null = null;
+  try {
+    d = await fetchAPI<DecisionDetail>(`/api/decisions/${id}`);
+  } catch {
+    notFound();
+  }
+  if (!d) notFound();
+
+  const verdicts = parseVerdicts(d.agent_verdicts);
+  const evidence = d.evidence ?? [];
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-3">
+          <Link href="/decisions" className="text-xs text-muted-foreground hover:text-foreground">
+            ← Decisions
+          </Link>
+          <h1 className="text-xl font-semibold text-foreground">{d.ticker}</h1>
+          <StatusBadge status={d.action} />
+          <span className="text-xs text-muted-foreground">#{d.id} · {d.date}</span>
+        </div>
+        {d.outcome && <StatusBadge status={d.outcome} />}
+      </div>
+
+      {/* Decision-time context (frozen) */}
+      <Card className="bg-card border-border">
+        <CardContent className="pt-4 pb-3">
+          <p className="text-[10px] text-muted-foreground mb-3">결정 시점 컨텍스트 (frozen)</p>
+          <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
+            <Metric label="Confidence" value={fmt(d.confidence, "%")} />
+            <Metric label="Agreement" value={d.agreement_rate === null ? "—" : `${Math.round(d.agreement_rate * 100)}%`} />
+            <Metric label="Regime" value={d.regime ?? "—"} />
+            <Metric label="VIX" value={fmt(d.vix)} />
+            <Metric label="Fear&Greed" value={fmt(d.fear_greed)} />
+            <Metric label="Macro" value={fmt(d.macro_score)} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Price ladder */}
+      <Card className="bg-card border-border">
+        <CardContent className="pt-4 pb-3">
+          <p className="text-[10px] text-muted-foreground mb-3">가격 레벨</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <Metric label="Entry" value={fmt(d.entry_price)} />
+            <Metric label="Stop" value={fmt(d.stop_loss)} color="red" />
+            <Metric label="Target 1" value={fmt(d.target_1)} color="green" />
+            <Metric label="Target 2" value={fmt(d.target_2)} color="green" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Outcome (forward PnL) */}
+      <Card className="bg-card border-border">
+        <CardContent className="pt-4 pb-3">
+          <p className="text-[10px] text-muted-foreground mb-3">실현 결과 (forward PnL %)</p>
+          <div className="grid grid-cols-4 gap-3">
+            <Metric label="7d" value={fmt(d.pnl_7d, "%")} color={pnlColor(d.pnl_7d)} />
+            <Metric label="30d" value={fmt(d.pnl_30d, "%")} color={pnlColor(d.pnl_30d)} />
+            <Metric label="60d" value={fmt(d.pnl_60d, "%")} color={pnlColor(d.pnl_60d)} />
+            <Metric label="90d" value={fmt(d.pnl_90d, "%")} color={pnlColor(d.pnl_90d)} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Reasoning */}
+      {d.reasoning && (
+        <Card className="bg-card border-border">
+          <CardContent className="pt-4 pb-3">
+            <p className="text-[10px] text-muted-foreground mb-2">근거</p>
+            <p className="text-sm text-foreground/90 whitespace-pre-wrap">{d.reasoning}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Agent verdicts */}
+      {verdicts.length > 0 && (
+        <Card className="bg-card border-border">
+          <CardContent className="pt-4 pb-3">
+            <p className="text-[10px] text-muted-foreground mb-3">에이전트 판정 ({verdicts.length})</p>
+            <div className="space-y-1.5">
+              {verdicts.map((v, i) => (
+                <div key={i} className="flex items-center gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                  <span className="w-28 shrink-0 text-muted-foreground">{v.agent_name}</span>
+                  <StatusBadge status={v.action} />
+                  <span className="text-foreground/60">
+                    {typeof v.confidence === "number" ? `${Math.round(v.confidence)}%` : "—"}
+                  </span>
+                  {typeof v.reasoning === "string" && (
+                    <span className="truncate text-foreground/70">{v.reasoning}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Evidence chain (provenance) */}
+      <Card className="bg-card border-border">
+        <CardContent className="pt-4 pb-3">
+          <p className="text-[10px] text-muted-foreground mb-3">증거 체인 ({evidence.length})</p>
+          {evidence.length === 0 ? (
+            <p className="text-xs text-muted-foreground">증거 없음</p>
+          ) : (
+            <div className="space-y-1.5">
+              {evidence.map((e) => (
+                <div key={e.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                  <span className="w-32 shrink-0 text-muted-foreground">{e.source_type}/{e.source_key}</span>
+                  {e.action && <StatusBadge status={e.action} />}
+                  {e.confidence !== null && <span className="text-foreground/60 shrink-0">{Math.round(e.confidence)}%</span>}
+                  {e.detail && <span className="truncate text-foreground/70 font-mono text-[10px]">{e.detail}</span>}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Loading() {
+  return (
+    <div className="space-y-5">
+      <div className="h-8 bg-card rounded w-64 animate-pulse" />
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="h-28 bg-card rounded-xl border border-border animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+export default async function DecisionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return (
+    <Suspense fallback={<Loading />}>
+      <DecisionProvenance id={id} />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/decisions/page.tsx
+++ b/frontend/src/app/decisions/page.tsx
@@ -149,7 +149,7 @@ function DecisionTable({ decisions }: { decisions: Decision[] }) {
                 <td className="px-3 py-2 text-xs text-muted-foreground font-mono">{d.date}</td>
                 <td className="px-3 py-2">
                   <Link
-                    href={`/ticker/${d.ticker}`}
+                    href={`/decisions/${d.id}`}
                     className="text-emerald-400 hover:underline font-medium"
                   >
                     {d.ticker}


### PR DESCRIPTION
## Summary

P6 (Lean MVP) — the "prove the basis" core (Shefrin). A new `/decisions/[id]` Server Component renders the **frozen historical decision + its evidence chain**, consuming the already-existing `GET /api/decisions/{id}` (had zero frontend callers):
- Decision-time context (regime / VIX / Fear&Greed / macro / confidence / agreement).
- Price ladder (entry / stop / target_1 / target_2) + forward PnL (7/30/60/90d, colored).
- Parsed agent verdicts + the `source_type/source_key` evidence rows.

Repoints the `/decisions` list link from `/ticker/{ticker}` (live state) to `/decisions/{id}` (the frozen decision).

## Review

Codex review: no P1. [P2] `parseVerdicts` only validated the outer array → hardened with per-item filtering (drops `null`/`{}`/type-mismatched entries) + render-time guards for missing confidence/reasoning. XSS-clean (React text, no dangerouslySetInnerHTML); Next.js 16 async-params/force-dynamic/Suspense shape confirmed correct.

## Test Coverage

`decision-detail.test.tsx` (9 tests): happy path, agent verdicts + evidence chain, notFound on 404/null, minimal/null fields, malformed JSON fallback, malformed-entry filtering, default-export Suspense/Loading. New page **100% line/statement/function** coverage. Full frontend suite 1380 passed (125 files); `tsc --noEmit` clean; production build compiles the `/decisions/[id]` route.

## Follow-up

The P0c honest-alpha panel (consuming `/api/alpha`, from #696) can be surfaced on `/decisions` in a later increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)