### PR TITLE
docs: surface kr-names/cspell-tickers in make help + sync rules.yaml count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ help:
 	@echo "  Verify:       make verify-help    (verify-quick → verify-all → verify-fast → verify, fastest first)"
 	@echo "  Data:         make collect, make collect-kis, make wallstreet, make filings"
 	@echo "  Universe:     make universe-sync[-us/-kr/-apply], make collect-universe[-1y], make validate-universe"
+	@echo "  Universe gen: make kr-names (KR 종목명 캐시), make cspell-tickers (cSpell 사전) — sync-apply 가 자동 체이닝"
 	@echo "  Analysis:     make analyze, make consensus, make scan, make backtest"
 	@echo "  Pipeline:     make full-scan, make quick-scan"
 	@echo "  Trading:      make targets, make rebalance, make recommend, make certify, make remediate"

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 438 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `siege_gates` incl. `regime_overrides`) | `nuri/core/rules.py` |
+| `rules.yaml` | 447 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 122 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |


### PR DESCRIPTION
## Summary

Doc-sync follow-up to this session's generator PRs (#746, #748, #750):

- **`make help`** — `make help` is a hand-curated `@echo` block (not auto-parsed from `##` comments), so the new `kr-names` (#746) and `cspell-tickers` (#750) targets weren't discoverable. Added a "Universe gen" line noting both are auto-chained by `universe-sync-apply`.
- **`config/CLAUDE.md`** — `rules.yaml` line count 438→447 (reflects #748's `external_applicable` additions + corrects pre-existing drift) + mention `external_applicable` in the description.

In-PR doc updates already shipped this session: STRATEGY §6 + CERTIFICATION_SPEC (SIEGE N/A, #748), backend test-file count 267→268 (#750). README "26 collectors" stays accurate (generators live in `scripts/ops/`, not `nuri/collectors/`).

Noted separately (NOT in this PR — pre-existing, untouched this session): `config/CLAUDE.md` claims `buy_signals.yaml` 122 lines, actual 131.

## Test plan
- [x] `make help` shows kr-names / cspell-tickers
- [x] `config/CLAUDE.md` rules.yaml count == `wc -l` (447)
- [x] doc-count drift check 13/13 (unaffected — these counts aren't gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)