### PR TITLE
feat(signals): record signal-evaluation heartbeat to split no-fire from outage

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ Configured in `.env` (see `.env.example`):
 - `KIS_PROD_APP_KEY` / `KIS_PROD_APP_SECRET` — KIS Open API live (optional; falls back to `config/kis/kis_devlp.yaml`, gitignored)
 - `KIS_PAPER_APP_KEY` / `KIS_PAPER_APP_SECRET` — KIS Open API paper (optional)
 ## DB Schema (SQLite, WAL mode)
-51 tables total (44 migrations as of 2026-05-05). Key tables:
+51 tables total (45 migrations as of 2026-07-08). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -5,10 +5,10 @@
 Layer A 설계 (Codex Round 5):
 - 100% rule-based — threshold 비교 (LLM 추론 X)
 - ZERO LLM
-- 6 detector 모두 결정적 (DB query + filesystem stat)
+- 7 detector 모두 결정적 (DB query + filesystem stat)
 - 모든 incident → audit_ledger + incidents 테이블 영구 기록
 
-6 Detector:
+7 Detector:
     1. orphan_run         — agent_run_ledger started + finished_at IS NULL + >1h
                             warning (1h+) / critical (3h+)
     2. disk_full          — shutil.disk_usage() percent_used > 80 (warn) / > 90 (crit)
@@ -19,6 +19,8 @@ Layer A 설계 (Codex Round 5):
                             3회 (warn) / 5회 (crit)
     6. data_freshness_critical — check_all_freshness() FAIL 개수:
                             ≥1 (warn) / ≥3 (crit)
+    7. signal_evaluation_stale — pipeline_events 'signal_evaluation_run'
+                            heartbeat 공백 영업일 (#825): ≥2 (warn) / ≥4 (crit)
 
 Idempotent semantics:
 - 동일 (incident_type, target) 의 open incident 는 단일 row → log_incident() 가
@@ -35,6 +37,7 @@ Discord routing:
 from __future__ import annotations
 
 import shutil
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +52,7 @@ from nuri.core.db import (
 from nuri.core.db import (
     resolve_incident as db_resolve_incident,
 )
+from nuri.core.timezone import kst_now, to_kst
 
 # ─── 임계값 (config 가능 — 추후 rules.yaml 이관) ──────────
 ORPHAN_WARN_HOURS = 1.0
@@ -61,6 +65,13 @@ FAILURE_STREAK_WARN = 3
 FAILURE_STREAK_CRIT = 5
 FRESHNESS_FAIL_WARN = 1
 FRESHNESS_FAIL_CRIT = 3
+# 시그널 평가 heartbeat 공백 (#825) — 영업일 단위 (KST 화~토, technical cron '0 7 * * 2-6')
+SIGNAL_EVAL_WARN_DAYS = 2
+SIGNAL_EVAL_CRIT_DAYS = 4
+# 당일은 이 시각(KST) 이후부터 미실행으로 계상 — 07:00 cron 전 새벽 scan false positive 방지
+SIGNAL_EVAL_GRACE_HOUR = 12
+# 평가 예정 요일 (Mon=0 기준 화~토 — 미국 거래일 마감 다음 날 아침 KST)
+SIGNAL_EVAL_WEEKDAYS = (1, 2, 3, 4, 5)
 
 HEARTBEAT_PATH = Path(__file__).resolve().parents[3] / "data" / ".scheduler_heartbeat"
 
@@ -70,7 +81,7 @@ class SREIncidentAgent(Actor):
     """Operational incident detection + lifecycle management — Layer A.
 
     Actions (input_data['action']):
-        scan        — 6 detector 모두 실행 → log_incident + Discord publish.
+        scan        — 7 detector 모두 실행 → log_incident + Discord publish.
         acknowledge — incident_id 사용자 확인 (audit-only).
         resolve     — incident_id 종료 (status='resolved').
         list_open   — open incident 목록 (severity 필터 optional).
@@ -110,7 +121,7 @@ class SREIncidentAgent(Actor):
     # ─── scan ────────────────────────────────────────────────
 
     def _scan(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
-        """6 detector 실행 → 발견된 incident 목록 반환."""
+        """7 detector 실행 → 발견된 incident 목록 반환."""
         detected: list[dict[str, Any]] = []
 
         for detector in (
@@ -120,6 +131,7 @@ class SREIncidentAgent(Actor):
             self._detect_scheduler_heartbeat,
             self._detect_actor_failure_streak,
             self._detect_data_freshness_critical,
+            self._detect_signal_evaluation_stale,
         ):
             try:
                 detected.extend(detector(ctx))
@@ -331,6 +343,43 @@ class SREIncidentAgent(Actor):
             )
         ]
 
+    def _detect_signal_evaluation_stale(self, ctx: RunContext) -> list[dict[str, Any]]:
+        """pipeline_events 'signal_evaluation_run' heartbeat 공백 검사 (#825).
+
+        signals 테이블은 발화(계산) 행만 저장 → 무기록이 '조건 미충족(정상)'인지
+        '평가 미실행(고장)'인지 구분 불가 (#734 silent outage 계열). technical
+        collector 가 평가마다 heartbeat 1행 (fired_count=0 포함) 을 남기고,
+        여기서 공백 영업일(KST 화~토) 수를 센다.
+
+        heartbeat 행이 전무하면 skip (미배포/신규 DB — scheduler_heartbeat 와 동일).
+        """
+        rows = query(
+            """SELECT MAX(timestamp) AS last_run FROM pipeline_events
+               WHERE event_type = 'signal_evaluation_run'"""
+        )
+        last_run = rows[0]["last_run"] if rows else None
+        if not last_run:
+            return []
+        missed = _missed_eval_days(str(last_run), kst_now())
+        if missed < SIGNAL_EVAL_WARN_DAYS:
+            return []
+        severity = "critical" if missed >= SIGNAL_EVAL_CRIT_DAYS else "warning"
+        evidence = {
+            "last_evaluated_at_utc": str(last_run),
+            "missed_eval_days": missed,
+            "warn_threshold_days": SIGNAL_EVAL_WARN_DAYS,
+            "critical_threshold_days": SIGNAL_EVAL_CRIT_DAYS,
+        }
+        return [
+            self._record_incident(
+                incident_type="signal_evaluation_stale",
+                severity=severity,
+                target="signals",
+                evidence=evidence,
+                ctx=ctx,
+            )
+        ]
+
     # ─── helpers ─────────────────────────────────────────────
 
     def _record_incident(
@@ -494,6 +543,32 @@ class SREIncidentAgent(Actor):
             pass
 
 
+def _missed_eval_days(last_run_utc: str, now: datetime) -> int:
+    """마지막 heartbeat 이후 놓친 평가 예정일(KST 화~토) 수 (#825).
+
+    pipeline_events.timestamp 는 sqlite DEFAULT datetime('now') = **UTC** —
+    KST 변환 없이 날짜를 자르면 07:00 KST 실행분이 전날로 밀려 1일 과대 계상
+    (07:00 KST = 전날 22:00 UTC).
+    **Test:** tests/agents/test_sre_incident_agent.py::TestMissedEvalDays
+    ::test_utc_timestamp_converted_to_kst — to_kst 변환을 제거하면 FAIL.
+
+    당일은 SIGNAL_EVAL_GRACE_HOUR(KST) 이후에만 미실행으로 계상 —
+    07:00 cron 이 아직 안 돈 새벽 scan 의 false positive 방지.
+    """
+    last_utc = datetime.strptime(last_run_utc[:19].replace("T", " "), "%Y-%m-%d %H:%M:%S")
+    last_date = to_kst(last_utc).date()  # to_kst 는 naive 를 UTC 로 간주
+    today = now.date()
+    missed = 0
+    day = last_date + timedelta(days=1)
+    while day <= today:
+        if day == today and now.hour < SIGNAL_EVAL_GRACE_HOUR:
+            break
+        if day.weekday() in SIGNAL_EVAL_WEEKDAYS:
+            missed += 1
+        day += timedelta(days=1)
+    return missed
+
+
 def _human_incident_summary(incident_type: str, target: str, evidence: dict[str, Any]) -> str:
     """인시던트 영향을 담은 사람이 읽는 한 줄 (evidence 수치 활용).
 
@@ -515,6 +590,11 @@ def _human_incident_summary(incident_type: str, target: str, evidence: dict[str,
     if incident_type == "data_freshness_critical":
         keys = ", ".join((e.get("fail_keys") or [])[:3])
         return f"데이터 소스 {e.get('fail_count', 0)}개 stale: {keys}"
+    if incident_type == "signal_evaluation_stale":
+        return (
+            f"{target} — {e.get('missed_eval_days', 0)}영업일째 시그널 평가 미실행 "
+            f"(마지막 {e.get('last_evaluated_at_utc', '?')} UTC)"
+        )
     return f"{incident_type} on {target}"
 
 

--- a/nuri/agents/discord/outbox.py
+++ b/nuri/agents/discord/outbox.py
@@ -490,6 +490,11 @@ _SRE_KIND_META: dict[str, dict[str, str]] = {
         "what": "복수 데이터 소스가 stale — 판단 근거 신뢰도 저하",
         "action": "조치: 해당 collector 수동 실행 / 수집 스케줄 점검",
     },
+    "sre_signal_evaluation_stale": {
+        "label": "🫀 시그널 평가 중단",
+        "what": "시그널 평가 heartbeat 공백 — 발화 0건(정상)과 평가 미실행(고장) 구분 불가 상태",
+        "action": "조치: `python -m nuri.collectors.technical` 수동 실행 / 스케줄러 점검",
+    },
 }
 
 

--- a/nuri/collectors/technical.py
+++ b/nuri/collectors/technical.py
@@ -19,6 +19,7 @@ import talib
 
 from nuri.collectors.base import BaseCollector
 from nuri.core.db import query_df, upsert_signals
+from nuri.core.events import emit_event
 
 
 class TechnicalCollector(BaseCollector):
@@ -112,10 +113,16 @@ class TechnicalCollector(BaseCollector):
         }
 
     def save(self, data: pd.DataFrame) -> int:
-        """기술적 지표를 DB에 저장."""
-        if data.empty:
-            return 0
-        return upsert_signals(data)
+        """기술적 지표를 DB에 저장 + 평가 heartbeat 1행 기록 (#825).
+
+        발화(계산) 0건이어도 heartbeat 는 남긴다 — signals 무기록이
+        '조건 미충족(정상)'인지 '평가 미실행(고장)'인지 pipeline_events 로 구분.
+        **Test:** tests/collectors/test_technical.py::TestSignalEvaluationHeartbeat
+        ::test_save_empty_still_emits_heartbeat — emit 을 empty 분기 안으로 되돌리면 FAIL.
+        """
+        fired_count = 0 if data.empty else upsert_signals(data)
+        emit_event("signal_evaluation_run", record_count=fired_count)
+        return fired_count
 
 
 if __name__ == "__main__":

--- a/nuri/core/db/execution_ops.py
+++ b/nuri/core/db/execution_ops.py
@@ -38,6 +38,7 @@ _INCIDENT_TYPES = (
     "scheduler_heartbeat",
     "actor_failure_streak",
     "data_freshness_critical",
+    "signal_evaluation_stale",
 )
 _INCIDENT_SEVERITIES = ("critical", "warning", "info")
 _INCIDENT_STATUSES = ("open", "acknowledged", "resolved")

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1394,4 +1394,40 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_postmortem_vix ON market_postmortem(vix, session);
     """,
     ),
+    (
+        45,
+        "incidents incident_type enum 확장 — signal_evaluation_stale (#825)",
+        # signals 테이블은 발화 행만 저장 → 평가 heartbeat (pipeline_events
+        # 'signal_evaluation_run') 공백이 N영업일 이상이면 SRE incident 로 surface.
+        # SQLite 는 CHECK 제약 변경 미지원 → 신 테이블 + INSERT SELECT + DROP +
+        # RENAME 패턴 (migration 42 와 동일). 기존 row 100% 보존.
+        """
+        CREATE TABLE incidents_new (
+            incident_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            incident_type TEXT NOT NULL CHECK(incident_type IN (
+                'orphan_run','disk_full','db_lock','scheduler_heartbeat',
+                'actor_failure_streak','data_freshness_critical','signal_evaluation_stale'
+            )),
+            severity TEXT NOT NULL CHECK(severity IN ('critical','warning','info')),
+            target TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('open','acknowledged','resolved')),
+            first_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+            last_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+            resolved_at TEXT,
+            evidence_json TEXT NOT NULL,
+            run_id TEXT,
+            UNIQUE(incident_type, target, status)
+        );
+        INSERT INTO incidents_new
+            (incident_id, incident_type, severity, target, status,
+             first_detected_at, last_detected_at, resolved_at, evidence_json, run_id)
+            SELECT incident_id, incident_type, severity, target, status,
+                   first_detected_at, last_detected_at, resolved_at, evidence_json, run_id
+              FROM incidents;
+        DROP TABLE incidents;
+        ALTER TABLE incidents_new RENAME TO incidents;
+        CREATE INDEX IF NOT EXISTS idx_incidents_status ON incidents(status, severity);
+        CREATE INDEX IF NOT EXISTS idx_incidents_type ON incidents(incident_type, last_detected_at);
+    """,
+    ),
 ]

--- a/nuri/core/events.py
+++ b/nuri/core/events.py
@@ -39,6 +39,12 @@ EVENT_TYPES = {
     "holdings_monitor_run",
     "holdings_monitor_technical_sell",
     "holdings_monitor_divergence",
+    # Signal-evaluation heartbeat (#825) — signals 테이블은 발화(계산) 행만 저장하므로
+    # 무기록이 '조건 미충족(정상)'인지 '평가 미실행(고장)'인지 구분 불가 (#734 계열).
+    # technical collector 가 평가 실행마다 1행 기록 (record_count=fired_count, 0 포함).
+    # emitter: nuri/collectors/technical.py save() /
+    # consumer: SREIncidentAgent._detect_signal_evaluation_stale.
+    "signal_evaluation_run",
 }
 
 # 6-step 파이프라인

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -3,8 +3,8 @@
 검증 (Codex Round 5 Layer A):
 - Layer A enforcement (outcome 필수, ZERO LLM)
 - 4 actions: scan / acknowledge / resolve / list_open
-- 6 detector 각각 (orphan_run / disk_full / db_lock / scheduler_heartbeat /
-  actor_failure_streak / data_freshness_critical)
+- 7 detector 각각 (orphan_run / disk_full / db_lock / scheduler_heartbeat /
+  actor_failure_streak / data_freshness_critical / signal_evaluation_stale)
 - Idempotent UNIQUE(incident_type,target,status='open') — 재detection 시 신규 row X
 - resolve 후 재발 시 신규 incident_id (status 가 UNIQUE 의 일부)
 - Discord publish — critical=INCIDENTS, warning=OPS, 재detection 시 publish 차단
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,8 +30,11 @@ from nuri.agents.actors.sre_incident_agent import (
     FRESHNESS_FAIL_WARN,
     ORPHAN_CRIT_HOURS,
     ORPHAN_WARN_HOURS,
+    SIGNAL_EVAL_CRIT_DAYS,
+    SIGNAL_EVAL_WARN_DAYS,
     SREIncidentAgent,
     _human_incident_summary,
+    _missed_eval_days,
     main,
 )
 from nuri.agents.base import Layer, Outcome
@@ -43,6 +47,7 @@ from nuri.core.db import (
     resolve_incident,
     start_agent_run,
 )
+from nuri.core.timezone import KST
 
 # ═══════════════════════════════════════════════════════
 # Fixtures
@@ -496,6 +501,101 @@ class TestDataFreshnessCriticalDetector:
         assert len(fr) == 1
         assert fr[0]["severity"] == "critical"
         assert fr[0]["evidence"]["fail_count"] >= FRESHNESS_FAIL_CRIT
+
+
+# ═══════════════════════════════════════════════════════
+# Detector: signal_evaluation_stale (#825)
+# ═══════════════════════════════════════════════════════
+
+# 고정 now (KST 2026-07-08 수요일 13:00, grace hour 이후) — kst_now 를 patch 하므로
+# wall-clock 무관 (time-bomb seed 아님, tests/CLAUDE.md 참고). seed timestamp 는
+# pipeline_events.timestamp 컨벤션(UTC, DEFAULT datetime('now')) 그대로 사용.
+_EVAL_FIXED_NOW = datetime(2026, 7, 8, 13, 0, tzinfo=KST)  # 수요일
+
+
+def _seed_signal_eval(db_path, ts_utc: str):
+    """pipeline_events 에 signal_evaluation_run heartbeat 1행 삽입 (timestamp 명시)."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO pipeline_events (event_type, timestamp, record_count) VALUES ('signal_evaluation_run', ?, 0)",
+            (ts_utc,),
+        )
+
+
+class TestSignalEvaluationStaleDetector:
+    """#825 Gotcha-Test Pair — 'N영업일째 평가 미실행' 시나리오.
+
+    heartbeat (signal_evaluation_run) 공백 영업일(KST 화~토) ≥ 2 → warning,
+    ≥ 4 → critical. heartbeat 전무 → skip (미배포/신규 DB).
+    """
+
+    def _scan_stale(self, now=_EVAL_FIXED_NOW):
+        actor = SREIncidentAgent()
+        with (
+            patch("nuri.agents.actors.sre_incident_agent.kst_now", return_value=now),
+            patch("nuri.core.freshness.check_all_freshness", return_value=[]),
+            patch(
+                "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
+                return_value=MagicMock(total=1000, used=100, free=900),
+            ),
+        ):
+            result = actor.run({"action": "scan"})
+        return [i for i in result.output["incidents"] if i["incident_type"] == "signal_evaluation_stale"]
+
+    def test_no_alert_when_no_heartbeat_rows(self, patched_db, no_publish):
+        """heartbeat 행 전무 → skip (미배포/신규 DB false positive 방지)."""
+        assert self._scan_stale() == []
+
+    def test_no_alert_when_evaluated_today(self, patched_db, no_publish):
+        """당일 07:00 KST 평가 (= UTC 전날 22:00) → 공백 0 → alert 없음."""
+        _seed_signal_eval(patched_db, "2026-07-07 22:00:00")
+        assert self._scan_stale() == []
+
+    def test_warning_at_2_missed_eval_days(self, patched_db, no_publish):
+        """마지막 평가 토 07:00 KST → 화+수 2영업일 미실행 → warning (주말 미계상)."""
+        _seed_signal_eval(patched_db, "2026-07-03 22:00:00")  # 토 2026-07-04 07:00 KST
+        out = self._scan_stale()
+        assert len(out) == 1
+        assert out[0]["severity"] == "warning"
+        assert out[0]["target"] == "signals"
+        # UTC→KST 변환 lock: KST 오독 시 토요일까지 계상돼 3이 된다.
+        assert out[0]["evidence"]["missed_eval_days"] == SIGNAL_EVAL_WARN_DAYS
+
+    def test_critical_at_4plus_missed_eval_days(self, patched_db, no_publish):
+        """마지막 평가 수 07:00 KST (1주 전) → 목금토화수 5영업일 미실행 → critical."""
+        _seed_signal_eval(patched_db, "2026-06-30 22:00:00")  # 수 2026-07-01 07:00 KST
+        out = self._scan_stale()
+        assert len(out) == 1
+        assert out[0]["severity"] == "critical"
+        assert out[0]["evidence"]["missed_eval_days"] >= SIGNAL_EVAL_CRIT_DAYS
+
+    def test_latest_heartbeat_wins(self, patched_db, no_publish):
+        """오래된 heartbeat 가 있어도 최신 행 기준으로 판정."""
+        _seed_signal_eval(patched_db, "2026-06-30 22:00:00")
+        _seed_signal_eval(patched_db, "2026-07-07 22:00:00")
+        assert self._scan_stale() == []
+
+
+class TestMissedEvalDays:
+    """_missed_eval_days 헬퍼 단위 검증 (pure function)."""
+
+    def test_utc_timestamp_converted_to_kst(self):
+        """UTC 전날 22:00 = 당일 07:00 KST → 공백 0. to_kst 변환 제거 시 1로 FAIL."""
+        assert _missed_eval_days("2026-07-07 22:00:00", _EVAL_FIXED_NOW) == 0
+
+    def test_grace_hour_excludes_today_before_noon(self):
+        """오전 scan 은 당일을 미계상 — 07:00 cron 전 false positive 방지."""
+        morning = datetime(2026, 7, 8, 9, 0, tzinfo=KST)  # 수 09:00 < grace 12:00
+        assert _missed_eval_days("2026-07-03 22:00:00", morning) == 1  # 화요일만
+
+    def test_weekend_not_counted(self):
+        """일·월요일(평가 예정일 아님)은 공백으로 계상하지 않는다."""
+        monday = datetime(2026, 7, 6, 15, 0, tzinfo=KST)  # 월 15:00
+        assert _missed_eval_days("2026-07-03 22:00:00", monday) == 0
+
+    def test_weekday_streak_counted(self):
+        """평일 연속 공백은 하루 1씩 계상."""
+        assert _missed_eval_days("2026-06-30 22:00:00", _EVAL_FIXED_NOW) == 5
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/agents/test_state_replicator_dr.py
+++ b/tests/agents/test_state_replicator_dr.py
@@ -218,7 +218,7 @@ class TestVerifyAction:
             role="replica",
             hostname="mbp-test",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=44,
+            last_sync_schema_version=45,  # 현행 schema version (#825 migration 45)
             sync_lag_seconds=120,
             status="healthy",
             db_path=patched_db,

--- a/tests/collectors/test_technical.py
+++ b/tests/collectors/test_technical.py
@@ -171,17 +171,29 @@ class TestComputeForTicker:
         assert "rsi_14" in result.columns
 
 
-class TestSaveEmpty:
-    """save(empty) → 0 (line 112)."""
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    """save() 가 default DB 를 쓰므로 (upsert_signals + emit_event) tmp 로 redirect."""
+    import nuri.core.db as db_mod
+    from nuri.core.db import init_db
 
-    def test_empty_returns_zero(self):
+    path = tmp_path / "test.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+class TestSaveEmpty:
+    """save(empty) → 0 (heartbeat 는 별도 — TestSignalEvaluationHeartbeat)."""
+
+    def test_empty_returns_zero(self, isolated_db):
         from nuri.collectors.technical import TechnicalCollector
 
         c = TechnicalCollector()
         assert c.save(pd.DataFrame()) == 0
 
-    def test_non_empty_calls_upsert(self, monkeypatch):
-        """non-empty → upsert_signals 호출 (line 113)."""
+    def test_non_empty_calls_upsert(self, isolated_db, monkeypatch):
+        """non-empty → upsert_signals 호출."""
         from nuri.collectors import technical as tech_mod
 
         called = {"n": 0}
@@ -196,6 +208,66 @@ class TestSaveEmpty:
         result = c.save(df)
         assert result == 1
         assert called["n"] == 1
+
+
+class TestSignalEvaluationHeartbeat:
+    """#825 Gotcha-Test Pair — 평가 실행마다 pipeline_events heartbeat 1행.
+
+    signals 테이블은 발화(계산) 행만 저장 → 발화 0건이어도 'evaluated,
+    fired_count=0' 기록이 남아야 '조건 미충족(정상)' vs '평가 미실행(고장)'
+    구분 가능 (#734 silent outage 계열).
+    """
+
+    @staticmethod
+    def _heartbeats(path):
+        from nuri.core.db import query
+
+        return query(
+            "SELECT record_count FROM pipeline_events WHERE event_type = 'signal_evaluation_run'",
+            db_path=path,
+        )
+
+    def test_save_empty_still_emits_heartbeat(self, isolated_db):
+        """발화 0건인 날에도 heartbeat 1행 — emit 을 empty 분기 뒤로 되돌리면 FAIL."""
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        assert c.save(pd.DataFrame()) == 0
+        rows = self._heartbeats(isolated_db)
+        assert len(rows) == 1
+        assert rows[0]["record_count"] == 0
+
+    def test_save_rows_emits_heartbeat_with_fired_count(self, isolated_db):
+        """발화 N건 → heartbeat record_count=N."""
+        from nuri.collectors.technical import TechnicalCollector
+
+        row = {
+            "ticker": "AAA",
+            "date": "2024-01-31",
+            "rsi_14": 50.0,
+            "macd": 0.1,
+            "macd_signal": 0.1,
+            "macd_hist": 0.0,
+            "bb_upper": 101.0,
+            "bb_middle": 100.0,
+            "bb_lower": 99.0,
+            "sma_20": 100.0,
+            "sma_50": 100.0,
+            "sma_200": None,
+            "ema_12": 100.0,
+            "ema_26": 100.0,
+        }
+        c = TechnicalCollector()
+        assert c.save(pd.DataFrame([row])) == 1
+        rows = self._heartbeats(isolated_db)
+        assert len(rows) == 1
+        assert rows[0]["record_count"] == 1
+
+    def test_event_type_registered(self):
+        """EVENT_TYPES whitelist 등록 lock — 제거 시 관측성 계약 위반."""
+        from nuri.core.events import EVENT_TYPES
+
+        assert "signal_evaluation_run" in EVENT_TYPES
 
 
 class TestTechnicalExpectedCountGuard:

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,10 +29,11 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_44(self, db_path):
+    def test_schema_version_at_45(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
-        held_add_shadow (#518) + market_postmortem (#596 Phase 2) → 44."""
-        assert get_schema_version(db_path) == 44
+        held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
+        incidents signal_evaluation_stale enum 확장 (#825) → 45."""
+        assert get_schema_version(db_path) == 45
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
Closes #825

## Why now
`signals` 테이블은 발화한 시그널만 저장 → 2026-07-03 이후 무기록이 '조건 미충족(정상)'인지 '평가 미실행(고장)'인지 판별 불가 (#734 silent outage 계열). 측정 기간 중 조용한 공백은 사후 복구 불가.

## What
- **Heartbeat emitter** — `TechnicalCollector.save()` 가 매 평가마다 `pipeline_events` 에 `signal_evaluation_run` 1행 기록 (`record_count`=fired_count, **0건 포함**). 기존 append-only 저널 재사용 — 새 테이블 불필요.
- **SRE 7th detector** — `SREIncidentAgent._detect_signal_evaluation_stale`: heartbeat 공백 평가 예정일(KST 화~토, technical cron `0 7 * * 2-6`) ≥2일 → warning, ≥4일 → critical. 임계값은 기존 detector 관례대로 모듈 상수 (`SIGNAL_EVAL_WARN_DAYS=2` 등, 추후 rules.yaml 이관 주석 동일). heartbeat 전무 시 skip (scheduler_heartbeat 패턴 — 미배포 DB false positive 방지). UTC(`datetime('now')`)→KST 변환 + grace hour(12시 이전 당일 미계상) 처리.
- **Migration 45** — `incidents.incident_type` CHECK 에 `signal_evaluation_stale` 추가 (migration 42 rebuild 패턴, 기존 row 100% 보존). forward-only, `_MIGRATIONS` 끝에 append.
- **Alert readability** — `_SRE_KIND_META` + `_human_incident_summary` 항목 추가 (의미+영향+조치).

## Acceptance (issue #825)
- ✅ 발화 0건인 날에도 '평가 수행' 행: `test_save_empty_still_emits_heartbeat`
- ✅ 감지 쿼리 1개: `SELECT MAX(timestamp) FROM pipeline_events WHERE event_type='signal_evaluation_run'`
- ✅ Gotcha-Test Pair: `TestSignalEvaluationStaleDetector` (2일 warning / 4일+ critical / 미배포 skip / 최신행 기준) + `TestMissedEvalDays` (UTC→KST lock, grace hour, 주말 미계상) — 코드 docstring 에 test 인용

## Verification
- `ruff check` clean (변경 파일 전체)
- 전체 fast suite: **6160 passed, 6 skipped** (`-m 'not slow'`)
- 라이브 E2E: 빈 save → heartbeat 1행 → 7일 백데이트 → `scan` 이 `signal_evaluation_stale` critical 감지 (missed_eval_days=4) 확인
- Migration transition 검증: v36 형태 incidents + 기존 row → migration 45 SQL 적용 → row 보존 + 신규 enum insert OK + UNIQUE 유지
- privacy scan (인자 없이 diff 스캔) 통과

## Notes (scope 밖 발견 — 별도 이슈 후보)
- `tests/collectors/test_macro.py::test_collect_prefers_fred` 가 `_collect_toss_fx` 를 mock 하지 않아 **실제 Toss API 호출** — `.env` 가 dotenv parent-dir 탐색으로 발견되는 로컬 환경(worktree 포함)에서 라이브 환율이 오면 실패 + `config/toss/cache/token.json` 에 라이브 토큰 캐시 기록. CI 는 creds 부재로 영향 없음. 본 PR 과 무관하여 미수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)