### PR TITLE
perf(api): #743 ticker-detail consensus DB read + candidates TTL cache

### DIFF
--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -1,5 +1,7 @@
 """종목 상세 API — 모든 데이터를 한 번에."""
 
+import json
+import time
 from dataclasses import asdict
 
 from fastapi import APIRouter, Query
@@ -7,6 +9,109 @@ from fastapi import APIRouter, Query
 from nuri.core.db import query
 
 router = APIRouter(tags=["ticker"])
+
+# screen_candidates 는 universe 전체를 스캔(O(종목수×지표계산)) → 종목 상세 GET 마다
+# 재실행하면 수초 지연. 다른 라우트와 동일한 5분 TTL 모듈 캐시로 1회 스캔 결과 공유.
+_CANDIDATES_CACHE_TTL = 300  # 5분
+_candidates_cache: dict = {"data": None, "timestamp": 0.0}
+
+# 스케줄러가 매일 consensus 를 저장하므로 정상 운영 시 최신 행은 오늘/어제.
+# 주말·공휴일 갭(최대 ~3일)은 허용하되, 그보다 오래되면(스케줄러 정지 등) live
+# 재계산으로 폴백 — stale consensus 를 권위 있는 값으로 serve 하지 않기 위함.
+_CONSENSUS_MAX_AGE_DAYS = 7
+
+
+def _read_consensus_from_db(ticker: str) -> dict | None:
+    """recommendations 테이블의 최근 consensus 1건을 복원. 없거나 stale 하면 None.
+
+    스케줄러가 매 consensus run 마다 save_to_recommendations 로 전 종목을 저장하므로
+    상세 GET 에서 analyze_ticker(10-agent, 네트워크+연산)를 재실행할 필요가 없다.
+    dissent 는 recommendations.signals 에 count 만 있어 agent_verdicts 에서 재구성한다
+    (final_action 기준 — divergence/veto penalty 가 적용된 행은 canonical scoring.py 의
+    pre-penalty 기준과 미세하게 다를 수 있으나, 표시용 설명 필드라 허용).
+    """
+    from datetime import timedelta
+
+    from nuri.core.timezone import kst_now
+
+    rows = query(
+        "SELECT action, confidence, signals, agent_verdicts, date "
+        "FROM recommendations WHERE ticker = ? ORDER BY date DESC LIMIT 1",
+        (ticker,),
+    )
+    if not rows:
+        return None
+
+    row = rows[0]
+    # freshness 가드: 너무 오래된 행이면 None → 호출자가 live 재계산
+    cutoff = (kst_now().date() - timedelta(days=_CONSENSUS_MAX_AGE_DAYS)).isoformat()
+    if not row["date"] or row["date"] < cutoff:
+        return None
+
+    try:
+        verdicts = json.loads(row["agent_verdicts"]) if row["agent_verdicts"] else []
+    except (json.JSONDecodeError, TypeError):
+        verdicts = []
+    if not isinstance(verdicts, list):
+        verdicts = []
+    try:
+        sig = json.loads(row["signals"]) if row["signals"] else {}
+    except (json.JSONDecodeError, TypeError):
+        sig = {}
+
+    final_action = row["action"]
+    dissent = [
+        f"{v.get('agent_name', '?')}({v.get('action', '?')}, {float(v.get('confidence') or 0):.0f}): {v.get('reasoning', '')}"
+        for v in verdicts
+        if isinstance(v, dict) and v.get("action") != final_action
+    ]
+    return {
+        "final_action": final_action,
+        "final_confidence": row["confidence"],
+        "agreement_rate": sig.get("agreement_rate") if isinstance(sig, dict) else None,
+        "verdicts": verdicts,
+        "dissent": dissent,
+        "as_of": row["date"],  # 캐시된 결정의 기준일 — staleness 투명성
+    }
+
+
+def _get_consensus(ticker: str) -> dict:
+    """DB(recommendations) 우선 read, 미스(포트폴리오 외 종목 등) 시에만 live 분석."""
+    cached = _read_consensus_from_db(ticker)
+    if cached is not None:
+        return cached
+
+    try:
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.consensus import analyze_ticker
+
+        consensus = analyze_ticker(ticker)
+        return {
+            "final_action": consensus.final_action,
+            "final_confidence": consensus.final_confidence,
+            "agreement_rate": consensus.agreement_rate,
+            "verdicts": [asdict(v) for v in consensus.verdicts],
+            "dissent": consensus.dissent,
+            "as_of": today_kst(),
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _get_signals(ticker: str) -> list:
+    """캐시된 universe 스캔 결과에서 해당 종목 시그널만 필터. 5분 TTL."""
+    now = time.time()
+    if _candidates_cache["data"] is None or (now - _candidates_cache["timestamp"]) >= _CANDIDATES_CACHE_TTL:
+        try:
+            from nuri.trading.recommend.candidates import screen_candidates
+
+            data = screen_candidates(lookback_days=10)
+        except Exception:
+            # 스캔 실패 시 캐시를 빈 결과로 고정하지 않음 — 다음 요청이 재시도
+            return []
+        _candidates_cache["data"] = data
+        _candidates_cache["timestamp"] = now
+    return [asdict(c) for c in _candidates_cache["data"] if c.ticker == ticker]
 
 
 @router.get("/tickers/search")
@@ -154,20 +259,9 @@ def get_ticker_detail(symbol: str):
     fund = query("SELECT * FROM fundamentals WHERE ticker=? ORDER BY date DESC LIMIT 1", (ticker,))
     result["fundamentals"] = dict(fund[0]) if fund else None
 
-    # 3. 10 에이전트 합의
-    try:
-        from nuri.trading.agents.consensus import analyze_ticker
-
-        consensus = analyze_ticker(ticker)
-        result["consensus"] = {
-            "final_action": consensus.final_action,
-            "final_confidence": consensus.final_confidence,
-            "agreement_rate": consensus.agreement_rate,
-            "verdicts": [asdict(v) for v in consensus.verdicts],
-            "dissent": consensus.dissent,
-        }
-    except Exception as e:
-        result["consensus"] = {"error": str(e)}
+    # 3. 10 에이전트 합의 — recommendations DB read 우선 (스케줄러 일일 저장),
+    #    미스 시에만 live analyze_ticker. 매 GET 10-agent 재실행 제거.
+    result["consensus"] = _get_consensus(ticker)
 
     # 4. Wall Street — 애널리스트 등급 (최근 10건)
     ratings = query(
@@ -205,15 +299,8 @@ def get_ticker_detail(symbol: str):
     )
     result["superinvestors"] = [dict(s) for s in si]
 
-    # 9. 최근 시그널
-    try:
-        from nuri.trading.recommend.candidates import screen_candidates
-
-        candidates = screen_candidates(lookback_days=10)
-        ticker_signals = [asdict(c) for c in candidates if c.ticker == ticker]
-        result["signals"] = ticker_signals
-    except Exception:
-        result["signals"] = []
+    # 9. 최근 시그널 — universe 스캔 결과 5분 캐시에서 필터 (매 GET 재스캔 제거)
+    result["signals"] = _get_signals(ticker)
 
     return result
 

--- a/tests/api/test_ticker.py
+++ b/tests/api/test_ticker.py
@@ -69,8 +69,8 @@ class TestTicker:
         assert r.status_code == 200
         assert r.json()["trend"] is None
 
-    def test_ticker_consensus_exception(self, client, monkeypatch):
-        """analyze_ticker raise → consensus.error 필드 (lines 164-165)."""
+    def test_ticker_consensus_db_miss_falls_back_to_live(self, client, monkeypatch):
+        """recommendations 행 없음 → live analyze_ticker fallback, raise 시 error 필드."""
 
         def boom(t):
             raise RuntimeError("consensus down")
@@ -81,8 +81,178 @@ class TestTicker:
         data = r.json()
         assert "error" in data["consensus"]
 
+    def test_ticker_consensus_read_from_db_no_live_call(self, client, tmp_path, monkeypatch):
+        """recommendations 행 존재(fresh) → DB read 로 복원, analyze_ticker 미호출.
+
+        P2 핵심: 매 GET 10-agent 재실행 제거. live 경로가 불리면 즉시 FAIL.
+        """
+        from nuri.core.timezone import today_kst
+
+        def explode(t):
+            raise AssertionError("analyze_ticker 가 호출되면 안 됨 (DB read 경로)")
+
+        monkeypatch.setattr("nuri.trading.agents.consensus.analyze_ticker", explode)
+
+        verdicts = [
+            {
+                "agent_name": "technical",
+                "ticker": "AAPL",
+                "action": "BUY",
+                "confidence": 72.0,
+                "reasoning": "RSI oversold",
+                "data_points": {},
+                "alpha_action": "LONG",
+                "portfolio_action": None,
+            },
+            {
+                "agent_name": "fundamental",
+                "ticker": "AAPL",
+                "action": "HOLD",
+                "confidence": 40.0,
+                "reasoning": "fair value",
+                "data_points": {},
+                "alpha_action": None,
+                "portfolio_action": None,
+            },
+        ]
+        # ⚠️ freshness 가드(now-window)와 결합되므로 날짜는 today_kst() 앵커 (time-bomb 방지)
+        today = today_kst()
+        with get_db(tmp_path / "test.db") as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, signals, agent_verdicts) "
+                "VALUES (?,?,?,?,?,?)",
+                (
+                    today,
+                    "AAPL",
+                    "BUY",
+                    72.0,
+                    json.dumps({"agreement_rate": 0.5, "dissent_count": 1}),
+                    json.dumps(verdicts, ensure_ascii=False),
+                ),
+            )
+
+        r = client.get("/api/ticker/AAPL")
+        assert r.status_code == 200
+        c = r.json()["consensus"]
+        assert c["final_action"] == "BUY"
+        assert c["agreement_rate"] == 0.5
+        assert c["as_of"] == today
+        assert len(c["verdicts"]) == 2
+        # dissent 는 final_action(BUY)과 다른 verdict 에서 재구성
+        assert any("fundamental" in d for d in c["dissent"])
+
+    def test_ticker_consensus_stale_row_falls_back_to_live(self, client, tmp_path, monkeypatch):
+        """오래된 행(>7일)은 stale → live analyze_ticker 재계산.
+
+        스케줄러 정지 등으로 행이 오래되면 stale 값을 권위 있게 serve 하지 않는다.
+        """
+        from datetime import timedelta
+
+        from nuri.core.timezone import kst_now, today_kst
+        from nuri.trading.agents.consensus.models import ConsensusResult
+
+        called = {"live": False}
+
+        def fake_live(t):
+            called["live"] = True
+            return ConsensusResult(
+                ticker=t,
+                final_action="HOLD",
+                final_confidence=55.0,
+                agreement_rate=0.9,
+                verdicts=[],
+                dissent=[],
+                reasoning="live recompute",
+            )
+
+        monkeypatch.setattr("nuri.trading.agents.consensus.analyze_ticker", fake_live)
+
+        stale_date = (kst_now().date() - timedelta(days=10)).isoformat()
+        with get_db(tmp_path / "test.db") as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, signals, agent_verdicts) "
+                "VALUES (?,?,?,?,?,?)",
+                (stale_date, "AAPL", "BUY", 80.0, json.dumps({"agreement_rate": 0.3}), "[]"),
+            )
+        r = client.get("/api/ticker/AAPL")
+        assert r.status_code == 200
+        c = r.json()["consensus"]
+        assert called["live"] is True
+        assert c["final_action"] == "HOLD"  # stale BUY 가 아닌 live HOLD
+        assert c["as_of"] == today_kst()
+
+    def test_ticker_consensus_db_miss_live_fallback_shape(self, client, monkeypatch):
+        """DB 미스(포트폴리오 외 종목) → live 복원 + 정상 shape (error 아님)."""
+        from nuri.core.timezone import today_kst
+        from nuri.trading.agents.base import AgentVerdict
+        from nuri.trading.agents.consensus.models import ConsensusResult
+
+        def fake_live(t):
+            return ConsensusResult(
+                ticker=t,
+                final_action="BUY",
+                final_confidence=70.0,
+                agreement_rate=0.6,
+                verdicts=[AgentVerdict("technical", t, "BUY", 70.0, "breakout")],
+                dissent=["fundamental(HOLD, 40): rich"],
+                reasoning="live",
+            )
+
+        monkeypatch.setattr("nuri.trading.agents.consensus.analyze_ticker", fake_live)
+        r = client.get("/api/ticker/ZZZZ")
+        assert r.status_code == 200
+        c = r.json()["consensus"]
+        assert "error" not in c
+        assert c["final_action"] == "BUY"
+        assert c["as_of"] == today_kst()
+        assert c["verdicts"][0]["agent_name"] == "technical"
+
+    def test_ticker_consensus_malformed_json_graceful(self, client, tmp_path, monkeypatch):
+        """legacy 행: agent_verdicts/signals 가 비-JSON 문자열 → graceful 빈 복원."""
+        from nuri.core.timezone import today_kst
+
+        def explode(t):
+            raise AssertionError("DB 행이 있으면 live 호출 금지")
+
+        monkeypatch.setattr("nuri.trading.agents.consensus.analyze_ticker", explode)
+        with get_db(tmp_path / "test.db") as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, signals, agent_verdicts) "
+                "VALUES (?,?,?,?,?,?)",
+                (today_kst(), "AAPL", "HOLD", 50.0, "rsi_oversold,macd_golden", "not-json"),
+            )
+        r = client.get("/api/ticker/AAPL")
+        assert r.status_code == 200
+        c = r.json()["consensus"]
+        assert c["final_action"] == "HOLD"
+        assert c["verdicts"] == []
+        assert c["dissent"] == []
+        assert c["agreement_rate"] is None
+
+    def test_ticker_consensus_verdicts_non_list_coerced(self, client, tmp_path, monkeypatch):
+        """agent_verdicts 가 valid JSON 이나 list 가 아니면(예: object) verdicts=[]."""
+        from nuri.core.timezone import today_kst
+
+        monkeypatch.setattr(
+            "nuri.trading.agents.consensus.analyze_ticker",
+            lambda t: (_ for _ in ()).throw(AssertionError("live 금지")),
+        )
+        with get_db(tmp_path / "test.db") as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, signals, agent_verdicts) "
+                "VALUES (?,?,?,?,?,?)",
+                (today_kst(), "AAPL", "HOLD", 50.0, json.dumps({"agreement_rate": 0.1}), "{}"),
+            )
+        r = client.get("/api/ticker/AAPL")
+        assert r.status_code == 200
+        assert r.json()["consensus"]["verdicts"] == []
+
     def test_ticker_candidates_exception(self, client, monkeypatch):
-        """screen_candidates raise → signals=[] (lines 209-210)."""
+        """screen_candidates raise → signals=[] (캐시 cold 강제)."""
+        from nuri.api.routes import ticker as ticker_mod
+
+        ticker_mod._candidates_cache["data"] = None
+        ticker_mod._candidates_cache["timestamp"] = 0.0
 
         def boom(**kw):
             raise RuntimeError("scan fail")
@@ -92,3 +262,29 @@ class TestTicker:
         assert r.status_code == 200
         data = r.json()
         assert data["signals"] == []
+
+    def test_ticker_signals_cache_hit_skips_rescan(self, client, monkeypatch):
+        """캐시 warm 시 screen_candidates 재호출 없이 캐시 결과 필터."""
+        from nuri.api.routes import ticker as ticker_mod
+
+        @dataclass
+        class _FakeCandidate:
+            ticker: str
+            signal_id: str = "rsi_oversold"
+            confidence: float = 80.0
+
+        ticker_mod._candidates_cache["data"] = [
+            _FakeCandidate(ticker="AAPL"),
+            _FakeCandidate(ticker="MSFT"),
+        ]
+        ticker_mod._candidates_cache["timestamp"] = _time.time()
+
+        def explode(**kw):
+            raise AssertionError("warm 캐시인데 screen_candidates 가 호출됨")
+
+        monkeypatch.setattr("nuri.trading.recommend.candidates.screen_candidates", explode)
+        r = client.get("/api/ticker/AAPL")
+        assert r.status_code == 200
+        signals = r.json()["signals"]
+        assert len(signals) == 1
+        assert signals[0]["ticker"] == "AAPL"


### PR DESCRIPTION
Closes #743

## Summary

`GET /ticker/{symbol}` (`get_ticker_detail`) ran two heavy ops synchronously on **every** request: `analyze_ticker` (10-agent consensus) + `screen_candidates` (full universe scan). Measured ~4.6s per detail-page load. Both removed from the hot path.

**consensus** → read the latest row from the `recommendations` table (scheduler writes it daily via `save_to_recommendations`). `agent_verdicts` JSON matches `asdict(AgentVerdict)` exactly; `dissent` is reconstructed from verdicts vs `final_action` (table stores only `dissent_count`). Falls back to live `analyze_ticker` only on **DB miss** (ticker not in portfolio) or **stale row (>7 days)**.

**signals** → `screen_candidates(lookback_days=10)` result cached in a 5-minute module TTL cache, shared across all ticker-detail requests (same pattern as `actions.py`/`dashboard.py`/`targets.py`). Scan failure returns `[]` without poisoning the cache (next request retries).

### Latency (measured, TSLA/NVDA)

| | before | after |
|---|---|---|
| consensus | part of 4.6s (10-agent) | **1.3ms** (DB read) |
| per-request | ~4.6s every time | warm **7ms** (cache hit + DB read) |
| cold (first in 5-min window) | ~4.6s | ~4.6s (one scan, then amortized) |

## Freshness guard

`_CONSENSUS_MAX_AGE_DAYS=7` — if the scheduler stops (cf. the 6-day silent outage this cycle), a stale consensus is **not** served as authoritative; the endpoint falls through to live recompute. `as_of` is surfaced in the payload for staleness transparency.

## Test Coverage

100% patch coverage on `nuri/api/routes/ticker.py`. New regression tests:
- `test_ticker_consensus_read_from_db_no_live_call` — fresh DB row → no `analyze_ticker` call
- `test_ticker_consensus_stale_row_falls_back_to_live` — 10-day-old row → live recompute
- `test_ticker_consensus_db_miss_live_fallback_shape` — not-in-portfolio → live shape (not error)
- `test_ticker_consensus_malformed_json_graceful` / `_verdicts_non_list_coerced` — legacy/corrupt rows
- `test_ticker_signals_cache_hit_skips_rescan` / `test_ticker_candidates_exception`

All test dates anchored to `today_kst()` (no time-bomb under the freshness window).

## Pre-Landing Review

Codex independent review, 2 rounds: round 1 NEEDS_REWORK (no freshness bound; cache self-poison on exception; bare-key dissent access) → all fixed → **round 2 PASS**.

## Test plan
- [x] `make test-fast` — 6024 passed, 6 skipped
- [x] ticker.py 100% patch coverage
- [x] live latency verified (4.6s → 7ms warm)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)