### PR TITLE
docs(tests): add time-bomb seed-date gotcha with Gotcha-Test Pair

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -42,6 +42,10 @@ patch.dict(sys.modules, {"openbb": mock_module})
 ### vi.mock() hoisting (frontend tests)
 `vi.mock("recharts")` affects ALL dynamic imports in the same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**.
 
+### Time-bomb seed dates (relative `now`-window queries)
+코드가 `date('now', '-N days')` 윈도우 + 최소 행 수 임계값으로 필터하면(예: `buy_candidate_emitter._get_price_signals`, 45일 윈도우 + `len(grp) < 6` skip), **고정 절대일로 seed한 fixture 는 wall-clock 이 지나며 윈도우 밖으로 밀려 silent 하게 누락**된다. 합성 가격/날짜 fixture 의 `end` 는 항상 `today_kst()` 로 앵커링 — 리터럴 날짜 금지. (#721: `end="2026-04-30"` → 39일 후 scored=0 회귀)
+**Test:** `tests/trading/recommend/test_buy_candidate_emitter.py::test_vix_caution_halves_allocation` (+`test_emit_above_threshold`, `test_allocation_split_by_score`) — 고정일로 되돌리면 즉시 FAIL.
+
 ## Privacy in Test Data
 
 Never use real broker names, holdings, prices, or account identifiers. Use placeholders: `Brokerage Alpha`, `Brokerage Beta`, round-million values like `1_000_000`.


### PR DESCRIPTION
## Summary

Records the fix-pattern from #721 as a Gotcha-Test Pair in `tests/CLAUDE.md`, per STRATEGY §5.3.1 (every saved fix-pattern gotcha must cite a regression test that fails if reverted) and the Flow phase-7 Reflect requirement.

**Gotcha:** code filtering on a relative `date('now', '-N days')` window plus a minimum-row threshold (e.g. `buy_candidate_emitter._get_price_signals`: 45-day window + `len(grp) < 6` skip) silently drops fixtures seeded at a hardcoded past date as wall-clock advances. Anchor synthetic price/date fixtures to `today_kst()`, never a literal date.

**Test cited:** `test_buy_candidate_emitter.py::test_vix_caution_halves_allocation` (+ `test_emit_above_threshold`, `test_allocation_split_by_score`). Verified: reverting the seed to `end="2026-04-30"` fails all 3 today.

## Test Coverage
Doc-only change. `make verify-doc-counts` → 13/13 passed.

## Pre-Landing Review
No issues — single gotcha entry, matches existing `tests/CLAUDE.md` gotcha format.

## Test plan
- [x] `make verify-doc-counts` green (no count drift)
- [x] Confirmed cited regression tests fail on revert (Gotcha-Test Pair validity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)