### PR TITLE
docs: fix fastapi-override gotcha + frontend test count drift

### DIFF
--- a/.claude/rules/gotchas.md
+++ b/.claude/rules/gotchas.md
@@ -2,7 +2,7 @@
 
 Most gotchas live in scoped CLAUDE.md or in code lock-tests (Gotcha-Test Pair, see `.claude/rules/invariants.md`). Cross-scope ones:
 
-- **fastapi < 0.129 pinned** (`openbb-core 1.6.7` constraint, dependabot.yml ignores 0.129+)
+- **fastapi/starlette override** — `openbb-core` 가 fastapi<0.129 로 하드 핀하나 nuri 는 openbb 의 fastapi 서버를 안 쓰므로(라이브러리 전용) `[tool.uv] override-dependencies` 로 **fastapi≥0.133·starlette≥1.3.1 강제**(현재 lock: fastapi 0.136.3 / starlette 1.3.1, 보안 패치 #790). `dependabot.yml` 은 fastapi 0.129+ 자동 PR 만 ignore(override 가 버전 관리)
 - **Korean stock tickers**: `.KS` suffix (e.g., `005930.KS`). yfinance returns most fundamentals but **`trailingPE` is missing for KR individuals** — use `forward_pe`. ETFs return empty `info`. Full quirks: `nuri/collectors/CLAUDE.md` "Korean Ticker `.KS` Suffix Convention".
 - **Concurrency asymmetry**: yfinance 10-thread OK; pykrx/KRX **must be sequential** + `time.sleep(0.1)`. New external APIs require concurrency measurement before integration.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1372 tests, 124 files)
+npm run test           # vitest (1383 tests, 126 files)
 npx playwright test    # E2E (57 tests, 8 specs)
 ```
 


### PR DESCRIPTION
## 왜
#790 보안 dep bump 점검 중 발견한 stale .md (둘 다 `make verify-doc-counts` 미검사 영역이라 묻혀 있었음).

## 변경
- **`.claude/rules/gotchas.md`**: "fastapi < 0.129 pinned" → 오해 소지. 실제는 `[tool.uv] override-dependencies` 로 **fastapi 0.136.3 / starlette 1.3.1 강제**(openbb fastapi 서버 미사용). dependabot.yml 은 자동 PR 만 ignore.
- **`frontend/README.md`**: vitest `1372 tests, 124 files` → 실측 **1383/126** (`frontend/CLAUDE.md`·CI 와 정합).

검증: `make verify-doc-counts` 13/13 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)