### PR TITLE
feat(research): backtests writer + /api/research read endpoints (P1a)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,7 +2,7 @@
 
 ## Code layout
 
-`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (26 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (70 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
+`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (26 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
 
 ## Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ README shows the high-level flow. Per-phase orientation table — each row point
 | 3 | **Consensus** | Phase 2 outputs + `portfolio` + `macro_events` | `recommendations` table rows with per-agent verdicts + weighted final action | `nuri/trading/agents/` (10 specialists + consensus engine, risk veto) | `nuri/trading/agents/CLAUDE.md` |
 | 4 | **Certify** | Phase 3 recommendations + `config/rules.yaml siege_gates` | `Certificate` → CERTIFIED / REJECTED + evidence trace via `pipeline_events` | `nuri/trading/engine/certification.py` | "SIEGE Engine" below + [CERTIFICATION_SPEC.md](CERTIFICATION_SPEC.md) |
 | 5 | **Track** | Phase 3 `recommendations.action` + actual prices after N days | `outcome_30d` / `outcome_60d` / `outcome_90d` + `agent_accuracy_snapshots` (feeds Learning Memory back to Phase 3 weights) | `nuri/trading/recommend/tracker.py` + `nuri/trading/engine/learning_memory.py` | "C→D→E Data Flow" below |
-The **Serve** layer (FastAPI `:8001` + Next.js `:3000` + Discord/Telegram) is a read-only projection from the DB — not a pipeline phase. See "API (70 endpoints)" and "Dashboard API" sections below.
+The **Serve** layer (FastAPI `:8001` + Next.js `:3000` + Discord/Telegram) is a read-only projection from the DB — not a pipeline phase. See "API (72 endpoints)" and "Dashboard API" sections below.
 ## DB as the Sole Integration Point
 `nuri/core/db/` is the **only** module that imports `sqlite3`. DB file: `data/portfolio.db` (WAL mode). All upsert functions accept optional `db_path` — tests inject `tmp_path` for isolation. Schema versioning via `schema_version` table + `_MIGRATIONS` list.
 Key DB access patterns:
@@ -57,8 +57,8 @@ Trade execution API (`nuri/api/routes/trades.py`):
 - `PUT /api/trades/{id}` — Update exit info
 ## Dashboard API (Projection-based, <5s)
 `/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display.
-## API (70 endpoints)
-`nuri/api/routes/` — 70 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 18 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
+## API (72 endpoints)
+`nuri/api/routes/` — 72 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 18 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
 ### Action-First Dashboard APIs (PR #264-#266)
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 259 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 261 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 259 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 261 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/main.py
+++ b/nuri/api/main.py
@@ -40,6 +40,7 @@ from nuri.api.routes import (
     portfolio,
     rebalance,
     regime,
+    research,
     signals,
     stream,
     swing,
@@ -126,6 +127,7 @@ app.include_router(targets.router, prefix="/api")
 app.include_router(trades.router, prefix="/api")
 app.include_router(decisions.router, prefix="/api")
 app.include_router(alpha.router, prefix="/api")
+app.include_router(research.router, prefix="/api")
 app.include_router(learning_memory.router, prefix="/api")
 
 

--- a/nuri/api/routes/research.py
+++ b/nuri/api/routes/research.py
@@ -1,0 +1,91 @@
+"""검증 창고 (validation warehouse) 읽기 — 백테스트 + walk-forward 실행 이력.
+
+backtests 테이블은 그동안 writer 가 없어 비어 있었다(Phase 3 placeholder). P1a 에서
+save_backtest() writer + engine persist 로 채워진다. walkforward_runs 는 Phase 2
+WalkForwardValidator 가 기록한다(현재 caller 부재 → P1b 에서 model_fn 어댑터로 활성화).
+
+이 엔드포인트들은 read-only 로, 저장된 실행 이력을 그대로 surface 한다. 승격(weight>0)
+판단의 근거가 되는 walk-forward 결과를 사람이 검토하기 위한 창구다. 자체 재계산 없음.
+
+/api/research/* 네임스페이스 — swing.py 가 /api/backtest 를 이미 소유하므로 분리.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, Query
+
+from nuri.core.db import query
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["research"])
+
+
+def _loads(raw: str | None) -> dict:
+    """TEXT 컬럼의 JSON 을 안전 파싱 (불량/None → 빈 dict)."""
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+@router.get("/research/backtests")
+def list_backtests(limit: int = Query(20, ge=1, le=200)) -> dict:
+    """backtests 테이블의 최근 실행 결과 (최신순)."""
+    rows = query(
+        """SELECT id, strategy_id, start_date, end_date, total_return, sharpe,
+                  max_drawdown, win_rate, params, created_at
+           FROM backtests
+           ORDER BY id DESC
+           LIMIT ?""",
+        (limit,),
+    )
+    backtests = [
+        {
+            "id": r["id"],
+            "strategy_id": r["strategy_id"],
+            "start_date": r["start_date"],
+            "end_date": r["end_date"],
+            "total_return": r["total_return"],
+            "sharpe": r["sharpe"],
+            "max_drawdown": r["max_drawdown"],
+            "win_rate": r["win_rate"],
+            "params": _loads(r["params"]),
+            "created_at": r["created_at"],
+        }
+        for r in rows
+    ]
+    return {"backtests": backtests, "count": len(backtests)}
+
+
+@router.get("/research/walkforward")
+def list_walkforward(limit: int = Query(20, ge=1, le=200)) -> dict:
+    """walkforward_runs 의 최근 실행 (최신순). metrics 는 aggregate 만 surface."""
+    rows = query(
+        """SELECT run_id, model_id, n_folds, n_train_obs, n_test_obs,
+                  metrics_json, started_at, finished_at, error_message
+           FROM walkforward_runs
+           ORDER BY started_at DESC
+           LIMIT ?""",
+        (limit,),
+    )
+    runs = [
+        {
+            "run_id": r["run_id"],
+            "model_id": r["model_id"],
+            "n_folds": r["n_folds"],
+            "n_train_obs": r["n_train_obs"],
+            "n_test_obs": r["n_test_obs"],
+            # 폴드별 상세는 생략, 집계 지표만 (검토용 요약)
+            "aggregate": _loads(r["metrics_json"]).get("aggregate", {}),
+            "started_at": r["started_at"],
+            "finished_at": r["finished_at"],
+            "error_message": r["error_message"],
+        }
+        for r in rows
+    ]
+    return {"runs": runs, "count": len(runs)}

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -86,6 +86,7 @@ from .research_ops import (  # noqa: F401, E402
     log_walkforward_run,
     register_hypothesis,
     reject_hypothesis,
+    save_backtest,
     validate_hypothesis,
 )
 from .trades import upsert_trade  # noqa: F401, E402

--- a/nuri/core/db/research_ops.py
+++ b/nuri/core/db/research_ops.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
+from ..timezone import kst_now
 from .connection import get_db
 
 _HYPOTHESIS_STATUSES = ("open", "validated", "rejected", "expired")
@@ -370,6 +371,49 @@ def log_foundation_benchmark(
                 walkforward_run_id,
                 notes,
                 actor_run_id,
+            ),
+        )
+        return cursor.lastrowid or 0
+
+
+def save_backtest(
+    strategy_id: str,
+    start_date: str,
+    end_date: str,
+    total_return: float,
+    sharpe: float,
+    max_drawdown: float,
+    win_rate: float,
+    params: Optional[dict] = None,
+    created_at: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """백테스트 결과 1행 기록 (backtests 테이블 — 그동안 writer 부재, Phase 3 placeholder 활성화).
+
+    엔진(run_momentum_backtest)이 반환한 메트릭을 영속화한다. start_date/end_date 는
+    실제 백테스트된 가격 구간(영업일 window)이며, period 문자열이 아닌 실측 날짜다.
+    params 는 재현용 설정 dict(JSON 저장). created_at None → kst_now() (KST invariant,
+    backtests 테이블엔 created_at DEFAULT 가 없어 명시 기록).
+
+    Returns: lastrowid (backtest id).
+    """
+    stamp = created_at or kst_now().strftime("%Y-%m-%d %H:%M:%S")
+    with get_db(db_path) as conn:
+        cursor = conn.execute(
+            """INSERT INTO backtests
+               (strategy_id, start_date, end_date, total_return, sharpe,
+                max_drawdown, win_rate, params, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                strategy_id,
+                start_date,
+                end_date,
+                float(total_return),
+                float(sharpe),
+                float(max_drawdown),
+                float(win_rate),
+                json.dumps(params or {}, default=str),
+                stamp,
             ),
         )
         return cursor.lastrowid or 0

--- a/nuri/core/db/research_ops.py
+++ b/nuri/core/db/research_ops.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from pathlib import Path
 from typing import Optional
 
@@ -376,6 +377,12 @@ def log_foundation_benchmark(
         return cursor.lastrowid or 0
 
 
+def _finite_or_none(x: float) -> float | None:
+    """비유한값(inf/-inf/nan) → None. 유한 float 만 그대로 반환."""
+    f = float(x)
+    return f if math.isfinite(f) else None
+
+
 def save_backtest(
     strategy_id: str,
     start_date: str,
@@ -395,6 +402,10 @@ def save_backtest(
     params 는 재현용 설정 dict(JSON 저장). created_at None → kst_now() (KST invariant,
     backtests 테이블엔 created_at DEFAULT 가 없어 명시 기록).
 
+    비유한 메트릭(inf/nan)은 NULL 로 저장한다. thin-data 백테스트(0 trades → inf Sharpe /
+    nan MDD)가 창고에 garbage 를 남기지 않도록 writer 경계에서 차단 — JSON Infinity/NaN
+    토큰은 invalid 라 읽기 엔드포인트를 깨뜨린다. SQLite NaN→NULL 묵시 변환에 의존하지 않고 명시.
+
     Returns: lastrowid (backtest id).
     """
     stamp = created_at or kst_now().strftime("%Y-%m-%d %H:%M:%S")
@@ -408,10 +419,10 @@ def save_backtest(
                 strategy_id,
                 start_date,
                 end_date,
-                float(total_return),
-                float(sharpe),
-                float(max_drawdown),
-                float(win_rate),
+                _finite_or_none(total_return),
+                _finite_or_none(sharpe),
+                _finite_or_none(max_drawdown),
+                _finite_or_none(win_rate),
                 json.dumps(params or {}, default=str),
                 stamp,
             ),

--- a/nuri/quant/backtest/engine.py
+++ b/nuri/quant/backtest/engine.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pandas as pd
 import vectorbt as vbt
 
-from nuri.core.db import query_df
+from nuri.core.db import query_df, save_backtest
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +28,7 @@ def run_momentum_backtest(
     period: str = "3mo",
     top_n: int = 5,
     rebalance_days: int = 20,
+    persist: bool = False,
 ) -> dict:
     """모멘텀 기반 Top-N 전략 백테스트.
 
@@ -35,9 +36,10 @@ def run_momentum_backtest(
         period: 가격 데이터 기간
         top_n: 상위 N 종목에 투자
         rebalance_days: 리밸런싱 주기 (영업일)
+        persist: True 면 결과를 backtests 테이블에 1행 기록 (실측 구간 + 메트릭)
 
     Returns:
-        백테스트 결과 딕셔너리
+        백테스트 결과 딕셔너리 (데이터 부족 시 빈 dict)
     """
     # 가격 데이터 로드
     prices_df = query_df("SELECT ticker, date, close FROM prices ORDER BY date")
@@ -113,6 +115,9 @@ def run_momentum_backtest(
     result = {
         "strategy": f"Momentum Top-{top_n}",
         "period": period,
+        # 실제 백테스트된 가격 구간 (period 문자열이 아닌 실측 날짜)
+        "start_date": pivot.index.min().strftime("%Y-%m-%d"),
+        "end_date": pivot.index.max().strftime("%Y-%m-%d"),
         "rebalance_days": rebalance_days,
         "total_return_pct": round(total_return, 2),
         "sharpe_ratio": round(sharpe, 2),
@@ -120,6 +125,23 @@ def run_momentum_backtest(
         "win_rate_pct": round(win_rate, 1),
         "total_trades": int(stats.get("Total Trades", 0)),
     }
+
+    if persist:
+        save_backtest(
+            strategy_id=result["strategy"],
+            start_date=result["start_date"],
+            end_date=result["end_date"],
+            total_return=result["total_return_pct"],
+            sharpe=result["sharpe_ratio"],
+            max_drawdown=result["max_drawdown_pct"],
+            win_rate=result["win_rate_pct"],
+            params={
+                "period": period,
+                "top_n": top_n,
+                "rebalance_days": rebalance_days,
+                "total_trades": result["total_trades"],
+            },
+        )
 
     return result
 
@@ -155,5 +177,6 @@ if __name__ == "__main__":
         period=args.period,
         top_n=args.top_n,
         rebalance_days=args.rebalance,
+        persist=True,
     )
     print_backtest(result)

--- a/tests/api/test_research.py
+++ b/tests/api/test_research.py
@@ -1,0 +1,101 @@
+"""Endpoint lock-tests for /api/research/* (P1a 검증 창고 read).
+
+- 빈 테이블 → {backtests:[], count:0} / {runs:[], count:0}
+- save_backtest 1행 → /research/backtests 가 그대로 surface (params JSON 파싱)
+- log_walkforward_run 1행 → /research/walkforward 가 aggregate 만 surface (folds 생략)
+- limit clamp (Query le=200)
+
+seed 는 db_path 없이 writer 호출 — client 픽스처가 DB_PATH 를 monkeypatch 하므로
+앱이 읽는 동일 DB 에 기록된다 (test_alpha 패턴과 동일).
+"""
+
+from nuri.core.db import log_walkforward_run, save_backtest
+
+
+class TestBacktestsEndpoint:
+    def test_empty(self, client):
+        r = client.get("/api/research/backtests")
+        assert r.status_code == 200
+        assert r.json() == {"backtests": [], "count": 0}
+
+    def test_returns_saved_row_with_parsed_params(self, client):
+        save_backtest(
+            strategy_id="Momentum Top-5",
+            start_date="2026-01-02",
+            end_date="2026-03-31",
+            total_return=12.3,
+            sharpe=1.4,
+            max_drawdown=-8.0,
+            win_rate=55.0,
+            params={"top_n": 5, "rebalance_days": 20},
+        )
+        data = client.get("/api/research/backtests").json()
+        assert data["count"] == 1
+        bt = data["backtests"][0]
+        assert bt["strategy_id"] == "Momentum Top-5"
+        assert bt["start_date"] == "2026-01-02"
+        assert bt["total_return"] == 12.3
+        assert bt["params"] == {"top_n": 5, "rebalance_days": 20}  # JSON 파싱됨
+
+    def test_newest_first(self, client):
+        for i in range(3):
+            save_backtest(
+                strategy_id=f"S{i}",
+                start_date="2026-01-01",
+                end_date="2026-02-01",
+                total_return=float(i),
+                sharpe=0.0,
+                max_drawdown=0.0,
+                win_rate=0.0,
+            )
+        data = client.get("/api/research/backtests").json()
+        assert [b["strategy_id"] for b in data["backtests"]] == ["S2", "S1", "S0"]
+
+    def test_limit_clamped_high(self, client):
+        assert client.get("/api/research/backtests?limit=999").status_code == 422
+
+    def test_limit_clamped_low(self, client):
+        assert client.get("/api/research/backtests?limit=0").status_code == 422
+
+
+class TestWalkforwardEndpoint:
+    def test_empty(self, client):
+        r = client.get("/api/research/walkforward")
+        assert r.status_code == 200
+        assert r.json() == {"runs": [], "count": 0}
+
+    def test_returns_run_with_aggregate_only(self, client):
+        log_walkforward_run(
+            run_id="wf_test_1",
+            model_id="m1",
+            fold_spec={"kind": "rolling", "train_size": 100, "test_size": 20, "step": 20},
+            metrics={"aggregate": {"sharpe_mean": 0.8, "sharpe_std": 0.1}, "folds": [{"fold": 0}]},
+            pit_hash="abc",
+            n_folds=3,
+            n_train_obs=300,
+            n_test_obs=60,
+            finished_at="2026-06-05 00:00:00",
+        )
+        data = client.get("/api/research/walkforward").json()
+        assert data["count"] == 1
+        run = data["runs"][0]
+        assert run["run_id"] == "wf_test_1"
+        assert run["model_id"] == "m1"
+        assert run["n_folds"] == 3
+        # aggregate 만 surface, 폴드별 상세 생략
+        assert run["aggregate"] == {"sharpe_mean": 0.8, "sharpe_std": 0.1}
+        assert "folds" not in run
+
+    def test_malformed_metrics_json_degrades_to_empty_aggregate(self, client):
+        # 직접 INSERT 로 잘못된 metrics_json 주입 → 엔드포인트가 빈 dict 로 방어
+        from nuri.core.db import get_db
+
+        with get_db() as conn:
+            conn.execute(
+                """INSERT INTO walkforward_runs
+                   (run_id, model_id, fold_spec_json, metrics_json, pit_hash, n_folds)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                ("wf_bad", "m2", "{}", "not-json{", "h", 1),
+            )
+        run = client.get("/api/research/walkforward").json()["runs"][0]
+        assert run["aggregate"] == {}

--- a/tests/core/test_research_ops.py
+++ b/tests/core/test_research_ops.py
@@ -96,3 +96,22 @@ class TestSaveBacktest:
         r = query("SELECT * FROM backtests", db_path=db_path)[0]
         assert r["total_return"] == 10.0
         assert isinstance(r["total_return"], float)
+
+    def test_non_finite_metrics_coerced_to_null(self, db_path):
+        """thin-data 백테스트(0 trades) → inf Sharpe / nan MDD. 창고엔 NULL 로 저장.
+
+        비유한값을 그대로 두면 JSON 직렬화가 Infinity/NaN(invalid) 토큰을 내보내 읽기
+        엔드포인트를 깨뜨린다. writer 경계에서 NULL 로 차단 (SQLite NaN→NULL 묵시 변환 비의존).
+        """
+        _save_minimal(
+            db_path,
+            total_return=1.5,  # 유한값은 보존
+            sharpe=float("inf"),
+            max_drawdown=float("nan"),
+            win_rate=float("-inf"),
+        )
+        r = query("SELECT * FROM backtests", db_path=db_path)[0]
+        assert r["total_return"] == 1.5
+        assert r["sharpe"] is None
+        assert r["max_drawdown"] is None
+        assert r["win_rate"] is None

--- a/tests/core/test_research_ops.py
+++ b/tests/core/test_research_ops.py
@@ -1,0 +1,98 @@
+"""Lock-tests for `save_backtest` (nuri/core/db/research_ops.py — P1a backtests writer).
+
+backtests 테이블은 그동안 writer 부재(Phase 3 placeholder)였다. save_backtest 가 채운다.
+- round-trip known-answer: 기록한 값이 그대로 읽힌다
+- params dict ↔ JSON round-trip / None → 빈 객체
+- created_at None → KST 자동 스탬프, 명시 → 보존
+- lastrowid 반환 (AUTOINCREMENT)
+- db_path 격리
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nuri.core.db import init_db, query, save_backtest
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "bt.db"
+    init_db(p)
+    return p
+
+
+def _save_minimal(db_path, **overrides):
+    kwargs = dict(
+        strategy_id="S",
+        start_date="2026-01-01",
+        end_date="2026-02-01",
+        total_return=1.0,
+        sharpe=0.5,
+        max_drawdown=-2.0,
+        win_rate=50.0,
+        db_path=db_path,
+    )
+    kwargs.update(overrides)
+    return save_backtest(**kwargs)
+
+
+class TestSaveBacktest:
+    def test_round_trip_known_values(self, db_path):
+        bid = save_backtest(
+            strategy_id="Momentum Top-5",
+            start_date="2026-01-02",
+            end_date="2026-03-31",
+            total_return=12.34,
+            sharpe=1.45,
+            max_drawdown=-8.7,
+            win_rate=55.5,
+            params={"period": "3mo", "top_n": 5, "rebalance_days": 20},
+            db_path=db_path,
+        )
+        assert bid == 1  # 첫 행 AUTOINCREMENT
+
+        rows = query("SELECT * FROM backtests", db_path=db_path)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["strategy_id"] == "Momentum Top-5"
+        assert r["start_date"] == "2026-01-02"
+        assert r["end_date"] == "2026-03-31"
+        assert r["total_return"] == 12.34
+        assert r["sharpe"] == 1.45
+        assert r["max_drawdown"] == -8.7
+        assert r["win_rate"] == 55.5
+
+    def test_params_json_round_trip(self, db_path):
+        _save_minimal(db_path, params={"top_n": 7, "nested": {"a": 1}})
+        raw = query("SELECT params FROM backtests", db_path=db_path)[0]["params"]
+        assert json.loads(raw) == {"top_n": 7, "nested": {"a": 1}}
+
+    def test_none_params_stored_as_empty_object(self, db_path):
+        _save_minimal(db_path)
+        assert query("SELECT params FROM backtests", db_path=db_path)[0]["params"] == "{}"
+
+    def test_created_at_auto_kst_stamp(self, db_path):
+        _save_minimal(db_path)
+        ca = query("SELECT created_at FROM backtests", db_path=db_path)[0]["created_at"]
+        # 'YYYY-MM-DD HH:MM:SS' (kst_now, datetime.now 금지 invariant)
+        assert ca is not None
+        assert ca[:4].isdigit() and ca[4] == "-"
+
+    def test_created_at_explicit_preserved(self, db_path):
+        _save_minimal(db_path, created_at="2020-01-01 00:00:00")
+        ca = query("SELECT created_at FROM backtests", db_path=db_path)[0]["created_at"]
+        assert ca == "2020-01-01 00:00:00"
+
+    def test_autoincrement_ids(self, db_path):
+        ids = [_save_minimal(db_path, strategy_id=f"S{i}", total_return=float(i)) for i in range(3)]
+        assert ids == [1, 2, 3]
+
+    def test_float_coercion(self, db_path):
+        # int 입력도 REAL 컬럼에 float 로 저장
+        _save_minimal(db_path, total_return=10, sharpe=1, max_drawdown=-3, win_rate=60)
+        r = query("SELECT * FROM backtests", db_path=db_path)[0]
+        assert r["total_return"] == 10.0
+        assert isinstance(r["total_return"], float)

--- a/tests/quant/backtest/test_engine.py
+++ b/tests/quant/backtest/test_engine.py
@@ -290,3 +290,51 @@ class TestCornerCases:
         with patch.object(engine, "query_df", return_value=prices):
             with pytest.raises(ZeroDivisionError):
                 engine.run_momentum_backtest(top_n=0)
+
+
+# ──────────────────────────────────────────────────────────────
+# persist=True → backtests 테이블 영속화 (P1a wiring)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestPersist:
+    def test_persist_true_writes_one_backtest_row(self, db_path_mp, stubbed_quantstats):
+        """persist=True → backtests 1행 (실측 구간 + 메트릭). 결과 dict 와 일치."""
+        from nuri.core.db import query
+        from nuri.quant.backtest import engine
+
+        prices = _make_prices_df(n_days=60)  # 2025-01-01 시작, 5개 US 종목
+        pf = _make_stub_portfolio()
+        with (
+            patch.object(engine, "query_df", return_value=prices),
+            patch.object(engine.vbt.Portfolio, "from_signals", return_value=pf),
+        ):
+            result = engine.run_momentum_backtest(top_n=3, rebalance_days=20, persist=True)
+
+        rows = query("SELECT * FROM backtests", db_path=db_path_mp)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["strategy_id"] == "Momentum Top-3"
+        assert r["total_return"] == 12.5  # stub Total Return [%]
+        assert r["sharpe"] == 1.4
+        assert r["max_drawdown"] == -8.2
+        assert r["win_rate"] == 62.0
+        # 실측 가격 구간 (period 문자열이 아닌 실제 날짜)
+        assert r["start_date"] == "2025-01-01"
+        assert r["start_date"] == result["start_date"]
+        assert r["end_date"] == result["end_date"]
+
+    def test_persist_false_writes_nothing(self, db_path_mp, stubbed_quantstats):
+        """기본값 persist=False → DB 미기록 (verify.py 등 read-only 호출 보호)."""
+        from nuri.core.db import query
+        from nuri.quant.backtest import engine
+
+        prices = _make_prices_df(n_days=60)
+        pf = _make_stub_portfolio()
+        with (
+            patch.object(engine, "query_df", return_value=prices),
+            patch.object(engine.vbt.Portfolio, "from_signals", return_value=pf),
+        ):
+            engine.run_momentum_backtest(top_n=3, persist=False)
+
+        assert query("SELECT * FROM backtests", db_path=db_path_mp) == []

--- a/tests/quant/backtest/test_engine.py
+++ b/tests/quant/backtest/test_engine.py
@@ -324,10 +324,20 @@ class TestPersist:
         assert r["start_date"] == result["start_date"]
         assert r["end_date"] == result["end_date"]
 
-    def test_persist_false_writes_nothing(self, db_path_mp, stubbed_quantstats):
-        """기본값 persist=False → DB 미기록 (verify.py 등 read-only 호출 보호)."""
+    def test_default_call_writes_nothing(self, db_path_mp, stubbed_quantstats):
+        """persist 인자 없이 호출(verify.py:203 스타일) → DB 미기록.
+
+        default 가 False 임을 시그니처+동작 양쪽에서 잠근다 — production data/portfolio.db
+        오염 방지. default 가 True 로 뒤집히거나 persist 분기가 제거되면 이 테스트가 깨진다.
+        """
+        import inspect
+
         from nuri.core.db import query
         from nuri.quant.backtest import engine
+
+        # 시그니처 레벨 잠금: default 자체가 False (read-only 호출 보호 계약)
+        sig = inspect.signature(engine.run_momentum_backtest)
+        assert sig.parameters["persist"].default is False
 
         prices = _make_prices_df(n_days=60)
         pf = _make_stub_portfolio()
@@ -335,6 +345,6 @@ class TestPersist:
             patch.object(engine, "query_df", return_value=prices),
             patch.object(engine.vbt.Portfolio, "from_signals", return_value=pf),
         ):
-            engine.run_momentum_backtest(top_n=3, persist=False)
+            engine.run_momentum_backtest(top_n=3)  # persist 인자 없음 → default 적용
 
         assert query("SELECT * FROM backtests", db_path=db_path_mp) == []


### PR DESCRIPTION
## Summary

**P1a of the validation warehouse** (Lean MVP roadmap). The `backtests` table (schema since Phase 3) had **zero writers** — this PR gives it its first one and exposes a read path, namespaced away from swing's `/api/backtest`.

- **`save_backtest()`** in `nuri/core/db/research_ops.py` — first writer for the `backtests` table. Mirrors the existing `log_foundation_benchmark()` pattern (returns `lastrowid`, `with get_db(db_path)`). Re-exported via the `nuri/core/db` facade.
- **`run_momentum_backtest(persist=False)`** — on persist, writes the **real price window** (`start_date`/`end_date` from `pivot.index`, not the `period` string) + metrics. CLI `__main__` persists by default; `verify.py` / tests keep `persist=False` so they never pollute the production DB.
- **`GET /api/research/backtests` + `/api/research/walkforward`** (`nuri/api/routes/research.py`) — read-only history surface for human review of promotion evidence. `aggregate`-only on walkforward (folds elided).

## Why this PR (엄밀하게)

The validation warehouse is the foundation P2's RS-ranker promotion will gate on (walk-forward + max-drawdown). A warehouse you can't write to or read from isn't a warehouse. P1b (model_fn adapter for `WalkForwardValidator`) lands next.

## Surfaced by live execution (7-phase Test gate → Build)

Running the real engine CLI against a thin-data local DB returned a degenerate result (0 trades → `inf` Sharpe / `nan` MDD). The persist path wrote `inf` straight into the table — and `inf`/`nan` serialize to the JSON `Infinity`/`NaN` tokens, which are **invalid JSON** that break the read endpoint. Fixed at the writer boundary: `_finite_or_none()` stores non-finite metrics as `NULL` (explicit, not relying on SQLite's NaN→NULL quirk).

## Tests (17 new, all lock-tests)

- `tests/core/test_research_ops.py` — `save_backtest` round-trip / known-answer / params JSON / `created_at` KST / **non-finite → NULL**
- `tests/api/test_research.py` — both endpoints: empty, seeded, newest-first, `limit` clamp, malformed-JSON degradation
- `tests/quant/backtest/test_engine.py::TestPersist` — `persist=True` writes one row (real window); **default-call writes nothing** (signature default + behavioral lock)

Live end-to-end verified: real writer → real route handlers → strict-valid JSON. `make test-fast` green.

## Review

- **Codex review ×2: PASS.** Round 1 verified window correctness, SQL param-binding, schema alignment, lock-test genuineness (mutation-tested). Round 2 (the finiteness delta) reverted the guard to confirm the lock-test fails on revert.
- Codex P3 hardening applied: `persist=False` default now locked at signature + behavior level (protects the prod-DB-write path).

## Notes

- Doc-count gate synced: endpoints 70→72, backend test files 259→261.
- **Pre-existing (not touched):** `docs/ARCHITECTURE.md` says "18 route modules" — live count is ~21 (ungated, stale before this PR). Flagged, not silently reconciled, per surgical-change discipline.
- The engine's *return dict* still hands raw `inf`/`nan` to the CLI/`print_backtest` (out of scope — `print_backtest` formats inf fine; the endpoint reads the table, which is now sanitized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)