### PR TITLE
chore(cspell): #749 reproducible .cspell/tickers.txt generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,13 @@ universe-sync-kr:    ## Dry-run KR KOSPI 200 sync only (requires: uv pip install
 universe-sync-apply: ## Apply universe.yaml updates (additions only — manual ETFs preserved)
 	$(PYTHON) -m nuri.collectors.universe_sync --apply
 	-$(PYTHON) scripts/ops/gen_kr_names.py  # best-effort: sync 성공 후 KR 종목명 캐시 갱신 (FDR 장애 시 무시)
+	$(PYTHON) scripts/ops/gen_cspell_tickers.py  # universe 변경분 cSpell 사전 반영
 
 kr-names:            ## Regenerate config/kr_ticker_names.json (KR 종목명 network-free 캐시)
 	$(PYTHON) scripts/ops/gen_kr_names.py
+
+cspell-tickers:      ## Regenerate .cspell/tickers.txt (universe.yaml 기반 cSpell 사전)
+	$(PYTHON) scripts/ops/gen_cspell_tickers.py
 
 validate-universe:   ## Universe + agent coverage 검증 (#272 Phase 2c)
 	$(PYTHON) scripts/doc/validate_universe.py

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,046 backend tests across 267 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,046 backend tests across 268 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,046 tests, 267 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,046 tests, 268 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/ops/gen_cspell_tickers.py
+++ b/scripts/ops/gen_cspell_tickers.py
@@ -1,0 +1,78 @@
+"""cSpell 티커 사전 생성 (.cspell/tickers.txt).
+
+universe.yaml 의 티커 심볼들을 cSpell custom dictionary 로 추출 → 코드/문서에 등장하는
+티커가 맞춤법 오류로 플래그되지 않게 한다. universe-sync 로 종목이 바뀌면 신규 티커가
+오류로 떠서 매뉴얼로 추가해야 했던 것을 재현 가능한 generator 로 자동화한다 (gen_kr_names
+와 동일 패턴 — scripts/ops 생성기 + make 타깃 + universe-sync-apply 체이닝).
+
+추출 규칙: 각 티커를 `.`/`-` 로 split 해 alpha 파트(길이 ≥ 2)만 대문자로 수집.
+- "BRK-B" → BRK (B 는 단일문자 제외 — cSpell 은 단일문자 미플래그)
+- "005930.KS" → KS (숫자 코드는 cSpell 미플래그라 자동 제외)
+정렬·중복제거 후 한 줄에 하나씩 기록.
+
+파일은 gitignored 가 아님 — US 티커는 공개 정보(privacy 무관)라 추적 대상.
+신규 clone 은 `make cspell-tickers`, universe 변경 시 universe-sync-apply 가 자동 갱신.
+
+사용:
+  make cspell-tickers                          # 재생성
+  python scripts/ops/gen_cspell_tickers.py     # 동일
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+UNIVERSE_PATH = _REPO_ROOT / "config" / "universe.yaml"
+TICKERS_PATH = _REPO_ROOT / ".cspell" / "tickers.txt"
+
+
+def build_ticker_words(universe: dict) -> list[str]:
+    """universe.yaml dict → 정렬된 cSpell 단어 목록.
+
+    각 티커를 `.`/`-` 로 분해해 alpha 파트(len >= 2)만 대문자 수집 (중복제거·정렬).
+    """
+    words: set[str] = set()
+    for group in universe.values():
+        if isinstance(group, dict) and "tickers" in group:
+            for ticker in group["tickers"]:
+                for part in re.split(r"[.-]", str(ticker)):
+                    if part.isalpha() and len(part) >= 2:
+                        words.add(part.upper())
+    return sorted(words)
+
+
+def write_ticker_words(words: list[str], path: Path | None = None) -> int:
+    """단어 목록을 한 줄에 하나씩 저장 (trailing newline). 반환: 단어 수.
+
+    path 기본값은 호출 시점에 모듈 전역 TICKERS_PATH 를 읽는다 (테스트 monkeypatch 안전).
+    """
+    path = path if path is not None else TICKERS_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(words) + "\n", encoding="utf-8")
+    return len(words)
+
+
+def regenerate(universe_path: Path | None = None, out_path: Path | None = None) -> int:
+    """universe.yaml 로드 → 단어 빌드 → 저장. 반환: 단어 수."""
+    universe_path = universe_path if universe_path is not None else UNIVERSE_PATH
+    universe = yaml.safe_load(universe_path.read_text(encoding="utf-8")) or {}
+    count = write_ticker_words(build_ticker_words(universe), out_path)
+    logger.info("cSpell 티커 사전 %d개 저장 → %s", count, out_path or TICKERS_PATH)
+    return count
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    count = regenerate()
+    print(f".cspell/tickers.txt: {count}개 저장")
+
+
+if __name__ == "__main__":  # pragma: no cover - main() 자체는 TestMain 커버, runpy 는 실제 사전 덮어쓰기 위험
+    main()

--- a/tests/scripts/test_gen_cspell_tickers.py
+++ b/tests/scripts/test_gen_cspell_tickers.py
@@ -1,0 +1,72 @@
+"""Tests for scripts/ops/gen_cspell_tickers.py — cSpell 티커 사전 생성."""
+
+from __future__ import annotations
+
+import yaml
+
+from scripts.ops import gen_cspell_tickers as g
+
+
+class TestBuildTickerWords:
+    def test_splits_dot_and_hyphen_alpha_only(self):
+        uni = {
+            "us": {"tickers": ["AAPL", "BRK-B", "BF-B"]},
+            "kr": {"tickers": ["005930.KS", "000660.KQ"]},
+        }
+        words = g.build_ticker_words(uni)
+        # alpha len>=2: AAPL, BRK, BF, KS, KQ. 단일문자 B 제외, 숫자코드 제외.
+        assert words == ["AAPL", "BF", "BRK", "KQ", "KS"]
+
+    def test_excludes_single_char_and_numeric(self):
+        uni = {"g": {"tickers": ["A", "F", "T", "123456.KS"]}}
+        # 단일문자 전부 제외, 숫자 제외 → KS 만
+        assert g.build_ticker_words(uni) == ["KS"]
+
+    def test_dedupe_and_sort(self):
+        uni = {"a": {"tickers": ["MSFT", "aapl"]}, "b": {"tickers": ["AAPL", "MSFT"]}}
+        assert g.build_ticker_words(uni) == ["AAPL", "MSFT"]
+
+    def test_ignores_groups_without_tickers(self):
+        uni = {"meta": {"description": "no tickers here"}, "g": {"tickers": ["NVDA"]}}
+        assert g.build_ticker_words(uni) == ["NVDA"]
+
+
+class TestWriteTickerWords:
+    def test_writes_one_per_line_trailing_newline(self, tmp_path):
+        path = tmp_path / "tickers.txt"
+        count = g.write_ticker_words(["AAPL", "MSFT", "NVDA"], path)
+        assert count == 3
+        assert path.read_text(encoding="utf-8") == "AAPL\nMSFT\nNVDA\n"
+
+    def test_creates_parent_dir(self, tmp_path):
+        path = tmp_path / "nested" / "tickers.txt"
+        g.write_ticker_words(["AAPL"], path)
+        assert path.exists()
+
+
+class TestRegenerate:
+    def test_load_build_write(self, tmp_path):
+        uni_path = tmp_path / "universe.yaml"
+        uni_path.write_text(yaml.safe_dump({"us": {"tickers": ["AAPL", "BRK-B"]}}), encoding="utf-8")
+        out_path = tmp_path / "tickers.txt"
+        count = g.regenerate(universe_path=uni_path, out_path=out_path)
+        assert count == 2
+        assert out_path.read_text(encoding="utf-8") == "AAPL\nBRK\n"
+
+    def test_empty_universe_yaml(self, tmp_path):
+        uni_path = tmp_path / "universe.yaml"
+        uni_path.write_text("", encoding="utf-8")  # yaml.safe_load → None → {} fallback
+        out_path = tmp_path / "tickers.txt"
+        assert g.regenerate(universe_path=uni_path, out_path=out_path) == 0
+
+
+class TestMain:
+    def test_main_writes_default_paths(self, tmp_path, monkeypatch, capsys):
+        uni_path = tmp_path / "universe.yaml"
+        uni_path.write_text(yaml.safe_dump({"us": {"tickers": ["AAPL", "NVDA"]}}), encoding="utf-8")
+        monkeypatch.setattr(g, "UNIVERSE_PATH", uni_path)
+        monkeypatch.setattr(g, "TICKERS_PATH", tmp_path / "tickers.txt")
+        g.main()
+        out = capsys.readouterr().out
+        assert "2개 저장" in out
+        assert (tmp_path / "tickers.txt").read_text(encoding="utf-8") == "AAPL\nNVDA\n"


### PR DESCRIPTION
Closes #749

## Summary

`.cspell/tickers.txt` (534 ticker words from `config/universe.yaml`) lost its generator in #741, so it drifts when `universe-sync` changes membership. This restores a reproducible generator, mirroring `gen_kr_names` (#746).

- **`scripts/ops/gen_cspell_tickers.py`** — extract from `universe.yaml`: split each ticker on `.`/`-`, keep alpha parts (len ≥ 2), uppercase, dedupe, sort. `BRK-B`→`BRK`, `005930.KS`→`KS`; single-char (`A`,`F`,`T`) and numeric KR codes excluded (cSpell doesn't flag them). **Reproduces the current committed file byte-for-byte (534 words).**
- **`make cspell-tickers`** — on-demand. `universe-sync-apply` chains it (deterministic, loud — no network).
- Backend test-file count 267→268.

## Verification

- `make cspell-tickers` → 534 words, `git diff .cspell/tickers.txt` empty (byte-identical to committed).
- Reverse-engineered the exact extraction rule by matching all 4 candidate rules against the committed file; `[.-]` split + alpha-len≥2 is the unique match (534/534).

## Pre-Landing Review

Self-review (structurally identical to #746 `gen_kr_names`, which passed Codex 2-round): same `path=None`→module-global deferred-binding pattern, same `# pragma` on the `__main__` guard, same `scripts/ops/` placement (not a runtime collector → keeps the "26 collectors" count accurate). New surface is only the regex extraction rule, verified by byte-identical reproduction.

## Test plan
- [x] 9 new tests (build/write/regenerate/main), `gen_cspell_tickers.py` 100% cov
- [x] `make cspell-tickers` byte-identical to committed file
- [x] doc-count 13/13, privacy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)