### PR TITLE
feat(validation): decision-level alpha adjudication tool — ticker-block placebo (§3.11)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,173 backend tests across 271 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 272 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 271 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 272 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/validation/decision_alpha.py
+++ b/nuri/quant/validation/decision_alpha.py
@@ -1,0 +1,380 @@
+"""Decision-level alpha 판정 도구 — STRATEGY §3.11 사전 고정 기준의 구현 (#831).
+
+3조건 통합 판정 리포트:
+  1. mean 30d alpha > 0
+  2. ticker-block placebo 순열 p < permutation_p_max (one-sided)
+  3. median-decision-date 등분 2분할 모두 mean alpha > 0
++ missing-outcome 비율 공시 (missing_outcome_max_pct 초과 시 판정 무효).
+
+판정 파라미터는 전부 `config/rules.yaml measurement_mode` (사전 고정, lock test
+`tests/core/test_rules.py::TestMeasurementMode`) 에서 로드 — 하드코딩 금지.
+
+순열 설계 (ticker_block_placebo, §3.11 표에 사전 고정):
+  실 표본의 (ticker → emit 일자 집합) 블록 구조를 유지한 채, 블록의 ticker 만
+  동일 시장 (US) eligible universe 에서 치환해 mean alpha null 분포를 생성한다.
+  같은 ticker 의 반복 emit 은 null 에서도 같은 치환 ticker 를 공유하므로,
+  중첩 관측창·동일일 배치·반복 종목의 의존 구조를 null 이 그대로 상속한다 —
+  naive iid 순열은 이 클러스터링을 무시해 anti-conservative (§3.11 근거란).
+
+가격/창 의미론은 ForwardOutcomeTracker 와 동일 (미러 — drift 시 판정 무효):
+  entry = close(ticker, emit_date) [정확 일치],
+  exit  = close_on_or_after(ticker, emit_date + window **calendar days**)
+  (forward_outcome_tracker.py `_add_business_days` 는 이름과 달리 calendar-day
+  덧셈이고 주말/휴장은 on_or_after 가 흡수 — 동일 규칙 적용).
+  단, 실 표본의 observed alpha 는 재계산하지 않고 원장 `decision_outcomes.alpha`
+  를 그대로 쓴다 (§3.11: 판정은 원장 쿼리만 인용).
+
+Usage:
+    python -m nuri.quant.validation.decision_alpha            # 진행 리포트 (JSON)
+    python -m nuri.quant.validation.decision_alpha --seed 828 --n-perm 1000
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from nuri.core.db import query
+from nuri.core.rules import RULES
+from nuri.core.timezone import today_kst
+
+# 순열 null 오염 방지 — 지수/선물 pseudo-ticker 는 universe 에서 제외.
+# (#710 실측: KOSDAQ 이 .KS 필터를 빠져나가 degenerate fold 유발.
+#  canonical 목록: config/walkforward_variants.yaml exclude_tickers)
+PSEUDO_TICKERS = frozenset({"KOSDAQ", "KOSPI", "GC=F", "TESTAA"})
+
+# 기본 순열 seed — 사전 고정 (reseed-shopping 방지). CLI --seed 로 명시 변경 시
+# 리포트에 seed 가 그대로 찍혀 재현 경로가 남는다.
+DEFAULT_SEED = 828
+
+
+def _criteria() -> dict:
+    """rules.yaml measurement_mode 블록 (사전 고정 판정 파라미터)."""
+    mm = RULES.get("measurement_mode")
+    if not mm:
+        raise RuntimeError("config/rules.yaml 에 measurement_mode 블록 없음 (§3.11)")
+    return mm
+
+
+class PriceBook:
+    """ticker 별 close 시계열 lazy 캐시 — 순열 1,000회의 가격 조회를 메모리에서.
+
+    tracker 와 동일 SQL 의미론: 정확일 close / on-or-after 첫 close.
+    """
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self._db_path = db_path
+        self._series: dict[str, tuple[list[str], list[float]]] = {}
+
+    def _load(self, ticker: str) -> tuple[list[str], list[float]]:
+        if ticker not in self._series:
+            rows = query(
+                "SELECT date, close FROM prices WHERE ticker = ? AND close IS NOT NULL ORDER BY date",
+                (ticker,),
+                db_path=self._db_path,
+            )
+            dates = [r["date"] for r in rows]
+            closes = [float(r["close"]) for r in rows]
+            self._series[ticker] = (dates, closes)
+        return self._series[ticker]
+
+    def close(self, ticker: str, date_str: str) -> Optional[float]:
+        dates, closes = self._load(ticker)
+        i = bisect.bisect_left(dates, date_str)
+        if i < len(dates) and dates[i] == date_str:
+            return closes[i]
+        return None
+
+    def close_on_or_after(self, ticker: str, date_str: str) -> Optional[float]:
+        dates, closes = self._load(ticker)
+        i = bisect.bisect_left(dates, date_str)
+        if i < len(dates):
+            return closes[i]
+        return None
+
+
+@dataclass
+class Sample:
+    """판정 표본 (US BUY, primary window, alpha 확정분) + 결측 집계."""
+
+    decisions: list[dict] = field(default_factory=list)  # {decision_id, ticker, emit_date, alpha}
+    n_missing_closed: int = 0  # 창이 닫혔는데 alpha 미기록 (결측 편향 공시 대상)
+
+    @property
+    def n(self) -> int:
+        return len(self.decisions)
+
+    @property
+    def missing_rate_pct(self) -> float:
+        total = self.n + self.n_missing_closed
+        return (self.n_missing_closed / total * 100.0) if total else 0.0
+
+
+def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) -> Sample:
+    """§3.11 표본 규약 구현 — declared_date~emit_cutoff 의 US BUY, distinct decision.
+
+    결측 정의: 창 (emit + window calendar days) 이 as_of 이전에 닫혔는데
+    primary window 의 alpha 가 원장에 없는 결정 (추적 실패/가격 결측).
+    """
+    mm = _criteria()
+    window = int(mm["primary_window_days"])
+    today = as_of or today_kst()
+
+    rows = query(
+        """
+        SELECT r.id AS rec_id, r.ticker AS ticker, r.date AS emit_date, o.alpha AS alpha
+        FROM recommendations r
+        JOIN agent_decisions ad ON ad.decision_id = 'rec_' || r.id
+        LEFT JOIN decision_outcomes o
+               ON o.decision_id = 'rec_' || r.id AND o.observation_window = ?
+        WHERE ad.action = 'BUY'
+          AND r.ticker NOT LIKE '%.KS'
+          AND r.date >= ? AND r.date <= ?
+        ORDER BY r.date, r.id
+        """,
+        (window, mm["declared_date"], mm["emit_cutoff_date"]),
+        db_path=db_path,
+    )
+
+    sample = Sample()
+    for raw in rows:
+        r = dict(raw)
+        if r["alpha"] is not None:
+            sample.decisions.append(
+                {
+                    "decision_id": f"rec_{r['rec_id']}",
+                    "ticker": r["ticker"],
+                    "emit_date": r["emit_date"],
+                    "alpha": float(r["alpha"]),
+                }
+            )
+            continue
+        # 창이 닫혔는데 미기록 → 결측 (lookahead 미도래분은 결측 아님)
+        target = (date.fromisoformat(r["emit_date"]) + timedelta(days=window)).isoformat()
+        if target <= today:
+            sample.n_missing_closed += 1
+    return sample
+
+
+def _blocks(decisions: list[dict]) -> dict[str, list[str]]:
+    """ticker → emit 일자 리스트 (실 표본의 반복 구조)."""
+    blocks: dict[str, list[str]] = {}
+    for d in decisions:
+        blocks.setdefault(d["ticker"], []).append(d["emit_date"])
+    return blocks
+
+
+def _placebo_alpha(book: PriceBook, ticker: str, emit_date: str, window: int, benchmark: str) -> Optional[float]:
+    """치환 ticker 의 (emit, window) alpha — tracker 공식 미러 (BUY 전용)."""
+    entry = book.close(ticker, emit_date)
+    target = (date.fromisoformat(emit_date) + timedelta(days=window)).isoformat()
+    exit_p = book.close_on_or_after(ticker, target)
+    b_entry = book.close(benchmark, emit_date)
+    b_exit = book.close_on_or_after(benchmark, target)
+    if None in (entry, exit_p, b_entry, b_exit) or entry <= 0 or b_entry <= 0:
+        return None
+    return (exit_p - entry) / entry - (b_exit - b_entry) / b_entry
+
+
+def _eligible_substitutes(
+    book: PriceBook,
+    blocks: dict[str, list[str]],
+    window: int,
+    benchmark: str,
+    db_path: Optional[Path] = None,
+) -> dict[str, list[str]]:
+    """블록별 치환 후보 — 해당 블록의 모든 emit 일자에서 placebo alpha 계산 가능한
+    US ticker (원 ticker·benchmark·pseudo 제외). 결정론 보장 위해 정렬 유지."""
+    rows = query(
+        "SELECT DISTINCT ticker FROM prices WHERE ticker NOT LIKE '%.KS' ORDER BY ticker",
+        db_path=db_path,
+    )
+    universe = [dict(r)["ticker"] for r in rows]
+    universe = [t for t in universe if t not in PSEUDO_TICKERS and t != benchmark]
+
+    eligible: dict[str, list[str]] = {}
+    for ticker, dates in blocks.items():
+        cands = []
+        for t in universe:
+            if t == ticker:
+                continue
+            if all(_placebo_alpha(book, t, d, window, benchmark) is not None for d in dates):
+                cands.append(t)
+        eligible[ticker] = cands
+    return eligible
+
+
+@dataclass
+class PermutationResult:
+    p_value: float
+    n_permutations: int
+    observed_mean: float
+    null_means: list[float]
+    seed: int
+    skipped_blocks: list[str]  # 치환 후보 없어 null 에서 실측 alpha 유지된 블록 (공시)
+
+
+def ticker_block_placebo(
+    sample: Sample,
+    n_perm: int,
+    seed: int,
+    db_path: Optional[Path] = None,
+) -> PermutationResult:
+    """§3.11 사전 고정 순열 — one-sided p = (1 + #{null ≥ obs}) / (N + 1)."""
+    mm = _criteria()
+    window = int(mm["primary_window_days"])
+    benchmark = str(mm["benchmark"])
+
+    observed = float(np.mean([d["alpha"] for d in sample.decisions]))
+    blocks = _blocks(sample.decisions)
+    book = PriceBook(db_path=db_path)
+    eligible = _eligible_substitutes(book, blocks, window, benchmark, db_path=db_path)
+    skipped = sorted([t for t, c in eligible.items() if not c])
+
+    rng = np.random.default_rng(seed)
+    tickers = sorted(blocks.keys())  # 결정론 — dict 순회 아닌 정렬 순서
+    null_means: list[float] = []
+    for _ in range(n_perm):
+        total, count = 0.0, 0
+        for t in tickers:
+            dates = blocks[t]
+            cands = eligible[t]
+            if not cands:
+                # 치환 불가 블록 — 실측 alpha 유지 (null 을 실측 쪽으로 끌어
+                # p 를 보수적으로 만든다; skipped_blocks 로 공시)
+                for d in sample.decisions:
+                    if d["ticker"] == t:
+                        total += d["alpha"]
+                        count += 1
+                continue
+            sub = cands[int(rng.integers(len(cands)))]
+            for dt in dates:
+                a = _placebo_alpha(book, sub, dt, window, benchmark)
+                total += a  # eligible 검증으로 None 불가
+                count += 1
+        null_means.append(total / count)
+
+    ge = sum(1 for m in null_means if m >= observed)
+    p = (1 + ge) / (n_perm + 1)
+    return PermutationResult(
+        p_value=p,
+        n_permutations=n_perm,
+        observed_mean=observed,
+        null_means=null_means,
+        seed=seed,
+        skipped_blocks=skipped,
+    )
+
+
+def median_split_means(sample: Sample) -> dict:
+    """median-decision-date 등분 2분할 (n 균형 보장 — §3.11)."""
+    ordered = sorted(sample.decisions, key=lambda d: (d["emit_date"], d["decision_id"]))
+    half = len(ordered) // 2
+    h1, h2 = ordered[:half], ordered[half:]
+    return {
+        "h1_n": len(h1),
+        "h1_mean": float(np.mean([d["alpha"] for d in h1])) if h1 else None,
+        "h2_n": len(h2),
+        "h2_mean": float(np.mean([d["alpha"] for d in h2])) if h2 else None,
+    }
+
+
+def adjudicate(
+    db_path: Optional[Path] = None,
+    n_perm: Optional[int] = None,
+    seed: int = DEFAULT_SEED,
+    as_of: Optional[str] = None,
+) -> dict:
+    """3조건 통합 판정 리포트 (JSON-직렬화 가능 dict).
+
+    evaluation_date 이전 실행은 verdict='PROGRESS_REPORT' — §3.11 조기 승격 금지.
+    """
+    mm = _criteria()
+    today = as_of or today_kst()
+    n_perm = int(n_perm if n_perm is not None else mm["permutation_n"])
+
+    sample = fetch_sample(db_path=db_path, as_of=today)
+    report: dict = {
+        "as_of": today,
+        "criteria_source": "config/rules.yaml measurement_mode (§3.11 사전 고정)",
+        "window_days": int(mm["primary_window_days"]),
+        "benchmark": mm["benchmark"],
+        "n": sample.n,
+        "min_n_required": int(mm["min_n_us_buy_decisions"]),
+        "missing_rate_pct": round(sample.missing_rate_pct, 1),
+        "missing_max_pct": int(mm["missing_outcome_max_pct"]),
+        "pre_evaluation": today < str(mm["evaluation_date"]),
+        "evaluation_date": mm["evaluation_date"],
+    }
+
+    if sample.n == 0:
+        report.update({"verdict": "NO_SAMPLE", "reason": "표본 0건 (declared_date 이후 확정 alpha 없음)"})
+        return report
+
+    perm = ticker_block_placebo(sample, n_perm=n_perm, seed=seed, db_path=db_path)
+    halves = median_split_means(sample)
+    cond = {
+        "mean_alpha_positive": perm.observed_mean > 0,
+        "permutation_significant": perm.p_value < float(mm["permutation_p_max"]),
+        "both_halves_positive": bool(
+            halves["h1_mean"] is not None
+            and halves["h2_mean"] is not None
+            and halves["h1_mean"] > 0
+            and halves["h2_mean"] > 0
+        ),
+    }
+    report.update(
+        {
+            "mean_alpha": round(perm.observed_mean, 6),
+            "p_value": round(perm.p_value, 6),
+            "p_max": float(mm["permutation_p_max"]),
+            "permutation": {
+                "scheme": mm["permutation_scheme"],
+                "n": perm.n_permutations,
+                "seed": perm.seed,
+                "one_sided": True,
+                "skipped_blocks": perm.skipped_blocks,
+            },
+            "halves": halves,
+            "conditions": cond,
+        }
+    )
+
+    # 판정 우선순위: 결측 무효 > 표본 미달 > 3조건
+    if sample.missing_rate_pct > float(mm["missing_outcome_max_pct"]):
+        verdict = "INVALID_MISSING"  # 판정 무효 — 측정 연장 (§3.11 오염 방지 행)
+    elif sample.n < int(mm["min_n_us_buy_decisions"]):
+        verdict = "INSUFFICIENT_N"
+    elif all(cond.values()):
+        verdict = "CRITERIA_MET"
+    else:
+        verdict = "CRITERIA_NOT_MET"
+    # 조기 승격 금지 — 판정일 이전엔 어떤 결과도 progress report 로만.
+    report["verdict"] = "PROGRESS_REPORT" if report["pre_evaluation"] else verdict
+    report["criteria_verdict_if_final"] = verdict
+    return report
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="§3.11 decision-level alpha 판정 리포트 (#831)")
+    parser.add_argument("--db", type=Path, default=None, help="DB 경로 (기본: production 원장 규약 — §3.11)")
+    parser.add_argument("--n-perm", type=int, default=None, help="순열 수 override (기본: config permutation_n)")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help=f"순열 seed (기본 {DEFAULT_SEED}, 사전 고정)")
+    args = parser.parse_args(argv)
+
+    report = adjudicate(db_path=args.db, n_perm=args.n_perm, seed=args.seed)
+    report.pop("null_means", None)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/quant/validation/test_decision_alpha.py
+++ b/tests/quant/validation/test_decision_alpha.py
@@ -1,0 +1,199 @@
+"""decision_alpha 판정 도구 테스트 (#831, STRATEGY §3.11).
+
+Gotcha-Test Pair:
+- ticker-block placebo 의 핵심 계약 = "같은 ticker 의 반복 emit 은 null 에서도
+  같은 치환 ticker 를 공유" (의존 구조 상속). 이 계약이 깨지면 (iid 화) null
+  분산이 과소평가돼 anti-conservative p — §3.11 이 지정한 P1 결함의 재유입.
+- 결측 정의 = "창이 닫혔는데 alpha 미기록" — lookahead 미도래분을 결측으로
+  세면 측정 기간 내내 INVALID_MISSING 오탐.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.quant.validation import decision_alpha as da
+
+# ─── 합성 원장 픽스처 ───────────────────────────────────
+# declared_date(2026-07-08) 이후 emit + 판정창 30d 가 닫히도록 과거 날짜 사용 불가
+# (declared_date 는 사전 고정) → emit 은 2026-07-10~, as_of 를 미래로 주입해
+# 창을 닫는다 (adjudicate/fetch_sample 의 as_of 파라미터 — wall-clock 무의존,
+# time-bomb fixture 방지).
+
+EMIT_1 = "2026-07-10"
+EMIT_2 = "2026-07-13"
+EMIT_3 = "2026-07-15"  # recommendations UNIQUE(date, ticker) — 반복 emit 은 날짜가 달라야 함
+AS_OF = "2026-09-01"  # 모든 emit 의 30d 창 닫힘
+
+
+def _business_dates(start: str, days: int) -> list[str]:
+    """주말 제외 date 시퀀스 (합성 가격용)."""
+    out, d = [], date.fromisoformat(start)
+    while len(out) < days:
+        if d.weekday() < 5:
+            out.append(d.isoformat())
+        d += timedelta(days=1)
+    return out
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "adjudicate.db"
+    init_db(path)
+    return path
+
+
+def _seed_prices(db_path, ticker: str, start: str, days: int, base: float, drift: float):
+    """일정 drift 의 합성 close 시계열."""
+    dates = _business_dates(start, days)
+    with get_db(db_path) as conn:
+        for i, d in enumerate(dates):
+            conn.execute(
+                "INSERT OR REPLACE INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                (ticker, d, base * (1 + drift) ** i),
+            )
+        conn.commit()
+
+
+def _seed_decision(db_path, rec_id: int, ticker: str, emit: str, action: str = "BUY", alpha=None, window: int = 30):
+    """recommendations + agent_decisions (+ optional decision_outcomes) 1건."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO recommendations (id, date, ticker, action, confidence) VALUES (?, ?, ?, ?, 80.0)",
+            (rec_id, emit, ticker, action),
+        )
+        conn.execute(
+            """INSERT INTO agent_decisions
+               (decision_id, ticker, as_of_date, action, conviction, inputs_json, rationale_json, status)
+               VALUES (?, ?, ?, ?, 0.8, '{}', '{}', 'emitted')""",
+            (f"rec_{rec_id}", ticker, emit, action),
+        )
+        if alpha is not None:
+            conn.execute(
+                """INSERT INTO decision_outcomes
+                   (decision_id, observation_window, tracked_as_of_date, realized_return,
+                    benchmark_return, alpha, hit_threshold, hypothesis_validation)
+                   VALUES (?, ?, ?, ?, 0.0, ?, 0, 'pass')""",
+                (f"rec_{rec_id}", window, AS_OF, alpha, alpha),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def seeded(db_path):
+    """SPY + 치환 universe 3종 + 실표본 2 ticker 4 decision."""
+    # 가격: 7/1 부터 60 영업일 — 30d 창 + on_or_after 여유
+    _seed_prices(db_path, "SPY", "2026-07-01", 60, 100.0, 0.001)
+    _seed_prices(db_path, "AAA", "2026-07-01", 60, 50.0, 0.002)
+    _seed_prices(db_path, "BBB", "2026-07-01", 60, 80.0, 0.000)
+    _seed_prices(db_path, "CCC", "2026-07-01", 60, 30.0, 0.003)
+    _seed_prices(db_path, "TSLA", "2026-07-01", 60, 200.0, 0.004)
+    _seed_prices(db_path, "NVDA", "2026-07-01", 60, 150.0, 0.002)
+    # 실표본: TSLA 3회 반복 (블록), NVDA 1회
+    _seed_decision(db_path, 1, "TSLA", EMIT_1, alpha=0.05)
+    _seed_decision(db_path, 2, "TSLA", EMIT_2, alpha=0.08)
+    _seed_decision(db_path, 3, "TSLA", EMIT_3, alpha=0.03)
+    _seed_decision(db_path, 4, "NVDA", EMIT_1, alpha=-0.01)
+    return db_path
+
+
+# ═══════════════════════════════════════════════════════
+# 표본 규약 (§3.11)
+# ═══════════════════════════════════════════════════════
+
+
+class TestFetchSample:
+    def test_us_buy_only(self, seeded):
+        # KR / SELL / 기간 밖은 표본 제외
+        _seed_decision(seeded, 10, "005930.KS", EMIT_1, alpha=0.5)  # KR
+        _seed_decision(seeded, 11, "AAA", EMIT_1, action="SELL", alpha=0.5)  # SELL
+        _seed_decision(seeded, 12, "BBB", "2026-07-01", alpha=0.5)  # declared_date 이전
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n == 4
+        assert all(not d["ticker"].endswith(".KS") for d in s.decisions)
+
+    def test_missing_only_when_window_closed(self, seeded):
+        # 창 닫힘 + alpha 없음 → 결측 / 창 미도래 → 결측 아님 (lookahead)
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # closed, missing
+        _seed_decision(seeded, 21, "BBB", "2026-08-25", alpha=None)  # 창 미도래 (as_of 9/1)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n_missing_closed == 1
+        assert round(s.missing_rate_pct, 1) == round(1 / 5 * 100, 1)
+
+
+# ═══════════════════════════════════════════════════════
+# 순열 — ticker-block placebo 계약
+# ═══════════════════════════════════════════════════════
+
+
+class TestTickerBlockPlacebo:
+    def test_block_shares_single_substitute(self, seeded):
+        """Gotcha lock: 한 블록(반복 ticker)의 모든 emit 이 같은 치환 ticker 를 쓴다.
+
+        이 계약이 깨지면 null 이 iid 화 → 분산 과소평가 → anti-conservative p.
+        (구현상 치환 추첨은 블록당 1회 — `ticker_block_placebo` 의 per-ticker
+        rng.integers 1회 호출. 블록 구조는 `_blocks`/`_eligible_substitutes` 로 고정.)
+        """
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        blocks = da._blocks(s.decisions)
+        assert blocks["TSLA"] == [EMIT_1, EMIT_2, EMIT_3]
+
+        book = da.PriceBook(db_path=seeded)
+        eligible = da._eligible_substitutes(book, blocks, 30, "SPY", db_path=seeded)
+        # 치환 후보에 원 ticker 제외 + pseudo/benchmark 제외
+        assert "TSLA" not in eligible["TSLA"]
+        assert "SPY" not in eligible["TSLA"]
+        assert set(eligible["TSLA"]) <= {"AAA", "BBB", "CCC", "NVDA"}
+
+    def test_deterministic_p_with_same_seed(self, seeded):
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        r1 = da.ticker_block_placebo(s, n_perm=50, seed=828, db_path=seeded)
+        r2 = da.ticker_block_placebo(s, n_perm=50, seed=828, db_path=seeded)
+        assert r1.p_value == r2.p_value
+        assert r1.null_means == r2.null_means
+
+    def test_one_sided_p_bounds(self, seeded):
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        r = da.ticker_block_placebo(s, n_perm=50, seed=1, db_path=seeded)
+        assert 1 / 51 <= r.p_value <= 1.0
+        assert r.observed_mean == pytest.approx((0.05 + 0.08 + 0.03 - 0.01) / 4)
+
+
+# ═══════════════════════════════════════════════════════
+# 반기 분할 + 통합 판정
+# ═══════════════════════════════════════════════════════
+
+
+class TestAdjudicate:
+    def test_median_split_balanced(self, seeded):
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        halves = da.median_split_means(s)
+        assert halves["h1_n"] == 2 and halves["h2_n"] == 2
+
+    def test_progress_report_before_evaluation_date(self, seeded):
+        # as_of 가 evaluation_date (2027-06-30) 이전 → 조기 승격 금지
+        report = da.adjudicate(db_path=seeded, n_perm=20, as_of=AS_OF)
+        assert report["pre_evaluation"] is True
+        assert report["verdict"] == "PROGRESS_REPORT"
+        assert report["criteria_verdict_if_final"] == "INSUFFICIENT_N"  # n=4 < 200
+        assert report["permutation"]["scheme"] == "ticker_block_placebo"
+
+    def test_invalid_when_missing_exceeds_cap(self, seeded):
+        # 결측 6건 추가 → 6/10 = 60% > 15% cap → 판정 무효 우선
+        miss_dates = _business_dates("2026-07-16", 6)
+        for i, d in enumerate(miss_dates):
+            _seed_decision(seeded, 30 + i, "AAA", d, alpha=None)
+        report = da.adjudicate(db_path=seeded, n_perm=20, as_of=AS_OF)
+        assert report["missing_rate_pct"] > report["missing_max_pct"]
+        assert report["criteria_verdict_if_final"] == "INVALID_MISSING"
+
+    def test_no_sample(self, db_path):
+        report = da.adjudicate(db_path=db_path, n_perm=20, as_of=AS_OF)
+        assert report["verdict"] == "NO_SAMPLE"
+
+    def test_cli_smoke(self, seeded, capsys):
+        rc = da.main(["--db", str(seeded), "--n-perm", "20"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert '"verdict"' in out


### PR DESCRIPTION
Closes #831. §3.11 미구축 ②③ 구현.

## What
`nuri/quant/validation/decision_alpha.py` — 사전 고정 판정 기준의 실행 가능한 구현:
- **표본 규약**: US BUY · declared_date~emit_cutoff · distinct decision · 30d 창 · 원장 alpha 그대로 (재계산 금지 — 판정은 원장 쿼리만)
- **ticker-block placebo 순열**: 블록(반복 emit ticker)당 치환 1회 → null 이 중첩 창·동일일 배치·반복 종목 의존성을 상속 (naive iid 는 anti-conservative — 검증 패널 P1). one-sided p, N/threshold 는 rules.yaml 로드, 기본 seed 828 사전 고정 (reseed-shopping 방지)
- **median-split 반기** + **결측 공시/상한** (창 닫힘 기준 — lookahead 미도래분 미포함)
- **조기 승격 금지**: evaluation_date 이전엔 무조건 `PROGRESS_REPORT` (조건 스냅샷은 `criteria_verdict_if_final` 로 병기)
- 가격/창 의미론 tracker 미러 명시 (calendar-day add + on-or-after — `_add_business_days` 는 이름과 달리 calendar)

## Verification
- 테스트 10/10: 표본 필터 (KR/SELL/기간) · 블록 계약 lock (Gotcha-Test Pair) · seed 결정론 · 결측 vs lookahead · 판정 우선순위 (INVALID_MISSING > INSUFFICIENT_N > 3조건) · CLI smoke
- 실스키마 라이브 실행: `python -m nuri.quant.validation.decision_alpha` → `NO_SAMPLE` (사전등록 당일 — 정직한 결과)
- ruff clean · 픽스처는 as_of 주입으로 wall-clock 무의존 (time-bomb 방지, #721 교훈)

## Notes
- `/api/alpha` 는 §3.11 대로 NOT_MEASURABLE 유지 (미변경)
- pseudo-ticker 제외 상수는 #710 교훈 인용 (KOSDAQ degenerate fold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)