### PR TITLE
test(wallstreet): anchor ud fixtures to kst_now() — 90d window time-bomb

### DIFF
--- a/tests/trading/agents/test_wallstreet.py
+++ b/tests/trading/agents/test_wallstreet.py
@@ -277,14 +277,17 @@ class TestWallStreetAgent_R23:
 
     def test_analyze_upgrades_and_downgrades(self, db_path, monkeypatch):
         """Downgrades exceed upgrades."""
+        from nuri.core.timezone import kst_now
         from nuri.trading.agents.wallstreet import WallStreetAgent
         agent = WallStreetAgent()
         monkeypatch.setattr(agent, "_check_cached", lambda *a, **kw: None)
+        # wallstreet 는 90일 윈도우로 필터 — 고정일 대신 kst_now() 앵커링 (time-bomb 회피)
+        recent = kst_now().replace(tzinfo=None) - timedelta(days=3)
         ud_data = pd.DataFrame({
             "Action": ["down", "down", "down", "down", "init"],
             "priceTargetAction": ["lowers", "lowers", "", "", "raises"],
             "currentPriceTarget": [100.0, 95.0, None, None, 110.0],
-        }, index=pd.to_datetime(["2026-03-28"] * 5))
+        }, index=pd.to_datetime([recent] * 5))
 
         class MockTicker:
             upgrades_downgrades = ud_data
@@ -479,14 +482,17 @@ class TestWallStreetAgent_R23:
 
     def test_analyze_sell_verdict(self, db_path, monkeypatch):
         """Enough negative score → SELL verdict."""
+        from nuri.core.timezone import kst_now
         from nuri.trading.agents.wallstreet import WallStreetAgent
         agent = WallStreetAgent()
         monkeypatch.setattr(agent, "_check_cached", lambda *a, **kw: None)
+        # 90일 윈도우 — 고정일 대신 kst_now() 앵커링 (time-bomb 회피)
+        recent = kst_now().replace(tzinfo=None) - timedelta(days=3)
         ud_data = pd.DataFrame({
             "Action": ["down", "down", "down", "down"],
             "priceTargetAction": ["lowers", "lowers", "lowers", ""],
             "currentPriceTarget": [100.0, 95.0, 90.0, None],
-        }, index=pd.to_datetime(["2026-03-28"] * 4))
+        }, index=pd.to_datetime([recent] * 4))
         eh_data = pd.DataFrame({
             "surprisePercent": [-0.15], "epsActual": [2.0], "epsEstimate": [3.0],
         })


### PR DESCRIPTION
## 왜 지금

CI run [28348052283](https://github.com/researcherhojin/nuri-quant/actions/runs/28348052283) 의 **Backend Tests · Fast 4** shard 가 `test_wallstreet.py::TestWallStreetAgent_R23::test_analyze_upgrades_and_downgrades` 에서 FAIL → 머지 차단.

## 근본 원인 (time-bomb seed date)

`wallstreet.py:63` 은 `upgrades_downgrades` 를 90일 윈도우(`kst_now() - timedelta(days=90)`)로 필터한다. 테스트 fixture 가 고정일 `"2026-03-28"` 을 쓰는데, 오늘(2026-06-29) 기준 cutoff(~3/31) 밖으로 밀려 데이터가 0건이 됐고 에이전트가 `"Wall Street 데이터 부족"` HOLD 를 반환 → assert 실패.

`tests/CLAUDE.md` 에 명시된 **time-bomb seed date** gotcha 그대로다 (#721 과 동일 클래스).

## 수정

- `test_analyze_upgrades_and_downgrades` — fixture 인덱스를 `kst_now()` 기준 최근일(`-3d`)로 앵커링
- `test_analyze_sell_verdict` — 동일 고정일 패턴이 있어 ud 다운그레이드 신호가 이미 silent 누락 중이었음(다른 신호가 SELL 을 carry해 통과). 같은 root cause 라 함께 수정

캐시 경로(`_check_cached`, SQL `LIMIT 10`)는 날짜 윈도우가 없어 영향 없음 — 손대지 않음.

## 검증

- `pytest tests/trading/agents/test_wallstreet.py` → **37 passed**
- `ruff check` → clean
- `check_privacy_leak.py` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)