### PR TITLE
feat(alerts): human-readable self-audit digest routed to #ops

### DIFF
--- a/nuri/agents/actors/brief_auditor.py
+++ b/nuri/agents/actors/brief_auditor.py
@@ -45,6 +45,13 @@ NOISE_THRESHOLD = 3  # 같은 ticker > 3 emit / 24h
 IDENTICAL_CONV_TOLERANCE = 1e-3  # conviction 차이 < 0.001 → identical
 IDENTICAL_CONV_MIN_SAMPLES = 5  # 최소 5 emit 이상에서만 검출
 
+# Issue type → 사람이 읽는 한 줄 의미 (digest summary 에 surface — cryptic 코드 대신)
+_ISSUE_MEANING = {
+    "conflict": "같은 종목에 BUY+SELL 24h 내 동시 emit (자기모순)",
+    "noise": "같은 종목 24h 내 3회 초과 emit (중복 스팸)",
+    "identical_conv": "conviction 점수가 전부 동일 (scoring 결함)",
+}
+
 # Issue type → suggested fix path (보고서에 surface)
 _SUGGESTED_FIX = {
     "conflict": "nuri/agents/discord/brief_card.py — same-ticker BUY+SELL 합쳐서 CONFLICT card 1건만 emit",
@@ -247,19 +254,21 @@ def _make_issue_id(issue_type: str, affected: list[str]) -> str:
 
 
 def _emit_incident(issue: dict[str, Any], run_id: str, db_path: Optional[Any]) -> bool:
-    """Stage incident to #incidents outbox (PR3 Codex Round 6).
+    """Stage self-audit issue to #ops outbox (시스템 자가점검 — 매매 신호 아님).
 
-    Dispatcher 가 6h cron 마다 종합. dedupe_key 로 24h 내 중복 방지 (outbox 자체).
-    Legacy round-trip dedupe (agent_messages 의 `[issue=...]` prefix) 는 outbox
-    dedupe_key 로 대체.
+    #incidents(사용자 조치용)와 분리해 #ops(운영 상태)로 보낸다. dispatcher 가
+    6h cron 마다 종합. dedupe_key 로 24h 내 중복 방지 (outbox 자체).
     """
     try:
-        from nuri.agents.discord.outbox import stage_incident
+        from nuri.agents.discord.outbox import stage_ops
 
-        stage_incident(
+        affected = ", ".join(issue["affected"][:3]) + ("…" if len(issue["affected"]) > 3 else "")
+        meaning = _ISSUE_MEANING.get(issue["type"], issue["type"])
+        stage_ops(
             payload={
                 "kind": f"brief_quality_{issue['type']}",
-                "summary": (f"{issue['type'].upper()} on {','.join(issue['affected'][:3])}: n={issue['n_decisions']}"),
+                # cryptic "CONFLICT on TSLA: n=19" 대신 사람이 읽는 한 줄.
+                "summary": f"{affected} ({issue['n_decisions']}회) — {meaning}",
                 "issue_id": issue["issue_id"],
                 "affected": issue["affected"],
                 "evidence": issue["evidence"],

--- a/nuri/agents/discord/outbox.py
+++ b/nuri/agents/discord/outbox.py
@@ -436,6 +436,27 @@ def bucket_brief_digest(
     }
 
 
+# BriefAuditor 자가점검 kind → 사람이 이해하는 그룹 메타 (cryptic 코드 대신).
+# label=친화적 제목, what=한 줄 의미, action=개발 조치. 없는 kind 는 raw 그대로.
+_QUALITY_KIND_META: dict[str, dict[str, str]] = {
+    "brief_quality_conflict": {
+        "label": "⚠️ 자기모순 신호",
+        "what": "같은 종목에 BUY+SELL 을 24h 내 동시 emit (추천 신뢰도 결함)",
+        "action": "조치(개발): brief_card.py — BUY+SELL 을 CONFLICT 카드 1건으로 통합",
+    },
+    "brief_quality_noise": {
+        "label": "🔁 중복 스팸",
+        "what": "같은 종목을 24h 내 3회 초과 emit (시그널이 묻힘)",
+        "action": "조치(개발): decision_compiler.py — 종목별 6h repeat-emit 쿨다운",
+    },
+    "brief_quality_identical_conv": {
+        "label": "📊 scoring 결함",
+        "what": "conviction 점수가 전부 동일 (가중치 산출 검증 필요)",
+        "action": "조치(개발): decision_compiler.py — conviction 입력 변동성 점검",
+    },
+}
+
+
 def bucket_generic_digest(
     events: list[dict[str, Any]],
     channel_label: str,
@@ -468,19 +489,27 @@ def bucket_generic_digest(
 
     fields = []
     for group, lines in by_group.items():
+        meta = _QUALITY_KIND_META.get(group)
+        group_name = f"{meta['label']} ({len(lines)})" if meta else f"{group} ({len(lines)})"
         body_lines: list[str] = []
-        running = 0
+        # 자가점검 kind 는 그룹 맨 위에 "무엇인지" 한 줄을 먼저 박는다.
+        if meta:
+            body_lines.append(f"ℹ️ {meta['what']}")
+        running = sum(len(b) + 1 for b in body_lines)
         for ln in lines:
             ln_trunc = _truncate(ln, 200)
             if running + len(ln_trunc) + 1 > _FIELD_VALUE_MAX:
-                hidden = len(lines) - len(body_lines)
+                hidden = len(lines) - (len(body_lines) - (1 if meta else 0))
                 body_lines.append(f"… (+{hidden} more)")
                 break
             body_lines.append(ln_trunc)
             running += len(ln_trunc) + 1
+        # 자가점검 kind 는 맨 아래 "조치" 를 붙인다 (사용자가 할 일이 아니라 코드 개선).
+        if meta and running + len(meta["action"]) + 1 <= _FIELD_VALUE_MAX:
+            body_lines.append(f"→ {meta['action']}")
         fields.append(
             {
-                "name": _truncate(f"{group} ({len(lines)})", _FIELD_NAME_MAX),
+                "name": _truncate(group_name, _FIELD_NAME_MAX),
                 "value": _truncate("\n".join(body_lines), _FIELD_VALUE_MAX),
                 "inline": False,
             }
@@ -488,9 +517,17 @@ def bucket_generic_digest(
         if len(fields) >= _MAX_FIELDS:
             break
 
+    # 자가점검 kind 가 하나라도 있으면 "매매 신호 아님" 을 description 에 명시.
+    has_quality = any(g in _QUALITY_KIND_META for g in by_group)
+    description = (
+        f"※ 매매 신호 아님 — 시스템 자가점검 결과 ({n}건). 아래 '조치'는 코드 개선 백로그입니다."
+        if has_quality
+        else f"{n} aggregated events"
+    )
+
     return {
         "title": _truncate(title, _TITLE_MAX),
-        "description": _truncate(f"{n} aggregated events", _DESC_MAX),
+        "description": _truncate(description, _DESC_MAX),
         "color": color,
         "fields": fields,
         "footer": {"text": "auto digest"},

--- a/tests/agents/test_brief_auditor.py
+++ b/tests/agents/test_brief_auditor.py
@@ -246,13 +246,13 @@ class TestEmitIncidentExceptionPath:
     """Lock-tests for _emit_incident exception (lines 256-275)."""
 
     def test_emit_incident_success(self, patched_db):
-        """stage_incident → True (lines 256-273)."""
+        """stage_ops → True (자가점검은 #ops 로 라우팅)."""
         from nuri.agents.actors.brief_auditor import _emit_incident
 
         with patch(
-            "nuri.agents.discord.outbox.stage_incident",
+            "nuri.agents.discord.outbox.stage_ops",
             return_value=42,
-        ):
+        ) as staged:
             ok = _emit_incident(
                 issue={
                     "type": "conflict",
@@ -266,13 +266,19 @@ class TestEmitIncidentExceptionPath:
                 db_path=patched_db,
             )
         assert ok is True
+        # 라우팅: #ops 로 stage (사용자 #incidents 와 분리)
+        staged.assert_called_once()
+        payload = staged.call_args.kwargs["payload"]
+        # cryptic "CONFLICT on AAPL: n=2" 대신 사람이 읽는 summary
+        assert "CONFLICT on" not in payload["summary"]
+        assert "AAPL" in payload["summary"] and "자기모순" in payload["summary"]
 
     def test_emit_incident_exception_returns_false(self, patched_db):
-        """stage_incident raise → False (line 274-275)."""
+        """stage_ops raise → False (stage 실패가 audit 을 깨면 안 됨)."""
         from nuri.agents.actors.brief_auditor import _emit_incident
 
         with patch(
-            "nuri.agents.discord.outbox.stage_incident",
+            "nuri.agents.discord.outbox.stage_ops",
             side_effect=RuntimeError("outbox full"),
         ):
             ok = _emit_incident(

--- a/tests/agents/test_discord_outbox.py
+++ b/tests/agents/test_discord_outbox.py
@@ -376,6 +376,29 @@ def test_bucket_generic_digest_groups_by_kind():
     assert any("rate_limit (1)" in n for n in field_names)
 
 
+def test_bucket_generic_digest_renders_quality_kind_human_readable():
+    """brief_quality_* 는 친화적 라벨 + 의미 + 조치 + '매매 신호 아님' 으로 렌더."""
+    events = [
+        {"kind": "brief_quality_conflict", "summary": "TSLA (19회) — 같은 종목 BUY+SELL"},
+        {"kind": "brief_quality_conflict", "summary": "AMD (6회) — 같은 종목 BUY+SELL"},
+    ]
+    embed = bucket_generic_digest(events, channel_label="Ops")
+    # 친화적 그룹 라벨 (raw kind 아님)
+    assert any("자기모순" in f["name"] for f in embed["fields"])
+    assert not any("brief_quality_conflict" in f["name"] for f in embed["fields"])
+    value = embed["fields"][0]["value"]
+    assert "ℹ️" in value  # 무엇인지 한 줄
+    assert "조치(개발)" in value  # 코드 조치
+    # 매매 신호 아님을 명시
+    assert "매매 신호 아님" in embed["description"]
+
+
+def test_bucket_generic_digest_non_quality_keeps_aggregated_desc():
+    """일반 kind 는 기존 description 유지 (backward compat)."""
+    embed = bucket_generic_digest([{"kind": "rate_limit", "summary": "x"}], channel_label="Ops")
+    assert embed["description"] == "1 aggregated events"
+
+
 # ─── dispatcher ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
사용자 피드백: #incidents digest 가 `CONFLICT on TSLA: n=19` 같은 cryptic 코드만 떠서 의미·조치를 알 수 없었음. 게다가 이건 **매매 신호가 아니라 시스템 자가점검**(BriefAuditor)인데 사용자 조치 채널에 섞여 혼란.

**라우팅 분리:** brief_quality 자가점검 → `#incidents`(사용자 조치용)에서 `#ops`(운영 상태)로 이동.
**포맷 개선:** 친화 라벨(⚠️ 자기모순) + ℹ️ 의미 + → 조치(개발) + "※ 매매 신호 아님" description.

Before: `CONFLICT on TSLA: n=19`
After:
```
※ 매매 신호 아님 — 시스템 자가점검 결과 (8건). 아래 '조치'는 코드 개선 백로그입니다.
[⚠️ 자기모순 신호 (5)]
ℹ️ 같은 종목에 BUY+SELL 을 24h 내 동시 emit (추천 신뢰도 결함)
  TSLA (19회) … / AMD (6회) …
→ 조치(개발): brief_card.py — CONFLICT 카드 1건으로 통합
```

agent_dev_log 가 의미상 이상적이나 dispatcher cron 미존재(#577-582 미완)라 작동하는 #ops 채택.

## Test plan
- [x] `pytest test_brief_auditor + test_discord_outbox(+branches)` 66 passed
- [x] 라우팅(#ops) + 읽는 summary + friendly digest + backward-compat(non-quality desc 유지) 커버
- [x] `ruff` clean · 실제 렌더 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)