### PR TITLE
feat(postmortem): #596 Phase 3 retro playbook — similar-day lessons

### DIFF
--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -221,6 +221,7 @@ def _format_markdown(
     holdings: dict[str, dict[str, Any]],
     pnl: dict[str, Any],
     sectors: list[dict[str, Any]],
+    retro_lessons: Optional[list[str]] = None,
 ) -> str:
     """Local persist artifact — Claude 가 다음 session 에서 읽을 수 있게 markdown."""
     title = "Post-market Brief — {} ({})".format(date, "KR session" if session == "kr" else "US session")
@@ -281,6 +282,13 @@ def _format_markdown(
         lines.append("")
         lines.append(f"**Actionable PnL**: {a_pnl:+,.0f} ({a_pct:+.2f}%)")
     lines.append("")
+
+    # Retro — 비슷했던 과거 + 그때 결과 (#596 Phase 3). 유사일 누적 전엔 빈 list → 섹션 생략.
+    if retro_lessons:
+        lines.append("## 📚 Retro — 비슷했던 과거")
+        for lesson in retro_lessons:
+            lines.append(f"- {lesson}")
+        lines.append("")
 
     return "\n".join(lines)
 
@@ -385,7 +393,7 @@ def _load_5d_price_delta_pct(ticker: str, *, db_path: Optional[Path] = None) -> 
     return (latest - five_back) / five_back * 100
 
 
-def _persist_postmortem(
+def _build_query_features(
     session: Literal["kr", "us"],
     date: str,
     macro: dict[str, Any],
@@ -393,11 +401,10 @@ def _persist_postmortem(
     sectors: list[dict[str, Any]],
     *,
     db_path: Optional[Path] = None,
-) -> None:
-    """`market_postmortem` row UPSERT — Phase 2 pattern memory (#596).
+) -> dict[str, Any]:
+    """오늘 스냅샷의 similarity feature vector — `find_similar_days` + upsert 공용.
 
-    Indexed feature columns drive `find_similar_days` cosine similarity;
-    JSON blobs preserve full markdown context for downstream LLM retro.
+    regime classify 가 가장 비싸므로 1회만 계산해 retro + persist 가 공유한다.
     """
     from nuri.quant.regime.classifier import classify_regime
 
@@ -411,20 +418,164 @@ def _persist_postmortem(
     valid_sectors = [s for s in sectors if s.get("delta_pct") is not None]
     top_sector = max(valid_sectors, key=lambda x: abs(x["delta_pct"])) if valid_sectors else None
 
-    vix_val = (macro.get("vix") or {}).get("value")
-    fg_val = (macro.get("fear_greed") or {}).get("value")
+    return {
+        "regime": regime,
+        "vix": (macro.get("vix") or {}).get("value"),
+        "fear_greed": (macro.get("fear_greed") or {}).get("value"),
+        "vix_5d_delta": _load_5d_macro_delta("vix", db_path=db_path),
+        "fg_5d_delta": _load_5d_macro_delta("fear_greed", db_path=db_path),
+        "spy_5d_delta": _load_5d_price_delta_pct("SPY", db_path=db_path),
+        "top_sector_delta_pct": top_sector["delta_pct"] if top_sector else None,
+        "holdings_total_pnl_pct": round(pnl.get("total_pct_weighted", 0.0), 4),
+    }
+
+
+def _forward_spy_return(date: str, *, days: int = 7, db_path: Optional[Path] = None) -> Optional[float]:
+    """`date` 이후 SPY 의 ~days 거래일 전방 수익률(%). 데이터 부족 시 None.
+
+    "오늘과 비슷했던 과거, 그때 그 후 어떻게 됐나" 의 outcome 측정 (#596 Phase 3).
+    """
+    rows = query(
+        "SELECT close FROM prices WHERE ticker = 'SPY' AND date >= ? ORDER BY date ASC LIMIT ?",
+        (date, days + 1),
+        db_path=db_path,
+    )
+    if len(rows) < days + 1:
+        return None
+    base = float(rows[0]["close"])
+    fwd = float(rows[days]["close"])
+    if base == 0:
+        return None
+    return (fwd - base) / base * 100
+
+
+def _ollama_host_is_local() -> bool:
+    """OLLAMA_HOST 가 localhost 인지 검증 (STRATEGY §4.4.3 — 포트폴리오 데이터 local-only).
+
+    빈 값(미설정) 또는 비-localhost 면 False → caller 가 LLM egress 를 막는다.
+    오설정/변조(OLLAMA_HOST=http://remote:11434)로 인한 외부 유출 방어.
+    """
+    import os
+    from urllib.parse import urlparse
+
+    host = os.getenv("OLLAMA_HOST", "").strip()
+    if not host:
+        return False
+    return urlparse(host).hostname in ("localhost", "127.0.0.1", "::1")
+
+
+def _synthesize_retro_llm(
+    public_features: dict[str, Any],
+    enriched: list[tuple[dict[str, Any], Optional[float]]],
+) -> list[str]:
+    """Ollama(local-only by design, STRATEGY §4.4.3) 로 유사-과거 패턴에서 정성 교훈 합성.
+
+    OLLAMA_HOST 미설정/비-localhost/실패 시 [] — LLM 의존 없이 caller 가 graceful degrade.
+    `public_features` 와 `enriched` 는 caller 가 **시장지표(VIX/F&G/regime/SPY)만** 담아
+    전달한다. 개인 보유/PnL/account 는 절대 포함 금지 (egress 경계).
+    """
+    if not _ollama_host_is_local():
+        return []
+    # EGRESS BOUNDARY — prompt 에는 시장-레벨 지표만. enriched/public_features 는
+    # caller 가 이미 public 필드로 projection 한 dict (개인 보유/PnL 미포함).
+    lines = [
+        f"- {s.get('date')}: VIX {s.get('vix')}, F&G {s.get('fear_greed')}, regime {s.get('regime')} → 다음주 SPY {fwd:+.1f}%"
+        for s, fwd in enriched
+        if fwd is not None
+    ]
+    if not lines:
+        return []
+    prompt = (
+        "다음은 오늘 시장과 비슷했던 과거 거래일과 그 다음주 SPY 결과다.\n"
+        f"오늘: VIX {public_features.get('vix')}, F&G {public_features.get('fear_greed')}, "
+        f"regime {public_features.get('regime')}.\n"
+        "유사 과거:\n" + "\n".join(lines) + "\n\n"
+        "위 데이터 패턴에서 다음에 비슷한 상황이 오면 참고할 교훈 2-3개를 한 줄씩 한국어로. 일반론 금지, 이 데이터 기반으로만."
+    )
+    try:
+        from nuri.llm.report import _generate_ollama
+
+        raw = _generate_ollama(prompt)
+    except Exception:  # noqa: BLE001 — LLM 실패는 retro 를 막지 않음
+        logger.warning("retro LLM 합성 실패", exc_info=True)
+        return []
+    if not raw or not raw.strip():
+        return []
+    parsed = [ln.strip(" -*•").strip() for ln in raw.splitlines() if ln.strip()]
+    return [f"💡 {ln}" for ln in parsed[:3] if len(ln) > 5]
+
+
+def _generate_retro_lessons(
+    session: Literal["kr", "us"],
+    date: str,
+    features: dict[str, Any],
+    *,
+    k: int = 5,
+    db_path: Optional[Path] = None,
+) -> list[str]:
+    """#596 Phase 3 — 오늘과 유사했던 과거 + 그때 전방 결과 → 교훈.
+
+    find_similar_days(cosine) 로 유사일 k개 → 각 SPY 7d 전방 수익률 enrich →
+    결정론적 요약(항상 가능) + Ollama 정성 합성(선택). 유사일 0건이면 [].
+    """
+    from nuri.core.db import find_similar_days
+
+    try:
+        similar = find_similar_days(session=session, k=k, exclude_date=date, db_path=db_path, **features)
+    except Exception:  # noqa: BLE001 — pattern memory 실패는 브리프를 막지 않음
+        logger.warning("find_similar_days 실패", exc_info=True)
+        return []
+    if not similar:
+        return []
+
+    # 유사 row 를 public 시장 필드로만 projection — find_similar_days(SELECT *)가 싣는
+    # holdings_pnl/macro_summary 등 개인 JSON blob 을 retro/LLM 데이터 흐름에서 제거.
+    pub = [
+        {"date": s["date"], "vix": s.get("vix"), "fear_greed": s.get("fear_greed"), "regime": s.get("regime")}
+        for s in similar
+    ]
+    enriched = [(p, _forward_spy_return(p["date"], db_path=db_path)) for p in pub]
+    outcomes = [fwd for _, fwd in enriched if fwd is not None]
+
+    lessons: list[str] = []
+    if outcomes:
+        import statistics
+
+        med = statistics.median(outcomes)
+        # headline 과 n= 모두 "전방결과 측정된 일수(outcomes)" 기준 — 카운트 일관.
+        lessons.append(
+            f"유사 {len(outcomes)}건 (regime {features.get('regime') or 'n/a'}): "
+            f"다음 7거래일 SPY 중앙값 {med:+.1f}% "
+            f"(범위 {min(outcomes):+.1f}~{max(outcomes):+.1f}%)"
+        )
+    public_features = {k: features.get(k) for k in ("vix", "fear_greed", "regime")}
+    lessons.extend(_synthesize_retro_llm(public_features, enriched))
+    return lessons
+
+
+def _persist_postmortem(
+    session: Literal["kr", "us"],
+    date: str,
+    macro: dict[str, Any],
+    pnl: dict[str, Any],
+    sectors: list[dict[str, Any]],
+    *,
+    features: Optional[dict[str, Any]] = None,
+    retro_lessons: Optional[list[str]] = None,
+    db_path: Optional[Path] = None,
+) -> None:
+    """`market_postmortem` row UPSERT — Phase 2 pattern memory + Phase 3 retro (#596).
+
+    Indexed feature columns drive `find_similar_days` cosine similarity;
+    JSON blobs preserve full markdown context. `retro_lessons` 는 Phase 3 합성 결과.
+    """
+    feats = (
+        features if features is not None else _build_query_features(session, date, macro, pnl, sectors, db_path=db_path)
+    )
 
     upsert_postmortem(
         date=date,
         session=session,
-        regime=regime,
-        vix=vix_val,
-        fear_greed=fg_val,
-        vix_5d_delta=_load_5d_macro_delta("vix", db_path=db_path),
-        fg_5d_delta=_load_5d_macro_delta("fear_greed", db_path=db_path),
-        spy_5d_delta=_load_5d_price_delta_pct("SPY", db_path=db_path),
-        top_sector_delta_pct=top_sector["delta_pct"] if top_sector else None,
-        holdings_total_pnl_pct=round(pnl.get("total_pct_weighted", 0.0), 4),
         macro_summary=macro,
         holdings_pnl={
             "total_abs": pnl.get("total_abs"),
@@ -432,9 +583,10 @@ def _persist_postmortem(
             "rows": pnl.get("rows", []),
         },
         sector_movers=sectors,
-        catalysts={},  # Phase 3: news + earnings join
-        retro_lessons=[],  # Phase 3: LLM synthesis
+        catalysts={},  # Phase 3: news + earnings join (별 후속)
+        retro_lessons=retro_lessons or [],
         db_path=db_path,
+        **feats,
     )
 
 
@@ -456,13 +608,23 @@ def write_brief(
     pnl = _compute_holdings_pnl(_filter_actionable_accounts(holdings))
     sectors = _load_sector_movers(session, db_path=db_path)
 
-    md = _format_markdown(session, d, macro, holdings, pnl, sectors)
+    # Phase 3 (#596): retro lessons — 유사 과거 + 전방 결과 + LLM 합성 (markdown/persist 공용 feature)
+    features = _build_query_features(session, d, macro, pnl, sectors, db_path=db_path)
+    retro_lessons: list[str] = []
+    try:
+        retro_lessons = _generate_retro_lessons(session, d, features, db_path=db_path)
+    except Exception:
+        logger.warning("retro lessons 생성 실패 (브리프 자체는 생성됨)", exc_info=True)
+
+    md = _format_markdown(session, d, macro, holdings, pnl, sectors, retro_lessons)
     path = _persist_markdown(md, session, d)
     logger.info("Post-market brief persisted: %s", path)
 
-    # Phase 2 (#596): pattern memory row — similarity-search ready
+    # Phase 2+3 (#596): pattern memory row — similarity-search ready + retro lessons
     try:
-        _persist_postmortem(session, d, macro, pnl, sectors, db_path=db_path)
+        _persist_postmortem(
+            session, d, macro, pnl, sectors, features=features, retro_lessons=retro_lessons, db_path=db_path
+        )
     except Exception:
         logger.warning("market_postmortem upsert 실패 (브리프 자체는 생성됨)", exc_info=True)
 

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -798,3 +798,281 @@ class TestWriteBriefBranchCoverage:
         assert "데이터 없음" in md
         # AAPL holdings 행은 표 안에 없음
         assert "## Holdings" in md
+
+
+# ─── #596 Phase 3 — retro lessons (similar days + forward outcome + LLM) ──────
+
+
+class TestRetroLessons:
+    """Pattern memory retro: 유사 과거 + 전방 결과 + LLM 합성 (disabled-safe)."""
+
+    def _seed_spy(self, path, start="2026-01-02", n=30, base=500.0, step=1.0):
+        import pandas as pd
+
+        from nuri.core.db import upsert_prices
+
+        dates = pd.date_range(start, periods=n, freq="B")
+        rows = [
+            {
+                "ticker": "SPY",
+                "date": d.strftime("%Y-%m-%d"),
+                "open": base + i * step,
+                "high": base + i * step + 1,
+                "low": base + i * step - 1,
+                "close": base + i * step,
+                "volume": 1_000_000,
+                "adj_close": base + i * step,
+            }
+            for i, d in enumerate(dates)
+        ]
+        upsert_prices(pd.DataFrame(rows), path)
+
+    def test_forward_spy_return_computes_pct(self, tmp_path, monkeypatch):
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db
+
+        path = tmp_path / "r.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        self._seed_spy(path, start="2026-01-02", n=10, base=500.0, step=1.0)
+        # 1/02 close=500, +2 거래일 close=502 → +0.4%
+        r = pmb._forward_spy_return("2026-01-02", days=2, db_path=path)
+        assert r is not None and abs(r - 0.4) < 0.01
+
+    def test_forward_spy_return_none_when_insufficient(self, tmp_path, monkeypatch):
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db
+
+        path = tmp_path / "r.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        self._seed_spy(path, start="2026-01-02", n=3, base=500.0)
+        assert pmb._forward_spy_return("2026-01-02", days=7, db_path=path) is None
+
+    def test_retro_empty_when_no_similar_days(self, tmp_path, monkeypatch):
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db
+
+        path = tmp_path / "r.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        feats = {"regime": "bull_low_vol", "vix": 16.0, "fear_greed": 60.0}
+        assert pmb._generate_retro_lessons("us", "2026-06-01", feats, db_path=path) == []
+
+    def test_retro_deterministic_summary_with_outcomes(self, tmp_path, monkeypatch):
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db, upsert_postmortem
+
+        path = tmp_path / "r.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        self._seed_spy(path, start="2026-01-02", n=30, base=500.0, step=1.0)
+        # 유사 과거 2건 — 같은 session/regime, 전방 SPY 데이터 충분한 초반 날짜
+        for d in ("2026-01-05", "2026-01-06"):
+            upsert_postmortem(
+                date=d,
+                session="us",
+                regime="bull_low_vol",
+                vix=16.0,
+                fear_greed=60.0,
+                vix_5d_delta=-1.0,
+                fg_5d_delta=5.0,
+                spy_5d_delta=1.0,
+                top_sector_delta_pct=1.5,
+                holdings_total_pnl_pct=2.0,
+                db_path=path,
+            )
+        feats = {
+            "regime": "bull_low_vol",
+            "vix": 16.0,
+            "fear_greed": 60.0,
+            "vix_5d_delta": -1.0,
+            "fg_5d_delta": 5.0,
+            "spy_5d_delta": 1.0,
+            "top_sector_delta_pct": 1.5,
+            "holdings_total_pnl_pct": 2.0,
+        }
+        with patch.dict("os.environ", {"OLLAMA_HOST": ""}):  # LLM off → deterministic only
+            lessons = pmb._generate_retro_lessons("us", "2026-06-01", feats, db_path=path)
+        assert lessons and "유사 2건" in lessons[0] and "SPY 중앙값" in lessons[0]
+
+    def test_synthesize_retro_llm_disabled_safe(self, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        out = pmb._synthesize_retro_llm({"vix": 16}, [({"date": "2026-01-05", "vix": 16}, 1.2)])
+        assert out == []
+
+    def test_synthesize_retro_llm_parses_ollama(self, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+        enriched = [({"date": "2026-01-05", "vix": 16, "fear_greed": 60, "regime": "bull"}, 1.2)]
+        with patch("nuri.llm.report._generate_ollama", return_value="- 변동성 낮을 때 추격 자제\n- 눌림목 분할 진입"):
+            out = pmb._synthesize_retro_llm({"vix": 16, "fear_greed": 60, "regime": "bull"}, enriched)
+        assert len(out) == 2 and out[0].startswith("💡") and "추격 자제" in out[0]
+
+    def test_retro_surfaces_in_markdown_and_persists(self, tmp_path, monkeypatch):
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db, query, upsert_macro, upsert_postmortem, upsert_prices
+
+        path = tmp_path / "r.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        monkeypatch.setattr(pmb, "__file__", str(tmp_path / "nuri" / "alerts" / "postmarket_brief.py"))
+        self._seed_spy(path, start="2026-01-02", n=40, base=500.0, step=1.0)
+        upsert_macro([{"indicator": "vix", "date": "2026-02-02", "value": 16.0, "source": "t"}], path)
+        for d in ("2026-01-05", "2026-01-06"):
+            upsert_postmortem(
+                date=d,
+                session="us",
+                regime=None,
+                vix=16.0,
+                fear_greed=None,
+                spy_5d_delta=1.0,
+                holdings_total_pnl_pct=0.0,
+                db_path=path,
+            )
+        with (
+            patch.dict("os.environ", {"OLLAMA_HOST": ""}),
+            patch("nuri.alerts.postmarket_brief._publish_discord", return_value=None),
+        ):
+            out_path = pmb.write_brief("us", date="2026-02-02", db_path=path)
+        md = out_path.read_text()
+        assert "📚 Retro" in md
+        row = query("SELECT retro_lessons FROM market_postmortem WHERE date='2026-02-02'", db_path=path)
+        assert row and row[0]["retro_lessons"] and "SPY 중앙값" in row[0]["retro_lessons"]
+
+    def test_synthesize_retro_llm_empty_response_safe(self, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+        enriched = [({"date": "2026-01-05", "vix": 16, "fear_greed": 60, "regime": "bull"}, 1.2)]
+        with patch("nuri.llm.report._generate_ollama", return_value="   "):
+            assert pmb._synthesize_retro_llm({"vix": 16}, enriched) == []
+
+    def test_synthesize_retro_llm_no_outcomes_safe(self, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+        # 전방 결과(fwd) 전부 None → 보낼 라인 없음 → []
+        assert pmb._synthesize_retro_llm({"vix": 16}, [({"date": "2026-01-05"}, None)]) == []
+
+    def test_synthesize_retro_llm_exception_safe(self, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+        enriched = [({"date": "2026-01-05", "vix": 16, "fear_greed": 60, "regime": "bull"}, 1.2)]
+        with patch("nuri.llm.report._generate_ollama", side_effect=RuntimeError("ollama down")):
+            assert pmb._synthesize_retro_llm({"vix": 16}, enriched) == []
+
+    def test_retro_find_similar_exception_safe(self, tmp_path, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        with patch("nuri.core.db.find_similar_days", side_effect=RuntimeError("db gone")):
+            assert pmb._generate_retro_lessons("us", "2026-06-01", {"vix": 16}, db_path=tmp_path / "x.db") == []
+
+    def test_forward_spy_return_none_on_zero_base(self, tmp_path, monkeypatch):
+        import pandas as pd
+
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db, upsert_prices
+
+        path = tmp_path / "z.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        dates = pd.date_range("2026-01-02", periods=5, freq="B")
+        rows = [
+            {
+                "ticker": "SPY",
+                "date": d.strftime("%Y-%m-%d"),
+                "open": 0,
+                "high": 0,
+                "low": 0,
+                "close": 0.0,
+                "volume": 1,
+                "adj_close": 0.0,
+            }
+            for d in dates
+        ]
+        upsert_prices(pd.DataFrame(rows), path)
+        assert pmb._forward_spy_return("2026-01-02", days=2, db_path=path) is None
+
+    def test_write_brief_survives_retro_failure(self, seeded_db, portfolio_yaml, tmp_path, monkeypatch):
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.setattr(pmb, "__file__", str(tmp_path / "nuri" / "alerts" / "postmarket_brief.py"))
+        with (
+            patch("nuri.alerts.postmarket_brief._generate_retro_lessons", side_effect=RuntimeError("boom")),
+            patch("nuri.alerts.postmarket_brief._publish_discord", return_value=None),
+        ):
+            out_path = pmb.write_brief("us", date="2026-05-01", db_path=seeded_db)
+        assert out_path.exists()  # 브리프 자체는 생성 (retro 실패 무관)
+
+    def test_ollama_host_local_guard(self, monkeypatch):
+        """STRATEGY §4.4.3 — 비-localhost OLLAMA_HOST 는 거부 (egress 방어)."""
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert pmb._ollama_host_is_local() is False
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+        assert pmb._ollama_host_is_local() is True
+        monkeypatch.setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+        assert pmb._ollama_host_is_local() is True
+        # 비-localhost → 거부 (외부 유출 방어)
+        monkeypatch.setenv("OLLAMA_HOST", "http://remote-host.example.com:11434")
+        assert pmb._ollama_host_is_local() is False
+
+    def test_synthesize_retro_llm_blocks_nonlocal_host(self, monkeypatch):
+        """비-localhost host 면 _generate_ollama 호출 자체가 안 일어남 (egress 차단)."""
+        from nuri.alerts import postmarket_brief as pmb
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://attacker.example.com:11434")
+        enriched = [({"date": "2026-01-05", "vix": 16, "fear_greed": 60, "regime": "bull"}, 1.2)]
+        with patch("nuri.llm.report._generate_ollama") as gen:
+            out = pmb._synthesize_retro_llm({"vix": 16}, enriched)
+        assert out == []
+        gen.assert_not_called()
+
+    def test_retro_strips_sensitive_fields_before_llm(self, tmp_path, monkeypatch):
+        """find_similar_days(SELECT *) 의 holdings_pnl blob 이 LLM 데이터 흐름에 안 들어감."""
+        import nuri.core.db as db_mod
+        from nuri.alerts import postmarket_brief as pmb
+        from nuri.core.db import init_db, upsert_postmortem
+
+        path = tmp_path / "r.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        self._seed_spy(path, start="2026-01-02", n=30, base=500.0, step=1.0)
+        upsert_postmortem(
+            date="2026-01-05",
+            session="us",
+            regime="bull",
+            vix=16.0,
+            fear_greed=60.0,
+            holdings_pnl={"rows": [{"ticker": "SECRET_TICKER", "account": "SECRET_ACCT", "pnl_abs": 99999}]},
+            spy_5d_delta=1.0,
+            holdings_total_pnl_pct=12.3,
+            db_path=path,
+        )
+        captured = {}
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+
+        def _fake(prompt):
+            captured["prompt"] = prompt
+            return "- 교훈1"
+
+        feats = {"regime": "bull", "vix": 16.0, "fear_greed": 60.0, "spy_5d_delta": 1.0, "holdings_total_pnl_pct": 12.3}
+        with patch("nuri.llm.report._generate_ollama", side_effect=_fake):
+            pmb._generate_retro_lessons("us", "2026-06-01", feats, db_path=path)
+        # 개인 보유/account/PnL 이 prompt 에 절대 미포함
+        assert "SECRET_TICKER" not in captured.get("prompt", "")
+        assert "SECRET_ACCT" not in captured.get("prompt", "")
+        assert "99999" not in captured.get("prompt", "")
+        assert "12.3" not in captured.get("prompt", "")


### PR DESCRIPTION
Closes #596 (Phase 3; Phase 1+2 이미 ship)

## 무엇
종장 brief 에 **"오늘과 비슷했던 과거 N건 + 그때 다음주 SPY 결과 → 교훈"** 추가. Phase 2 의 `market_postmortem` pattern memory(similarity 벡터)를 소비해 의사결정 품질을 높임 (사용자 "오늘과 비슷한 과거, 그때 결과는?" 니즈).

## 구현
- `_generate_retro_lessons`: `find_similar_days`(cosine) k개 → 각 SPY 7거래일 전방 결과 enrich → **결정론적 중앙값/범위 요약(항상 가능)** + **Ollama 정성 합성(선택)**
- `_forward_spy_return`: date 이후 SPY ~7거래일 전방 수익률 (outcome)
- markdown `📚 Retro` 섹션 + `market_postmortem.retro_lessons` persist
- **disabled-safe**: Ollama 미설정/비-localhost/실패/유사일0 → 전부 `[]` graceful (프로덕션 daily job 무중단)
- backward-compat: 유사일 누적 전엔 retro 섹션 생략 (기존 brief 불변)

## 보안/프라이버시 (adversarial review 31-agent 반영)
- `_ollama_host_is_local`: 비-localhost `OLLAMA_HOST` 거부 (STRATEGY §4.4.3 — 포트폴리오 data local-only egress 방어). lock-test.
- 유사 row 를 **public 시장 필드(VIX/F&G/regime/SPY)로만 projection** — `find_similar_days(SELECT *)` 가 싣는 `holdings_pnl` blob 을 retro/LLM 데이터 흐름에서 제거. **LLM prompt 에 개인 보유/PnL/account 절대 미포함** (lock-test: SECRET_TICKER/account/PnL 부재 검증)

## 검증
- **100% line coverage**, 53 postmarket 테스트 (보안 가드 + 프라이버시 projection + graceful-degrade 전 분기)
- 450 관련 테스트(alerts+postmortem+llm) 통과, ruff clean

## Out of scope (follow-up)
- `nuri/llm/report.py:_generate_ollama` 전역 localhost 가드 (기존 report 경로도 동일 §4.4.3 갭) — 별 이슈
- `find_similar_days` `SELECT *` → explicit columns (공유 함수, 별 이슈)
- Phase 3 잔여: catalysts(news+earnings join)

🤖 Generated with [Claude Code](https://claude.com/claude-code)