### PR TITLE
feat(validation): strategy walk-forward adapter (P1b)

### DIFF
--- a/config/walkforward.yaml
+++ b/config/walkforward.yaml
@@ -1,6 +1,6 @@
 # 전략 walk-forward 검증 — pre-registered 파라미터 (P1b 검증 창고)
 #
-# 모든 값은 *결과를 보기 전에* commit 된다 (overfitting / p-hacking 방지).
+# 모든 값은 *결과를 보기 전에* commit 된다 (사후 선택 편향 방지).
 # 변경은 STRATEGY PR + 근거 필요 (config-driven invariant — 코드 하드코딩 금지).
 # 거래비용(cost_bps)·FX(fx_series)는 여기 두지 않는다 — 매 run 의 필수 입력으로
 # 호출자가 명시해야 한다 (gross/통화-naive 검증 차단 gate).
@@ -26,3 +26,7 @@ costs:
 gate:
   min_oos_sharpe: 0.5            # 승격 전제 최소 walk-forward OOS net Sharpe (pre-registered PASS)
   min_holdout_sharpe: 0.0        # FROZEN holdout 최소 net Sharpe (음수면 FAIL)
+  # ⚠️ 알려진 한계: lookback_grid 위 argmax-Sharpe 선택은 noise 에서도 약한 양의 Sharpe 를
+  # 만든다(다중비교 편향). same-bar lookahead 는 제거됐으나 이 gate 만으로 null-edge 를
+  # 완전히 차단하지 못한다. 승격 STRATEGY PR 은 nested-CV/벤치마크 대비를 추가로 요구할 것.
+  # (별도 이슈 — 본 P1b 스코프 아님)

--- a/config/walkforward.yaml
+++ b/config/walkforward.yaml
@@ -1,0 +1,28 @@
+# 전략 walk-forward 검증 — pre-registered 파라미터 (P1b 검증 창고)
+#
+# 모든 값은 *결과를 보기 전에* commit 된다 (overfitting / p-hacking 방지).
+# 변경은 STRATEGY PR + 근거 필요 (config-driven invariant — 코드 하드코딩 금지).
+# 거래비용(cost_bps)·FX(fx_series)는 여기 두지 않는다 — 매 run 의 필수 입력으로
+# 호출자가 명시해야 한다 (gross/통화-naive 검증 차단 gate).
+
+strategy:
+  lookback_grid: [20, 60, 120]   # 각 train fold 에서 선택할 모멘텀 lookback 후보 (영업일)
+  top_n: 5                       # 상위 N 종목 동일가중
+  rebalance_days: 20             # 리밸런싱 주기 (영업일)
+
+fold:
+  kind: rolling                  # rolling | expanding
+  train_size: 252                # ~1년 in-sample (lookback 선택)
+  test_size: 63                  # ~1분기 OOS 평가
+  step: 63                       # 다음 fold 이동 (= test_size, non-overlapping)
+
+holdout:
+  frac: 0.2                      # 최근 20% = FROZEN holdout. walk-forward 가 보지 않고
+                                 # 선택된 lookback 으로 1회 최종 평가 (P2-P6 미열람)
+
+costs:
+  survivorship_haircut_bps_annual: 200   # 생존자-only universe 상승편향 보정 (연 2%, 일할 차감)
+
+gate:
+  min_oos_sharpe: 0.5            # 승격 전제 최소 walk-forward OOS net Sharpe (pre-registered PASS)
+  min_holdout_sharpe: 0.0        # FROZEN holdout 최소 net Sharpe (음수면 FAIL)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 261 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 262 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 261 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 262 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -1,0 +1,235 @@
+"""전략 walk-forward 검증 어댑터 (P1b) — WalkForwardValidator 의 첫 caller.
+
+미국 모멘텀 top-N 전략을 walk-forward 로 검증한다. 각 train fold 에서 lookback 을
+선택(= model 'fit')하고 다음 test fold 에서 OOS 평가한다. 수익률은 **거래비용 +
+KRW→USD FX + 생존자 haircut 차감 후**의 KRW home-currency net return 이다
+(KakaoPay 계좌 통화 = KRW; US 보유분의 실현 P&L 은 FX drift 를 포함).
+
+설계 (user 선택 = '전략 수익률', Option A):
+- WalkForwardValidator(28-test, Codex Round 5 hardened) 는 **무수정** — 일반 eval
+  primitive 로 유지. cost/FX/생존자/holdout 등 strategy 책임은 전부 이 어댑터에 산다.
+- 거래비용(cost_bps) + FX(fx_series) 는 **필수 입력** — 없으면 run 거부. gross 이거나
+  통화-naive 한 검증이 승격 근거로 새는 것을 writer 경계에서 차단한다.
+- FROZEN holdout: 최근 frac 구간은 walk-forward 가 보지 않는다. non-holdout 에서 고른
+  lookback 으로 holdout 을 **1회만** 최종 평가 (P2-P6 가 튜닝에 쓸 수 없는 봉인 구간).
+- 생존자 universe: 현재 prices 에 존재하는 ticker 만. survivorship 상승편향은 haircut 으로
+  보정 (제거 불가 — 실측 사실로 명시).
+- model 'fit' = train fold 에서 OOS net Sharpe 를 최대화하는 lookback 선택. 단순 plumbing
+  이 아니라 in-sample 파라미터 선택 → strictly-OOS 평가 (López de Prado walk-forward 규율).
+- 승격(weight>0)은 이 결과 + max-drawdown 통과 후 **별도 STRATEGY PR**. 이 모듈은 측정만 한다.
+
+WalkForwardValidator 가 결과를 walkforward_runs 에 기록하므로 /api/research/walkforward
+(P1a) 로 자동 surface 된다.
+
+known-answer gate: buy-and-hold 상수수익 → annualized Sharpe 손계산 일치 (Sharpe 식 lock).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from nuri.agents.actors.walkforward_validator import WalkForwardValidator, _sharpe_from_returns
+from nuri.core.db import query_df
+
+_CONFIG_PATH = Path(__file__).parent.parent.parent.parent / "config" / "walkforward.yaml"
+
+
+def _load_wf_config(path: Optional[Path] = None) -> dict:
+    """config/walkforward.yaml 로드 (pre-registered 파라미터)."""
+    p = path or _CONFIG_PATH
+    with open(p, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _max_drawdown(returns: np.ndarray) -> float:
+    """일별 수익률 시계열의 최대 낙폭 (peak-to-trough, <= 0)."""
+    r = np.asarray(returns, dtype=np.float64)
+    if r.size == 0:
+        return 0.0
+    cum = np.cumprod(1.0 + r)
+    peak = np.maximum.accumulate(cum)
+    return float((cum / peak - 1.0).min())
+
+
+def _portfolio_usd_returns(
+    prices: pd.DataFrame, lookback: int, top_n: int, rebalance_days: int
+) -> tuple[pd.Series, pd.Series]:
+    """모멘텀 top-N 동일가중 포트폴리오의 일별 USD 수익률 + 리밸런싱 turnover.
+
+    turnover ∈ [0,1]: 첫 진입 = 1.0(전량 배치), 이후 = 교체 비중(symmetric diff / 2N).
+    """
+    rets = prices.pct_change()
+    mom = prices.pct_change(lookback)
+    idx = prices.index
+    daily = pd.Series(0.0, index=idx)
+    turnover = pd.Series(0.0, index=idx)
+    held: list[str] = []
+    for i in range(len(idx)):
+        if i < lookback:
+            continue
+        if (i - lookback) % rebalance_days == 0:
+            row = mom.iloc[i].dropna()
+            new = row.nlargest(min(top_n, len(row))).index.tolist()
+            prev = set(held)
+            newset = set(new)
+            if not prev:
+                turnover.iloc[i] = 1.0 if newset else 0.0
+            else:
+                turnover.iloc[i] = len(prev.symmetric_difference(newset)) / (2 * top_n)
+            held = new
+        if held:
+            daily.iloc[i] = rets.iloc[i][held].mean()
+    return daily, turnover
+
+
+def _strategy_net_returns(
+    prices: pd.DataFrame,
+    fx_ret: pd.Series,
+    lookback: int,
+    top_n: int,
+    rebalance_days: int,
+    cost_bps: float,
+    haircut_daily: float,
+) -> pd.Series:
+    """거래비용 + FX + 생존자 haircut 차감 후의 KRW home-currency 일별 net return.
+
+    KRW net = (1+USD수익률)(1+FX변화) - 1 - 거래비용 - haircut.
+    warmup(< lookback) 구간은 0 (보유 없음 → FX 노출도 없음).
+    """
+    usd, turnover = _portfolio_usd_returns(prices, lookback, top_n, rebalance_days)
+    krw = (1.0 + usd) * (1.0 + fx_ret) - 1.0
+    cost = turnover * (cost_bps / 10000.0)
+    net = krw - cost - haircut_daily
+    net.iloc[:lookback] = 0.0
+    return net
+
+
+def _build_us_panel(db_path: Optional[Path] = None) -> pd.DataFrame:
+    """prices 에서 미국 생존자 universe 의 date-indexed USD close 패널.
+
+    .KS(한국) 제외 — 통화 혼합 방지 (engine.py 와 동일 규율). 현재 prices 에 존재하는
+    ticker = 생존자 (survivorship bias 는 haircut 으로 보정).
+    """
+    df = query_df("SELECT ticker, date, close FROM prices ORDER BY date", db_path=db_path)
+    if df.empty:
+        return pd.DataFrame()
+    pivot = df.pivot_table(index="date", columns="ticker", values="close")
+    pivot.index = pd.to_datetime(pivot.index)
+    pivot = pivot[[t for t in pivot.columns if not str(t).endswith(".KS")]]
+    return pivot.dropna(axis=1, how="all").ffill()
+
+
+def run_strategy_walkforward(
+    *,
+    cost_bps: float,
+    fx_series: pd.Series,
+    prices: Optional[pd.DataFrame] = None,
+    db_path: Optional[Path] = None,
+    config: Optional[dict] = None,
+) -> dict[str, Any]:
+    """전략 walk-forward 실행 → OOS net Sharpe + FROZEN holdout Sharpe/maxDD.
+
+    cost_bps / fx_series 는 필수 — None 이면 ValueError (gross/통화-naive 검증 차단).
+    WalkForwardValidator 가 결과를 walkforward_runs 에 기록한다.
+
+    Returns: 요약 dict (oos_sharpe_mean, holdout_sharpe, holdout_max_drawdown,
+             selected_lookback_holdout, frozen_universe_n, gate.passed, ...).
+    """
+    if cost_bps is None:
+        raise ValueError("cost_bps required — gross(거래비용 미반영) 검증은 승격 근거로 금지")
+    if fx_series is None:
+        raise ValueError("fx_series (KRW/USD) required — 통화-naive 검증은 승격 근거로 금지")
+
+    cfg = config or _load_wf_config()
+    if prices is None:
+        prices = _build_us_panel(db_path)
+    if prices.empty or len(prices) < 2:
+        raise ValueError("insufficient price history for walk-forward")
+
+    grid: list[int] = cfg["strategy"]["lookback_grid"]
+    top_n: int = cfg["strategy"]["top_n"]
+    reb: int = cfg["strategy"]["rebalance_days"]
+    haircut_daily = cfg["costs"]["survivorship_haircut_bps_annual"] / 10000.0 / 252.0
+    gate = cfg["gate"]
+
+    frozen = list(prices.columns)
+    fx_ret = fx_series.pct_change().reindex(prices.index).fillna(0.0)
+
+    # lookback 별 net return 시계열 → 공통 warmup(=max lookback) 이후만 사용 (warmup 편향 제거)
+    series = {L: _strategy_net_returns(prices, fx_ret, L, top_n, reb, cost_bps, haircut_daily) for L in grid}
+    warmup = max(grid)
+    if len(prices) <= warmup + 2:
+        raise ValueError(f"need > {warmup + 2} rows after warmup={warmup}, got {len(prices)}")
+
+    aligned = {L: series[L].iloc[warmup:].reset_index(drop=True) for L in grid}
+    dates = prices.index[warmup:]
+    n = len(dates)
+    holdout_n = int(n * cfg["holdout"]["frac"])
+    split = n - holdout_n  # walk-forward 는 [0, split), holdout 은 [split, n)
+
+    # validator data (non-holdout 만)
+    data = pd.DataFrame({"date": dates.strftime("%Y-%m-%d")})
+    for L in grid:
+        data[f"r_lb{L}"] = aligned[L].to_numpy()
+    data_wf = data.iloc[:split].reset_index(drop=True)
+
+    def model_fn(train_df: pd.DataFrame):
+        # 'fit' = train fold 에서 OOS Sharpe 최대 lookback 선택
+        best_l = max(grid, key=lambda L: _sharpe_from_returns(train_df[f"r_lb{L}"].to_numpy()))
+
+        def predict_fn(test_df: pd.DataFrame) -> np.ndarray:
+            return test_df[f"r_lb{best_l}"].to_numpy()
+
+        return predict_fn
+
+    actor = WalkForwardValidator()
+    result = actor.run(
+        {
+            "action": "run",
+            "data": data_wf,
+            "fold_spec": cfg["fold"],
+            "model_fn": model_fn,
+            # target_col 은 형식 요건 — 평가 지표는 predict 의 Sharpe(net return) 만 소비.
+            "target_col": f"r_lb{grid[0]}",
+            "metric_kind": "regression",
+            "model_id": "momentum-topN-walkforward",
+        }
+    )
+    oos_sharpe = result.output.get("metrics", {}).get("aggregate", {}).get("sharpe_mean")
+
+    # FROZEN holdout: non-holdout 전체에서 고른 lookback 으로 holdout 1회 평가
+    best_l_full = max(grid, key=lambda L: _sharpe_from_returns(aligned[L].iloc[:split].to_numpy()))
+    holdout_ret = aligned[best_l_full].iloc[split:].to_numpy()
+    holdout_sharpe = _sharpe_from_returns(holdout_ret)
+    holdout_maxdd = _max_drawdown(holdout_ret)
+
+    passed = (
+        oos_sharpe is not None and oos_sharpe >= gate["min_oos_sharpe"] and holdout_sharpe >= gate["min_holdout_sharpe"]
+    )
+
+    return {
+        "model_id": "momentum-topN-walkforward",
+        "walkforward_run_id": result.output.get("run_id"),
+        "n_folds": result.output.get("n_folds"),
+        "outcome": result.outcome.name,
+        "oos_sharpe_mean": oos_sharpe,
+        "holdout_sharpe": holdout_sharpe,
+        "holdout_max_drawdown": holdout_maxdd,
+        "selected_lookback_holdout": best_l_full,
+        "walkforward_n": split,  # walk-forward 가 본 row 수 (holdout 제외)
+        "holdout_n": holdout_n,  # FROZEN holdout row 수 (봉인)
+        "frozen_universe_n": len(frozen),
+        "cost_bps": cost_bps,
+        "survivorship_haircut_bps_annual": cfg["costs"]["survivorship_haircut_bps_annual"],
+        "holdout_frac": cfg["holdout"]["frac"],
+        "gate": {
+            "passed": bool(passed),
+            "min_oos_sharpe": gate["min_oos_sharpe"],
+            "min_holdout_sharpe": gate["min_holdout_sharpe"],
+        },
+    }

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -3,7 +3,7 @@
 미국 모멘텀 top-N 전략을 walk-forward 로 검증한다. 각 train fold 에서 lookback 을
 선택(= model 'fit')하고 다음 test fold 에서 OOS 평가한다. 수익률은 **거래비용 +
 KRW→USD FX + 생존자 haircut 차감 후**의 KRW home-currency net return 이다
-(KakaoPay 계좌 통화 = KRW; US 보유분의 실현 P&L 은 FX drift 를 포함).
+(원화 계좌 기준; US 보유분의 실현 P&L 은 FX drift 를 포함).
 
 설계 (user 선택 = '전략 수익률', Option A):
 - WalkForwardValidator(28-test, Codex Round 5 hardened) 는 **무수정** — 일반 eval

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -82,11 +82,11 @@ def _portfolio_usd_returns(
             row = mom.iloc[i].dropna()
             new = row.nlargest(min(top_n, len(row))).index.tolist()
             prev = set(held)
-            newset = set(new)
+            new_set = set(new)
             if not prev:
-                turnover.iloc[i] = 1.0 if newset else 0.0
+                turnover.iloc[i] = 1.0 if new_set else 0.0
             else:
-                turnover.iloc[i] = len(prev.symmetric_difference(newset)) / (2 * top_n)
+                turnover.iloc[i] = len(prev.symmetric_difference(new_set)) / (2 * top_n)
             held = new
     return daily, turnover
 
@@ -177,7 +177,7 @@ def run_strategy_walkforward(
     split = n - holdout_n  # walk-forward 는 [0, split), holdout 은 [split, n)
 
     # validator data (non-holdout 만)
-    data = pd.DataFrame({"date": dates.strftime("%Y-%m-%d")})
+    data = pd.DataFrame({"date": pd.DatetimeIndex(dates).strftime("%Y-%m-%d")})
     for L in grid:
         data[f"r_lb{L}"] = aligned[L].to_numpy()
     data_wf = data.iloc[:split].reset_index(drop=True)
@@ -210,7 +210,7 @@ def run_strategy_walkforward(
     best_l_full = max(grid, key=lambda L: _sharpe_from_returns(aligned[L].iloc[:split].to_numpy()))
     holdout_ret = aligned[best_l_full].iloc[split:].to_numpy()
     holdout_sharpe = _sharpe_from_returns(holdout_ret)
-    holdout_maxdd = _max_drawdown(holdout_ret)
+    holdout_drawdown = _max_drawdown(holdout_ret)
 
     passed = (
         oos_sharpe is not None and oos_sharpe >= gate["min_oos_sharpe"] and holdout_sharpe >= gate["min_holdout_sharpe"]
@@ -220,10 +220,11 @@ def run_strategy_walkforward(
         "model_id": "momentum-topN-walkforward",
         "walkforward_run_id": result.output.get("run_id"),
         "n_folds": result.output.get("n_folds"),
-        "outcome": result.outcome.name,
+        # outcome 은 Optional[Outcome] 타입이나 action=run 은 항상 PASS/WARN 설정
+        "outcome": result.outcome.name if result.outcome is not None else "UNKNOWN",
         "oos_sharpe_mean": oos_sharpe,
         "holdout_sharpe": holdout_sharpe,
-        "holdout_max_drawdown": holdout_maxdd,
+        "holdout_max_drawdown": holdout_drawdown,
         "selected_lookback_holdout": best_l_full,
         "walkforward_n": split,  # walk-forward 가 본 row 수 (holdout 제외)
         "holdout_n": holdout_n,  # FROZEN holdout row 수 (봉인)

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -72,6 +72,12 @@ def _portfolio_usd_returns(
     for i in range(len(idx)):
         if i < lookback:
             continue
+        # ① day-i 수익률은 *day-i 이전*에 결정된 보유분으로만 번다 (same-bar lookahead 차단).
+        #    momentum 선택(mom.iloc[i], price[i] 포함)과 그날 수익률(price[i]/price[i-1])을
+        #    같은 날 보유분에 동시 적용하면 이미 본 움직임으로 보상받는 누설이 된다.
+        if held:
+            daily.iloc[i] = rets.iloc[i][held].mean()
+        # ② 리밸런싱은 day-i 종가 신호로 결정 → day i+1 부터 유효 (거래비용은 거래일 i 에 부과).
         if (i - lookback) % rebalance_days == 0:
             row = mom.iloc[i].dropna()
             new = row.nlargest(min(top_n, len(row))).index.tolist()
@@ -82,8 +88,6 @@ def _portfolio_usd_returns(
             else:
                 turnover.iloc[i] = len(prev.symmetric_difference(newset)) / (2 * top_n)
             held = new
-        if held:
-            daily.iloc[i] = rets.iloc[i][held].mean()
     return daily, turnover
 
 

--- a/tests/quant/validation/test_strategy_walkforward.py
+++ b/tests/quant/validation/test_strategy_walkforward.py
@@ -195,6 +195,38 @@ class TestIntegration:
         assert result["holdout_max_drawdown"] <= 0.0
 
 
+# ── PIT 누설 회귀 (null-edge gate) ─────────────────────────────
+
+
+class TestNullEdge:
+    """same-bar lookahead 회귀 lock-test — zero-edge random walk 는 gate 통과 금지.
+
+    선택일(day i) 수익률을 그날 보유분에 적립하면 (momentum 신호가 그날 수익률을 포함)
+    순수 noise 도 +0.7 Sharpe 로 부풀어 gate(0.5)를 통과한다 (codex 실측). 누설이
+    되살아나면 이 테스트가 깨진다 (§5.3.1 Gotcha-Test Pair).
+    """
+
+    def test_random_walk_does_not_clear_gate(self, db_path_mp):
+        rng = np.random.default_rng(7)
+        n, ntick = 500, 20
+        dates = pd.date_range("2020-01-01", periods=n, freq="B")
+        prices = pd.DataFrame(
+            {f"T{j}": 100 * np.exp(np.cumsum(rng.normal(0.0, 0.02, n))) for j in range(ntick)},
+            index=dates,
+        )
+        cfg = {
+            "strategy": {"lookback_grid": [20, 60], "top_n": 5, "rebalance_days": 20},
+            "fold": {"kind": "rolling", "train_size": 120, "test_size": 20, "step": 20},
+            "holdout": {"frac": 0.2},
+            "costs": {"survivorship_haircut_bps_annual": 0},
+            "gate": {"min_oos_sharpe": 0.5, "min_holdout_sharpe": 0.0},
+        }
+        r = run_strategy_walkforward(cost_bps=0.0, fx_series=pd.Series(1300.0, index=dates), prices=prices, config=cfg)
+        # zero-edge → Sharpe ~0, gate 통과 금지. 누설 있으면 +0.7 로 통과 → 실패.
+        assert abs(r["oos_sharpe_mean"]) < 0.5
+        assert r["gate"]["passed"] is False
+
+
 # ── frozen survivor universe ──────────────────────────────────
 
 

--- a/tests/quant/validation/test_strategy_walkforward.py
+++ b/tests/quant/validation/test_strategy_walkforward.py
@@ -1,0 +1,217 @@
+"""Lock-tests for strategy walk-forward adapter (P1b 검증 창고).
+
+- known-answer: _sharpe_from_returns 손계산 일치 + _max_drawdown 손계산
+- mandatory gate: cost_bps / fx_series None → ValueError (gross/통화-naive 차단)
+- cost·FX 가 실제로 net return 에 반영됨 (cargo-cult 아님) — monotonicity lock
+- frozen universe: .KS 제외 (통화 혼합 방지)
+- WalkForwardValidator 무수정 구동 + walkforward_runs 1행 기록 (P1a 엔드포인트로 surface)
+- FROZEN holdout 은 walk-forward fold 가 보지 않음
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from nuri.agents.actors.walkforward_validator import _sharpe_from_returns
+from nuri.quant.validation.strategy_walkforward import (
+    _build_us_panel,
+    _max_drawdown,
+    _strategy_net_returns,
+    run_strategy_walkforward,
+)
+
+SQRT252 = math.sqrt(252)
+
+# 작은 pre-registered config — 빠른 fold 구성 (train 10 / test 5 / holdout 20%)
+SMALL_CFG = {
+    "strategy": {"lookback_grid": [2, 3], "top_n": 2, "rebalance_days": 2},
+    "fold": {"kind": "rolling", "train_size": 10, "test_size": 5, "step": 5},
+    "holdout": {"frac": 0.2},
+    "costs": {"survivorship_haircut_bps_annual": 200},
+    "gate": {"min_oos_sharpe": 0.5, "min_holdout_sharpe": 0.0},
+}
+
+
+def _panel(n: int = 30, tickers=("AAA", "BBB", "CCC", "DDD")) -> pd.DataFrame:
+    """결정론적 US close 패널 — 종목별 상이한 추세 + sin 변동(std>0 보장)."""
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    data = {}
+    for k, t in enumerate(tickers):
+        steps = 0.001 * (k + 1) + 0.002 * np.sin(np.arange(n))
+        data[t] = 100.0 * np.cumprod(1.0 + steps)
+    return pd.DataFrame(data, index=dates)
+
+
+def _flat_fx(idx: pd.Index, rate: float = 1300.0) -> pd.Series:
+    return pd.Series(rate, index=idx, dtype=float)
+
+
+# ── known-answer ──────────────────────────────────────────────
+
+
+class TestKnownAnswer:
+    def test_sharpe_hand_computed(self):
+        # returns=[0.01,0.02,0.03]: mean=0.02, std(ddof=1)=0.01 → Sharpe = 2*sqrt(252)
+        r = np.array([0.01, 0.02, 0.03])
+        assert _sharpe_from_returns(r) == pytest.approx(2.0 * SQRT252, rel=1e-9)
+
+    def test_max_drawdown_hand_computed(self):
+        # cum=[1.1, 0.55, 0.55], peak=1.1 → trough dd = 0.55/1.1 - 1 = -0.5
+        assert _max_drawdown(np.array([0.1, -0.5, 0.0])) == pytest.approx(-0.5)
+
+    def test_max_drawdown_monotonic_up_is_zero(self):
+        assert _max_drawdown(np.array([0.01, 0.02, 0.01])) == pytest.approx(0.0)
+
+    def test_max_drawdown_empty(self):
+        assert _max_drawdown(np.array([])) == 0.0
+
+
+# ── mandatory cost / FX gate ──────────────────────────────────
+
+
+class TestMandatoryInputs:
+    def test_refuses_without_cost(self):
+        with pytest.raises(ValueError, match="cost_bps"):
+            run_strategy_walkforward(cost_bps=None, fx_series=_flat_fx(_panel().index), prices=_panel())
+
+    def test_refuses_without_fx(self):
+        with pytest.raises(ValueError, match="fx_series"):
+            run_strategy_walkforward(cost_bps=10.0, fx_series=None, prices=_panel())
+
+    def test_refuses_too_few_rows(self):
+        # < 2 row → 즉시 거부 (empty/단일 row guard)
+        one = _panel(n=1)
+        with pytest.raises(ValueError, match="insufficient price history"):
+            run_strategy_walkforward(cost_bps=10.0, fx_series=_flat_fx(one.index), prices=one, config=SMALL_CFG)
+
+    def test_refuses_insufficient_after_warmup(self):
+        # row 는 있지만 warmup(max lookback) 이후 fold 구성 불가 → 거부
+        tiny = _panel(n=5)
+        with pytest.raises(ValueError):
+            run_strategy_walkforward(cost_bps=10.0, fx_series=_flat_fx(tiny.index), prices=tiny, config=SMALL_CFG)
+
+
+# ── cost / FX genuinely applied (not cargo-cult) ──────────────
+
+
+class TestCostFxApplied:
+    def test_higher_cost_lowers_net(self):
+        p = _panel()
+        fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
+        lo = _strategy_net_returns(p, fx_ret, 3, 2, 2, cost_bps=0.0, haircut_daily=0.0)
+        hi = _strategy_net_returns(p, fx_ret, 3, 2, 2, cost_bps=100.0, haircut_daily=0.0)
+        # 거래비용이 클수록 누적 net 이 낮다 (turnover 발생 구간에서만 차감 → strictly lower)
+        assert hi.sum() < lo.sum()
+
+    def test_fx_drift_changes_net(self):
+        p = _panel()
+        flat = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)  # 변화 0
+        rising = pd.Series(1300.0 * (1.001 ** np.arange(len(p))), index=p.index)
+        rising_ret = rising.pct_change().reindex(p.index).fillna(0.0)
+        base = _strategy_net_returns(p, flat, 3, 2, 2, cost_bps=0.0, haircut_daily=0.0)
+        fxd = _strategy_net_returns(p, rising_ret, 3, 2, 2, cost_bps=0.0, haircut_daily=0.0)
+        # FX 상승(원화 약세)은 US 보유분의 KRW net 을 끌어올린다 → 다름
+        assert not np.allclose(base.to_numpy(), fxd.to_numpy())
+        assert fxd.sum() > base.sum()
+
+    def test_haircut_lowers_net(self):
+        p = _panel()
+        fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
+        no_hc = _strategy_net_returns(p, fx_ret, 3, 2, 2, cost_bps=0.0, haircut_daily=0.0)
+        hc = _strategy_net_returns(p, fx_ret, 3, 2, 2, cost_bps=0.0, haircut_daily=0.001)
+        assert hc.sum() < no_hc.sum()
+
+    def test_warmup_is_zero(self):
+        p = _panel()
+        fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
+        net = _strategy_net_returns(p, fx_ret, 5, 2, 2, cost_bps=10.0, haircut_daily=0.001)
+        assert (net.iloc[:5] == 0.0).all()  # 보유 전 구간은 net=0 (FX 노출 없음)
+
+
+# ── integration: drives validator + logs walkforward_runs ─────
+
+
+class TestIntegration:
+    def test_run_returns_summary_and_logs(self, db_path_mp):
+        from nuri.core.db import query
+
+        p = _panel(n=30)
+        result = run_strategy_walkforward(cost_bps=10.0, fx_series=_flat_fx(p.index), prices=p, config=SMALL_CFG)
+        # 요약 dict 구조
+        assert result["model_id"] == "momentum-topN-walkforward"
+        assert result["walkforward_run_id"]
+        assert result["n_folds"] >= 1
+        assert result["frozen_universe_n"] == 4
+        assert result["cost_bps"] == 10.0
+        assert result["selected_lookback_holdout"] in (2, 3)
+        assert isinstance(result["holdout_max_drawdown"], float)
+        assert result["holdout_max_drawdown"] <= 0.0
+        assert isinstance(result["gate"]["passed"], bool)
+
+        # WalkForwardValidator 가 walkforward_runs 에 기록 → P1a 엔드포인트로 surface
+        rows = query(
+            "SELECT run_id, model_id FROM walkforward_runs WHERE run_id = ?",
+            (result["walkforward_run_id"],),
+            db_path=db_path_mp,
+        )
+        assert len(rows) == 1
+        assert rows[0]["model_id"] == "momentum-topN-walkforward"
+
+    def test_end_to_end_from_db_with_real_config(self, db_path_mp):
+        # config/prices 모두 미지정 → 실제 config/walkforward.yaml 로드 + _build_us_panel(DB) 경로.
+        # 실제 config 는 train 252 + holdout 0.2 → warmup 120 후 충분한 row 시드 (520).
+        from nuri.core.db import get_db, query
+
+        p = _panel(n=520)
+        with get_db(db_path_mp) as conn:
+            conn.executemany(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                [(t, d.strftime("%Y-%m-%d"), float(p.loc[d, t])) for t in p.columns for d in p.index],
+            )
+        result = run_strategy_walkforward(cost_bps=10.0, fx_series=_flat_fx(p.index))
+        assert result["n_folds"] >= 1
+        assert result["frozen_universe_n"] == 4
+        assert result["holdout_n"] > 0
+        # 실제 config 라도 walkforward_runs 기록은 동일
+        rows = query(
+            "SELECT run_id FROM walkforward_runs WHERE run_id = ?",
+            (result["walkforward_run_id"],),
+            db_path=db_path_mp,
+        )
+        assert len(rows) == 1
+
+    def test_holdout_reserved(self, db_path_mp):
+        # warmup 3 → 27 rows, holdout frac 0.2 → holdout_n=5, walkforward_n=22? 봉인 검증.
+        p = _panel(n=30)
+        result = run_strategy_walkforward(cost_bps=10.0, fx_series=_flat_fx(p.index), prices=p, config=SMALL_CFG)
+        # holdout 은 walk-forward 가 보지 않는 별도 구간 (둘의 합 = warmup 이후 전체)
+        assert result["holdout_n"] > 0
+        assert result["walkforward_n"] + result["holdout_n"] == 30 - max(SMALL_CFG["strategy"]["lookback_grid"])
+        # holdout 평가가 실제로 돌았다 (maxDD 산출됨)
+        assert result["holdout_max_drawdown"] <= 0.0
+
+
+# ── frozen survivor universe ──────────────────────────────────
+
+
+class TestFrozenUniverse:
+    def test_build_panel_excludes_kr(self, db_path):
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            for t in ("AAA", "005930.KS"):
+                for d in pd.date_range("2024-01-01", periods=5, freq="B"):
+                    conn.execute(
+                        "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                        (t, d.strftime("%Y-%m-%d"), 100.0),
+                    )
+        panel = _build_us_panel(db_path=db_path)
+        assert "AAA" in panel.columns
+        assert "005930.KS" not in panel.columns  # 통화 혼합 방지
+
+    def test_build_panel_empty_db(self, db_path):
+        assert _build_us_panel(db_path=db_path).empty

--- a/tests/quant/validation/test_strategy_walkforward.py
+++ b/tests/quant/validation/test_strategy_walkforward.py
@@ -20,6 +20,7 @@ from nuri.agents.actors.walkforward_validator import _sharpe_from_returns
 from nuri.quant.validation.strategy_walkforward import (
     _build_us_panel,
     _max_drawdown,
+    _portfolio_usd_returns,
     _strategy_net_returns,
     run_strategy_walkforward,
 )
@@ -195,36 +196,47 @@ class TestIntegration:
         assert result["holdout_max_drawdown"] <= 0.0
 
 
-# ── PIT 누설 회귀 (null-edge gate) ─────────────────────────────
+# ── same-bar lookahead 회귀 (결정론적 micro-case) ──────────────
 
 
-class TestNullEdge:
-    """same-bar lookahead 회귀 lock-test — zero-edge random walk 는 gate 통과 금지.
+class TestNoSameBarLookahead:
+    """리밸런싱일 점프가 그날 수익으로 적립되면 안 된다 (§5.3.1 Gotcha-Test Pair).
 
-    선택일(day i) 수익률을 그날 보유분에 적립하면 (momentum 신호가 그날 수익률을 포함)
-    순수 noise 도 +0.7 Sharpe 로 부풀어 gate(0.5)를 통과한다 (codex 실측). 누설이
-    되살아나면 이 테스트가 깨진다 (§5.3.1 Gotcha-Test Pair).
+    SPIKE 이 리밸런싱일 i=4 에 +100% 점프 → 그날 모멘텀 1위로 '선택'되지만, day-4 수익은
+    *이전* 보유분(STEADY)으로 번다. 누설(선택일 수익을 그날 보유분에 적립)이 되살아나면
+    daily[4]=1.0(점프) 가 되어 이 테스트가 깨진다. 확률적 Sharpe 경계와 달리 seed-drift
+    에 면역인 결정론적 메커니즘 lock (codex 권고).
     """
 
-    def test_random_walk_does_not_clear_gate(self, db_path_mp):
-        rng = np.random.default_rng(7)
-        n, ntick = 500, 20
-        dates = pd.date_range("2020-01-01", periods=n, freq="B")
+    def test_rebalance_day_spike_not_credited_same_bar(self):
+        idx = pd.date_range("2024-01-01", periods=8, freq="B")
         prices = pd.DataFrame(
-            {f"T{j}": 100 * np.exp(np.cumsum(rng.normal(0.0, 0.02, n))) for j in range(ntick)},
-            index=dates,
+            {
+                "STEADY": [100, 101, 102, 103, 104, 105, 106, 107],
+                "SPIKE": [100, 100, 100, 100, 200, 200, 200, 200],  # i=4 에 +100% 점프
+            },
+            index=idx,
+            dtype=float,
         )
-        cfg = {
-            "strategy": {"lookback_grid": [20, 60], "top_n": 5, "rebalance_days": 20},
-            "fold": {"kind": "rolling", "train_size": 120, "test_size": 20, "step": 20},
-            "holdout": {"frac": 0.2},
-            "costs": {"survivorship_haircut_bps_annual": 0},
-            "gate": {"min_oos_sharpe": 0.5, "min_holdout_sharpe": 0.0},
-        }
-        r = run_strategy_walkforward(cost_bps=0.0, fx_series=pd.Series(1300.0, index=dates), prices=prices, config=cfg)
-        # zero-edge → Sharpe ~0, gate 통과 금지. 누설 있으면 +0.7 로 통과 → 실패.
-        assert abs(r["oos_sharpe_mean"]) < 0.5
-        assert r["gate"]["passed"] is False
+        daily, _turnover = _portfolio_usd_returns(prices, lookback=2, top_n=1, rebalance_days=2)
+        # i=2 첫 리밸런싱: mom(STEADY)=0.02 > mom(SPIKE)=0 → STEADY 보유
+        # i=4 리밸런싱: SPIKE 가 모멘텀 1위로 선택되지만, day-4 수익은 STEADY(104/103-1)로 번다.
+        assert daily.iloc[4] == pytest.approx(104 / 103 - 1, rel=1e-9)
+        assert daily.iloc[4] < 0.02  # 점프(1.0) 미반영 — 누설이면 1.0 → 실패
+        # i=5: 이제 SPIKE 보유 → 그 다음 수익(200/200-1=0) 반영
+        assert daily.iloc[5] == pytest.approx(0.0)
+
+    def test_first_return_not_dropped(self):
+        # 첫 리밸런싱(i=lookback) 다음 bar 부터 정상 적립 (off-by-one 반대 방향 점검)
+        idx = pd.date_range("2024-01-01", periods=6, freq="B")
+        prices = pd.DataFrame(
+            {"A": [100, 110, 121, 133.1, 146.41, 161.051]},  # 매일 +10%
+            index=idx,
+            dtype=float,
+        )
+        daily, _ = _portfolio_usd_returns(prices, lookback=2, top_n=1, rebalance_days=2)
+        assert daily.iloc[2] == pytest.approx(0.0)  # 첫 선택일 = 보유 전 → 0
+        assert daily.iloc[3] == pytest.approx(0.1, rel=1e-9)  # 다음 bar 부터 +10% 적립
 
 
 # ── frozen survivor universe ──────────────────────────────────


### PR DESCRIPTION
## Summary

**P1b of the validation warehouse.** The first caller of `WalkForwardValidator` (a 28-test, Codex-Round-5-hardened eval primitive with zero callers since #529). Validates a US momentum top-N strategy via walk-forward, producing OOS net Sharpe + a FROZEN-holdout Sharpe + max-drawdown. The validator stays **byte-identical** — all strategy concerns live in the new adapter.

- `nuri/quant/validation/strategy_walkforward.py` — net-of-cost + KRW→USD FX + survivorship-haircut returns in **KRW home currency** (KRW home currency). `model_fn` selects the lookback on each train fold ('fit') → strictly-OOS evaluation. `cost_bps` + `fx_series` are **mandatory** (raises if None — blocks gross/currency-naive validation as promotion evidence).
- `config/walkforward.yaml` — pre-registered lookback grid / fold spec / FROZEN holdout / haircut / PASS thresholds (committed before results — anti post-selection-bias).
- Results land in `walkforward_runs` → surfaced by P1a `/api/research/walkforward`.

Promotion (weight>0) gates on this + max-drawdown via a **separate STRATEGY PR**. This module only measures.

## Framing decision

User chose **strategy-return walk-forward** (net OOS Sharpe + max-DD = the actual promotion metric) over cross-sectional prediction (which would have required modifying the hardened validator for date-grouped folds).

## Codex review (2 rounds → converged)

- **R1 found a P1 blocker**: same-bar lookahead — holdings ranked on day *i* AND credited day *i*'s own return. Codex **empirically proved** it: pure random walk scored **+0.73 OOS Sharpe**, clearing the 0.5 gate (noise certified as edge). **Fixed**: each day's return is earned on holdings selected strictly before it; rebalance acts from day i+1. Verified +0.73 → **-0.069**.
- **R2**: confirmed the code fix correct (PIT closed, no off-by-one, cost timing right), but flagged the first null-test as **folklore** (passed on pre-fix code at seed=7). **Replaced** with a deterministic micro-case (a rebalance-day +100% spike must not be credited same-bar). Proven to discriminate: pre-fix `daily[4]=1.0` (fails) / fixed `daily[4]=0.0097` (passes) — a genuine §5.3.1 Gotcha-Test Pair.

## Tests (19, module 100% covered)

known-answer (Sharpe/drawdown hand-computed) · mandatory cost/FX refusal · cost·FX·haircut genuinely-applied monotonicity · frozen universe (.KS excluded) · validator integration (lands a `walkforward_runs` row) · FROZEN holdout reserved · **deterministic lookahead lock-test**.

## Known limitations (separate issues — NOT this PR's scope)

1. **Gate not fully null-safe**: lookback-selection-on-noise (argmax-Sharpe over the grid = multiple-comparisons bias) still yields weak positive Sharpe on ~27% of random seeds. Documented in `config/walkforward.yaml`; the promotion STRATEGY PR must add nested-CV / benchmark comparison.
2. **`engine.py:64-86` carries the same same-bar-selection pattern** (codex cross-cutting flag). The P1a `backtests` persist path inherits it. Pre-existing; file separately before using engine numbers against this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
