### PR TITLE
sec(llm): #797 enforce local-only Ollama egress + find_similar_days column projection

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -241,6 +241,7 @@
     "finvizfinance",
     "fomc",
     "FOMC",
+    "footgun",
     "FRED",
     "fred",
     "fredapi",

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -450,18 +450,16 @@ def _forward_spy_return(date: str, *, days: int = 7, db_path: Optional[Path] = N
 
 
 def _ollama_host_is_local() -> bool:
-    """OLLAMA_HOST 가 localhost 인지 검증 (STRATEGY §4.4.3 — 포트폴리오 데이터 local-only).
+    """OLLAMA_HOST(runtime) 가 localhost 인지 — LLM egress 전 pre-check (STRATEGY §4.4.3).
 
-    빈 값(미설정) 또는 비-localhost 면 False → caller 가 LLM egress 를 막는다.
-    오설정/변조(OLLAMA_HOST=http://remote:11434)로 인한 외부 유출 방어.
+    예측 차단(비-localhost 면 prompt 구성 자체 skip). 최종 가드는 `_generate_ollama`
+    내부에도 있음(이중 방어). predicate 는 report._host_is_local 공유.
     """
     import os
-    from urllib.parse import urlparse
 
-    host = os.getenv("OLLAMA_HOST", "").strip()
-    if not host:
-        return False
-    return urlparse(host).hostname in ("localhost", "127.0.0.1", "::1")
+    from nuri.llm.report import _host_is_local
+
+    return _host_is_local(os.getenv("OLLAMA_HOST"))
 
 
 def _synthesize_retro_llm(
@@ -548,7 +546,7 @@ def _generate_retro_lessons(
             f"다음 7거래일 SPY 중앙값 {med:+.1f}% "
             f"(범위 {min(outcomes):+.1f}~{max(outcomes):+.1f}%)"
         )
-    public_features = {k: features.get(k) for k in ("vix", "fear_greed", "regime")}
+    public_features = {key: features.get(key) for key in ("vix", "fear_greed", "regime")}
     lessons.extend(_synthesize_retro_llm(public_features, enriched))
     return lessons
 

--- a/nuri/core/db/postmortem_ops.py
+++ b/nuri/core/db/postmortem_ops.py
@@ -157,9 +157,17 @@ def find_similar_days(
     if session not in _VALID_SESSIONS:
         raise ValueError(f"session must be one of {_VALID_SESSIONS}, got {session!r}")
 
+    # indexed feature 컬럼만 SELECT — cosine 는 이 수치만 사용. 개인 JSON blob
+    # (holdings_pnl/macro_summary/sector_movers/catalysts/retro_lessons)은 결과에서
+    # 제외해 caller egress footgun 차단 (#797, STRATEGY §4.4.3). blob 필요 시 별 fetch.
+    _SIM_COLS = (
+        "date, session, regime, vix, fear_greed, vix_5d_delta, fg_5d_delta, "
+        "spy_5d_delta, top_sector_delta_pct, holdings_total_pnl_pct"
+    )
     with get_db(db_path) as conn:
         rows = [
-            dict(r) for r in conn.execute("SELECT * FROM market_postmortem WHERE session = ?", (session,)).fetchall()
+            dict(r)
+            for r in conn.execute(f"SELECT {_SIM_COLS} FROM market_postmortem WHERE session = ?", (session,)).fetchall()
         ]
     if exclude_date:
         rows = [r for r in rows if r["date"] != exclude_date]

--- a/nuri/core/db/postmortem_ops.py
+++ b/nuri/core/db/postmortem_ops.py
@@ -150,7 +150,9 @@ def find_similar_days(
 ) -> list[dict[str, Any]]:
     """Return the top-k most similar prior postmortems to the supplied query vector.
 
-    Each result dict carries the original row fields plus `similarity` (cosine).
+    Each result dict carries the **indexed feature columns** (date/session/regime/
+    vix/fear_greed/5d-deltas/top_sector/holdings_pnl_pct) plus `similarity` (cosine)
+    — personal JSON blobs are intentionally NOT returned (egress safety, #797).
     Sorted descending by similarity. Caller can join with `decision_outcomes`
     on date to recover N+7d outcome (Phase 3 wiring).
     """

--- a/nuri/llm/report.py
+++ b/nuri/llm/report.py
@@ -587,9 +587,30 @@ def _generate_llamacpp(prompt: str) -> str:
         return ""
 
 
+def _host_is_local(host: str | None) -> bool:
+    """`host` URL 의 hostname 이 localhost 계열인지 (STRATEGY §4.4.3).
+
+    포트폴리오 분석 데이터의 외부 egress 방어 — 빈 값/비-localhost 면 False.
+    pure predicate (env 미read) — caller 가 host 출처를 결정.
+    """
+    from urllib.parse import urlparse
+
+    if not host:
+        return False
+    return urlparse(host).hostname in ("localhost", "127.0.0.1", "::1")
+
+
 def _generate_ollama(prompt: str) -> str:
     """Ollama HTTP API로 생성. Qwen3.5 thinking 모델 호환."""
     if not OLLAMA_HOST:
+        return ""
+    # STRATEGY §4.4.3 — Ollama 는 local-only. 비-localhost host (오설정/변조) 면
+    # 포트폴리오 분석 prompt 의 외부 egress 를 차단하고 graceful degrade.
+    if not _host_is_local(OLLAMA_HOST):
+        logger.warning(
+            "OLLAMA_HOST '%s' 가 localhost 아님 — STRATEGY §4.4.3 local-only 위반, Ollama 비활성.",
+            OLLAMA_HOST,
+        )
         return ""
     import requests as _requests
 

--- a/tests/llm/test_report_branch_coverage.py
+++ b/tests/llm/test_report_branch_coverage.py
@@ -331,6 +331,27 @@ class TestGenerateOllamaNoHost:
         assert _generate_ollama("prompt") == ""
 
 
+class TestOllamaLocalOnlyGuard:
+    """STRATEGY §4.4.3 — 비-localhost OLLAMA_HOST 는 egress 차단 (#797)."""
+
+    def test_host_is_local_predicate(self) -> None:
+        from nuri.llm.report import _host_is_local
+
+        assert _host_is_local("http://localhost:11434") is True
+        assert _host_is_local("http://127.0.0.1:11434") is True
+        assert _host_is_local("http://[::1]:11434") is True
+        assert _host_is_local("http://remote.example.com:11434") is False
+        assert _host_is_local("") is False
+        assert _host_is_local(None) is False
+
+    def test_nonlocal_host_blocks_post(self, monkeypatch) -> None:
+        # 비-localhost host → requests.post 호출 자체가 안 일어남 (egress 차단).
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://attacker.example.com:11434")
+        with patch("requests.post") as post:
+            assert _generate_ollama("portfolio prompt") == ""
+        post.assert_not_called()
+
+
 # ─── 227 / 229 standalone branch fillers ─────────────────────────────
 
 
@@ -621,7 +642,7 @@ class TestOllamaNoMarker:
         mock_requests.post.return_value = fake_resp
         mock_requests.ConnectionError = ConnectionError
         monkeypatch.setitem(sys.modules, "requests", mock_requests)
-        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://fake-ollama")
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://localhost:11434")
 
         result = _generate_ollama("test prompt")
         # 마커 없음 → response 가 그대로 (re.sub 적용된 형태) 반환
@@ -639,7 +660,7 @@ class TestOllamaNoMarker:
         mock_requests.post.return_value = fake_resp
         mock_requests.ConnectionError = ConnectionError
         monkeypatch.setitem(sys.modules, "requests", mock_requests)
-        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://fake-ollama")
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://localhost:11434")
 
         result = _generate_ollama("test prompt")
         assert "thinking content" in result
@@ -656,7 +677,7 @@ class TestOllamaNoMarker:
         mock_requests.post.return_value = fake_resp
         mock_requests.ConnectionError = ConnectionError
         monkeypatch.setitem(sys.modules, "requests", mock_requests)
-        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://fake-ollama")
+        monkeypatch.setattr(report_mod, "OLLAMA_HOST", "http://localhost:11434")
 
         result = _generate_ollama("test prompt")
         assert result == ""


### PR DESCRIPTION
Closes #797

## 왜
#796(#596 retro) adversarial review(31-agent) 의 **공유 코드** 보안 발견 — #796 scope 밖이라 분리했던 follow-up.

## 변경
1. **`report._generate_ollama` local-only 가드** (STRATEGY §4.4.3) — 비-localhost `OLLAMA_HOST`(오설정/변조) 면 포트폴리오 분석 prompt 의 외부 egress 를 차단 + WARNING, graceful return "". 공유 pure predicate `_host_is_local` 신설.
2. **`postmarket._ollama_host_is_local` → 위임** — 중복 urlparse 제거(DRY), 동일 predicate 재사용.
3. **`find_similar_days` SELECT * → indexed 컬럼** — 개인 JSON blob(`holdings_pnl`/`macro_summary`/...)을 결과에서 제외(caller egress footgun 차단). **유일 호출자(postmarket retro)는 indexed 컬럼만 사용** — 동작 영향 0. docstring 정합.
4. **nit**: `_generate_retro_lessons` 컴프리헨션 변수 `k`→`key` (함수 param `k` shadow 해소, 동작 무관 clarity).

## 검증
- lock-test: 비-localhost host → `requests.post` **미호출** 검증 + `_host_is_local` predicate (localhost/127.0.0.1/::1/원격/빈값/None)
- 기존 report 테스트 fixture `http://fake-ollama` → `http://localhost:11434` 정합(host 임의값→localhost 필수)
- **320 통과** (llm + postmortem + postmarket), ruff + cspell clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)