### PR TITLE
feat(validation): #715 leader-exit growth-conditional targeted harness (growth 34<40 → defer)

### DIFF
--- a/config/walkforward_exits_growth.yaml
+++ b/config/walkforward_exits_growth.yaml
@@ -1,0 +1,58 @@
+# #715 leader-exit growth-conditional 표적 검증 — 결과를 보기 전에 동결된 pre-registered 파라미터.
+#
+# 동기: #713(P4)에서 e1_leader_ma(50MA 이탈 청산)는 랜덤 진입 일반 testbed 에서
+#   ΔSharpe −0.68 vs E0 ladder (FAIL). 그러나 #679 leader-exit 는 growth-type 보유
+#   한정 조건부 룰이라 일반 testbed 결과가 직접 반증은 아니다. 본 검증은 진입 universe 를
+#   growth-classified(classify_stock_type==growth) 종목으로 한정해 표적 paired 측정한다.
+#
+# 규율 (#713 과 동일):
+# - 단일 검정(e1 vs E0)이므로 Bonferroni 불필요(n_test=1). 발견단계 통과 = 순열 p < alpha
+#   AND ΔSharpe > 0. 통과 룰만 FROZEN holdout 1회 개봉.
+# - E0/E1 파라미터는 config/rules.yaml 현행 값의 동결 복사. rules.yaml 변경은 통과 후 별도 STRATEGY PR.
+# - 거래비용(cost_bps)·FX(fx_series)는 매 run 필수 입력. panel/gate/holdout 은 #713 와 동일.
+#
+# 알려진 caveat: classify_stock_type 은 최신 fundamentals(pe_ratio>30) + 섹터로 분류하므로
+#   역사적 진입에 *현재* growth 멤버십을 적용한다(point-in-time 분류 불가 — 테이블에 최신만).
+#   단, 프로덕션 #679 룰도 결정 시점의 현재 데이터로 분류하므로 동일 속성이다.
+
+panel:                           # #713 동일 품질 필터 (US-only, .KS 제외)
+  exclude_tickers: [KOSDAQ, KOSPI, GC=F, TESTAA]
+  min_history: 504
+  min_breadth: 40
+
+entries:                         # 랜덤 진입 Monte Carlo — exit 기여를 진입 신호와 분리
+  universe: growth               # ★ #715: growth-classified 종목 컬럼만 진입 샘플 대상
+  n: 2000                        # (ticker, 진입일) 무작위 쌍 수
+  seed: 0                        # 재현성 (진입 set 은 두 룰이 공유 — paired 비교)
+  max_horizon: 250               # 최대 보유 영업일 (룰 미발화 시 강제 청산)
+  warmup: 60                     # 진입일 하한 (MA50 계산 가능 구간 확보)
+
+holdout:
+  frac: 0.2                      # 패널 마지막 20% 에 진입하는 포지션 = FROZEN (봉인)
+
+costs:
+  survivorship_haircut_bps_annual: 200
+
+gate:
+  permutation:
+    n: 200                       # 시간셔플 null 표본 수 (#707 first-valid anchor 재사용)
+    alpha: 0.05                  # 단일 검정 — alpha / n_test_rules = 0.05/1 = 0.05
+    seed: 0
+  multiple_comparison: bonferroni  # n_test=1 이라 실질 무효 (0.05/1)
+  min_delta_sharpe: 0.0          # ΔSharpe(e1 − E0) > 0 필수 (개선이어야 의미)
+  min_holdout_delta: 0.0         # holdout 재확인 floor
+
+# exit 룰 registry — #713 의 e0/e1 동결 복사 (단일 표적 검정).
+rules:
+  - name: e0_ladder
+    baseline: true
+    theory: "대조군 — O'Neil CAN SLIM 현행 production ladder (rules.yaml 동결 복사)"
+    stop_pct: -7
+    tp1: {pct: 20, sell: 0.5}
+    tp2: {pct: 40, sell: 0.25}
+    trailing_pct: -15            # 잔여 25% 는 고점 대비 트레일링
+
+  - name: e1_leader_ma
+    theory: "#679 leader-exit growth-한정 표적 검증 — Minervini 추세추종: 고정 TP 없이 50MA 종가 이탈 청산"
+    stop_pct: -7
+    trail_ma: 50

--- a/nuri/quant/validation/exit_walkforward.py
+++ b/nuri/quant/validation/exit_walkforward.py
@@ -39,10 +39,27 @@ logger = logging.getLogger(__name__)
 _CONFIG_PATH = Path(__file__).parent.parent.parent.parent / "config" / "walkforward_exits.yaml"
 
 
+_GROWTH_CONFIG_PATH = Path(__file__).parent.parent.parent.parent / "config" / "walkforward_exits_growth.yaml"
+
+
 def _load_exits_config(path: Optional[Path] = None) -> dict:
     """config/walkforward_exits.yaml 로드 (pre-registered 파라미터)."""
     with open(path or _CONFIG_PATH, encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _filter_growth_columns(close: pd.DataFrame, db_path: Optional[Path] = None) -> pd.DataFrame:
+    """패널 컬럼을 growth-classified(classify_stock_type==growth) 종목으로 한정 (#715).
+
+    #679 leader-exit 은 growth-type 보유 한정 룰이므로 표적 검증은 진입 universe 를
+    growth 종목으로 좁힌다. classify_stock_type 은 최신 fundamentals(pe_ratio>30) +
+    섹터 기반 — 프로덕션 룰과 동일한 분류기를 재사용한다(caveat: point-in-time 아님).
+    """
+    from nuri.trading.recommend.price_targets import classify_stock_type
+
+    keep = [t for t in close.columns if classify_stock_type(str(t), db_path=db_path) == "growth"]
+    logger.info("growth filter: %d/%d columns retained", len(keep), close.shape[1])
+    return close[keep]
 
 
 # ── 진입 샘플링 (모든 룰 공유 — paired) ────────────────────────
@@ -252,6 +269,15 @@ def run_exit_search(
     cfg = config or _load_exits_config()
     if close is None:
         close, _vol = _build_panels(cfg, db_path=db_path)
+    # #715: growth-한정 표적 검증 — 패널 빌드 후 growth 컬럼만 1회 필터링.
+    # 진입 샘플·순열 null 전부 축소 패널에서 도출되므로 paired 비교는 유지된다.
+    if cfg["entries"].get("universe") == "growth" and not close.empty:
+        close = _filter_growth_columns(close, db_path=db_path)
+        if close.shape[1] < int(cfg["panel"]["min_breadth"]):
+            raise ValueError(
+                f"growth universe too narrow: {close.shape[1]} < min_breadth "
+                f"{cfg['panel']['min_breadth']} (표본 부족 — #715 보류)"
+            )
     if close.empty or len(close) < 2:
         raise ValueError("insufficient price history after panel quality filter")
 
@@ -397,16 +423,27 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="exit-walkforward")
     parser.add_argument("--cost-bps", type=float, default=10.0, help="거래비용 (bps, 필수 가정)")
     parser.add_argument("--no-persist", action="store_true", help="backtests 기록 생략")
+    parser.add_argument(
+        "--growth",
+        action="store_true",
+        help="#715 growth-한정 표적 검증 (walkforward_exits_growth.yaml 사전등록 config 로드)",
+    )
     args = parser.parse_args(argv)
 
+    growth_cfg = _load_exits_config(_GROWTH_CONFIG_PATH) if args.growth else None
     try:
-        r = run_exit_validation(cost_bps=args.cost_bps, persist=not args.no_persist)
+        r = run_exit_validation(cost_bps=args.cost_bps, config=growth_cfg, persist=not args.no_persist)
     except ValueError as exc:
         print(_json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
         return 2
 
     print(f"\n{'=' * 80}")
-    print("  P4 Exit-Rule Walk-Forward (#713) — paired vs e0_ladder")
+    _title = (
+        "  #715 Leader-Exit Growth-Conditional Walk-Forward — paired vs e0_ladder"
+        if args.growth
+        else "  P4 Exit-Rule Walk-Forward (#713) — paired vs e0_ladder"
+    )
+    print(_title)
     print(
         f"  Universe {r['universe_n']} | {r['panel_start']}..{r['panel_end']} | cost {r['cost_bps']}bps"
         f" | entries {r['n_discovery']}d/{r['n_holdout']}h | Bonferroni {r['alpha']}/{r['n_test_rules']}"

--- a/tests/quant/validation/test_exit_walkforward.py
+++ b/tests/quant/validation/test_exit_walkforward.py
@@ -426,3 +426,60 @@ class TestCLI:
         r = run_exit_validation(cost_bps=10.0, config=SMALL_CFG, persist=False)
         assert r["universe_n"] == 4
         assert "promotion_eligible" in r
+
+
+class TestGrowthFilter:
+    """#715 growth-conditional 표적 검증 — 진입 universe 를 growth 종목으로 한정.
+
+    - _filter_growth_columns: classify_stock_type==growth 컬럼만 잔존
+    - 보류 가드: growth 컬럼 < min_breadth → ValueError (이슈 '표본 부족하면 보류')
+    - 충분 시: universe=growth 가 정상 실행되고 universe_n = growth 종목 수
+    """
+
+    @staticmethod
+    def _seed_fundamentals(db_path):
+        # GRW* = pe>30 (growth), VAL* = pe<30 (value). 섹터/portfolio 없음 → PE 만으로 분류.
+        from nuri.core.db import get_db
+
+        rows = [("GRW1", 50.0), ("GRW2", 45.0), ("VAL1", 10.0), ("VAL2", 8.0)]
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio) VALUES (?, '2026-01-01', ?)",
+                rows,
+            )
+
+    def test_filter_keeps_only_growth(self, db_path_mp):
+        from nuri.quant.validation.exit_walkforward import _filter_growth_columns
+
+        self._seed_fundamentals(db_path_mp)
+        p = _panel(tickers=("GRW1", "GRW2", "VAL1", "VAL2"))
+        g = _filter_growth_columns(p, db_path=db_path_mp)
+        assert set(g.columns) == {"GRW1", "GRW2"}
+
+    def test_growth_universe_too_narrow_defers(self, db_path_mp):
+        self._seed_fundamentals(db_path_mp)
+        p = _panel(tickers=("GRW1", "GRW2", "VAL1", "VAL2"))  # growth=2
+        cfg = {
+            **SMALL_CFG,
+            "panel": {**SMALL_CFG["panel"], "min_breadth": 3},  # 2 growth < 3 → 보류
+            "entries": {**SMALL_CFG["entries"], "universe": "growth"},
+        }
+        with pytest.raises(ValueError, match="too narrow"):
+            run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, db_path=db_path_mp, config=cfg)
+
+    def test_growth_universe_runs_when_sufficient(self, db_path_mp):
+        self._seed_fundamentals(db_path_mp)
+        p = _panel(tickers=("GRW1", "GRW2", "VAL1", "VAL2"))  # growth=2
+        cfg = {
+            **SMALL_CFG,
+            "panel": {**SMALL_CFG["panel"], "min_breadth": 2},  # 2 growth == 2 → 통과
+            "entries": {**SMALL_CFG["entries"], "universe": "growth"},
+        }
+        r = run_exit_search(cost_bps=10.0, fx_series=_flat_fx(p.index), close=p, db_path=db_path_mp, config=cfg)
+        assert r["universe_n"] == 2  # growth 종목만 (VAL* 제외)
+
+    def test_cli_growth_flag_loads_config(self, db_path_mp):
+        # --growth 는 walkforward_exits_growth.yaml 을 로드 — 데이터 부족 시 defer(exit 2).
+        from nuri.quant.validation import exit_walkforward as E
+
+        assert E.main(["--growth", "--no-persist"]) == 2


### PR DESCRIPTION
## Summary

Builds the targeted-validation capability for #715 (does the #679 50MA leader-exit beat the E0 ladder *when the entry universe is restricted to growth stocks?*) and runs the issue's prerequisite sample-size gate.

**Background:** #713 measured `e1_leader_ma` at ΔSharpe **−0.68** vs E0 ladder on a generic random-entry testbed (FAIL). But #679 leader-exit is a **growth-type-only** rule, so that generic result is not a direct refutation. The only supporting evidence so far was a 17-ticker informal backtest.

### Changes (harness only)
- **`config/walkforward_exits_growth.yaml`** — pre-registered (frozen before measuring) single test `e0_ladder` vs `e1_leader_ma`, `entries.universe: growth`, panel/gate/holdout copied verbatim from #713. Single test → Bonferroni moot; holdout sealing retained.
- **`exit_walkforward.py`** — `_filter_growth_columns()` restricts the panel to `classify_stock_type==growth` columns (reuses the production classifier); wired into `run_exit_search` behind the `universe` flag; `--growth` CLI loads the frozen config. Defer guard raises when growth columns `< min_breadth`. Surgical — no change to the shared `_build_panels` or the generic #713 path.
- **4 lock-tests** — filter correctness, defer guard, sufficient-sample run, CLI flag.

## Data-driven verdict: DEFER (not run)

The issue's prerequisite: *"growth 분류 가능한 US 종목 수 먼저 실측 (표본 부족하면 보류)."*

| measure | value |
|---|---|
| US panel at `min_history 504` (needed for `max_horizon 250`) | 90 tickers |
| of which `classify_stock_type==growth` | **34** |
| pre-registered `min_breadth` floor | 40 |

34 < 40 → **`#715` deferred** per the "표본 부족하면 보류" clause. No edge pass/fail is claimed. The harness is ready; re-run after data depth expansion (NEXT_SESSION ③, `make collect` full universe 5y+) grows the deep-history universe. Decision confirmed with the repo owner before freezing methodology (did **not** lower the breadth floor to force a verdict — that would be post-hoc p-hacking).

**Caveat (documented in config):** `classify_stock_type` uses latest fundamentals (point-in-time classification unavailable), matching how the production #679 rule classifies at decision time.

## Test Coverage
- `tests/quant/validation/test_exit_walkforward.py`: **35 → 39** (+4), all green
- Module patch coverage: **99%** (2 uncovered lines = cosmetic success-path title print, unreachable without a real 504-row ≥40-growth panel)
- ruff clean, yaml valid

## Test plan
- [x] `_filter_growth_columns` keeps only growth columns (seeded pe_ratio)
- [x] defer guard raises when growth < min_breadth
- [x] sufficient-sample path runs, `universe_n` reflects growth count
- [x] `--growth` CLI loads frozen config
- [x] real-DB run hits the defer guard: `growth universe too narrow: 34 < min_breadth 40`

Issue #715 stays **open** (deferred, infra landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)