### PR TITLE
chore(siege): #747 non-US external-evidence gate → N/A for commodity/bond/kr_index

### DIFF
--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -240,7 +240,9 @@ siege_gates:
       asset_class: us_equity
 
   # Asset class 별 gate 정책. 현 PR: kr_equity + us_equity primary path.
-  # 기타 class (commodity/bond/kr_index) 는 정책만 선언 — 데이터 없으면 graceful skip.
+  # commodity/bond/kr_index 는 external_applicable:false — 애널리스트 컨센서스/13F 가
+  # 구조적으로 비적용인 자산군이라 external 게이트를 N/A(vacuous pass)로 처리.
+  # (kr_equity 는 적용 유지 — 커버리지는 존재하나 KR external collector 미구현 → warning 정직)
   asset_classes:
     us_equity:
       freshness_primary: SPY
@@ -270,8 +272,7 @@ siege_gates:
       volatility_primary_threshold: 5.0
       volatility_secondary: [usd_krw_3d_change]
       volatility_secondary_threshold: 3.0
-      external_min_records: 3
-      external_min_sources: 1
+      external_applicable: false           # 지수 ETF — 종목별 애널리스트 컨센서스 N/A
     commodity:
       freshness_primary: "GC=F"            # gold futures
       freshness_secondary: []
@@ -279,8 +280,7 @@ siege_gates:
       volatility_primary: gold_3d_change
       volatility_primary_threshold: 5.0
       volatility_secondary: []
-      external_min_records: 3
-      external_min_sources: 1
+      external_applicable: false           # 원자재 — 애널리스트 컨센서스/슈퍼투자자 13F N/A
     bond:
       freshness_primary: TLT
       freshness_secondary: []
@@ -288,8 +288,7 @@ siege_gates:
       volatility_primary: yield_3d_change
       volatility_primary_threshold: 0.3
       volatility_secondary: []
-      external_min_records: 3
-      external_min_sources: 1
+      external_applicable: false           # 채권 ETF — 애널리스트 컨센서스 N/A
 
   # E3-3c (PR TBD) — regime-adaptive position cap multipliers.
   # STRATEGY §3.6 Stage 2 PASS verdict (#402, paired counterfactual N=254,

--- a/docs/CERTIFICATION_SPEC.md
+++ b/docs/CERTIFICATION_SPEC.md
@@ -60,7 +60,7 @@ Dimension 3: Execution Market (실행 시장)
 - `asset_classes.<class>` — primary + secondary 지표 (cross-market spillover)
   - `freshness_primary` / `freshness_secondary` / `freshness_max_hours`
   - `volatility_primary` + threshold / `volatility_secondary` + threshold
-  - `external_min_records` / `external_min_sources`
+  - external 게이트: `external_applicable:false` 면 N/A vacuous pass(애널리스트 컨센서스/13F 비적용 자산군 commodity/bond/kr_index — 해당 class 는 `external_min_*` 미지정). 적용 class(us_equity/kr_equity)는 `external_min_records` / `external_min_sources` 로 평가
 
 **Phase 2 backlog** — `config/rules.yaml` 미배선 (spec only):
 - `hedge_status` (per-ticker) — currency_shift 분기용

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -468,7 +468,7 @@ Phase 1 ship + brief 재실행 검증 중 발견된 4건 — 별도 PR로 fix:
 | # | 조건 | 등급 | 출처 |
 | 5 | data_fresh | warning | `freshness_primary` + `freshness_secondary[]` + `freshness_max_hours` |
 | 7 | volatility_gate | warning | `volatility_primary` + threshold (+ secondary). us_equity VIX>30, kr_equity USD/KRW 3d>3% + VIX>30, kr_index KOSPI 3d>5% + USD/KRW>3% |
-| 8 | external_data | warning | `external_min_records` + `external_min_sources`. us≥10/3, kr≥5/2, kr_index/commodity/bond≥3/1 |
+| 8 | external_data | warning | `external_min_records` + `external_min_sources`. us≥10/3, kr≥5/2. **kr_index/commodity/bond = `external_applicable:false` → N/A vacuous pass** (애널리스트 컨센서스/13F 가 구조적으로 비적용인 자산군이라 영구 미충족 warning 대신 N/A 처리; kr_equity 는 적용 유지 — 커버리지 존재하나 KR external collector 미구현이라 warning 이 정직) |
 **예시**: us_equity 3 + kr_equity 2 포트폴리오 flatten 결과 (2026-04-16 기준) = base 8 + data_fresh 3 + volatility 3 + external_data 2 = **총 16 conditions**. 다른 포트폴리오는 다른 수치. 상세 per-class rule: `config/rules.yaml siege_gates` + `docs/CERTIFICATION_SPEC.md`. 생성 로직: `nuri/trading/engine/certification.py` `_check_{freshness,volatility,external}_for_class()` → `certify()` flatten.
 ## 7. 작업 정책
 운영 backlog (Tier 1/2/3) 는 `docs/TODO.md`. STRATEGY 는 **변하지 않는 정책** 만. 새 세션 시작 시 `NEXT_SESSION.md` → `docs/TODO.md`.

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -616,9 +616,23 @@ def _count_external_for_class(asset_class: str, tickers: list[str], db_path=None
 
 def _check_external_for_class(asset_class: str, tickers: list[str], policy: dict, db_path=None) -> CertCondition:
     """Asset class 별 external data gate."""
+    cid = f"external_data_{asset_class}"
+
+    # 애널리스트 컨센서스/슈퍼투자자 13F 가 구조적으로 비적용인 자산군
+    # (commodity/bond/kr_index — config external_applicable:false). 영구 미충족
+    # warning 대신 N/A 로 vacuous pass — 데이터를 위조하지 않으면서 오해 소지 제거.
+    # (kr_equity 는 적용 유지: 커버리지 존재하나 KR external collector 미구현 → warning)
+    if policy.get("external_applicable", True) is False:
+        return CertCondition(
+            cid,
+            f"[{asset_class}] external 근거 비적용 (N/A)",
+            True,
+            "애널리스트 컨센서스/13F 비적용 자산군 — 외부근거 요구 없음",
+            "info",
+        )
+
     min_rec = policy.get("external_min_records", 10)
     min_src = policy.get("external_min_sources", 3)
-    cid = f"external_data_{asset_class}"
     desc = f"[{asset_class}] external >= {min_rec}건 / {min_src}소스"
     try:
         records, sources = _count_external_for_class(asset_class, tickers, db_path=db_path)

--- a/tests/trading/engine/test_certification.py
+++ b/tests/trading/engine/test_certification.py
@@ -982,6 +982,42 @@ class TestAssetClassGates:
         # 6건 ≥ 5, 2소스 ≥ 2 — PASS
         assert kr_cond.passed is True, f"KR 완화 기준 통과 기대: {kr_cond.detail}"
 
+    def test_external_not_applicable_class_returns_na_pass(self, db_path):
+        """external_applicable:false 자산군(commodity/bond/kr_index) 은 영구 warning 대신 N/A vacuous pass."""
+        from nuri.trading.engine.certification import _check_external_for_class
+
+        cond = _check_external_for_class("commodity", ["GC=F"], {"external_applicable": False}, db_path=db_path)
+        assert cond.id == "external_data_commodity"
+        assert cond.passed is True
+        assert cond.severity == "info"
+        assert "비적용" in cond.description and "비적용" in cond.detail
+
+    def test_external_applicable_default_still_gates(self, db_path):
+        """external_applicable 미지정(default True) + 데이터 0 → 기존대로 warning (회귀 가드)."""
+        from nuri.trading.engine.certification import _check_external_for_class
+
+        cond = _check_external_for_class(
+            "us_equity", ["AAPL"], {"external_min_records": 10, "external_min_sources": 3}, db_path=db_path
+        )
+        assert cond.passed is False
+        assert cond.severity == "warning"
+
+    def test_commodity_holding_external_na_in_full_check(self, db_path):
+        """commodity 보유 시 _check_external_data 가 external_data_commodity 를 N/A pass 로 발행 (config 경로)."""
+        from nuri.trading.engine.certification import _check_external_data
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("test", "GC=F", 1, 2000.0, "USD", "ETF/Commodity"),
+            )
+
+        ext = _check_external_data(db_path=db_path)
+        commodity_cond = next((c for c in ext if c.id == "external_data_commodity"), None)
+        assert commodity_cond is not None, "commodity 보유 시 external_data_commodity 조건 발행 기대"
+        assert commodity_cond.passed is True
+        assert commodity_cond.severity == "info"
+
     def test_usd_krw_volatility_primary_fires_when_high(self, db_path):
         """USD/KRW 3일 변동 > 3% → kr_equity volatility primary warning."""
         from nuri.trading.engine.certification import _check_volatility_gates


### PR DESCRIPTION
Closes #747

## Summary

SIEGE v2's `external_data` gate (soft `warning` — `certified = failed(error)==0`, never blocks) demanded analyst-consensus / 13F external evidence per asset class. For **commodity (GC=F) / bond (TLT) / kr_index (KOSPI ETFs)** that evidence is **structurally N/A** (no analyst rating on gold futures or an index tracker), so the gate emitted a **perpetually-unsatisfiable warning** — misleading noise that reads as a deficiency.

Honest reframe (no faked data): mark those classes N/A.

- `config/rules.yaml` — `external_applicable: false` on commodity/bond/kr_index (dropped their now-moot `external_min_*`).
- `certification.py::_check_external_for_class` — flag false → `CertCondition(passed=True, severity="info", "…비적용…")` vacuous pass, before the threshold check. Guard is `is False` (a config typo degrades to the stricter warning path, never silently to pass).
- `kr_equity` keeps the gate — coverage *exists*, only the KR external collector is unbuilt, so that warning is honest and tracks a real future item. `us_equity` unchanged.
- docs: STRATEGY §6 + CERTIFICATION_SPEC.

## Live verification

```
external_data_bond       ✅ info  N/A (was warning)
external_data_commodity  ✅ info  N/A (was warning)
external_data_kr_index   ✅ info  N/A (was warning)
external_data_kr_equity  ⚠️ warning  2건/1소스 < 5/2  (honest — KR collector gap)
external_data_us_equity  ✅ error  34건/3소스
```
warnings 10→7. **REJECT status unchanged** (the 2 hard fails — concentration / stop-loss — are error-grade and unrelated). The reframe removes misleading signal without touching the Escalation Ladder.

## Pre-Landing Review

Codex independent review: **PASS, no P1/P2**. Confirmed: aggregation can't miscount an `info`/`passed=True` condition; `is False` guard is fail-safe; scoping correct (kr_equity excluded); removed keys have no other readers; persisted `severity:"info"` has no consumer that assumes only error/warning. One P3 doc-framing nit applied; one P3 (N/A counts toward score) left as benign/defensible.

## Test plan
- [x] 3 new cert tests (N/A pass / default-True still gates / full-check commodity) + 80 cert tests green
- [x] 328 tests/trading/engine green
- [x] live certify: 3 non-US external warnings → N/A pass, REJECT unchanged
- [x] doc-count 13/13, privacy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)