### PR TITLE
fix(deps): lift fastapi pin via uv override for starlette security (#63)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,13 @@ dependencies = [
     "discord.py>=2.7.1",
 
     # ─── API server ───────────────────────────────────────────
-    # openbb-core>=1.6.3 requires fastapi>=0.128.0,<0.129.0 — lower bound
-    # pinned to that range until openbb relaxes its fastapi constraint (#277).
-    # uv.lock resolves to fastapi 0.128.8 which carries all current security
-    # fixes we need. Dependabot will keep proposing newer versions; ignore
-    # the PR until openbb unblocks.
-    "fastapi>=0.128.0,<0.129.0",
+    # openbb-core(최신 1.6.10까지) 가 fastapi>=0.128.0,<0.129.0 로 하드 핀하나,
+    # 그 핀은 openbb 자체 REST 서버 서브기능용 — nuri 는 openbb 를 라이브러리
+    # (obb.*) 로만 쓰고 openbb 의 fastapi 서버를 호출하지 않는다(grep 확인).
+    # 따라서 [tool.uv] override 로 fastapi/starlette 를 핀 너머로 강제한다
+    # (#277 → starlette ≤1.0.0 Host-header bypass 패치는 starlette≥1.0.1 = fastapi≥0.133
+    # 에서만 가능). 런타임 호환 실측: API 545 + 전체 5992 테스트 green.
+    "fastapi>=0.128.0",
     "httpx>=0.27.0",
     "uvicorn>=0.32.0",
 
@@ -122,6 +123,13 @@ override-dependencies = [
     # aiohttp-client-cache) 전부 aiohttp 제약 (any) 라 floor 만 강제.
     # 3.13.4 → 3.14.0 minor bump (실측: test suite green).
     "aiohttp>=3.14.0",
+    # dependabot #63 (starlette ≤1.0.0 Host header bypass → path 보안 우회) —
+    # 패치는 starlette≥1.0.1 에만 존재, fastapi 는 0.133.0 부터 starlette 1.x
+    # 허용. openbb-core(최신 1.6.10)까지 fastapi<0.129 하드 핀이나, nuri 는
+    # openbb 의 fastapi 서버를 안 쓰므로(라이브러리 전용) override 로 강제.
+    # 실측: openbb_core/obb import OK + API 545 + 전체 5992 테스트 green.
+    "fastapi>=0.133.0",
+    "starlette>=1.0.1",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,9 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "aiohttp", specifier = ">=3.14.0" },
+    { name = "fastapi", specifier = ">=0.133.0" },
     { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "starlette", specifier = ">=1.0.1" },
 ]
 
 [[package]]
@@ -1048,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.8"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1057,9 +1059,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/72/0df5c58c954742f31a7054e2dd1143bae0b408b7f36b59b85f928f9b456c/fastapi-0.128.8.tar.gz", hash = "sha256:3171f9f328c4a218f0a8d2ba8310ac3a55d1ee12c28c949650288aee25966007", size = 375523, upload-time = "2026-02-11T15:19:36.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/37/37b07e276f8923c69a5df266bfcb5bac4ba8b55dfe4a126720f8c48681d1/fastapi-0.128.8-py3-none-any.whl", hash = "sha256:5618f492d0fe973a778f8fec97723f598aa9deee495040a8d51aaf3cf123ecf1", size = 103630, upload-time = "2026-02-11T15:19:35.209Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -2187,7 +2189,7 @@ requires-dist = [
     { name = "cvxpy", specifier = ">=1.4.0" },
     { name = "discord-py", specifier = ">=2.7.1" },
     { name = "edgartools", specifier = ">=5.0.0" },
-    { name = "fastapi", specifier = ">=0.128.0,<0.129.0" },
+    { name = "fastapi", specifier = ">=0.128.0" },
     { name = "finance-datareader", specifier = ">=0.9.110" },
     { name = "finvizfinance", specifier = ">=1.3.0" },
     { name = "fredapi", specifier = ">=0.5.2" },
@@ -4054,15 +4056,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Clears the **last** open dependabot alert (#63, starlette ≤1.0.0 Host-header validation bypass) by forcing fastapi + starlette past openbb-core's pin via `[tool.uv] override-dependencies`.

### Why it was thought "blocked" — and why it isn't
- starlette fix exists only in **≥1.0.1**; fastapi allows starlette 1.x only from **0.133.0** (it dropped the `<1.0.0` cap there).
- openbb-core (latest **1.6.10**) hard-pins `fastapi>=0.128.0,<0.129.0`.

That pin guards openbb's **own optional REST-server subfeature**. nuri uses openbb purely as a **library** (`obb.etf.info(...)`, `obb.equity.*`) and never invokes openbb's fastapi server — grep-confirmed (`openbb_core.api` / openbb app: 0 hits in `nuri/`). So the fastapi version is irrelevant to openbb's runtime path in nuri. A uv override (same mechanism as the existing `python-multipart` and `aiohttp` security floors) lifts it cleanly.

### Resolution
| Alert | Package | Status |
|---|---|---|
| #61 | aiohttp deserialization | ✅ (#723, →3.14.1) |
| #62 | aiohttp redirect cookie | ✅ (#723, →3.14.1) |
| #63 | starlette Host-header bypass | ✅ this PR (fastapi 0.128.8→0.136.3, starlette 0.52.1→1.2.1) |

openbb-core stays at 1.6.7.

## Test Coverage
Runtime compatibility measured, not assumed:
- Smoke: `openbb_core` / `obb` / `nuri.api.main` import OK under fastapi 0.136.3 + starlette 1.2.1
- API tests (starlette TestClient surface): **545 passed**
- CI-equivalent suite (`-m "not slow and not integration"`): **5992 passed, 0 failed**
- `ruff check nuri/`: clean
- `make verify-doc-counts`: 13/13

## Risk
The override permanently supersedes openbb's `fastapi<0.129` constraint, so a future openbb that genuinely needs `<X` would be masked — identical accepted-risk profile to the existing python-multipart/aiohttp overrides, each documented inline with rationale. The #277 pin comment is updated to reflect the validated lift.

## Test plan
- [x] uv lock pins fastapi 0.136.3 + starlette 1.2.1, openbb-core 1.6.7 retained
- [x] openbb library imports OK (no fastapi-server code path in nuri)
- [x] 545 API + 5992 full CI-equivalent tests green
- [x] ruff + doc-counts clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)