### PR TITLE
fix(alerts): #782 human-readable SRE #incidents digest (label+impact+action)

### DIFF
--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -477,7 +477,8 @@ class SREIncidentAgent(Actor):
             stage_fn(
                 payload={
                     "kind": f"sre_{incident_type}",
-                    "summary": (f"{incident_type} {severity} on {target} (incident_id={incident_id})"),
+                    # cryptic "type severity on target (incident_id=...)" 대신 영향 수치 한 줄.
+                    "summary": _human_incident_summary(incident_type, target, evidence),
                     "incident_id": incident_id,
                     "incident_type": incident_type,
                     "severity": severity,
@@ -491,6 +492,30 @@ class SREIncidentAgent(Actor):
             )
         except Exception:  # noqa: BLE001
             pass
+
+
+def _human_incident_summary(incident_type: str, target: str, evidence: dict[str, Any]) -> str:
+    """인시던트 영향을 담은 사람이 읽는 한 줄 (evidence 수치 활용).
+
+    #incidents 디지스트가 cryptic "type severity on target" 대신 "무엇이/얼마나"
+    를 보이게 한다 ([[feedback_alert_readability]] 의미+영향). 의미/조치는 outbox
+    _SRE_KIND_META 가 그룹 단위로 붙인다.
+    """
+    e = evidence
+    if incident_type == "scheduler_heartbeat":
+        return f"{target} — {e.get('age_minutes', 0):.0f}분째 갱신 없음 (임계 {e.get('warn_threshold_min', 30):.0f}분)"
+    if incident_type == "disk_full":
+        return f"{target} — 사용률 {e.get('percent_used', 0):.0f}% (여유 {e.get('free_gb', 0):.0f}GB)"
+    if incident_type == "db_lock":
+        return f"{target} — DB 접근 실패: {e.get('error', '?')}"
+    if incident_type == "orphan_run":
+        return f"{target} 작업 — {e.get('age_hours', 0):.1f}h 미완료(orphan)"
+    if incident_type == "actor_failure_streak":
+        return f"{target} — {e.get('consecutive_failures', 0)}회 연속 실패"
+    if incident_type == "data_freshness_critical":
+        keys = ", ".join((e.get("fail_keys") or [])[:3])
+        return f"데이터 소스 {e.get('fail_count', 0)}개 stale: {keys}"
+    return f"{incident_type} on {target}"
 
 
 def _short_json(payload: dict[str, Any], max_len: int = 800) -> str:

--- a/nuri/agents/discord/outbox.py
+++ b/nuri/agents/discord/outbox.py
@@ -456,6 +456,42 @@ _QUALITY_KIND_META: dict[str, dict[str, str]] = {
     },
 }
 
+# SREIncidentAgent 인프라 인시던트 kind → 사람이 이해하는 메타 (#incidents).
+# brief_quality(자가점검)와 달리 **실제 운영 사고**라 "매매 신호 아님" disclaimer 안 붙는다.
+# 영향 수치(42분째 등)는 producer 가 만든 summary 한 줄이 담고, 여기선 의미+조치를 제공.
+_SRE_KIND_META: dict[str, dict[str, str]] = {
+    "sre_scheduler_heartbeat": {
+        "label": "🔴 스케줄러 정지",
+        "what": "스케줄러 heartbeat 갱신 중단 — 데이터 수집이 멈춤",
+        "action": "조치: watchdog 자동 재시작 동작 / 수동 `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`",
+    },
+    "sre_disk_full": {
+        "label": "💾 디스크 부족",
+        "what": "디스크 사용률이 임계 초과 — 수집/백업 실패 위험",
+        "action": "조치: data/backups·오래된 로그/export 정리",
+    },
+    "sre_db_lock": {
+        "label": "🔒 DB 접근 장애",
+        "what": "DB SELECT 실패 — 락 또는 파일 접근 불가",
+        "action": "조치: 동시 쓰기 확인 후 필요시 스케줄러 재시작",
+    },
+    "sre_orphan_run": {
+        "label": "👻 멈춘 작업",
+        "what": "agent run 이 정상 종료 없이 장시간 미완료(orphan)",
+        "action": "조치: 해당 actor 로그 확인 후 재실행 / 데몬 재시작",
+    },
+    "sre_actor_failure_streak": {
+        "label": "🔁 작업 연속 실패",
+        "what": "특정 actor 가 연속 실패 중 — 수집/분석 중단",
+        "action": "조치: scheduler.err 로그 확인 후 원인 수정",
+    },
+    "sre_data_freshness_critical": {
+        "label": "📉 데이터 신선도 위험",
+        "what": "복수 데이터 소스가 stale — 판단 근거 신뢰도 저하",
+        "action": "조치: 해당 collector 수동 실행 / 수집 스케줄 점검",
+    },
+}
+
 
 def bucket_generic_digest(
     events: list[dict[str, Any]],
@@ -489,7 +525,7 @@ def bucket_generic_digest(
 
     fields = []
     for group, lines in by_group.items():
-        meta = _QUALITY_KIND_META.get(group)
+        meta = _QUALITY_KIND_META.get(group) or _SRE_KIND_META.get(group)
         group_name = f"{meta['label']} ({len(lines)})" if meta else f"{group} ({len(lines)})"
         body_lines: list[str] = []
         # 자가점검 kind 는 그룹 맨 위에 "무엇인지" 한 줄을 먼저 박는다.

--- a/tests/agents/test_discord_outbox.py
+++ b/tests/agents/test_discord_outbox.py
@@ -399,6 +399,22 @@ def test_bucket_generic_digest_non_quality_keeps_aggregated_desc():
     assert embed["description"] == "1 aggregated events"
 
 
+def test_bucket_generic_digest_renders_sre_kind_human_readable():
+    """sre_* 인프라 인시던트는 친화 라벨+의미+조치로 렌더 (실제 사고 → disclaimer 없음)."""
+    events = [
+        {"kind": "sre_scheduler_heartbeat", "summary": "scheduler — 42분째 갱신 없음 (임계 30분)"},
+    ]
+    embed = bucket_generic_digest(events, channel_label="Incidents")
+    assert any("스케줄러 정지" in f["name"] for f in embed["fields"])
+    assert not any("sre_scheduler_heartbeat" in f["name"] for f in embed["fields"])
+    value = embed["fields"][0]["value"]
+    assert "ℹ️" in value  # 의미 한 줄
+    assert "42분째" in value  # producer 가 만든 영향 수치 보존
+    assert "조치" in value  # 운영 조치
+    # 실제 사고라 "매매 신호 아님" disclaimer 안 붙음
+    assert "매매 신호 아님" not in embed["description"]
+
+
 # ─── dispatcher ──────────────────────────────────────────
 
 

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -30,6 +30,7 @@ from nuri.agents.actors.sre_incident_agent import (
     ORPHAN_CRIT_HOURS,
     ORPHAN_WARN_HOURS,
     SREIncidentAgent,
+    _human_incident_summary,
     main,
 )
 from nuri.agents.base import Layer, Outcome
@@ -834,3 +835,26 @@ class TestCli:
     def test_cli_resolve_unknown_returns_2(self, patched_db, capsys):
         rc = main(["resolve", "--incident-id", "999999"])
         assert rc == 2
+
+
+class TestHumanIncidentSummary:
+    """#incidents 디지스트가 cryptic 코드 대신 영향 수치 한 줄을 보이는지 (alert readability)."""
+
+    def test_scheduler_heartbeat_shows_age_and_threshold(self):
+        s = _human_incident_summary("scheduler_heartbeat", "scheduler", {"age_minutes": 42.0, "warn_threshold_min": 30})
+        assert "42분째" in s and "임계 30분" in s
+        assert "incident_id" not in s  # 의미없는 식별자 헤드라인에서 제거
+
+    def test_disk_full_shows_percent_and_free(self):
+        s = _human_incident_summary("disk_full", "disk", {"percent_used": 96.0, "free_gb": 50.0})
+        assert "96%" in s and "50GB" in s
+
+    def test_data_freshness_lists_failed_keys(self):
+        s = _human_incident_summary(
+            "data_freshness_critical", "freshness", {"fail_count": 3, "fail_keys": ["stock", "macro", "news"]}
+        )
+        assert "3개" in s and "stock" in s
+
+    def test_unknown_type_falls_back_gracefully(self):
+        s = _human_incident_summary("brand_new_type", "x", {})
+        assert "brand_new_type" in s and "x" in s


### PR DESCRIPTION
Closes #782

## 왜 지금
사용자 보고: Discord 인시던트 출력이 cryptic. #738/#739 가 brief_quality 자가점검을 사람이 읽게 만들고 #ops 로 분리했지만, **정작 실제 사고 채널 #incidents** 의 SRE 인프라 인시던트는 여전히 cryptic — `scheduler_heartbeat critical on scheduler (incident_id=a1b2c3d4e5f6)`. evidence 에 `age_minutes=42` 등 영향 수치가 다 있는데 미사용.

## Before → After
```
# Before
sre_scheduler_heartbeat (1)
scheduler_heartbeat critical on scheduler (incident_id=a1b2c3d4e5f6)

# After
🔴 스케줄러 정지 (1)
ℹ️ 스케줄러 heartbeat 갱신 중단 — 데이터 수집이 멈춤
scheduler — 42분째 갱신 없음 (임계 30분)
→ 조치: watchdog 자동 재시작 동작 / 수동 launchctl kickstart -k …
```

## 변경
- `_SRE_KIND_META` (outbox.py): 6종(scheduler_heartbeat/disk_full/db_lock/orphan_run/actor_failure_streak/data_freshness_critical)에 친화 라벨+의미+조치. brief_quality 와 달리 실제 사고라 `※ 매매 신호 아님` disclaimer 안 붙음
- `_human_incident_summary` (sre_incident_agent.py): cryptic summary → evidence 영향 수치 한 줄. incident_id 는 payload 에 유지(ack/resolve용)하되 헤드라인에서 제거
- backward compat: 일반 kind 는 `N aggregated events` description 유지

## 테스트
- `test_bucket_generic_digest_renders_sre_kind_human_readable` (라벨+의미+영향+조치, disclaimer 없음)
- `TestHumanIncidentSummary` 4종 (age/threshold, disk %, freshness keys, unknown fallback)
- 88 통과

## 참고
- 이번 알림이 watchdog 직접 webhook(이미 readable)이 아니라 SRE→outbox→digest 경로로 떴을 때 적용. brief_quality digest 는 #738 이후 이미 readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)