### PR TITLE
fix(alerts): route heartbeat watchdog to per-channel webhook (INCIDENTS)

### DIFF
--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -17,12 +17,28 @@ Usage:
     python -m nuri.alerts.heartbeat_watchdog
 """
 
+import os
 import sys
 import time
 from pathlib import Path
 
 from nuri.alerts.discord_bot import send_webhook_text
 from nuri.core.timezone import kst_now
+
+# 시스템 알림 컨벤션: per-channel webhook (DiscordPublisher Channel enum).
+# heartbeat stale = 운영 incident → INCIDENTS 채널 우선. 빈 값이면 OPS → 범용 URL 순.
+# generic DISCORD_WEBHOOK_URL 은 빈 값으로 두고 채널별 webhook 을 쓰는 배포가 정상.
+_WEBHOOK_ENV_PRIORITY = ("DISCORD_WEBHOOK_INCIDENTS", "DISCORD_WEBHOOK_OPS", "DISCORD_WEBHOOK_URL")
+
+
+def _resolve_webhook_url() -> str | None:
+    """설정된(non-empty) per-channel webhook 을 우선순위대로 탐색."""
+    for key in _WEBHOOK_ENV_PRIORITY:
+        val = os.getenv(key, "").strip()
+        if val:
+            return val
+    return None
+
 
 # repo_root/data/.scheduler_heartbeat — heartbeat 는 1분 간격 기록 (nuri/scheduler.py).
 HEARTBEAT_PATH = Path(__file__).resolve().parents[2] / "data" / ".scheduler_heartbeat"
@@ -56,8 +72,9 @@ def main() -> int:
         f"확인: `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`\n"
         f"[{kst_now().strftime('%Y-%m-%d %H:%M KST')}]"
     )
+    webhook_url = _resolve_webhook_url()
     try:
-        sent = send_webhook_text(msg)
+        sent = send_webhook_text(msg, webhook_url=webhook_url)
     except Exception as e:  # 네트워크/webhook 실패도 outage 신호 — 삼키지 말고 surface
         print(f"STALE detected ({age:.1f}분) but webhook FAILED: {e}", file=sys.stderr)
         return 2

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -30,6 +30,25 @@ class TestHeartbeatAge:
         assert 39.0 < age < 41.0
 
 
+class TestWebhookResolution:
+    def test_prefers_incidents_channel(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_WEBHOOK_INCIDENTS", "https://x/incidents")
+        monkeypatch.setenv("DISCORD_WEBHOOK_OPS", "https://x/ops")
+        assert hw._resolve_webhook_url() == "https://x/incidents"
+
+    def test_falls_back_past_empty_url(self, monkeypatch):
+        # generic URL 빈 값 + OPS 만 설정 → OPS 선택 (실제 mini 배포 형태).
+        monkeypatch.setenv("DISCORD_WEBHOOK_INCIDENTS", "")
+        monkeypatch.setenv("DISCORD_WEBHOOK_OPS", "https://x/ops")
+        monkeypatch.setenv("DISCORD_WEBHOOK_URL", "")
+        assert hw._resolve_webhook_url() == "https://x/ops"
+
+    def test_none_when_all_empty(self, monkeypatch):
+        for k in ("DISCORD_WEBHOOK_INCIDENTS", "DISCORD_WEBHOOK_OPS", "DISCORD_WEBHOOK_URL"):
+            monkeypatch.setenv(k, "")
+        assert hw._resolve_webhook_url() is None
+
+
 class TestMain:
     def test_fresh_heartbeat_no_alert(self, tmp_path, monkeypatch):
         p = tmp_path / "hb"


### PR DESCRIPTION
#734 후속 (이전 #735는 stacked-on-squash로 DIRTY → 닫고 main 위 cherry-pick으로 재생성).

watchdog이 generic `DISCORD_WEBHOOK_URL`(실배포 빈 값)을 봐서 stale 탐지는 돼도 알림 미전송. mini는 `DiscordPublisher` 컨벤션대로 per-channel webhook(`DISCORD_WEBHOOK_INCIDENTS/OPS/...` 값 있음)을 쓴다. heartbeat stale = 운영 incident → INCIDENTS 우선, OPS, URL 순 non-empty 탐색.

## Test plan
- [x] `pytest tests/alerts/test_heartbeat_watchdog.py` 9 passed
- [x] mini env 실측: INCIDENTS/OPS/BRIEF/ROLLOUT 값 있음(len 121), URL 빈 값

🤖 Generated with [Claude Code](https://claude.com/claude-code)