### PR TITLE
config(measurement): finalize sleeve cap initial values + value lock

### DIFF
--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -226,7 +226,8 @@ measurement_mode:
   permutation_n: 1000            # null 표본 수
   robustness_split: median_split_halves  # median decision date 등분 — 반기 n 균형 (VIX 게이트 accrual 비대칭 대비)
   missing_outcome_max_pct: 15    # 추적 결측 비율 상한 — 초과 시 판정 무효 (결측 편향)
-  sleeve_max_equity_pct:         # account_strategy 별 실험 슬리브 상한 (us_equity+kr_equity 합산 대비 %, 사용자 확정 필요)
+  sleeve_max_equity_pct:         # account_strategy 별 실험 슬리브 상한 (us_equity+kr_equity 합산 대비 %)
+                                 # 확정 2026-07-08 (#848) — 이후 상향은 판정 통과 + STRATEGY PR (lock test 동시 개정)
     core: 10
     active: 20
     swing: 100                   # swing 프로파일 계좌 = 실험 전용 슬리브

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -211,6 +211,22 @@ class TestMeasurementMode:
         for name, pct in sleeve.items():
             assert 0 <= pct <= 100, f"{name}: equity 내부 % 범위 위반"
 
+    def test_sleeve_cap_values_locked(self):
+        """확정 초기값 lock (#848, 2026-07-08) — §3.11 상향-sticky 발효.
+
+        상향은 판정 통과 + STRATEGY PR (본 테스트 동시 개정) 로만. 하향은
+        prudential 상시 허용이나, silent 변경 방지 위해 값 자체를 고정한다
+        — 하향도 의도라면 이 테스트를 함께 고치는 가시적 diff 를 남길 것."""
+        from nuri.core.rules import RULES
+
+        assert RULES["measurement_mode"]["sleeve_max_equity_pct"] == {
+            "core": 10,
+            "active": 20,
+            "swing": 100,
+            "long_term": 0,
+            "pension": 0,
+        }
+
 
 # ═══════════════════════════════════════════════════════
 # 폴백 테스트


### PR DESCRIPTION
Closes #848. 사용자 위임 결정 (2026-07-08 세션) — 근거는 이슈 본문.

- rules.yaml placeholder 문구 제거 + 확정 주석
- lock test: 5개 값 고정 — 상향-sticky 기계적 발효 (silent 변경 시 즉시 FAIL)
- 판정 표본은 emit 기준이라 측정력 무관 · 하향 상시 자유 (비대칭 설계)

검증: rules 테스트 전체 green · ruff · privacy scan ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)