### PR TITLE
fix(discord): repair /health script path drift from #557 + class-wide path lock

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,173 backend tests across 272 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 273 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,173 backend tests across 271 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,173 backend tests across 272 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 272 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 273 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 271 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,173 tests, 272 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/discord/bot.py
+++ b/nuri/agents/discord/bot.py
@@ -34,6 +34,10 @@ logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
+# health check 스크립트 경로 — #557 scripts/ 7-subdir 리팩터로 이동 (#846 경로 drift fix).
+# 상수 노출 → tests/test_script_path_lock.py sweep 이 실존 검증.
+HEALTH_CHECK_SCRIPT = "scripts/ops/health_check.sh"
+
 # .env auto-load — `python -m` / launchd 양쪽 다 동일하게 작동.
 load_dotenv(REPO_ROOT / ".env")
 
@@ -123,7 +127,7 @@ def build_bot():
         def _run() -> tuple[int, str]:
             try:
                 proc = subprocess.run(
-                    ["bash", "scripts/health_check.sh"],
+                    ["bash", HEALTH_CHECK_SCRIPT],
                     cwd=REPO_ROOT,
                     capture_output=True,
                     text=True,

--- a/tests/test_script_path_lock.py
+++ b/tests/test_script_path_lock.py
@@ -1,0 +1,47 @@
+"""스크립트 경로 drift 클래스 킬러 (#846, Gotcha-Test Pair).
+
+#557 scripts/ 7-subdir 리팩터가 만든 silent 고장 3건 중 2건이 실증됨:
+- scheduler backup (scripts/backup.sh → db/) — 2개월 무백업 (#836)
+- discord /health (scripts/health_check.sh → ops/) — rc=127 (#846)
+
+개별 상수 lock 대신, nuri/ 소스의 "scripts/…" 리터럴을 전수 수집해 실존을
+검증한다 — 다음 리팩터가 어떤 스크립트를 옮겨도 이 테스트가 즉시 FAIL.
+mock-only 테스트 (subprocess patch) 로는 경로 drift 를 못 잡는다 (§5.3).
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# "scripts/foo/bar.sh" / 'scripts/x.py' 형태의 문자열 리터럴
+_SCRIPT_LITERAL = re.compile(r"""["'](scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))["']""")
+
+
+def _collect_script_literals() -> list[tuple[str, str]]:
+    """(참조 위치, 스크립트 경로) 목록 — nuri/ 전체 .py 스캔."""
+    found: list[tuple[str, str]] = []
+    for py in sorted((REPO_ROOT / "nuri").rglob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        for m in _SCRIPT_LITERAL.finditer(text):
+            found.append((str(py.relative_to(REPO_ROOT)), m.group(1)))
+    return found
+
+
+class TestScriptPathLock:
+    def test_all_referenced_scripts_exist(self):
+        found = _collect_script_literals()
+        # 스캔 자체가 비어 있으면 정규식/구조 변화 — sweep 무력화 감지
+        assert found, "nuri/ 에서 scripts/ 리터럴을 하나도 못 찾음 — sweep 정규식 확인"
+        missing = [(src, script) for src, script in found if not (REPO_ROOT / script).is_file()]
+        assert not missing, (
+            f"스크립트 경로 drift (#557 클래스, #836/#846 재발 방지): {missing} — "
+            "스크립트를 옮겼다면 참조 상수를 함께 갱신할 것"
+        )
+
+    def test_known_constants_still_covered(self):
+        """알려진 3개 참조가 sweep 에 잡히는지 — 정규식 회귀 방지 canary."""
+        scripts = {script for _, script in _collect_script_literals()}
+        assert "scripts/db/backup.sh" in scripts  # nuri/scheduler.py (#836)
+        assert "scripts/ops/health_check.sh" in scripts  # nuri/agents/discord/bot.py (#846)
+        assert "scripts/dev/llm_consult.py" in scripts  # nuri/llm/thesis_query.py


### PR DESCRIPTION
Closes #846.

## Root cause
Discord `/health` 가 pre-#557 경로 `scripts/health_check.sh` 호출 → rc=127, **2026-04-30 부터 silent** — #557 경로 drift 클래스의 3번째 실증 (① backup #836 ② health ③ thesis_query 는 실존 확인).

## Fix + Class killer
- `HEALTH_CHECK_SCRIPT` 상수 추출 + `scripts/ops/health_check.sh` 로 갱신
- **`tests/test_script_path_lock.py`**: nuri/ 소스의 `"scripts/…"` 리터럴 전수 sweep → 실존 검증. 개별 Gotcha-Test 3개 대신 구조적 lock 1개 — 다음 scripts/ 이동은 즉시 FAIL (canary 테스트로 sweep 자체의 무력화도 감지)

## Verification
- sweep 2/2 · discord bot 테스트 20/20 · ruff clean · privacy scan ✓ · doc counts 13/13 (271→272 sync 포함)

## Deploy note
mini 반영은 discord-bot 재시작 필요 시점에 자연 반영 (bot 은 launchd 관리 대상 여부 확인 — scheduler 와 별개 plist).

관련: #836 (동일 클래스 1번째), #557 (원인 리팩터)

🤖 Generated with [Claude Code](https://claude.com/claude-code)