### PR TITLE
test(api): mock pykrx — fix flaky test_search_korean_name (#712)

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -2,6 +2,7 @@
 
 Auto-loaded by pytest. Helpers live in _helpers.py to be importable.
 """
+
 import asyncio
 import json
 import time as _time
@@ -18,6 +19,27 @@ from fastapi.testclient import TestClient
 
 from nuri.core.db import get_db, init_db, upsert_macro, upsert_portfolio, upsert_prices
 from tests.api._helpers import _csv_file  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def _mock_pykrx_names(monkeypatch):
+    """#712: pykrx get_market_ticker_name 은 live KRX 네트워크 의존 → CI flaky.
+
+    yfinance 가 전역 모킹되듯 KR 종목명 해석도 결정적 stub 으로 network-free 화.
+    get_ticker_name 은 @lru_cache 라 테스트 간 stale(None) 캐시 오염을 막기 위해
+    앞뒤로 cache_clear (네트워크 미가용 시 None 이 캐시되면 후속 테스트도 빈 결과).
+    """
+    import sys
+    import types
+
+    from nuri.core import ticker_names as _tn
+
+    _KR_NAMES = {"005930": "삼성전자", "000660": "SK하이닉스", "005380": "현대차"}
+    _fake_stock = types.SimpleNamespace(get_market_ticker_name=lambda code: _KR_NAMES.get(str(code), ""))
+    monkeypatch.setitem(sys.modules, "pykrx", types.SimpleNamespace(stock=_fake_stock))
+    _tn.get_ticker_name.cache_clear()
+    yield
+    _tn.get_ticker_name.cache_clear()
 
 
 @pytest.fixture()
@@ -38,23 +60,32 @@ def client(tmp_path, monkeypatch):
     init_db(db_path)
 
     import nuri.core.db as db_mod
+
     monkeypatch.setattr(db_mod, "DB_PATH", db_path)
 
     import nuri.core.portfolio_sync as sync_mod
+
     monkeypatch.setattr(sync_mod, "CONFIG_PATH", tmp_path / "portfolio.yaml")
 
     from nuri.api.main import app
+
     return TestClient(app)
 
 
 @pytest.fixture()
 def seeded_client(client):
     """Client with one holding pre-added."""
-    client.post("/api/portfolio", json={
-        "account": "sample", "ticker": "AAPL",
-        "quantity": 10, "avg_price": 180.0,
-        "currency": "USD", "sector": "Tech",
-    })
+    client.post(
+        "/api/portfolio",
+        json={
+            "account": "sample",
+            "ticker": "AAPL",
+            "quantity": 10,
+            "avg_price": 180.0,
+            "currency": "USD",
+            "sector": "Tech",
+        },
+    )
     return client
 
 
@@ -77,18 +108,27 @@ def populated_db(db_path):
     dates = pd.bdate_range("2024-01-01", periods=250)
     for ticker, base in [("SPY", 450), ("AAPL", 150), ("MSFT", 300), ("TSLA", 340)]:
         close = np.linspace(base, base * 1.1, 250)
-        df = pd.DataFrame({
-            "ticker": ticker, "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": close * 0.99, "high": close * 1.01,
-            "low": close * 0.98, "close": close,
-            "volume": [1000000] * 250, "adj_close": close,
-        })
+        df = pd.DataFrame(
+            {
+                "ticker": ticker,
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": close * 0.99,
+                "high": close * 1.01,
+                "low": close * 0.98,
+                "close": close,
+                "volume": [1000000] * 250,
+                "adj_close": close,
+            }
+        )
         upsert_prices(df, db_path)
 
-    upsert_macro([
-        {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
-        {"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"},
-    ], db_path)
+    upsert_macro(
+        [
+            {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
+            {"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"},
+        ],
+        db_path,
+    )
     return db_path
 
 
@@ -129,7 +169,9 @@ def _seed_prices(db_path):
         msft_close = base_msft + np.random.randn() * 3 + i * 0.15
         rows.append(("AAPL", d, aapl_close - 1, aapl_close + 1, aapl_close - 2, aapl_close, 1000000, aapl_close))
         rows.append(("MSFT", d, msft_close - 1, msft_close + 1, msft_close - 2, msft_close, 800000, msft_close))
-        rows.append(("VOO", d, msft_close / 2, msft_close / 2 + 1, msft_close / 2 - 1, msft_close / 2, 500000, msft_close / 2))
+        rows.append(
+            ("VOO", d, msft_close / 2, msft_close / 2 + 1, msft_close / 2 - 1, msft_close / 2, 500000, msft_close / 2)
+        )
     with get_db(db_path) as conn:
         conn.executemany(
             "INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",


### PR DESCRIPTION
## Summary
`Closes #712`. CI에서 `test_search_korean_name` 이 `assert '005930.KS' in []` 로 flaky 실패 — `get_ticker_name` 2차 fallback이 `pykrx.get_market_ticker_name`(live KRX 네트워크)을 호출하는데 CI에서 네트워크가 막혀 None 반환 → 한글이름 매칭 실패.

**근본 원인:** yfinance는 전역 conftest로 모킹돼 tests network-free인데, **pykrx는 모킹 누락**. KR 종목명 해석이 live KRX에 의존.

**Fix:** `tests/api/conftest.py`에 pykrx `get_market_ticker_name`을 결정적 stub(005930→삼성전자 등)으로 모킹하는 autouse fixture. `get_ticker_name`의 `@lru_cache` stale(None) 오염 방지 위해 앞뒤 `cache_clear`.

(부수효과: 이 flaky 테스트가 다른 PR들의 Backend Tests도 간헐 차단 중이었음 — 안정화됨.)

## Test plan
- [x] `pytest tests/api/test_ticker_search.py` 17 passed in **0.9s** (network 제거, 이전 4.8s)
- [x] `ruff` clean
- [x] conftest fixture라 test-file 카운트 불변 (doc-drift 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)