### PR TITLE
test(toss): restore 100% coverage — Codecov #805 patch gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every BUY / SELL recommendation runs through a 5-phase pipeline — **collect �
 - 🔁 **Self-correcting** — agent weights adjust based on actual prediction accuracy, not hand-tuning.
 - 🛡️ **3-D certification** — gates apply per `Account × Asset Class × Market`. One error-grade fail → REJECTED, no manual override.
 - 🔓 **Open data flow** — phases coupled only via SQLite tables. Re-run any phase, downstream consumers refresh automatically.
-- ✅ **Tested rigorously** — 6,164 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
+- ✅ **Tested rigorously** — 6,167 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
 
 ## Quick Start
 
@@ -157,7 +157,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 
 | Metric | Value |
 |--------|-------|
-| **Backend tests** | 6,164 (271 files) — **100% statement coverage** |
+| **Backend tests** | 6,167 (271 files) — **100% statement coverage** |
 | **Frontend tests** | 1,383 (126 files) |
 | **E2E tests** | 57 (Playwright, 8 specs) |
 | **Pipeline phases** | 5 (collect / analyze / consensus / certify / track) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,164 backend tests across 271 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,167 backend tests across 271 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,164 tests, 271 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,167 tests, 271 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/collectors/test_main_runpy.py
+++ b/tests/collectors/test_main_runpy.py
@@ -224,3 +224,11 @@ def monkeypatch_uvs(monkeypatch):
 
     monkeypatch.setattr(UniverseSyncCollector, "run", _fake_run)
     return state
+
+
+class TestTossRunpy:
+    """toss.py __main__ — 비 BaseCollector. no-args → print_help → exit 0 (creds/network 불필요)."""
+
+    def test_main_no_args_prints_help(self, monkeypatch):
+        out = _run_module_capture("nuri.collectors.toss", monkeypatch, argv=["toss"])
+        assert "verify" in out.lower()

--- a/tests/collectors/test_toss.py
+++ b/tests/collectors/test_toss.py
@@ -233,3 +233,19 @@ class TestAccountsHoldings:
             h = toss.get_holdings(account_seq="seq9")
         assert h[0]["symbol"] == "005930"
         assert get.call_args.kwargs["headers"]["X-Tossinvest-Account"] == "seq9"
+
+
+class TestCoverageGaps:
+    def test_get_access_token_no_cache_fetches(self, monkeypatch):
+        # force=False + 캐시 부재 → _read_cached_token None(L73) → fetch 경로(95->98)
+        monkeypatch.setenv("TOSS_API_KEY", "c")
+        monkeypatch.setenv("TOSS_SECRET_KEY", "s")
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"access_token": "fetched", "expires_in": 86400}
+        with patch("requests.post", return_value=resp):
+            assert toss.get_access_token(force=False) == "fetched"
+
+    def test_unwrap_list_non_dict_result_returns_empty(self):
+        # result 가 list/dict 아님 → return [] (L149)
+        assert toss._unwrap_list({"result": "notalist"}, "k") == []
+        assert toss._unwrap_list({"result": None}, "k") == []


### PR DESCRIPTION
## 무엇
#805 가 `nuri/collectors/toss.py` 에 미커버 라인 남김 (Codecov patch **92%**, 2 lines). `--cov=nuri` 범위라 "100% statement coverage" 불변식 위반 → 복원.

| 미커버 | 원인 | 커버 방법 |
|---|---|---|
| L73 + `95->98` (partial branch) | force=False·캐시 부재 → fetch 경로 미테스트 | `get_access_token(force=False)` 캐시 없이 호출 |
| L149 | `_unwrap_list` result 가 비-list·비-dict | `_unwrap_list({"result": non-list})` |
| L222-224 `__main__` | CLI entry 미커버 | `test_main_runpy.py` runpy 패턴 추가 |

`toss.py` **100% stmt+branch** 복원 (126 stmt 0 missing, 36 branch 0 partial). `reconcile_toss.py` 는 `--cov=nuri` 범위 밖(scripts/)이라 게이트 무관.

## doc
test 6,164→**6,167** (3개 추가, 4곳 동기 — README ×2 · ARCHITECTURE · STRATEGY). 파일 271 불변.

## 검증
privacy(인자 없이) ✓ · doc-count 13/13 ✓ · 54 테스트 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)