### PR TITLE
feat(collectors): Toss 증권 Open API credential scaffold + auth verify (read-only)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,7 +2,7 @@
 
 ## Code layout
 
-`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (26 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
+`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (27 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
 
 ## Commands
 

--- a/.cspell.json
+++ b/.cspell.json
@@ -718,6 +718,8 @@
     "tozeroy",
     "tqdm",
     "TQQQ",
+    "tossinvest",
+    "Tossinvest",
     "tradingeconomics",
     "transmat",
     "Treemap",

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,22 @@ KIS_HTS_ID=
 
 
 # ───────────────────────────────────────────────────────────────
+# 1-b. Toss 증권 Open API (토스증권)
+# ───────────────────────────────────────────────────────────────
+# 발급: https://developers.tossinvest.com  (Toss 계좌 보유 + 약관/본인/계좌인증)
+# OAuth 2.0 Client Credentials — POST /oauth2/token (token 86400s, client당 1개).
+# read-only (시세/환율/잔고) endpoint 만 호출 — 주문(create/modify/cancel) 미사용
+# (STRATEGY §7.1 자동 매매 영구 deferred). 검증: python -m nuri.collectors.toss --verify
+# 자격 증명: 1) 아래 env (권장)  2) config/toss/toss_devlp.yaml (gitignored)
+#   TOSS_API_KEY     = Toss 개발자센터 "API Key"    (OAuth client_id)
+#   TOSS_SECRET_KEY  = Toss 개발자센터 "Secret Key" (OAuth client_secret)
+#   TOSS_ACCOUNT_SEQ = (선택) 계좌/보유 조회용 accountSeq → X-Tossinvest-Account 헤더
+TOSS_API_KEY=
+TOSS_SECRET_KEY=
+TOSS_ACCOUNT_SEQ=
+
+
+# ───────────────────────────────────────────────────────────────
 # 2. LLM Providers  (STRATEGY §4.4.3 Egress Policy 필독)
 # ───────────────────────────────────────────────────────────────
 # 모든 외부 LLM 호출은 `nuri/llm/openai_client.py` 단일 wrapper 경유.

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ config/kis_*.yml
 #    .gitkeep만 tracking해서 디렉토리 자체는 repo에 보존
 config/kis/*
 !config/kis/.gitkeep
+# 3-b) config/toss/ 디렉토리 내부 전체 (Toss creds + OAuth token cache)
+config/toss/*
+!config/toss/.gitkeep
 # 4) 레거시 ~/KIS 참조 (프로젝트 외부지만 안전장치)
 .kis/
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ flowchart TB
 
 | Phase | What it does | Key outputs |
 |-------|--------------|-------------|
-| ① **Collect** | 26 collectors — yfinance / OpenBB · pykrx (KR) · FRED · GoogleNews · KIS Open API | `prices` · `fundamentals` · `macro` · `news` |
+| ① **Collect** | 27 collectors — yfinance / OpenBB · pykrx (KR) · FRED · GoogleNews · KIS / Toss Open API | `prices` · `fundamentals` · `macro` · `news` |
 | ② **Analyze** | 22 signals (20 actionable + 2 shadow) · 10 regimes (6 base + 4 special) · 3 factor scorers | `signals` · `factors` · `regime_transitions` |
 | ③ **Consensus** | 10 specialist agents · weighted vote · risk-veto on `alpha_action==FLAT` | `recommendations` (with `agent_verdicts` JSON) |
 | ④ **Certify** | Certification — `Account × Asset Class × Market` · 1 error-grade fail → REJECTED | `certifications` (with evidence trail) |
@@ -161,7 +161,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 | **Frontend tests** | 1,383 (126 files) |
 | **E2E tests** | 57 (Playwright, 8 specs) |
 | **Pipeline phases** | 5 (collect / analyze / consensus / certify / track) |
-| **Data collectors** | 26 collectors (BaseCollector pattern) |
+| **Data collectors** | 27 collectors (BaseCollector pattern) |
 | **Specialist agents** | 10 |
 | **Strategy regimes** | 10 (6 base + 4 special) |
 | **Trading signals** | 22 (20 actionable + 2 shadow) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,046 backend tests across 269 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,148 backend tests across 270 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,046 tests, 269 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,148 tests, 270 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -1,4 +1,4 @@
-# nuri/collectors/ — 26 Data Collectors
+# nuri/collectors/ — 27 Data Collectors
 
 ## BaseCollector Contract
 

--- a/nuri/collectors/toss.py
+++ b/nuri/collectors/toss.py
@@ -1,0 +1,179 @@
+"""Toss 증권 Open API 커넥터 — credential 세팅 + 인증 검증 (read-only).
+
+목적(현 단계): `.env` 의 TOSS_API_KEY/TOSS_SECRET_KEY 가 올바른지 검증.
+  `python -m nuri.collectors.toss --verify` → OAuth 토큰 발급 + 환율 smoke test.
+
+OAuth 2.0 Client Credentials (POST /oauth2/token, x-www-form-urlencoded):
+  body: grant_type=client_credentials&client_id={KEY}&client_secret={SECRET}
+  resp: {access_token, token_type: "Bearer", expires_in: 86400}
+토큰은 config/toss/cache/token.json 에 캐시 (client 당 1개·24h). 만료 마진 5분.
+
+⚠️ STRATEGY §7.1 — 주문(create/modify/cancel) endpoint 는 **절대 호출 안 함**.
+   시세/환율/잔고 read-only 만. 자동 매매 영구 deferred.
+
+자격 증명 우선순위: 1) env (TOSS_API_KEY/TOSS_SECRET_KEY) 2) config/toss/toss_devlp.yaml
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from dotenv import load_dotenv
+
+from nuri.core.timezone import kst_now
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+TOSS_BASE = "https://openapi.tossinvest.com"
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_TOSS_DIR = _PROJECT_ROOT / "config" / "toss"
+_TOKEN_CACHE = _TOSS_DIR / "cache" / "token.json"
+_EXPIRY_MARGIN_SEC = 300  # 만료 5분 전 갱신
+
+
+class TossCredentialsError(RuntimeError):
+    """TOSS_API_KEY / TOSS_SECRET_KEY 미설정 또는 인증 실패."""
+
+
+def _load_creds() -> tuple[str, str]:
+    """(api_key, secret) — env 우선, config/toss/toss_devlp.yaml fallback.
+
+    미설정 시 TossCredentialsError. secret 은 로깅 금지.
+    """
+    import os
+
+    key = (os.getenv("TOSS_API_KEY") or "").strip()
+    secret = (os.getenv("TOSS_SECRET_KEY") or "").strip()
+    if key and secret:
+        return key, secret
+
+    yaml_path = _TOSS_DIR / "toss_devlp.yaml"
+    if yaml_path.exists():
+        import yaml
+
+        cfg = yaml.safe_load(yaml_path.read_text()) or {}
+        key = key or str(cfg.get("api_key", "")).strip()
+        secret = secret or str(cfg.get("secret_key", "")).strip()
+    if not (key and secret):
+        raise TossCredentialsError(
+            "TOSS_API_KEY / TOSS_SECRET_KEY 미설정 — .env 에 추가 후 재시도 "
+            "(또는 config/toss/toss_devlp.yaml). 발급: https://developers.tossinvest.com"
+        )
+    return key, secret
+
+
+def _read_cached_token() -> Optional[str]:
+    """캐시된 access_token — 만료(마진 포함) 전이면 반환, 아니면 None."""
+    if not _TOKEN_CACHE.exists():
+        return None
+    try:
+        data = json.loads(_TOKEN_CACHE.read_text())
+        expires_at = float(data.get("expires_at", 0))
+        if expires_at - _EXPIRY_MARGIN_SEC > kst_now().timestamp():
+            return str(data.get("access_token") or "") or None
+    except Exception:  # noqa: BLE001 — 캐시 손상 시 무시하고 재발급
+        return None
+    return None
+
+
+def _cache_token(access_token: str, expires_in: int) -> None:
+    _TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    _TOKEN_CACHE.write_text(
+        json.dumps({"access_token": access_token, "expires_at": kst_now().timestamp() + int(expires_in)})
+    )
+
+
+def get_access_token(*, force: bool = False) -> str:
+    """OAuth Client Credentials 토큰 — 캐시 재사용, 없으면 발급."""
+    if not force:
+        cached = _read_cached_token()
+        if cached:
+            return cached
+
+    import requests
+
+    key, secret = _load_creds()
+    resp = requests.post(
+        f"{TOSS_BASE}/oauth2/token",
+        data={"grant_type": "client_credentials", "client_id": key, "client_secret": secret},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        raise TossCredentialsError(f"토큰 발급 실패 (HTTP {resp.status_code}): {resp.text[:200]}")
+    body = resp.json()
+    token = body.get("access_token")
+    if not token:
+        raise TossCredentialsError(f"응답에 access_token 없음: {body}")
+    _cache_token(token, body.get("expires_in", 86400))
+    return token
+
+
+def _authed_get(path: str, params: dict[str, Any], *, account_seq: Optional[str] = None) -> dict[str, Any]:
+    """Bearer 인증 GET — 계좌 endpoint 는 account_seq(X-Tossinvest-Account) 필요."""
+    import requests
+
+    headers = {"Authorization": f"Bearer {get_access_token()}"}
+    if account_seq:
+        headers["X-Tossinvest-Account"] = account_seq
+    resp = requests.get(f"{TOSS_BASE}{path}", params=params, headers=headers, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_exchange_rate(base: str = "USD", quote: str = "KRW") -> dict[str, Any]:
+    """GET /api/v1/exchange-rate — USD/KRW 등 (read-only, 계좌 불필요).
+
+    Returns: {rate, midRate, validFrom, validUntil, ...} (result 언랩).
+    """
+    data = _authed_get("/api/v1/exchange-rate", {"baseCurrency": base, "quoteCurrency": quote})
+    return data.get("result", data)
+
+
+def verify() -> int:
+    """credential 검증 — 토큰 발급 + 환율 smoke test. secret/token 미출력.
+
+    exit code: 0 = OK, 2 = creds/auth 실패.
+    """
+    try:
+        token = get_access_token(force=True)
+        print(f"✓ OAuth 토큰 발급 성공 (len={len(token)}, 캐시: {_TOKEN_CACHE})")
+    except TossCredentialsError as e:
+        print(f"✗ 인증 실패: {e}")
+        return 2
+    except Exception as e:  # noqa: BLE001 — 네트워크 등
+        print(f"✗ 토큰 발급 중 오류: {e}")
+        return 2
+
+    try:
+        fx = get_exchange_rate("USD", "KRW")
+        print(f"✓ 환율 smoke test: USD/KRW = {fx.get('rate')} (valid {fx.get('validFrom')})")
+    except Exception as e:  # noqa: BLE001
+        print(f"⚠️ 토큰은 OK 였으나 환율 조회 실패: {e}")
+        return 2
+    print("✅ Toss Open API 적용 가능 — 키/시크릿 정상 동작 확인.")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="toss", description="Toss Open API connector (read-only)")
+    parser.add_argument("--verify", action="store_true", help="키/시크릿 검증 (토큰+환율 smoke test)")
+    args = parser.parse_args(argv)
+
+    if args.verify:
+        return verify()
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/tests/collectors/test_toss.py
+++ b/tests/collectors/test_toss.py
@@ -1,0 +1,180 @@
+"""Toss Open API connector lock-tests — creds 로더 + 토큰 캐시 + verify 분기.
+
+네트워크(POST token / GET exchange-rate)는 mock. 실제 키 없이 결정적 검증.
+주문 endpoint 부재(STRATEGY §7.1) 도 간접 보장 — 모듈에 order 함수 없음.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nuri.collectors import toss
+
+
+@pytest.fixture(autouse=True)
+def _isolate_creds_and_cache(monkeypatch, tmp_path):
+    """env creds 비우고 토큰 캐시를 tmp 로 격리 (실제 config/toss 미오염)."""
+    monkeypatch.delenv("TOSS_API_KEY", raising=False)
+    monkeypatch.delenv("TOSS_SECRET_KEY", raising=False)
+    monkeypatch.setattr(toss, "_TOKEN_CACHE", tmp_path / "token.json")
+    monkeypatch.setattr(toss, "_TOSS_DIR", tmp_path / "toss")
+
+
+class TestCreds:
+    def test_missing_raises(self):
+        with pytest.raises(toss.TossCredentialsError):
+            toss._load_creds()
+
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("TOSS_API_KEY", "c_test")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s_test")
+        assert toss._load_creds() == ("c_test", "s_test")
+
+
+class TestToken:
+    def test_uses_unexpired_cache(self, monkeypatch):
+        # 만료 충분히 남은 캐시 → 네트워크 호출 없이 반환
+        from nuri.core.timezone import kst_now
+
+        toss._TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        toss._TOKEN_CACHE.write_text(
+            json.dumps({"access_token": "cached_tok", "expires_at": kst_now().timestamp() + 99999})
+        )
+        with patch("requests.post") as post:
+            assert toss.get_access_token() == "cached_tok"
+        post.assert_not_called()
+
+    def test_issues_and_caches_when_no_cache(self, monkeypatch):
+        monkeypatch.setenv("TOSS_API_KEY", "c_test")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s_test")
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"access_token": "new_tok", "token_type": "Bearer", "expires_in": 86400}
+        with patch("requests.post", return_value=resp) as post:
+            tok = toss.get_access_token(force=True)
+        assert tok == "new_tok"
+        post.assert_called_once()
+        # form-encoded client_credentials 로 호출
+        assert post.call_args.kwargs["data"]["grant_type"] == "client_credentials"
+        # 캐시 기록됨
+        assert json.loads(toss._TOKEN_CACHE.read_text())["access_token"] == "new_tok"
+
+    def test_non200_raises(self, monkeypatch):
+        monkeypatch.setenv("TOSS_API_KEY", "c_test")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s_test")
+        resp = MagicMock(status_code=401, text="invalid_client")
+        with patch("requests.post", return_value=resp):
+            with pytest.raises(toss.TossCredentialsError):
+                toss.get_access_token(force=True)
+
+
+class TestVerify:
+    def test_missing_creds_returns_2(self, capsys):
+        assert toss.verify() == 2
+        assert "미설정" in capsys.readouterr().out
+
+    def test_full_path_ok(self, monkeypatch, capsys):
+        monkeypatch.setenv("TOSS_API_KEY", "c_test")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s_test")
+        tok_resp = MagicMock(status_code=200)
+        tok_resp.json.return_value = {"access_token": "tok", "expires_in": 86400}
+        fx_resp = MagicMock()
+        fx_resp.raise_for_status.return_value = None
+        fx_resp.json.return_value = {"result": {"rate": "1380.5", "validFrom": "2026-06-22T09:30:00+09:00"}}
+        with patch("requests.post", return_value=tok_resp), patch("requests.get", return_value=fx_resp):
+            rc = toss.verify()
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "1380.5" in out and "적용 가능" in out
+        # secret 이 출력에 새지 않음
+        assert "s_test" not in out
+
+
+def test_no_order_endpoints():
+    """STRATEGY §7.1 — 모듈에 주문(create/cancel/order) 함수 부재 보장."""
+    names = [n for n in dir(toss) if "order" in n.lower() or "buy" in n.lower() or "sell" in n.lower()]
+    assert names == []
+
+
+class TestRemaining:
+    def test_creds_yaml_fallback(self, monkeypatch, tmp_path):
+        # env 없고 config/toss/toss_devlp.yaml 있으면 거기서 읽음
+        d = tmp_path / "toss"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "toss_devlp.yaml").write_text("api_key: yk\nsecret_key: ys\n")
+        monkeypatch.setattr(toss, "_TOSS_DIR", d)
+        assert toss._load_creds() == ("yk", "ys")
+
+    def test_get_exchange_rate_unwraps_result(self, monkeypatch):
+        from nuri.core.timezone import kst_now
+
+        toss._TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        toss._TOKEN_CACHE.write_text(json.dumps({"access_token": "t", "expires_at": kst_now().timestamp() + 99999}))
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"result": {"rate": "1377"}}
+        with patch("requests.get", return_value=resp) as get:
+            fx = toss.get_exchange_rate("USD", "KRW")
+        assert fx["rate"] == "1377"
+        assert get.call_args.kwargs["params"] == {"baseCurrency": "USD", "quoteCurrency": "KRW"}
+
+    def test_cli_verify_dispatch(self, monkeypatch):
+        monkeypatch.setattr(toss, "verify", lambda: 0)
+        assert toss.main(["--verify"]) == 0
+
+    def test_cli_no_args_prints_help(self, capsys):
+        assert toss.main([]) == 0
+        assert "verify" in capsys.readouterr().out.lower()
+
+
+class TestBranches:
+    def test_cached_token_corrupt_returns_none(self):
+        toss._TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        toss._TOKEN_CACHE.write_text("not-json{")
+        assert toss._read_cached_token() is None
+
+    def test_cached_token_expired_returns_none(self):
+        from nuri.core.timezone import kst_now
+
+        toss._TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        toss._TOKEN_CACHE.write_text(json.dumps({"access_token": "old", "expires_at": kst_now().timestamp() - 1}))
+        assert toss._read_cached_token() is None
+
+    def test_token_response_without_access_token_raises(self, monkeypatch):
+        monkeypatch.setenv("TOSS_API_KEY", "c")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s")
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"token_type": "Bearer"}  # access_token 없음
+        with patch("requests.post", return_value=resp):
+            with pytest.raises(toss.TossCredentialsError):
+                toss.get_access_token(force=True)
+
+    def test_authed_get_sends_account_header(self):
+        from nuri.core.timezone import kst_now
+
+        toss._TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        toss._TOKEN_CACHE.write_text(json.dumps({"access_token": "t", "expires_at": kst_now().timestamp() + 99999}))
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"result": {}}
+        with patch("requests.get", return_value=resp) as get:
+            toss._authed_get("/api/v1/holdings", {}, account_seq="acct9")
+        assert get.call_args.kwargs["headers"]["X-Tossinvest-Account"] == "acct9"
+
+    def test_verify_token_network_error_returns_2(self, monkeypatch, capsys):
+        monkeypatch.setenv("TOSS_API_KEY", "c")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s")
+        with patch("requests.post", side_effect=RuntimeError("network down")):
+            rc = toss.verify()
+        assert rc == 2
+        assert "오류" in capsys.readouterr().out
+
+    def test_verify_fx_fails_after_token_ok_returns_2(self, monkeypatch, capsys):
+        monkeypatch.setenv("TOSS_API_KEY", "c")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s")
+        tok = MagicMock(status_code=200)
+        tok.json.return_value = {"access_token": "t", "expires_in": 86400}
+        with patch("requests.post", return_value=tok), patch("requests.get", side_effect=RuntimeError("fx down")):
+            rc = toss.verify()
+        assert rc == 2
+        assert "환율 조회 실패" in capsys.readouterr().out


### PR DESCRIPTION
Closes #801

## 무엇
Toss 증권 Open API 적용 가능성 확인용 **크레덴셜 세팅 + 인증 검증** (KIS 패턴 미러). 사용자가 발급한 키로 **`--verify` 실동작 확인 완료**(OAuth 토큰 + USD/KRW 환율).

## 변경
| 파일 | 내용 |
|---|---|
| `.env` / `.env.example` | `TOSS_API_KEY`/`TOSS_SECRET_KEY`/`TOSS_ACCOUNT_SEQ` (양식 통일, .env 는 gitignored) |
| `.gitignore` | `config/toss/*` + `!config/toss/.gitkeep` (토큰 캐시 보호) |
| `nuri/collectors/toss.py` | creds 로더(env 우선·yaml 폴백) + OAuth Client Credentials 토큰(86400s 캐시) + `get_exchange_rate` + `--verify` |
| `tests/collectors/test_toss.py` | 18 lock-test (creds/토큰/캐시/verify + **주문함수 부재 §7.1**) |
| docs/cspell | collectors 26→27 · test 269→270/6,148 · "Tossinvest" |

## 불변식 준수
- **read-only** — 주문(create/modify/cancel) endpoint **미구현**. `test_no_order_endpoints` 로 부재 보장 (STRATEGY §7.1 자동매매 영구 deferred).
- secret/token **출력·로깅·커밋 금지** — `.env`·`config/toss/cache/token.json` gitignored, verify 출력에 secret 미노출(테스트로 보장).

## 검증
- `python -m nuri.collectors.toss --verify` → 토큰 발급 + USD/KRW 환율 정상 (실키, len=834 token)
- 18 테스트 97% cov (남은 미커버 = `__main__` guard, 코드베이스 표준), ruff clean, doc-count 13/13

## 후속 (별 PR)
- holdings reconcile (Toss 계좌 한정 — KakaoPay/한화는 별 브로커라 미커버) · 1분 FX → macro `usd_krw` 배선

🤖 Generated with [Claude Code](https://claude.com/claude-code)