### PR TITLE
docs: fix backend test count drift — 6,167 → 6,173 (#809 후속)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every BUY / SELL recommendation runs through a 5-phase pipeline — **collect �
 - 🔁 **Self-correcting** — agent weights adjust based on actual prediction accuracy, not hand-tuning.
 - 🛡️ **3-D certification** — gates apply per `Account × Asset Class × Market`. One error-grade fail → REJECTED, no manual override.
 - 🔓 **Open data flow** — phases coupled only via SQLite tables. Re-run any phase, downstream consumers refresh automatically.
-- ✅ **Tested rigorously** — 6,167 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
+- ✅ **Tested rigorously** — 6,173 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
 
 ## Quick Start
 
@@ -157,7 +157,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 
 | Metric | Value |
 |--------|-------|
-| **Backend tests** | 6,167 (271 files) — **100% statement coverage** |
+| **Backend tests** | 6,173 (271 files) — **100% statement coverage** |
 | **Frontend tests** | 1,383 (126 files) |
 | **E2E tests** | 57 (Playwright, 8 specs) |
 | **Pipeline phases** | 5 (collect / analyze / consensus / certify / track) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,167 backend tests across 271 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 271 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -227,7 +227,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,167 tests, 271 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 271 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |


### PR DESCRIPTION
## 왜

PR #809(`TestMacroCollectorTossFX` 6개 추가)로 backend 총 collected 가 6,167 → **6,173** 으로 늘었으나 문서 4곳이 stale. CI `Doc Count Drift Check` 는 test **파일 수**(271, 불변)만 검사 → test **개수** prose 는 게이트 밖이라 미검출.

## 변경

| 파일 | before → after |
|---|---|
| README.md (2곳) | 6,167 → 6,173 |
| docs/ARCHITECTURE.md | 6,167 → 6,173 |
| docs/STRATEGY.md | 6,167 → 6,173 |

frontend(1,383)·파일 수(271)·E2E(57) 불변.

## 실측 근거

\`\`\`
pytest --collect-only -q → 6164/6173 tests collected (9 deselected)
\`\`\`
총 collected = **6,173** (기존 6,167 = 6,173 − 6 신규, 총계 추적 일치 확인).

정책: 정량 클레임은 실측 정확 숫자, round/≥/+ 금지 (CLAUDE.md drift-fix).