### PR TITLE
fix(alerts): route heartbeat watchdog to per-channel webhook (INCIDENTS)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-5,892 backend tests across 265 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,041 backend tests across 266 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 5,892 tests, 265 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,041 tests, 266 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -17,12 +17,28 @@ Usage:
     python -m nuri.alerts.heartbeat_watchdog
 """
 
+import os
 import sys
 import time
 from pathlib import Path
 
 from nuri.alerts.discord_bot import send_webhook_text
 from nuri.core.timezone import kst_now
+
+# 시스템 알림 컨벤션: per-channel webhook (DiscordPublisher Channel enum).
+# heartbeat stale = 운영 incident → INCIDENTS 채널 우선. 빈 값이면 OPS → 범용 URL 순.
+# generic DISCORD_WEBHOOK_URL 은 빈 값으로 두고 채널별 webhook 을 쓰는 배포가 정상.
+_WEBHOOK_ENV_PRIORITY = ("DISCORD_WEBHOOK_INCIDENTS", "DISCORD_WEBHOOK_OPS", "DISCORD_WEBHOOK_URL")
+
+
+def _resolve_webhook_url() -> str | None:
+    """설정된(non-empty) per-channel webhook 을 우선순위대로 탐색."""
+    for key in _WEBHOOK_ENV_PRIORITY:
+        val = os.getenv(key, "").strip()
+        if val:
+            return val
+    return None
+
 
 # repo_root/data/.scheduler_heartbeat — heartbeat 는 1분 간격 기록 (nuri/scheduler.py).
 HEARTBEAT_PATH = Path(__file__).resolve().parents[2] / "data" / ".scheduler_heartbeat"
@@ -56,8 +72,9 @@ def main() -> int:
         f"확인: `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`\n"
         f"[{kst_now().strftime('%Y-%m-%d %H:%M KST')}]"
     )
+    webhook_url = _resolve_webhook_url()
     try:
-        sent = send_webhook_text(msg)
+        sent = send_webhook_text(msg, webhook_url=webhook_url)
     except Exception as e:  # 네트워크/webhook 실패도 outage 신호 — 삼키지 말고 surface
         print(f"STALE detected ({age:.1f}분) but webhook FAILED: {e}", file=sys.stderr)
         return 2

--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -1,0 +1,69 @@
+"""스케줄러 heartbeat staleness watchdog — DB·scheduler 무의존 독립 감시.
+
+독립 launchd job (`com.nuri-quant.heartbeat-watchdog`, 15분 간격) 으로 실행.
+`data/.scheduler_heartbeat` mtime 이 임계값보다 오래되면 Discord webhook 으로
+직접 알림한다.
+
+왜 SRE incident agent 와 별도인가:
+  SREIncidentAgent 도 heartbeat staleness 를 탐지하지만, `_record_incident` 가
+  **DB INSERT 성공 후에만** alert 를 publish 한다. DB 장애(`unable to open
+  database file`) 가 곧 outage 인 경우 incident 기록 자체가 실패해 알림이 영영
+  안 간다 — 자기감시가 가장 잘 죽는 서브시스템(DB)에 의존하는 chicken-and-egg.
+  본 watchdog 은 파일 mtime + webhook 만 사용 (DB·scheduler 무의존) 하므로
+  DB 장애나 scheduler 데몬 사망 같은 outage 자체를 잡는다.
+  (2026-06-09 6일 silent outage 교훈 — heartbeat 가 6일 stale 인데 무알림.)
+
+Usage:
+    python -m nuri.alerts.heartbeat_watchdog
+"""
+
+import sys
+import time
+from pathlib import Path
+
+from nuri.alerts.discord_bot import send_webhook_text
+from nuri.core.timezone import kst_now
+
+# repo_root/data/.scheduler_heartbeat — heartbeat 는 1분 간격 기록 (nuri/scheduler.py).
+HEARTBEAT_PATH = Path(__file__).resolve().parents[2] / "data" / ".scheduler_heartbeat"
+
+# 30분 이상 stale 이면 alert. sre_incident_agent.SCHEDULER_WARN_MIN 과 동일값 유지.
+STALE_THRESHOLD_MIN = 30.0
+
+
+def heartbeat_age_minutes(path: Path | None = None, now_epoch: float | None = None) -> float | None:
+    """heartbeat 파일 mtime 의 age(분) 반환. 파일 미존재 시 None (미배포 환경 → skip)."""
+    p = path or HEARTBEAT_PATH
+    if not p.exists():
+        return None
+    now = now_epoch if now_epoch is not None else time.time()
+    return (now - p.stat().st_mtime) / 60.0
+
+
+def main() -> int:
+    """exit code: 0 = OK/skip, 2 = stale (alert 시도). DB·scheduler 미접근."""
+    age = heartbeat_age_minutes()
+    if age is None:
+        print(f"heartbeat 파일 없음 ({HEARTBEAT_PATH}) — skip (미배포 환경)")
+        return 0
+    if age <= STALE_THRESHOLD_MIN:
+        print(f"heartbeat OK ({age:.1f}분, 임계 {STALE_THRESHOLD_MIN:.0f}분)")
+        return 0
+
+    msg = (
+        f"🔴 **스케줄러 heartbeat STALE** — {age:.0f}분째 갱신 없음 "
+        f"(임계 {STALE_THRESHOLD_MIN:.0f}분). 데이터 수집 중단 의심.\n"
+        f"확인: `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`\n"
+        f"[{kst_now().strftime('%Y-%m-%d %H:%M KST')}]"
+    )
+    try:
+        sent = send_webhook_text(msg)
+    except Exception as e:  # 네트워크/webhook 실패도 outage 신호 — 삼키지 말고 surface
+        print(f"STALE detected ({age:.1f}분) but webhook FAILED: {e}", file=sys.stderr)
+        return 2
+    print(f"STALE alert {'sent' if sent else 'NOT sent (no webhook url)'} ({age:.1f}분)")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/launchd/com.nuri-quant.heartbeat-watchdog.plist
+++ b/scripts/launchd/com.nuri-quant.heartbeat-watchdog.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  com.nuri-quant.heartbeat-watchdog
+
+  스케줄러 heartbeat staleness 독립 감시. 15분 간격으로
+  nuri.alerts.heartbeat_watchdog 실행 — data/.scheduler_heartbeat mtime 이
+  30분 이상 stale 이면 Discord webhook 으로 직접 알림.
+
+  SRE incident agent 와 달리 DB·scheduler 에 의존하지 않으므로 (파일 mtime +
+  webhook 만), DB 장애나 scheduler 데몬 사망 같은 outage 자체를 잡는다.
+  (2026-06-09 6일 silent outage 재발 방지.)
+
+  설치: bash scripts/launchd/install_crons.sh (USER → $HOME 자동 치환).
+-->
+<dict>
+    <key>Label</key>
+    <string>com.nuri-quant.heartbeat-watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>cd /Users/USER/workspace/nuri-quant &amp;&amp; .venv/bin/python -m nuri.alerts.heartbeat_watchdog</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/USER/workspace/nuri-quant</string>
+
+    <!-- 15분 간격. heartbeat 는 1분마다 기록되므로 30분 임계면 최대 ~45분 내 탐지. -->
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/heartbeat_watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/heartbeat_watchdog.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -30,6 +30,25 @@ class TestHeartbeatAge:
         assert 39.0 < age < 41.0
 
 
+class TestWebhookResolution:
+    def test_prefers_incidents_channel(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_WEBHOOK_INCIDENTS", "https://x/incidents")
+        monkeypatch.setenv("DISCORD_WEBHOOK_OPS", "https://x/ops")
+        assert hw._resolve_webhook_url() == "https://x/incidents"
+
+    def test_falls_back_past_empty_url(self, monkeypatch):
+        # generic URL 빈 값 + OPS 만 설정 → OPS 선택 (실제 mini 배포 형태).
+        monkeypatch.setenv("DISCORD_WEBHOOK_INCIDENTS", "")
+        monkeypatch.setenv("DISCORD_WEBHOOK_OPS", "https://x/ops")
+        monkeypatch.setenv("DISCORD_WEBHOOK_URL", "")
+        assert hw._resolve_webhook_url() == "https://x/ops"
+
+    def test_none_when_all_empty(self, monkeypatch):
+        for k in ("DISCORD_WEBHOOK_INCIDENTS", "DISCORD_WEBHOOK_OPS", "DISCORD_WEBHOOK_URL"):
+            monkeypatch.setenv(k, "")
+        assert hw._resolve_webhook_url() is None
+
+
 class TestMain:
     def test_fresh_heartbeat_no_alert(self, tmp_path, monkeypatch):
         p = tmp_path / "hb"

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -1,0 +1,70 @@
+"""heartbeat_watchdog 테스트 — DB·scheduler 무의존 staleness 알림.
+
+Gotcha-Test Pair (2026-06-09 6일 silent outage 재발 방지): watchdog 이 stale
+heartbeat 에 alert 를 보내고, fresh/missing 에는 안 보내는 계약을 고정.
+회귀(임계 비교/스킵 로직 변경) 시 silent outage 탐지 불능.
+"""
+
+import os
+import time
+from unittest.mock import patch
+
+from nuri.alerts import heartbeat_watchdog as hw
+
+
+def _write_heartbeat(path, age_minutes: float):
+    """주어진 age(분) 만큼 과거 mtime 으로 heartbeat 파일 생성."""
+    path.write_text("2026-06-15T00:00:00")
+    past = time.time() - age_minutes * 60.0
+    os.utime(path, (past, past))
+
+
+class TestHeartbeatAge:
+    def test_age_none_when_file_missing(self, tmp_path):
+        assert hw.heartbeat_age_minutes(path=tmp_path / "nope") is None
+
+    def test_age_computed_from_mtime(self, tmp_path):
+        p = tmp_path / "hb"
+        _write_heartbeat(p, age_minutes=40.0)
+        age = hw.heartbeat_age_minutes(path=p, now_epoch=time.time())
+        assert 39.0 < age < 41.0
+
+
+class TestMain:
+    def test_fresh_heartbeat_no_alert(self, tmp_path, monkeypatch):
+        p = tmp_path / "hb"
+        _write_heartbeat(p, age_minutes=1.0)
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", p)
+        with patch("nuri.alerts.heartbeat_watchdog.send_webhook_text") as send:
+            rc = hw.main()
+        assert rc == 0
+        send.assert_not_called()
+
+    def test_missing_heartbeat_skips(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", tmp_path / "nope")
+        with patch("nuri.alerts.heartbeat_watchdog.send_webhook_text") as send:
+            rc = hw.main()
+        assert rc == 0
+        send.assert_not_called()
+
+    def test_stale_heartbeat_alerts(self, tmp_path, monkeypatch):
+        p = tmp_path / "hb"
+        _write_heartbeat(p, age_minutes=hw.STALE_THRESHOLD_MIN + 15.0)
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", p)
+        with patch("nuri.alerts.heartbeat_watchdog.send_webhook_text", return_value=True) as send:
+            rc = hw.main()
+        assert rc == 2
+        send.assert_called_once()
+        msg = send.call_args.args[0]
+        assert "STALE" in msg
+
+    def test_stale_but_webhook_failure_still_returns_2(self, tmp_path, monkeypatch):
+        p = tmp_path / "hb"
+        _write_heartbeat(p, age_minutes=hw.STALE_THRESHOLD_MIN + 15.0)
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", p)
+        with patch(
+            "nuri.alerts.heartbeat_watchdog.send_webhook_text",
+            side_effect=RuntimeError("network down"),
+        ):
+            rc = hw.main()
+        assert rc == 2  # webhook 실패도 stale 신호로 surface (exit 2)


### PR DESCRIPTION
## Summary
#734 후속. watchdog 이 generic `DISCORD_WEBHOOK_URL` 을 읽었는데 실배포(mini)는 그 값을 **빈 값으로 두고** `DiscordPublisher` 컨벤션대로 per-channel webhook(`DISCORD_WEBHOOK_INCIDENTS`/`_OPS`/`_BRIEF`/`_ROLLOUT`)을 쓴다. 그래서 stale 탐지는 돼도 알림이 안 갔음.

heartbeat stale = 운영 incident → `DISCORD_WEBHOOK_INCIDENTS` 우선, `_OPS`, `_URL` 순으로 non-empty webhook 탐색. 봇/신규 크레덴셜 불필요 (이미 설정된 채널 webhook 재사용).

## Test plan
- [x] `pytest tests/alerts/test_heartbeat_watchdog.py` 9 passed (resolution 우선순위 3케이스 추가)
- [x] `ruff` clean
- [x] mini env 실측: `DISCORD_WEBHOOK_INCIDENTS/OPS/BRIEF/ROLLOUT` 값 있음(len 121), `_URL` 빈 값 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)