### PR TITLE
feat(validation): P4 exit-rule walk-forward — all 4 alternatives FAIL paired permutation gate, keep E0 ladder (#713)

### DIFF
--- a/config/walkforward_exits.yaml
+++ b/config/walkforward_exits.yaml
@@ -1,0 +1,63 @@
+# P4 exit-룰 사후검증 (#713) — 결과를 보기 전에 동결된 pre-registered 파라미터.
+#
+# 규율 (#706 과 동일):
+# - 룰은 이론 동기가 있는 5개만 (E0 대조 + E1-E4 검정). 결과 보고 추가/수정 금지.
+# - 다중비교 = Bonferroni: 발견단계 통과 = 순열 p < alpha / n_test_rules AND ΔSharpe > 0.
+# - 발견단계 통과 룰만 FROZEN holdout(패널 마지막 frac 진입분) 1회 개봉.
+# - E0/E1 파라미터는 config/rules.yaml 현행 값의 동결 복사 (실험 가설은 production
+#   loader 와 분리 — rules.yaml 변경은 통과 후 별도 STRATEGY PR).
+# - 거래비용(cost_bps)·FX(fx_series)는 매 run 필수 입력.
+
+panel:                           # #706 과 동일한 품질 필터 (walkforward_variants.yaml 복사)
+  exclude_tickers: [KOSDAQ, KOSPI, GC=F, TESTAA]
+  min_history: 504
+  min_breadth: 40
+
+entries:                         # 랜덤 진입 Monte Carlo — exit 기여를 진입 신호와 분리
+  n: 2000                        # (ticker, 진입일) 무작위 쌍 수
+  seed: 0                        # 재현성 (진입 set 은 모든 룰이 공유 — paired 비교)
+  max_horizon: 250               # 최대 보유 영업일 (룰 미발화 시 강제 청산)
+  warmup: 60                     # 진입일 하한 (MA50 등 룰 지표 계산 가능 구간 확보)
+
+holdout:
+  frac: 0.2                      # 패널 마지막 20% 에 진입하는 포지션 = FROZEN (봉인)
+
+costs:
+  survivorship_haircut_bps_annual: 200
+
+gate:
+  permutation:
+    n: 200                       # 시간셔플 null 표본 수 (#707 first-valid anchor 재사용)
+    alpha: 0.05                  # 가족 유의수준 — 발견단계는 alpha / n_test_rules
+    seed: 0
+  multiple_comparison: bonferroni
+  min_delta_sharpe: 0.0          # ΔSharpe(룰 − E0) > 0 필수 (개선이어야 의미)
+  min_holdout_delta: 0.0         # holdout 재확인 floor
+
+# exit 룰 registry — kind: exit_walkforward.py 의 시뮬레이터가 해석.
+# 모든 % 는 진입가 대비 (trailing 은 고점 대비). E0 가 paired 비교의 기준점.
+rules:
+  - name: e0_ladder
+    baseline: true
+    theory: "대조군 — O'Neil CAN SLIM 현행 production ladder (rules.yaml 동결 복사)"
+    stop_pct: -7
+    tp1: {pct: 20, sell: 0.5}
+    tp2: {pct: 40, sell: 0.25}
+    trailing_pct: -15            # 잔여 25% 는 고점 대비 트레일링
+
+  - name: e1_leader_ma
+    theory: "#679 leader-exit 사후검증 — Minervini 추세추종: 고정 TP 없이 50MA 종가 이탈 청산"
+    stop_pct: -7
+    trail_ma: 50
+
+  - name: e2_trail25
+    theory: "2026-05-29 약식 백테스트 raw 1위 — 무TP + 고점 대비 -25% 고정 트레일 엄밀 재검"
+    stop_pct: -7
+    trailing_pct: -25
+
+  - name: e3_buy_hold
+    theory: "바닥 대조 — exit 룰이 아예 가치를 더하는가 (max_horizon 까지 무조건 보유)"
+
+  - name: e4_stop_only
+    theory: "처분효과 회피의 최소형 — -7% 손절만, 승자는 절대 자르지 않음"
+    stop_pct: -7

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 264 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 265 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 264 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 265 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/validation/exit_walkforward.py
+++ b/nuri/quant/validation/exit_walkforward.py
@@ -1,0 +1,408 @@
+"""P4 exit-룰 사후검증 하니스 (#713) — pre-registered E0-E4 를 동일 순열 gate 로.
+
+config/walkforward_exits.yaml 에 *결과를 보기 전에* 동결된 exit 룰 5개(E0 현행 ladder
+대조 + E1-E4 검정)를 **랜덤 진입 Monte Carlo** testbed 에서 paired 비교한다.
+
+설계 (#706 규율 상속 + exit 특화):
+- **랜덤 진입**: 무작위 (ticker, 진입일) 쌍 N개를 모든 룰이 공유 → 진입 신호와 분리된
+  순수 exit 기여 측정 (paired). momentum 진입은 #706 에서 엣지 없음 확정.
+- **주 지표 = ΔSharpe(룰 − E0)**: 동일 진입 집합에서 룰별 일별 net 포트폴리오 수익률
+  (활성 포지션 평균, 비용+FX+haircut 차감) 의 Sharpe 차이.
+- **순열 null**: exit 룰은 가격 *경로*(추세 지속·드로다운)를 착취한다. 시간셔플(#707
+  first-valid anchor)은 분포는 보존하고 경로 구조만 파괴 → 셔플 경로에서도 나오는
+  ΔSharpe 는 룰의 가치가 아닌 mechanical artifact. 발견 = Δp < alpha/k (Bonferroni).
+- **FROZEN holdout**: 패널 마지막 frac 구간에 진입하는 포지션은 봉인. 발견 통과 룰만
+  1회 개봉 (Δ ≥ floor). discovery 진입은 만기가 holdout 시작 전에 끝나는 것만
+  (경계 누설 차단 buffer — 사이 진입은 제외).
+- 체결 규약(동결): 진입 = 진입일 종가, 이벤트 판정 = 일별 종가, 같은 날 중복 시
+  full-exit(stop/trailing/MA) 이 partial(TP) 에 우선. 거래비용은 거래 fraction 에 부과.
+- 통과 룰의 rules.yaml 반영은 **별도 STRATEGY PR** — 이 모듈은 측정만 한다.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from nuri.agents.actors.walkforward_validator import _sharpe_from_returns
+from nuri.core.db import save_backtest
+from nuri.quant.validation.strategy_walkforward import _max_drawdown, _permute_prices
+from nuri.quant.validation.variant_walkforward import _build_panels
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path(__file__).parent.parent.parent.parent / "config" / "walkforward_exits.yaml"
+
+
+def _load_exits_config(path: Optional[Path] = None) -> dict:
+    """config/walkforward_exits.yaml 로드 (pre-registered 파라미터)."""
+    with open(path or _CONFIG_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+# ── 진입 샘플링 (모든 룰 공유 — paired) ────────────────────────
+
+
+def _sample_entries(close: pd.DataFrame, ecfg: dict) -> list[tuple[int, int]]:
+    """무작위 (col_idx, t0) 진입 쌍 — 진입일 종가가 유효한 조합만.
+
+    seed 고정 → 모든 룰·모든 순열 패널이 동일 진입 set 사용 (paired 비교의 전제).
+    """
+    rng = np.random.default_rng(int(ecfg["seed"]))
+    arr = close.to_numpy()
+    n_days, n_cols = arr.shape
+    lo, hi = int(ecfg["warmup"]), n_days - 2  # 최소 1일은 보유 가능해야
+    if hi <= lo:
+        raise ValueError(f"panel too short for entries: warmup={lo}, days={n_days}")
+    out: list[tuple[int, int]] = []
+    target = int(ecfg["n"])
+    # 유효 진입(종가 존재)만 수집 — 무한루프 방지 상한
+    for _ in range(target * 10):
+        if len(out) >= target:
+            break
+        j = int(rng.integers(0, n_cols))
+        t0 = int(rng.integers(lo, hi + 1))
+        if not np.isnan(arr[t0, j]):
+            out.append((j, t0))
+    if len(out) < target:
+        logger.warning("entries: %d/%d sampled (sparse panel)", len(out), target)
+    return out
+
+
+# ── 단일 포지션 exit 해석 (first-crossing, 결정론) ─────────────
+
+
+def _first_at_or_after(mask: np.ndarray) -> int:
+    """mask[1:] 중 첫 True 의 index (없으면 큰 수). index 는 윈도 내 day(1..H)."""
+    idx = np.flatnonzero(mask[1:])
+    return int(idx[0]) + 1 if idx.size else 10**9
+
+
+def _resolve_exit(
+    c: np.ndarray, ma: Optional[np.ndarray], rule: dict, horizon: int
+) -> tuple[int, list[tuple[int, float]]]:
+    """포지션 가격 윈도 c[0..H](c[0]=진입 종가)에 rule 적용 → (청산 day, [(day, 매도 fraction)]).
+
+    full-exit 후보 = stop / trailing / MA-이탈 / horizon 중 최선착. partial(TP) 은
+    full-exit 이전에 발생한 것만 유효. 같은 날 충돌 시 full-exit 우선 (동결 규약).
+    """
+    H = len(c) - 1
+    entry = c[0]
+    liq_candidates = [min(H, horizon)]
+
+    if "stop_pct" in rule:
+        liq_candidates.append(_first_at_or_after(c <= entry * (1.0 + rule["stop_pct"] / 100.0)))
+    if "trailing_pct" in rule:
+        hwm = np.maximum.accumulate(c)
+        liq_candidates.append(_first_at_or_after(c <= hwm * (1.0 + rule["trailing_pct"] / 100.0)))
+    if "trail_ma" in rule and ma is not None:
+        below = np.where(np.isnan(ma), False, c < ma)  # MA 미계산 구간은 보유 (#679 와 동일)
+        liq_candidates.append(_first_at_or_after(below))
+
+    liq = min(liq_candidates)
+    events: list[tuple[int, float]] = []
+    remaining = 1.0
+    for key in ("tp1", "tp2"):
+        if key in rule:
+            d = _first_at_or_after(c >= entry * (1.0 + rule[key]["pct"] / 100.0))
+            if d < liq:  # full-exit 과 같은 날이면 full-exit 우선
+                frac = rule[key]["sell"]
+                events.append((d, frac))
+                remaining -= frac
+    events.append((liq, remaining))  # 청산일에 잔여 전량
+    return liq, events
+
+
+# ── 룰별 일별 USD 수익률 (포지션 집계) ─────────────────────────
+
+
+def _simulate_rule(
+    close: pd.DataFrame,
+    entries: list[tuple[int, int]],
+    rule: dict,
+    cost_bps: float,
+    max_horizon: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """전 진입 포지션에 rule 적용 → (일별 수익 합, 일별 활성 수) 배열.
+
+    포지션 day-k 수익 = (직전 보유 fraction) × 종목 수익률 − 그날 거래비용.
+    진입 매수 비용은 첫 보유일에 부과. 활성 = 진입 다음날부터 청산일까지.
+    """
+    arr = close.to_numpy()
+    n_days = arr.shape[0]
+    ma_arr: Optional[np.ndarray] = None
+    if "trail_ma" in rule:
+        ma_arr = close.rolling(int(rule["trail_ma"])).mean().to_numpy()
+
+    cost = cost_bps / 10000.0
+    daily_sum = np.zeros(n_days)
+    daily_cnt = np.zeros(n_days)
+    for j, t0 in entries:
+        end = min(t0 + max_horizon, n_days - 1)
+        c = arr[t0 : end + 1, j]
+        ma = ma_arr[t0 : end + 1, j] if ma_arr is not None else None
+        liq, events = _resolve_exit(c, ma, rule, max_horizon)
+        # 보유 fraction f[k] = day k(1..liq) 동안 보유분 — 이벤트 day d 매도는 d+1 부터 반영
+        f = np.ones(liq + 1)  # index 1..liq 사용
+        trade_cost = np.zeros(liq + 1)
+        trade_cost[1] += cost  # 진입 매수 비용 (첫 보유일 부과)
+        for d, frac in events:
+            if d < liq:
+                f[d + 1 :] -= frac
+            trade_cost[d if d >= 1 else 1] += cost * frac
+        r = c[1 : liq + 1] / c[:liq] - 1.0
+        contrib = f[1:] * r - trade_cost[1:]
+        daily_sum[t0 + 1 : t0 + 1 + liq] += contrib
+        daily_cnt[t0 + 1 : t0 + 1 + liq] += 1.0
+    return daily_sum, daily_cnt
+
+
+def _rule_daily_krw(
+    daily_sum: np.ndarray, daily_cnt: np.ndarray, fx_ret: np.ndarray, haircut_daily: float
+) -> np.ndarray:
+    """활성 포지션 평균 USD 수익률 → KRW net (FX + haircut). 활성 0 인 날은 0."""
+    usd = np.divide(daily_sum, daily_cnt, out=np.zeros_like(daily_sum), where=daily_cnt > 0)
+    krw = (1.0 + usd) * (1.0 + fx_ret) - 1.0 - haircut_daily
+    return np.where(daily_cnt > 0, krw, 0.0)
+
+
+# ── discovery / holdout 분할 (진입일 기준, buffer 동결) ────────
+
+
+def _partition_entries(
+    entries: list[tuple[int, int]], n_days: int, holdout_frac: float, max_horizon: int
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]], int]:
+    """진입을 (discovery, holdout) 로 분할 — 경계 누설 차단.
+
+    split = 패널 마지막 frac 시작점. discovery = 만기(진입+max_horizon)가 split 이전에
+    끝나는 진입만, holdout = split 이후 진입만. 사이(경계 걸침) 진입은 제외 (buffer).
+    """
+    split = n_days - int(n_days * holdout_frac)
+    disc = [(j, t0) for j, t0 in entries if t0 + max_horizon < split]
+    hold = [(j, t0) for j, t0 in entries if t0 >= split]
+    return disc, hold, split
+
+
+# ── 룰 1개 평가 (paired ΔSharpe + 순열 gate) ──────────────────
+
+
+def _delta_sharpe(
+    close: pd.DataFrame,
+    entries: list[tuple[int, int]],
+    rule: dict,
+    base_rule: dict,
+    fx_ret: np.ndarray,
+    cost_bps: float,
+    haircut_daily: float,
+    max_horizon: int,
+) -> tuple[float, float, np.ndarray]:
+    """ΔSharpe(rule − base) + rule Sharpe + rule 일별 KRW 시계열."""
+    s_r, c_r = _simulate_rule(close, entries, rule, cost_bps, max_horizon)
+    s_b, c_b = _simulate_rule(close, entries, base_rule, cost_bps, max_horizon)
+    kr = _rule_daily_krw(s_r, c_r, fx_ret, haircut_daily)
+    kb = _rule_daily_krw(s_b, c_b, fx_ret, haircut_daily)
+    sr, sb = _sharpe_from_returns(kr), _sharpe_from_returns(kb)
+    return sr - sb, sr, kr
+
+
+def run_exit_search(
+    *,
+    cost_bps: float,
+    fx_series: pd.Series,
+    close: Optional[pd.DataFrame] = None,
+    db_path: Optional[Path] = None,
+    config: Optional[dict] = None,
+    persist: bool = False,
+) -> dict[str, Any]:
+    """pre-registered exit 룰 전체를 paired 순열 gate 로 측정 → 결과 표 + 승격 자격.
+
+    cost_bps / fx_series 필수 (gross/통화-naive 검증 차단). persist=True 면 룰별 1행을
+    backtests(`wf-exit:*`) 에 기록.
+    """
+    if cost_bps is None:
+        raise ValueError("cost_bps required — gross(거래비용 미반영) 검증은 승격 근거로 금지")
+    if fx_series is None:
+        raise ValueError("fx_series (KRW/USD) required — 통화-naive 검증은 승격 근거로 금지")
+
+    cfg = config or _load_exits_config()
+    if close is None:
+        close, _vol = _build_panels(cfg, db_path=db_path)
+    if close.empty or len(close) < 2:
+        raise ValueError("insufficient price history after panel quality filter")
+
+    rules: list[dict] = cfg["rules"]
+    bases = [r for r in rules if r.get("baseline")]
+    if len(bases) != 1:
+        raise ValueError("exactly one baseline rule (E0) required")
+    base_rule = bases[0]
+    n_test = len(rules) - 1
+    alpha = float(cfg["gate"]["permutation"]["alpha"])
+    alpha_eff = alpha / max(n_test, 1)
+
+    ecfg = cfg["entries"]
+    max_horizon = int(ecfg["max_horizon"])
+    haircut_daily = cfg["costs"]["survivorship_haircut_bps_annual"] / 10000.0 / 252.0
+    fx_ret = fx_series.pct_change(fill_method=None).reindex(close.index).fillna(0.0).to_numpy()
+
+    entries = _sample_entries(close, ecfg)
+    disc, hold, split = _partition_entries(entries, len(close), cfg["holdout"]["frac"], max_horizon)
+    if not disc:
+        raise ValueError("no discovery entries — panel too short for max_horizon + holdout")
+
+    perm = cfg["gate"]["permutation"]
+    n_perm = int(perm["n"])
+    min_delta = float(cfg["gate"]["min_delta_sharpe"])
+
+    results: list[dict[str, Any]] = []
+    for rule in rules:
+        name = rule["name"]
+        logger.info("evaluating exit rule %s ...", name)
+        is_base = bool(rule.get("baseline", False))
+        delta, sharpe, kr = _delta_sharpe(close, disc, rule, base_rule, fx_ret, cost_bps, haircut_daily, max_horizon)
+
+        # 순열 null: 셔플 경로에서 같은 paired Δ 를 만들면 mechanical artifact.
+        # seed 리셋 → 순열 j 가 룰 간 공유 (#706 과 동일한 공정 비교).
+        p_value = 1.0
+        null_p95 = float("nan")
+        if not is_base:
+            rng = np.random.default_rng(int(perm["seed"]))
+            null_delta = np.empty(n_perm)
+            for i in range(n_perm):
+                pc = _permute_prices(close, rng)
+                null_delta[i], _, _ = _delta_sharpe(
+                    pc, disc, rule, base_rule, fx_ret, cost_bps, haircut_daily, max_horizon
+                )
+            p_value = float((np.sum(null_delta >= delta) + 1) / (n_perm + 1)) if n_perm else 1.0
+            null_p95 = float(np.percentile(null_delta, 95)) if n_perm else float("nan")
+
+        discovery = (not is_base) and p_value < alpha_eff and delta > min_delta
+
+        # FROZEN holdout: 발견 통과 룰만 1회 개봉 (#706 codex P1 봉인 규약 상속)
+        holdout_delta: Optional[float] = None
+        holdout_ok = False
+        if discovery and hold:
+            holdout_delta, _, _ = _delta_sharpe(
+                close, hold, rule, base_rule, fx_ret, cost_bps, haircut_daily, max_horizon
+            )
+            holdout_ok = holdout_delta >= float(cfg["gate"]["min_holdout_delta"])
+
+        results.append(
+            {
+                "name": name,
+                "baseline": is_base,
+                "theory": rule["theory"],
+                "sharpe": sharpe,
+                "delta_sharpe": None if is_base else delta,
+                "p_value": None if is_base else p_value,
+                "null_p95": None if is_base else null_p95,
+                "max_drawdown": _max_drawdown(kr),
+                "discovery_passed": bool(discovery),
+                "holdout_delta": holdout_delta,  # None = 봉인
+                "holdout_passed": bool(holdout_ok),
+                "promotion_eligible": bool(discovery and holdout_ok),
+            }
+        )
+        if persist:
+            save_backtest(
+                strategy_id=f"wf-exit:{name}",
+                start_date=pd.Timestamp(close.index[0]).strftime("%Y-%m-%d"),
+                end_date=pd.Timestamp(close.index[-1]).strftime("%Y-%m-%d"),
+                total_return=None,
+                sharpe=sharpe,
+                max_drawdown=results[-1]["max_drawdown"],
+                win_rate=None,
+                params={
+                    k: results[-1][k]
+                    for k in (
+                        "baseline",
+                        "theory",
+                        "delta_sharpe",
+                        "p_value",
+                        "discovery_passed",
+                        "holdout_delta",
+                        "holdout_passed",
+                        "promotion_eligible",
+                    )
+                }
+                | {"cost_bps": cost_bps, "n_entries_discovery": len(disc), "alpha_effective": alpha_eff},
+                db_path=db_path,
+            )
+
+    return {
+        "universe_n": close.shape[1],
+        "panel_start": pd.Timestamp(close.index[0]).strftime("%Y-%m-%d"),
+        "panel_end": pd.Timestamp(close.index[-1]).strftime("%Y-%m-%d"),
+        "cost_bps": cost_bps,
+        "n_entries": len(entries),
+        "n_discovery": len(disc),
+        "n_holdout": len(hold),
+        "split_idx": split,
+        "n_test_rules": n_test,
+        "alpha": alpha,
+        "alpha_effective": alpha_eff,
+        "rules": results,
+        "promotion_eligible": [r["name"] for r in results if r["promotion_eligible"]],
+    }
+
+
+def run_exit_validation(
+    cost_bps: float = 10.0,
+    db_path: Optional[Path] = None,
+    config: Optional[dict] = None,
+    persist: bool = True,
+) -> dict[str, Any]:
+    """CLI 진입점: prices(DB) + usd_krw(macro) 로드 → exit search → (persist 시) 기록."""
+    from nuri.quant.validation.strategy_walkforward import _load_fx_series
+
+    fx = _load_fx_series(db_path)
+    return run_exit_search(cost_bps=cost_bps, fx_series=fx, db_path=db_path, config=config, persist=persist)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: python -m nuri.quant.validation.exit_walkforward [--cost-bps 10] [--no-persist]"""
+    import argparse
+    import json as _json
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(prog="exit-walkforward")
+    parser.add_argument("--cost-bps", type=float, default=10.0, help="거래비용 (bps, 필수 가정)")
+    parser.add_argument("--no-persist", action="store_true", help="backtests 기록 생략")
+    args = parser.parse_args(argv)
+
+    try:
+        r = run_exit_validation(cost_bps=args.cost_bps, persist=not args.no_persist)
+    except ValueError as exc:
+        print(_json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+    print(f"\n{'=' * 80}")
+    print("  P4 Exit-Rule Walk-Forward (#713) — paired vs e0_ladder")
+    print(
+        f"  Universe {r['universe_n']} | {r['panel_start']}..{r['panel_end']} | cost {r['cost_bps']}bps"
+        f" | entries {r['n_discovery']}d/{r['n_holdout']}h | Bonferroni {r['alpha']}/{r['n_test_rules']}"
+        f" = {r['alpha_effective']:.4f}"
+    )
+    print(f"{'=' * 80}")
+    print(f"  {'rule':<16}{'Sharpe':>8}{'ΔvsE0':>8}{'p':>8}{'null95':>8}{'maxDD':>8}{'holdoutΔ':>10}  verdict")
+    for v in r["rules"]:
+        verdict = "PROMOTE-ELIGIBLE" if v["promotion_eligible"] else ("baseline" if v["baseline"] else "FAIL")
+        ds = f"{v['delta_sharpe']:>+8.3f}" if v["delta_sharpe"] is not None else f"{'—':>8}"
+        pv = f"{v['p_value']:>8.3f}" if v["p_value"] is not None else f"{'—':>8}"
+        np95 = f"{v['null_p95']:>+8.2f}" if v["null_p95"] is not None else f"{'—':>8}"
+        hd = f"{v['holdout_delta']:>+10.3f}" if v["holdout_delta"] is not None else f"{'sealed':>10}"
+        print(f"  {v['name']:<16}{v['sharpe']:>+8.3f}{ds}{pv}{np95}{v['max_drawdown']:>+8.2f}{hd}  {verdict}")
+    print(f"\n  >>> promotion-eligible: {r['promotion_eligible'] or 'NONE — 현행 E0 ladder 유지가 데이터 기반 디폴트'}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/nuri/quant/validation/exit_walkforward.py
+++ b/nuri/quant/validation/exit_walkforward.py
@@ -259,6 +259,10 @@ def run_exit_search(
     bases = [r for r in rules if r.get("baseline")]
     if len(bases) != 1:
         raise ValueError("exactly one baseline rule (E0) required")
+    # MA 룰은 진입 시점에 MA 가 계산 가능해야 사전등록 룰 그대로 평가됨 (codex R2 guardrail)
+    for r in rules:
+        if "trail_ma" in r and int(cfg["entries"]["warmup"]) < int(r["trail_ma"]):
+            raise ValueError(f"{r['name']}: entries.warmup must be >= trail_ma ({r['trail_ma']})")
     base_rule = bases[0]
     n_test = len(rules) - 1
     alpha = float(cfg["gate"]["permutation"]["alpha"])

--- a/nuri/quant/validation/exit_walkforward.py
+++ b/nuri/quant/validation/exit_walkforward.py
@@ -61,13 +61,15 @@ def _sample_entries(close: pd.DataFrame, ecfg: dict) -> list[tuple[int, int]]:
         raise ValueError(f"panel too short for entries: warmup={lo}, days={n_days}")
     out: list[tuple[int, int]] = []
     target = int(ecfg["n"])
-    # 유효 진입(종가 존재)만 수집 — 무한루프 방지 상한
+    # 유효 진입만 수집 — 진입 종가 + **per-ticker warmup 히스토리**(t0-warmup 시점 비NaN)
+    # 둘 다 요구 (codex P2: 히스토리 없으면 E1 의 MA 가 미계산이라 stop-only 로 퇴화 —
+    # pre-registered 룰과 다른 룰을 평가하게 됨). ffill 패널이라 t0-warmup 비NaN ⇒ 구간 연속.
     for _ in range(target * 10):
         if len(out) >= target:
             break
         j = int(rng.integers(0, n_cols))
         t0 = int(rng.integers(lo, hi + 1))
-        if not np.isnan(arr[t0, j]):
+        if not np.isnan(arr[t0, j]) and not np.isnan(arr[t0 - lo, j]):
             out.append((j, t0))
     if len(out) < target:
         logger.warning("entries: %d/%d sampled (sparse panel)", len(out), target)
@@ -191,6 +193,19 @@ def _partition_entries(
 # ── 룰 1개 평가 (paired ΔSharpe + 순열 gate) ──────────────────
 
 
+def _exposure_mask(entries: list[tuple[int, int]], n_days: int, max_horizon: int) -> np.ndarray:
+    """진입 subset 의 잠재 보유일 합집합 mask (룰-무관 — 진입에만 의존).
+
+    codex P1: Sharpe 를 전체 캘린더(반대 구간의 0-수익 stretch 포함)로 계산하면 Sharpe
+    비선형성 때문에 공동 0-구간이 Δ 에 비중립적으로 작용. 평가 창을 이 mask 로 한정하면
+    discovery/holdout 교차 오염이 사라지고, mask 가 룰과 무관하므로 paired 공정성 유지.
+    """
+    mask = np.zeros(n_days, dtype=bool)
+    for _, t0 in entries:
+        mask[t0 + 1 : min(t0 + max_horizon, n_days - 1) + 1] = True
+    return mask
+
+
 def _delta_sharpe(
     close: pd.DataFrame,
     entries: list[tuple[int, int]],
@@ -201,13 +216,18 @@ def _delta_sharpe(
     haircut_daily: float,
     max_horizon: int,
 ) -> tuple[float, float, np.ndarray]:
-    """ΔSharpe(rule − base) + rule Sharpe + rule 일별 KRW 시계열."""
+    """ΔSharpe(rule − base) + rule Sharpe + rule 일별 KRW 시계열 (노출 mask 한정).
+
+    Sharpe 는 진입 subset 의 잠재 노출일에서만 계산 — discovery 평가에 holdout 구간의
+    0-수익 꼬리가 (또는 그 반대가) 섞이지 않는다 (codex P1).
+    """
     s_r, c_r = _simulate_rule(close, entries, rule, cost_bps, max_horizon)
     s_b, c_b = _simulate_rule(close, entries, base_rule, cost_bps, max_horizon)
     kr = _rule_daily_krw(s_r, c_r, fx_ret, haircut_daily)
     kb = _rule_daily_krw(s_b, c_b, fx_ret, haircut_daily)
-    sr, sb = _sharpe_from_returns(kr), _sharpe_from_returns(kb)
-    return sr - sb, sr, kr
+    mask = _exposure_mask(entries, len(kr), max_horizon)
+    sr, sb = _sharpe_from_returns(kr[mask]), _sharpe_from_returns(kb[mask])
+    return sr - sb, sr, kr[mask]
 
 
 def run_exit_search(

--- a/tests/quant/test_main_runpy.py
+++ b/tests/quant/test_main_runpy.py
@@ -124,6 +124,15 @@ class TestBacktestMainRunpy:
             runpy.run_module("nuri.quant.validation.variant_walkforward", run_name="__main__")
         assert exc.value.code == 2  # FX 부재 graceful error
 
+    def test_exit_walkforward_main(self, monkeypatch, db_path_mp):
+        """exit_walkforward main: 빈 DB → usd_krw 부재 → graceful error(exit 2). __main__ guard 커버."""
+        monkeypatch.setattr(sys, "argv", ["exit_walkforward"])
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        monkeypatch.setattr(sys, "stderr", io.StringIO())
+        with pytest.raises(SystemExit) as exc:
+            runpy.run_module("nuri.quant.validation.exit_walkforward", run_name="__main__")
+        assert exc.value.code == 2  # FX 부재 graceful error
+
     def test_optimizer_main(self, monkeypatch, db_path_mp):
         """optimizer main without --signal: optimize_all branch."""
         # Patch optimize_all to a no-op (it iterates many signals)

--- a/tests/quant/validation/test_exit_walkforward.py
+++ b/tests/quant/validation/test_exit_walkforward.py
@@ -237,6 +237,19 @@ class TestRunner:
         with pytest.raises(ValueError, match="fx_series"):
             run_exit_search(cost_bps=10.0, fx_series=None, close=p, config=SMALL_CFG)
 
+    def test_warmup_must_cover_trail_ma(self):
+        # warmup < trail_ma 면 진입 시 MA 미계산 → 사전등록과 다른 룰 평가 → 거부 (codex R2)
+        p = _panel()
+        cfg = {
+            **SMALL_CFG,
+            "rules": [
+                {"name": "e0", "baseline": True, "theory": "c", "stop_pct": -7},
+                {"name": "e1", "theory": "t", "trail_ma": 50},  # warmup 3 < 50
+            ],
+        }
+        with pytest.raises(ValueError, match="warmup must be >= trail_ma"):
+            run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=cfg)
+
     def test_requires_exactly_one_baseline(self):
         p = _panel()
         cfg = {**SMALL_CFG, "rules": [{"name": "a", "theory": "t", "stop_pct": -7}]}

--- a/tests/quant/validation/test_exit_walkforward.py
+++ b/tests/quant/validation/test_exit_walkforward.py
@@ -1,0 +1,386 @@
+"""Lock-tests for P4 exit-rule walk-forward (#713).
+
+- _resolve_exit known-answer: stop / TP ladder partial / trailing(HWM) / MA 이탈 /
+  buy-hold horizon / 같은 날 full-exit > TP 우선 (체결 규약 동결)
+- _simulate_rule: 매도 다음날부터 fraction 축소 (same-bar 규약) + 비용 부과
+- paired: 동일 룰 vs 자기 자신 → Δ=0 (paired 비교의 sanity)
+- mandatory gate: cost/fx 필수, baseline 정확히 1개
+- discovery/holdout 분할: buffer (경계 걸침 진입 제외)
+- holdout 봉인: 발견 미통과 룰은 holdout_delta=None
+- 랜덤워크: promotion 자격 없음 (#701 원칙 상속)
+- persist + CLI
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from nuri.quant.validation.exit_walkforward import (
+    _load_exits_config,
+    _partition_entries,
+    _resolve_exit,
+    _sample_entries,
+    _simulate_rule,
+    run_exit_search,
+)
+
+SMALL_CFG = {
+    "panel": {"exclude_tickers": ["KOSDAQ"], "min_history": 5, "min_breadth": 2},
+    "entries": {"n": 40, "seed": 0, "max_horizon": 10, "warmup": 3},
+    "holdout": {"frac": 0.2},
+    "costs": {"survivorship_haircut_bps_annual": 200},
+    "gate": {
+        "permutation": {"n": 10, "alpha": 0.05, "seed": 0},
+        "multiple_comparison": "bonferroni",
+        "min_delta_sharpe": 0.0,
+        "min_holdout_delta": 0.0,
+    },
+    "rules": [
+        {
+            "name": "e0",
+            "baseline": True,
+            "theory": "control",
+            "stop_pct": -7,
+            "tp1": {"pct": 20, "sell": 0.5},
+            "tp2": {"pct": 40, "sell": 0.25},
+            "trailing_pct": -15,
+        },
+        {"name": "e4", "theory": "stop only", "stop_pct": -7},
+    ],
+}
+
+
+def _panel(n: int = 60, tickers=("AAA", "BBB", "CCC", "DDD")) -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=n, freq="B")
+    data = {}
+    for k, t in enumerate(tickers):
+        steps = 0.001 * (k + 1) + 0.002 * np.sin(np.arange(n))
+        data[t] = 100.0 * np.cumprod(1.0 + steps)
+    return pd.DataFrame(data, index=dates)
+
+
+def _flat_fx(idx: pd.Index) -> pd.Series:
+    return pd.Series(1300.0, index=idx, dtype=float)
+
+
+# ── _resolve_exit known-answer (결정론) ────────────────────────
+
+
+class TestResolveExit:
+    def test_stop_first_crossing(self):
+        c = np.array([100.0, 98.0, 92.0, 90.0])  # day2 에 -8% (≤ -7%)
+        liq, events = _resolve_exit(c, None, {"stop_pct": -7}, horizon=10)
+        assert liq == 2
+        assert events == [(2, 1.0)]
+
+    def test_tp_ladder_partials_then_trailing(self):
+        # day1 +20%(TP1 50%), day2 +40%(TP2 25%), day4 고점대비 -15%(트레일 잔여 청산)
+        c = np.array([100.0, 120.0, 140.0, 141.0, 119.0])
+        rule = {"stop_pct": -7, "tp1": {"pct": 20, "sell": 0.5}, "tp2": {"pct": 40, "sell": 0.25}, "trailing_pct": -15}
+        liq, events = _resolve_exit(c, None, rule, horizon=10)
+        assert liq == 4  # 119 ≤ 141 × 0.85 = 119.85
+        assert (1, 0.5) in events and (2, 0.25) in events
+        assert events[-1] == (4, pytest.approx(0.25))
+
+    def test_trailing_uses_high_water_mark(self):
+        # 고점 130 후 110 = -15.4% → 트레일 발동 (진입가 대비는 +10% 인데도)
+        c = np.array([100.0, 130.0, 125.0, 110.0])
+        liq, events = _resolve_exit(c, None, {"trailing_pct": -15}, horizon=10)
+        assert liq == 3
+        assert events == [(3, 1.0)]
+
+    def test_ma_exit_and_nan_ma_holds(self):
+        c = np.array([100.0, 101.0, 102.0, 95.0])
+        ma = np.array([np.nan, np.nan, 100.0, 100.0])  # MA 미계산 구간은 보유
+        liq, _ = _resolve_exit(c, ma, {"trail_ma": 3}, horizon=10)
+        assert liq == 3  # day3: 95 < MA 100 (day1-2 는 NaN → 무시)
+
+    def test_buy_hold_runs_to_horizon(self):
+        c = np.array([100.0, 50.0, 40.0, 30.0, 20.0])  # 어떤 폭락에도 무반응
+        liq, events = _resolve_exit(c, None, {}, horizon=3)
+        assert liq == 3
+        assert events == [(3, 1.0)]
+
+    def test_same_day_full_exit_beats_tp(self):
+        # day1 에 +20%(TP1) 와 고점대비 트레일이 동시 발생할 수 없으므로 stop 동시 케이스:
+        # 진입 후 day1 에 TP1 도달가 = stop 도달가가 양립 불가 → trailing 동시 케이스로 검증.
+        # c: day1 +25% (TP1 충족) 이면서 고점(125) 대비 0% — 트레일 미발동. day2 폭락으로
+        # 같은 날 TP2(미충족)·트레일 발동 → full-exit 이 잔여 전량.
+        c = np.array([100.0, 125.0, 106.0])  # day2: 106 ≤ 125×0.85=106.25 → 트레일
+        rule = {"tp1": {"pct": 20, "sell": 0.5}, "tp2": {"pct": 40, "sell": 0.25}, "trailing_pct": -15}
+        liq, events = _resolve_exit(c, None, rule, horizon=10)
+        assert liq == 2
+        assert events == [(1, 0.5), (2, pytest.approx(0.5))]  # TP2 는 liq 이후 → 무효
+
+    def test_horizon_caps_window(self):
+        c = np.full(12, 100.0)
+        liq, _ = _resolve_exit(c, None, {"stop_pct": -7}, horizon=5)
+        assert liq == 5
+
+
+# ── _simulate_rule: fraction 타이밍 + 비용 ─────────────────────
+
+
+class TestSimulateRule:
+    def test_sell_reduces_fraction_next_day(self):
+        # 단일 포지션: day1 +20% → TP1 50% 매도 → day2 수익은 fraction 0.5 로만 적립
+        idx = pd.date_range("2024-01-01", periods=4, freq="B")
+        close = pd.DataFrame({"X": [100.0, 120.0, 132.0, 132.0]}, index=idx)
+        rule = {"tp1": {"pct": 20, "sell": 0.5}}
+        s, c = _simulate_rule(close, [(0, 0)], rule, cost_bps=0.0, max_horizon=10)
+        assert s[1] == pytest.approx(0.20)  # day1: 전량 보유 +20%
+        assert s[2] == pytest.approx(0.5 * 0.10)  # day2: 잔여 0.5 × +10%
+        assert c[1] == 1.0 and c[2] == 1.0
+
+    def test_cost_charged_on_trades(self):
+        idx = pd.date_range("2024-01-01", periods=3, freq="B")
+        close = pd.DataFrame({"X": [100.0, 100.0, 100.0]}, index=idx)
+        free, _ = _simulate_rule(close, [(0, 0)], {}, cost_bps=0.0, max_horizon=2)
+        paid, _ = _simulate_rule(close, [(0, 0)], {}, cost_bps=100.0, max_horizon=2)
+        assert paid.sum() < free.sum()  # 진입 1.0 + 청산 1.0 비용 부과
+
+    def test_trail_ma_rule_in_simulation(self):
+        # trail_ma 룰이 MA 패널 계산 경로를 타는지 (MA 이탈 → 청산 후 비활성)
+        idx = pd.date_range("2024-01-01", periods=10, freq="B")
+        px = np.array([100.0, 101, 102, 103, 104, 105, 90, 89, 88, 87])
+        close = pd.DataFrame({"X": px}, index=idx)
+        s, c = _simulate_rule(close, [(0, 0)], {"trail_ma": 3}, cost_bps=0.0, max_horizon=9)
+        # day6(90) 에서 MA3 이탈 → 청산 → day7+ 비활성
+        assert c[6] == 1.0 and c[7] == 0.0
+
+    def test_inactive_days_zero(self):
+        idx = pd.date_range("2024-01-01", periods=6, freq="B")
+        close = pd.DataFrame({"X": np.linspace(100, 105, 6)}, index=idx)
+        s, c = _simulate_rule(close, [(0, 2)], {}, cost_bps=0.0, max_horizon=2)
+        assert c[1] == 0.0 and c[3] == 1.0 and c[5] == 0.0  # 진입 전/청산 후 비활성
+
+
+# ── 진입 샘플링 / 분할 ─────────────────────────────────────────
+
+
+class TestEntries:
+    def test_sample_deterministic_and_valid(self):
+        p = _panel()
+        e1 = _sample_entries(p, {"n": 20, "seed": 0, "warmup": 3, "max_horizon": 10})
+        e2 = _sample_entries(p, {"n": 20, "seed": 0, "warmup": 3, "max_horizon": 10})
+        assert e1 == e2  # seed 고정 → 재현 (paired 전제)
+        assert all(t0 >= 3 for _, t0 in e1)
+
+    def test_partition_buffer_excludes_straddlers(self):
+        # n_days=100, frac 0.2 → split=80. horizon 10 → discovery 는 t0+10<80 (t0≤69),
+        # holdout 은 t0≥80, 70..79 진입은 buffer 로 제외.
+        entries = [(0, 50), (0, 69), (0, 75), (0, 80), (0, 90)]
+        disc, hold, split = _partition_entries(entries, 100, 0.2, 10)
+        assert split == 80
+        assert (0, 50) in disc and (0, 69) in disc
+        assert (0, 75) not in disc and (0, 75) not in hold  # buffer
+        assert (0, 80) in hold and (0, 90) in hold
+
+    def test_too_short_panel_raises(self):
+        p = _panel(n=4)
+        with pytest.raises(ValueError, match="panel too short"):
+            _sample_entries(p, {"n": 5, "seed": 0, "warmup": 3, "max_horizon": 10})
+
+    def test_sparse_panel_skips_nan_and_warns(self, caplog):
+        # 유효 진입 구간이 전부 NaN → NaN 진입 스킵 + 목표 미달 warning
+        import logging as _logging
+
+        idx = pd.date_range("2024-01-01", periods=10, freq="B")
+        col = np.full(10, np.nan)
+        col[0] = 100.0  # warmup(3) 이전에만 유효 → 진입 가능 조합 0
+        p = pd.DataFrame({"A": col, "B": col}, index=idx)
+        with caplog.at_level(_logging.WARNING):
+            entries = _sample_entries(p, {"n": 5, "seed": 0, "warmup": 3, "max_horizon": 5})
+        assert entries == []  # NaN 진입은 전부 스킵
+        assert "sampled" in caplog.text  # 목표 미달 → warning
+
+
+# ── runner / gate ──────────────────────────────────────────────
+
+
+class TestRunner:
+    def test_refuses_without_cost_or_fx(self):
+        p = _panel()
+        with pytest.raises(ValueError, match="cost_bps"):
+            run_exit_search(cost_bps=None, fx_series=_flat_fx(p.index), close=p, config=SMALL_CFG)
+        with pytest.raises(ValueError, match="fx_series"):
+            run_exit_search(cost_bps=10.0, fx_series=None, close=p, config=SMALL_CFG)
+
+    def test_requires_exactly_one_baseline(self):
+        p = _panel()
+        cfg = {**SMALL_CFG, "rules": [{"name": "a", "theory": "t", "stop_pct": -7}]}
+        with pytest.raises(ValueError, match="baseline"):
+            run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=cfg)
+
+    def test_result_shape_and_bonferroni(self):
+        p = _panel()
+        r = run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=SMALL_CFG)
+        assert r["n_test_rules"] == 1
+        assert r["alpha_effective"] == pytest.approx(0.05)
+        names = [v["name"] for v in r["rules"]]
+        assert names == ["e0", "e4"]
+        e0 = r["rules"][0]
+        assert e0["baseline"] is True
+        assert e0["delta_sharpe"] is None and e0["p_value"] is None  # 대조군은 Δ/p 없음
+        assert e0["promotion_eligible"] is False
+
+    def test_identical_rule_paired_delta_zero(self):
+        # 자기 자신과의 paired Δ = 정확히 0 (순열 불요 — _delta_sharpe 직접)
+        from nuri.quant.validation.exit_walkforward import _delta_sharpe
+
+        p = _panel()
+        fx_ret = np.zeros(len(p))
+        rule = {"name": "x", "stop_pct": -7}
+        d, _, _ = _delta_sharpe(p, [(0, 5), (1, 10)], rule, rule, fx_ret, 10.0, 0.0, 10)
+        assert d == pytest.approx(0.0)
+
+    def test_holdout_sealed_on_discovery_fail(self):
+        p = _panel()
+        r = run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=SMALL_CFG)
+        e4 = r["rules"][1]
+        # n_perm=10 → 최소 p=1/11>0.05 → discovery 불가능 → holdout 봉인
+        assert e4["discovery_passed"] is False
+        assert e4["holdout_delta"] is None
+        assert e4["promotion_eligible"] is False
+
+    def test_random_walk_no_promotion(self):
+        rng = np.random.default_rng(11)
+        idx = pd.date_range("2022-01-01", periods=100, freq="B")
+        p = pd.DataFrame({f"T{j}": 100 * np.exp(np.cumsum(rng.normal(0, 0.02, 100))) for j in range(6)}, index=idx)
+        r = run_exit_search(cost_bps=0.0, fx_series=_flat_fx(idx), close=p, config=SMALL_CFG)
+        assert r["promotion_eligible"] == []
+
+    def test_holdout_opened_when_discovery_forced(self):
+        # gate 를 결정론적으로 통과시켜(alpha 0.99 + Δ floor 바닥) holdout 개봉 경로 lock
+        p = _panel(n=80)
+        cfg = {
+            **SMALL_CFG,
+            "entries": {"n": 30, "seed": 0, "max_horizon": 5, "warmup": 3},
+            "gate": {
+                # alpha>1 → p≤1.0 이 항상 통과 (결정론적 강제 — 봉인 해제 경로 lock 전용)
+                "permutation": {"n": 10, "alpha": 1.5, "seed": 0},
+                "multiple_comparison": "bonferroni",
+                "min_delta_sharpe": -100.0,
+                "min_holdout_delta": -100.0,
+            },
+        }
+        r = run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=cfg)
+        e4 = r["rules"][1]
+        assert e4["discovery_passed"] is True
+        assert e4["holdout_delta"] is not None  # 개봉됨
+        assert e4["holdout_passed"] is True
+        assert e4["promotion_eligible"] is True
+
+    def test_no_discovery_entries_raises(self):
+        # max_horizon 이 panel 을 초과 → 모든 진입이 buffer/holdout → discovery 0
+        p = _panel(n=30)
+        cfg = {**SMALL_CFG, "entries": {"n": 10, "seed": 0, "max_horizon": 28, "warmup": 3}}
+        with pytest.raises(ValueError, match="no discovery entries"):
+            run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=cfg)
+
+    def test_persist_writes_backtests(self, db_path_mp):
+        from nuri.core.db import query
+
+        p = _panel()
+        run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, config=SMALL_CFG, persist=True)
+        rows = query("SELECT strategy_id, params FROM backtests ORDER BY strategy_id", db_path=db_path_mp)
+        assert [row["strategy_id"] for row in rows] == ["wf-exit:e0", "wf-exit:e4"]
+
+    def test_empty_db_panel_rejected(self, db_path_mp):
+        with pytest.raises(ValueError, match="panel quality filter"):
+            run_exit_search(cost_bps=10.0, fx_series=_flat_fx(pd.date_range("2024-01-01", periods=5)), config=SMALL_CFG)
+
+    def test_loads_real_config_preregistered_shape(self):
+        cfg = _load_exits_config()
+        names = [r["name"] for r in cfg["rules"]]
+        assert names == ["e0_ladder", "e1_leader_ma", "e2_trail25", "e3_buy_hold", "e4_stop_only"]
+        assert sum(1 for r in cfg["rules"] if r.get("baseline")) == 1
+        assert cfg["gate"]["multiple_comparison"] == "bonferroni"
+        # E0 은 rules.yaml 현행 값의 동결 복사 (drift 시 의도 확인 필요)
+        e0 = cfg["rules"][0]
+        assert e0["stop_pct"] == -7 and e0["tp1"]["pct"] == 20 and e0["tp2"]["pct"] == 40
+        assert e0["trailing_pct"] == -15
+        assert cfg["rules"][1]["trail_ma"] == 50
+
+
+# ── CLI ────────────────────────────────────────────────────────
+
+
+class TestCLI:
+    def test_main_success_prints_table(self, monkeypatch, capsys):
+        import nuri.quant.validation.exit_walkforward as E
+
+        fake = {
+            "universe_n": 90,
+            "panel_start": "2021-04-20",
+            "panel_end": "2026-06-04",
+            "cost_bps": 10.0,
+            "n_entries": 2000,
+            "n_discovery": 1300,
+            "n_holdout": 400,
+            "split_idx": 1000,
+            "n_test_rules": 4,
+            "alpha": 0.05,
+            "alpha_effective": 0.0125,
+            "promotion_eligible": [],
+            "rules": [
+                {
+                    "name": "e0_ladder",
+                    "baseline": True,
+                    "sharpe": 0.5,
+                    "delta_sharpe": None,
+                    "p_value": None,
+                    "null_p95": None,
+                    "max_drawdown": -0.3,
+                    "holdout_delta": None,
+                    "promotion_eligible": False,
+                },
+                {
+                    "name": "e1_leader_ma",
+                    "baseline": False,
+                    "sharpe": 0.7,
+                    "delta_sharpe": 0.2,
+                    "p_value": 0.2,
+                    "null_p95": 0.5,
+                    "max_drawdown": -0.25,
+                    "holdout_delta": None,
+                    "promotion_eligible": False,
+                },
+            ],
+        }
+        monkeypatch.setattr(E, "run_exit_validation", lambda **k: fake)
+        assert E.main([]) == 0
+        out = capsys.readouterr().out
+        assert "Bonferroni" in out
+        assert "sealed" in out
+        assert "E0 ladder 유지" in out
+
+    def test_main_error_returns_2(self, monkeypatch):
+        import nuri.quant.validation.exit_walkforward as E
+
+        def boom(**k):
+            raise ValueError("usd_krw not in macro")
+
+        monkeypatch.setattr(E, "run_exit_validation", boom)
+        assert E.main([]) == 2
+
+    def test_run_exit_validation_loads_fx(self, db_path_mp):
+        from nuri.core.db import get_db
+        from nuri.quant.validation.exit_walkforward import run_exit_validation
+
+        p = _panel()
+        with get_db(db_path_mp) as conn:
+            conn.executemany(
+                "INSERT INTO prices (ticker, date, close, volume) VALUES (?, ?, ?, ?)",
+                [(t, d.strftime("%Y-%m-%d"), float(p.loc[d, t]), 1e6) for t in p.columns for d in p.index],
+            )
+            for d in p.index:
+                conn.execute(
+                    "INSERT INTO macro (indicator, date, value) VALUES (?, ?, ?)",
+                    ("usd_krw", d.strftime("%Y-%m-%d"), 1300.0),
+                )
+        r = run_exit_validation(cost_bps=10.0, config=SMALL_CFG, persist=False)
+        assert r["universe_n"] == 4
+        assert "promotion_eligible" in r

--- a/tests/quant/validation/test_exit_walkforward.py
+++ b/tests/quant/validation/test_exit_walkforward.py
@@ -183,6 +183,35 @@ class TestEntries:
         with pytest.raises(ValueError, match="panel too short"):
             _sample_entries(p, {"n": 5, "seed": 0, "warmup": 3, "max_horizon": 10})
 
+    def test_per_ticker_warmup_history_required(self):
+        # codex P2: late-start ticker 는 자기 시작 후 warmup 일이 지나야 진입 가능
+        # (아니면 E1 의 MA 미계산 → stop-only 로 퇴화한 다른 룰을 평가)
+        idx = pd.date_range("2024-01-01", periods=30, freq="B")
+        late = np.full(30, np.nan)
+        late[20:] = 100.0  # index 20 부터 상장
+        p = pd.DataFrame({"OK": np.linspace(100, 110, 30), "LATE": late}, index=idx)
+        entries = _sample_entries(p, {"n": 100, "seed": 0, "warmup": 5, "max_horizon": 5})
+        arr = p.to_numpy()
+        for j, t0 in entries:
+            assert not np.isnan(arr[t0 - 5, j])  # t0-warmup 시점에도 히스토리 존재
+        late_j = list(p.columns).index("LATE")
+        assert all(t0 >= 25 for j, t0 in entries if j == late_j)  # 20+5 이후만
+
+    def test_exposure_mask_windows_sharpe(self):
+        # codex P1: 평가 창 밖(예: holdout 의 0-수익 꼬리)이 Δ/Sharpe 에 안 섞인다 —
+        # 동일 진입·동일 활동인데 패널 뒤에 무활동 구간을 늘려도 Δ 불변
+        from nuri.quant.validation.exit_walkforward import _delta_sharpe
+
+        short = _panel(n=40)
+        long = _panel(n=120)  # 동일 생성식 — 앞 40일 가격 동일, 뒤는 무진입 구간
+        entries = [(0, 5), (1, 10), (2, 15)]  # 활동 전부 index<30
+        fx_s, fx_l = np.zeros(40), np.zeros(120)
+        rule, base = {"stop_pct": -7}, {"trailing_pct": -15}
+        d_short, s_short, _ = _delta_sharpe(short, entries, rule, base, fx_s, 10.0, 0.0, 10)
+        d_long, s_long, _ = _delta_sharpe(long, entries, rule, base, fx_l, 10.0, 0.0, 10)
+        assert d_long == pytest.approx(d_short, rel=1e-12)
+        assert s_long == pytest.approx(s_short, rel=1e-12)
+
     def test_sparse_panel_skips_nan_and_warns(self, caplog):
         # 유효 진입 구간이 전부 NaN → NaN 진입 스킵 + 목표 미달 warning
         import logging as _logging


### PR DESCRIPTION
Closes #713

## 무엇

P4 — 실계좌를 지배하는 exit 룰의 사후검증. pre-registered 5룰(E0 현행 ladder 대조 + E1–E4)을 **랜덤 진입 Monte Carlo**(n=2000, seed 동결, 모든 룰 공유 = paired) testbed 에서 **ΔSharpe(룰−E0)** 로 비교, #707 순열 null(경로 구조 파괴) + Bonferroni α/4 + FROZEN holdout(발견 통과 시만 개봉, 진입일 기준 + 경계 buffer) gate. Sharpe 는 **룰-무관 노출 mask**(진입 subset 잠재 보유일 합집합)에서만 산출 — 교차구간 0-수익 오염 차단. #706 패널 품질 필터·규율 재사용.

## 측정 결과 (90종목 2021-04~2026-06, cost 10bps+FX+haircut, 진입 1171 discovery / 431 holdout, 200 순열)

| 룰 | 이론 | Sharpe | ΔvsE0 | p | null p95 | maxDD | 판정 |
|---|---|---|---|---|---|---|---|
| e0_ladder | O'Neil 현행 (rules.yaml 동결복사) | +0.08 | — | — | — | -0.26 | baseline |
| e1_leader_ma | #679 Minervini 50MA | -0.60 | **-0.68** | 0.706 | +0.44 | -0.55 | FAIL |
| e2_trail25 | 5-29 약식 1위 재검 | +0.33 | +0.25 | 0.721 | +0.96 | -0.29 | FAIL |
| e3_buy_hold | exit 가치 바닥 대조 | +0.67 | +0.59 | 0.990 | +1.92 | -0.33 | FAIL |
| e4_stop_only | 손절-only 최소형 | +0.53 | +0.45 | 0.687 | +1.17 | -0.27 | FAIL |

**결론: promotion-eligible = NONE — 현행 E0 ladder 유지가 데이터 기반 디폴트.**
- buy-hold 의 raw Δ+0.59 조차 p=0.99: 셔플 경로에서도 "exit 이 노출을 줄이면 drift 를 놓친다"는 기계적 노출 효과가 같은 Δ를 만든다 → null 이 정확히 흡수. **어떤 exit 변형도 경로-타이밍 가치를 노이즈 초과로 입증 못함.**
- ⚠️ **e1(50MA leader-exit) Δ −0.68**: 랜덤 진입 일반화에선 현행 ladder 보다 열위. #679 는 growth-리더 조건부라 직접 반증은 아니나 지지 증거도 없음 — **growth-조건부 표적 검증 후속 권장**.
- FROZEN holdout 미개봉 (봉인 보존). 결과 `backtests` `wf-exit:*` persist.

## codex review (2 round)

- R1 **P1**: discovery/holdout Sharpe 가 전체 캘린더(반대 구간 0-수익 stretch 포함)로 계산 → Sharpe 비선형성으로 Δ 오염 → **노출 mask**(진입에만 의존, 룰-무관 → paired 공정) 한정으로 수정. **P2**: late-start ticker 에서 E1 의 MA 미계산 → stop-only 퇴화(사전등록과 다른 룰) → 진입 샘플링에 per-ticker warmup 히스토리 요건 추가. 시뮬레이션 자체(first-crossing/우선순위/fraction 타이밍/비용/HWM)는 "internally consistent" 확인.
- 수정 후 재측정 — 결론 불변 (전 룰 FAIL).

## 검증

- 신규 모듈 100% statement+branch (31 lock-tests + runpy guard) — mask 윈도잉 불변성·per-ticker warmup lock 포함
- `make test-fast`: 5998 passed, TOTAL 100% / `make verify-doc-counts`: 13/13 (264→265)
- pre-registration: 이슈 #713 + config 를 측정 전 commit (1st commit), 측정은 그 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)
