### PR TITLE
feat(factors): RS + dollar-volume leadership ranker (P2 shadow)

### DIFF
--- a/config/buy_signals.yaml
+++ b/config/buy_signals.yaml
@@ -12,6 +12,15 @@ weights:
   momentum_5d: 0.25           # 단기 추세 — 5d % return
   technical_rsi: 0.15         # RSI < 70 정상, > 80 과열 페널티
   breakout_30d: 0.20          # 30d high 돌파 = 강한 신호
+  # P2 leadership shadow — weight=0 (라이브 점수 무변경, sources 노출만).
+  # 승격(weight>0)은 P1 walk-forward + max-drawdown 통과 후 별도 STRATEGY PR.
+  rs_rank: 0.0                # cross-sectional RS percentile (리더 순위)
+  dollar_volume: 0.0          # 거래대금 surge (crowding 가드 — 과열 추격 페널티)
+
+# ─── Leadership 팩터 파라미터 (P2 shadow, relative_strength.compute_leadership) ──
+leadership:
+  lookback: 120               # RS 수익률 + 거래대금 baseline (영업일). 120d 히스토리 floor 겸용.
+  surge_window: 20            # 최근 거래대금 평균 구간 (영업일)
 
 # ─── Quality bar (final score 0-100, when to emit) ──────────────────
 quality_bar:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 262 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 264 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 262 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 264 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/factors/relative_strength.py
+++ b/nuri/quant/factors/relative_strength.py
@@ -1,0 +1,86 @@
+"""상대강도(RS) + 거래대금 leadership 팩터 (P2 shadow).
+
+"돈이 몰리는 리더" 측정: cross-sectional RS percentile(trailing 수익률 순위) +
+거래대금(close×volume) surge. prices 테이블만 사용 (신규 수집 없음).
+
+규율:
+- 120d 히스토리 floor: lookback 미만 종목은 제외 (짧은 히스토리로 랭킹 왜곡 방지).
+- KR/US 동일 lookback: 데이터 가용성이 아닌 strength 를 랭킹한다. RS percentile(수익률
+  순위)·거래대금 surge(비율) 모두 통화-무관 → KR/US 직접 비교 가능.
+- crowding 가드는 점수화 단계(_score_ticker)에서 적용 — 완만한 거래대금 확장은 보상,
+  과열(parabolic) 추격은 페널티. 이 모듈은 raw surge 비율만 산출.
+
+shadow: buy_candidate_emitter 에 weight=0 으로 편입 → 라이브 점수 무변경, sources 노출만.
+승격(weight>0)은 P1 walk-forward 통과 후 별도 STRATEGY PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from nuri.core.db import query_df
+
+_EMPTY = pd.DataFrame(columns=["rs_percentile", "dollar_volume_surge"])
+
+
+def compute_leadership(
+    lookback: int = 120,
+    surge_window: int = 20,
+    db_path: Optional[Path] = None,
+) -> pd.DataFrame:
+    """종목별 RS percentile + 거래대금 surge.
+
+    Args:
+        lookback: RS 수익률 + 거래대금 baseline 기간 (영업일). 120d floor 겸용.
+        surge_window: 최근 거래대금 평균 구간 (영업일).
+
+    Returns:
+        ticker-indexed DataFrame:
+          rs_percentile (0~100): trailing-`lookback` 수익률의 cross-sectional 순위
+          dollar_volume_surge (배): 최근 surge_window 거래대금 평균 / lookback 평균
+        조건 미달(데이터 부족) 시 빈 DataFrame.
+    """
+    prices = query_df("SELECT ticker, date, close, volume FROM prices ORDER BY date", db_path=db_path)
+    if prices.empty:
+        return _EMPTY.copy()
+
+    close = prices.pivot_table(index="date", columns="ticker", values="close").sort_index()
+    vol = prices.pivot_table(index="date", columns="ticker", values="volume").sort_index()
+    if close.shape[0] < lookback:
+        return _EMPTY.copy()
+
+    # 120d floor: lookback 이상 non-NaN close 보유 종목만 (KR/US 동일 기준)
+    enough = [t for t in close.columns if close[t].notna().sum() >= lookback]
+    if not enough:
+        return _EMPTY.copy()
+    close = close[enough].ffill()
+    vol = vol[enough].ffill()
+
+    # RS: trailing-lookback 수익률의 cross-sectional percentile (통화-무관)
+    trailing_ret = close.iloc[-1] / close.iloc[-lookback] - 1.0
+    rs_pct = trailing_ret.rank(pct=True) * 100.0
+
+    # 거래대금 surge: 최근 surge_window 평균 / lookback 평균 (비율 → 통화-무관)
+    dollar_vol = close * vol
+    dv_recent = dollar_vol.iloc[-surge_window:].mean()
+    dv_base = dollar_vol.iloc[-lookback:].mean()
+    surge = (dv_recent / dv_base).replace([np.inf, -np.inf], np.nan).fillna(1.0)
+
+    out = pd.DataFrame({"rs_percentile": rs_pct.round(2), "dollar_volume_surge": surge.round(3)})
+    return out.dropna(subset=["rs_percentile"])
+
+
+def leadership_snapshot(
+    lookback: int = 120,
+    surge_window: int = 20,
+    db_path: Optional[Path] = None,
+) -> dict[str, tuple[float, float]]:
+    """compute_leadership → {ticker: (rs_percentile, dollar_volume_surge)} 룩업 맵."""
+    df = compute_leadership(lookback, surge_window, db_path=db_path)
+    if df.empty:
+        return {}
+    return {str(t): (float(r["rs_percentile"]), float(r["dollar_volume_surge"])) for t, r in df.iterrows()}

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -345,9 +345,16 @@ def _score_ticker(
 
 
 def _build_why_now(sources: dict[str, float], price: dict[str, float], rsi: float | None) -> str:
-    """Single-sentence catalyst from strongest source."""
-    top = max(sources.items(), key=lambda kv: kv[1])
-    name, val = top
+    """Single-sentence catalyst from strongest source.
+
+    P2 leadership shadow 채널(rs_rank/dollar_volume)은 weight=0 이므로 why_now 후보에서
+    제외한다 — 점수뿐 아니라 brief 텍스트도 라이브 무변경 (진짜 shadow). 승격(weight>0) 시
+    별도 STRATEGY PR 에서 leadership 분기를 추가한다.
+    """
+    live = {k: v for k, v in sources.items() if k in ("factor", "momentum", "rsi", "breakout")}
+    if not live:
+        return "Multi-source 강세"  # 라이브 채널 부재 (정상 경로엔 4채널 항상 존재 — 방어)
+    name, val = max(live.items(), key=lambda kv: kv[1])
     if name == "factor":
         return f"Multi-factor 상위 (composite {val:.0f}/100)"
     if name == "momentum":
@@ -356,12 +363,11 @@ def _build_why_now(sources: dict[str, float], price: dict[str, float], rsi: floa
         if rsi is not None and rsi <= 35:
             return f"RSI {rsi:.0f} 과매도 반등 setup"
         return f"RSI {rsi:.0f} 정상 구간 (overbought 페널티 없음)" if rsi else "RSI 정상"
-    if name == "breakout":
-        bo = price.get("breakout_pct", 0)
-        if bo >= 0:
-            return f"30d 고가 돌파 +{bo:.1f}%"
-        return f"30d 고가 -{abs(bo):.1f}% 근접 (pullback)"
-    return "Multi-source 강세"
+    # name == "breakout" (live 의 유일 잔여 키)
+    bo = price.get("breakout_pct", 0)
+    if bo >= 0:
+        return f"30d 고가 돌파 +{bo:.1f}%"
+    return f"30d 고가 -{abs(bo):.1f}% 근접 (pullback)"
 
 
 def emit_buy_candidates(

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -34,6 +34,7 @@ import yaml
 
 from nuri.core.db import query_df
 from nuri.core.timezone import kst_now
+from nuri.quant.factors.relative_strength import leadership_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -272,11 +273,16 @@ def _score_ticker(
     price: dict[str, float],
     rsi: float | None,
     weights: dict[str, float],
+    rs_rank: float | None = None,
+    dollar_volume: float | None = None,
 ) -> tuple[float, dict[str, float]]:
     """Fuse sources to single 0-100 score. Returns (final_score, source_breakdown).
 
     Each source normalized to 0-100 then weighted-summed.
     Missing source = 50 (neutral) so partial data doesn't block.
+
+    rs_rank / dollar_volume 은 P2 leadership shadow 채널 — config weight=0 이면 점수에
+    기여하지 않고 sources 로만 노출된다. 승격(weight>0)은 P1 walk-forward 후 STRATEGY PR.
     """
     # factor composite already 0-1, scale to 0-100
     factor_pct = (factor.get("composite", 0.5)) * 100.0
@@ -306,11 +312,26 @@ def _score_ticker(
     else:
         breakout_pct = max(0.0, 70.0 + bo * 4.0)
 
+    # RS percentile (cross-sectional leadership): 0-100 직접 사용. 없으면 중립.
+    rs_pct = 50.0 if rs_rank is None else max(0.0, min(100.0, rs_rank))
+
+    # 거래대금 surge: 완만한 확장은 보상(1.0→50 … 2.5→90), 과열(parabolic) 추격은
+    # 페널티 (crowding 가드 — 급등주 추격 금지). surge 는 배수(ratio).
+    if dollar_volume is None:
+        dv_pct = 50.0
+    elif dollar_volume <= 2.5:
+        dv_pct = max(0.0, min(90.0, 50.0 + (dollar_volume - 1.0) * 26.667))
+    else:
+        dv_pct = max(20.0, 90.0 - (dollar_volume - 2.5) * 20.0)
+
     final = (
         weights.get("factor_composite", 0.4) * factor_pct
         + weights.get("momentum_5d", 0.25) * momentum_pct
         + weights.get("technical_rsi", 0.15) * rsi_pct
         + weights.get("breakout_30d", 0.2) * breakout_pct
+        # P2 leadership shadow — weight=0 이면 기여 0 (라이브 점수 무변경)
+        + weights.get("rs_rank", 0.0) * rs_pct
+        + weights.get("dollar_volume", 0.0) * dv_pct
     )
 
     return final, {
@@ -318,6 +339,8 @@ def _score_ticker(
         "momentum": round(momentum_pct, 1),
         "rsi": round(rsi_pct, 1),
         "breakout": round(breakout_pct, 1),
+        "rs_rank": round(rs_pct, 1),
+        "dollar_volume": round(dv_pct, 1),
     }
 
 
@@ -391,6 +414,9 @@ def emit_buy_candidates(
     factors = _get_factor_scores()
     prices = _get_price_signals()
     rsi_map = _get_rsi_snapshot()
+    # P2 leadership shadow 스냅샷 (weight=0 — sources 노출만, 라이브 점수 무변경)
+    lead_cfg = cfg.get("leadership", {})
+    leadership = leadership_snapshot(lead_cfg.get("lookback", 120), lead_cfg.get("surge_window", 20))
 
     if not factors:
         result.blocked_reason = "factors 테이블 비어있음 (composite_score 데이터 부재)"
@@ -412,7 +438,10 @@ def emit_buy_candidates(
         if not price:
             continue  # silent skip if no price — too many to surface
         rsi = rsi_map.get(ticker)
-        score, sources = _score_ticker(ticker, factor, price, rsi, weights)
+        lead = leadership.get(ticker)
+        rs_rank = lead[0] if lead else None
+        dollar_volume = lead[1] if lead else None
+        score, sources = _score_ticker(ticker, factor, price, rsi, weights, rs_rank, dollar_volume)
         scored.append((ticker, score, sources, price, rsi))
 
     # Filter by quality bar, sort, top-N

--- a/tests/quant/factors/test_relative_strength.py
+++ b/tests/quant/factors/test_relative_strength.py
@@ -1,0 +1,100 @@
+"""Lock-tests for RS + 거래대금 leadership 팩터 (P2 shadow).
+
+- known-answer: 최고 trailing 수익률 → RS percentile 최상위
+- 120d 히스토리 floor: lookback 미만 종목 제외
+- 거래대금 surge: 최근 거래대금 급증 → surge > 1
+- KR/US 동일 lookback (통화-무관 — surge·percentile 모두 ratio/rank)
+- 빈 prices / 데이터 부족 → 빈 DataFrame
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nuri.quant.factors.relative_strength import compute_leadership, leadership_snapshot
+
+
+def _seed(db_path, rows):
+    from nuri.core.db import get_db
+
+    with get_db(db_path) as conn:
+        conn.executemany("INSERT INTO prices (ticker, date, close, volume) VALUES (?, ?, ?, ?)", rows)
+
+
+def _series(ticker, closes, vols, start="2024-01-01"):
+    dates = pd.date_range(start, periods=len(closes), freq="B")
+    return [(ticker, d.strftime("%Y-%m-%d"), float(c), int(v)) for d, c, v in zip(dates, closes, vols)]
+
+
+class TestComputeLeadership:
+    def test_rs_percentile_ranks_trailing_return(self, db_path):
+        # 15일 패널, lookback=10. WINNER 상승 > FLAT 평탄 > LOSER 하락.
+        rows = []
+        rows += _series("WINNER", [100 + i * 5 for i in range(15)], [1000] * 15)  # 강한 상승
+        rows += _series("FLAT", [100] * 15, [1000] * 15)  # 평탄
+        rows += _series("LOSER", [100 - i * 2 for i in range(15)], [1000] * 15)  # 하락
+        _seed(db_path, rows)
+
+        df = compute_leadership(lookback=10, surge_window=3, db_path=db_path)
+        assert set(df.index) == {"WINNER", "FLAT", "LOSER"}
+        # 3종목 cross-sectional rank → 33.33 / 66.67 / 100
+        assert df.loc["WINNER", "rs_percentile"] == pytest.approx(100.0)
+        assert df.loc["LOSER", "rs_percentile"] == pytest.approx(33.33, abs=0.1)
+        assert df.loc["WINNER", "rs_percentile"] > df.loc["FLAT", "rs_percentile"] > df.loc["LOSER", "rs_percentile"]
+
+    def test_120d_floor_excludes_short_history(self, db_path):
+        rows = []
+        rows += _series("LONG", [100 + i for i in range(15)], [1000] * 15)
+        rows += _series("SHORT", [100 + i for i in range(5)], [1000] * 5)  # 5일 < lookback 10
+        _seed(db_path, rows)
+
+        df = compute_leadership(lookback=10, surge_window=3, db_path=db_path)
+        assert "LONG" in df.index
+        assert "SHORT" not in df.index  # 히스토리 부족 → 제외
+
+    def test_dollar_volume_surge_detects_recent_spike(self, db_path):
+        # 최근 3일 거래대금이 baseline 대비 급증 → surge > 1
+        vols = [1000] * 12 + [10000] * 3  # 마지막 3일 10배
+        _seed(db_path, _series("SURGE", [100] * 15, vols))
+        _seed(db_path, _series("CALM", [100] * 15, [1000] * 15))  # 평탄
+
+        df = compute_leadership(lookback=10, surge_window=3, db_path=db_path)
+        assert df.loc["SURGE", "dollar_volume_surge"] > 1.5
+        assert df.loc["CALM", "dollar_volume_surge"] == pytest.approx(1.0, abs=0.01)
+
+    def test_surge_is_currency_agnostic_ratio(self, db_path):
+        # KR(고가 KRW)·US(저가 USD) 동일 패턴 → 동일 surge (비율이라 통화 무관)
+        pattern_v = [1000] * 12 + [3000] * 3
+        _seed(db_path, _series("US", [100] * 15, pattern_v))
+        _seed(db_path, _series("005930.KS", [70000] * 15, pattern_v))
+        df = compute_leadership(lookback=10, surge_window=3, db_path=db_path)
+        assert df.loc["US", "dollar_volume_surge"] == pytest.approx(
+            df.loc["005930.KS", "dollar_volume_surge"], rel=1e-6
+        )
+
+    def test_empty_prices(self, db_path):
+        assert compute_leadership(db_path=db_path).empty
+
+    def test_insufficient_rows(self, db_path):
+        _seed(db_path, _series("A", [100] * 5, [1000] * 5))  # 5 rows < default lookback 120
+        assert compute_leadership(db_path=db_path).empty
+
+    def test_all_below_floor_despite_enough_matrix_rows(self, db_path):
+        # 매트릭스 행수는 lookback 이상이나 각 종목 non-NaN < lookback (staggered 구간)
+        _seed(db_path, _series("A", [100] * 8, [1000] * 8, start="2024-01-01"))
+        _seed(db_path, _series("B", [100] * 8, [1000] * 8, start="2024-02-01"))  # 비중첩 구간
+        # 합쳐 16 날짜(> lookback 10)지만 각 종목 8 non-NaN < 10 → 전부 floor 미달
+        assert compute_leadership(lookback=10, surge_window=3, db_path=db_path).empty
+
+
+class TestLeadershipSnapshot:
+    def test_snapshot_maps_ticker_to_tuple(self, db_path):
+        _seed(db_path, _series("A", [100 + i for i in range(15)], [1000] * 15))
+        snap = leadership_snapshot(lookback=10, surge_window=3, db_path=db_path)
+        assert "A" in snap
+        rs, surge = snap["A"]
+        assert isinstance(rs, float) and isinstance(surge, float)
+
+    def test_snapshot_empty_when_no_data(self, db_path):
+        assert leadership_snapshot(lookback=10, db_path=db_path) == {}

--- a/tests/trading/recommend/test_leadership_shadow.py
+++ b/tests/trading/recommend/test_leadership_shadow.py
@@ -1,0 +1,50 @@
+"""Lock-tests for P2 leadership shadow channels in _score_ticker.
+
+핵심 불변식: weight=0 인 shadow 채널은 라이브 점수를 바꾸지 않는다 (sources 노출만).
++ crowding 가드(과열 추격 페널티) + RS percentile clamp.
+"""
+
+import pytest
+
+from nuri.trading.recommend.buy_candidate_emitter import _score_ticker
+
+FACTOR = {"composite": 0.7}
+PRICE = {"ret_5d": 2.0, "breakout_pct": 1.0, "close": 100.0}
+LEGACY_W = {"factor_composite": 0.40, "momentum_5d": 0.25, "technical_rsi": 0.15, "breakout_30d": 0.20}
+SHADOW_W = {**LEGACY_W, "rs_rank": 0.0, "dollar_volume": 0.0}
+
+
+class TestLeadershipShadow:
+    def test_adding_shadow_weights_keeps_legacy_score(self):
+        # config 에 rs_rank/dollar_volume(=0) 추가 + 값 전달해도 점수는 legacy 와 동일
+        legacy, _ = _score_ticker("X", FACTOR, PRICE, 50.0, LEGACY_W)
+        shadow, _ = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=95.0, dollar_volume=2.0)
+        assert legacy == pytest.approx(shadow)
+
+    def test_weight_zero_invariant_to_leadership_values(self):
+        none_lead, _ = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W)
+        strong_lead, _ = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=99.0, dollar_volume=2.4)
+        assert none_lead == pytest.approx(strong_lead)  # weight=0 → 값 무관
+
+    def test_sources_expose_shadow_channels(self):
+        _, sources = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=95.0, dollar_volume=2.0)
+        assert "rs_rank" in sources and "dollar_volume" in sources
+        assert sources["rs_rank"] == 95.0
+
+    def test_missing_leadership_is_neutral(self):
+        _, sources = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W)
+        assert sources["rs_rank"] == 50.0
+        assert sources["dollar_volume"] == 50.0
+
+    def test_crowding_guard_penalizes_overheated_surge(self):
+        _, moderate = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, dollar_volume=2.0)
+        _, overheated = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, dollar_volume=6.0)
+        # 과열 추격(surge 6.0)은 완만한 확장(2.0)보다 낮은 dollar_volume 점수 (급등주 추격 금지)
+        assert overheated["dollar_volume"] < moderate["dollar_volume"]
+        assert moderate["dollar_volume"] == pytest.approx(76.7, abs=0.1)
+
+    def test_rs_percentile_clamped(self):
+        _, hi = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=150.0)
+        _, lo = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=-10.0)
+        assert hi["rs_rank"] == 100.0
+        assert lo["rs_rank"] == 0.0

--- a/tests/trading/recommend/test_leadership_shadow.py
+++ b/tests/trading/recommend/test_leadership_shadow.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from nuri.trading.recommend.buy_candidate_emitter import _score_ticker
+from nuri.trading.recommend.buy_candidate_emitter import _build_why_now, _score_ticker
 
 FACTOR = {"composite": 0.7}
 PRICE = {"ret_5d": 2.0, "breakout_pct": 1.0, "close": 100.0}
@@ -16,15 +16,29 @@ SHADOW_W = {**LEGACY_W, "rs_rank": 0.0, "dollar_volume": 0.0}
 
 class TestLeadershipShadow:
     def test_adding_shadow_weights_keeps_legacy_score(self):
-        # config 에 rs_rank/dollar_volume(=0) 추가 + 값 전달해도 점수는 legacy 와 동일
+        # config 에 rs_rank/dollar_volume(=0) 추가 + 값 전달해도 점수는 legacy 와 IEEE-exact 동일
         legacy, _ = _score_ticker("X", FACTOR, PRICE, 50.0, LEGACY_W)
         shadow, _ = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=95.0, dollar_volume=2.0)
-        assert legacy == pytest.approx(shadow)
+        assert legacy == shadow  # x + 0.0*finite == x (strict)
 
     def test_weight_zero_invariant_to_leadership_values(self):
         none_lead, _ = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W)
         strong_lead, _ = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=99.0, dollar_volume=2.4)
-        assert none_lead == pytest.approx(strong_lead)  # weight=0 → 값 무관
+        assert none_lead == strong_lead  # weight=0 → 값 무관 (strict)
+
+    def test_why_now_ignores_shadow_channels(self):
+        # rs_rank/dollar_volume 이 sources 최댓값이어도 why_now 는 라이브 채널만 본다 (진짜 shadow)
+        sources = {
+            "factor": 60.0,
+            "momentum": 55.0,
+            "rsi": 50.0,
+            "breakout": 50.0,
+            "rs_rank": 99.0,  # shadow 최댓값
+            "dollar_volume": 90.0,
+        }
+        why = _build_why_now(sources, {"ret_5d": 1.0, "breakout_pct": 0.0}, 50.0)
+        assert "Multi-factor" in why  # factor(60) 가 라이브 최댓값 → factor 텍스트
+        assert "Multi-source" not in why  # shadow argmax fallthrough 아님
 
     def test_sources_expose_shadow_channels(self):
         _, sources = _score_ticker("X", FACTOR, PRICE, 50.0, SHADOW_W, rs_rank=95.0, dollar_volume=2.0)

--- a/tests/trading/recommend/test_recommend_branch_coverage_v2.py
+++ b/tests/trading/recommend/test_recommend_branch_coverage_v2.py
@@ -262,6 +262,7 @@ class TestBuyCandidateEmitterCooldownBranches:
         monkeypatch.setattr(bce, "_get_factor_scores", lambda: {})
         monkeypatch.setattr(bce, "_get_price_signals", lambda: {})
         monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda: {})
+        monkeypatch.setattr(bce, "leadership_snapshot", lambda *a, **k: {})  # P2 shadow (prices 미시드)
         monkeypatch.setattr(bce, "_get_regime", lambda: ("neutral", 18.0))
 
         result = bce.emit_buy_candidates(config_path=cfg_path)
@@ -301,6 +302,7 @@ class TestBuyCandidateEmitterCooldownBranches:
         monkeypatch.setattr(bce, "_get_factor_scores", lambda: {"NOPRICE": {"composite": 0.9}})
         monkeypatch.setattr(bce, "_get_price_signals", lambda: {})  # NOPRICE missing
         monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda: {})
+        monkeypatch.setattr(bce, "leadership_snapshot", lambda *a, **k: {})  # P2 shadow (prices 미시드)
         monkeypatch.setattr(bce, "_get_regime", lambda: ("neutral", 18.0))
 
         result = bce.emit_buy_candidates(config_path=cfg_path)


### PR DESCRIPTION
## Summary

**P2 of the flow roadmap.** A RS + dollar-volume "leadership" factor — "where is money flowing?" — added as a **shadow channel (config weight=0 → zero live impact)** to the buy-candidate emitter, ready for a future promotion decision.

- `nuri/quant/factors/relative_strength.py` (NEW): `compute_leadership()` over the `prices` table only (no new collection). Per ticker: `rs_percentile` (cross-sectional rank of trailing-`lookback` return) + `dollar_volume_surge` (recent `surge_window` dollar-vol / `lookback` baseline). **120d history floor** (excludes thin-history tickers); **identical KR/US lookback** (ranks strength, not data availability); both signals **currency-agnostic** (rank / ratio → KR-KRW and US-USD compare directly).
- `buy_candidate_emitter`: `rs_rank` + `dollar_volume` scoring channels at config **weight=0**. **Crowding guard** penalizes parabolic dollar-volume surges (no chasing blow-offs — 1.0→50, peak 2.5→90, decays past). Surfaced in `sources`.
- `config/buy_signals.yaml`: shadow weights (0.0) + `leadership` lookback/surge params.

Promotion (weight>0) gates on **P1 walk-forward + max-drawdown** via a separate STRATEGY PR. This PR only measures + shadows.

## True shadow (proven)

- **Score**: IEEE-exact unchanged — `final += weights.get("rs_rank", 0.0)*rs_pct + ...`, and `x + 0.0*finite == x` (channels clamped finite). Test asserts strict `legacy == shadow`.
- **Brief text**: codex flagged that `_build_why_now` keyed off the full `sources` argmax, so a high shadow value could flip the "Why now" to generic text. **Fixed** — why_now now considers only the live channels. So the shadow channel changes *neither* score *nor* brief.

## Codex review: PASS

Verified score invariant (provably, not just empirically), RS/surge math, crowding-guard continuity at the 2.5 peak, KR/US currency-agnosticism. The one P3 (why_now live regression) is fixed in this PR.

## Tests (15 new, both modules 100% covered)

known-answer RS rank (33.33/66.67/100) · 120d floor (incl. staggered-window edge) · currency-agnostic surge (`rel=1e-6` KRW vs USD) · crowding guard · **strict-`==` score invariant** · **why_now ignores shadow keys**.

## Deferred to the promotion PR (codex P3, harmless at weight=0)

- ffill staleness (a stalled ticker gets a carried-forward ~0 return) and surge-window⊂lookback magnitude compression — ranking survives (monotonic), but magnitude bias must be addressed before weight>0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)