### PR TITLE
feat(tracking): backfill regime labels on recommendations (diagnostic only, §3.11 ①) (#832)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,173 backend tests across 273 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 274 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,173 backend tests across 274 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 275 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 274 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 275 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 273 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 274 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/regime/classifier.py
+++ b/nuri/quant/regime/classifier.py
@@ -227,6 +227,16 @@ SPECIAL_REGIMES: tuple[str, ...] = tuple(SPECIAL_REGIME_SIZING.keys())
 ALL_REGIMES: tuple[str, ...] = BASE_REGIMES + SPECIAL_REGIMES  # 6 + 4 = 10
 
 
+def canonical_regime_or_none(value: str | None) -> str | None:
+    """ALL_REGIMES 원소만 통과, 그 외(빈문자열·free-text)는 None (#832).
+
+    recommendations.regime 컬럼은 canonical 10-regime 값 또는 NULL 만 허용 —
+    "" / "[recovery] 비중 축소" 같은 free-text 유입이 라벨 커버리지 3% 의 원인이었음.
+    진단 전용 라벨 (STRATEGY §3.11 이 regime 을 판정 축에서 제외).
+    """
+    return value if value in ALL_REGIMES else None
+
+
 def _detect_euphoria(vix: float | None, fear_greed: float | None) -> bool:
     """VIX < 12 AND Fear&Greed > 80 → 시장 과열."""
     if vix is None or fear_greed is None:

--- a/nuri/trading/agents/consensus/persistence.py
+++ b/nuri/trading/agents/consensus/persistence.py
@@ -35,15 +35,15 @@ def save_to_recommendations(results: list[ConsensusResult], db_path=None) -> int
     today = today_kst()
 
     # PR A: regime 을 한 번 classify 해 배치 전체에 공유 (codex Q3 권고 — per-ticker
-    # classify 는 ~30ms × N 추가 latency). 실패 시 None 으로 폴백 (legacy 동작
-    # 유지), tracker.py 가 이후 backfill.
+    # classify 는 ~30ms × N 추가 latency). 실패 시 None 으로 폴백 (legacy 동작 유지).
+    # #832: canonical ALL_REGIMES 값만 저장 — free-text 유입 시 NULL 로 정규화.
     batch_regime: str | None = None
     try:
-        from nuri.quant.regime.classifier import classify_regime
+        from nuri.quant.regime.classifier import canonical_regime_or_none, classify_regime
 
         rr = classify_regime(db_path=db_path)
         if rr is not None:
-            batch_regime = rr.regime
+            batch_regime = canonical_regime_or_none(rr.regime)
     except Exception:
         logger.debug("save_to_recommendations: regime classify 실패, NULL 유지", exc_info=True)
 

--- a/nuri/trading/recommend/tracker.py
+++ b/nuri/trading/recommend/tracker.py
@@ -67,6 +67,19 @@ def save_recommendations(candidates=None, actions=None, verdicts=None, db_path=N
     today = today_kst()
     records = []
 
+    # #832: regime 라벨 batch 1회 classify (consensus persistence.py 와 동일 패턴).
+    # 기존 E-1 "" / E-2 free-text(regime_note) 유입이 라벨 커버리지 3% 의 원인.
+    # canonical ALL_REGIMES 값만 저장, 분류 실패 시 NULL 유지 ('unknown' 금지).
+    batch_regime: str | None = None
+    try:
+        from nuri.quant.regime.classifier import canonical_regime_or_none, classify_regime
+
+        rr = classify_regime(db_path=db_path)
+        if rr is not None:
+            batch_regime = canonical_regime_or_none(rr.regime)
+    except Exception:
+        logger.debug("save_recommendations: regime classify 실패, NULL 유지", exc_info=True)
+
     # held set 한 번만 fetch — SELL/TRIM filter 용. set 검사 O(1).
     held_rows = query(
         "SELECT DISTINCT ticker FROM portfolio WHERE quantity > 0",
@@ -96,7 +109,7 @@ def save_recommendations(candidates=None, actions=None, verdicts=None, db_path=N
                 "alpha_action": derive_alpha_action(c.direction),
                 "portfolio_action": None,  # E-1 signal-driven — portfolio rule 아님
                 "confidence": c.confidence,
-                "regime": "",
+                "regime": batch_regime,  # #832: "" 대신 canonical 라벨 (분류 실패 시 NULL)
                 "signals": json.dumps([c.signal_id]),
                 "entry_price": c.price,
             }
@@ -141,7 +154,9 @@ def save_recommendations(candidates=None, actions=None, verdicts=None, db_path=N
                 "alpha_action": derive_alpha_action(a.action),
                 "portfolio_action": None,  # E-2 rebalance 는 legacy 경로. PR C 에서 재분류.
                 "confidence": 50.0,  # 리밸런싱 기반은 기본 50
-                "regime": a.regime_note,
+                # #832: regime_note 는 free-text ("[recovery] 비중 축소" 등) 라 regime
+                # 컬럼 오염 원인 — canonical batch 라벨로 대체 (note 는 컬럼 미persist).
+                "regime": batch_regime,
                 "signals": json.dumps(a.signals),
                 "entry_price": price,
             }

--- a/scripts/ops/backfill_regime_labels.py
+++ b/scripts/ops/backfill_regime_labels.py
@@ -1,0 +1,112 @@
+"""recommendations.regime 라벨 백필 (#832 — 진단 전용, STRATEGY §3.11 판정 비사용).
+
+과거 recommendations 행의 regime 을 해당 date 기준 `classify_regime(date=...)` 역산으로
+채운다. 라벨은 진단 대시보드/리포트 전용 — 판정 로직에 연결하지 않는다.
+
+규칙:
+- canonical ALL_REGIMES 값이 이미 있는 행은 건드리지 않음 (멱등 — 재실행 시 skip)
+- 당시 시점 데이터 부족(SPY < 200일 등)으로 분류 불가한 행은 NULL 유지 ('unknown' 라벨 금지)
+- 빈문자열·free-text ("[recovery] 비중 축소" 등) 행은 재분류, 재분류 불가 시 NULL 로 정규화
+  (emit 경로가 canonical-or-NULL invariant 를 강제하므로 원장도 동일 상태로 수렴)
+
+사용법:
+    .venv/bin/python scripts/ops/backfill_regime_labels.py --dry-run   # 변경 미리보기 (write 없음)
+    .venv/bin/python scripts/ops/backfill_regime_labels.py             # 실제 백필
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _coverage(db_path=None) -> tuple[int, int]:
+    """(canonical 라벨 행 수, 전체 행 수) 반환."""
+    from nuri.core.db import query
+    from nuri.quant.regime.classifier import ALL_REGIMES
+
+    placeholders = ",".join("?" * len(ALL_REGIMES))
+    total = query("SELECT COUNT(*) AS c FROM recommendations", db_path=db_path)[0]["c"]
+    labeled = query(
+        f"SELECT COUNT(*) AS c FROM recommendations WHERE regime IN ({placeholders})",
+        tuple(ALL_REGIMES),
+        db_path=db_path,
+    )[0]["c"]
+    return labeled, total
+
+
+def backfill_regime_labels(db_path=None, dry_run: bool = False) -> dict:
+    """비-canonical regime 행을 date 기준 classify_regime 역산으로 백필.
+
+    Returns:
+        stats dict — candidates / relabeled / normalized_null / kept_null /
+        unclassifiable_dates / coverage_before / coverage_after
+    """
+    from nuri.core.db import get_db, query
+    from nuri.quant.regime.classifier import ALL_REGIMES, canonical_regime_or_none, classify_regime
+
+    labeled_before, total = _coverage(db_path)
+
+    placeholders = ",".join("?" * len(ALL_REGIMES))
+    rows = query(
+        f"SELECT id, date, regime FROM recommendations WHERE regime IS NULL OR regime NOT IN ({placeholders})",
+        tuple(ALL_REGIMES),
+        db_path=db_path,
+    )
+
+    # date 별 1회 classify (같은 날 행들이 라벨 공유 — emit 경로 batch classify 와 동일 semantic)
+    regime_by_date: dict[str, str | None] = {}
+    for d in sorted({r["date"] for r in rows}):
+        state = classify_regime(date=d, db_path=db_path)
+        regime_by_date[d] = canonical_regime_or_none(state.regime) if state is not None else None
+
+    updates: list[tuple[str | None, int]] = []
+    stats = {
+        "candidates": len(rows),
+        "relabeled": 0,  # canonical 라벨 채움
+        "normalized_null": 0,  # 빈문자열/free-text 인데 분류 불가 → NULL 정규화
+        "kept_null": 0,  # NULL 인데 분류 불가 → NULL 유지
+    }
+    for r in rows:
+        label = regime_by_date.get(r["date"])
+        if label is not None:
+            updates.append((label, r["id"]))
+            stats["relabeled"] += 1
+        elif r["regime"] is not None:
+            updates.append((None, r["id"]))
+            stats["normalized_null"] += 1
+        else:
+            stats["kept_null"] += 1
+
+    if updates and not dry_run:
+        with get_db(db_path) as conn:
+            conn.executemany("UPDATE recommendations SET regime = ? WHERE id = ?", updates)
+
+    labeled_after = labeled_before if dry_run else _coverage(db_path)[0]
+    stats["unclassifiable_dates"] = sorted(d for d, v in regime_by_date.items() if v is None)
+    stats["coverage_before"] = f"{labeled_before}/{total}"
+    stats["coverage_after"] = f"{labeled_after}/{total}" + (" (dry-run, write 없음)" if dry_run else "")
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="recommendations.regime 라벨 백필 (#832)")
+    parser.add_argument("--dry-run", action="store_true", help="DB write 없이 변경 예정 카운트만 출력")
+    args = parser.parse_args(argv)
+
+    stats = backfill_regime_labels(dry_run=args.dry_run)
+    print(f"백필 대상 행: {stats['candidates']}")
+    print(f"  canonical 라벨 채움: {stats['relabeled']}")
+    print(f"  free-text/빈문자열 → NULL 정규화 (분류 불가): {stats['normalized_null']}")
+    print(f"  NULL 유지 (분류 불가): {stats['kept_null']}")
+    if stats["unclassifiable_dates"]:
+        print(f"  분류 불가 날짜: {', '.join(stats['unclassifiable_dates'])}")
+    print(f"커버리지: {stats['coverage_before']} → {stats['coverage_after']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_backfill_regime_labels.py
+++ b/tests/scripts/test_backfill_regime_labels.py
@@ -1,0 +1,98 @@
+"""Tests for scripts/ops/backfill_regime_labels.py — recommendations.regime 백필 (#832).
+
+#832 Gotcha-Test Pair (b): 백필 멱등성 — 재실행 시 이미 canonical 라벨된 행 skip.
+tmp_path DB 격리 (tests/CLAUDE.md), 티커/가격은 전부 합성 placeholder (privacy).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nuri.core.db import get_db, init_db, query, upsert_prices
+from nuri.core.timezone import today_kst
+from scripts.ops.backfill_regime_labels import backfill_regime_labels
+
+
+@pytest.fixture
+def seeded_db(tmp_path):
+    """SPY 260 영업일 (today_kst 앵커 — time-bomb 방지) + 비-canonical regime 행 6개."""
+    path = tmp_path / "test.db"
+    init_db(path)
+
+    # 완만한 상승 추세 → classify_regime 이 deterministic 하게 canonical 라벨 반환
+    dates = pd.bdate_range(end=today_kst(), periods=260)
+    rows = []
+    for i, d in enumerate(dates):
+        p = 100.0 + i * 0.5
+        rows.append(
+            {
+                "ticker": "SPY",
+                "date": d.strftime("%Y-%m-%d"),
+                "open": p,
+                "high": p + 1,
+                "low": p - 1,
+                "close": p,
+                "volume": 1_000_000,
+                "adj_close": p,
+            }
+        )
+    upsert_prices(pd.DataFrame(rows), path)
+
+    recent = dates[-3].strftime("%Y-%m-%d")
+    with get_db(path) as conn:
+        conn.executemany(
+            "INSERT INTO recommendations (date, ticker, action, confidence, regime, signals, entry_price) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (recent, "TEST1", "BUY", 70.0, None, "[]", 100.0),  # NULL → 라벨
+                (recent, "TEST2", "BUY", 70.0, "", "[]", 100.0),  # 빈문자열 → 라벨
+                (recent, "TEST3", "SELL", 60.0, "[recovery] 비중 축소", "[]", 100.0),  # free-text → 라벨
+                (recent, "TEST4", "BUY", 70.0, "bear_high_vol", "[]", 100.0),  # canonical → skip
+                ("2020-01-02", "TEST5", "BUY", 70.0, None, "[]", 100.0),  # 데이터 이전 → NULL 유지
+                ("2020-01-03", "TEST6", "BUY", 70.0, "junk", "[]", 100.0),  # 분류불가 free-text → NULL 정규화
+            ],
+        )
+    return path
+
+
+def _regimes(db_path) -> dict[str, str | None]:
+    rows = query("SELECT ticker, regime FROM recommendations", db_path=db_path)
+    return {r["ticker"]: r["regime"] for r in rows}
+
+
+class TestBackfill:
+    def test_backfill_labels_noncanonical_rows(self, seeded_db):
+        from nuri.quant.regime.classifier import ALL_REGIMES
+
+        stats = backfill_regime_labels(db_path=seeded_db)
+
+        assert stats["candidates"] == 5  # TEST4 (canonical) 제외
+        assert stats["relabeled"] == 3  # TEST1/2/3
+        assert stats["kept_null"] == 1  # TEST5
+        assert stats["normalized_null"] == 1  # TEST6
+
+        regimes = _regimes(seeded_db)
+        for t in ("TEST1", "TEST2", "TEST3"):
+            assert regimes[t] in ALL_REGIMES, f"{t} 는 canonical 라벨이어야 함"
+        assert regimes["TEST4"] == "bear_high_vol", "이미 canonical 인 행은 미변경"
+        assert regimes["TEST5"] is None, "분류 불가 NULL 행은 NULL 유지 ('unknown' 금지)"
+        assert regimes["TEST6"] is None, "분류 불가 free-text 는 NULL 로 정규화"
+
+    def test_backfill_idempotent_on_rerun(self, seeded_db):
+        """재실행 시 이미 라벨된 행 skip — 결과/행 값 불변 (멱등성)."""
+        backfill_regime_labels(db_path=seeded_db)
+        first = _regimes(seeded_db)
+
+        stats2 = backfill_regime_labels(db_path=seeded_db)
+        assert stats2["candidates"] == 2  # TEST5 + TEST6 (둘 다 NULL 잔존) 만 재후보
+        assert stats2["relabeled"] == 0
+        assert stats2["normalized_null"] == 0
+        assert stats2["kept_null"] == 2
+        assert _regimes(seeded_db) == first, "재실행이 어떤 행도 바꾸지 않아야 함"
+
+    def test_dry_run_writes_nothing(self, seeded_db):
+        before = _regimes(seeded_db)
+        stats = backfill_regime_labels(db_path=seeded_db, dry_run=True)
+        assert stats["relabeled"] == 3  # 변경 예정 카운트는 보고
+        assert _regimes(seeded_db) == before, "dry-run 은 DB write 없음"

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -1617,6 +1617,35 @@ class TestSaveToRecommendations:
         assert rows[0]["confidence"] == 50.0
         assert rows[0]["id"] == first_id, "ON CONFLICT DO UPDATE 는 id 보존 — FK 안전"
 
+    def test_regime_label_canonical_only(self, db_path):
+        """#832 Gotcha-Test Pair: regime 컬럼은 canonical ALL_REGIMES 값 또는 NULL 만.
+
+        canonical guard (`canonical_regime_or_none`) 를 제거하면 free-text 케이스가
+        그대로 persist 되어 이 테스트가 fail. 진단 전용 라벨 (STRATEGY §3.11).
+        """
+        from unittest.mock import patch
+
+        from nuri.core.db import query
+        from nuri.quant.regime.classifier import RegimeState
+        from nuri.trading.agents.consensus import save_to_recommendations
+
+        def _state(regime):
+            return RegimeState(
+                date="2026-01-02", trend="bull", volatility="low", regime=regime, confidence=0.8, details={}
+            )
+
+        # canonical 값 → 그대로 저장
+        with patch("nuri.quant.regime.classifier.classify_regime", return_value=_state("bull_low_vol")):
+            save_to_recommendations([self._result(ticker="CANON")], db_path=db_path)
+        row = query("SELECT regime FROM recommendations WHERE ticker='CANON'", db_path=db_path)[0]
+        assert row["regime"] == "bull_low_vol"
+
+        # free-text → NULL 로 정규화 (오염 차단)
+        with patch("nuri.quant.regime.classifier.classify_regime", return_value=_state("[recovery] 비중 축소")):
+            save_to_recommendations([self._result(ticker="FREET")], db_path=db_path)
+        row = query("SELECT regime FROM recommendations WHERE ticker='FREET'", db_path=db_path)[0]
+        assert row["regime"] is None
+
 
 class TestScoringDetailPersist:
     """Phase 2 A-2a — scoring_detail JSON persist + shape 검증.

--- a/tests/trading/recommend/test_tracker.py
+++ b/tests/trading/recommend/test_tracker.py
@@ -1308,3 +1308,71 @@ class TestTrackOutcomesEntryZeroGuard:
 
         updated = tracker_mod.track_outcomes(db_path=db)
         assert updated == 0  # entry=0 → continue → no update
+
+
+class TestRegimeLabelEmit:
+    """#832 Gotcha-Test Pair: save_recommendations 의 regime 라벨 저장 회귀 방지.
+
+    기존 E-1 경로는 `"regime": ""`, E-2 경로는 free-text `regime_note` 를 그대로
+    persist 해 라벨 커버리지 3% 의 원인이었음. batch classify + canonical guard 로
+    되돌아가면 (regime="" / regime=regime_note 복원) 이 테스트가 fail.
+    진단 전용 라벨 — STRATEGY §3.11 이 regime 을 판정 축에서 제외.
+    """
+
+    @staticmethod
+    def _regime_state(regime: str):
+        from nuri.quant.regime.classifier import RegimeState
+
+        return RegimeState(
+            date="2026-01-02", trend="bull", volatility="low", regime=regime, confidence=0.8, details={}
+        )
+
+    def test_e1_candidate_saves_canonical_regime(self, rich_db):
+        """E-1 후보 저장 시 batch classify 라벨이 regime 컬럼에 기록 ("" 회귀 방지)."""
+        from nuri.trading.recommend.candidates import Candidate
+        from nuri.trading.recommend.tracker import save_recommendations
+
+        with patch(
+            "nuri.quant.regime.classifier.classify_regime",
+            return_value=self._regime_state("bull_low_vol"),
+        ):
+            candidates = [
+                Candidate("AAPL", "rsi_oversold", "2026-01-02", "BUY", 75.0, 0.6, 2.0, True, 170.0, "test"),
+            ]
+            assert save_recommendations(candidates=candidates, db_path=rich_db) == 1
+
+        row = query("SELECT regime FROM recommendations WHERE ticker='AAPL'", db_path=rich_db)[0]
+        assert row["regime"] == "bull_low_vol"
+
+    def test_e2_action_never_saves_freetext_regime_note(self, rich_db):
+        """E-2 액션의 free-text regime_note 가 regime 컬럼에 유입되지 않음."""
+        from nuri.trading.recommend.tracker import save_recommendations
+
+        action = MagicMock()
+        action.ticker = "AAPL"
+        action.action = "BUY"
+        action.signals = ["rebalance"]
+        action.regime_note = "[recovery] 비중 축소"
+
+        with patch(
+            "nuri.quant.regime.classifier.classify_regime",
+            return_value=self._regime_state("recovery"),
+        ):
+            assert save_recommendations(actions=[action], db_path=rich_db) == 1
+
+        row = query("SELECT regime FROM recommendations WHERE ticker='AAPL'", db_path=rich_db)[0]
+        assert row["regime"] == "recovery"
+
+    def test_classify_failure_keeps_null_not_empty_string(self, rich_db):
+        """classify 실패(None) 시 regime 은 NULL — "" 나 'unknown' 금지."""
+        from nuri.trading.recommend.candidates import Candidate
+        from nuri.trading.recommend.tracker import save_recommendations
+
+        with patch("nuri.quant.regime.classifier.classify_regime", return_value=None):
+            candidates = [
+                Candidate("AAPL", "rsi_oversold", "2026-01-02", "BUY", 75.0, 0.6, 2.0, True, 170.0, "test"),
+            ]
+            assert save_recommendations(candidates=candidates, db_path=rich_db) == 1
+
+        row = query("SELECT regime FROM recommendations WHERE ticker='AAPL'", db_path=rich_db)[0]
+        assert row["regime"] is None


### PR DESCRIPTION
Closes #832

## Root cause (라벨 커버리지 3%)

`recommendations.regime` 에는 write 경로가 2개뿐인데, 둘 다 canonical 라벨을 안정적으로 넣지 못했다:

1. **`tracker.py` E-1 (candidates) 경로** — `"regime": ""` 하드코딩 → 빈문자열 오염
2. **`tracker.py` E-2 (rebalance) 경로** — `"regime": a.regime_note` free-text (`"[recovery] 비중 축소"` 등) → free-text 오염
3. **`consensus/persistence.py`** — batch classify 는 있었으나 canonical 검증 지점 없음 + 주석의 "tracker.py 가 이후 backfill" 은 존재하지 않는 phantom (tracker 에 regime backfill 없음). NULL 대부분은 batch classify wiring (PR A) 이전 행 + classify 실패 폴백.

## Fix (진단 전용 — STRATEGY §3.11 판정 축 비연결)

- `nuri/quant/regime/classifier.py` — `canonical_regime_or_none()` 추가 (ALL_REGIMES 단일 소스 옆, 10-regime 값만 통과)
- `nuri/trading/recommend/tracker.py` — `save_recommendations` 가 batch 1회 `classify_regime` 후 E-1/E-2 모두 canonical 라벨 또는 NULL 저장 (`""` / free-text / `'unknown'` 금지)
- `nuri/trading/agents/consensus/persistence.py` — batch regime 을 canonical guard 로 검증
- `scripts/ops/backfill_regime_labels.py` — 과거 행을 `classify_regime(date=...)` 역산으로 백필. 멱등 (canonical 행 skip), 분류 불가 행은 NULL 유지 + 사유 카운트, `--dry-run` 지원

## 검증

- `pytest tests/trading/ tests/scripts/ tests/quant/regime/ -m "not slow"` → **1865 passed, 1 skipped**
- ruff clean, privacy scan clean
- Gotcha-Test Pair:
  - (a) emit 회귀: `tests/trading/recommend/test_tracker.py::TestRegimeLabelEmit` (3 tests) + `tests/trading/agents/test_consensus.py::TestSaveToRecommendations::test_regime_label_canonical_only`
  - (b) 백필 멱등성: `tests/scripts/test_backfill_regime_labels.py` (재실행 시 relabeled=0, 행 값 불변)
- **dev 로컬 DB dry-run 실측 (read-only, write 없음)**: candidates 168 (NULL 156 + `""` 9 + free-text 3), relabeled 168, kept_null 0 → 커버리지 149/317 → 317/317 (100%, acceptance ≥ 95% 충족 예상)

## 프로덕션 백필 실행 절차 (Mac mini 원장 — 이 PR 에서는 실행하지 않음)

```bash
# 1. 머지 + Mac mini 코드 반영 후 (autopull 또는 make deploy-mini)
cd ~/workspace/nuri-quant

# 2. DB 백업
scripts/db/backup.sh

# 3. 미리보기 (write 없음) — relabeled / kept_null 카운트 확인
.venv/bin/python scripts/ops/backfill_regime_labels.py --dry-run

# 4. 실제 백필 (멱등 — 재실행 안전)
.venv/bin/python scripts/ops/backfill_regime_labels.py

# 5. 커버리지 검증 (≥ 95%)
.venv/bin/python -c "
from nuri.core.db import query
from nuri.quant.regime.classifier import ALL_REGIMES
ph = ','.join('?'*len(ALL_REGIMES))
total = query('SELECT COUNT(*) c FROM recommendations')[0]['c']
ok = query(f'SELECT COUNT(*) c FROM recommendations WHERE regime IN ({ph})', tuple(ALL_REGIMES))[0]['c']
print(f'{ok}/{total} = {ok/total:.1%}')"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
