### PR TITLE
docs(frontend): fix route count 17 → 18

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,7 +15,7 @@ npx playwright test    # E2E (57 tests, 8 specs)
 
 See [`CLAUDE.md`](CLAUDE.md) for full details. Key points:
 
-- **17 routes** — Server Components with `force-dynamic`
+- **18 routes** — Server Components with `force-dynamic`
 - **Action-First dashboard** — SystemHealth, ActionItems, OpportunityExplorer, MarketContext
 - **API proxy** — Next.js rewrites `/api/*` to FastAPI `:8001`
 - **i18n** — `src/lib/strings.ts` (Korean UI constants, not next-intl)


### PR DESCRIPTION
## 왜
.md drift 정리 후속. `frontend/README.md` 가 **17 routes** 로 stale — 실측 **18** (`find frontend/src/app -name page.tsx | wc -l` = 18, `/decisions/[id]` 포함). `frontend/CLAUDE.md` 의 "18 Routes" 와 정합.

1줄 정정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)