### PR TITLE
fix(api): #754 expose macro_score from MacroScore dataclass in market-context

### DIFF
--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -188,8 +188,9 @@ def get_market_context():
     try:
         from nuri.quant.regime.macro_score import compute_macro_score
 
+        # compute_macro_score 는 MacroScore dataclass 를 반환한다 (dict 아님 — #754).
         macro = compute_macro_score()
-        macro_score = macro.get("total_score") if isinstance(macro, dict) else None
+        macro_score = macro.total_score
     except Exception:
         macro_score = None
 

--- a/tests/api/test_ticker.py
+++ b/tests/api/test_ticker.py
@@ -44,6 +44,24 @@ class TestTicker:
         assert r.status_code == 200
         assert r.json()["macro_score"] is None
 
+    def test_market_context_macro_score_present(self, client, monkeypatch):
+        """#754 회귀: compute_macro_score 는 MacroScore dataclass 를 반환한다.
+
+        과거 코드는 ``isinstance(macro, dict)`` 체크로 dataclass 를 항상 None
+        처리해 macro_score 가 영구 null 이었다. dataclass 속성 접근으로 노출.
+        """
+
+        class FakeMacro:
+            total_score = 62.5
+
+        monkeypatch.setattr(
+            "nuri.quant.regime.macro_score.compute_macro_score",
+            lambda: FakeMacro(),
+        )
+        r = client.get("/api/tickers/market-context")
+        assert r.status_code == 200
+        assert r.json()["macro_score"] == 62.5
+
     def test_market_context_classify_returns_regime(self, client, monkeypatch):
         """classify_regime returns truthy → trend set (line 95)."""
 


### PR DESCRIPTION
Closes #754

## 문제
`GET /api/tickers/market-context` 의 `macro_score` 가 **항상 null** 로 반환됐다. 핸들러가 `macro.get("total_score") if isinstance(macro, dict) else None` 를 썼으나 `compute_macro_score()` 는 `dict` 가 아니라 `MacroScore` **dataclass** 를 반환 → `isinstance` 분기가 항상 None 경로.

## Fix
- `ticker.py:189-192`: `macro.total_score` 직접 접근 (dataclass 속성, `macro_agent.py:35` 와 동일).
- 회귀 테스트 추가: `test_market_context_macro_score_present` — 기존엔 예외 경로(`test_market_context_macro_exception`)만 커버해 정상 경로 결손이 버그를 통과시켰다.

## 검증
- fail-first: 새 테스트가 수정 전 `assert None == 62.5` 로 FAIL 확인.
- `tests/api/test_ticker.py` 14 passed, ruff clean.
- 라이브: 핸들러 로직이 실 macro 점수 `65.7` (Neutral) 반환 — 수정 전 `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)