### PR TITLE
chore(validation): #711 thread db_path through WalkForwardValidator

### DIFF
--- a/nuri/agents/actors/walkforward_validator.py
+++ b/nuri/agents/actors/walkforward_validator.py
@@ -346,6 +346,9 @@ class WalkForwardValidator(Actor):
             n_train_obs=n_train_total,
             n_test_obs=n_test_total,
             finished_at=kst_now().isoformat(),
+            # explicit-db caller (strategy/variant walk-forward) 는 backtests 와 동일
+            # DB 로 기록해야 split-write 회피 (#711). None 이면 기본 DB.
+            db_path=input_data.get("db_path"),
         )
 
         outcome = Outcome.WARN if any_failed else Outcome.PASS

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -275,6 +275,7 @@ def run_strategy_walkforward(
             "target_col": f"r_lb{grid[0]}",
             "metric_kind": "regression",
             "model_id": "momentum-topN-walkforward",
+            "db_path": db_path,  # walkforward_runs 를 backtests 와 동일 DB 로 (#711)
         }
     )
     oos_sharpe = result.output.get("metrics", {}).get("aggregate", {}).get("sharpe_mean")

--- a/nuri/quant/validation/variant_walkforward.py
+++ b/nuri/quant/validation/variant_walkforward.py
@@ -411,7 +411,11 @@ def run_variant_search(
             )
 
     # WalkForwardValidator 로 변형별 per-fold 기록 (walkforward_runs → /api/research/walkforward)
-    run_ids = _log_walkforward_runs(close, vol, fx_ret, variants, cfg, cost_bps, global_warmup) if persist else {}
+    run_ids = (
+        _log_walkforward_runs(close, vol, fx_ret, variants, cfg, cost_bps, global_warmup, db_path=db_path)
+        if persist
+        else {}
+    )
     for r in results:
         r["walkforward_run_id"] = run_ids.get(r["name"])
 
@@ -437,15 +441,14 @@ def _log_walkforward_runs(
     cfg: dict,
     cost_bps: float,
     global_warmup: int,
+    db_path: Optional[Path] = None,
 ) -> dict[str, Optional[str]]:
     """변형별 WalkForwardValidator run (per-fold 메트릭 → walkforward_runs 기록).
 
     _evaluate_variant 와 동일한 global_warmup 슬라이스 사용 (캘린더 창 일치).
 
-    주의: WalkForwardValidator 는 db_path 를 받지 않아 기본 DB 에만 기록한다
-    (baseline strategy_walkforward 와 동일한 기존 속성 — 무수정 원칙). 명시적
-    db_path 호출자는 backtests 와 walkforward_runs 가 다른 DB 로 갈 수 있음.
-    테스트는 db_path_mp(기본 DB monkeypatch)로 우회. 해소는 별도 이슈.
+    db_path 는 actor input 으로 전달돼 walkforward_runs 가 backtests 와 동일 DB 로
+    기록된다 (#711, split-write 회피). None 이면 기본 DB.
     """
     actor = WalkForwardValidator()
     run_ids: dict[str, Optional[str]] = {}
@@ -469,6 +472,7 @@ def _log_walkforward_runs(
                 "target_col": f"r_k{keys[0]}",  # 형식 요건 — 평가는 predict 수익률만 소비
                 "metric_kind": "regression",
                 "model_id": f"wf-variant:{v['name']}",
+                "db_path": db_path,  # walkforward_runs 를 backtests 와 동일 DB 로 (#711)
             }
         )
         run_ids[v["name"]] = result.output.get("run_id")

--- a/tests/agents/test_walkforward_validator.py
+++ b/tests/agents/test_walkforward_validator.py
@@ -46,7 +46,10 @@ def patched_db(db_path):
 
     def make_redirect(fn):
         def wrapped(*args, **kwargs):
-            kwargs.setdefault("db_path", db_path)
+            # actor 가 db_path=None 을 명시 전달(#711)해도 tmp DB 로 라우팅되도록
+            # setdefault 대신 None 도 덮어쓴다.
+            if kwargs.get("db_path") is None:
+                kwargs["db_path"] = db_path
             return fn(*args, **kwargs)
 
         return wrapped
@@ -411,6 +414,38 @@ class TestActionRun:
         assert len(rows) == 1
         assert rows[0]["model_id"] == "persist_test"
         assert rows[0]["finished_at"] is not None
+
+    def test_db_path_routes_walkforward_run_to_caller_db(self, tmp_path, monkeypatch, synthetic_data):
+        """#711 lock-test: input_data['db_path'] 가 walkforward_runs 를 caller DB 로 보내고
+        기본 DB 는 건드리지 않는다. db_path passthrough 를 되돌리면(기본 DB 기록) FAIL —
+        explicit-db caller 의 backtests/walkforward_runs split-write 회귀를 잡는다."""
+        from nuri.core import db as db_module
+
+        default_db = tmp_path / "default.db"
+        caller_db = tmp_path / "caller.db"
+        init_db(default_db)
+        init_db(caller_db)
+        # 기본 DB resolution(=db_path None) 을 tmp default 로 가둬 실제 DB 오염 방지.
+        monkeypatch.setattr(db_module, "DB_PATH", default_db)
+
+        actor = WalkForwardValidator()
+        result = actor.run(
+            {
+                "action": "run",
+                "data": synthetic_data,
+                "fold_spec": {"kind": "rolling", "train_size": 50, "test_size": 10, "step": 10},
+                "model_id": "db_path_route",
+                "model_fn": _dummy_classifier,
+                "target_col": "target",
+                "metric_kind": "classification",
+                "db_path": caller_db,
+            }
+        )
+        run_id = result.output["run_id"]
+        caller_rows = query("SELECT 1 FROM walkforward_runs WHERE run_id = ?", (run_id,), db_path=caller_db)
+        default_rows = query("SELECT 1 FROM walkforward_runs WHERE run_id = ?", (run_id,), db_path=default_db)
+        assert len(caller_rows) == 1, "walkforward_run 이 caller DB 에 기록돼야 함"
+        assert len(default_rows) == 0, "walkforward_run 이 기본 DB 로 새면 안 됨 (split-write)"
 
     def test_failed_fold_returns_warn(self, patched_db, synthetic_data):
         """일부 fold 의 model_fn 이 raise 하면 outcome=WARN (전체 panic 아님)."""


### PR DESCRIPTION
Closes #711.

## Problem
`WalkForwardValidator` logged `walkforward_runs` via `log_walkforward_run()` but never forwarded `db_path`. Explicit-db callers (`strategy_walkforward.py` / `variant_walkforward.py`) therefore wrote `backtests` to the **caller DB** while `walkforward_runs` went to the **default DB** — a split-write. Tests masked it via a default-DB monkeypatch.

## Fix (plumbing/consistency only — not an edge change)
- `walkforward_validator.py`: `log_walkforward_run(..., db_path=input_data.get("db_path"))`
- `strategy_walkforward.py`: pass `"db_path": db_path` into the actor input (db_path already threaded for `save_backtest`)
- `variant_walkforward.py`: `_log_walkforward_runs` gains a `db_path` param, threaded from `run_variant_search`; stale "validator doesn't accept db_path" docstring corrected
- `log_walkforward_run` already supported `db_path=` — no writer change
- CLI `main()` caller excluded (action=`pit_hash`, never logs a run)

## Test
- New lock-test `test_db_path_routes_walkforward_run_to_caller_db`: asserts the run lands in the caller DB and **not** the default DB. Verified to FAIL if the passthrough is reverted (Gotcha-Test Pair §5.3.1).
- `patched_db` fixture redirect changed `setdefault` → `if kwargs.get("db_path") is None` (actor now always passes `db_path`, incl. `None`).
- 114/114 validation + validator tests green locally.

Codex review: PASS (no P1/P2), independently confirmed revert→FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)