### PR TITLE
chore(collectors): #745 reproducible KR ticker name map generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,10 @@ universe-sync-kr:    ## Dry-run KR KOSPI 200 sync only (requires: uv pip install
 
 universe-sync-apply: ## Apply universe.yaml updates (additions only — manual ETFs preserved)
 	$(PYTHON) -m nuri.collectors.universe_sync --apply
+	-$(PYTHON) scripts/ops/gen_kr_names.py  # best-effort: sync 성공 후 KR 종목명 캐시 갱신 (FDR 장애 시 무시)
+
+kr-names:            ## Regenerate config/kr_ticker_names.json (KR 종목명 network-free 캐시)
+	$(PYTHON) scripts/ops/gen_kr_names.py
 
 validate-universe:   ## Universe + agent coverage 검증 (#272 Phase 2c)
 	$(PYTHON) scripts/doc/validate_universe.py

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,046 backend tests across 266 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,046 backend tests across 267 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,046 tests, 266 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,046 tests, 267 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/ops/gen_kr_names.py
+++ b/scripts/ops/gen_kr_names.py
@@ -1,0 +1,98 @@
+"""KOSPI 200 종목코드 → 한글명 맵 생성 (config/kr_ticker_names.json).
+
+`nuri.core.ticker_names` 의 2차 tier(network-free 로컬 맵)를 채운다. 맵이 없으면
+`get_ticker_name` 이 `/tickers/search` 요청당 live pykrx 호출로 회귀(검색 경로 느려짐)
+→ 재현성을 위한 재생성 도구. 런타임 collector(daily collect 사이클) 가 아니라 on-demand
+생성 유틸이라 nuri/collectors/ 가 아닌 scripts/ops/ 에 둔다.
+
+소스: FinanceDataReader `StockListing("KOSPI")` 시총 상위 200 (universe_sync.
+`_fetch_kospi200` 과 **동일 기준**). 리스팅에 `Name` 컬럼이 이미 포함돼 추가 네트워크
+없음 (pykrx per-ticker 호출 불필요). universe membership 과 거의 일치하나, universe-sync
+와 별개 fetch 라 marcap 경계(200위 근처) 종목이 시점차로 미세하게 다를 수 있다 — 맵에
+없는 종목은 ticker_names 가 live pykrx 로 self-healing fallback 하므로 무해.
+
+파일은 gitignored — KOSPI200 구성종목에 증권사 상호가 포함돼 privacy 스캐너가
+차단하기 때문. 따라서 신규 clone/머신은 `make kr-names` 로 1회 생성하고,
+`make universe-sync-apply` 가 멤버십 변경 후 자동으로 뒤이어 갱신한다.
+
+사용:
+  make kr-names                          # 재생성
+  python scripts/ops/gen_kr_names.py     # 동일
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# nuri.core.ticker_names._KR_NAMES_PATH 와 동일 파일 (config/kr_ticker_names.json)
+KR_NAMES_PATH = Path(__file__).resolve().parents[2] / "config" / "kr_ticker_names.json"
+_TOP_N = 200
+
+
+def _fetch_kospi_listing():
+    """FDR `StockListing("KOSPI")` df 반환. Code/Name/Marcap 컬럼 필요.
+
+    Raises:
+        FileNotFoundError: FDR 미설치.
+        RuntimeError: 설치됐지만 데이터 못 받음 / 컬럼 이상.
+    """
+    try:
+        import FinanceDataReader as fdr  # type: ignore[import-untyped]
+    except ImportError as e:
+        raise FileNotFoundError(
+            "KR 종목명 맵 생성에는 finance-datareader 필요: `uv pip install finance-datareader`"
+        ) from e
+
+    try:
+        df = fdr.StockListing("KOSPI")
+    except Exception as e:
+        raise RuntimeError(f"FinanceDataReader KOSPI listing fetch 실패: {e}") from e
+
+    if df is None or df.empty or not {"Code", "Name", "Marcap"}.issubset(df.columns):
+        cols = df.columns.tolist() if df is not None else None
+        raise RuntimeError(f"FinanceDataReader returned unexpected KOSPI data. cols: {cols}")
+    return df
+
+
+def build_name_map(df) -> dict[str, str]:
+    """시총 상위 _TOP_N 의 {code.KS: 한글명} (key 정렬). 빈 이름은 제외."""
+    top = df.nlargest(_TOP_N, "Marcap")
+    mapping = {
+        f"{str(code)}.KS": str(name).strip() for code, name in zip(top["Code"], top["Name"]) if str(name).strip()
+    }
+    return dict(sorted(mapping.items()))
+
+
+def write_name_map(mapping: dict[str, str], path: Path | None = None) -> int:
+    """맵을 json 으로 저장 (UTF-8, key 정렬). 반환: 항목 수.
+
+    path 기본값은 호출 시점에 모듈 전역 KR_NAMES_PATH 를 읽는다 (테스트 monkeypatch 안전 —
+    def-time 바인딩 회피).
+    """
+    path = path if path is not None else KR_NAMES_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(mapping, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return len(mapping)
+
+
+def regenerate(path: Path | None = None) -> int:
+    """KOSPI200 listing fetch → 맵 빌드 → 저장. 반환: 저장 항목 수."""
+    path = path if path is not None else KR_NAMES_PATH
+    df = _fetch_kospi_listing()
+    count = write_name_map(build_name_map(df), path)
+    logger.info("KR 종목명 맵 %d건 저장 → %s", count, path)
+    return count
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    count = regenerate()
+    print(f"config/kr_ticker_names.json: {count}건 저장")
+
+
+if __name__ == "__main__":  # pragma: no cover - main() 자체는 TestMain 커버, runpy 는 실제 캐시 덮어쓰기 위험
+    main()

--- a/tests/scripts/test_gen_kr_names.py
+++ b/tests/scripts/test_gen_kr_names.py
@@ -1,0 +1,114 @@
+"""Tests for scripts/ops/gen_kr_names.py — KR 종목명 맵 생성."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from scripts.ops import gen_kr_names as kr_names
+
+
+def _listing_df(n: int) -> pd.DataFrame:
+    """Mock StockListing('KOSPI') — Code/Name/Marcap 컬럼."""
+    return pd.DataFrame(
+        {
+            "Code": [f"{i:06d}" for i in range(n)],
+            "Name": [f"종목{i}" for i in range(n)],
+            "Marcap": [n - i for i in range(n)],  # 내림차순 시총
+        }
+    )
+
+
+class TestBuildNameMap:
+    def test_maps_code_to_name_sorted(self):
+        df = _listing_df(3)
+        result = kr_names.build_name_map(df)
+        assert result == {"000000.KS": "종목0", "000001.KS": "종목1", "000002.KS": "종목2"}
+        assert list(result.keys()) == sorted(result.keys())
+
+    def test_caps_at_top_n_by_marcap(self, monkeypatch):
+        monkeypatch.setattr(kr_names, "_TOP_N", 2)
+        df = _listing_df(5)  # Marcap 5,4,3,2,1 → top2 = code 000000, 000001
+        result = kr_names.build_name_map(df)
+        assert set(result) == {"000000.KS", "000001.KS"}
+
+    def test_skips_blank_names(self):
+        df = pd.DataFrame({"Code": ["005930", "000660"], "Name": ["삼성전자", "  "], "Marcap": [100, 90]})
+        result = kr_names.build_name_map(df)
+        assert result == {"005930.KS": "삼성전자"}
+
+
+class TestWriteNameMap:
+    def test_writes_json_returns_count(self, tmp_path):
+        path = tmp_path / "kr.json"
+        count = kr_names.write_name_map({"005930.KS": "삼성전자", "000660.KS": "SK하이닉스"}, path)
+        assert count == 2
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        assert loaded["005930.KS"] == "삼성전자"
+
+    def test_creates_parent_dir(self, tmp_path):
+        path = tmp_path / "nested" / "kr.json"
+        kr_names.write_name_map({"005930.KS": "삼성전자"}, path)
+        assert path.exists()
+
+
+class TestFetchKospiListing:
+    def test_fdr_not_installed(self):
+        with patch.dict(sys.modules, {"FinanceDataReader": None}):
+            with pytest.raises(FileNotFoundError, match="finance-datareader"):
+                kr_names._fetch_kospi_listing()
+
+    def test_fdr_returns_data(self):
+        mock_fdr = MagicMock()
+        mock_fdr.StockListing.return_value = _listing_df(10)
+        with patch.dict(sys.modules, {"FinanceDataReader": mock_fdr}):
+            df = kr_names._fetch_kospi_listing()
+        assert len(df) == 10
+
+    def test_fdr_empty(self):
+        mock_fdr = MagicMock()
+        mock_fdr.StockListing.return_value = pd.DataFrame()
+        with patch.dict(sys.modules, {"FinanceDataReader": mock_fdr}):
+            with pytest.raises(RuntimeError, match="unexpected"):
+                kr_names._fetch_kospi_listing()
+
+    def test_fdr_missing_name_column(self):
+        mock_fdr = MagicMock()
+        mock_fdr.StockListing.return_value = pd.DataFrame({"Code": ["005930"], "Marcap": [100]})
+        with patch.dict(sys.modules, {"FinanceDataReader": mock_fdr}):
+            with pytest.raises(RuntimeError, match="unexpected"):
+                kr_names._fetch_kospi_listing()
+
+    def test_fdr_raises(self):
+        mock_fdr = MagicMock()
+        mock_fdr.StockListing.side_effect = ValueError("KRX API change")
+        with patch.dict(sys.modules, {"FinanceDataReader": mock_fdr}):
+            with pytest.raises(RuntimeError, match="KOSPI listing fetch 실패"):
+                kr_names._fetch_kospi_listing()
+
+
+class TestRegenerate:
+    def test_fetch_build_write(self, tmp_path):
+        mock_fdr = MagicMock()
+        mock_fdr.StockListing.return_value = _listing_df(3)
+        path = tmp_path / "kr.json"
+        with patch.dict(sys.modules, {"FinanceDataReader": mock_fdr}):
+            count = kr_names.regenerate(path)
+        assert count == 3
+        assert json.loads(path.read_text(encoding="utf-8"))["000000.KS"] == "종목0"
+
+
+class TestMain:
+    def test_main_writes_default_path(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(kr_names, "KR_NAMES_PATH", tmp_path / "kr.json")
+        mock_fdr = MagicMock()
+        mock_fdr.StockListing.return_value = _listing_df(4)
+        with patch.dict(sys.modules, {"FinanceDataReader": mock_fdr}):
+            kr_names.main()
+        out = capsys.readouterr().out
+        assert "4건 저장" in out
+        assert (tmp_path / "kr.json").exists()


### PR DESCRIPTION
Closes #745

## Summary

`config/kr_ticker_names.json` (gitignored, ~200 KOSPI200 Korean names) backs the network-free 2nd tier of `nuri.core.ticker_names.get_ticker_name` (the search-path fix from #743/#742). It was generated ad-hoc via an inline pykrx one-liner → absent on fresh clones, forcing per-request live pykrx fallback. This adds a reproducible generator.

- **`scripts/ops/gen_kr_names.py`** — fetches `FinanceDataReader.StockListing("KOSPI")` (the same source `universe_sync._fetch_kospi200` already uses for KOSPI200 membership; it carries a `Name` column → **zero extra network**, no pykrx per-ticker calls), takes top-200 by Marcap, writes `{code.KS: 한글명}`.
- **`make kr-names`** — on-demand regeneration. **`universe-sync-apply`** chains it (best-effort `-` prefix: a name-cache failure won't fail an already-successful sync; the standalone target still fails loudly).
- Placed in `scripts/ops/` (not `nuri/collectors/`) on purpose — it's a generation utility, not a runtime `BaseCollector`. Keeps the "26 collectors (BaseCollector)" count accurate.

## Notes

- The json stays **gitignored** — KOSPI200 constituents include brokerage names the privacy scanner blocks (the generator/test contain none).
- `universe_sync._fetch_kospi200` is left untouched: changing its return type would ripple to ~8 test sites incl. integration tests (not surgical). Minor top-200-boundary drift between the two independent fetches is benign — a name absent from the cache self-heals via live pykrx fallback (documented in the module docstring).
- Backend test-file count 266→267.

## Test Coverage

`scripts/ops/gen_kr_names.py` 100% (12 tests): build_name_map (top-N/blank-skip/sort), write (tmp path/parent-dir), fetch errors (FDR missing/empty/missing-col/raises), regenerate, main.

## Pre-Landing Review

Codex independent review: **PASS, no P1**. Two P2 applied — (1) softened the "lockstep" docstring to note benign boundary drift, (2) `-` prefix on the chained recipe so `universe-sync-apply` stays green if only the name-cache step fails.

## Test plan
- [x] `make kr-names` → 200 entries, Korean names correct
- [x] ticker_names resolves network-free from regenerated map (pykrx blocked)
- [x] 983 passed (tests/scripts + tests/collectors), gen_kr_names 100% cov
- [x] doc-count drift check 13/13, privacy scan clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)