### PR TITLE
docs(strategy): §3.11 measurement mode — single ledger, experiment sleeve, pre-registered adjudication (#828)

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,10 +6,10 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 447 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 473 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
-| `buy_signals.yaml` | 122 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |
+| `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |
 | `alerts.yaml` | 24 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
 | `stock_types.yaml` | 49 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |
 | `universe.yaml` | 755 | 746 tickers: `us_core` (85) + `us_sp500_extended` (458) + `kr_kospi200` (203). Auto-maintained by `make universe-sync`; manual entries preserved | `nuri/collectors/universe_sync.py` |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -209,6 +209,30 @@ rebalance_policy:
   cadence: quarterly             # 분기 1회 (3/6/9/12 첫 영업일)
   behavior_gap_warning: true     # 시장 timing 시도 시 경고 emit (DALBAR/Morningstar 격차 ~1-3%/yr)
 
+# ─── 측정 모드 (Measurement mode) ── docs/STRATEGY.md §3.11 (#824/#828) ──
+# 시스템 알파 입증 전까지 추천 집행 자본을 실험 슬리브로 한정.
+# 판정 기준은 사전 고정 — evaluation_date 이전 amend 금지 (§3.6 선례).
+# 슬리브는 SAA equity bucket 내부 sub-cap (자산 클래스 아님, drift 계산 포함).
+measurement_mode:
+  enabled: true
+  declared_date: "2026-07-08"    # 사전등록 기준일 — 이후 emit 된 결정만 판정 표본
+  evaluation_date: "2027-06-30"  # 판정일. 조기 승격 금지, 하향은 상시 (prudential)
+  emit_cutoff_date: "2027-05-15" # 표본 emit 마감 — 판정일까지 30d 창 완결 보장
+  benchmark: SPY                 # forward_outcome_tracker DEFAULT_BENCHMARK_TICKER 와 일치 (#675)
+  primary_window_days: 30        # 판정 창 (7/14d 는 진단용, §3.11 표 — 파일럿 기반 선택 경위 명시)
+  min_n_us_buy_decisions: 200    # US BUY 결정만 (KR/SELL 은 진단 전용 — §3.11 표본 규약), distinct decision_id
+  permutation_p_max: 0.05        # one-sided. scheme 은 아래 사전 고정 (구현만 follow-up — §3.11 미구축 ②)
+  permutation_scheme: ticker_block_placebo  # ticker→emit일 구조 유지, 동일 시장 universe 치환 (의존성 상속)
+  permutation_n: 1000            # null 표본 수
+  robustness_split: median_split_halves  # median decision date 등분 — 반기 n 균형 (VIX 게이트 accrual 비대칭 대비)
+  missing_outcome_max_pct: 15    # 추적 결측 비율 상한 — 초과 시 판정 무효 (결측 편향)
+  sleeve_max_equity_pct:         # account_strategy 별 실험 슬리브 상한 (us_equity+kr_equity 합산 대비 %, 사용자 확정 필요)
+    core: 10
+    active: 20
+    swing: 100                   # swing 프로파일 계좌 = 실험 전용 슬리브
+    long_term: 0
+    pension: 0
+
 # ─── SIEGE Gate 정책 (v2: Asset Class 차원) ────────────────
 # 근거: docs/CERTIFICATION_SPEC.md §4. Issue #248.
 # Gate #5 (data_fresh), #7 (volatility / 구 vix_gate), #8 (external_data) 는

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -223,6 +223,24 @@ base = regime_win_rate × 60% + profit_factor × 40%
 - All Weather risk parity (Dalio) — leverage 필요 (4-environment hedge), STRATEGY §7.1 자동 매매 deferred 와 호환 X.
 - Yale model (Swensen) — 비전통 자산 (PE / hedge fund) 접근 제약.
 **참조**: `config/rules.yaml strategic_allocation_targets` (canonical 값, Phase 1 skeleton), `nuri/analysis/rebalance_advisor.py` (drift 계산 — Phase 2 확장 예정).
+### 3.11 소액+측정 모드 (Measurement mode) — 시스템 알파의 입증책임 (#824/#828, 2026-07-07)
+**결정**: 시스템 추천을 따르는 실집행 자본을 계좌 equity 비중 **내부**의 "실험 슬리브" sub-cap 으로 한정하고, 나머지 equity 는 §3.10 SAA 기반 broad-index passive core 로 둔다. 슬리브 상한 상향은 아래 사전 고정 판정 기준 통과 + STRATEGY PR 로만 (§2.6 운용 원칙 2 준용). 하향/동결은 상시 허용 (prudential). 입증책임은 시스템에 있다 — 엣지의 기본값은 "없음".
+**왜 지금**: 2026-06 Edge Reality Check. Live 성적 (#675, 116 picks / 7wk 단일 강세장): BUY alpha vs SPY +2.8/+5.0/+19.8%p (7/14/30d) 이나 growth-peer QQQ 대비 ~56% beat (30d) — style 효과가 지배하는 표본. 순열 검정은 momentum/RS 엣지 기각 (#709: 퇴화 버그 fix 후 p=0.791), exit 개선 기각 (#715: Δ−0.318, p=0.552 → #800 leader-exit 비활성). 측정 인프라 (#674/#675) 는 가동 중이나 판정 기준이 사전 고정돼 있지 않으면 사후 해석이 반복된다 (§3.6 의 spec amend 거부와 동일 원리).
+**Escalation Ladder (§2.6)**: 성적표 원장 = **Surface** (증거 노출만). 슬리브 상한 = 현재 **Surface** (config 선언 — 소비 코드 미배선, 미구축 ⑤) → 배선 후 "슬리브 잔여 소진 시 신규 매수 차단" face 만 **Hard veto** (VIX>30 신규 매수 차단 계열). 상한 **초과 상태의 해소**는 `portfolio_action=REBALANCE` 로만 surface (§3.7/#429 axis — alpha SELL 로 표출 금지). §3.8 축 분리 준수 — 슬리브 상한은 prudential constraint 로만 인용하며, downside-predictive 주장이 아니다. §3.8 이 열어둔 "real-portfolio replay + `recommendations.outcome` 누적" 경로의 실측 개통이 본 절의 측정 대상이다.
+**1) 성적표 단일 원장 (ledger of record)**: 판정에 쓰이는 측정 기록 (`decision_outcomes` 등) 의 원장은 **production (Mac mini) DB 단일** (#824) — dev 머신 DB 는 read-replica 이며, 판정·리포트는 원장 쿼리만 인용한다 (2026-07-07 두 원장 혼용 오탐이 계기). 운영 상세 (sync 방향, writer-job 금지) 는 `docs/SOURCE_OF_TRUTH.md` (local), 원장 스냅샷/백업 정책은 미구축 ⑥.
+**2) 슬리브 × SAA 결합 규칙** (§3.10 TAA×SAA 패턴 준용): 슬리브는 자산 클래스가 아니라 equity bucket **내부** 구획 (상한 분모 = us_equity+kr_equity **합산** 대비 %) — SAA target/drift ±5% 계산은 슬리브 포함 통상 계산 (이중 계상 없음). 상한 값은 `config/rules.yaml measurement_mode.sleeve_max_equity_pct` (account_strategy 별, canonical). 집행은 §7.1 대로 사용자 수동 — 본 절은 §3.6 Phase 3 (alpha-amplified live) 의 우회 부활이 아니다.
+**3) 판정 기준 (2026-07-08 사전 고정 — 사후 amend 거부, §3.6 선례)**:
+| 항목 | 값 | 근거 |
+|---|---|---|
+| 판정일 | 2027-06-30. 조기 승격 금지 (하향은 상시). 표본 emit cutoff = 2027-05-15 (30d 창 완결 보장) | pre-registration — Harvey, Liu & Zhu (2016) multiple testing / p-hacking |
+| 표본 규약 | `declared_date` (2026-07-08) ~ emit cutoff 에 emit 된 **US BUY** 결정만 (distinct `decision_id`). 30d window 단일 판정 창 — 7/14d 는 진단용 (30d 는 파일럿 #675 탐색 결과 기반 선택, 판정 표본은 declared_date 이후 disjoint). n ≥ 200. SELL 은 진단 전용 (원장 alpha 는 방향 보정 저장 — tracker 부호 반전) | 원장 실측 σ≈25.0%p (US BUY 30d, n=62, #828 코멘트 쿼리): n=200 의 검출 하한 ≈ +4.4%p/30d (one-sided α=0.05, 80% power), accrual 실측 ~43건/월 → 판정 시점 기대 n≈400 → ≈ +3.1%p. **미검출 ≠ 엣지 부재** (power 한계 명시). §2.1 30-trade 는 per-signal tier, 본 n 은 system-level (별개 축) |
+| 벤치마크 | SPY (`forward_outcome_tracker.py` `DEFAULT_BENCHMARK_TICKER`). **본 판정은 US-only 로 고정** — KR 결정은 KR benchmark (#675 명시 follow-up, 미구축 ④) 착륙 후 **별도 사전등록** 을 거쳐야 판정 대상, 그 전까지 진단 전용 | #675 caveat: SPY 는 growth 대비 과대평가 |
+| 승격 조건 (3개 동시) | mean 30d alpha > 0 · 순열 p < 0.05 (**ticker-block placebo**: 실 표본의 ticker→emit일 구조 유지, 동일 시장 eligible universe 에서 ticker 치환, N=1000, 통계량 = mean 30d alpha, one-sided — 중첩 창·동일일 배치·반복 종목 의존성을 null 이 상속) · **median-decision-date 등분 2분할** 모두 mean alpha > 0 (반기 n 균형 보장) | López de Prado (2018) PBO/deflated-Sharpe 정신 — 단일 통계 아닌 강건성 요구. naive iid 순열은 클러스터링으로 anti-conservative |
+| regime 축 | 내부 10-regime 분류는 진단 Surface 전용, 판정 비사용 — 원장 라벨 커버리지 3% (12/383, #828 코멘트 쿼리), 2026-04 이후 transition 1회 (판정 교착 위험), 자기 분류기 순환성 | 실측 2026-07-07 (production 원장) |
+| 오염 방지 | `decision_id` 없는 ad-hoc 체결은 표본 제외 (#715 사전등록 원칙의 자본 버전). missing outcome (추적 실패/가격 결측) 은 제외하되 비율을 판정 리포트에 공시 — **15% 초과 시 판정 무효 (측정 연장)** | Shefrin & Statman (1985) — ad-hoc 개입이 처분효과 재유입 경로. 결측 편향 (탈락은 나쁜 outcome 과 상관 가능) |
+**판정 결과 처리**: 3조건 통과 → **US 집행분 슬리브에 한해** 상한 상향 STRATEGY PR (새 상한도 본 표 개정으로 사전 고정). 미달 → 슬리브 유지/축소 + 측정 연장 또는 §3.10 passive 로 수렴 — "조금만 더" 없이 본 표가 답이다. 사전등록 대상은 판정 **기준**이지 상한 초기값이 아니다 — 슬리브 초기값은 판정 표본에 영향이 없으므로 최초 사용자 확정 PR 까지 placeholder 로 두며 일반 PR 로 정정 가능. 확정 이후부터 상향-sticky 발효.
+**미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 (진단용) ② 순열 도구 구현 (설계는 본 표에 사전 고정 — 구현만 follow-up; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall) ⑥ 원장 스냅샷/백업 정책.
+**참조**: `config/rules.yaml measurement_mode` (canonical 값), `nuri/agents/actors/forward_outcome_tracker.py` (측정 파이프라인, 매일 17:00 KST), `docs/SOURCE_OF_TRUTH.md` (원장 매핑, local-only).
 ## 4. 개발 품질 기준
 PR 전 확인.
 ### 4.1 테스트

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -1,4 +1,5 @@
 """nuri.core.rules 모듈 테스트 — YAML 로딩, 상수 노출, 계좌별 전략 프로파일."""
+
 from pathlib import Path
 from unittest.mock import patch
 
@@ -23,36 +24,42 @@ def db_path(tmp_path):
 class TestRulesLoading:
     def test_rules_dict_loaded(self):
         from nuri.core.rules import RULES
+
         assert isinstance(RULES, dict)
         assert "position_limits" in RULES
         assert "stop_loss" in RULES
 
     def test_position_limit_constants(self):
         from nuri.core.rules import MAX_SECTOR_EXPOSURE, MAX_SINGLE_POSITION, MIN_CASH_RESERVE
+
         assert 0 < MAX_SINGLE_POSITION <= 1.0
         assert 0 < MAX_SECTOR_EXPOSURE <= 1.0
         assert 0 < MIN_CASH_RESERVE <= 1.0
 
     def test_stop_loss_constants(self):
         from nuri.core.rules import PORTFOLIO_STOP, STOCK_STOP_LOSS, STOCK_STOP_LOSS_VALUE
+
         assert STOCK_STOP_LOSS < 0
         assert STOCK_STOP_LOSS_VALUE < 0
         assert PORTFOLIO_STOP < 0
 
     def test_take_profit_constants(self):
         from nuri.core.rules import TAKE_PROFIT_GROWTH, TAKE_PROFIT_SWING, TAKE_PROFIT_VALUE
+
         assert TAKE_PROFIT_GROWTH["target_1"] > 0
         assert TAKE_PROFIT_VALUE["target_1"] > 0
         assert TAKE_PROFIT_SWING["target_1"] > 0
 
     def test_trailing_stop_constants(self):
         from nuri.core.rules import TRAILING_STOP_GROWTH, TRAILING_STOP_VALUE, TRAILING_STOP_VOLATILE
+
         assert TRAILING_STOP_GROWTH < 0
         assert TRAILING_STOP_VALUE < 0
         assert TRAILING_STOP_VOLATILE < 0
 
     def test_leverage_etfs(self):
         from nuri.core.rules import LEVERAGE_ETFS
+
         assert isinstance(LEVERAGE_ETFS, set)
         assert "TQQQ" in LEVERAGE_ETFS
         assert "TSLL" in LEVERAGE_ETFS
@@ -61,6 +68,7 @@ class TestRulesLoading:
 class TestAccountStrategies:
     def test_account_strategies_loaded(self):
         from nuri.core.rules import ACCOUNT_STRATEGIES
+
         assert "core" in ACCOUNT_STRATEGIES
         assert "active" in ACCOUNT_STRATEGIES
         assert "swing" in ACCOUNT_STRATEGIES
@@ -69,6 +77,7 @@ class TestAccountStrategies:
 
     def test_core_strategy_values(self):
         from nuri.core.rules import ACCOUNT_STRATEGIES
+
         core = ACCOUNT_STRATEGIES["core"]
         assert core["stop_loss"] == -7
         assert core["max_single_position"] == 0.15
@@ -76,6 +85,7 @@ class TestAccountStrategies:
     def test_active_strategy_between_core_and_swing(self):
         """active 전략은 core와 swing 사이의 중간값."""
         from nuri.core.rules import ACCOUNT_STRATEGIES
+
         core = ACCOUNT_STRATEGIES["core"]
         active = ACCOUNT_STRATEGIES["active"]
         swing = ACCOUNT_STRATEGIES["swing"]
@@ -90,6 +100,7 @@ class TestAccountStrategies:
 
     def test_swing_strategy_more_permissive(self):
         from nuri.core.rules import ACCOUNT_STRATEGIES
+
         core = ACCOUNT_STRATEGIES["core"]
         swing = ACCOUNT_STRATEGIES["swing"]
         assert swing["stop_loss"] < core["stop_loss"]  # -15 < -7 (더 넓은 허용)
@@ -100,11 +111,15 @@ class TestAccountStrategies:
         from nuri.core.rules import get_account_strategy
 
         portfolio_yaml = tmp_path / "portfolio.yaml"
-        portfolio_yaml.write_text(yaml.dump({
-            "accounts": {
-                "test_acct": {"strategy": "swing", "tickers": {}},
-            }
-        }))
+        portfolio_yaml.write_text(
+            yaml.dump(
+                {
+                    "accounts": {
+                        "test_acct": {"strategy": "swing", "tickers": {}},
+                    }
+                }
+            )
+        )
 
         real_open = open
 
@@ -132,15 +147,69 @@ class TestAccountStrategies:
         from nuri.core.rules import get_account_strategy
 
         portfolio_yaml = tmp_path / "portfolio.yaml"
-        portfolio_yaml.write_text(yaml.dump({
-            "accounts": {
-                "test_acct": {"tickers": {}},
-            }
-        }))
+        portfolio_yaml.write_text(
+            yaml.dump(
+                {
+                    "accounts": {
+                        "test_acct": {"tickers": {}},
+                    }
+                }
+            )
+        )
 
         with patch("builtins.open", side_effect=lambda p, **kw: open(portfolio_yaml, **kw)):
             result = get_account_strategy("test_acct")
             assert result["stop_loss"] == -7  # core default
+
+
+# ═══════════════════════════════════════════════════════
+# §3.11 측정 모드 — 사전 고정 판정 기준 lock
+# ═══════════════════════════════════════════════════════
+
+
+class TestMeasurementMode:
+    """STRATEGY §3.11 (#824/#828) — 판정 기준은 사전 고정. 이 lock 을 깨는 변경은
+    STRATEGY PR (본 테스트 + §3.11 표 동시 개정) 을 강제해 silent amend 를 차단한다."""
+
+    def test_adjudication_params_locked(self):
+        from nuri.core.rules import RULES
+
+        mm = RULES["measurement_mode"]
+        assert mm["enabled"] is True
+        assert mm["declared_date"] == "2026-07-08"
+        assert mm["evaluation_date"] == "2027-06-30"
+        assert mm["emit_cutoff_date"] == "2027-05-15"
+        assert mm["primary_window_days"] == 30
+        # 키 이름이 모집단 정의 (US-only, BUY-only) 까지 잠근다 — rename = silent amend 불가
+        assert mm["min_n_us_buy_decisions"] == 200
+        assert mm["permutation_p_max"] == 0.05
+        assert mm["permutation_scheme"] == "ticker_block_placebo"
+        assert mm["permutation_n"] == 1000
+        assert mm["robustness_split"] == "median_split_halves"
+        assert mm["missing_outcome_max_pct"] == 15
+
+    def test_benchmark_matches_tracker_constant(self):
+        """rules.yaml benchmark 와 tracker 코드 상수의 silent 분기 방지 (SSoT lock)."""
+        from nuri.agents.actors.forward_outcome_tracker import DEFAULT_BENCHMARK_TICKER
+        from nuri.core.rules import RULES
+
+        assert RULES["measurement_mode"]["benchmark"] == DEFAULT_BENCHMARK_TICKER
+
+    def test_primary_window_supported_by_tracker(self):
+        """판정 창은 tracker 가 실제 측정하는 window 여야 함."""
+        from nuri.agents.actors.forward_outcome_tracker import SUPPORTED_WINDOWS
+        from nuri.core.rules import RULES
+
+        assert RULES["measurement_mode"]["primary_window_days"] in SUPPORTED_WINDOWS
+
+    def test_sleeve_caps_cover_all_strategies(self):
+        """슬리브 상한은 account_strategies 5개 프로파일과 1:1 (누락/고아 키 방지)."""
+        from nuri.core.rules import ACCOUNT_STRATEGIES, RULES
+
+        sleeve = RULES["measurement_mode"]["sleeve_max_equity_pct"]
+        assert set(sleeve.keys()) == set(ACCOUNT_STRATEGIES.keys())
+        for name, pct in sleeve.items():
+            assert 0 <= pct <= 100, f"{name}: equity 내부 % 범위 위반"
 
 
 # ═══════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #828. Completes the STRATEGY declaration item of #824 (ops items already done: MBP writer jobs unloaded 2026-07-07, SOURCE_OF_TRUTH local doc updated).

## What
- **STRATEGY §3.11**: 시스템 알파 입증 전까지 추천 집행 자본을 실험 슬리브 (SAA equity bucket 내부 sub-cap) 로 한정. 성적표 단일 원장 (production DB). 판정 기준 사전 고정.
- **rules.yaml `measurement_mode`**: 판정 파라미터 canonical 값 + per-strategy 슬리브 상한.
- **Lock tests ×4**: 판정 파라미터 고정 (silent amend 시 본 테스트+§3.11 동시 개정 강제), benchmark/window ↔ tracker 상수 SSoT, 슬리브 키 ↔ 프로파일 1:1.

## 판정 기준 (사전 고정, 2026-07-08)
US BUY 결정만 · 30d 창 · n≥200 (emit cutoff 2027-05-15, 판정일 2027-06-30) · ticker-block placebo 순열 (N=1000, one-sided p<0.05) · median-split 반기 모두 mean alpha>0 · missing-outcome >15% 시 판정 무효. Power 는 원장 실측 σ=25.0%p 앵커 (수치 재현 쿼리: #828 코멘트).

## Review (4-lens 적대적 패널 + Codex-fallback self-review)
통계/정합/프라이버시/Codex 4 심사 → P1 2건 (σ 오앵커, 순열 scheme 미고정) 포함 15건 전부 반영 또는 처리 근거 기록. 주요 반영: iid 순열의 anti-conservative 클러스터링 → ticker-block placebo 사전 고정, Hard veto 오분류 → Surface(현재)+배선 후 신규매수차단 face 만 Hard veto+초과 해소는 REBALANCE only (#429 axis), US-only 를 키 이름 (`min_n_us_buy_decisions`) 으로 물리 잠금.

## Verification
- `make lint` ✓ · lock tests 25/25 ✓ · privacy scan ✓ · `make verify-doc-counts` 13/13 ✓
- `make verify-quick`: 6,161 passed / 1 failed — 기존 flaky #829 (toss FX 네트워크 의존, main 클린 체크아웃 대조로 본 diff 무관 입증)
- Backtest N/A — 트레이딩 신호가 아닌 측정 프로토콜 + 자본 상한 선언 (§3.10 Phase-1 skeleton 선례). 검증 수단 = 사전등록 라이브 측정 자체.

## Merge 전 확인 필요
- [ ] 슬리브 상한 초기값 확정 (현재 placeholder: core 10 / active 20 / swing 100 / long_term 0 / pension 0 — §3.11 상 확정 전 일반 PR 정정 가능)
- [ ] 판정일 2027-06-30 확정

## Follow-ups (§3.11 미구축 ①-⑥ — merge 후 이슈 분리)
regime 백필 · 순열 도구 구현 · 통합 판정 쿼리 · KR benchmark · 슬리브 배선 · 원장 백업

🤖 Generated with [Claude Code](https://claude.com/claude-code)