### PR TITLE
fix(recommend): #788 resume held_add shadow accumulation (graduation silent-loss)

### DIFF
--- a/config/buy_signals.yaml
+++ b/config/buy_signals.yaml
@@ -101,11 +101,14 @@ exclude_etfs:
 # ─── Held add-mode (#518 Phase 2a, shadow 14d) ──────────────────────
 # 보유 종목에 대한 add 후보. 3 modes (precedence + mutual exclusion). spec
 # §4 (docs/plans/507_buy_candidate_emitter_phase2_spec.md).
-# shadow_mode_until 이전: emit → held_add_shadow 테이블 only (brief surface 없음).
-# 이후: 사용자 brief 에 surface (Phase 2a 후속 — 본 PR 미포함).
+# shadow_mode_until 까지: emit → held_add_shadow 테이블 only (brief surface 없음).
+# 경과 시 caller 가 brief surface 해야 하나 그 배선이 미구현(#788) — graduation 이
+# 날짜로 자동 발생하면 persist(if shadow) 도 멈춰 candidate 가 buffer 없이 버려진다
+# (2026-05-15~06-22 silent loss 실측). #788 calibration+surface 완료 전까지 연장해
+# calibration sample 축적을 유지한다.
 held_add_mode:
   enabled: true
-  shadow_mode_until: "2026-05-15"   # 14d shadow before live brief surfacing
+  shadow_mode_until: "2026-12-31"   # #788 까지 연장 (축적 유지; live surface 는 #519 calibration 선결)
   earnings_blackout_days: 5         # earnings_date ± 5d 차단 (Qwen risk)
 
   modes:


### PR DESCRIPTION
Part of #788

## 왜 (2026-06-22 발견 — stale-open 검증 중)
held_add(#518)는 `shadow_mode_until: 2026-05-15` 로 날짜 graduation. 그러나 graduation 후 brief surface 배선이 미구현(#788, *"본 PR 미포함"*). 결과 `held_add.py:487`:
```python
result.candidates.append(candidate)
if shadow:                  # graduation 후 False
    _persist_shadow(...)    # → skip
```
+ caller `_run_held_add_shadow` 는 결과 버림 + 어떤 brief 도 미호출 → **2026-05-15~06-22 5주간 보유종목 add 후보가 매일 계산되어 버려짐** (shadow 테이블·brief 둘 다 미도달).

## 변경 (즉시 조치 — 축적 복구)
- `shadow_mode_until` 2026-05-15 → **2026-12-31** 연장 → `_is_shadow_mode` True 재개 → persist 재개 → calibration sample 축적 재개
- 주석에 graduation silent-loss 메커니즘 + #788 명시
- config-only (designed lever, 코드 미변경)

## 검증
- `_is_shadow_mode(today=2026-06-22)` → True (persist 재개 확인)
- `tests/trading/recommend/` 456 통과, yaml 로더 OK

## 후속 (#788)
live surface 배선 + #519 calibration gate + accumulation≠surface 분리(date-bomb 재발 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)