### PR TITLE
feat(ops): register API/dashboard under launchd + watchdog port coverage

### DIFF
--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -51,15 +51,21 @@ STALE_THRESHOLD_MIN = 30.0
 # heartbeat 만 멈추는 경우 KeepAlive 는 무력(크래시 아님) — kickstart -k 만 fd 를 회수.
 SCHEDULER_LABEL = "com.nuri-quant.scheduler"
 
+# 표출 계층 포트 감시 대상 (#826) — launchd 에 로드된 머신(production)에서만 검사.
+# KeepAlive 는 크래시만 복구; 살아있되 hung/포트 미바인딩 상태는 kickstart -k 로 회수.
+SERVICE_PORTS: dict[str, int] = {
+    "com.nuri-quant.api": int(os.getenv("API_PORT", "8001")),
+    "com.nuri-quant.dashboard": int(os.getenv("FRONTEND_PORT", "3000")),
+}
 
-def _kickstart_scheduler() -> bool:
-    """scheduler 데몬을 강제 재시작(kickstart -k). 성공 시 True.
 
-    stale 의 주원인은 fd 고갈로 인한 hung heartbeat 이므로, 알림과 함께
-    데몬을 재시작해 자동 복구한다(외근 중 수동 개입 불가 대비). 재시작 후
-    heartbeat 는 ~45초 내 갱신되므로 15분 간격 watchdog 에서 restart-loop 없음.
+def _kickstart(label: str) -> bool:
+    """launchd job 강제 재시작(kickstart -k). 성공 시 True.
+
+    stale 의 주원인은 fd 고갈로 인한 hung 상태이므로, 알림과 함께 데몬을
+    재시작해 자동 복구한다(외근 중 수동 개입 불가 대비).
     """
-    target = f"gui/{os.getuid()}/{SCHEDULER_LABEL}"
+    target = f"gui/{os.getuid()}/{label}"
     try:
         proc = subprocess.run(
             ["launchctl", "kickstart", "-k", target],
@@ -68,12 +74,62 @@ def _kickstart_scheduler() -> bool:
             timeout=30,
         )
     except Exception as e:  # launchctl 부재(비배포 환경)/타임아웃 — 알림은 계속 진행
-        print(f"auto-restart 호출 실패: {e}", file=sys.stderr)
+        print(f"auto-restart 호출 실패 ({label}): {e}", file=sys.stderr)
         return False
     if proc.returncode == 0:
         return True
-    print(f"auto-restart launchctl rc={proc.returncode}: {proc.stderr.strip()}", file=sys.stderr)
+    print(f"auto-restart launchctl rc={proc.returncode} ({label}): {proc.stderr.strip()}", file=sys.stderr)
     return False
+
+
+def _kickstart_scheduler() -> bool:
+    """scheduler 데몬 재시작 — 재시작 후 heartbeat 는 ~45초 내 갱신되므로
+    15분 간격 watchdog 에서 restart-loop 없음."""
+    return _kickstart(SCHEDULER_LABEL)
+
+
+def _label_loaded(label: str) -> bool:
+    """launchd 에 해당 label 이 로드돼 있으면 True — 미설치 머신(dev)은 감시 skip."""
+    try:
+        proc = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # launchctl 부재 (CI/linux) — 미배포 취급
+        return False
+    return proc.returncode == 0
+
+
+def _port_open(port: int, timeout_s: float = 3.0) -> bool:
+    """127.0.0.1:port TCP 연결 가능 여부 — DB·HTTP 스택 무의존 (socket 만)."""
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout_s):
+            return True
+    except OSError:
+        return False
+
+
+def check_services() -> list[str]:
+    """로드돼 있는데 포트가 닫힌 표출 서비스 → kickstart + 알림 라인 반환 (#826).
+
+    heartbeat 감시와 동일 철학: launchctl + socket 만 사용 (DB 무의존).
+    launchd 미설치 머신(dev MBP)은 label 미로드로 자동 skip — 환경 분기 불필요.
+    """
+    problems: list[str] = []
+    for label, port in SERVICE_PORTS.items():
+        if not _label_loaded(label):
+            continue
+        if _port_open(port):
+            continue
+        restarted = _kickstart(label)
+        short = label.removeprefix("com.nuri-quant.")
+        note = "🔄 자동 재시작 시도 완료 — 포트 곧 복구." if restarted else "⚠️ 자동 재시작 실패 — 수동 확인 필요."
+        problems.append(f"🔴 **{short} DOWN** — 127.0.0.1:{port} 응답 없음 (launchd 로드 상태). {note}")
+    return problems
 
 
 def heartbeat_age_minutes(path: Path | None = None, now_epoch: float | None = None) -> float | None:
@@ -86,35 +142,41 @@ def heartbeat_age_minutes(path: Path | None = None, now_epoch: float | None = No
 
 
 def main() -> int:
-    """exit code: 0 = OK/skip, 2 = stale (alert 시도). DB·scheduler 미접근."""
+    """exit code: 0 = OK/skip, 2 = 이상 감지 (alert 시도). DB·scheduler 미접근."""
+    alerts: list[str] = []
+
     age = heartbeat_age_minutes()
     if age is None:
         print(f"heartbeat 파일 없음 ({HEARTBEAT_PATH}) — skip (미배포 환경)")
-        return 0
-    if age <= STALE_THRESHOLD_MIN:
+    elif age <= STALE_THRESHOLD_MIN:
         print(f"heartbeat OK ({age:.1f}분, 임계 {STALE_THRESHOLD_MIN:.0f}분)")
+    else:
+        # stale 감지 → 데몬 자동 재시작 후 결과를 알림에 포함.
+        restarted = _kickstart_scheduler()
+        restart_note = (
+            "🔄 자동 재시작 완료 (`launchctl kickstart -k`) — heartbeat 곧 갱신."
+            if restarted
+            else "⚠️ 자동 재시작 실패 — 수동 확인: `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`"
+        )
+        alerts.append(
+            f"🔴 **스케줄러 heartbeat STALE** — {age:.0f}분째 갱신 없음 "
+            f"(임계 {STALE_THRESHOLD_MIN:.0f}분). 데이터 수집 중단 의심.\n{restart_note}"
+        )
+
+    # 표출 계층 (API/dashboard) 포트 감시 — 미설치 머신은 내부에서 skip (#826).
+    alerts.extend(check_services())
+
+    if not alerts:
         return 0
 
-    # stale 감지 → 데몬 자동 재시작 후 결과를 알림에 포함.
-    restarted = _kickstart_scheduler()
-    restart_note = (
-        "🔄 자동 재시작 완료 (`launchctl kickstart -k`) — heartbeat 곧 갱신."
-        if restarted
-        else "⚠️ 자동 재시작 실패 — 수동 확인: `launchctl kickstart -k gui/$(id -u)/com.nuri-quant.scheduler`"
-    )
-    msg = (
-        f"🔴 **스케줄러 heartbeat STALE** — {age:.0f}분째 갱신 없음 "
-        f"(임계 {STALE_THRESHOLD_MIN:.0f}분). 데이터 수집 중단 의심.\n"
-        f"{restart_note}\n"
-        f"[{kst_now().strftime('%Y-%m-%d %H:%M KST')}]"
-    )
+    msg = "\n".join(alerts) + f"\n[{kst_now().strftime('%Y-%m-%d %H:%M KST')}]"
     webhook_url = _resolve_webhook_url()
     try:
         sent = send_webhook_text(msg, webhook_url=webhook_url)
     except Exception as e:  # 네트워크/webhook 실패도 outage 신호 — 삼키지 말고 surface
-        print(f"STALE detected ({age:.1f}분) but webhook FAILED: {e}", file=sys.stderr)
+        print(f"이상 감지 but webhook FAILED: {e}", file=sys.stderr)
         return 2
-    print(f"STALE alert {'sent' if sent else 'NOT sent (no webhook url)'} ({age:.1f}분)")
+    print(f"alert {'sent' if sent else 'NOT sent (no webhook url)'} — {len(alerts)}건")
     return 2
 
 

--- a/scripts/launchd/com.nuri-quant.api.plist
+++ b/scripts/launchd/com.nuri-quant.api.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  com.nuri-quant.api — FastAPI 표출 계층 (:8001) launchd 상시 서비스 (#826).
+
+  왜: 2026-07-07 실측 — `make start` (nohup) 로 띄운 API 가 죽은 채 기간 불명
+  방치 (수집·측정·알림은 launchd 보호, 표출만 자동 복구 밖). KeepAlive 가
+  크래시 복구, hung/미바인딩 상태는 heartbeat-watchdog 포트 감시가 kickstart.
+
+  설치 (production 머신):
+    1) 기존 수동 인스턴스 정리 — 포트 점유 시 KeepAlive crash-loop:
+       lsof -ti :8001 | xargs kill 2>/dev/null
+    2) bash scripts/launchd/install_crons.sh - -only api
+       (USER → $HOME 자동 치환. plist 수정 후엔 mini 에서 재설치 필요 — #778)
+-->
+<dict>
+    <key>Label</key>
+    <string>com.nuri-quant.api</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/USER/workspace/nuri-quant/.venv/bin/python</string>
+        <string>-m</string>
+        <string>uvicorn</string>
+        <string>nuri.api.main:app</string>
+        <string>--host</string>
+        <string>0.0.0.0</string>
+        <string>--port</string>
+        <string>8001</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/USER/workspace/nuri-quant</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- crash-loop 완화 — 재시작 최소 간격 30초 -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <!-- scheduler.plist 와 동일 근거: yfinance/HTTP fd 누수 헤드룸 (기본 256 → 4096) -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/api.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/api.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchd/com.nuri-quant.dashboard.plist
+++ b/scripts/launchd/com.nuri-quant.dashboard.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  com.nuri-quant.dashboard — Next.js 대시보드 (:3000) launchd 상시 서비스 (#826).
+
+  전제: frontend/.next production build 존재 (`npm run build`) — `npm run start`
+  는 production 서버. 배포 시 build 를 먼저 갱신할 것.
+
+  ⚠️ PATH 에 /opt/homebrew/bin 필수 — production 머신의 node/npm 은 fnm 이
+  아니라 homebrew 설치 (2026-07-07 실측: 비대화형 셸에서 npm not found).
+
+  설치 (production 머신):
+    1) 기존 수동 인스턴스 정리 — 포트 점유 시 KeepAlive crash-loop:
+       lsof -ti :3000 | xargs kill 2>/dev/null
+    2) bash scripts/launchd/install_crons.sh - -only dashboard
+       (USER → $HOME 자동 치환. plist 수정 후엔 mini 에서 재설치 필요 — #778)
+-->
+<dict>
+    <key>Label</key>
+    <string>com.nuri-quant.dashboard</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>cd /Users/USER/workspace/nuri-quant/frontend &amp;&amp; exec npm run start</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/USER/workspace/nuri-quant/frontend</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- crash-loop 완화 — build 부재 등 즉사 케이스에서 재시작 최소 간격 30초 -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/dashboard.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/dashboard.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -9,6 +9,8 @@ import os
 import time
 from unittest.mock import patch
 
+import pytest
+
 from nuri.alerts import heartbeat_watchdog as hw
 
 
@@ -50,6 +52,11 @@ class TestWebhookResolution:
 
 
 class TestMain:
+    @pytest.fixture(autouse=True)
+    def _no_services(self, monkeypatch):
+        """heartbeat 계약만 격리 검증 — 포트 감시는 TestServiceCheck 에서 별도."""
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {})
+
     def test_fresh_heartbeat_no_alert(self, tmp_path, monkeypatch):
         p = tmp_path / "hb"
         _write_heartbeat(p, age_minutes=1.0)
@@ -119,6 +126,88 @@ class TestMain:
             rc = hw.main()
         assert rc == 2
         assert "자동 재시작 실패" in send.call_args.args[0]
+
+
+class TestServiceCheck:
+    """#826 표출 계층 포트 감시 — 로드+포트닫힘 → kickstart+알림, 미설치 → skip.
+
+    Gotcha-Test Pair: 2026-07-07 실측 — mini 의 API/dashboard 가 launchd 밖에서
+    (`make start` nohup) 돌다 죽은 채 기간 불명 방치. KeepAlive 만으로는 hung/
+    미바인딩 상태 복구 불가 → 포트 감시 계약을 고정.
+    """
+
+    def test_loaded_and_port_closed_kickstarts_and_alerts(self, monkeypatch):
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.api": 18001})
+        with (
+            patch.object(hw, "_label_loaded", return_value=True),
+            patch.object(hw, "_port_open", return_value=False),
+            patch.object(hw, "_kickstart", return_value=True) as kick,
+        ):
+            problems = hw.check_services()
+        kick.assert_called_once_with("com.nuri-quant.api")
+        assert len(problems) == 1
+        assert "api DOWN" in problems[0]
+        assert "자동 재시작 시도 완료" in problems[0]
+
+    def test_not_loaded_skips_silently(self, monkeypatch):
+        # dev 머신 (launchd 미설치) — 검사·재시작 모두 없음.
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.api": 18001})
+        with (
+            patch.object(hw, "_label_loaded", return_value=False),
+            patch.object(hw, "_kickstart") as kick,
+        ):
+            problems = hw.check_services()
+        kick.assert_not_called()
+        assert problems == []
+
+    def test_loaded_and_port_open_is_healthy(self, monkeypatch):
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.dashboard": 13000})
+        with (
+            patch.object(hw, "_label_loaded", return_value=True),
+            patch.object(hw, "_port_open", return_value=True),
+            patch.object(hw, "_kickstart") as kick,
+        ):
+            problems = hw.check_services()
+        kick.assert_not_called()
+        assert problems == []
+
+    def test_kickstart_failure_reports_manual_step(self, monkeypatch):
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.dashboard": 13000})
+        with (
+            patch.object(hw, "_label_loaded", return_value=True),
+            patch.object(hw, "_port_open", return_value=False),
+            patch.object(hw, "_kickstart", return_value=False),
+        ):
+            problems = hw.check_services()
+        assert "자동 재시작 실패" in problems[0]
+
+    def test_main_combines_service_alert_with_fresh_heartbeat(self, tmp_path, monkeypatch):
+        # heartbeat 정상이어도 서비스 down 이면 rc=2 + 알림 발송.
+        p = tmp_path / "hb"
+        _write_heartbeat(p, age_minutes=1.0)
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", p)
+        with (
+            patch.object(hw, "check_services", return_value=["🔴 **api DOWN** — test"]),
+            patch("nuri.alerts.heartbeat_watchdog.send_webhook_text", return_value=True) as send,
+        ):
+            rc = hw.main()
+        assert rc == 2
+        send.assert_called_once()
+        assert "api DOWN" in send.call_args.args[0]
+
+    def test_port_open_real_socket(self):
+        # 실소켓 왕복 1회 — mock 없는 실측 (loopback listener).
+        import socket
+
+        srv = socket.socket()
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        try:
+            assert hw._port_open(port) is True
+        finally:
+            srv.close()
+        assert hw._port_open(port) is False  # 닫힌 뒤엔 False
 
 
 class TestKickstart:

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -195,6 +195,25 @@ class TestServiceCheck:
         send.assert_called_once()
         assert "api DOWN" in send.call_args.args[0]
 
+    def test_label_loaded_true_on_zero_rc(self, monkeypatch):
+        class _Proc:
+            returncode = 0
+
+        monkeypatch.setattr(hw.subprocess, "run", lambda *a, **k: _Proc())
+        assert hw._label_loaded("com.nuri-quant.api") is True
+
+    def test_label_loaded_false_on_nonzero_rc(self, monkeypatch):
+        class _Proc:
+            returncode = 113  # launchctl list: 미로드 label
+
+        monkeypatch.setattr(hw.subprocess, "run", lambda *a, **k: _Proc())
+        assert hw._label_loaded("com.nuri-quant.api") is False
+
+    def test_label_loaded_false_when_launchctl_missing(self, monkeypatch):
+        # CI/linux — launchctl 부재는 미배포 취급 (skip)
+        monkeypatch.setattr(hw.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+        assert hw._label_loaded("com.nuri-quant.api") is False
+
     def test_port_open_real_socket(self):
         # 실소켓 왕복 1회 — mock 없는 실측 (loopback listener).
         import socket


### PR DESCRIPTION
Closes #826.

## Why
2026-07-07 실측: production 의 API :8001 + dashboard :3000 이 둘 다 down (기간 불명, 무감지). launchd 에는 scheduler/watchdog/autopull 만 등재 — `make start` (nohup) 표출 계층은 죽으면 방치. 수집·측정·알림은 보호되는데 표출만 자동 복구 밖 (Palantir 감사 'UI 도달 불가' 재현).

## What
1. **plist ×2** (`com.nuri-quant.api` / `com.nuri-quant.dashboard`): KeepAlive + ThrottleInterval 30s + fd 4096 (API) + `/opt/homebrew/bin` PATH (production node 는 fnm 아닌 homebrew — 2026-07-07 실측 gotcha, plist 주석 기록). `install_crons.sh` 자동 발견 대상.
2. **watchdog 확장** (`heartbeat_watchdog.py`): label 로드 + 포트 닫힘 → `kickstart -k` + Discord 알림. KeepAlive 는 크래시만 복구 — hung/미바인딩은 포트 감시가 회수. dev 머신은 label 미로드로 자동 skip (환경 분기 없음). heartbeat 알림과 단일 메시지 통합.

## Verification
- `plutil -lint` ×2 OK · watchdog 테스트 20/20 (신규 6: kickstart 계약 + 실소켓 왕복) · ruff clean
- DB 무의존 철학 유지 (launchctl + socket 만 — #734 self-monitor independence)

## Deploy (production, 수동 1회)
```
lsof -ti :8001 | xargs kill 2>/dev/null; lsof -ti :3000 | xargs kill 2>/dev/null
bash scripts/launchd/install_crons.sh --only api dashboard heartbeat-watchdog
```
(기존 nohup 인스턴스 정리 필수 — 포트 점유 시 KeepAlive crash-loop. watchdog plist 는 코드 변경 반영 위해 재설치.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)