### PR TITLE
test(macro): mock toss FX in collect() tests — network-free regression lock

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -42,6 +42,10 @@ patch.dict(sys.modules, {"openbb": mock_module})
 ### vi.mock() hoisting (frontend tests)
 `vi.mock("recharts")` affects ALL dynamic imports in the same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**.
 
+### Toss FX not covered by global yfinance mock
+conftest 전역 mock 은 **yfinance 만** 커버. `MacroCollector.collect()` 는 `_collect_toss_fx()` 로 실 HTTP 를 타므로 `collect()` 를 부르는 테스트는 `_collect_toss_fx` 를 명시 stub 해야 한다. toss 성공 시 usd_krw source='toss' 가 FRED 를 override 하는 건 **의도된 우선순위**라 'FRED 여야 함' assertion 이 네트워크 상태 따라 flaky 했음 (#829).
+**Test:** `tests/collectors/test_macro.py::TestMacroCollectorTossFX::test_collect_toss_overrides_fred_usd_krw_in_db` — toss-성공 시나리오를 mock 으로 결정론 고정 (DB 최종 상태까지 lock).
+
 ### Time-bomb seed dates (relative `now`-window queries)
 코드가 `date('now', '-N days')` 윈도우 + 최소 행 수 임계값으로 필터하면(예: `buy_candidate_emitter._get_price_signals`, 45일 윈도우 + `len(grp) < 6` skip), **고정 절대일로 seed한 fixture 는 wall-clock 이 지나며 윈도우 밖으로 밀려 silent 하게 누락**된다. 합성 가격/날짜 fixture 의 `end` 는 항상 `today_kst()` 로 앵커링 — 리터럴 날짜 금지. (#721: `end="2026-04-30"` → 39일 후 scored=0 회귀)
 **Test:** `tests/trading/recommend/test_buy_candidate_emitter.py::test_vix_caution_halves_allocation` (+`test_emit_above_threshold`, `test_allocation_split_by_score`) — 고정일로 되돌리면 즉시 FAIL.

--- a/tests/collectors/test_macro.py
+++ b/tests/collectors/test_macro.py
@@ -114,6 +114,9 @@ class TestMacroCollectorFREDAndYFinance:
         monkeypatch.setitem(sys.modules, "fredapi", MagicMock(Fred=MagicMock(return_value=mock_fred)))
         # yfinance 분기 차단 — _collect_yfinance 에서 yfinance.download mock 안 하면
         # 실제 네트워크 호출 됨. conftest.py 의 yfinance.download stub (빈 df) 활용.
+        # toss FX 는 conftest 전역 mock 대상 아님 (실 HTTP) — 명시 차단 (#829).
+        # toss 성공 시 usd_krw source='toss' 는 의도된 override (TossFX 클래스에서 검증).
+        monkeypatch.setattr(MacroCollector, "_collect_toss_fx", lambda self: [])
         collector = MacroCollector()
         collector.api_key = "real_key"
         results = collector.collect(days=30)
@@ -158,6 +161,8 @@ class TestMacroCollectorEdgeCases:
         import sys
 
         monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+        # toss FX 실 HTTP 차단 (#829)
+        monkeypatch.setattr(MacroCollector, "_collect_toss_fx", lambda self: [])
         collector = MacroCollector()
         collector.api_key = ""
         assert isinstance(collector.collect(days=30), list)
@@ -176,6 +181,8 @@ class TestMacroCollectorEdgeCases:
         mock_obb = MagicMock()
         mock_obb.equity.price.historical.return_value = mock_result
         monkeypatch.setitem(sys.modules, "openbb", MagicMock(obb=mock_obb))
+        # toss FX 실 HTTP 차단 (#829)
+        monkeypatch.setattr(MacroCollector, "_collect_toss_fx", lambda self: [])
         collector = MacroCollector()
         collector.api_key = "real_key"
         assert isinstance(collector.collect(days=30), list)
@@ -264,6 +271,51 @@ class TestMacroCollectorTossFX:
         assert toss_rows == [{"indicator": "usd_krw", "date": today_kst(), "value": 1540.86, "source": "toss"}]
         # toss 레코드가 마지막 (upsert OR REPLACE 가 오늘자 usd_krw 를 toss 로 확정)
         assert results[-1] == toss_rows[0]
+
+    def test_collect_toss_overrides_fred_usd_krw_in_db(self, monkeypatch, db_with_portfolio):
+        """Gotcha-Test Pair (#829): FRED 가 오늘자 usd_krw 를 emit + toss 성공 시나리오.
+
+        기존 flaky 원인: test_collect_prefers_fred 가 toss 미mock 상태로 네트워크
+        성공 시 usd_krw source='toss' 를 만나 'FRED 여야 함' assertion 실패.
+        여기서는 그 시나리오를 mock 으로 결정론 재현 — usd_krw 는 toss 가 FRED 를
+        override 하는 게 의도된 우선순위 (macro.py collect() 주석, UNIQUE(indicator,
+        date) + INSERT OR REPLACE). save() 후 DB 최종 상태까지 lock.
+        """
+        import sys
+
+        import pandas as pd
+
+        from nuri.collectors.macro import MacroCollector
+        from nuri.core.db import query
+        from nuri.core.timezone import today_kst
+
+        # FRED stub — 모든 시리즈(usd_krw 포함)를 오늘자 값으로 emit → PK 충돌 유도
+        mock_series = pd.Series([1500.0], index=pd.to_datetime([today_kst()]))
+        mock_fred = MagicMock()
+        mock_fred.get_series.return_value = mock_series
+        monkeypatch.setitem(sys.modules, "fredapi", MagicMock(Fred=MagicMock(return_value=mock_fred)))
+        monkeypatch.setattr(MacroCollector, "_collect_yfinance", lambda self, days: [])
+        monkeypatch.setattr(
+            "nuri.collectors.toss.get_exchange_rate",
+            lambda base="USD", quote="KRW": {"rate": 1540.86},
+        )
+
+        collector = MacroCollector()
+        collector.api_key = "real_key"
+        results = collector.collect(days=30)
+
+        # 오늘자 usd_krw 가 FRED·toss 양쪽에서 emit — toss 가 뒤 (override 순서)
+        usd_sources = [r["source"] for r in results if r["indicator"] == "usd_krw"]
+        assert usd_sources == ["FRED", "toss"]
+
+        # DB 최종 상태: INSERT OR REPLACE 로 오늘자 usd_krw 는 toss 값이 확정
+        collector.save(results)
+        rows = query(
+            "SELECT source, value FROM macro WHERE indicator='usd_krw' AND date=?",
+            (today_kst(),),
+            db_path=db_with_portfolio,
+        )
+        assert rows == [{"source": "toss", "value": 1540.86}]
 
 
 class TestPartAIndicatorRegistry:
@@ -355,6 +407,8 @@ class TestPartAIndicatorRegistry:
             ]
 
         monkeypatch.setattr(MacroCollector, "_collect_yfinance", stub_yf)
+        # toss FX 실 HTTP 차단 (#829)
+        monkeypatch.setattr(MacroCollector, "_collect_toss_fx", lambda self: [])
 
         collector = MacroCollector()
         collector.api_key = "real_key"


### PR DESCRIPTION
## Summary

`MacroCollector.collect()` reaches `_collect_toss_fx()` (nuri/collectors/macro.py:105,125-144), a real HTTP call not covered by the conftest yfinance-only global mock. Network success produced a `usd_krw source='toss'` row that broke the `'must be FRED'` assertion in `test_collect_prefers_fred`; failure fell into graceful skip and passed — flaky by network state, violating tests/CLAUDE.md "All tests run network-free".

## Changes

- **Explicit per-test stub** of `_collect_toss_fx` in all 4 `collect()`-calling tests (`test_collect_prefers_fred`, `test_collect_uses_yfinance_when_no_fred_key`, `test_collect_fred_returns_empty_falls_to_yfinance`, `test_collect_merges_yf_supplement_when_fred_set`). Chose per-test mocks over a conftest global stub: a global toss stub would silently affect `TestMacroCollectorTossFX` and `tests/collectors/test_toss.py`, and the existing convention (`_collect_yfinance` monkeypatch) is already per-test.
- **Gotcha-Test Pair**: new `TestMacroCollectorTossFX::test_collect_toss_overrides_fred_usd_krw_in_db` deterministically reproduces the previously-flaky scenario (FRED emits today's `usd_krw` AND toss succeeds) and locks the intended priority from the macro.py:103 comment — toss appended last, and after `save()` the `UNIQUE(indicator,date)` + `INSERT OR REPLACE` upsert leaves `source='toss'` as the final DB state.
- tests/CLAUDE.md Gotchas entry with `**Test:**` citation per STRATEGY §5.3.1.

## Verification

- `tests/collectors/test_macro.py`: 24 passed (0.46s)
- `tests/collectors/` full suite: 803 passed, 2 skipped (12.84s)
- ruff: clean; privacy scan (no-arg diff mode): clean
- All 6 `collect()` call sites in test_macro.py now have the toss path stubbed (grep-verified)

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)