### PR TITLE
fix(strategy): #715 disable leader-exit — walk-forward FAIL, revert to ladder

### DIFF
--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -82,16 +82,18 @@ take_profit:
     min_agent_confidence: 50    # 최소 에이전트 합의 신뢰도
   # O'Neil 8주 규칙: 매수 후 3주 이내에 +20% 돌파 시 최소 8주 보유
   eight_week_hold: true
-  # ─── Leader exception (8주 룰 운영화) ───────────────────────
-  # 성장주(classify_stock_type==growth) 보유는 고정 +20/+40 익절 미적용, trail_ma 이동평균
-  # 종가 이탈 시 청산 (승자 run). value/swing 은 위 ladder 유지. -7% 하드손절 공통.
-  # 백테스트(17 성장주 2021~26, 비중첩·트레일동일·비용·연율화, skeptic 검증): 무TP+MA50
-  # 트레일이 고정TP ladder 대비 CAGR 12.8% → 19.5%, 낙폭 더 얕음 (위험조정 0.30→0.53).
-  # 성장주 판정은 nuri/trading/recommend/price_targets.classify_stock_type (stock_types.yaml
-  # 수동 override > PE>30 > 성장 섹터). 50일선 미계산(< 50 종가) 시 고정 ladder 유지.
+  # ─── Leader exception (8주 룰 운영화) — DISABLED by #715 ─────
+  # 의도: 성장주 보유는 고정 +20/+40 익절 대신 trail_ma 종가 이탈 청산 (승자 run).
+  # 도입 근거(#679)는 17 성장주 약식 백테스트(무TP+MA50 위험조정 0.30→0.53)뿐이었다.
+  # #715 엄밀 검증(2026-06-22): growth 197종목·random entries 2000·permutation null 200·
+  # holdout 20%·비용·survivorship haircut walk-forward → e1_leader_ma Sharpe +0.226 vs
+  # e0_ladder +0.543 (Δ−0.318, p=0.552 노이즈, maxDD −0.29 vs −0.23). promotion-eligible
+  # NONE. 17종목 근거를 강한 표본이 반증 → 라이브 정당화 실패. enabled=false 로 검증된
+  # O'Neil ladder 복원이 데이터 기반 디폴트 (사전등록 프로토콜). 코드는 보존 — validated
+  # leader-entry 조건부 재검증 시 재활성(follow-up). 성장주 판정/50일선 로직 불변.
   leader:
-    enabled: true
-    trail_ma: 50                  # 50일 이동평균 종가 이탈 시 청산 (고정 익절 대체)
+    enabled: false                # #715 FAIL → ladder 복원. 재활성은 STRATEGY PR + 재검증 PASS
+    trail_ma: 50                  # 50일 이동평균 종가 이탈 시 청산 (재활성 시 사용)
 
 # ─── 트레일링 스톱 ──────────────────────────────────────
 # 근거: 11년 백테스트에서 15-20% 트레일링 스톱이 최적 수익 (73.9% 누적)

--- a/tests/trading/recommend/test_leader_exit.py
+++ b/tests/trading/recommend/test_leader_exit.py
@@ -4,12 +4,16 @@ Source of truth: `config/rules.yaml take_profit.leader` -> `nuri.core.rules.TAKE
 리더 = 성장주(classify_stock_type==growth) + 50일선 계산가능. 고정 익절 대신 50일선 트레일.
 Reverting is_leader / TP skip / check_leader_trail_signals / actions wiring fails these.
 
-근거: 백테스트(17 성장주 2021~26, 비중첩·트레일동일·비용·연율화, skeptic 검증) —
-무TP+MA50 트레일이 고정TP ladder 대비 CAGR 12.8% → 19.5%, 낙폭 더 얕음.
-설계(codex 4-round review): growth-type 기준 (gain-threshold stickiness 문제 회피).
+**#715 (2026-06-22): config 기본값 enabled=false 로 DISABLED.** growth 197종목 walk-forward
+(random entries·permutation null·holdout) 에서 leader-exit 가 ladder 대비 열위(Δ−0.318,
+p=0.55) → 라이브 정당화 실패, O'Neil ladder 복원. **코드는 보존**(validated leader-entry
+조건부 재검증 대비). 따라서 이 파일의 behavior lock-test 는 `_enable_leader` autouse
+fixture 로 enabled=true 를 명시 주입해 동작 자체를 잠근다 (config 정책값과 분리).
 """
 
 from datetime import date, timedelta
+
+import pytest
 
 from nuri.core.db import get_db
 from nuri.trading.recommend.price_targets import (
@@ -19,6 +23,15 @@ from nuri.trading.recommend.price_targets import (
     format_target_tree,
     is_leader,
 )
+
+
+@pytest.fixture(autouse=True)
+def _enable_leader(monkeypatch):
+    """leader-exit 는 #715 로 config 기본값 disabled — behavior lock-test 는 enabled=true
+    를 명시 주입해 코드 경로를 잠근다. `test_disabled*` 는 본문에서 다시 false 로 override."""
+    import nuri.trading.recommend.price_targets as pt
+
+    monkeypatch.setattr(pt, "TAKE_PROFIT_LEADER", {"enabled": True, "trail_ma": 50})
 
 
 def _seed(db_path, ticker, avg_price, closes, sector="AI"):
@@ -138,3 +151,22 @@ class TestLeaderTargets:
         tree = format_target_tree(t)
         assert "리더" in tree
         assert "일선" in tree
+
+
+class TestConfigDefaultDisabled715:
+    """#715 정책 결정 lock — config 기본값이 disabled 임을 고정.
+
+    leader-exit 가 growth walk-forward(#715)에서 ladder 대비 열위(Δ−0.318, p=0.55)로
+    FAIL → enabled=false 가 데이터 기반 디폴트. 무근거 재활성(true 복귀)이 이 테스트를
+    깬다 — 재활성은 STRATEGY PR + 재검증 PASS 가 선결. (autouse _enable_leader 는 모듈
+    상수만 패치하므로 YAML 직접 read 는 영향 없음.)
+    """
+
+    def test_rules_yaml_leader_disabled(self):
+        from pathlib import Path
+
+        import yaml
+
+        cfg = yaml.safe_load((Path(__file__).resolve().parents[3] / "config" / "rules.yaml").read_text())
+        leader = cfg["take_profit"]["leader"]
+        assert leader["enabled"] is False, "leader-exit 재활성은 #715 재검증 PASS 선결 (STRATEGY PR)"


### PR DESCRIPTION
Closes #715

## 왜 (사전등록 검증 결과)
leader-exit(성장주 보유 고정 +20/+40 익절 → 50MA 이탈 청산)는 **라이브(`enabled:true`)** 였으나 근거는 #715가 지목한 *17 성장주 약식 백테스트*(permutation null·holdout 없음, 승자 선택편향 의심)뿐이었다.

**#715 엄밀 walk-forward (2026-06-22, 5y 데이터 수집 후):**
| rule | Sharpe | ΔvsE0 | p | maxDD | verdict |
|---|---|---|---|---|---|
| e0_ladder (baseline) | **+0.543** | — | — | −0.23 | baseline |
| e1_leader_ma | +0.226 | **−0.318** | **0.552** | −0.29 | **FAIL** |

growth **197종목** · random entries 2000 · permutation null 200 · holdout 20% · 비용 10bps · survivorship haircut. **promotion-eligible: NONE.**

강한 표본이 약식 근거를 **반증** → 라이브 정당화 실패 + 점추정 열위 + maxDD 더 깊음. 사전등록 프로토콜("FAIL→비활성")대로 **검증된 O'Neil ladder 복원**이 데이터 기반 디폴트.

## 변경
- `config/rules.yaml`: `take_profit.leader.enabled` true→**false** + 근거 주석을 #715 verdict 로 교체. **코드/50일선 로직은 보존** (validated leader-entry 조건부 재검증 #799 시 재활성)
- `test_leader_exit.py`: behavior lock-test 는 `_enable_leader` autouse 로 명시 enable(코드 잠금 ≠ config 정책값 분리), **decision-lock 신규**(YAML `enabled=false` 고정 — 무근거 재활성 시 CI fail)

## 검증
- **end-to-end 실측**: `is_leader('NVDA')`/`is_leader('TSLA')` → `False` (growth 보유가 +20/+40/trailing ladder 로 복원)
- 199 leader 관련 테스트 green (price_targets / actions / targets / leader_trail), ruff + yaml clean

## 정직한 caveat → #799
random-entries 검증은 "확인된 리더 진입" 전제를 반영 못 함. 단 그 진입 엣지가 **미입증**(#706/#707/#713/#714)이므로 입증 안 된 전제로 라이브 룰 유지 불가. validated leader-entry 조건부 재검증은 **#799**(선결: 진입 엣지 입증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)