### PR TITLE
feat(validation): pre-registered variant edge search — 5 variants, all FAIL null-safe gate (#706)

### DIFF
--- a/config/walkforward_variants.yaml
+++ b/config/walkforward_variants.yaml
@@ -1,0 +1,82 @@
+# Pre-registered 변형 edge search (#706) — 결과를 보기 전에 동결된 파라미터.
+#
+# p-hacking 차단 규율:
+# - 변형은 이론 동기가 있는 5개만 (grid search 금지). 각 param grid ≤ 3.
+# - 다중비교 보정 = Bonferroni: 발견단계 통과 = 순열 p < alpha / n_test_variants.
+# - 발견단계 통과분만 FROZEN holdout 에서 1회 재확인 (둘 다 통과해야 승격 자격).
+# - 이 파일 변경은 STRATEGY PR + 근거 필요. select_fn 로직은
+#   nuri/quant/validation/variant_walkforward.py 의 registry (이름으로 매핑).
+# - 거래비용(cost_bps)·FX(fx_series)는 baseline 과 동일하게 매 run 필수 입력.
+
+panel:
+  # 비-주식 pseudo ticker 제거 (KRW 지수/선물/테스트 — US USD 패널 통화 오염 방지).
+  # 실측: KOSDAQ 가 .KS 필터를 빠져나가 2018-2020 단일종목 degenerate fold 의 정체였음.
+  exclude_tickers: [KOSDAQ, KOSPI, GC=F, TESTAA]
+  min_history: 504               # 종목별 최소 non-NaN close 일수 (~2년) — 얕은 신규 backfill 제외
+  min_breadth: 40                # cross-section 폭 < 40 인 선두 날짜 trim (degenerate fold 제거)
+
+portfolio:                       # 모든 변형 공통 (신호만 다르게 — 공정 비교)
+  top_n: 5
+  rebalance_days: 20
+
+fold:
+  kind: rolling
+  train_size: 252                # ~1년 in-sample (param 선택)
+  test_size: 63                  # ~1분기 OOS
+  step: 63
+
+holdout:
+  frac: 0.2                      # 최근 20% FROZEN — 발견단계 통과 변형만 1회 재확인
+
+costs:
+  survivorship_haircut_bps_annual: 200
+
+gate:
+  min_oos_sharpe: 0.5            # pooled OOS net Sharpe 절대 floor (경제적 유의)
+  min_holdout_sharpe: 0.0        # holdout 재확인 floor (음수면 FAIL)
+  permutation:
+    n: 200                       # 시간셔플 Monte-Carlo null 표본 수 (#701 재사용)
+    alpha: 0.05                  # 가족 유의수준 — 발견단계는 alpha / n_test_variants (Bonferroni)
+    seed: 0                      # 재현성
+  multiple_comparison: bonferroni
+
+# 변형 registry — select: variant_walkforward.py 의 select_fn 이름.
+# baseline(V0)은 대조군이라 Bonferroni 분모(n_test_variants)에서 제외.
+variants:
+  - name: v0_momentum
+    select: momentum
+    baseline: true
+    theory: "대조군 — 현재 trailing-return top-N (#701 gate FAIL p=0.169 known)"
+    params:
+      - {lookback: 20}
+      - {lookback: 60}
+      - {lookback: 120}
+
+  - name: v1_skip_momentum
+    select: skip_momentum
+    theory: "Jegadeesh-Titman 1993 정통 12-1 모멘텀 — 최근 1개월은 반전이라 제외해야 persistence 포착"
+    params:
+      - {lookback: 126, skip: 21}
+      - {lookback: 252, skip: 21}
+
+  - name: v2_vol_scaled
+    select: vol_scaled
+    theory: "Blitz-Huij-Martens 2011 residual momentum — 순수 수익률 랭킹의 고변동 노이즈 과대선택을 vol 스케일로 보정"
+    params:
+      - {lookback: 60}
+      - {lookback: 120}
+
+  - name: v3_volume_confirmed
+    select: volume_confirmed
+    theory: "Lee-Swaminathan 2000 + '돈 몰리는 리더' — 모멘텀 top-2N 중 거래대금 surge 상위 N (기관 매집 확인)"
+    params:
+      - {lookback: 60, surge_window: 20}
+      - {lookback: 120, surge_window: 20}
+
+  - name: v4_regime_momentum
+    select: regime_momentum
+    theory: "Daniel-Moskowitz 2016 Momentum Crashes — SPY<200MA 약세장은 cash (좌측꼬리 제거, MA 고정·비튜닝)"
+    regime: {ticker: SPY, ma: 200}
+    params:
+      - {lookback: 60}
+      - {lookback: 120}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 263 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 264 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 263 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 264 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/validation/variant_walkforward.py
+++ b/nuri/quant/validation/variant_walkforward.py
@@ -1,0 +1,499 @@
+"""Pre-registered 변형 edge search 하니스 (#706) — 여러 신호함수를 동일 #701 gate 로.
+
+config/walkforward_variants.yaml 에 *결과를 보기 전에* 동결된 변형 set(이론 동기 ≤5개)을
+단일 측정 절차로 돌린다. 각 변형 = price/volume 패널 위의 select_fn (registry 매핑).
+
+p-hacking 차단 규율 (둘 다 통과해야 승격 자격):
+- **Bonferroni 발견단계**: 검정 변형(baseline 제외) k개 → 순열 p < alpha/k AND
+  pooled OOS Sharpe ≥ min. 변형을 여럿 시도하는 것 자체가 다중비교이므로 가족 오류율 통제.
+- **FROZEN holdout 재확인**: 발견단계 통과 변형만 최근 frac 봉인 구간에서 1회 재평가
+  (holdout Sharpe ≥ min floor). walk-forward 가 한 번도 보지 않은 구간.
+
+패널 품질 필터(사전등록, 모든 변형 + permutation null 에 동일 적용):
+- exclude_tickers: KRW 지수/선물/테스트 pseudo-ticker 제거 (통화 오염 — 실측 KOSDAQ 적발)
+- min_history: 종목별 최소 non-NaN close 일수 (얕은 신규 backfill 제외)
+- min_breadth: cross-section 폭 미달 선두 날짜 trim (1~2종목 degenerate fold 제거)
+
+baseline(strategy_walkforward)과 동일 규율 유지: 거래비용+FX 필수 입력, same-bar
+lookahead 차단(선택일 수익은 이전 보유분), 생존자 haircut, first-valid-anchor 순열(#707).
+승격(weight>0)은 이 runner 통과 + 별도 STRATEGY PR. 이 모듈은 측정만 한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from nuri.agents.actors.walkforward_validator import (
+    FoldSpec,
+    WalkForwardValidator,
+    _generate_folds,
+    _sharpe_from_returns,
+)
+from nuri.core.db import query_df, save_backtest
+from nuri.quant.validation.strategy_walkforward import (
+    _max_drawdown,
+    _permute_prices,
+    _pooled_oos_sharpe,
+)
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path(__file__).parent.parent.parent.parent / "config" / "walkforward_variants.yaml"
+
+# select_fn(close, vol, i, param, top_n, variant_cfg) -> 보유 ticker 리스트.
+# bar i 까지의 데이터(close[i] 포함)로 선택하며, 수익 적립은 i+1 부터 (same-bar 차단은
+# _variant_daily_returns 의 루프 순서가 보장 — baseline _portfolio_usd_returns 와 동일).
+SelectFn = Callable[[pd.DataFrame, Optional[pd.DataFrame], int, dict, int, dict], list[str]]
+
+
+def _load_variants_config(path: Optional[Path] = None) -> dict:
+    """config/walkforward_variants.yaml 로드 (pre-registered 파라미터)."""
+    with open(path or _CONFIG_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+# ── select_fn registry (V0-V4) ─────────────────────────────────
+
+
+def _top_n(scores: pd.Series, top_n: int) -> list[str]:
+    """NaN 제외 상위 top_n ticker (후보 부족 시 가능한 만큼)."""
+    s = scores.dropna()
+    return s.nlargest(min(top_n, len(s))).index.tolist()
+
+
+def _sel_momentum(close, vol, i, param, top_n, variant_cfg) -> list[str]:
+    """V0 대조군: trailing-return top-N (baseline 과 동일 신호)."""
+    lb = param["lookback"]
+    return _top_n(close.iloc[i] / close.iloc[i - lb] - 1.0, top_n)
+
+
+def _sel_skip_momentum(close, vol, i, param, top_n, variant_cfg) -> list[str]:
+    """V1: 12-1 skip-month 모멘텀 — t-lookback → t-skip 수익률 (최근 skip 일 반전 제외)."""
+    lb, skip = param["lookback"], param["skip"]
+    return _top_n(close.iloc[i - skip] / close.iloc[i - lb] - 1.0, top_n)
+
+
+def _sel_vol_scaled(close, vol, i, param, top_n, variant_cfg) -> list[str]:
+    """V2: 변동성-스케일 모멘텀 — 일평균수익/일변동성 (Sharpe-류 랭킹)."""
+    lb = param["lookback"]
+    window = close.iloc[i - lb + 1 : i + 1].pct_change(fill_method=None)
+    sd = window.std()
+    score = window.mean() / sd.replace(0.0, np.nan)
+    return _top_n(score, top_n)
+
+
+def _sel_volume_confirmed(close, vol, i, param, top_n, variant_cfg) -> list[str]:
+    """V3: 거래대금-확인 리더 — 모멘텀 top-2N 중 거래대금 surge 상위 N."""
+    lb, sw = param["lookback"], param["surge_window"]
+    cand = _top_n(close.iloc[i] / close.iloc[i - lb] - 1.0, 2 * top_n)
+    if not cand:
+        return []
+    dv = close[cand].iloc[i - lb + 1 : i + 1] * vol[cand].iloc[i - lb + 1 : i + 1]
+    surge = dv.iloc[-sw:].mean() / dv.mean().replace(0.0, np.nan)
+    return _top_n(surge, top_n)
+
+
+def _sel_regime_momentum(close, vol, i, param, top_n, variant_cfg) -> list[str]:
+    """V4: regime-조건부 모멘텀 — 지표 ticker < MA(고정) 면 cash (Momentum Crashes 좌측꼬리 제거)."""
+    regime = variant_cfg["regime"]
+    spy = close[regime["ticker"]]
+    ma = regime["ma"]
+    if spy.iloc[i] < spy.iloc[i - ma + 1 : i + 1].mean():
+        return []
+    return _sel_momentum(close, vol, i, param, top_n, variant_cfg)
+
+
+_SELECT_REGISTRY: dict[str, SelectFn] = {
+    "momentum": _sel_momentum,
+    "skip_momentum": _sel_skip_momentum,
+    "vol_scaled": _sel_vol_scaled,
+    "volume_confirmed": _sel_volume_confirmed,
+    "regime_momentum": _sel_regime_momentum,
+}
+
+
+def _param_warmup(variant: dict, param: dict) -> int:
+    """param 이 읽는 최대 과거 bar 수 (regime MA 포함)."""
+    w = param["lookback"]
+    if "regime" in variant:
+        w = max(w, variant["regime"]["ma"])
+    return w
+
+
+# ── 패널 (close + volume, 품질 필터) ───────────────────────────
+
+
+def _build_panels(cfg: dict, db_path: Optional[Path] = None) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """prices 에서 (close, volume) US 패널 — 사전등록 품질 필터 적용.
+
+    .KS 제외(통화 혼합 방지) + exclude_tickers(지수/선물/테스트) + min_history +
+    min_breadth 선두 trim. 필터는 모든 변형과 permutation null 에 동일하게 적용된다.
+    """
+    pc = cfg["panel"]
+    df = query_df("SELECT ticker, date, close, volume FROM prices ORDER BY date", db_path=db_path)
+    if df.empty:
+        return pd.DataFrame(), pd.DataFrame()
+    excl = set(pc["exclude_tickers"])
+    df = df[~df["ticker"].str.endswith(".KS") & ~df["ticker"].isin(excl)]
+    close = df.pivot_table(index="date", columns="ticker", values="close")
+    close.index = pd.to_datetime(close.index)
+    # min_history: 종목별 충분한 실데이터 (ffill 전 기준)
+    counts = close.notna().sum()
+    keep = [t for t in close.columns if counts[t] >= pc["min_history"]]
+    if not keep:
+        return pd.DataFrame(), pd.DataFrame()
+    close = close[keep]
+    # min_breadth: cross-section 폭 미달 선두 구간 trim (degenerate fold 제거)
+    width = close.notna().sum(axis=1)
+    ok = width[width >= pc["min_breadth"]]
+    if ok.empty:
+        return pd.DataFrame(), pd.DataFrame()
+    close = close.loc[ok.index[0] :]
+    vol = df.pivot_table(index="date", columns="ticker", values="volume")
+    vol.index = pd.to_datetime(vol.index)
+    vol = vol.reindex(index=close.index, columns=close.columns)
+    return close.ffill(), vol.ffill()
+
+
+# ── 일별 net return (변형 일반화) ──────────────────────────────
+
+
+def _variant_daily_returns(
+    close: pd.DataFrame,
+    vol: Optional[pd.DataFrame],
+    select_fn: SelectFn,
+    param: dict,
+    variant: dict,
+    top_n: int,
+    rebalance_days: int,
+    warmup: int,
+) -> tuple[pd.Series, pd.Series]:
+    """select_fn 보유 set 의 일별 USD 수익률 + turnover (same-bar lookahead 차단).
+
+    baseline _portfolio_usd_returns 와 동일 규율: day-i 수익은 *이전* 보유분으로 벌고,
+    리밸런싱(bar i 신호)은 i+1 부터 유효. 일별 적립은 numpy (순열 200회 × 변형 비용 절감).
+    """
+    n = len(close.index)
+    rets_np = close.pct_change(fill_method=None).to_numpy()
+    col_idx = {t: j for j, t in enumerate(close.columns)}
+    daily = np.zeros(n)
+    turnover = np.zeros(n)
+    held: list[str] = []
+    held_idx: list[int] = []
+    for i in range(n):
+        if i < warmup:
+            continue
+        if held_idx:
+            daily[i] = float(np.nanmean(rets_np[i, held_idx]))
+        if (i - warmup) % rebalance_days == 0:
+            new = select_fn(close, vol, i, param, top_n, variant)
+            prev, new_set = set(held), set(new)
+            if not prev:
+                turnover[i] = 1.0 if new_set else 0.0
+            else:
+                turnover[i] = len(prev.symmetric_difference(new_set)) / (2 * top_n)
+            held = new
+            held_idx = [col_idx[t] for t in new]
+    return pd.Series(daily, index=close.index), pd.Series(turnover, index=close.index)
+
+
+def _variant_net_returns(
+    close: pd.DataFrame,
+    vol: Optional[pd.DataFrame],
+    fx_ret: pd.Series,
+    select_fn: SelectFn,
+    param: dict,
+    variant: dict,
+    top_n: int,
+    rebalance_days: int,
+    cost_bps: float,
+    haircut_daily: float,
+    warmup: int,
+) -> pd.Series:
+    """거래비용 + FX + 생존자 haircut 차감 후 KRW net return (baseline 과 동일 공식)."""
+    usd, turnover = _variant_daily_returns(close, vol, select_fn, param, variant, top_n, rebalance_days, warmup)
+    krw = (1.0 + usd) * (1.0 + fx_ret) - 1.0
+    net = krw - turnover * (cost_bps / 10000.0) - haircut_daily
+    net.iloc[:warmup] = 0.0
+    return net
+
+
+def _aligned_variant_returns(
+    close: pd.DataFrame,
+    vol: Optional[pd.DataFrame],
+    fx_ret: pd.Series,
+    variant: dict,
+    cfg: dict,
+    cost_bps: float,
+    common_warmup: int,
+) -> dict[int, np.ndarray]:
+    """변형의 param-index 별 net return (공통 warmup 이후 정렬) → {k: np.ndarray}."""
+    top_n = cfg["portfolio"]["top_n"]
+    reb = cfg["portfolio"]["rebalance_days"]
+    haircut = cfg["costs"]["survivorship_haircut_bps_annual"] / 10000.0 / 252.0
+    select_fn = _SELECT_REGISTRY[variant["select"]]
+    out: dict[int, np.ndarray] = {}
+    for k, param in enumerate(variant["params"]):
+        w = _param_warmup(variant, param)
+        net = _variant_net_returns(close, vol, fx_ret, select_fn, param, variant, top_n, reb, cost_bps, haircut, w)
+        out[k] = net.iloc[common_warmup:].reset_index(drop=True).to_numpy()
+    return out
+
+
+# ── 변형 1개 평가 (gate 공통 절차) ─────────────────────────────
+
+
+def _evaluate_variant(
+    close: pd.DataFrame,
+    vol: Optional[pd.DataFrame],
+    fx_ret: pd.Series,
+    variant: dict,
+    cfg: dict,
+    cost_bps: float,
+    alpha_eff: float,
+) -> dict[str, Any]:
+    """단일 변형: pooled OOS Sharpe + 순열 p + FROZEN holdout (baseline 과 동일 절차)."""
+    gate = cfg["gate"]
+    keys = list(range(len(variant["params"])))
+    warmup = max(_param_warmup(variant, p) for p in variant["params"])
+    if len(close) <= warmup + 2:
+        raise ValueError(f"{variant['name']}: need > {warmup + 2} rows after warmup={warmup}, got {len(close)}")
+
+    aligned = _aligned_variant_returns(close, vol, fx_ret, variant, cfg, cost_bps, warmup)
+    n = len(close.index) - warmup
+    holdout_n = int(n * cfg["holdout"]["frac"])
+    split = n - holdout_n
+
+    real_pooled = _pooled_oos_sharpe(aligned, keys, cfg["fold"], split)
+    n_folds = len(_generate_folds(split, FoldSpec(**cfg["fold"])))
+
+    # permutation null: close 만 셔플 (#707 first-valid anchor), volume 은 원본 유지 —
+    # 가격 예측성만 파괴해 "거래대금이 (셔플된) 미래 수익을 맞추는가" 를 검정.
+    perm = gate["permutation"]
+    rng = np.random.default_rng(int(perm["seed"]))
+    n_perm = int(perm["n"])
+    null_pooled = np.empty(n_perm)
+    for j in range(n_perm):
+        pa = _aligned_variant_returns(_permute_prices(close, rng), vol, fx_ret, variant, cfg, cost_bps, warmup)
+        null_pooled[j] = _pooled_oos_sharpe(pa, keys, cfg["fold"], split)
+    p_value = float((np.sum(null_pooled >= real_pooled) + 1) / (n_perm + 1)) if n_perm else 1.0
+
+    # FROZEN holdout: non-holdout 전체에서 고른 param 으로 1회 평가 (발견단계 통과 시만 의미)
+    best_k = max(keys, key=lambda k: _sharpe_from_returns(aligned[k][:split]))
+    holdout_ret = aligned[best_k][split:]
+    holdout_sharpe = _sharpe_from_returns(holdout_ret)
+
+    discovery = p_value < alpha_eff and real_pooled >= gate["min_oos_sharpe"]
+    holdout_ok = holdout_sharpe >= gate["min_holdout_sharpe"]
+    return {
+        "name": variant["name"],
+        "baseline": bool(variant.get("baseline", False)),
+        "theory": variant["theory"],
+        "oos_sharpe_pooled": real_pooled,
+        "p_value": p_value,
+        "null_p95": float(np.percentile(null_pooled, 95)) if n_perm else float("nan"),
+        "alpha_effective": alpha_eff,
+        "n_folds": n_folds,
+        "selected_param": variant["params"][best_k],
+        "holdout_sharpe": holdout_sharpe,
+        "holdout_max_drawdown": _max_drawdown(holdout_ret),
+        "discovery_passed": bool(discovery),
+        "holdout_passed": bool(holdout_ok),
+        # 승격 자격 = Bonferroni 발견 AND holdout 재확인 (baseline 은 대조군 — 항상 False)
+        "promotion_eligible": bool(discovery and holdout_ok and not variant.get("baseline", False)),
+        "walkforward_n": split,
+        "holdout_n": holdout_n,
+    }
+
+
+# ── runner ─────────────────────────────────────────────────────
+
+
+def run_variant_search(
+    *,
+    cost_bps: float,
+    fx_series: pd.Series,
+    close: Optional[pd.DataFrame] = None,
+    vol: Optional[pd.DataFrame] = None,
+    db_path: Optional[Path] = None,
+    config: Optional[dict] = None,
+    persist: bool = False,
+) -> dict[str, Any]:
+    """pre-registered 변형 전체를 동일 gate 로 측정 → 결과 표 + 승격 자격 판정.
+
+    cost_bps / fx_series 필수 (gross/통화-naive 검증 차단 — baseline 과 동일).
+    persist=True 면 변형별 1행을 backtests 에 기록 (/api/research/backtests surface).
+    """
+    if cost_bps is None:
+        raise ValueError("cost_bps required — gross(거래비용 미반영) 검증은 승격 근거로 금지")
+    if fx_series is None:
+        raise ValueError("fx_series (KRW/USD) required — 통화-naive 검증은 승격 근거로 금지")
+
+    cfg = config or _load_variants_config()
+    if close is None:
+        close, vol = _build_panels(cfg, db_path=db_path)
+    if close.empty or len(close) < 2:
+        raise ValueError("insufficient price history after panel quality filter")
+
+    variants = cfg["variants"]
+    unknown = [v["select"] for v in variants if v["select"] not in _SELECT_REGISTRY]
+    if unknown:
+        raise ValueError(f"unknown select_fn in config: {unknown}")
+    for v in variants:
+        if "regime" in v and v["regime"]["ticker"] not in close.columns:
+            raise ValueError(f"{v['name']}: regime ticker {v['regime']['ticker']} not in panel")
+
+    # Bonferroni: 검정 변형(baseline 제외) 수로 alpha 분할 (가족 오류율 통제)
+    n_test = sum(1 for v in variants if not v.get("baseline", False))
+    alpha = float(cfg["gate"]["permutation"]["alpha"])
+    alpha_eff = alpha / max(n_test, 1)
+
+    fx_ret = fx_series.pct_change(fill_method=None).reindex(close.index).fillna(0.0)
+    results = []
+    for v in variants:
+        logger.info("evaluating variant %s ...", v["name"])
+        r = _evaluate_variant(close, vol, fx_ret, v, cfg, cost_bps, alpha_eff)
+        results.append(r)
+        if persist:
+            save_backtest(
+                strategy_id=f"wf-variant:{r['name']}",
+                start_date=pd.Timestamp(close.index[0]).strftime("%Y-%m-%d"),
+                end_date=pd.Timestamp(close.index[-1]).strftime("%Y-%m-%d"),
+                total_return=None,
+                sharpe=r["oos_sharpe_pooled"],
+                max_drawdown=r["holdout_max_drawdown"],
+                win_rate=None,
+                params={
+                    k: r[k]
+                    for k in (
+                        "baseline",
+                        "theory",
+                        "p_value",
+                        "alpha_effective",
+                        "holdout_sharpe",
+                        "selected_param",
+                        "discovery_passed",
+                        "holdout_passed",
+                        "promotion_eligible",
+                        "n_folds",
+                    )
+                }
+                | {"cost_bps": cost_bps, "universe_n": close.shape[1]},
+                db_path=db_path,
+            )
+
+    # WalkForwardValidator 로 변형별 per-fold 기록 (walkforward_runs → /api/research/walkforward)
+    run_ids = _log_walkforward_runs(close, vol, fx_ret, variants, cfg, cost_bps) if persist else {}
+    for r in results:
+        r["walkforward_run_id"] = run_ids.get(r["name"])
+
+    return {
+        "universe_n": close.shape[1],
+        "panel_rows": len(close),
+        "panel_start": pd.Timestamp(close.index[0]).strftime("%Y-%m-%d"),
+        "panel_end": pd.Timestamp(close.index[-1]).strftime("%Y-%m-%d"),
+        "cost_bps": cost_bps,
+        "n_test_variants": n_test,
+        "alpha": alpha,
+        "alpha_effective": alpha_eff,
+        "variants": results,
+        "promotion_eligible": [r["name"] for r in results if r["promotion_eligible"]],
+    }
+
+
+def _log_walkforward_runs(
+    close: pd.DataFrame,
+    vol: Optional[pd.DataFrame],
+    fx_ret: pd.Series,
+    variants: list[dict],
+    cfg: dict,
+    cost_bps: float,
+) -> dict[str, Optional[str]]:
+    """변형별 WalkForwardValidator run (per-fold 메트릭 → walkforward_runs 기록)."""
+    actor = WalkForwardValidator()
+    run_ids: dict[str, Optional[str]] = {}
+    for v in variants:
+        keys = list(range(len(v["params"])))
+        warmup = max(_param_warmup(v, p) for p in v["params"])
+        aligned = _aligned_variant_returns(close, vol, fx_ret, v, cfg, cost_bps, warmup)
+        n = len(close.index) - warmup
+        split = n - int(n * cfg["holdout"]["frac"])
+        data = pd.DataFrame({f"r_k{k}": aligned[k] for k in keys}).iloc[:split].reset_index(drop=True)
+
+        def model_fn(train_df: pd.DataFrame, _keys=keys):
+            best = max(_keys, key=lambda k: _sharpe_from_returns(train_df[f"r_k{k}"].to_numpy()))
+            return lambda test_df: test_df[f"r_k{best}"].to_numpy()
+
+        result = actor.run(
+            {
+                "action": "run",
+                "data": data,
+                "fold_spec": cfg["fold"],
+                "model_fn": model_fn,
+                "target_col": f"r_k{keys[0]}",  # 형식 요건 — 평가는 predict 수익률만 소비
+                "metric_kind": "regression",
+                "model_id": f"wf-variant:{v['name']}",
+            }
+        )
+        run_ids[v["name"]] = result.output.get("run_id")
+    return run_ids
+
+
+def run_variant_validation(
+    cost_bps: float = 10.0,
+    db_path: Optional[Path] = None,
+    config: Optional[dict] = None,
+    persist: bool = True,
+) -> dict[str, Any]:
+    """CLI 진입점: prices(DB) + usd_krw(macro) 로드 → 변형 search → (persist 시) 기록."""
+    from nuri.quant.validation.strategy_walkforward import _load_fx_series
+
+    fx = _load_fx_series(db_path)
+    return run_variant_search(cost_bps=cost_bps, fx_series=fx, db_path=db_path, config=config, persist=persist)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.quant.validation.variant_walkforward [--cost-bps 10] [--no-persist]"""
+    import argparse
+    import json as _json
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(prog="variant-walkforward")
+    parser.add_argument("--cost-bps", type=float, default=10.0, help="거래비용 (bps, 필수 가정)")
+    parser.add_argument("--no-persist", action="store_true", help="backtests/walkforward_runs 기록 생략")
+    args = parser.parse_args(argv)
+
+    try:
+        r = run_variant_validation(cost_bps=args.cost_bps, persist=not args.no_persist)
+    except ValueError as exc:
+        print(_json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+    print(f"\n{'=' * 78}")
+    print("  Pre-registered Variant Edge Search (#706)")
+    print(f"  Universe {r['universe_n']} | {r['panel_start']}..{r['panel_end']} | cost {r['cost_bps']}bps", end="")
+    print(f" | Bonferroni alpha {r['alpha']}/{r['n_test_variants']} = {r['alpha_effective']:.4f}")
+    print(f"{'=' * 78}")
+    print(f"  {'variant':<22}{'pooled':>8}{'p':>8}{'null95':>8}{'holdout':>9}{'maxDD':>8}  verdict")
+    for v in r["variants"]:
+        verdict = "PROMOTE-ELIGIBLE" if v["promotion_eligible"] else ("baseline" if v["baseline"] else "FAIL")
+        print(
+            f"  {v['name']:<22}{v['oos_sharpe_pooled']:>+8.3f}{v['p_value']:>8.3f}{v['null_p95']:>+8.2f}"
+            f"{v['holdout_sharpe']:>+9.3f}{v['holdout_max_drawdown']:>+8.2f}  {verdict}"
+        )
+    print(f"\n  >>> promotion-eligible: {r['promotion_eligible'] or 'NONE — 노이즈 초과 엣지 없음'}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/quant/validation/variant_walkforward.py
+++ b/nuri/quant/validation/variant_walkforward.py
@@ -143,9 +143,13 @@ def _build_panels(cfg: dict, db_path: Optional[Path] = None) -> tuple[pd.DataFra
     df = df[~df["ticker"].str.endswith(".KS") & ~df["ticker"].isin(excl)]
     close = df.pivot_table(index="date", columns="ticker", values="close")
     close.index = pd.to_datetime(close.index)
-    # min_history: 종목별 충분한 실데이터 (ffill 전 기준)
-    counts = close.notna().sum()
-    keep = [t for t in close.columns if counts[t] >= pc["min_history"]]
+    vol_raw = df.pivot_table(index="date", columns="ticker", values="volume")
+    vol_raw.index = pd.to_datetime(vol_raw.index)
+    # min_history: close + volume 양쪽 모두 충분한 실데이터 (ffill 전 기준) —
+    # close 만 검사하면 V3(거래대금)가 ffill 된 합성 volume 으로 거래한다 (codex P2)
+    c_counts = close.notna().sum()
+    v_counts = vol_raw.reindex(columns=close.columns).notna().sum()
+    keep = [t for t in close.columns if c_counts[t] >= pc["min_history"] and v_counts[t] >= pc["min_history"]]
     if not keep:
         return pd.DataFrame(), pd.DataFrame()
     close = close[keep]
@@ -155,9 +159,7 @@ def _build_panels(cfg: dict, db_path: Optional[Path] = None) -> tuple[pd.DataFra
     if ok.empty:
         return pd.DataFrame(), pd.DataFrame()
     close = close.loc[ok.index[0] :]
-    vol = df.pivot_table(index="date", columns="ticker", values="volume")
-    vol.index = pd.to_datetime(vol.index)
-    vol = vol.reindex(index=close.index, columns=close.columns)
+    vol = vol_raw.reindex(index=close.index, columns=close.columns)
     return close.ffill(), vol.ffill()
 
 
@@ -257,16 +259,22 @@ def _evaluate_variant(
     cfg: dict,
     cost_bps: float,
     alpha_eff: float,
+    global_warmup: int,
 ) -> dict[str, Any]:
-    """단일 변형: pooled OOS Sharpe + 순열 p + FROZEN holdout (baseline 과 동일 절차)."""
+    """단일 변형: pooled OOS Sharpe + 순열 p + FROZEN holdout (baseline 과 동일 절차).
+
+    codex P1 반영 2가지:
+    - **global_warmup**: 모든 변형이 동일한 캘린더 discovery/holdout 슬라이스를 공유
+      (변형별 warmup 을 쓰면 장기-메모리 변형이 불리한 초기 구간을 떨어내고 다른
+      holdout 기간을 받는 gate-gaming 경로가 생긴다).
+    - **holdout 봉인**: discovery(Bonferroni) 통과 시에만 holdout 을 평가·노출.
+      실패 변형의 holdout 값이 보이면 사후 변형 재설계에 누설된다 (수치로 안 써도).
+    """
     gate = cfg["gate"]
     keys = list(range(len(variant["params"])))
-    warmup = max(_param_warmup(variant, p) for p in variant["params"])
-    if len(close) <= warmup + 2:
-        raise ValueError(f"{variant['name']}: need > {warmup + 2} rows after warmup={warmup}, got {len(close)}")
 
-    aligned = _aligned_variant_returns(close, vol, fx_ret, variant, cfg, cost_bps, warmup)
-    n = len(close.index) - warmup
+    aligned = _aligned_variant_returns(close, vol, fx_ret, variant, cfg, cost_bps, global_warmup)
+    n = len(close.index) - global_warmup
     holdout_n = int(n * cfg["holdout"]["frac"])
     split = n - holdout_n
 
@@ -275,22 +283,30 @@ def _evaluate_variant(
 
     # permutation null: close 만 셔플 (#707 first-valid anchor), volume 은 원본 유지 —
     # 가격 예측성만 파괴해 "거래대금이 (셔플된) 미래 수익을 맞추는가" 를 검정.
+    # seed 는 변형마다 리셋 → 순열 j 가 변형 간 공유 (공정 비교).
     perm = gate["permutation"]
     rng = np.random.default_rng(int(perm["seed"]))
     n_perm = int(perm["n"])
     null_pooled = np.empty(n_perm)
     for j in range(n_perm):
-        pa = _aligned_variant_returns(_permute_prices(close, rng), vol, fx_ret, variant, cfg, cost_bps, warmup)
+        pa = _aligned_variant_returns(_permute_prices(close, rng), vol, fx_ret, variant, cfg, cost_bps, global_warmup)
         null_pooled[j] = _pooled_oos_sharpe(pa, keys, cfg["fold"], split)
     p_value = float((np.sum(null_pooled >= real_pooled) + 1) / (n_perm + 1)) if n_perm else 1.0
 
-    # FROZEN holdout: non-holdout 전체에서 고른 param 으로 1회 평가 (발견단계 통과 시만 의미)
+    # param 선택은 discovery 구간([:split])만 사용 — holdout 미접촉
     best_k = max(keys, key=lambda k: _sharpe_from_returns(aligned[k][:split]))
-    holdout_ret = aligned[best_k][split:]
-    holdout_sharpe = _sharpe_from_returns(holdout_ret)
-
     discovery = p_value < alpha_eff and real_pooled >= gate["min_oos_sharpe"]
-    holdout_ok = holdout_sharpe >= gate["min_holdout_sharpe"]
+
+    # FROZEN holdout: discovery 통과 변형만 1회 개봉. 실패 변형은 봉인 유지 (None).
+    holdout_sharpe: Optional[float] = None
+    holdout_drawdown: Optional[float] = None
+    holdout_ok = False
+    if discovery:
+        holdout_ret = aligned[best_k][split:]
+        holdout_sharpe = _sharpe_from_returns(holdout_ret)
+        holdout_drawdown = _max_drawdown(holdout_ret)
+        holdout_ok = holdout_sharpe >= gate["min_holdout_sharpe"]
+
     return {
         "name": variant["name"],
         "baseline": bool(variant.get("baseline", False)),
@@ -301,8 +317,8 @@ def _evaluate_variant(
         "alpha_effective": alpha_eff,
         "n_folds": n_folds,
         "selected_param": variant["params"][best_k],
-        "holdout_sharpe": holdout_sharpe,
-        "holdout_max_drawdown": _max_drawdown(holdout_ret),
+        "holdout_sharpe": holdout_sharpe,  # None = 봉인 (discovery 미통과)
+        "holdout_max_drawdown": holdout_drawdown,
         "discovery_passed": bool(discovery),
         "holdout_passed": bool(holdout_ok),
         # 승격 자격 = Bonferroni 발견 AND holdout 재확인 (baseline 은 대조군 — 항상 False)
@@ -354,11 +370,17 @@ def run_variant_search(
     alpha = float(cfg["gate"]["permutation"]["alpha"])
     alpha_eff = alpha / max(n_test, 1)
 
+    # 전역 warmup (codex P1): 모든 변형의 max — 변형 전부가 동일한 캘린더
+    # discovery/holdout 슬라이스를 공유해야 다중비교 gate 가 공정하다.
+    global_warmup = max(_param_warmup(v, p) for v in variants for p in v["params"])
+    if len(close) <= global_warmup + 2:
+        raise ValueError(f"need > {global_warmup + 2} rows after global warmup={global_warmup}, got {len(close)}")
+
     fx_ret = fx_series.pct_change(fill_method=None).reindex(close.index).fillna(0.0)
     results = []
     for v in variants:
         logger.info("evaluating variant %s ...", v["name"])
-        r = _evaluate_variant(close, vol, fx_ret, v, cfg, cost_bps, alpha_eff)
+        r = _evaluate_variant(close, vol, fx_ret, v, cfg, cost_bps, alpha_eff, global_warmup)
         results.append(r)
         if persist:
             save_backtest(
@@ -389,7 +411,7 @@ def run_variant_search(
             )
 
     # WalkForwardValidator 로 변형별 per-fold 기록 (walkforward_runs → /api/research/walkforward)
-    run_ids = _log_walkforward_runs(close, vol, fx_ret, variants, cfg, cost_bps) if persist else {}
+    run_ids = _log_walkforward_runs(close, vol, fx_ret, variants, cfg, cost_bps, global_warmup) if persist else {}
     for r in results:
         r["walkforward_run_id"] = run_ids.get(r["name"])
 
@@ -414,15 +436,18 @@ def _log_walkforward_runs(
     variants: list[dict],
     cfg: dict,
     cost_bps: float,
+    global_warmup: int,
 ) -> dict[str, Optional[str]]:
-    """변형별 WalkForwardValidator run (per-fold 메트릭 → walkforward_runs 기록)."""
+    """변형별 WalkForwardValidator run (per-fold 메트릭 → walkforward_runs 기록).
+
+    _evaluate_variant 와 동일한 global_warmup 슬라이스 사용 (캘린더 창 일치).
+    """
     actor = WalkForwardValidator()
     run_ids: dict[str, Optional[str]] = {}
     for v in variants:
         keys = list(range(len(v["params"])))
-        warmup = max(_param_warmup(v, p) for p in v["params"])
-        aligned = _aligned_variant_returns(close, vol, fx_ret, v, cfg, cost_bps, warmup)
-        n = len(close.index) - warmup
+        aligned = _aligned_variant_returns(close, vol, fx_ret, v, cfg, cost_bps, global_warmup)
+        n = len(close.index) - global_warmup
         split = n - int(n * cfg["holdout"]["frac"])
         data = pd.DataFrame({f"r_k{k}": aligned[k] for k in keys}).iloc[:split].reset_index(drop=True)
 
@@ -484,9 +509,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  {'variant':<22}{'pooled':>8}{'p':>8}{'null95':>8}{'holdout':>9}{'maxDD':>8}  verdict")
     for v in r["variants"]:
         verdict = "PROMOTE-ELIGIBLE" if v["promotion_eligible"] else ("baseline" if v["baseline"] else "FAIL")
+        # holdout 은 discovery 통과 시에만 개봉 — 봉인 상태는 'sealed' 로 표기
+        hs = f"{v['holdout_sharpe']:>+9.3f}" if v["holdout_sharpe"] is not None else f"{'sealed':>9}"
+        dd = f"{v['holdout_max_drawdown']:>+8.2f}" if v["holdout_max_drawdown"] is not None else f"{'—':>8}"
         print(
-            f"  {v['name']:<22}{v['oos_sharpe_pooled']:>+8.3f}{v['p_value']:>8.3f}{v['null_p95']:>+8.2f}"
-            f"{v['holdout_sharpe']:>+9.3f}{v['holdout_max_drawdown']:>+8.2f}  {verdict}"
+            f"  {v['name']:<22}{v['oos_sharpe_pooled']:>+8.3f}{v['p_value']:>8.3f}{v['null_p95']:>+8.2f}{hs}{dd}  {verdict}"
         )
     print(f"\n  >>> promotion-eligible: {r['promotion_eligible'] or 'NONE — 노이즈 초과 엣지 없음'}")
     print()

--- a/nuri/quant/validation/variant_walkforward.py
+++ b/nuri/quant/validation/variant_walkforward.py
@@ -441,6 +441,11 @@ def _log_walkforward_runs(
     """변형별 WalkForwardValidator run (per-fold 메트릭 → walkforward_runs 기록).
 
     _evaluate_variant 와 동일한 global_warmup 슬라이스 사용 (캘린더 창 일치).
+
+    주의: WalkForwardValidator 는 db_path 를 받지 않아 기본 DB 에만 기록한다
+    (baseline strategy_walkforward 와 동일한 기존 속성 — 무수정 원칙). 명시적
+    db_path 호출자는 backtests 와 walkforward_runs 가 다른 DB 로 갈 수 있음.
+    테스트는 db_path_mp(기본 DB monkeypatch)로 우회. 해소는 별도 이슈.
     """
     actor = WalkForwardValidator()
     run_ids: dict[str, Optional[str]] = {}

--- a/tests/quant/test_main_runpy.py
+++ b/tests/quant/test_main_runpy.py
@@ -115,6 +115,15 @@ class TestBacktestMainRunpy:
             runpy.run_module("nuri.quant.validation.strategy_walkforward", run_name="__main__")
         assert exc.value.code == 2  # FX 부재 graceful error
 
+    def test_variant_walkforward_main(self, monkeypatch, db_path_mp):
+        """variant_walkforward main: 빈 DB → usd_krw 부재 → graceful error(exit 2). __main__ guard 커버."""
+        monkeypatch.setattr(sys, "argv", ["variant_walkforward"])
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        monkeypatch.setattr(sys, "stderr", io.StringIO())
+        with pytest.raises(SystemExit) as exc:
+            runpy.run_module("nuri.quant.validation.variant_walkforward", run_name="__main__")
+        assert exc.value.code == 2  # FX 부재 graceful error
+
     def test_optimizer_main(self, monkeypatch, db_path_mp):
         """optimizer main without --signal: optimize_all branch."""
         # Patch optimize_all to a no-op (it iterates many signals)

--- a/tests/quant/validation/test_variant_walkforward.py
+++ b/tests/quant/validation/test_variant_walkforward.py
@@ -206,6 +206,22 @@ class TestPanelFilter:
         close, vol = _build_panels(SMALL_CFG, db_path=db_path)
         assert close.empty and vol.empty
 
+    def test_min_history_applies_to_volume_too(self, db_path):
+        # codex P2: close 만 충분하고 volume 이 희박한 ticker 는 제외
+        # (아니면 V3 가 ffill 된 합성 거래대금으로 거래)
+        rows = []
+        dates = pd.date_range("2024-01-01", periods=10, freq="B")
+        for i, d in enumerate(dates):
+            ds = d.strftime("%Y-%m-%d")
+            rows.append(("FULL", ds, 100.0 + i, 1e6))
+            rows.append(("FULL2", ds, 100.0 + i, 1e6))
+            # NOVOL: close 는 전부, volume 은 2일치만 (< min_history 5)
+            rows.append(("NOVOL", ds, 100.0 + i, 1e6 if i >= 8 else None))
+        self._seed(db_path, rows)
+        close, _ = _build_panels(SMALL_CFG, db_path=db_path)
+        assert "NOVOL" not in close.columns
+        assert {"FULL", "FULL2"} <= set(close.columns)
+
     def test_all_filtered_returns_empty(self, db_path):
         # min_history 미달만 존재 → 빈 패널
         rows = [("X", "2024-01-02", 100.0, 1e6)]
@@ -260,8 +276,39 @@ class TestRunner:
         for v in r["variants"]:
             assert 0.0 < v["p_value"] <= 1.0
             assert isinstance(v["promotion_eligible"], bool)
-            assert v["holdout_max_drawdown"] <= 0.0
+            # holdout 은 discovery 통과 시에만 개봉 (codex P1 봉인) — 봉인이면 None
+            if v["discovery_passed"]:
+                assert v["holdout_max_drawdown"] <= 0.0
+            else:
+                assert v["holdout_sharpe"] is None
+                assert v["holdout_max_drawdown"] is None
         assert r["universe_n"] == 4
+
+    def test_all_variants_share_calendar_window(self):
+        # codex P1: 변형별 warmup 이 달라도 동일한 캘린더 discovery/holdout 슬라이스 공유
+        idx = pd.date_range("2024-01-01", periods=60, freq="B")
+        spy = pd.Series(100 * np.cumprod(1.0 + np.full(60, 0.002)), index=idx)
+        p = _panel(n=60)
+        p["SPY"] = spy
+        cfg = {
+            **SMALL_CFG,
+            "variants": [
+                {"name": "v0", "select": "momentum", "baseline": True, "theory": "c", "params": [{"lookback": 2}]},
+                {
+                    "name": "v4",
+                    "select": "regime_momentum",
+                    "theory": "t",
+                    "regime": {"ticker": "SPY", "ma": 20},  # warmup 20 ≫ v0 의 2
+                    "params": [{"lookback": 2}],
+                },
+            ],
+        }
+        r = run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=cfg)
+        v0, v4 = r["variants"]
+        # 전역 warmup = 20 → 두 변형의 창이 완전히 일치해야 함
+        assert v0["walkforward_n"] == v4["walkforward_n"]
+        assert v0["holdout_n"] == v4["holdout_n"]
+        assert v0["walkforward_n"] + v0["holdout_n"] == 60 - 20
 
     def test_baseline_never_promotion_eligible(self):
         p = _panel()
@@ -362,22 +409,38 @@ class TestRunner:
 
 
 class TestEvaluateVariant:
-    def test_holdout_reserved_and_reported(self):
+    def test_holdout_window_reserved(self):
         p = _panel()
         fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
         v = SMALL_CFG["variants"][0]
-        r = _evaluate_variant(p, _vol_panel(p), fx_ret, v, SMALL_CFG, cost_bps=10.0, alpha_eff=0.05)
-        warmup = 2
-        assert r["walkforward_n"] + r["holdout_n"] == len(p) - warmup
+        r = _evaluate_variant(p, _vol_panel(p), fx_ret, v, SMALL_CFG, cost_bps=10.0, alpha_eff=0.05, global_warmup=3)
+        assert r["walkforward_n"] + r["holdout_n"] == len(p) - 3  # 전역 warmup 기준 봉인 분할
         assert r["holdout_n"] > 0
         assert r["selected_param"] in v["params"]
 
-    def test_too_short_panel_raises(self):
-        p = _panel(n=4)
+    def test_holdout_sealed_when_discovery_fails(self):
+        # codex P1: discovery 미통과 변형의 holdout 은 봉인 (계산·노출 금지)
+        p = _panel()
         fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
         v = SMALL_CFG["variants"][0]
-        with pytest.raises(ValueError, match="need >"):
-            _evaluate_variant(p, _vol_panel(p), fx_ret, v, SMALL_CFG, cost_bps=10.0, alpha_eff=0.05)
+        # alpha_eff=0 → p < 0 불가능 → discovery 항상 실패 (결정론적)
+        r = _evaluate_variant(p, _vol_panel(p), fx_ret, v, SMALL_CFG, cost_bps=10.0, alpha_eff=0.0, global_warmup=3)
+        assert r["discovery_passed"] is False
+        assert r["holdout_sharpe"] is None
+        assert r["holdout_max_drawdown"] is None
+        assert r["holdout_passed"] is False
+        assert r["promotion_eligible"] is False
+
+    def test_holdout_opened_when_discovery_passes(self):
+        # discovery 강제 통과 (alpha_eff>1 → p<alpha 항상, min_oos_sharpe 바닥) → holdout 1회 개봉
+        p = _panel()
+        fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
+        cfg = {**SMALL_CFG, "gate": {**SMALL_CFG["gate"], "min_oos_sharpe": -100.0}}
+        v = SMALL_CFG["variants"][0]
+        r = _evaluate_variant(p, _vol_panel(p), fx_ret, v, cfg, cost_bps=10.0, alpha_eff=1.01, global_warmup=3)
+        assert r["discovery_passed"] is True
+        assert isinstance(r["holdout_sharpe"], float)
+        assert r["holdout_max_drawdown"] <= 0.0
 
 
 # ── CLI ────────────────────────────────────────────────────────
@@ -407,13 +470,24 @@ class TestCLI:
                     "holdout_sharpe": 0.1,
                     "holdout_max_drawdown": -0.2,
                     "promotion_eligible": False,
-                }
+                },
+                {
+                    "name": "v1_skip_momentum",
+                    "baseline": False,
+                    "oos_sharpe_pooled": 0.4,
+                    "p_value": 0.3,
+                    "null_p95": 1.1,
+                    "holdout_sharpe": None,  # discovery 미통과 → 봉인
+                    "holdout_max_drawdown": None,
+                    "promotion_eligible": False,
+                },
             ],
         }
         monkeypatch.setattr(V, "run_variant_validation", lambda **k: fake)
         assert V.main([]) == 0
         out = capsys.readouterr().out
         assert "Bonferroni" in out
+        assert "sealed" in out  # 봉인된 holdout 표기
         assert "노이즈 초과 엣지 없음" in out
 
     def test_main_error_returns_2(self, monkeypatch):

--- a/tests/quant/validation/test_variant_walkforward.py
+++ b/tests/quant/validation/test_variant_walkforward.py
@@ -1,0 +1,445 @@
+"""Lock-tests for pre-registered variant edge search (#706).
+
+- select_fn known-answer: 각 변형이 의도한 신호로 선택하는지 결정론적 micro-case
+- 패널 품질 필터: exclude_tickers / min_history / min_breadth (사전등록 필터 lock)
+- Bonferroni: alpha_effective = alpha / n_test_variants (baseline 분모 제외)
+- mandatory gate: cost_bps / fx_series None → ValueError (gross/통화-naive 차단)
+- same-bar lookahead: 리밸런싱일 점프 미적립 (baseline 과 동일 규율, §5.3.1)
+- 승격 자격 = discovery AND holdout AND not baseline
+- persist: 변형별 backtests 1행 + walkforward_runs 기록
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from nuri.quant.validation.variant_walkforward import (
+    _build_panels,
+    _evaluate_variant,
+    _load_variants_config,
+    _param_warmup,
+    _sel_momentum,
+    _sel_regime_momentum,
+    _sel_skip_momentum,
+    _sel_vol_scaled,
+    _sel_volume_confirmed,
+    _variant_daily_returns,
+    run_variant_search,
+)
+
+# 작은 pre-registered config — 빠른 fold (테스트 전용; 실 config 와 구조 동일)
+SMALL_CFG = {
+    "panel": {"exclude_tickers": ["KOSDAQ"], "min_history": 5, "min_breadth": 2},
+    "portfolio": {"top_n": 2, "rebalance_days": 2},
+    "fold": {"kind": "rolling", "train_size": 10, "test_size": 5, "step": 5},
+    "holdout": {"frac": 0.2},
+    "costs": {"survivorship_haircut_bps_annual": 200},
+    "gate": {
+        "min_oos_sharpe": 0.5,
+        "min_holdout_sharpe": 0.0,
+        "permutation": {"n": 10, "alpha": 0.05, "seed": 0},
+        "multiple_comparison": "bonferroni",
+    },
+    "variants": [
+        {"name": "v0", "select": "momentum", "baseline": True, "theory": "control", "params": [{"lookback": 2}]},
+        {"name": "v2", "select": "vol_scaled", "theory": "vol-scaled", "params": [{"lookback": 3}]},
+    ],
+}
+
+
+def _panel(n: int = 40, tickers=("AAA", "BBB", "CCC", "DDD")) -> pd.DataFrame:
+    """결정론적 close 패널 — 종목별 상이한 추세 + sin 변동."""
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    data = {}
+    for k, t in enumerate(tickers):
+        steps = 0.001 * (k + 1) + 0.002 * np.sin(np.arange(n))
+        data[t] = 100.0 * np.cumprod(1.0 + steps)
+    return pd.DataFrame(data, index=dates)
+
+
+def _vol_panel(close: pd.DataFrame, base: float = 1e6) -> pd.DataFrame:
+    return pd.DataFrame(base, index=close.index, columns=close.columns)
+
+
+def _flat_fx(idx: pd.Index) -> pd.Series:
+    return pd.Series(1300.0, index=idx, dtype=float)
+
+
+# ── select_fn known-answer (결정론적 micro-case) ───────────────
+
+
+class TestSelectFns:
+    def test_momentum_picks_highest_trailing_return(self):
+        p = _panel()
+        # DDD(가장 큰 drift) > CCC > BBB > AAA — top 2 = DDD, CCC
+        held = _sel_momentum(p, None, 20, {"lookback": 10}, 2, {})
+        assert held == ["DDD", "CCC"]
+
+    def test_skip_momentum_excludes_recent_window(self):
+        # JUMPY 는 최근 2일에만 급등 — skip=2 면 그 급등이 신호에서 빠져 STEADY 가 이긴다
+        idx = pd.date_range("2024-01-01", periods=12, freq="B")
+        steady = 100 * np.cumprod(1.0 + np.full(12, 0.01))
+        jumpy = np.full(12, 100.0)
+        jumpy[10:] = 130.0  # i-2 이후 급등
+        p = pd.DataFrame({"STEADY": steady, "JUMPY": jumpy}, index=idx)
+        held_skip = _sel_skip_momentum(p, None, 11, {"lookback": 8, "skip": 2}, 1, {})
+        held_plain = _sel_momentum(p, None, 11, {"lookback": 8}, 1, {})
+        assert held_skip == ["STEADY"]  # 최근 점프 제외 → 꾸준한 추세 승
+        assert held_plain == ["JUMPY"]  # 일반 모멘텀은 점프 포함
+
+    def test_vol_scaled_prefers_low_vol_trend(self):
+        # 같은 누적수익이라도 변동성 낮은 쪽이 ret/vol 랭킹 승
+        idx = pd.date_range("2024-01-01", periods=20, freq="B")
+        smooth = 100 * np.cumprod(1.0 + np.full(20, 0.01))
+        wild_steps = np.full(20, 0.01)
+        wild_steps[::2] = 0.06
+        wild_steps[1::2] = -0.035
+        wild = 100 * np.cumprod(1.0 + wild_steps)
+        p = pd.DataFrame({"SMOOTH": smooth, "WILD": wild}, index=idx)
+        held = _sel_vol_scaled(p, None, 19, {"lookback": 10}, 1, {})
+        assert held == ["SMOOTH"]
+
+    def test_volume_confirmed_filters_by_dollar_volume_surge(self):
+        # 모멘텀 top-2N 후보 중 거래대금 surge 큰 쪽이 선택된다
+        p = _panel()
+        vol = _vol_panel(p)
+        vol.loc[p.index[26:31], "CCC"] = 5e6  # CCC surge — 선택 시점 i=30 의 surge_window(26..30)
+        held = _sel_volume_confirmed(p, vol, 30, {"lookback": 10, "surge_window": 5}, 1, {})
+        assert held == ["CCC"]  # 모멘텀 1위 DDD 보다 surge 우위 CCC
+
+    def test_regime_momentum_goes_cash_below_ma(self):
+        idx = pd.date_range("2024-01-01", periods=30, freq="B")
+        spy = np.linspace(100, 80, 30)  # 하락 추세 → 가격 < MA
+        stock = np.linspace(100, 120, 30)
+        p = pd.DataFrame({"SPY": spy, "AAA": stock}, index=idx)
+        cfg = {"regime": {"ticker": "SPY", "ma": 10}}
+        assert _sel_regime_momentum(p, None, 29, {"lookback": 5}, 1, cfg) == []  # cash
+
+    def test_regime_momentum_holds_above_ma(self):
+        idx = pd.date_range("2024-01-01", periods=30, freq="B")
+        spy = np.linspace(100, 130, 30)  # 상승 추세 → 가격 > MA
+        stock = np.linspace(100, 120, 30)
+        p = pd.DataFrame({"SPY": spy, "AAA": stock}, index=idx)
+        cfg = {"regime": {"ticker": "SPY", "ma": 10}}
+        held = _sel_regime_momentum(p, None, 29, {"lookback": 5}, 1, cfg)
+        assert held == ["SPY"]  # 모멘텀 1위 (SPY 도 패널 멤버 — 후보 포함)
+
+    def test_volume_confirmed_empty_when_no_momentum_candidates(self):
+        # lookback 시점이 전부 NaN(상장 전) → 모멘텀 후보 0 → cash
+        idx = pd.date_range("2024-01-01", periods=10, freq="B")
+        late = np.full(10, np.nan)
+        late[8:] = 100.0
+        p = pd.DataFrame({"AAA": late, "BBB": late}, index=idx)
+        held = _sel_volume_confirmed(p, _vol_panel(p), 9, {"lookback": 8, "surge_window": 2}, 1, {})
+        assert held == []
+
+    def test_param_warmup_includes_regime_ma(self):
+        assert _param_warmup({"regime": {"ticker": "SPY", "ma": 200}}, {"lookback": 60}) == 200
+        assert _param_warmup({}, {"lookback": 60}) == 60
+
+
+# ── 패널 품질 필터 (사전등록 lock) ─────────────────────────────
+
+
+class TestPanelFilter:
+    @staticmethod
+    def _seed(db_path, rows):
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.executemany("INSERT INTO prices (ticker, date, close, volume) VALUES (?, ?, ?, ?)", rows)
+
+    def test_excludes_pseudo_tickers_and_kr(self, db_path):
+        rows = []
+        for i, d in enumerate(pd.date_range("2024-01-01", periods=10, freq="B")):
+            ds = d.strftime("%Y-%m-%d")
+            for t in ("AAA", "BBB", "KOSDAQ", "005930.KS"):
+                rows.append((t, ds, 100.0 + i, 1e6))
+        self._seed(db_path, rows)
+        close, vol = _build_panels(SMALL_CFG, db_path=db_path)
+        assert set(close.columns) == {"AAA", "BBB"}  # KOSDAQ(denylist) + .KS 제외
+        assert list(vol.columns) == list(close.columns)
+
+    def test_min_history_drops_shallow_tickers(self, db_path):
+        rows = []
+        dates = pd.date_range("2024-01-01", periods=10, freq="B")
+        for i, d in enumerate(dates):
+            ds = d.strftime("%Y-%m-%d")
+            rows.append(("DEEP", ds, 100.0 + i, 1e6))
+            rows.append(("DEEP2", ds, 100.0 + i, 1e6))
+            if i >= 8:  # SHALLOW 는 2일치만 (< min_history 5)
+                rows.append(("SHALLOW", ds, 50.0, 1e6))
+        self._seed(db_path, rows)
+        close, _ = _build_panels(SMALL_CFG, db_path=db_path)
+        assert "SHALLOW" not in close.columns
+        assert {"DEEP", "DEEP2"} <= set(close.columns)
+
+    def test_min_breadth_trims_degenerate_lead(self, db_path):
+        # 처음 5일은 LONE 1종목뿐 (< min_breadth 2) → trim, 폭 2 이상부터 시작
+        rows = []
+        dates = pd.date_range("2024-01-01", periods=12, freq="B")
+        for i, d in enumerate(dates):
+            ds = d.strftime("%Y-%m-%d")
+            rows.append(("LONE", ds, 100.0 + i, 1e6))
+            if i >= 5:
+                rows.append(("LATER", ds, 100.0 + i, 1e6))
+        self._seed(db_path, rows)
+        close, _ = _build_panels(SMALL_CFG, db_path=db_path)
+        assert close.index[0] == dates[5]  # degenerate 선두 trim
+
+    def test_empty_db_returns_empty(self, db_path):
+        close, vol = _build_panels(SMALL_CFG, db_path=db_path)
+        assert close.empty and vol.empty
+
+    def test_breadth_never_reached_returns_empty(self, db_path):
+        # 종목들이 min_history 는 넘지만 동시 존재 폭이 min_breadth 미달 → 빈 패널
+        rows = []
+        for i, d in enumerate(pd.date_range("2024-01-01", periods=14, freq="B")):
+            ds = d.strftime("%Y-%m-%d")
+            if i < 7:
+                rows.append(("EARLY", ds, 100.0 + i, 1e6))
+            else:
+                rows.append(("LATE", ds, 100.0 + i, 1e6))
+        self._seed(db_path, rows)
+        close, vol = _build_panels(SMALL_CFG, db_path=db_path)
+        assert close.empty and vol.empty
+
+    def test_all_filtered_returns_empty(self, db_path):
+        # min_history 미달만 존재 → 빈 패널
+        rows = [("X", "2024-01-02", 100.0, 1e6)]
+        self._seed(db_path, rows)
+        close, vol = _build_panels(SMALL_CFG, db_path=db_path)
+        assert close.empty and vol.empty
+
+
+# ── same-bar lookahead (baseline 과 동일 규율) ─────────────────
+
+
+class TestNoSameBarLookahead:
+    def test_rebalance_day_spike_not_credited_same_bar(self):
+        # SPIKE 가 리밸런싱일 i=4 에 +100% 점프 — 그날 수익은 이전 보유분(STEADY)으로 번다
+        idx = pd.date_range("2024-01-01", periods=8, freq="B")
+        prices = pd.DataFrame(
+            {
+                "STEADY": [100, 101, 102, 103, 104, 105, 106, 107],
+                "SPIKE": [100, 100, 100, 100, 200, 200, 200, 200],
+            },
+            index=idx,
+            dtype=float,
+        )
+        daily, _ = _variant_daily_returns(
+            prices, None, _sel_momentum, {"lookback": 2}, {}, top_n=1, rebalance_days=2, warmup=2
+        )
+        assert daily.iloc[4] == pytest.approx(104 / 103 - 1, rel=1e-9)  # 점프(1.0) 미적립
+        assert daily.iloc[5] == pytest.approx(0.0)  # 다음 bar 부터 SPIKE 보유
+
+
+# ── gate / Bonferroni / runner ─────────────────────────────────
+
+
+class TestRunner:
+    def test_refuses_without_cost_or_fx(self):
+        p = _panel()
+        with pytest.raises(ValueError, match="cost_bps"):
+            run_variant_search(cost_bps=None, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p))
+        with pytest.raises(ValueError, match="fx_series"):
+            run_variant_search(cost_bps=10.0, fx_series=None, close=p, vol=_vol_panel(p))
+
+    def test_bonferroni_alpha_excludes_baseline(self):
+        p = _panel()
+        r = run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=SMALL_CFG)
+        assert r["n_test_variants"] == 1  # v0 은 baseline — 분모 제외
+        assert r["alpha_effective"] == pytest.approx(0.05 / 1)
+
+    def test_result_table_shape(self):
+        p = _panel()
+        r = run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=SMALL_CFG)
+        assert [v["name"] for v in r["variants"]] == ["v0", "v2"]
+        for v in r["variants"]:
+            assert 0.0 < v["p_value"] <= 1.0
+            assert isinstance(v["promotion_eligible"], bool)
+            assert v["holdout_max_drawdown"] <= 0.0
+        assert r["universe_n"] == 4
+
+    def test_baseline_never_promotion_eligible(self):
+        p = _panel()
+        r = run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=SMALL_CFG)
+        v0 = next(v for v in r["variants"] if v["name"] == "v0")
+        assert v0["baseline"] is True
+        assert v0["promotion_eligible"] is False  # 대조군은 정의상 승격 불가
+
+    def test_unknown_select_fn_rejected(self):
+        cfg = {**SMALL_CFG, "variants": [{"name": "x", "select": "nope", "theory": "t", "params": [{"lookback": 2}]}]}
+        p = _panel()
+        with pytest.raises(ValueError, match="unknown select_fn"):
+            run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=cfg)
+
+    def test_missing_regime_ticker_rejected(self):
+        cfg = {
+            **SMALL_CFG,
+            "variants": [
+                {
+                    "name": "v4",
+                    "select": "regime_momentum",
+                    "theory": "t",
+                    "regime": {"ticker": "SPY", "ma": 5},
+                    "params": [{"lookback": 2}],
+                }
+            ],
+        }
+        p = _panel()  # SPY 없음
+        with pytest.raises(ValueError, match="regime ticker"):
+            run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=cfg)
+
+    def test_empty_db_panel_rejected(self, db_path_mp):
+        # close 미지정 → DB 패널 빌드 → 빈 패널이면 거부 (품질 필터 후 부족 메시지)
+        with pytest.raises(ValueError, match="panel quality filter"):
+            run_variant_search(
+                cost_bps=10.0, fx_series=_flat_fx(pd.date_range("2024-01-01", periods=5)), config=SMALL_CFG
+            )
+
+    def test_insufficient_rows_rejected(self):
+        p = _panel(n=3)
+        with pytest.raises(ValueError):
+            run_variant_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, vol=_vol_panel(p), config=SMALL_CFG)
+
+    def test_random_walk_not_promotion_eligible(self):
+        # noise 에서 승격 자격이 나오면 안 된다 (#701 null-safe 원칙 상속)
+        rng = np.random.default_rng(7)
+        idx = pd.date_range("2022-01-01", periods=120, freq="B")
+        p = pd.DataFrame({f"T{j}": 100 * np.exp(np.cumsum(rng.normal(0.0, 0.02, 120))) for j in range(8)}, index=idx)
+        cfg = {
+            **SMALL_CFG,
+            "fold": {"kind": "rolling", "train_size": 40, "test_size": 15, "step": 15},
+            "variants": [
+                {"name": "v0", "select": "momentum", "baseline": True, "theory": "c", "params": [{"lookback": 5}]},
+                {"name": "v2", "select": "vol_scaled", "theory": "t", "params": [{"lookback": 5}, {"lookback": 10}]},
+            ],
+        }
+        r = run_variant_search(cost_bps=0.0, fx_series=_flat_fx(idx), close=p, vol=_vol_panel(p), config=cfg)
+        assert r["promotion_eligible"] == []
+
+    def test_persist_writes_backtests_and_walkforward_runs(self, db_path_mp):
+        from nuri.core.db import query
+
+        p = _panel()
+        r = run_variant_search(
+            cost_bps=10.0,
+            fx_series=_flat_fx(p.index),
+            close=p,
+            vol=_vol_panel(p),
+            config=SMALL_CFG,
+            persist=True,
+        )
+        rows = query("SELECT strategy_id, sharpe, params FROM backtests ORDER BY strategy_id", db_path=db_path_mp)
+        assert [row["strategy_id"] for row in rows] == ["wf-variant:v0", "wf-variant:v2"]
+        runs = query("SELECT model_id FROM walkforward_runs", db_path=db_path_mp)
+        assert {row["model_id"] for row in runs} == {"wf-variant:v0", "wf-variant:v2"}
+        assert all(v["walkforward_run_id"] for v in r["variants"])
+
+    def test_loads_real_config_and_registry_complete(self):
+        cfg = _load_variants_config()
+        assert cfg["gate"]["multiple_comparison"] == "bonferroni"
+        names = [v["name"] for v in cfg["variants"]]
+        assert names == [
+            "v0_momentum",
+            "v1_skip_momentum",
+            "v2_vol_scaled",
+            "v3_volume_confirmed",
+            "v4_regime_momentum",
+        ]
+        # 사전등록 규율: 검정 변형 4개, 각 param grid ≤ 3, baseline 은 v0 만
+        assert sum(1 for v in cfg["variants"] if not v.get("baseline", False)) == 4
+        assert all(len(v["params"]) <= 3 for v in cfg["variants"])
+        from nuri.quant.validation.variant_walkforward import _SELECT_REGISTRY
+
+        assert all(v["select"] in _SELECT_REGISTRY for v in cfg["variants"])
+
+
+# ── 변형 단건 평가 (holdout 봉인) ──────────────────────────────
+
+
+class TestEvaluateVariant:
+    def test_holdout_reserved_and_reported(self):
+        p = _panel()
+        fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
+        v = SMALL_CFG["variants"][0]
+        r = _evaluate_variant(p, _vol_panel(p), fx_ret, v, SMALL_CFG, cost_bps=10.0, alpha_eff=0.05)
+        warmup = 2
+        assert r["walkforward_n"] + r["holdout_n"] == len(p) - warmup
+        assert r["holdout_n"] > 0
+        assert r["selected_param"] in v["params"]
+
+    def test_too_short_panel_raises(self):
+        p = _panel(n=4)
+        fx_ret = _flat_fx(p.index).pct_change().reindex(p.index).fillna(0.0)
+        v = SMALL_CFG["variants"][0]
+        with pytest.raises(ValueError, match="need >"):
+            _evaluate_variant(p, _vol_panel(p), fx_ret, v, SMALL_CFG, cost_bps=10.0, alpha_eff=0.05)
+
+
+# ── CLI ────────────────────────────────────────────────────────
+
+
+class TestCLI:
+    def test_main_success_prints_table(self, monkeypatch, capsys):
+        import nuri.quant.validation.variant_walkforward as V
+
+        fake = {
+            "universe_n": 90,
+            "panel_rows": 1200,
+            "panel_start": "2021-04-09",
+            "panel_end": "2026-06-04",
+            "cost_bps": 10.0,
+            "n_test_variants": 4,
+            "alpha": 0.05,
+            "alpha_effective": 0.0125,
+            "promotion_eligible": [],
+            "variants": [
+                {
+                    "name": "v0_momentum",
+                    "baseline": True,
+                    "oos_sharpe_pooled": 0.3,
+                    "p_value": 0.5,
+                    "null_p95": 1.2,
+                    "holdout_sharpe": 0.1,
+                    "holdout_max_drawdown": -0.2,
+                    "promotion_eligible": False,
+                }
+            ],
+        }
+        monkeypatch.setattr(V, "run_variant_validation", lambda **k: fake)
+        assert V.main([]) == 0
+        out = capsys.readouterr().out
+        assert "Bonferroni" in out
+        assert "노이즈 초과 엣지 없음" in out
+
+    def test_main_error_returns_2(self, monkeypatch):
+        import nuri.quant.validation.variant_walkforward as V
+
+        def boom(**k):
+            raise ValueError("usd_krw not in macro")
+
+        monkeypatch.setattr(V, "run_variant_validation", boom)
+        assert V.main([]) == 2
+
+    def test_run_variant_validation_loads_fx(self, db_path_mp):
+        from nuri.core.db import get_db
+        from nuri.quant.validation.variant_walkforward import run_variant_validation
+
+        p = _panel()
+        with get_db(db_path_mp) as conn:
+            conn.executemany(
+                "INSERT INTO prices (ticker, date, close, volume) VALUES (?, ?, ?, ?)",
+                [(t, d.strftime("%Y-%m-%d"), float(p.loc[d, t]), 1e6) for t in p.columns for d in p.index],
+            )
+            for d in p.index:
+                conn.execute(
+                    "INSERT INTO macro (indicator, date, value) VALUES (?, ?, ?)",
+                    ("usd_krw", d.strftime("%Y-%m-%d"), 1300.0),
+                )
+        r = run_variant_validation(cost_bps=10.0, config=SMALL_CFG, persist=False)
+        assert r["universe_n"] == 4
+        assert "promotion_eligible" in r


### PR DESCRIPTION
Closes #706

## 무엇

이론 동기가 있는 모멘텀 변형 5개(V0 대조군 + V1–V4)를 **결과 보기 전에 동결**(이슈 #706 + `config/walkforward_variants.yaml`)하고, 단일 #701 gate(pooled OOS net Sharpe + #707 교정 순열 null)로 측정하는 하니스. p-hacking 차단: **Bonferroni**(α/4=0.0125) 발견단계 + **FROZEN holdout**(발견 통과 시에만 1회 개봉, 그 외 봉인) — 둘 다 통과해야 승격 자격.

패널 품질 필터 사전등록 (모든 변형+null 동일 적용): pseudo-ticker 제거(KOSDAQ/KOSPI/GC=F/TESTAA — KRW 지수가 US USD 패널을 오염하던 것 실측 적발) + min_history 504 (close **및 volume**) + min_breadth 40 (degenerate 초기 fold 제거). **전역 warmup**으로 모든 변형이 동일 캘린더 discovery/holdout 창 공유.

## 측정 결과 (실데이터: 90종목 2021-04-20..2026-06-04, cost 10bps + FX + 생존자 haircut, 200 순열, 공유 252d warmup)

| 변형 | 이론 | pooled OOS | p | null p95 | holdout | 판정 |
|---|---|---|---|---|---|---|
| v0_momentum | 대조군 | +1.67 | 0.109 | +1.93 | 봉인 | baseline |
| v1_skip_momentum | Jegadeesh-Titman 12-1 | +1.65 | **0.095** | +1.77 | 봉인 | **FAIL** |
| v2_vol_scaled | Blitz residual momentum | +1.46 | 0.100 | +1.63 | 봉인 | FAIL |
| v3_volume_confirmed | Lee-Swaminathan 거래대금 | +1.61 | 0.114 | +1.86 | 봉인 | FAIL |
| v4_regime_momentum | Daniel-Moskowitz crashes | +1.40 | 0.154 | +1.82 | 봉인 | FAIL |

**결론: promotion-eligible = NONE.** 최선의 V1(정통 12-1, p=0.095)조차 무보정 α=0.05 미달 — Bonferroni 0.0125 는 더 멀다. 절대 Sharpe 는 전부 높아 보이지만(+1.4~1.7) 시간셔플 null 이 동일 절차로 p95 +1.6~1.9 를 만든다 → 전부 리밸런싱/선택편향 artifact 범위 안. **이 universe(미국 생존자 90종목, 2021–2026)에서 momentum/RS 계열의 통계적 엣지는 입증되지 않음.** FROZEN holdout 은 개봉되지 않아 후속 연구에 봉인 상태로 보존됨.

후속 판단(별도): P2 leadership weight=0 shadow 유지(승격 금지 — folklore 차단), alpha 원천은 superinvestor/factor 쪽 재평가.

## codex review (2 round)

- R1 **P1 ×2 적발 → 2nd commit 수정**: ① holdout 봉인 깨짐(실패 변형도 holdout 노출 → 사후 재설계 누설 경로) → discovery 통과 시에만 개봉, 실패는 None/'sealed'. ② 변형별 warmup 상이 → 캘린더 창 불일치(장기-메모리 변형이 다른 holdout 을 받는 gate-gaming) → 전역 warmup 으로 통일. P2: volume 커버리지 필터(min_history 를 volume 에도) 반영.
- R1 확인 사항: Bonferroni 분모 baseline 제외 OK, 순열 seed 변형 간 공유(공정 비교) OK, same-bar 경계 보존 OK.

## 검증

- 신규 모듈 100% statement+branch (33 lock-tests + runpy main guard) — 봉인/개봉, 공유 캘린더 창, volume 필터 lock 포함
- `make test-fast`: 5965 passed, TOTAL 100% / `make verify-doc-counts`: 13/13 (backend test files 263→264)
- 결과 persist: `backtests` + `walkforward_runs` 변형별 5행 → `/api/research/*` surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
