### PR TITLE
test(alerts): cover _human_incident_summary remaining branches (#783 follow-up)

### DIFF
--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -855,6 +855,18 @@ class TestHumanIncidentSummary:
         )
         assert "3개" in s and "stock" in s
 
+    def test_db_lock_shows_error(self):
+        s = _human_incident_summary("db_lock", "db", {"error": "database is locked"})
+        assert "db" in s and "database is locked" in s
+
+    def test_orphan_run_shows_age_hours(self):
+        s = _human_incident_summary("orphan_run", "stock-collector", {"age_hours": 3.5})
+        assert "stock-collector" in s and "3.5h" in s and "orphan" in s
+
+    def test_actor_failure_streak_shows_count(self):
+        s = _human_incident_summary("actor_failure_streak", "consensus", {"consecutive_failures": 5})
+        assert "consensus" in s and "5회 연속 실패" in s
+
     def test_unknown_type_falls_back_gracefully(self):
         s = _human_incident_summary("brand_new_type", "x", {})
         assert "brand_new_type" in s and "x" in s


### PR DESCRIPTION
## 왜
Codecov(PR #783, `sre_incident_agent.py`)가 `_human_incident_summary` 의 3개 반환 분기를 미커버로 표시:
- `db_lock` (line 510), `orphan_run` (512), `actor_failure_streak` (514)

#783 의 단위 테스트는 scheduler_heartbeat/disk_full/data_freshness/unknown 만 커버했음.

## 변경
- `TestHumanIncidentSummary` 에 3 테스트 추가 → 6종 incident_type 전부 커버
- 측정: `--cov=nuri.agents.actors.sre_incident_agent` missing 에서 510/512/514 제거 확인. 55 통과(+3)

## 참고 (out of scope — 보고만)
- 같은 파일 523-528(`_short_json`)은 호출처 없는 **기존 dead code**(내 patch 아님). 별도 정리 필요 시 이슈 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)