### PR TITLE
fix(scheduler): #780 daily self-restart to reclaim leaked yfinance fds

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -372,6 +372,27 @@ def _run_outbox_watchdog():
 # 스케줄 정의
 # ═══════════════════════════════════════════════════════
 
+
+def _self_restart():
+    """fd 누수 누적 차단용 일일 자가 재시작 (#780).
+
+    yfinance 내부 SQLite 캐시(tkr-tz.db/cookies.db)와 curl-cffi 소켓 fd 가 장수
+    데몬에서 단조 증가한다 (#778: 6일째 536 fd → 256 천장 → sqlite unable-to-open).
+    누수는 yfinance 내부라 직접 못 닫으므로, 하루 1회 fresh 프로세스로 교체해 fd 를
+    회수한다. `launchctl kickstart -k` → SIGTERM (graceful shutdown handler) → launchd
+    재기동. 재시작 후 heartbeat 는 ~45초 내 갱신되어 watchdog 30분 임계 미달 → false
+    STALE 없음. launchctl 부재(비배포 dev) 시 graceful skip.
+    """
+    import subprocess
+
+    target = f"gui/{os.getuid()}/com.nuri-quant.scheduler"
+    logger.info("일일 자가 재시작 — fd 회수 (#780)")
+    try:
+        subprocess.run(["launchctl", "kickstart", "-k", target], timeout=30, check=False)
+    except Exception as e:  # launchctl 부재(비배포)/타임아웃 — 데몬은 계속 구동
+        logger.warning(f"self-restart skip (비배포 환경?): {e}")
+
+
 SCHEDULES = [
     # 미국장 주가 (KST 23:30~06:00, 5분)
     {"name": "stock_us_night", "func": _run_collector, "args": ("stock",), "cron": "*/5 23 * * 1-5"},
@@ -490,6 +511,9 @@ SCHEDULES = [
         "kwargs": {"days": 365, "source": "all"},
         "cron": "30 5 * * 0",
     },
+    # 일일 자가 재시작 (#780) — KST 08:40, 모닝 배치(07-08) 종료 후·KR 개장(09:00) 전 idle
+    # window. yfinance fd 누수를 fresh 프로세스 교체로 회수 (plist 4096 천장도 결국 고갈).
+    {"name": "self_restart", "func": _self_restart, "args": (), "cron": "40 8 * * *"},
 ]
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -263,6 +263,24 @@ class TestScheduler:
         _write_heartbeat()
         assert hb_path.exists()
 
+    def test_self_restart_kickstarts_scheduler(self):
+        """_self_restart() launchctl kickstart -k 로 자가 재시작 요청 (#780)."""
+        from nuri.scheduler import _self_restart
+
+        with patch("subprocess.run") as mock_run:
+            _self_restart()
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == ["launchctl", "kickstart", "-k"]
+        assert cmd[3].endswith("com.nuri-quant.scheduler")
+
+    def test_self_restart_handles_missing_launchctl(self):
+        """launchctl 부재(비배포) — 예외 삼키고 데몬 계속 (#780)."""
+        from nuri.scheduler import _self_restart
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("launchctl")):
+            _self_restart()  # 예외 전파 없이 graceful skip
+
 
 # ═══════════════════════════════════════════════════════
 # TestScheduler_R2 — from test_coverage_round2.py


### PR DESCRIPTION
Closes #780

## 왜 지금
#778/#779 는 fd 고갈을 완화(plist 256→4096)·자기복구(watchdog 자동 재시작)했지만 누수 **자체**는 안 막았다. yfinance 내부 SQLite 캐시(`tkr-tz.db`/`cookies.db`)와 curl-cffi 소켓 fd 가 장수 데몬에서 단조 증가 → 4096 천장도 결국 고갈. 누수는 yfinance 내부라 우리가 직접 close 불가 (25+ ad-hoc 호출, `session=` 미사용).

## 접근 (사용자 결정: 주기적 self-restart)
gunicorn `max_requests` 패턴 — 하루 1회 fresh 프로세스로 교체해 fd 를 결정론적으로 회수. session 풀링 25-파일 리팩터(고위험·내부 캐시 누수 못 잡음)보다 단순·확실.

## 변경
- `_self_restart()`: `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler` → SIGTERM(graceful shutdown handler) → launchd 재기동
- SCHEDULES `self_restart` 엔트리, cron `40 8 * * *` (**KST 08:40** — 모닝 배치 07-08 종료 후·KR 개장 09:00 전 idle window, 매분 dispatcher만 idempotent)
- 비배포(dev, launchctl 부재) 시 graceful skip
- 재시작 후 heartbeat ~45초 갱신 → watchdog 30분 임계 미달, false STALE 없음

## 테스트
- `tests/test_scheduler.py`: `test_self_restart_kickstarts_scheduler`(kickstart 명령 검증) + `test_self_restart_handles_missing_launchctl`(graceful skip). 89 통과.

## 운영 메모
- 머지 후 Mac mini scheduler 재시작 필요(코드 반영) — autopull 디스크만 동기화

🤖 Generated with [Claude Code](https://claude.com/claude-code)