### PR TITLE
fix(frontend): suppress body hydration warning + close last branch-coverage partial

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 265 files + 1382 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+5,892 backend tests across 265 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -228,7 +228,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 265 files (statement coverage **100%**, 2026-05-06) |
-| Frontend tests | 목표 ≥ 90% | 1382 tests, 126 files |
+| Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1382 tests, 126 files)
+npm run test           # vitest run (1383 tests, 126 files)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -111,6 +111,17 @@ describe("DecisionProvenance", () => {
     expect(screen.queryByText(/에이전트 판정/)).not.toBeInTheDocument();
   });
 
+  it("falls back to [] when evidence is null (page.tsx:96 ?? branch)", async () => {
+    // 기존 테스트는 항상 evidence 배열을 줘서 `d.evidence ?? []` 의 left 분기만 탐.
+    // evidence=null → right(`[]`) fallback 분기 커버 (codecov partial 해소).
+    mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, evidence: null });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText("증거 없음")).toBeInTheDocument();
+  });
+
   it("falls back to empty verdicts on malformed JSON + renders evidence with null fields", async () => {
     mockFetchAPI = vi.fn().mockResolvedValue({
       ...mockDetail,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,7 +16,8 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`} suppressHydrationWarning>
-      <body className="min-h-screen flex bg-background text-foreground">
+      {/* suppressHydrationWarning: 브라우저 확장(ColorZilla 등)이 <body>에 cz-shortcut-listen 같은 속성을 주입해 SSR↔CSR 불일치 경고가 뜸 — 무해하므로 억제 */}
+      <body className="min-h-screen flex bg-background text-foreground" suppressHydrationWarning>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           <Sidebar />
 


### PR DESCRIPTION
## Summary
프론트엔드 품질 2건 (CI 1회로 묶음):

1. **Hydration 경고 억제** (`layout.tsx`) — 브라우저 확장(ColorZilla 등)이 `<body>`에 `cz-shortcut-listen` 속성을 주입해 SSR↔CSR 불일치 경고가 dev 콘솔에 떴음. 코드 버그 아님(확장 개입). `<html>`과 동일하게 `<body>`에도 `suppressHydrationWarning` 추가 — 프로덕션 무영향, 콘솔 노이즈 제거.

2. **Codecov partial 0** (`decision-detail.test.tsx`) — 전 레포 유일하게 남았던 분기 partial 1개(`decisions/[id]/page.tsx:96` `d.evidence ?? []`의 null fallback) 해소. 기존 테스트는 항상 evidence 배열을 줘 left 분기만 탐. `evidence: null` 케이스 추가 → **frontend 분기 100% (2125/2125)**.

3. doc count 동기화: 테스트 1382 → **1383** (파일 126 불변) — ARCHITECTURE.md / STRATEGY.md / frontend CLAUDE.md.

## Test plan
- [x] `vitest run --coverage` → Stmts/Branch/Funcs/Lines 모두 **100%** (1383 passed, 126 files)
- [x] `eslint` layout.tsx + decision-detail.test.tsx clean
- [x] `make verify-doc-counts` 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)