### PR TITLE
docs(frontend): document next 16.2.9 RSC import-boundary gotcha + guard test

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 265 files + 1380 frontend vitest (125 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 265 files + 1382 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -228,7 +228,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 265 files (statement coverage **100%**, 2026-05-06) |
-| Frontend tests | 목표 ≥ 90% | 1380 tests, 125 files |
+| Frontend tests | 목표 ≥ 90% | 1382 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1372 tests, 124 files)
+npm run test           # vitest run (1382 tests, 126 files)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```
@@ -23,6 +23,8 @@ npx vitest run -t "renders verdict"                    # single test by name
 All pages are **Server Components** with `force-dynamic`. Data fetched server-side via `fetchAPI()` (`src/lib/api.ts`).
 
 Client Components: `/report` (LLM generation), `/pipeline` (ReactFlow DAG), `<CompositionDonut>` (Recharts pie), `<ActionItems>` (expand/collapse), `<OpportunityExplorer>` (10-Agent fetch), `<PriceChart>` (period selector).
+
+**RSC boundary — never import a server util through a `"use client"` module.** next 16.2.9+ throws at *request time* (not build/vitest) when a Server Component calls a function re-exported from a `"use client"` module. `composition-section-lazy.tsx` is `"use client"` and re-exports the pure `parseCompositionTab`; importing it there from `page.tsx` made the whole dashboard render the error boundary. Import pure utils from their **source server module** (`composition-section`), take only the lazy wrapper component from the `-lazy` file. **Test:** `src/__tests__/pages/page-rsc-import-guard.test.tsx::page.tsx RSC import boundary` (asserts the import source — the runtime error is invisible to `next build` and jsdom render). (#731)
 
 ## 17 Routes
 

--- a/frontend/src/__tests__/pages/page-rsc-import-guard.test.tsx
+++ b/frontend/src/__tests__/pages/page-rsc-import-guard.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * RSC boundary import guard for src/app/page.tsx.
+ *
+ * Gotcha-Test Pair (frontend/CLAUDE.md "Server Components Pattern"):
+ * next 16.2.9 blocks a Server Component from calling a function re-exported
+ * through a "use client" module. `composition-section-lazy.tsx` is "use client"
+ * and re-exports the pure `parseCompositionTab`; importing it there from
+ * page.tsx (a Server Component) made next treat it as a client reference and
+ * throw at request time — the whole dashboard rendered the error boundary.
+ *
+ * This regression is invisible to `next build` and vitest render (it only fires
+ * during a real server render), so this guard asserts the *import source* in
+ * page.tsx source text: parseCompositionTab must come from the server module
+ * `composition-section`, never from the "use client" `composition-section-lazy`
+ * wrapper. If reverted, the dashboard 500s on every load. (#731)
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pageSrc = readFileSync(resolve(here, "../../app/page.tsx"), "utf8");
+
+describe("page.tsx RSC import boundary", () => {
+  it("imports parseCompositionTab from the server module, not the client wrapper", () => {
+    // parseCompositionTab must be imported from composition-section (server).
+    expect(pageSrc).toMatch(
+      /import\s*\{[^}]*\bparseCompositionTab\b[^}]*\}\s*from\s*["']@\/components\/ui\/composition-section["']/,
+    );
+    // ...and never from the "use client" lazy wrapper (would re-trip the next
+    // 16.2.9 RSC boundary error).
+    expect(pageSrc).not.toMatch(
+      /import\s*\{[^}]*\bparseCompositionTab\b[^}]*\}\s*from\s*["']@\/components\/ui\/composition-section-lazy["']/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
#731 의 후속. 그 PR 이 고친 RSC 경계 회귀는 `next build` 와 vitest render 가 못 잡고 **요청 시점에만** 터진다. 재발하면 대시보드 전체가 500. 재발 방지 가드 + 문서화.

- **frontend/CLAUDE.md** "Server Components Pattern" 에 gotcha 추가 — Server Component 는 `"use client"` 모듈이 re-export 한 순수 util 을 import 하면 안 됨. 원본 server 모듈에서 직접 import. Gotcha-Test Pair 로 아래 테스트 인용.
- **page-rsc-import-guard.test.tsx** (신규) — `page.tsx` 소스 텍스트에서 `parseCompositionTab` 이 `composition-section`(server)에서 import 되고 `composition-section-lazy`(client)에서는 안 됨을 단언. 런타임 RSC 에러가 build/jsdom 에 안 보이므로 import 출처를 가드.
- doc-count 정합: 신규 테스트 파일로 frontend vitest 카운트 갱신 (ARCHITECTURE.md / STRATEGY.md / frontend CLAUDE.md → **1382 tests, 126 files**). `make verify-doc-counts` 13/13 통과.

## Test plan
- [x] `vitest run` 전체 1382 passed (126 files)
- [x] guard test 단독 통과 + reverting 시 fail (import 출처 정규식)
- [x] `make verify-doc-counts` 13 passed, drift 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)