### PR TITLE
fix(quant): #786 pct_change(fill_method=None) — pandas 3.0 FutureWarning

### DIFF
--- a/nuri/analysis/correlation.py
+++ b/nuri/analysis/correlation.py
@@ -8,6 +8,7 @@
 사용법:
     python -m nuri.analysis.correlation
 """
+
 import logging
 from pathlib import Path
 
@@ -39,7 +40,7 @@ def analyze_correlation(min_days: int = 60) -> tuple[pd.DataFrame, list[dict]]:
     pivot = pivot[valid_tickers]
 
     # 일간 수익률 → 상관행렬
-    returns = pivot.ffill().pct_change().dropna()
+    returns = pivot.ffill().pct_change(fill_method=None).dropna()
     corr_matrix = returns.corr()
 
     # 고상관 경고 (|r| > 0.80)
@@ -49,11 +50,13 @@ def analyze_correlation(min_days: int = 60) -> tuple[pd.DataFrame, list[dict]]:
         for j in range(i + 1, n):
             r = corr_matrix.iloc[i, j]
             if abs(r) > 0.80:
-                warnings.append({
-                    "ticker_a": valid_tickers[i],
-                    "ticker_b": valid_tickers[j],
-                    "correlation": round(r, 3),
-                })
+                warnings.append(
+                    {
+                        "ticker_a": valid_tickers[i],
+                        "ticker_b": valid_tickers[j],
+                        "correlation": round(r, 3),
+                    }
+                )
 
     return corr_matrix, warnings
 
@@ -62,6 +65,7 @@ def save_heatmap(corr_matrix: pd.DataFrame) -> None:
     """상관관계 히트맵 저장."""
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import seaborn as sns
@@ -70,9 +74,15 @@ def save_heatmap(corr_matrix: pd.DataFrame) -> None:
 
         fig, ax = plt.subplots(figsize=(12, 10))
         sns.heatmap(
-            corr_matrix, annot=True, fmt=".2f",
-            cmap="RdYlGn_r", center=0, vmin=-1, vmax=1,
-            ax=ax, square=True,
+            corr_matrix,
+            annot=True,
+            fmt=".2f",
+            cmap="RdYlGn_r",
+            center=0,
+            vmin=-1,
+            vmax=1,
+            ax=ax,
+            square=True,
         )
         ax.set_title("Nuri-Quant Portfolio Correlation Matrix")
         fig.tight_layout()

--- a/nuri/analysis/performance.py
+++ b/nuri/analysis/performance.py
@@ -11,6 +11,7 @@ HTML 리포트를 생성한다.
     python -m nuri.analysis.performance
     python -m nuri.analysis.performance --html   # HTML 티어시트 생성
 """
+
 import argparse
 import logging
 from pathlib import Path
@@ -53,7 +54,7 @@ def get_portfolio_returns(days: int = 90) -> pd.Series:
     # 일간 수익률
     prices = query_df("SELECT ticker, date, close FROM prices ORDER BY date")
     pivot = prices.pivot_table(index="date", columns="ticker", values="close")
-    returns = pivot.ffill().pct_change().dropna()
+    returns = pivot.ffill().pct_change(fill_method=None).dropna()
 
     # 포트폴리오 수익률
     w = pd.Series(weights)
@@ -70,15 +71,13 @@ def get_portfolio_returns(days: int = 90) -> pd.Series:
 
 def get_benchmark_returns() -> pd.Series:
     """VOO 벤치마크 수익률."""
-    prices = query_df(
-        "SELECT date, close FROM prices WHERE ticker = 'VOO' ORDER BY date"
-    )
+    prices = query_df("SELECT date, close FROM prices WHERE ticker = 'VOO' ORDER BY date")
     if prices.empty:
         return pd.Series(dtype=float)
 
     prices["date"] = pd.to_datetime(prices["date"])
     prices = prices.set_index("date")
-    returns = prices["close"].pct_change().dropna()
+    returns = prices["close"].pct_change(fill_method=None).dropna()
     returns.name = "VOO"
     return returns
 

--- a/nuri/analysis/rebalance.py
+++ b/nuri/analysis/rebalance.py
@@ -33,7 +33,7 @@ def analyze_rebalance(method: str = "mvo") -> pd.DataFrame:
     # 수익률 데이터
     prices = query_df("SELECT ticker, date, close FROM prices ORDER BY date")
     pivot = prices.pivot_table(index="date", columns="ticker", values="close")
-    returns = pivot.ffill().pct_change().dropna()
+    returns = pivot.ffill().pct_change(fill_method=None).dropna()
 
     if returns.empty or len(returns) < 10:
         logger.warning("수익률 데이터 부족")

--- a/nuri/analysis/risk.py
+++ b/nuri/analysis/risk.py
@@ -10,6 +10,7 @@ VaR, CVaR, Sharpe, Sortino, Max Drawdown 등을 Riskfolio-Lib으로 계산.
 사용법:
     python -m nuri.analysis.risk
 """
+
 import logging
 
 import numpy as np
@@ -51,7 +52,7 @@ def _get_portfolio_returns() -> tuple[pd.DataFrame, dict]:
     # 일간 수익률
     prices = query_df("SELECT ticker, date, close FROM prices ORDER BY date")
     pivot = prices.pivot_table(index="date", columns="ticker", values="close")
-    returns = pivot.ffill().pct_change().dropna()
+    returns = pivot.ffill().pct_change(fill_method=None).dropna()
 
     return returns, weights
 
@@ -70,9 +71,7 @@ def analyze_risk() -> dict:
     port_returns = (returns[common] * w).sum(axis=1)
 
     # 리스크프리 레이트
-    rf_rows = query(
-        "SELECT value FROM macro WHERE indicator = 'fed_funds_rate' ORDER BY date DESC LIMIT 1"
-    )
+    rf_rows = query("SELECT value FROM macro WHERE indicator = 'fed_funds_rate' ORDER BY date DESC LIMIT 1")
     rf_annual = rf_rows[0]["value"] / 100 if rf_rows else 0.05
 
     # 연환산 수익률/변동성

--- a/nuri/quant/backtest/leverage_study.py
+++ b/nuri/quant/backtest/leverage_study.py
@@ -141,8 +141,8 @@ def scenario_buy_and_hold(
     """시나리오 A: Buy-and-hold TSLL vs TSLA 비교."""
     result = {"scenario": "A_buy_and_hold"}
 
-    lev_returns = leveraged_prices["close"].pct_change().dropna()
-    und_returns = underlying_prices["close"].pct_change().dropna()
+    lev_returns = leveraged_prices["close"].pct_change(fill_method=None).dropna()
+    und_returns = underlying_prices["close"].pct_change(fill_method=None).dropna()
 
     result["leveraged"] = _calc_metrics(lev_returns)
     result["underlying"] = _calc_metrics(und_returns)
@@ -160,7 +160,7 @@ def scenario_vix_filter(
     """시나리오 B: VIX < entry_below일 때만 TSLL 보유, VIX >= exit_above 시 퇴장."""
     result = {"scenario": "B_vix_filter", "entry_below": entry_below, "exit_above": exit_above}
 
-    lev_returns = leveraged_prices["close"].pct_change().dropna()
+    lev_returns = leveraged_prices["close"].pct_change(fill_method=None).dropna()
 
     if vix.empty:
         result["leveraged"] = _calc_metrics(pd.Series(dtype=float))
@@ -213,7 +213,7 @@ def scenario_trend_follow(
     # SMA 교차 기반 포지션
     trend_up = sma_s > sma_l
 
-    lev_returns = close.pct_change().dropna()
+    lev_returns = close.pct_change(fill_method=None).dropna()
     trend_aligned = trend_up.reindex(lev_returns.index).fillna(False)
     filtered_returns = lev_returns.where(trend_aligned, 0.0)
 
@@ -228,7 +228,7 @@ def scenario_max_hold(
     """시나리오 D: 최대 max_days일 보유 후 강제 청산, 1일 쿨다운 후 재진입."""
     result = {"scenario": "D_max_hold", "max_days": max_days}
 
-    lev_returns = leveraged_prices["close"].pct_change().dropna()
+    lev_returns = leveraged_prices["close"].pct_change(fill_method=None).dropna()
     if lev_returns.empty:
         result["leveraged"] = _calc_metrics(pd.Series(dtype=float))
         result["trade_count"] = 0

--- a/nuri/trading/agents/risk_agent.py
+++ b/nuri/trading/agents/risk_agent.py
@@ -75,7 +75,7 @@ class RiskAgent(BaseAgent):
             db_path=db_path,
         )
         if len(recent) >= 10:
-            vol = recent["close"].pct_change().std() * 100
+            vol = recent["close"].pct_change(fill_method=None).std() * 100
             if vol > vol_high:
                 score -= 1
                 reasons.append(f"고변동성 (일간σ {vol:.1f}%)")

--- a/nuri/trading/strategy/ls_backtest.py
+++ b/nuri/trading/strategy/ls_backtest.py
@@ -172,7 +172,7 @@ def classify_historical_regimes(db_path=None, sma_period: int = 50) -> pd.DataFr
     # 백테스트는 히스테리시스 미적용 (과거 데이터는 확정된 종가이므로 노이즈 없음)
 
     # SPY 일간 수익률
-    spy["return"] = spy["close"].pct_change()
+    spy["return"] = spy["close"].pct_change(fill_method=None)
 
     return spy.reset_index()
 
@@ -200,7 +200,7 @@ def run_interactive_backtest(
     if not sh.empty:
         sh["date"] = pd.to_datetime(sh["date"])
         sh = sh.set_index("date")
-        sh["sh_return"] = sh["close"].pct_change()
+        sh["sh_return"] = sh["close"].pct_change(fill_method=None)
     else:
         sh = pd.DataFrame()
 
@@ -371,7 +371,7 @@ def run_backtest(regimes_df: pd.DataFrame, db_path=None) -> BacktestResult:
     if not sh.empty:
         sh["date"] = pd.to_datetime(sh["date"])
         sh = sh.set_index("date")
-        sh["sh_return"] = sh["close"].pct_change()
+        sh["sh_return"] = sh["close"].pct_change(fill_method=None)
         sh["sh_open_return"] = sh["close"] / sh["open"] - 1  # 시가→종가
     else:
         sh = pd.DataFrame()

--- a/nuri/trading/strategy/pairs.py
+++ b/nuri/trading/strategy/pairs.py
@@ -10,6 +10,7 @@ Pairs Trading 전략 — 상관관계 높은 종목 쌍의 스프레드 수렴�
 사용법:
     python -m nuri.trading.strategy.pairs
 """
+
 import logging
 from dataclasses import dataclass
 from itertools import combinations
@@ -31,11 +32,11 @@ LOOKBACK = 60  # 상관관계/스프레드 계산 기간
 
 @dataclass
 class PairSignal:
-    ticker_long: str    # 매수 (underperformer)
-    ticker_short: str   # 매도 (outperformer)
+    ticker_long: str  # 매수 (underperformer)
+    ticker_short: str  # 매도 (outperformer)
     correlation: float
     z_score: float
-    spread_pct: float   # 현재 스프레드 %
+    spread_pct: float  # 현재 스프레드 %
     date: str
 
 
@@ -66,7 +67,8 @@ def find_pairs(
     for ticker in us_tickers:
         df = query_df(
             "SELECT date, close FROM prices WHERE ticker=? ORDER BY date DESC LIMIT ?",
-            (ticker, LOOKBACK), db_path=db_path,
+            (ticker, LOOKBACK),
+            db_path=db_path,
         )
         if len(df) >= LOOKBACK // 2:
             prices[ticker] = df.set_index("date")["close"]
@@ -79,7 +81,7 @@ def find_pairs(
     if len(price_df) < 30:
         return []
 
-    returns_df = price_df.pct_change().dropna()
+    returns_df = price_df.pct_change(fill_method=None).dropna()
     pairs = []
 
     for t1, t2 in combinations(returns_df.columns, 2):
@@ -91,18 +93,23 @@ def find_pairs(
         ratio = np.log(price_df[t1] / price_df[t2])
         mean_spread = ratio.mean()
         std_spread = ratio.std()
-        if std_spread == 0:  # pragma: no cover — defensive: pandas std with ddof=1 returns ~1e-16 (not exact 0) for identical N>=30 values, so this path requires hand-built series; real DB data flow never triggers. See tests/trading/strategy/test_pairs.py::TestFindPairsZeroStdSpread.
+        if (
+            std_spread == 0
+        ):  # pragma: no cover — defensive: pandas std with ddof=1 returns ~1e-16 (not exact 0) for identical N>=30 values, so this path requires hand-built series; real DB data flow never triggers. See tests/trading/strategy/test_pairs.py::TestFindPairsZeroStdSpread.
             continue
 
         current_z = (ratio.iloc[-1] - mean_spread) / std_spread
 
-        pairs.append(PairStats(
-            ticker_a=t1, ticker_b=t2,
-            correlation=round(corr, 3),
-            mean_spread=round(mean_spread, 4),
-            std_spread=round(std_spread, 4),
-            current_z=round(current_z, 2),
-        ))
+        pairs.append(
+            PairStats(
+                ticker_a=t1,
+                ticker_b=t2,
+                correlation=round(corr, 3),
+                mean_spread=round(mean_spread, 4),
+                std_spread=round(std_spread, 4),
+                current_z=round(current_z, 2),
+            )
+        )
 
     pairs.sort(key=lambda p: abs(p.current_z), reverse=True)
     return pairs
@@ -127,14 +134,16 @@ def scan_pair_signals(
             long_ticker = p.ticker_a
             short_ticker = p.ticker_b
 
-        signals.append(PairSignal(
-            ticker_long=long_ticker,
-            ticker_short=short_ticker,
-            correlation=p.correlation,
-            z_score=p.current_z,
-            spread_pct=p.std_spread * abs(p.current_z) * 100,
-            date="latest",
-        ))
+        signals.append(
+            PairSignal(
+                ticker_long=long_ticker,
+                ticker_short=short_ticker,
+                correlation=p.correlation,
+                z_score=p.current_z,
+                spread_pct=p.std_spread * abs(p.current_z) * 100,
+                date="latest",
+            )
+        )
 
     return signals
 
@@ -155,11 +164,13 @@ def backtest_pairs(
     for pair in eligible[:10]:  # 상위 10개 쌍만
         price_a = query_df(
             "SELECT date, close FROM prices WHERE ticker=? ORDER BY date",
-            (pair.ticker_a,), db_path=db_path,
+            (pair.ticker_a,),
+            db_path=db_path,
         )
         price_b = query_df(
             "SELECT date, close FROM prices WHERE ticker=? ORDER BY date",
-            (pair.ticker_b,), db_path=db_path,
+            (pair.ticker_b,),
+            db_path=db_path,
         )
 
         if price_a.empty or price_b.empty:
@@ -173,7 +184,7 @@ def backtest_pairs(
 
         i = LOOKBACK
         while i < len(merged) - 1:
-            window = ratio[i - LOOKBACK:i]
+            window = ratio[i - LOOKBACK : i]
             mean_r = window.mean()
             std_r = window.std()
             if std_r == 0:
@@ -196,11 +207,13 @@ def backtest_pairs(
                 spread_ret = (ratio[entry_i] - ratio[j]) if z > 0 else (ratio[j] - ratio[entry_i])
                 pct_ret = spread_ret * 100
 
-                all_trades.append({
-                    "pair": f"{pair.ticker_a}/{pair.ticker_b}",
-                    "return_pct": pct_ret,
-                    "hold_days": j - entry_i,
-                })
+                all_trades.append(
+                    {
+                        "pair": f"{pair.ticker_a}/{pair.ticker_b}",
+                        "return_pct": pct_ret,
+                        "hold_days": j - entry_i,
+                    }
+                )
                 i = j + 1
             else:
                 i += 1
@@ -234,8 +247,7 @@ if __name__ == "__main__":
     print("\n=== Pair Signals (Z > 2.0) ===")
     signals = scan_pair_signals()
     for s in signals:
-        print(f"  Long {s.ticker_long} / Short {s.ticker_short}: "
-              f"corr={s.correlation} Z={s.z_score}")
+        print(f"  Long {s.ticker_long} / Short {s.ticker_short}: corr={s.correlation} Z={s.z_score}")
 
     print("\n=== Pairs Backtest ===")
     result = backtest_pairs()

--- a/scripts/ops/run_phase2_chain.py
+++ b/scripts/ops/run_phase2_chain.py
@@ -84,7 +84,7 @@ def fetch_ticker_returns(ticker: str, start_date: str = "2025-01-01") -> pd.Data
         "SELECT date, close FROM prices WHERE ticker = ? AND date >= ? ORDER BY date",
         (ticker, start_date),
     )
-    df["return_1d"] = df["close"].pct_change()
+    df["return_1d"] = df["close"].pct_change(fill_method=None)
     return df.dropna()
 
 


### PR DESCRIPTION
Closes #786

## 왜 지금
전체 테스트에서 pandas `FutureWarning` 발생 — `Series.pct_change` 의 기본 `fill_method='pad'` 가 deprecated(pandas 3.0 제거). 미지정 시 향후 pandas bump(dependabot)에서 **백테스트 수익률이 조용히 바뀔 time-bomb**.

## 수치 안전성 (16 call site 전부 behavior-preserving)
`pad` vs `None` 차이는 **interior NaN(중간 결측)** 있을 때만 발생. 본 코드는 전부 그 전에 결측 제거:
| 분류 | 사이트 | 근거 |
|---|---|---|
| ffill 선행 | risk/correlation/performance:56/rebalance (4) | `ffill()` 이 interior NaN 제거 → leading NaN 만 (양쪽 동일) |
| dropna 선행 | pairs.py:82 (1) | `pd.DataFrame(prices).dropna()` 후 pct_change → NaN 0 |
| 단일 컬럼 close | leverage_study/performance:81/risk_agent/ls_backtest/run_phase2_chain (11) | prices.close 행당 값 존재 → interior NaN 없음 |

→ `None` 명시가 동작 불변(+ 의미적으로도 정확 — pad 는 비거래일 spurious 0% 수익 생성). **`nuri/quant/validation/*` walk-forward 코드는 이미 `fill_method=None` 사용** — 구코드를 established 패턴에 정합.

## 검증
- 전체 **6081 passed, 6 skipped** (변경 전과 동일 — 백테스트 수치 assert 포함, **수치 회귀 0**)
- targeted `-W error::FutureWarning` 1035 통과 → pct_change FutureWarning 제거(경고 22→18)
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)