### PR TITLE
fix(recommend): #753 read VIX from macro table in buy_candidate_emitter

### DIFF
--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -257,11 +257,13 @@ def _get_regime() -> tuple[str, float]:
     except Exception:
         regime = "neutral"
     try:
+        # VIX 는 macro 테이블(indicator='vix')에만 수집된다. prices.VIX 는 미수집이라
+        # 과거 prices 경로는 항상 fallback 20.0 으로 떨어져 VIX 게이트가 무력화됐다 (#753).
         df_vix = query_df(
-            """SELECT close FROM prices WHERE ticker = 'VIX'
+            """SELECT value FROM macro WHERE indicator = 'vix'
                ORDER BY date DESC LIMIT 1"""
         )
-        vix = float(df_vix["close"].iloc[0]) if not df_vix.empty else 20.0
+        vix = float(df_vix["value"].iloc[0]) if not df_vix.empty else 20.0
     except Exception:
         vix = 20.0
     return regime, vix

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -110,12 +110,11 @@ def _seed_rsi(db_path, ticker: str, rsi: float):
 
 
 def _seed_vix(db_path, value: float):
-    """Seed VIX into prices (emitter reads ticker='VIX' from prices)."""
+    """Seed VIX into macro (emitter reads indicator='vix' from macro — #753)."""
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT OR REPLACE INTO prices (ticker, date, open, high, low, close, volume, adj_close) "
-            "VALUES ('VIX', '2026-04-30', ?, ?, ?, ?, 0, ?)",
-            (value, value, value, value, value),
+            "INSERT INTO macro (indicator, date, value, source) VALUES ('vix', '2026-04-30', ?, 'test')",
+            (value,),
         )
 
 
@@ -183,6 +182,28 @@ def test_vix_block_above_30(db, cfg_path):
     assert res.candidates == []
     assert res.blocked_reason is not None
     assert "VIX" in res.blocked_reason
+
+
+def test_vix_gate_reads_macro_not_prices(db, cfg_path):
+    """#753 회귀: VIX 는 macro 테이블에서 읽어야 한다 (prices.VIX 는 미수집).
+
+    macro(indicator='vix') 에만 block 임계 초과 VIX 를 seed 하고 prices.VIX 는
+    의도적으로 비운다. emitter 가 prices 경로(버그)로 되돌아가면 macro VIX 를
+    무시해 vix=20.0 fallback → 차단 미발화 → FAIL.
+    """
+    _seed_factor(db, "AAPL", 0.9)
+    _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
+    _seed_regime(db, "neutral")
+    with get_db(db) as conn:
+        conn.execute("INSERT INTO macro (indicator, date, value, source) VALUES ('vix', '2026-04-30', 35.0, 'test')")
+        # prices.VIX 행이 없음을 명시 (버그 mask 방지 가드)
+        assert conn.execute("SELECT COUNT(*) FROM prices WHERE ticker='VIX'").fetchone()[0] == 0
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.candidates == []
+    assert res.blocked_reason is not None
+    assert "VIX" in res.blocked_reason
+    assert res.vix == pytest.approx(35.0)
 
 
 def test_vix_caution_halves_allocation(db, cfg_path):


### PR DESCRIPTION
Closes #753

## 문제
`buy_candidate_emitter._get_regime()` 가 VIX 를 `prices.VIX`(미수집, 0행)에서 읽어 **항상 fallback `20.0`** → `vix_block_above`(30) / `vix_caution_above`(25) 게이트가 BUY candidate 경로(`scheduler.py:323` + `make buy-candidates`)에서 절대 발화하지 않았다. "VIX > 30 → 신규 매수 차단" invariant 무력화.

## Fix
- `_get_regime()` VIX 쿼리를 `prices.close` → `macro.value` (`indicator='vix'`) 로 변경. canonical `candidates._check_vix_gate` 패턴과 일치. fallback `20.0` 유지.
- 테스트 헬퍼 `_seed_vix` 를 `macro` seed 로 갱신 — 기존에 `prices.VIX` 를 seed 해 버그를 mask 하던 것을 진짜 경로로 전환 (기존 14개 VIX 테스트가 real-path 회귀가 됨).
- 회귀 가드 추가: `test_vix_gate_reads_macro_not_prices` (macro VIX seed + `prices.VIX` 부재 명시 → block 발화 검증).

## 검증
- fail-first: 새 테스트가 수정 전 코드에서 FAIL 확인 (AAPL이 35 VIX에도 30% deploy로 emit).
- `tests/trading/recommend/` 454 passed, ruff clean.
- 라이브: `_get_regime()` 이 실 macro VIX(16.32, 2026-06-15) 반환 — 수정 전 `20.0` 이었음.

## Scope 제외 (별도 추적)
line 396 `>` vs candidates `>=` 연산자 비대칭 · `buy_signals.yaml` VIX 임계 중복 · `LEVERAGE_ETFS` drift — 별도 P2 이슈.

## Gotcha-Test Pair
**Test:** `tests/trading/recommend/test_buy_candidate_emitter.py::test_vix_gate_reads_macro_not_prices`

🤖 Generated with [Claude Code](https://claude.com/claude-code)