### PR TITLE
chore(deps): #790 bump starlette/pyjwt/python-multipart (security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
 
     # ─── Security ─────────────────────────────────────────────
     "bcrypt>=4.0.0",
-    "PyJWT>=2.8.0",
+    "PyJWT>=2.13.0",  # dependabot #66-70 (<2.13.0 보안 패치)
     "slowapi>=0.1.9",
 
     # ─── Config / Environment ─────────────────────────────────
@@ -113,23 +113,23 @@ Issues = "https://github.com/researcherhojin/nuri-quant/issues"
 # ═══════════════════════════════════════════════════════════════
 [tool.uv]
 override-dependencies = [
-    # GHSA-mj87-hwqh-73pj (DoS via multipart preamble/epilogue) —
-    # openbb-core 1.6.7 이 python-multipart>=0.0.22,<0.0.23 로 하드 핀했지만
-    # 0.0.22 → 0.0.26 은 패치 수준 API 차이 없음 (실측: test suite green).
+    # GHSA-mj87-hwqh-73pj (DoS via multipart preamble/epilogue) +
+    # dependabot #71 (<0.0.31) — openbb-core 1.6.7 이 python-multipart>=0.0.22,
+    # <0.0.23 로 하드 핀했지만 패치 수준 API 차이 없음 (실측: test suite green).
     # openbb 가 pin 을 완화하면 이 override 제거 가능.
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.31",
     # dependabot #61/#62 (aiohttp <3.14.0: 신뢰불가 데이터 역직렬화 +
     # cross-origin redirect 쿠키 유출) — 부모(openbb-core/discord-py/
     # aiohttp-client-cache) 전부 aiohttp 제약 (any) 라 floor 만 강제.
     # 3.13.4 → 3.14.0 minor bump (실측: test suite green).
     "aiohttp>=3.14.0",
-    # dependabot #63 (starlette ≤1.0.0 Host header bypass → path 보안 우회) —
-    # 패치는 starlette≥1.0.1 에만 존재, fastapi 는 0.133.0 부터 starlette 1.x
+    # dependabot #63 (starlette ≤1.0.0 Host header bypass) + #79/#80 (<1.3.1) —
+    # 패치는 starlette≥1.3.1 에 존재, fastapi 는 0.133.0 부터 starlette 1.x
     # 허용. openbb-core(최신 1.6.10)까지 fastapi<0.129 하드 핀이나, nuri 는
     # openbb 의 fastapi 서버를 안 쓰므로(라이브러리 전용) override 로 강제.
-    # 실측: openbb_core/obb import OK + API 545 + 전체 5992 테스트 green.
+    # 실측: openbb_core/obb import OK + API + 전체 테스트 green.
     "fastapi>=0.133.0",
-    "starlette>=1.0.1",
+    "starlette>=1.3.1",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,8 +15,8 @@ resolution-markers = [
 overrides = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "fastapi", specifier = ">=0.133.0" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
-    { name = "starlette", specifier = ">=1.0.1" },
+    { name = "python-multipart", specifier = ">=0.0.31" },
+    { name = "starlette", specifier = ">=1.3.1" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "plotly", specifier = ">=5.18.0" },
-    { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pykrx", specifier = ">=1.2.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
@@ -3316,11 +3316,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]
@@ -3445,11 +3445,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.30"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -4056,15 +4056,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #790

## 변경 (Python uv)
Dependabot 보안 알림 — `[tool.uv] override-dependencies` floor 상향(openbb-core fastapi<0.129 핀 우회 기존 패턴):
| pkg | 1.2.1→ | advisory |
|---|---|---|
| starlette | 1.2.1 → **1.3.1** | #79/#80 |
| pyjwt | 2.12.1 → **2.13.0** | #66-70 |
| python-multipart | 0.0.30 → **0.0.32** | #71 |

fastapi 0.136.3 호환 유지 (uv lock 충돌 0).

## 검증 (런타임 실측)
- import: fastapi 0.136.3 / starlette 1.3.1 / pyjwt 2.13.0 / openbb_core OK / nuri API app 79 routes
- `tests/api/` **552 통과** (starlette 1.3.1 프레임워크 호환)
- auth/jwt **64 통과** (pyjwt 2.13.0 호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)