### PR TITLE
fix(rebalance): #758 exclude leverage ETFs from optimization universe

### DIFF
--- a/nuri/analysis/rebalance.py
+++ b/nuri/analysis/rebalance.py
@@ -14,6 +14,7 @@
     python -m nuri.analysis.rebalance
     python -m nuri.analysis.rebalance --method rp   # Risk Parity
 """
+
 import argparse
 import logging
 
@@ -65,17 +66,15 @@ def analyze_rebalance(method: str = "mvo") -> pd.DataFrame:
 
     # Riskfolio 포트폴리오
     common_tickers = sorted(set(returns.columns) & set(current_weights.keys()))
-    port = rp.Portfolio(returns=returns[common_tickers])
+    # 레버리지 ETF 는 스윙 전용 — 장기 리밸런스 최적화 유니버스에서 제외해 목표 비중을
+    # 0% 로 강제한다 (#758). 보유 중인 레버리지 ETF 는 아래 결과 루프에서 w.index 에
+    # 없으므로 optimal_weight=0 + 'SELL (레버리지)' 로 표시된다.
+    opt_tickers = [t for t in common_tickers if t not in LEVERAGE_ETFS]
+    port = rp.Portfolio(returns=returns[opt_tickers])
     port.assets_stats(method_mu="hist", method_cov="hist")
 
     # 제약조건: 단일 종목 ≤ 15%
     port.upperlng = MAX_SINGLE_POSITION
-
-    # 레버리지 ETF 비중 0으로 강제
-    for i, ticker in enumerate(common_tickers):
-        if ticker in LEVERAGE_ETFS:
-            if port.upperlng is not None:
-                pass  # upperlng이 이미 글로벌 상한
 
     # 최적화 실행
     if method == "rp":
@@ -112,16 +111,18 @@ def analyze_rebalance(method: str = "mvo") -> pd.DataFrame:
         elif trade_value > 100:
             action = "BUY"
 
-        results.append({
-            "ticker": ticker,
-            "sector": sectors.get(ticker, ""),
-            "current_weight": round(cur_weight * 100, 2),
-            "optimal_weight": round(opt_weight * 100, 2),
-            "drift": round(drift * 100, 2),
-            "trade_value_usd": round(trade_value, 0),
-            "trade_shares": round(trade_value / current_price, 1),
-            "action": action,
-        })
+        results.append(
+            {
+                "ticker": ticker,
+                "sector": sectors.get(ticker, ""),
+                "current_weight": round(cur_weight * 100, 2),
+                "optimal_weight": round(opt_weight * 100, 2),
+                "drift": round(drift * 100, 2),
+                "trade_value_usd": round(trade_value, 0),
+                "trade_shares": round(trade_value / current_price, 1),
+                "action": action,
+            }
+        )
 
     df = pd.DataFrame(results).sort_values("drift", key=abs, ascending=False)
     df.attrs["method"] = "Risk Parity" if method == "rp" else "Mean-Variance (Max Sharpe)"
@@ -139,7 +140,7 @@ def print_rebalance(df: pd.DataFrame) -> None:
 
     print(f"\n{'=' * 65}")
     print(f"  리밸런싱 제안 — {method} (Riskfolio-Lib)")
-    print(f"  제약: 단일종목 ≤{MAX_SINGLE_POSITION*100:.0f}%, 섹터 ≤{MAX_SECTOR_EXPOSURE*100:.0f}%")
+    print(f"  제약: 단일종목 ≤{MAX_SINGLE_POSITION * 100:.0f}%, 섹터 ≤{MAX_SECTOR_EXPOSURE * 100:.0f}%")
     print(f"{'=' * 65}")
 
     if actionable.empty:
@@ -148,9 +149,11 @@ def print_rebalance(df: pd.DataFrame) -> None:
         print(f"\n  {'Ticker':<12} {'현재%':>8} {'최적%':>8} {'차이%':>8} {'제안':>12}")
         print(f"  {'-' * 52}")
         for _, row in actionable.iterrows():
-            print(f"  {row['ticker']:<12} {row['current_weight']:>7.1f}% "
-                  f"{row['optimal_weight']:>7.1f}% {row['drift']:>+7.1f}% "
-                  f"{row['action']:>12}")
+            print(
+                f"  {row['ticker']:<12} {row['current_weight']:>7.1f}% "
+                f"{row['optimal_weight']:>7.1f}% {row['drift']:>+7.1f}% "
+                f"{row['action']:>12}"
+            )
     print()
 
 
@@ -158,8 +161,9 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint: 리밸런싱 제안 (mvo / rp)."""
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser()
-    parser.add_argument("--method", choices=["mvo", "rp"], default="mvo",
-                        help="최적화 방법: mvo(샤프 최대화) 또는 rp(리스크 패리티)")
+    parser.add_argument(
+        "--method", choices=["mvo", "rp"], default="mvo", help="최적화 방법: mvo(샤프 최대화) 또는 rp(리스크 패리티)"
+    )
     args = parser.parse_args(argv)
 
     df = analyze_rebalance(method=args.method)

--- a/tests/analysis/test_rebalance.py
+++ b/tests/analysis/test_rebalance.py
@@ -1,4 +1,5 @@
 """Tests for nuri.analysis.rebalance — split from tests/test_analysis_all.py (#157)."""
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -6,61 +7,77 @@ import pytest
 
 class TestAnalysisRebalance:
     """From test_coverage_push.py."""
+
     def test_empty_db(self, db_path):
         from nuri.analysis.rebalance import analyze_rebalance
+
         result = analyze_rebalance(method="rp")
         assert isinstance(result, pd.DataFrame)
 
     def test_with_data(self, price_db):
         from nuri.analysis.rebalance import analyze_rebalance
+
         result = analyze_rebalance(method="rp")
         assert isinstance(result, pd.DataFrame)
 
     def test_mvo_method(self, price_db):
         from nuri.analysis.rebalance import analyze_rebalance
+
         result = analyze_rebalance(method="mvo")
         assert isinstance(result, pd.DataFrame)
 
 
 class TestRebalanceModule:
     """From test_coverage_round3.py."""
+
     def test_analyze_rebalance_returns_df(self, db_path):
         from nuri.analysis.rebalance import analyze_rebalance
+
         result = analyze_rebalance()
         assert isinstance(result, pd.DataFrame)
 
 
 class TestAnalysisRebalance_Final:
     """From test_coverage_final.py."""
+
     def test_import(self):
         from nuri.analysis.rebalance import analyze_rebalance
+
         assert callable(analyze_rebalance)
 
     def test_empty_db(self, db_path):
         from nuri.analysis.rebalance import analyze_rebalance
+
         result = analyze_rebalance(method="rp")
         assert isinstance(result, pd.DataFrame)
 
 
 class TestPrintRebalance:
     """From test_coverage_round22.py."""
+
     def test_empty(self, capsys):
         from nuri.analysis.rebalance import print_rebalance
+
         print_rebalance(pd.DataFrame())
         assert "데이터가 없습니다" in capsys.readouterr().out
 
     def test_no_actionable(self, capsys):
         from nuri.analysis.rebalance import print_rebalance
-        df = pd.DataFrame([{
-            "ticker": "AAPL",
-            "sector": "Tech",
-            "current_weight": 10.0,
-            "optimal_weight": 10.0,
-            "drift": 0.0,
-            "trade_value_usd": 0,
-            "trade_shares": 0,
-            "action": "HOLD",
-        }])
+
+        df = pd.DataFrame(
+            [
+                {
+                    "ticker": "AAPL",
+                    "sector": "Tech",
+                    "current_weight": 10.0,
+                    "optimal_weight": 10.0,
+                    "drift": 0.0,
+                    "trade_value_usd": 0,
+                    "trade_shares": 0,
+                    "action": "HOLD",
+                }
+            ]
+        )
         df.attrs["method"] = "Mean-Variance (Max Sharpe)"
         print_rebalance(df)
         out = capsys.readouterr().out
@@ -68,28 +85,31 @@ class TestPrintRebalance:
 
     def test_with_actions(self, capsys):
         from nuri.analysis.rebalance import print_rebalance
-        df = pd.DataFrame([
-            {
-                "ticker": "AAPL",
-                "sector": "Tech",
-                "current_weight": 25.0,
-                "optimal_weight": 10.0,
-                "drift": 15.0,
-                "trade_value_usd": -5000,
-                "trade_shares": -30,
-                "action": "SELL",
-            },
-            {
-                "ticker": "MSFT",
-                "sector": "Tech",
-                "current_weight": 5.0,
-                "optimal_weight": 15.0,
-                "drift": -10.0,
-                "trade_value_usd": 3000,
-                "trade_shares": 10,
-                "action": "BUY",
-            },
-        ])
+
+        df = pd.DataFrame(
+            [
+                {
+                    "ticker": "AAPL",
+                    "sector": "Tech",
+                    "current_weight": 25.0,
+                    "optimal_weight": 10.0,
+                    "drift": 15.0,
+                    "trade_value_usd": -5000,
+                    "trade_shares": -30,
+                    "action": "SELL",
+                },
+                {
+                    "ticker": "MSFT",
+                    "sector": "Tech",
+                    "current_weight": 5.0,
+                    "optimal_weight": 15.0,
+                    "drift": -10.0,
+                    "trade_value_usd": 3000,
+                    "trade_shares": 10,
+                    "action": "BUY",
+                },
+            ]
+        )
         df.attrs["method"] = "Risk Parity"
         print_rebalance(df)
         out = capsys.readouterr().out
@@ -100,18 +120,24 @@ class TestPrintRebalance:
 
 class TestAnalyzeRebalanceEmpty:
     """From test_coverage_round22.py."""
+
     def test_empty_portfolio(self, db_path, monkeypatch):
         import nuri.analysis.rebalance as mod
+
         call_count = [0]
+
         def mock_query_df(sql, *a, **kw):
             call_count[0] += 1
             if call_count[0] == 1:
-                return pd.DataFrame({
-                    "ticker": ["AAPL"] * 15,
-                    "date": [f"2025-01-{i:02d}" for i in range(1, 16)],
-                    "close": [150 + i for i in range(15)],
-                })
+                return pd.DataFrame(
+                    {
+                        "ticker": ["AAPL"] * 15,
+                        "date": [f"2025-01-{i:02d}" for i in range(1, 16)],
+                        "close": [150 + i for i in range(15)],
+                    }
+                )
             return pd.DataFrame()
+
         monkeypatch.setattr(mod, "query", lambda sql, *a, **kw: [])
         monkeypatch.setattr(mod, "query_df", mock_query_df)
         result = mod.analyze_rebalance()
@@ -119,22 +145,30 @@ class TestAnalyzeRebalanceEmpty:
 
     def test_insufficient_returns(self, db_path, monkeypatch):
         import nuri.analysis.rebalance as mod
-        prices_df = pd.DataFrame({
-            "ticker": ["AAPL", "AAPL", "AAPL"],
-            "date": ["2025-01-01", "2025-01-02", "2025-01-03"],
-            "close": [150, 151, 152],
-        })
+
+        prices_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL", "AAPL", "AAPL"],
+                "date": ["2025-01-01", "2025-01-02", "2025-01-03"],
+                "close": [150, 151, 152],
+            }
+        )
+
         def mock_query_df(sql, *a, **kw):
             if "prices" in sql:
                 return prices_df
             return pd.DataFrame()
+
         monkeypatch.setattr(mod, "query_df", mock_query_df)
         monkeypatch.setattr(mod, "query", lambda sql, *a, **kw: [])
         result = mod.analyze_rebalance()
         assert result.empty
 
     def test_leverage_etf_branches(self, db_path, monkeypatch):
-        """LEVERAGE_ETFS 종목이 holdings 에 있으면 → 77-78 (upperlng pass) + 109 (SELL 레버리지) 분기 진입."""
+        """LEVERAGE_ETFS 종목이 holdings 에 있으면 → 'SELL (레버리지)' 액션 분기 진입.
+
+        목표 비중 0% 검증은 test_leverage_etf_target_weight_zero 가 담당 (#758).
+        """
         import nuri.analysis.rebalance as mod
         from nuri.core.rules import LEVERAGE_ETFS
 
@@ -146,17 +180,22 @@ class TestAnalyzeRebalanceEmpty:
         prices_rows = []
         for ticker, base in [(leverage_ticker, 50.0), ("AAPL", 150.0)]:
             for i, d in enumerate(dates):
-                prices_rows.append({
-                    "ticker": ticker, "date": d,
-                    "close": base + i * 0.3 + np.random.randn() * 0.5,
-                })
+                prices_rows.append(
+                    {
+                        "ticker": ticker,
+                        "date": d,
+                        "close": base + i * 0.3 + np.random.randn() * 0.5,
+                    }
+                )
         prices_df = pd.DataFrame(prices_rows)
 
-        holdings_df = pd.DataFrame({
-            "ticker": [leverage_ticker, "AAPL"],
-            "total_qty": [10, 10],
-            "sector": ["Leverage", "Tech"],
-        })
+        holdings_df = pd.DataFrame(
+            {
+                "ticker": [leverage_ticker, "AAPL"],
+                "total_qty": [10, 10],
+                "sector": ["Leverage", "Tech"],
+            }
+        )
 
         def _query_df(sql, *a, **kw):
             if "prices" in sql:
@@ -193,20 +232,89 @@ class TestAnalyzeRebalanceEmpty:
         # action 이 'SELL (레버리지)' 으로 강제 마킹
         assert leverage_rows.iloc[0]["action"] == "SELL (레버리지)"
 
+    def test_leverage_etf_target_weight_zero(self, db_path, monkeypatch):
+        """#758 회귀: 레버리지 ETF 는 최적화 유니버스에서 제외 → optimal_weight=0.
+
+        레버리지 ETF 에 고Sharpe(완만한 강세) 프로파일을 부여한다. 과거 코드는
+        no-op 루프로 제약을 강제하지 않아 MVO 가 레버리지 ETF 에 비중(상한 15%)을
+        할당 → optimal_weight > 0 → FAIL. 수정 후엔 유니버스 제외로 항상 0.
+        upperlng=0.15 가 feasible 하도록 일반 종목 8개 + 레버리지 1개 구성.
+        """
+        import numpy as np
+
+        import nuri.analysis.rebalance as mod
+        from nuri.core.rules import LEVERAGE_ETFS
+
+        lev = next(iter(LEVERAGE_ETFS))
+        normals = ["AAA", "BBB", "CCC", "DDD", "EEE", "FFF", "GGG", "HHH"]
+        dates = pd.bdate_range("2024-01-01", periods=60).strftime("%Y-%m-%d").tolist()
+
+        np.random.seed(7)
+        rows = []
+        # 레버리지 ETF: 완만한 강세 + 저변동 → 높은 Sharpe (MVO 가 선호)
+        for i, d in enumerate(dates):
+            rows.append({"ticker": lev, "date": d, "close": 50.0 + i * 0.5 + np.random.randn() * 0.05})
+        # 일반 종목: noisy → 낮은 Sharpe
+        for ticker in normals:
+            base = 100.0 + 10 * normals.index(ticker)
+            for i, d in enumerate(dates):
+                rows.append({"ticker": ticker, "date": d, "close": base + i * 0.1 + np.random.randn() * 1.5})
+        prices_df = pd.DataFrame(rows)
+
+        holdings_df = pd.DataFrame(
+            {
+                "ticker": [lev, *normals],
+                "total_qty": [10] * (len(normals) + 1),
+                "sector": ["Leverage", *(["Tech"] * len(normals))],
+            }
+        )
+
+        def _query_df(sql, *a, **kw):
+            if "prices" in sql:
+                return prices_df
+            if "portfolio" in sql:
+                return holdings_df
+            return pd.DataFrame()
+
+        def _query(sql, *a, **kw):
+            if "DESC LIMIT 1" in sql:
+                tk = a[0][0] if a and a[0] else None
+                return [{"close": 50.0 if tk == lev else 150.0}]
+            return []
+
+        monkeypatch.setattr(mod, "query_df", _query_df)
+        monkeypatch.setattr(mod, "query", _query)
+
+        result = mod.analyze_rebalance(method="mvo")
+        if result.empty:
+            pytest.skip("riskfolio 최적화 빈 결과 — 환경 의존")
+            return
+
+        lev_rows = result[result["ticker"] == lev]
+        assert not lev_rows.empty, "보유 레버리지 ETF 는 결과에 표시되어야 함"
+        assert lev_rows.iloc[0]["optimal_weight"] == 0.0, "레버리지 ETF 목표 비중은 0% 여야 함"
+        assert lev_rows.iloc[0]["action"] == "SELL (레버리지)"
+
     def test_zero_total_value(self, db_path, monkeypatch):
         import nuri.analysis.rebalance as mod
+
         dates = pd.bdate_range("2024-01-01", periods=20).strftime("%Y-%m-%d").tolist()
-        prices_df = pd.DataFrame({
-            "ticker": ["AAPL"] * 20,
-            "date": dates,
-            "close": [150 + i * 0.5 for i in range(20)],
-        })
-        holdings_df = pd.DataFrame({
-            "ticker": ["AAPL"],
-            "total_qty": [10],
-            "sector": ["Tech"],
-        })
+        prices_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"] * 20,
+                "date": dates,
+                "close": [150 + i * 0.5 for i in range(20)],
+            }
+        )
+        holdings_df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "total_qty": [10],
+                "sector": ["Tech"],
+            }
+        )
         call_count = [0]
+
         def mock_query_df(sql, *a, **kw):
             call_count[0] += 1
             if "prices" in sql:
@@ -214,6 +322,7 @@ class TestAnalyzeRebalanceEmpty:
             if "portfolio" in sql:
                 return holdings_df
             return pd.DataFrame()
+
         monkeypatch.setattr(mod, "query_df", mock_query_df)
         monkeypatch.setattr(mod, "query", lambda sql, *a, **kw: [])
         result = mod.analyze_rebalance()


### PR DESCRIPTION
Closes #758

## 문제
\`analyze_rebalance\` 의 "레버리지 ETF 비중 0으로 강제" 루프가 \`pass\` no-op 이라 제약이 적용되지 않았다. MVO 최적화가 레버리지 ETF 에 비중(상한 15%)을 할당할 수 있는데 결과 루프는 \`action="SELL (레버리지)"\` 로 표시 → **optimal_weight 비0 인데 SELL** 모순. 레버리지 ETF 는 스윙 전용(rules.yaml banned_etfs)이라 장기 리밸런스 배분은 0% 여야 한다.

## Fix
- 레버리지 ETF 를 최적화 유니버스(\`opt_tickers\`)에서 제외 → 보유분은 결과 루프에서 \`w.index\` 에 없어 \`optimal_weight=0\` + \`SELL (레버리지)\` 로 표시, 100% 배분은 비레버리지 자산에만.
- dead no-op 루프 제거.

## 검증
- fail-first: 새 테스트가 수정 전 코드에서 \`assert 15.0 == 0.0\` 로 FAIL (MVO 가 레버리지 ETF 를 상한까지 할당) 확인.
- \`test_leverage_etf_target_weight_zero\`: 고Sharpe 레버리지 ETF + 일반 8종(upperlng 0.15 feasible) → optimal_weight==0 검증.
- analysis/trading/api rebalance 스위트 85 passed, ruff clean.

## Gotcha-Test Pair
**Test:** \`tests/analysis/test_rebalance.py::TestAnalyzeRebalanceEmpty::test_leverage_etf_target_weight_zero\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)