### PR TITLE
docs(architecture): fix stale scheduler job count (24 → 39)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 24 cron jobs in `SCHEDULES` list. All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects.
+`nuri/scheduler.py` — 39 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors.
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)


### PR DESCRIPTION
## 왜
사용자 요청(문서 엄밀 동기화) 중 발견한 doc drift. `docs/ARCHITECTURE.md` 가 `SCHEDULES` 를 **24 cron jobs** 로 표기했으나 코드 실측 **39 entries** (+ 1분 `heartbeat` interval job). #781 `self_restart` 잡 추가 시점에 정합화.

## 변경
- `24 cron jobs` → `39 cron jobs in SCHEDULES list (+ heartbeat interval job)`
- 일일 `self_restart`(08:40 KST, yfinance fd 회수) 한 줄 명시

검증: `.venv/bin/python -c "from nuri.scheduler import SCHEDULES; print(len(SCHEDULES))"` → 39. `make verify-doc-counts` 13/13 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)