### PR TITLE
fix(alerts): dedupe brief-audit against #ops channel (#738 follow-up)

### DIFF
--- a/nuri/agents/actors/brief_auditor.py
+++ b/nuri/agents/actors/brief_auditor.py
@@ -40,6 +40,10 @@ from typing import Any, Optional
 from nuri.agents.base import Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import query
 
+# 자가점검 emit/dedupe 채널 — _emit_incident(stage_ops) 와 _dedupe_recent 가
+# 반드시 일치해야 함 (불일치 시 dedupe 미스 → 6h 마다 재emit 스팸).
+_AUDIT_CHANNEL = "ops"
+
 DEFAULT_AUDIT_HOURS = 24
 NOISE_THRESHOLD = 3  # 같은 ticker > 3 emit / 24h
 IDENTICAL_CONV_TOLERANCE = 1e-3  # conviction 차이 < 0.001 → identical
@@ -139,10 +143,10 @@ def _dedupe_recent(
         return []
     rows = query(
         """SELECT dedupe_key FROM discord_outbox
-            WHERE channel = 'incidents'
+            WHERE channel = ?
               AND dedupe_key IS NOT NULL
               AND created_at > datetime('now', ?)""",
-        (f"-{hours} hours",),
+        (_AUDIT_CHANNEL, f"-{hours} hours"),
         db_path=db_path,
     )
     seen_keys = {r["dedupe_key"] for r in rows if r["dedupe_key"]}

--- a/tests/agents/test_brief_auditor.py
+++ b/tests/agents/test_brief_auditor.py
@@ -225,8 +225,9 @@ def test_audit_dedupes_against_recent_outbox_stage(patched_db):
     _seed_decision(patched_db, decision_id="dc-2", ticker="TST_A", action="SELL", conviction=0.82)
 
     issue_id = _make_issue_id("conflict", ["TST_A"])
+    # 자가점검은 #ops 로 stage → dedupe 도 #ops 를 조회해야 매칭 (채널 일치 lock).
     stage_outbox(
-        channel="incidents",
+        channel="ops",
         payload={"summary": "prior brief_quality issue"},
         dedupe_key=f"brief_quality:{issue_id}",
         actor_name="brief-auditor",


### PR DESCRIPTION
## Summary
#738에서 자가점검 emit을 #incidents → #ops로 옮겼는데 `_dedupe_recent`가 여전히 `channel='incidents'`를 조회 → **dedupe 미스 → 6h마다 같은 issue 재emit 스팸 회귀**.

emit(stage_ops)과 dedupe 조회 채널을 `_AUDIT_CHANNEL="ops"` 단일 상수로 고정 (이번 버그의 근본 = 두 곳 하드코딩 드리프트).

기존 dedupe 테스트가 `channel="incidents"`로 stage해 버그와 짝이 맞아 CI 녹색이었음(test illusion). `channel="ops"`로 수정 → 채널 불일치 시 즉시 FAIL(lock).

## Test plan
- [x] `pytest test_brief_auditor.py` 16 passed
- [x] `ruff` clean
- [x] dedupe 테스트가 emit 채널(ops)과 일치 — 'incidents'로 되돌리면 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)