### PR TITLE
fix(api): network-free KR name resolution for /tickers/search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,6 @@ coverage.json
 # emit holdings-derived output (privacy risk, STRATEGY §4.4.1). Keep local;
 # promote validated tooling to a tracked, reviewed location before committing.
 scripts/analysis/
+
+# KOSPI200 종목명 맵 — 로컬 생성 (privacy 스캐너가 증권사 회사명 차단). get_ticker_name 가 graceful fallback
+config/kr_ticker_names.json

--- a/nuri/core/ticker_names.py
+++ b/nuri/core/ticker_names.py
@@ -2,15 +2,34 @@
 
 .KS 티커(예: 132030.KS)는 사람이 알아볼 수 없으므로 종목명을 조회한다.
 1차: portfolio.metadata.note (사용자가 YAML에 입력한 이름)
-2차: pykrx get_market_ticker_name (주식, LRU 캐시)
+2차: config/kr_ticker_names.json 로컬 맵 (KOSPI200 정적 — network-free)
+3차: pykrx get_market_ticker_name (1·2차 미스 시에만, 주식 only)
 US 티커(MSFT, TSLA 등)는 이미 식별 가능하므로 None 반환.
+
+⚠️ 2차 로컬 맵이 핵심: /tickers/search 가 KR 이름 검색 시 수백 ticker 를
+순회하는데, 맵 없이는 ticker 당 live pykrx 호출 → 요청당 수백 네트워크 콜
+(지연/hang/CI flaky). 맵은 요청 경로를 network-free 로 만든다.
+config/kr_ticker_names.json 갱신: universe-sync 로 KOSPI200 변경 시 재생성.
 """
 
 import json
 import logging
 from functools import lru_cache
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+_KR_NAMES_PATH = Path(__file__).resolve().parents[2] / "config" / "kr_ticker_names.json"
+
+
+@lru_cache(maxsize=1)
+def _load_kr_name_map() -> dict[str, str]:
+    """config/kr_ticker_names.json 1회 로드 (KOSPI200 정적 맵). 없으면 빈 dict."""
+    try:
+        return json.loads(_KR_NAMES_PATH.read_text(encoding="utf-8"))
+    except Exception as e:  # 파일 부재/파싱 실패 시 graceful — pykrx fallback 으로 흐름
+        logger.debug("KR name map load failed: %s", e)
+        return {}
 
 
 @lru_cache(maxsize=500)
@@ -44,7 +63,12 @@ def get_ticker_name(ticker: str) -> str | None:
     except Exception as e:
         logger.debug("DB name lookup failed for %s: %s", ticker, e)
 
-    # 2차: pykrx 주식 이름 조회 (ETF는 미지원)
+    # 2차: 로컬 KOSPI200 맵 (network-free — search 요청 경로 보호)
+    mapped = _load_kr_name_map().get(ticker)
+    if mapped:
+        return mapped
+
+    # 3차: pykrx 주식 이름 조회 (1·2차 미스 시에만 — ETF/맵외 종목 fallback)
     code = ticker.replace(".KS", "").replace(".KQ", "")
     try:
         from pykrx import stock as krx

--- a/tests/core/test_ticker_names.py
+++ b/tests/core/test_ticker_names.py
@@ -76,3 +76,31 @@ class TestGetTickerName:
             patch("pykrx.stock.get_market_ticker_name", side_effect=_boom_pykrx),
         ):
             assert ticker_names.get_ticker_name("100200.KS") is None
+
+    def test_kr_local_map_resolves_network_free(self) -> None:
+        """DB 미스 → 로컬 KOSPI200 맵에서 해석, pykrx 미호출 (#712 prod fix 핵심).
+
+        맵 tier 가 제거되면 /tickers/search 가 요청당 수백 pykrx 호출로 회귀 →
+        이 테스트가 FAIL. pykrx 를 raise 로 막아도 맵으로 이름이 나와야 network-free.
+        """
+        ticker_names._load_kr_name_map.cache_clear()
+
+        def _boom_pykrx(*a, **kw):
+            raise RuntimeError("network blocked")
+
+        with (
+            patch("nuri.core.db.query", return_value=[]),
+            patch.object(ticker_names, "_load_kr_name_map", return_value={"005930.KS": "삼성전자"}),
+            patch("pykrx.stock.get_market_ticker_name", side_effect=_boom_pykrx),
+        ):
+            assert ticker_names.get_ticker_name("005930.KS") == "삼성전자"
+
+    def test_kr_not_in_map_falls_to_pykrx(self) -> None:
+        """맵에 없는 종목은 pykrx fallback (맵외 ETF 등 — graceful)."""
+        ticker_names._load_kr_name_map.cache_clear()
+        with (
+            patch("nuri.core.db.query", return_value=[]),
+            patch.object(ticker_names, "_load_kr_name_map", return_value={}),
+            patch("pykrx.stock.get_market_ticker_name", return_value="맵외종목"),
+        ):
+            assert ticker_names.get_ticker_name("999000.KS") == "맵외종목"


### PR DESCRIPTION
## Summary
`/tickers/search` 의 한글 이름 검색이 universe의 ~200 KR 티커를 순회하며 `get_ticker_name`을 호출하는데, 이게 `pykrx.get_market_ticker_name`(**live KRX 네트워크**)으로 빠짐 → cold cache 시 **요청 1회에 수백 네트워크 콜** → API 지연/hang. (#712에서 테스트만 mock으로 막았던 경로의 **프로덕션 본체**.)

**Fix:** `get_ticker_name`에 2차 tier 추가 — `config/kr_ticker_names.json`(KOSPI200 203종 정적 맵)을 pykrx 전에 조회 → 요청 경로 **network-free**.
- 맵은 **gitignored** (privacy 스캐너가 KOSPI200 증권사 회사명 차단 — 카카오페이·미래에셋증권 등). dev+mini 로컬 생성. 부재 시 pykrx graceful fallback.

## Test plan
- [x] `pytest tests/core/test_ticker_names.py` 10 passed (맵 tier network-free + 맵외 fallback 회귀 2건 추가)
- [x] 실측: pykrx raise 로 막아도 삼성전자/현대차/KB금융 등 203종 로컬 해석
- [x] `ruff` clean

## 후속 (NEXT_SESSION 명시)
- ticker-detail GET 무거운 동기 호출(P2), KR맵 재현성(collector 통합), SIEGE 비US 근거 — deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)