### PR TITLE
docs(readme): precise frontend version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 
 **Frontend**
 
-![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs&logoColor=white)
-![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind-4-06B6D4?logo=tailwindcss&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-16.2.9-000000?logo=nextdotjs&logoColor=white)
+![React](https://img.shields.io/badge/React-19.2.7-61DAFB?logo=react&logoColor=black)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.3.1-06B6D4?logo=tailwindcss&logoColor=white)
 ![shadcn/ui](https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white)
 
 **Quant**


### PR DESCRIPTION
실측 node_modules 기준 정밀 버전: Next.js 16→16.2.9 · React 19→19.2.7 · Tailwind 4→4.3.1. (Python 3.12 는 requires-python 플로어라 유지.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)