### PR TITLE
fix(validation): anchor permutation null at first valid price — restores #701 gate validity (#707)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
   // ─── Python ─────────────────────────────────────────────
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "python.analysis.extraPaths": ["${workspaceFolder}"],
-  "python.analysis.typeCheckingMode": "basic",
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["tests"],
   "python.testing.unittestEnabled": false,
@@ -116,5 +114,26 @@
     "**/.env.production": true,
     "**/kis_devlp.yaml": true,
     "**/token_*.json": true
-  }
+  },
+
+  // ─── cSpell (도메인/통계/저자명 사전 — #706 edge search) ──
+  "cSpell.words": [
+    "Bonferroni",
+    "bonferroni",
+    "Jegadeesh",
+    "Titman",
+    "Blitz",
+    "Huij",
+    "Martens",
+    "Swaminathan",
+    "Moskowitz",
+    "multiset",
+    "nanmean",
+    "rtol",
+    "lookback",
+    "lookbacks",
+    "walkforward",
+    "KOSDAQ",
+    "KOSPI"
+  ]
 }

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -171,19 +171,32 @@ def _pooled_oos_sharpe(aligned: dict[int, np.ndarray], grid: list[int], fold_spe
 
 
 def _permute_prices(prices: pd.DataFrame, rng: np.random.Generator) -> pd.DataFrame:
-    """각 종목 일별 수익률을 시간축 셔플 → 시계열 예측성(모멘텀) 파괴, 수익률 분포·t0 가격 보존.
+    """각 종목 일별 수익률을 시간축 셔플 → 시계열 예측성(모멘텀) 파괴, 수익률 분포·기준가 보존.
 
     permutation null 의 핵심: 동일 파이프라인을 '예측성 없는' 데이터에 적용해 리밸런싱
     artifact + lookback 선택 편향을 null 분포로 포착한다.
+
+    anchor = **first valid price** (#707): 패널 첫 행이 아니라 종목별 첫 유효 가격을 기준으로
+    재구성한다. 첫 행 가격(to_numpy()[0])을 쓰면 패널 시작일에 없던 ticker(leading NaN)가
+    base=NaN 으로 null 패널에서 전부 탈락 — 실측 557종목 중 1종목만 남아 null 이 단일자산
+    포트폴리오로 퇴화했다. leading NaN 은 보존 (real 패널과 동일한 universe 진입 시점).
     """
     rets = prices.pct_change(fill_method=None)
     out: dict[str, np.ndarray] = {}
     for t in prices.columns:
+        px = prices[t].to_numpy()
         r = rets[t].to_numpy()
         idx = np.where(~np.isnan(r))[0]
         shuffled = r.copy()
         shuffled[idx] = r[rng.permutation(idx)]
-        out[str(t)] = prices[t].to_numpy()[0] * np.cumprod(1.0 + np.nan_to_num(shuffled))
+        col = np.full(px.shape, np.nan)
+        valid = np.where(~np.isnan(px))[0]
+        if valid.size:
+            f = valid[0]
+            col[f] = px[f]
+            if f + 1 < len(px):
+                col[f + 1 :] = px[f] * np.cumprod(1.0 + np.nan_to_num(shuffled[f + 1 :]))
+        out[str(t)] = col
     return pd.DataFrame(out, index=prices.index)
 
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,6 +8,8 @@
     "**/node_modules"
   ],
   "pythonVersion": "3.12",
+  "typeCheckingMode": "basic",
+  "extraPaths": ["."],
   "executionEnvironments": [
     {
       "root": "tests",

--- a/tests/quant/validation/test_strategy_walkforward.py
+++ b/tests/quant/validation/test_strategy_walkforward.py
@@ -333,6 +333,90 @@ class TestNullSafeGate:
         assert r["gate"]["p_value"] == r["permutation"]["p_value"]
 
 
+# ── #707 permutation null: staggered-start 패널 보존 ───────────
+
+
+class TestPermutationStaggeredStart:
+    """#707: leading-NaN ticker 가 null 패널에서 탈락하면 안 된다 (§5.3.1 Gotcha-Test Pair).
+
+    구버전은 base 가격을 패널 첫 행(to_numpy()[0])에서 읽어, 패널 시작일에 없던 ticker
+    (base=NaN)가 null 에서 전부 NaN 탈락 → 실측 557종목 중 1종목(KOSDAQ)만 남아 null 이
+    단일자산으로 퇴화, #701 p-value 무효. fix = first-valid-price anchor. 이 테스트는
+    staggered-start 패널에서 per-ticker non-NaN 개수가 real == null 임을 lock 한다.
+    """
+
+    @staticmethod
+    def _staggered():
+        from nuri.quant.validation.strategy_walkforward import _permute_prices
+
+        idx = pd.date_range("2024-01-01", periods=20, freq="B")
+        early = 100.0 * np.cumprod(1.0 + 0.01 * np.sin(np.arange(20)))
+        late = np.full(20, np.nan)
+        late[8:] = 50.0 * np.cumprod(1.0 + 0.02 * np.cos(np.arange(12)))
+        prices = pd.DataFrame({"EARLY": early, "LATE": late}, index=idx)
+        return prices, _permute_prices(prices, np.random.default_rng(0))
+
+    def test_late_start_ticker_survives_in_null(self):
+        prices, null = self._staggered()
+        # 회귀 핵심: LATE 가 전부 NaN 으로 탈락하면 null 이 단일자산으로 퇴화 (#701 무효 원인)
+        assert null["LATE"].notna().sum() == prices["LATE"].notna().sum()
+        assert null["EARLY"].notna().sum() == prices["EARLY"].notna().sum()
+
+    def test_leading_nan_preserved(self):
+        prices, null = self._staggered()
+        # universe 진입 시점은 real 과 동일해야 (셔플은 수익률만, 진입 시점은 구조)
+        assert null["LATE"].iloc[:8].isna().all()
+        assert null["LATE"].iloc[8] == pytest.approx(prices["LATE"].iloc[8])  # first-valid anchor 보존
+
+    def test_clean_panel_identical_to_legacy_formula(self):
+        from nuri.quant.validation.strategy_walkforward import _permute_prices
+
+        # leading NaN 없는 클린 패널: 구 공식(px[0]*cumprod, 셔플 동일 rng 재현)과
+        # **전 행 동일** lock (codex P2 — 첫 행만 비교하면 후행 회귀를 못 잡음)
+        p = _panel(n=15)
+        null = _permute_prices(p, np.random.default_rng(1))
+        rng2 = np.random.default_rng(1)  # 동일 seed → 동일 셔플 재현 (컬럼 순서대로 1 call/col)
+        rets = p.pct_change(fill_method=None)
+        for t in p.columns:
+            r = rets[t].to_numpy()
+            idx = np.where(~np.isnan(r))[0]
+            shuffled = r.copy()
+            shuffled[idx] = r[rng2.permutation(idx)]
+            legacy = p[t].to_numpy()[0] * np.cumprod(1.0 + np.nan_to_num(shuffled))
+            np.testing.assert_allclose(null[t].to_numpy(), legacy, rtol=1e-12)
+
+    def test_all_nan_column_stays_all_nan(self):
+        from nuri.quant.validation.strategy_walkforward import _permute_prices
+
+        # 전체 NaN 컬럼(유효 가격 0개): anchor 불가 → null 도 전체 NaN (valid.size==0 분기)
+        idx = pd.date_range("2024-01-01", periods=10, freq="B")
+        prices = pd.DataFrame({"OK": np.linspace(100, 110, 10), "EMPTY": np.full(10, np.nan)}, index=idx)
+        null = _permute_prices(prices, np.random.default_rng(0))
+        assert null["EMPTY"].isna().all()
+        assert null["OK"].notna().all()
+
+    def test_first_valid_on_last_row(self):
+        from nuri.quant.validation.strategy_walkforward import _permute_prices
+
+        # 첫 유효 가격이 마지막 행: anchor 만 보존, 재구성 구간 없음 (f+1==len 분기)
+        idx = pd.date_range("2024-01-01", periods=5, freq="B")
+        late = np.full(5, np.nan)
+        late[4] = 70.0
+        prices = pd.DataFrame({"OK": np.linspace(100, 104, 5), "LAST": late}, index=idx)
+        null = _permute_prices(prices, np.random.default_rng(0))
+        assert null["LAST"].iloc[4] == pytest.approx(70.0)
+        assert null["LAST"].iloc[:4].isna().all()
+
+    def test_shuffle_destroys_order_not_distribution(self):
+        prices, null = self._staggered()
+        # 수익률 multiset 보존 (분포 동일, 순서만 파괴) — f==0(EARLY) 와 f>0(LATE,
+        # 이 PR 이 고친 staggered 경로) 둘 다 (codex P2)
+        for t in ("EARLY", "LATE"):
+            real_r = np.sort(prices[t].pct_change().dropna().to_numpy())
+            null_r = np.sort(null[t].pct_change().dropna().to_numpy())
+            np.testing.assert_allclose(real_r, null_r, rtol=1e-9)
+
+
 # ── frozen survivor universe ──────────────────────────────────
 
 


### PR DESCRIPTION
Closes #707. Supersedes #708 (코멧 재구성 — codecov patch-gate 분기 테스트를 fix 커밋에 합침, force-push 금지 준수).

## 문제

`_permute_prices` 가 null 패널 재구성 base 로 **패널 첫 행 가격**(`to_numpy()[0]`)을 사용. 패널 시작일(2018-11-09)에 존재한 ticker 는 KOSDAQ 뿐이라, 나머지 556 종목은 base=NaN → null 패널에서 전체 NaN 탈락.

**실측 재현:** real 패널 557 종목 → null 패널 생존 1 종목 (KOSDAQ, KRW 지수). #701 의 순열 null 이 "동일 파이프라인을 시간셔플 데이터에" 가 아닌 **단일자산 포트폴리오**로 퇴화 → p=0.169 무효. 합성 테스트는 모든 ticker 가 row 0 시작이라 leading-NaN 경로 미커버 (test illusion §5.3.1).

## Fix

종목별 **first valid price 를 anchor** 로 재구성. leading NaN 보존 (real 과 동일한 universe 진입 시점). 클린 패널에서는 구 공식과 동일 값 — 동일 RNG 재현 full-series 비교 테스트로 lock (codex P2 반영).

## 교정된 null 로 baseline 재측정 (실데이터, 200 순열, 80s)

| 지표 | 깨진 null (#704 당시) | **교정 null (이 PR)** |
|---|---|---|
| OOS pooled Sharpe | +0.50 | +0.50 (불변 — 버그는 null 쪽만) |
| 순열 p-value | 0.169 (무효) | **0.791** |
| null p95 Sharpe | — | **+1.50** |
| GATE | FAIL | **FAIL (유효하게 확정)** |

→ momentum top-N "엣지 없음" 결론은 유지·강화: 노이즈가 동일 절차로 Sharpe +1.50(p95)까지 만들므로 real +0.50 은 노이즈 한복판.

## 리뷰 / 검증

- **codex review GATE: PASS** (#708 에 기록 — 동일 fix diff). P1 0건. P2 2건(테스트 강화) 반영: full-series legacy 비교 + f>0 경로 multiset assert.
- codecov patch gate: all-NaN 컬럼 / last-row anchor 분기 micro-test 추가 (로컬 branch-coverage 검증).
- `make verify-quick`: 5946 passed. 이 파일 테스트 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
