### PR TITLE
fix(test): anchor buy-candidate emitter seed prices to today_kst

### DIFF
--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 from nuri.core.db import get_db, init_db, upsert_portfolio, upsert_prices
+from nuri.core.timezone import today_kst
 from nuri.trading.recommend.buy_candidate_emitter import (
     LEVERAGE_ETFS,
     BuyCandidate,
@@ -78,8 +79,13 @@ def _seed_factor(db_path, ticker: str, composite: float):
 
 
 def _seed_prices(db_path, ticker: str, closes: list[float]):
-    """Backfill ~45 trading days ending today."""
-    dates = pd.bdate_range(end="2026-04-30", periods=len(closes))
+    """Backfill ~45 trading days ending today.
+
+    end 를 today 로 고정(상대일)해야 emitter 의 ``date('now', '-45 days')``
+    윈도우 안에 들어온다. 고정 절대일로 두면 시간이 흐를수록 윈도우 밖으로
+    밀려 ``len(grp) < 6`` 으로 skip → scored=0 회귀 (time-bomb).
+    """
+    dates = pd.bdate_range(end=today_kst(), periods=len(closes))
     df = pd.DataFrame(
         {
             "ticker": ticker,


### PR DESCRIPTION
## Summary

`tests/trading/recommend/test_buy_candidate_emitter.py` had a **time-bomb seed**: `_seed_prices` hardcoded `pd.bdate_range(end="2026-04-30", ...)`, but the emitter (`buy_candidate_emitter.py:210`) filters prices with `WHERE date >= date('now', '-45 days')` and skips any ticker with `len(grp) < 6` in-window rows (line 216).

As real time advanced past the seed date, the number of seeded rows inside the 45-day window dropped below 6 → ticker skipped → `scored=0` → blocked. This surfaced on **2026-06-08** (~39 days after the seed date) on the post-merge full-CI run, failing 3 tests:
- `test_vix_caution_halves_allocation`
- `test_emit_above_threshold`
- `test_allocation_split_by_score`

The PR-path CI didn't catch it because the triggering merges were frontend-only (dependabot), and path-based change detection skips backend tests.

**Fix:** anchor the seed `end` to `today_kst()` so the synthetic price history always lands inside the emitter's relative window. This matches the docstring's own stated intent ("Backfill ~45 trading days ending today"). Production code is unchanged — the 45-day window is intentional.

Only `_seed_prices` rotted; factors/signals/regime seeds use `MAX(date)` / `ORDER BY date DESC` and are absolute-date-independent.

## Test Coverage
Test-only change. Full file green:
- `pytest tests/trading/recommend/test_buy_candidate_emitter.py` → **29 passed**
- `pytest tests/trading/recommend/` → **453 passed**

## Pre-Landing Review
No issues. Surgical, single-file, single-helper change. `today_kst()` returns a `date` accepted by `pd.bdate_range`; verified by the green suite.

## Test plan
- [x] Reproduced the 3 failures locally before the fix
- [x] All 29 emitter tests pass after the fix
- [x] Full recommend suite (453 tests) green
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)