### PR TITLE
fix(scheduler): repair DB backup path drift from #557 scripts refactor

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -236,12 +236,17 @@ def _run_report():
         logger.error(f"[daily_report] 실행 실패: {e}", exc_info=True)
 
 
+# 백업 스크립트 경로 — #557 scripts/ 7-subdir 리팩터로 이동 (#836 경로 drift 회귀 fix).
+# 상수로 노출해 lock test 가 실존을 검증한다 (mock-only 테스트로는 경로 drift 미탐).
+BACKUP_SCRIPT = "scripts/db/backup.sh"
+
+
 def _run_backup():
     """DB 백업을 안전하게 실행."""
     import subprocess
 
     try:
-        subprocess.run(["bash", "scripts/backup.sh"], check=True)
+        subprocess.run(["bash", BACKUP_SCRIPT], check=True)
     except Exception as e:
         logger.error(f"[backup] 실행 실패: {e}", exc_info=True)
 

--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -2,8 +2,9 @@
 # Nuri-Quant DB 백업 — 30일 롤링
 set -euo pipefail
 
+# scripts/db/ 로 이동 (#557) 후 repo root 는 두 단계 위 (#836 경로 drift fix)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 BACKUP_DIR="$PROJECT_DIR/data/backups"
 DB_FILE="$PROJECT_DIR/data/portfolio.db"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -209,6 +209,22 @@ class TestScheduler:
             _run_backup()
         mock_run.assert_called_once()
 
+    def test_backup_script_path_exists(self):
+        """Gotcha-Test Pair (#836): scheduler 가 참조하는 백업 스크립트 경로 실존 lock.
+
+        #557 리팩터가 scripts/backup.sh → scripts/db/backup.sh 로 옮기면서
+        scheduler 호출 경로가 2개월간 silent 404 (rc=127, logger.error 만) —
+        mock-only 테스트 (위 test_run_backup) 로는 경로 drift 를 못 잡는다.
+        스크립트를 다시 옮기면 본 테스트가 즉시 FAIL.
+        """
+        from pathlib import Path
+
+        from nuri.scheduler import BACKUP_SCRIPT
+
+        repo_root = Path(__file__).resolve().parents[1]
+        script = repo_root / BACKUP_SCRIPT
+        assert script.is_file(), f"백업 스크립트 경로 drift: {script} 없음 (#836)"
+
     def test_run_backup_exception(self):
         """_run_backup catches exceptions."""
         from nuri.scheduler import _run_backup


### PR DESCRIPTION
Closes #836.

## Root cause
#557 (2026-04-30) 이 `scripts/backup.sh` → `scripts/db/backup.sh` 로 이동하면서 이중 breakage:
1. `nuri/scheduler.py` `_run_backup` 이 옛 경로 호출 → bash rc=127 → `logger.error` 만 남고 **2개월+ silent** (production 최신 백업 = 2026-04-30, #557 머지일과 정확히 일치)
2. 이동된 스크립트 내부 `PROJECT_DIR` 이 한 단계 얕게 해석 (`<repo>/scripts`) → 직접 실행해도 'DB 파일 없음' exit 1

## Fix
- `BACKUP_SCRIPT = "scripts/db/backup.sh"` 상수 추출 + 호출 갱신
- `PROJECT_DIR` 두 단계 상위로 수정
- **Gotcha-Test Pair**: `test_backup_script_path_exists` — 참조 경로 실존 lock (기존 mock-only 테스트는 경로 drift 미탐 — §5.3 test illusion 실례)

## Verification
- 라이브 실행: 백업 생성 + SHA256 검증 OK (dev replica)
- `tests/test_scheduler.py` 90/90 · shellcheck clean · ruff clean

## Deploy note
머지 후 mini 는 **scheduler 재시작 필요** (importlib cache — autopull 은 디스크만). 다음 KST 08:40 self-restart (#781) 로도 자동 반영.

관련: #835 (오프머신 사본 + watchdog 백업 나이 감시 — 본 fix 위에 후속), §3.11 미구축 ⑥

🤖 Generated with [Claude Code](https://claude.com/claude-code)