### PR TITLE
fix(ops): route remote ssh through -4 + dscacheutil fallback helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ sync-status:
 scheduler-reload-remote: ## Reload scheduler on Mac mini (nuri/scheduler.py 변경 반영)
 	@test -n "$$DEV2_HOST" || { echo "❌ DEV2_HOST 미설정. ~/.zshrc 에 export DEV2_HOST=ehbebe@Ehbebeui-Macmini.local 추가 필요"; exit 1; }
 	@echo "→ Mac mini scheduler reload..."
-	@ssh "$$DEV2_HOST" '\
+	@bash scripts/deploy/ssh_dev2.sh "$$DEV2_HOST" '\
 		launchctl unload ~/Library/LaunchAgents/com.nuri-quant.scheduler.plist 2>/dev/null; \
 		sleep 2; \
 		launchctl load ~/Library/LaunchAgents/com.nuri-quant.scheduler.plist && \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,173 backend tests across 273 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 274 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 273 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 274 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -31,6 +31,9 @@ REMOTE="${DEV2_HOST:-}"
 REMOTE_PATH="${DEV2_PATH:-~/workspace/nuri-quant}"
 PLIST_NAME="com.nuri-quant.scheduler.plist"
 
+# bare ssh 대신 공용 helper (#827) — ssh -4 강제 + .local 해석 실패 시 dscacheutil IPv4 fallback
+SSH="${SCRIPT_DIR}/ssh_dev2.sh"
+
 # ── 색상 ──
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -52,7 +55,7 @@ echo "  local HEAD: $(git log -1 --oneline)"
 
 # ── 1. SSH 연결 ──
 step 1 "SSH 연결 확인"
-if ssh -o BatchMode=yes -o ConnectTimeout=5 "${REMOTE}" "echo ok" >/dev/null 2>&1; then
+if "${SSH}" -o BatchMode=yes -o ConnectTimeout=5 "${REMOTE}" "echo ok" >/dev/null 2>&1; then
     ok "연결 성공"
 else
     fail "SSH 연결 실패. 네트워크/키 확인 필요"
@@ -60,15 +63,15 @@ fi
 
 # ── 2. 원격 git pull ──
 step 2 "원격 git pull (ff-only)"
-REMOTE_BEFORE=$(ssh "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse --short HEAD")
-ssh "${REMOTE}" "cd ${REMOTE_PATH} && git fetch origin main --quiet && git merge --ff-only origin/main --quiet" 2>&1 || true
-REMOTE_AFTER=$(ssh "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse --short HEAD")
+REMOTE_BEFORE=$("${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse --short HEAD")
+"${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git fetch origin main --quiet && git merge --ff-only origin/main --quiet" 2>&1 || true
+REMOTE_AFTER=$("${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse --short HEAD")
 
 if [[ "${REMOTE_BEFORE}" == "${REMOTE_AFTER}" ]]; then
     ok "이미 최신 (${REMOTE_AFTER})"
 else
     ok "${REMOTE_BEFORE} → ${REMOTE_AFTER}"
-    CHANGED_FILES=$(ssh "${REMOTE}" "cd ${REMOTE_PATH} && git diff --name-only ${REMOTE_BEFORE}..${REMOTE_AFTER}")
+    CHANGED_FILES=$("${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git diff --name-only ${REMOTE_BEFORE}..${REMOTE_AFTER}")
     echo "  변경 파일: $(echo "${CHANGED_FILES}" | wc -l | tr -d ' ')개"
 fi
 
@@ -79,8 +82,8 @@ for f in .env config/portfolio.yaml NEXT_SESSION.md; do
     if [[ -f "${PROJECT_ROOT}/${f}" ]]; then
         # 원격 디렉토리 보장
         REMOTE_DIR=$(dirname "${REMOTE_PATH}/${f}")
-        ssh "${REMOTE}" "mkdir -p ${REMOTE_DIR}" 2>/dev/null || true
-        scp -q "${PROJECT_ROOT}/${f}" "${REMOTE}:${REMOTE_PATH}/${f}"
+        "${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_DIR}" 2>/dev/null || true
+        scp -q -S "${SSH}" "${PROJECT_ROOT}/${f}" "${REMOTE}:${REMOTE_PATH}/${f}"
         ok "${f}"
         SYNC_COUNT=$((SYNC_COUNT + 1))
     else
@@ -107,11 +110,11 @@ echo "  ${SYNC_COUNT}개 파일 동기화"
 #   에 실행, (c) misfire_grace_time=300 가 부분 흡수. acceptable.
 PLIST_REMOTE="\$HOME/Library/LaunchAgents/${PLIST_NAME}"
 SCHEDULER_LABEL="${PLIST_NAME%.plist}"
-SCHEDULER_INSTALLED=$(ssh "${REMOTE}" "[ -f ${PLIST_REMOTE} ] && echo yes || echo no")
+SCHEDULER_INSTALLED=$("${SSH}" "${REMOTE}" "[ -f ${PLIST_REMOTE} ] && echo yes || echo no")
 
 # launchctl PID 조회 — running 시 숫자, 미실행/미등록 시 빈 문자열
 get_scheduler_pid() {
-    ssh "${REMOTE}" "launchctl list 2>/dev/null | awk -v label='${SCHEDULER_LABEL}' '\$3==label && \$1 ~ /^[0-9]+\$/ { print \$1; exit }'" || true
+    "${SSH}" "${REMOTE}" "launchctl list 2>/dev/null | awk -v label='${SCHEDULER_LABEL}' '\$3==label && \$1 ~ /^[0-9]+\$/ { print \$1; exit }'" || true
 }
 
 # polling: 20초 동안 0.5초 간격으로 condition (gone|alive) 체크.
@@ -147,7 +150,7 @@ step 4 "scheduler bounce + 의존성 동기화"
 
 # 4a. scheduler unload + verify PID 사라짐
 if [[ "${SCHEDULER_INSTALLED}" == "yes" ]]; then
-    ssh "${REMOTE}" "launchctl unload ${PLIST_REMOTE} 2>/dev/null" || true
+    "${SSH}" "${REMOTE}" "launchctl unload ${PLIST_REMOTE} 2>/dev/null" || true
     if wait_scheduler gone >/dev/null; then
         ok "scheduler unloaded (PID 사라짐 verified)"
     else
@@ -160,15 +163,15 @@ fi
 # 4b. uv sync --frozen (항상 실행, 1회 retry)
 # ssh non-interactive shell 은 ~/.zprofile 미로드 → homebrew PATH 누락. 명시 prepend 필수.
 SYNC_CMD="export PATH=/opt/homebrew/bin:\$PATH && cd ${REMOTE_PATH} && uv sync --extra dev --frozen --quiet"
-if ssh "${REMOTE}" "${SYNC_CMD}" 2>&1; then
+if "${SSH}" "${REMOTE}" "${SYNC_CMD}" 2>&1; then
     ok "uv sync --frozen 성공"
-elif sleep 5 && ssh "${REMOTE}" "${SYNC_CMD}" 2>&1; then
+elif sleep 5 && "${SSH}" "${REMOTE}" "${SYNC_CMD}" 2>&1; then
     ok "uv sync --frozen 성공 (retry 1회 후)"
 else
     # sync 실패 시 scheduler 재가동 시도 (이전 .venv 상태로라도 복구) 후 abort.
     # load + stable check — partial .venv 로 인한 crash-loop 도 감지.
     if [[ "${SCHEDULER_INSTALLED}" == "yes" ]]; then
-        ssh "${REMOTE}" "launchctl load ${PLIST_REMOTE} 2>/dev/null" || true
+        "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE} 2>/dev/null" || true
         if RECOVERY_PID=$(wait_scheduler alive) && verify_stable_pid "${RECOVERY_PID}"; then
             warn "sync 실패 — 이전 .venv 상태로 scheduler 재가동 성공 (PID ${RECOVERY_PID} stable)"
         else
@@ -181,10 +184,10 @@ fi
 # 4c. scheduler load + verify PID 살아남
 step 5 "scheduler 재기동"
 if [[ "${SCHEDULER_INSTALLED}" == "no" ]]; then
-    ssh "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && cp ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} ${PLIST_REMOTE}"
-    ssh "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
+    "${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && cp ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} ${PLIST_REMOTE}"
+    "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
 else
-    ssh "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
+    "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
 fi
 
 if NEW_PID=$(wait_scheduler alive) && verify_stable_pid "${NEW_PID}"; then
@@ -196,7 +199,7 @@ fi
 # ── 6. 최종 검증 ──
 step 6 "최종 검증"
 
-REMOTE_HEAD=$(ssh "${REMOTE}" "cd ${REMOTE_PATH} && git log -1 --oneline")
+REMOTE_HEAD=$("${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git log -1 --oneline")
 LOCAL_HEAD=$(git log -1 --oneline)
 if [[ "${REMOTE_HEAD}" == "${LOCAL_HEAD}" ]]; then
     ok "git HEAD 일치: ${LOCAL_HEAD}"
@@ -204,14 +207,14 @@ else
     warn "git HEAD 불일치 — local: ${LOCAL_HEAD} / remote: ${REMOTE_HEAD}"
 fi
 
-SCHEDULER_PID=$(ssh "${REMOTE}" "launchctl list | grep ${PLIST_NAME%.plist} | awk '{print \$1}'" 2>/dev/null || echo "-")
+SCHEDULER_PID=$("${SSH}" "${REMOTE}" "launchctl list | grep ${PLIST_NAME%.plist} | awk '{print \$1}'" 2>/dev/null || echo "-")
 if [[ "${SCHEDULER_PID}" != "-" && "${SCHEDULER_PID}" != "" ]]; then
     ok "scheduler running (PID ${SCHEDULER_PID})"
 else
     warn "scheduler 미실행 상태 — 수동 확인 필요"
 fi
 
-AUTOPULL_STATUS=$(ssh "${REMOTE}" "launchctl list | grep autopull | awk '{print \$1}'" 2>/dev/null || echo "-")
+AUTOPULL_STATUS=$("${SSH}" "${REMOTE}" "launchctl list | grep autopull | awk '{print \$1}'" 2>/dev/null || echo "-")
 ok "autopull: ${AUTOPULL_STATUS:-active}"
 
 echo ""

--- a/scripts/deploy/ssh_dev2.sh
+++ b/scripts/deploy/ssh_dev2.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# DEV2 원격 ssh 공용 helper — ssh -4 강제 + .local 해석 실패 시 dscacheutil IPv4 fallback (#827)
+#
+# 실측 문제 2건:
+#   (a) 외근망: IPv6 우선 해석 → No route to host  → ssh -4 로 IPv4 강제
+#   (b) 홈 LAN: .local 이름 해석 자체 실패          → dscacheutil -q host 로 IPv4 를 얻어 직접 접속
+#
+# 사용법 (ssh drop-in — 옵션은 destination 앞에 위치해야 함, 기존 호출처 전부 충족):
+#   scripts/deploy/ssh_dev2.sh [ssh옵션...] <[user@]host> [원격명령...]
+#   scp -S scripts/deploy/ssh_dev2.sh ...   # scp 전송 프로그램으로도 사용 가능
+#
+# 동작:
+#   1차: ssh -4 <원본 인자 그대로>
+#   1차가 exit 255 (ssh 연결층 실패 = 원격 명령 미실행) 인 경우에만:
+#     dscacheutil 로 IPv4 를 얻어 destination 을 IP 로 치환해 재시도.
+#     -o HostKeyAlias=<원래 host> 로 known_hosts 검증은 hostname 기준 유지.
+#   원격 명령 자체의 실패 (exit != 255) 는 재시도 없이 그대로 전파.
+
+set -euo pipefail
+
+usage() {
+    echo "usage: ssh_dev2.sh [ssh options...] <[user@]host> [remote command...]" >&2
+    exit 2
+}
+
+(( $# >= 1 )) || usage
+
+# ── destination (첫 non-option 인자) 탐색 ──
+args=("$@")
+dest_idx=-1
+i=0
+while (( i < ${#args[@]} )); do
+    case "${args[i]}" in
+        --)
+            # scp -S 가 '-- host cmd...' 형태로 호출 — 다음 인자가 destination
+            dest_idx=$((i + 1))
+            break
+            ;;
+        -o | -l | -p | -i | -F | -E | -J | -b | -c | -e | -m | -w | -B | -D | -L | -R | -W | -S)
+            # 값을 별도 인자로 받는 옵션 — 다음 인자를 값으로 소비
+            i=$((i + 2))
+            ;;
+        -*)
+            i=$((i + 1))
+            ;;
+        *)
+            dest_idx=$i
+            break
+            ;;
+    esac
+done
+if (( dest_idx < 0 || dest_idx >= ${#args[@]} )); then usage; fi
+dest="${args[dest_idx]}"
+
+# user@ 접두 분리 (없으면 빈 문자열)
+userpart=""
+host="${dest}"
+if [[ "${dest}" == *@* ]]; then
+    userpart="${dest%%@*}@"
+    host="${dest#*@}"
+fi
+
+# ── 1차 시도: IPv4 강제 (외근망 IPv6 우선 해석 → no-route 회피) ──
+rc=0
+ssh -4 "$@" || rc=$?
+if (( rc != 255 )); then
+    exit "${rc}"
+fi
+
+# ── 2차 시도: dscacheutil IPv4 fallback (.local 이름 해석 실패 시) ──
+if [[ "${host}" =~ ^[0-9]+(\.[0-9]+){3}$ ]]; then
+    exit "${rc}"  # 이미 IPv4 literal — fallback 무의미
+fi
+
+ip="$(dscacheutil -q host -a name "${host}" 2>/dev/null | awk '/^ip_address:/ { print $2; exit }' || true)"
+if [[ -z "${ip}" ]]; then
+    echo "ssh_dev2: dscacheutil 로도 '${host}' IPv4 해석 실패 — fallback 불가 (exit ${rc})" >&2
+    exit "${rc}"
+fi
+
+echo "ssh_dev2: ssh 연결 실패 (255) → dscacheutil fallback: ${host} → ${ip}" >&2
+
+# destination 을 IP 로 치환 후 재시도 — known_hosts 는 HostKeyAlias 로 원래 hostname 기준 검증
+args[dest_idx]="${userpart}${ip}"
+exec ssh -4 -o "HostKeyAlias=${host}" "${args[@]}"

--- a/tests/scripts/test_ssh_dev2.py
+++ b/tests/scripts/test_ssh_dev2.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/deploy/ssh_dev2.sh — ssh -4 + dscacheutil IPv4 fallback helper (#827).
+
+Network-free: PATH 앞에 stub ssh/dscacheutil 을 주입해 분기 검증.
+(a) 외근망 IPv6 no-route → -4 강제, (b) .local 해석 실패 → dscacheutil IP fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+HELPER = Path(__file__).parent.parent.parent / "scripts" / "deploy" / "ssh_dev2.sh"
+
+HOST = "devtwo.local"
+DEST = f"deploy@{HOST}"
+FAKE_IP = "192.168.0.99"
+
+# dscacheutil -q host 실제 출력 형식 재현
+DSCACHEUTIL_OK = f"name: {HOST}\\nip_address: {FAKE_IP}"
+
+
+def _make_stub(bin_dir: Path, name: str, body: str) -> None:
+    """호출 인자를 로그에 남기는 실행 가능 stub 생성."""
+    path = bin_dir / name
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n")
+    path.chmod(0o755)
+
+
+def _run(bin_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    return subprocess.run(
+        ["bash", str(HELPER), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _setup(tmp_path: Path, ssh_body: str, dscacheutil_body: str = "exit 0") -> tuple[Path, Path]:
+    log = tmp_path / "calls.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_stub(bin_dir, "ssh", f'echo "ssh $*" >> "{log}"\n{ssh_body}')
+    _make_stub(bin_dir, "dscacheutil", f'echo "dscacheutil $*" >> "{log}"\n{dscacheutil_body}')
+    return bin_dir, log
+
+
+def test_first_attempt_success_forces_ipv4_no_fallback(tmp_path):
+    """정상 연결: ssh -4 1회 호출, fallback 없음."""
+    bin_dir, log = _setup(tmp_path, "exit 0")
+    r = _run(bin_dir, DEST, "echo ok")
+    assert r.returncode == 0
+    assert log.read_text().splitlines() == [f"ssh -4 {DEST} echo ok"]
+
+
+def test_exit_255_falls_back_to_dscacheutil_ip(tmp_path):
+    """연결 실패 (255): dscacheutil IPv4 로 destination 치환 + HostKeyAlias 재시도."""
+    ssh_body = f'case "$*" in *{FAKE_IP}*) exit 0;; *) exit 255;; esac'
+    bin_dir, log = _setup(tmp_path, ssh_body, f'printf "{DSCACHEUTIL_OK}\\n"')
+    r = _run(bin_dir, DEST, "echo ok")
+    assert r.returncode == 0
+    calls = log.read_text().splitlines()
+    assert calls == [
+        f"ssh -4 {DEST} echo ok",
+        f"dscacheutil -q host -a name {HOST}",
+        f"ssh -4 -o HostKeyAlias={HOST} deploy@{FAKE_IP} echo ok",
+    ]
+    assert f"{HOST} → {FAKE_IP}" in r.stderr
+
+
+def test_fallback_preserves_leading_options(tmp_path):
+    """옵션 (-o k=v) 뒤의 destination 만 IP 로 치환 — 옵션/원격명령은 그대로."""
+    ssh_body = f'case "$*" in *{FAKE_IP}*) exit 0;; *) exit 255;; esac'
+    bin_dir, log = _setup(tmp_path, ssh_body, f'printf "{DSCACHEUTIL_OK}\\n"')
+    r = _run(bin_dir, "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", DEST, "echo ok")
+    assert r.returncode == 0
+    assert log.read_text().splitlines()[-1] == (
+        f"ssh -4 -o HostKeyAlias={HOST} -o BatchMode=yes -o ConnectTimeout=5 deploy@{FAKE_IP} echo ok"
+    )
+
+
+def test_scp_style_double_dash_destination(tmp_path):
+    """scp -S 호출 형태 (-l user ... -- host cmd): '--' 다음 인자가 destination."""
+    ssh_body = f'case "$*" in *{FAKE_IP}*) exit 0;; *) exit 255;; esac'
+    bin_dir, log = _setup(tmp_path, ssh_body, f'printf "{DSCACHEUTIL_OK}\\n"')
+    r = _run(bin_dir, "-x", "-oForwardAgent=no", "-l", "deploy", "--", HOST, "scp", "-t", "/tmp/x")
+    assert r.returncode == 0
+    assert log.read_text().splitlines()[-1] == (
+        f"ssh -4 -o HostKeyAlias={HOST} -x -oForwardAgent=no -l deploy -- {FAKE_IP} scp -t /tmp/x"
+    )
+
+
+def test_remote_command_failure_no_retry(tmp_path):
+    """원격 명령 실패 (exit 1): 연결층 실패가 아니므로 재시도 없이 그대로 전파."""
+    bin_dir, log = _setup(tmp_path, "exit 1")
+    r = _run(bin_dir, DEST, "false")
+    assert r.returncode == 1
+    assert len(log.read_text().splitlines()) == 1  # ssh 1회만 — dscacheutil 미호출
+
+
+def test_dscacheutil_no_ip_exits_255(tmp_path):
+    """dscacheutil 도 해석 실패: fallback 불가 메시지 + 원래 exit 255 유지."""
+    bin_dir, log = _setup(tmp_path, "exit 255", "exit 0")
+    r = _run(bin_dir, DEST, "echo ok")
+    assert r.returncode == 255
+    assert "fallback 불가" in r.stderr
+    calls = log.read_text().splitlines()
+    assert calls[0] == f"ssh -4 {DEST} echo ok"
+    assert calls[1].startswith("dscacheutil ")
+    assert len(calls) == 2  # ssh 재시도 없음
+
+
+def test_ipv4_literal_destination_skips_fallback(tmp_path):
+    """destination 이 이미 IPv4 literal: dscacheutil fallback 무의미 — 즉시 255."""
+    bin_dir, log = _setup(tmp_path, "exit 255")
+    r = _run(bin_dir, f"deploy@{FAKE_IP}", "echo ok")
+    assert r.returncode == 255
+    assert len(log.read_text().splitlines()) == 1  # dscacheutil 미호출
+
+
+def test_no_destination_usage_error(tmp_path):
+    """destination 없이 옵션만: usage 에러 (exit 2)."""
+    bin_dir, _ = _setup(tmp_path, "exit 0")
+    r = _run(bin_dir, "-o", "BatchMode=yes")
+    assert r.returncode == 2
+    assert "usage:" in r.stderr


### PR DESCRIPTION
Closes #827

## Why now
반복 마찰 실측 2건: (a) 외근망 IPv6 우선 해석 → bare ssh no-route, (b) 2026-07-07 홈 LAN 에서도 `.local` 이름 해석 실패 — `dscacheutil` 로 IP 얻어 직접 접속만 성공. `make scheduler-reload-remote` / `make deploy-mini` 가 bare `ssh $DEV2_HOST` 사용 중이었음.

## What
- **`scripts/deploy/ssh_dev2.sh` (신규, drop-in ssh wrapper)**
  - 1차: `ssh -4 <원본 인자>` — IPv6 우선 해석 회피
  - 1차 exit 255 (ssh 연결층 실패 = 원격 명령 미실행) 시에만: `dscacheutil -q host -a name <host>` 로 IPv4 를 얻어 destination 치환 후 재시도. `-o HostKeyAlias=<원래 host>` 로 known_hosts 검증은 hostname 기준 유지 (IP 접속 시 host-key 프롬프트 방지)
  - 원격 명령 자체 실패 (exit != 255) 는 재시도 없이 그대로 전파 — 이중 실행 없음
  - scp 의 `-S` 전송 프로그램 규약 (`-l user -- host cmd`) 도 지원
- **`Makefile`** `scheduler-reload-remote`: `@ssh "$$DEV2_HOST"` → `@bash scripts/deploy/ssh_dev2.sh "$$DEV2_HOST"` (1줄)
- **`scripts/deploy/deploy_to_mini.sh`**: 전 ssh 호출 (17곳) 을 helper 경유로, scp 는 `-S "${SSH}"` 추가. 그 외 로직 변경 없음

스코프 유지: `dev_sync.sh` / `sync_dev.sh` / `state_replicator.sh` / `deploy_remote.sh` 의 bare ssh 는 이슈 scope 밖 (Makefile 원격 ssh 타겟 = scheduler-reload-remote + deploy-mini) — 필요 시 별도 이슈로 동일 helper 적용 가능.

## Verification
- **회귀 테스트** `tests/scripts/test_ssh_dev2.py` (8개, PATH 앞에 stub ssh/dscacheutil 주입 — network-free, Linux CI 에서도 동작): 1차 성공 시 `-4` 강제 + 무재시도 / 255→IP fallback + HostKeyAlias / 옵션 보존 / scp `--` 규약 / 원격 명령 실패 무재시도 / dscacheutil 실패 시 255 유지 / IPv4 literal skip / usage 에러 → **8 passed**
- `tests/scripts/` 전체 243 passed / ruff clean / shellcheck (helper + deploy_to_mini.sh) clean / `make lint-sh` pass / `bash -n` OK / `make -n scheduler-reload-remote` 로 recipe 확인
- **라이브 (MBP → Mac mini)**:
  - `bash scripts/deploy/ssh_dev2.sh -o BatchMode=yes -o ConnectTimeout=5 "$DEV2_HOST" "echo ok && hostname"` → `ok` + `Ehbebeui-Macmini.local` (정상망 1차 경로)
  - fallback 재시도와 동일 형태 명령 수동 실행: `dscacheutil` → `192.168.45.x` 해석 후 `ssh -4 -o HostKeyAlias=Ehbebeui-Macmini.local <ip> "echo fallback-path-ok"` → 성공 (host-key 프롬프트 없음)
  - 존재하지 않는 host: 1차 255 → fallback 시도 → 최종 255 + 진단 메시지 (무한루프/행 없음)
- **수동 검증 절차 (해석 실패 환경 재현 시)**: .local 해석이 깨진 망에서 `make scheduler-reload-remote` 실행 → stderr 에 `ssh_dev2: ... dscacheutil fallback: <host> → <ip>` 후 reload 성공하면 acceptance 충족

🤖 Generated with [Claude Code](https://claude.com/claude-code)