### PR TITLE
feat(collectors): Toss live USD/KRW → macro usd_krw 배선 (#808)

### DIFF
--- a/nuri/collectors/macro.py
+++ b/nuri/collectors/macro.py
@@ -19,7 +19,7 @@ from dotenv import load_dotenv
 
 from nuri.collectors.base import BaseCollector
 from nuri.core.db import upsert_macro
-from nuri.core.timezone import kst_now
+from nuri.core.timezone import kst_now, today_kst
 
 load_dotenv()
 
@@ -99,10 +99,15 @@ class MacroCollector(BaseCollector):
         if self.api_key and self.api_key != "your_fred_api_key_here":
             fred_records = self._collect_fred(days)
 
+        # Toss 라이브 USD/KRW (1분 단위) — 마지막에 append 해 오늘자 usd_krw 를
+        # override (upsert OR REPLACE 가 indicator+date PK 로 toss 를 확정).
+        # FRED(DEXKOUS 일별·지연)/yfinance 대비 신선. creds/IP 없으면 [] (graceful).
+        toss_fx = self._collect_toss_fx()
+
         # FRED 가 비었으면 legacy 경로 — yfinance only.
         if not fred_records:
             self.logger.info("FRED 미사용 → yfinance fallback으로 매크로 수집")
-            return self._collect_yfinance(days)
+            return self._collect_yfinance(days) + toss_fx
 
         # FRED + yfinance merge — yfinance-only indicator 보충.
         yf_records = self._collect_yfinance(days)
@@ -115,7 +120,28 @@ class MacroCollector(BaseCollector):
                 len(yf_only_keys),
                 yf_only_keys,
             )
-        return fred_records + yf_supplement
+        return fred_records + yf_supplement + toss_fx
+
+    def _collect_toss_fx(self) -> list[dict]:
+        """Toss Open API 라이브 USD/KRW → 오늘자 usd_krw 레코드 1건.
+
+        Toss `get_exchange_rate` 는 1분 단위 라이브 환율을 주지만 IP allowlist 라
+        dev/CI(비등록 IP)에선 인증/IP 실패 → []. production(Mac mini) 에서만 채워짐.
+        rate(라이브 거래환율) 우선, midRate 폴백.
+        """
+        from nuri.collectors import toss
+
+        try:
+            fx = toss.get_exchange_rate("USD", "KRW")
+        except Exception as e:  # noqa: BLE001 — creds/IP/네트워크 실패 시 FRED/yf 로 폴백
+            self.logger.info("Toss FX 미수집 (FRED/yfinance usd_krw 사용) — %s", e)
+            return []
+
+        rate = fx.get("rate") or fx.get("midRate")
+        if not rate:
+            self.logger.info("Toss FX 응답에 rate/midRate 없음 — usd_krw 스킵")
+            return []
+        return [{"indicator": "usd_krw", "date": today_kst(), "value": float(rate), "source": "toss"}]
 
     def _collect_fred(self, days: int) -> list[dict]:
         """FRED API에서 매크로 지표 수집."""

--- a/tests/collectors/test_macro.py
+++ b/tests/collectors/test_macro.py
@@ -2,6 +2,7 @@
 
 Split from tests/test_collectors_all.py for module-level isolation.
 """
+
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -30,7 +31,6 @@ class TestMacroCollector:
         ]
         count = c.save(records)
         assert count == 2
-
 
 
 class TestMacroCollectorFREDAndYFinance:
@@ -65,10 +65,16 @@ class TestMacroCollectorFREDAndYFinance:
 
         from nuri.collectors.macro import MacroCollector
 
-        mock_df = pd.DataFrame({
-            "Date": pd.to_datetime(["2025-01-15"]),
-            "Close": [4.5], "Open": [4.4], "High": [4.6], "Low": [4.3], "Volume": [0],
-        })
+        mock_df = pd.DataFrame(
+            {
+                "Date": pd.to_datetime(["2025-01-15"]),
+                "Close": [4.5],
+                "Open": [4.4],
+                "High": [4.6],
+                "Low": [4.3],
+                "Volume": [0],
+            }
+        )
         monkeypatch.setattr(yf, "download", lambda *a, **kw: mock_df)
         collector = MacroCollector()
         collector.api_key = ""
@@ -140,7 +146,6 @@ class TestMacroCollectorFREDAndYFinance:
         assert MacroCollector().save([{"indicator": "vix", "date": "2025-01-30", "value": 18.5, "source": "test"}]) == 1
 
 
-
 class TestMacroCollectorEdgeCases:
     def test_collect_uses_yfinance_when_no_fred_key(self, monkeypatch, db_with_portfolio):
         from nuri.collectors.macro import MacroCollector
@@ -176,6 +181,91 @@ class TestMacroCollectorEdgeCases:
         assert isinstance(collector.collect(days=30), list)
 
 
+class TestMacroCollectorTossFX:
+    """Toss 라이브 USD/KRW → macro usd_krw 배선 (#805 후속).
+
+    Toss `get_exchange_rate` 는 1분 단위 라이브 환율을 주지만 IP allowlist 라
+    dev/CI 에선 인증/IP 실패 → graceful skip. production(Mac mini) 에서만 채워짐.
+    """
+
+    def test_collect_toss_fx_returns_usd_krw_record(self, monkeypatch):
+        from nuri.collectors.macro import MacroCollector
+        from nuri.core.timezone import today_kst
+
+        monkeypatch.setattr(
+            "nuri.collectors.toss.get_exchange_rate",
+            lambda base="USD", quote="KRW": {"rate": 1540.86, "validFrom": "2026-06-24"},
+        )
+        records = MacroCollector()._collect_toss_fx()
+        assert records == [{"indicator": "usd_krw", "date": today_kst(), "value": 1540.86, "source": "toss"}]
+
+    def test_collect_toss_fx_uses_midrate_when_rate_missing(self, monkeypatch):
+        from nuri.collectors.macro import MacroCollector
+
+        monkeypatch.setattr(
+            "nuri.collectors.toss.get_exchange_rate",
+            lambda base="USD", quote="KRW": {"midRate": 1535.0},
+        )
+        records = MacroCollector()._collect_toss_fx()
+        assert records[0]["value"] == 1535.0
+
+    def test_collect_toss_fx_graceful_on_creds_error(self, monkeypatch):
+        """creds/IP 미설정(dev/CI) → [] 반환, 예외 전파 안 함."""
+        from nuri.collectors.macro import MacroCollector
+        from nuri.collectors.toss import TossCredentialsError
+
+        def _raise(base="USD", quote="KRW"):
+            raise TossCredentialsError("IP address not allowed")
+
+        monkeypatch.setattr("nuri.collectors.toss.get_exchange_rate", _raise)
+        assert MacroCollector()._collect_toss_fx() == []
+
+    def test_collect_toss_fx_graceful_on_generic_error(self, monkeypatch):
+        from nuri.collectors.macro import MacroCollector
+
+        def _raise(base="USD", quote="KRW"):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("nuri.collectors.toss.get_exchange_rate", _raise)
+        assert MacroCollector()._collect_toss_fx() == []
+
+    def test_collect_toss_fx_skips_when_no_rate(self, monkeypatch):
+        """rate/midRate 모두 없거나 0 → []."""
+        from nuri.collectors.macro import MacroCollector
+
+        monkeypatch.setattr("nuri.collectors.toss.get_exchange_rate", lambda base="USD", quote="KRW": {})
+        assert MacroCollector()._collect_toss_fx() == []
+
+    def test_collect_appends_toss_fx_overriding_usd_krw(self, monkeypatch, db_with_portfolio):
+        """collect() 가 toss usd_krw 를 마지막에 붙여 upsert 시 오늘자 환율을 override."""
+        import sys
+
+        import pandas as pd
+
+        from nuri.collectors.macro import MacroCollector
+        from nuri.core.timezone import today_kst
+
+        # FRED stub — usd_krw 를 옛 값(어제)으로 채움
+        mock_series = pd.Series([1500.0], index=pd.to_datetime(["2026-06-23"]))
+        mock_fred = MagicMock()
+        mock_fred.get_series.return_value = mock_series
+        monkeypatch.setitem(sys.modules, "fredapi", MagicMock(Fred=MagicMock(return_value=mock_fred)))
+        monkeypatch.setattr(MacroCollector, "_collect_yfinance", lambda self, days: [])
+        monkeypatch.setattr(
+            "nuri.collectors.toss.get_exchange_rate",
+            lambda base="USD", quote="KRW": {"rate": 1540.86},
+        )
+
+        collector = MacroCollector()
+        collector.api_key = "real_key"
+        results = collector.collect(days=30)
+
+        toss_rows = [r for r in results if r["indicator"] == "usd_krw" and r["source"] == "toss"]
+        assert toss_rows == [{"indicator": "usd_krw", "date": today_kst(), "value": 1540.86, "source": "toss"}]
+        # toss 레코드가 마지막 (upsert OR REPLACE 가 오늘자 usd_krw 를 toss 로 확정)
+        assert results[-1] == toss_rows[0]
+
+
 class TestPartAIndicatorRegistry:
     """Issue #362 Part A — 10 신규 yfinance 지표 등록 lock-in."""
 
@@ -184,8 +274,16 @@ class TestPartAIndicatorRegistry:
         from nuri.collectors.macro import YFINANCE_SYMBOLS
 
         expected = {
-            "nasdaq_composite", "sp500", "dow", "nasdaq100_futures", "sox",
-            "dxy", "silver", "natgas", "copper", "wheat",
+            "nasdaq_composite",
+            "sp500",
+            "dow",
+            "nasdaq100_futures",
+            "sox",
+            "dxy",
+            "silver",
+            "natgas",
+            "copper",
+            "wheat",
         }
         missing = expected - set(YFINANCE_SYMBOLS.keys())
         assert not missing, (
@@ -220,8 +318,7 @@ class TestPartAIndicatorRegistry:
         """기존 vix/gold/wti_oil/us_*_yield/usd_krw 가 그대로 남아있음 — 회귀 방지."""
         from nuri.collectors.macro import YFINANCE_SYMBOLS
 
-        legacy = {"us_10y_yield", "us_2y_yield", "us_5y_yield", "us_30y_yield",
-                  "vix", "wti_oil", "usd_krw", "gold"}
+        legacy = {"us_10y_yield", "us_2y_yield", "us_5y_yield", "us_30y_yield", "vix", "wti_oil", "usd_krw", "gold"}
         missing = legacy - set(YFINANCE_SYMBOLS.keys())
         assert not missing, f"기존 지표 회귀 — {missing} 사라짐"
 
@@ -252,10 +349,11 @@ class TestPartAIndicatorRegistry:
         # 따라서 _collect_yfinance 자체를 monkeypatch.
         def stub_yf(self, days):
             return [
-                {"indicator": "vix",   "date": "2025-01-15", "value": 19.0, "source": "yfinance"},  # FRED dup
+                {"indicator": "vix", "date": "2025-01-15", "value": 19.0, "source": "yfinance"},  # FRED dup
                 {"indicator": "sp500", "date": "2025-01-15", "value": 7000.0, "source": "yfinance"},  # yf-only
-                {"indicator": "dxy",   "date": "2025-01-15", "value": 98.5, "source": "yfinance"},  # yf-only
+                {"indicator": "dxy", "date": "2025-01-15", "value": 98.5, "source": "yfinance"},  # yf-only
             ]
+
         monkeypatch.setattr(MacroCollector, "_collect_yfinance", stub_yf)
 
         collector = MacroCollector()


### PR DESCRIPTION
## 왜 지금

#805 에서 Toss `get_exchange_rate` (1분 라이브 USD/KRW) 동작 확인 (라이브 1540.86). 기존 `macro.usd_krw` 는 FRED(DEXKOUS, 발행 지연)/yfinance(KRW=X) 만 채워 포트폴리오 KRW/USD 평가에 **지연된 환율** 사용. 라이브 환율로 오늘자만 override.

## 변경

`MacroCollector.collect()` 가 `_collect_toss_fx()` 결과를 **마지막에 append** → `upsert OR REPLACE` (indicator+date PK) 가 오늘자 `usd_krw` 를 Toss 값으로 확정. 리더들은 `ORDER BY date DESC LIMIT 1` 이라 오늘자=Toss 값을 읽음.

- `rate`(라이브 거래환율) 우선, `midRate` 폴백
- **read-only** (§7.1 — 기존 `get_exchange_rate` 재사용, 주문 endpoint 미호출)
- Toss **IP allowlist** → dev/CI(비등록 IP)는 인증/IP 실패 → **graceful skip** (FRED/yfinance `usd_krw` 유지). production(Mac mini, allowlisted) 에서만 채워짐.

## 배선 확인

`make collect`/`full-scan`/`quick-scan` + `scheduler.py:86` 모두 `MacroCollector` 호출 → production 일일 수집에 자동 반영.

## 테스트

- 신규 lock-test `tests/collectors/test_macro.py::TestMacroCollectorTossFX` (6): rate/midRate 폴백, creds/IP graceful, no-rate skip, override 우선
- fail-first 확인 (`_collect_toss_fx` 부재 시 AttributeError)
- 패치 커버리지 100% (신규 메서드 125-144 전부 cover)
- full suite **6143 passed, 6 skipped** (회귀 0)

Closes #808