### PR TITLE
docs(rules): fix command drift + document nuri/agents actor fleet

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,14 +2,14 @@
 
 ## Code layout
 
-`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (27 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm`. Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
+`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (27 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm` / `agents` (top-level actor fleet: 18 `actors/` — SRE incident · drift sentinel · forward outcome tracker · walkforward validator · execution firewall · … — plus `discord/` bot layer, wired by `nuri/scheduler.py`). Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
 
 ## Commands
 
 `make help` for full target inventory. Daily essentials:
 - Setup: `make setup` (1회) — venv + deps + DB init + portfolio import
 - Daily: `make quick-scan` (~2분 4-step) / `make full-scan` (8-phase + SIEGE) / `make consensus`
-- Reactive: `make buy-candidates` / `make thesis ticker=<T>` / `make earnings-preview ticker=<T>`
+- Reactive: `make recommend` (BUY candidates + tracker) / `/nuri-thesis <T>` skill (`nuri/llm/thesis_query.py`) / `make earnings-preview ticker=<T>`
 - LLM consult dual-archive: `make llm-consult slug=<kebab> prompt=<file>`
 - Lint+Test: `make lint` / `make test-fast` / `.venv/bin/python -m pytest <path>::<test> -v`
 - Deploy: `make start` (API :8001 + Dashboard :3000) / `make deploy-mini` (MBP → Mac mini 6단계 동기화)

--- a/.claude/rules/load-triggers.md
+++ b/.claude/rules/load-triggers.md
@@ -13,6 +13,7 @@
 | `config/rules.yaml`, `config/agents.yaml`, `config/signals.yaml` | `config/CLAUDE.md` + `docs/STRATEGY.md §2.6, §3.4-§3.5` |
 | `frontend/` | `frontend/CLAUDE.md` (Next.js 16 breaking changes — read `node_modules/next/dist/docs/` first) |
 | `tests/` | `tests/CLAUDE.md` (DB isolation, mock pitfalls, privacy in fixtures) |
+| `nuri/agents/` (actor fleet + discord bot) | `nuri/agents/base.py` (actor contract) + `nuri/scheduler.py` (wiring) — no scoped CLAUDE.md yet |
 | `nuri/api/` (FastAPI routes) | `docs/ARCHITECTURE.md` §"Dashboard API" + `.claude/rules/architecture.md` "API Access Pattern" + source convention from existing `nuri/api/routes/` |
 | `scripts/` (shell automation, no scoped CLAUDE.md) | source docstring; `make lint-sh` (shellcheck); `scripts/verify/pre_push_check.sh` for safety contract |
 | DB migrations / schema changes | `nuri/core/CLAUDE.md` + `_MIGRATIONS` list in `nuri/core/db_migrations.py` (forward-only, never edit existing migration) |


### PR DESCRIPTION
Closes #839.

/init 실측 (2026-07-07) drift fix:
- `architecture.md`: 존재하지 않는 `make buy-candidates` / `make thesis` → 실제 진입점 `make recommend` / `/nuri-thesis` 스킬 (`nuri/llm/thesis_query.py`). `nuri/agents` actor fleet (18 actors + discord, `nuri/scheduler.py` wiring) layout 서술 추가 — 실측 일치 확인.
- `load-triggers.md`: `nuri/agents/` read-first 행 추가 (scoped CLAUDE.md 미보유 명시).

검증: `make verify-doc-counts` 13/13 (collectors 27 · endpoints 72 anchor 불변).

🤖 Generated with [Claude Code](https://claude.com/claude-code)