### PR TITLE
fix(verify): repair pre-push flat script paths + extend path lock to shell

### DIFF
--- a/scripts/verify/pre_push_check.sh
+++ b/scripts/verify/pre_push_check.sh
@@ -28,7 +28,7 @@ echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━�
 
 # ─── 1. Drift check ─────────────────────────────────
 echo -e "${YELLOW}━━━ 1. Drift Check ━━━${NC}"
-if $PYTHON scripts/check_drift.py --strict; then
+if $PYTHON scripts/verify/check_drift.py --strict; then
     echo -e "${GREEN}✓ No drift risk${NC}\n"
 else
     echo -e "${RED}✗ Drift risk detected — see analysis above${NC}"
@@ -101,7 +101,7 @@ fi
 
 # ─── 4. Privacy leak scan (#138) ─────────────────────────────────
 echo -e "${YELLOW}━━━ 4. Privacy Leak Scan (files) ━━━${NC}"
-if $PYTHON scripts/check_privacy_leak.py --quiet; then
+if $PYTHON scripts/verify/check_privacy_leak.py --quiet; then
     echo -e "${GREEN}✓ No personal financial data leaks in tracked files${NC}\n"
 else
     echo -e "${RED}✗ Personal financial data leak detected — see above${NC}"
@@ -111,7 +111,7 @@ fi
 
 # ─── 4b. Unpushed commit messages (ticker+PnL, PR #202 class) ──────
 echo -e "${YELLOW}━━━ 4b. Commit Message Privacy Scan ━━━${NC}"
-if $PYTHON scripts/check_privacy_leak.py --unpushed-commits --quiet; then
+if $PYTHON scripts/verify/check_privacy_leak.py --unpushed-commits --quiet; then
     echo -e "${GREEN}✓ No ticker+PnL leaks in unpushed commit messages${NC}\n"
 else
     echo -e "${RED}✗ Ticker + PnL disclosure detected in a commit message${NC}"

--- a/tests/test_script_path_lock.py
+++ b/tests/test_script_path_lock.py
@@ -1,11 +1,12 @@
-"""스크립트 경로 drift 클래스 킬러 (#846, Gotcha-Test Pair).
+"""스크립트 경로 drift 클래스 킬러 (#846/#852, Gotcha-Test Pair).
 
-#557 scripts/ 7-subdir 리팩터가 만든 silent 고장 3건 중 2건이 실증됨:
+#557 scripts/ 7-subdir 리팩터가 만든 silent 고장 — 실증 3건:
 - scheduler backup (scripts/backup.sh → db/) — 2개월 무백업 (#836)
 - discord /health (scripts/health_check.sh → ops/) — rc=127 (#846)
+- pre_push_check.sh 의 flat 경로 호출 — 로컬 pre-push 게이트 일부 무력화 (#852)
 
-개별 상수 lock 대신, nuri/ 소스의 "scripts/…" 리터럴을 전수 수집해 실존을
-검증한다 — 다음 리팩터가 어떤 스크립트를 옮겨도 이 테스트가 즉시 FAIL.
+개별 상수 lock 대신, nuri/ 전체 .py + scripts/ 전체 .sh 의 "scripts/…" 리터럴을
+전수 수집해 실존을 검증한다 — 다음 리팩터가 어떤 스크립트를 옮겨도 즉시 FAIL.
 mock-only 테스트 (subprocess patch) 로는 경로 drift 를 못 잡는다 (§5.3).
 """
 
@@ -19,12 +20,13 @@ _SCRIPT_LITERAL = re.compile(r"""["'](scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))["']"
 
 
 def _collect_script_literals() -> list[tuple[str, str]]:
-    """(참조 위치, 스크립트 경로) 목록 — nuri/ 전체 .py 스캔."""
+    """(참조 위치, 스크립트 경로) 목록 — nuri/ .py + scripts/ .sh 스캔 (#852 확장)."""
     found: list[tuple[str, str]] = []
-    for py in sorted((REPO_ROOT / "nuri").rglob("*.py")):
-        text = py.read_text(encoding="utf-8")
+    sources = sorted((REPO_ROOT / "nuri").rglob("*.py")) + sorted((REPO_ROOT / "scripts").rglob("*.sh"))
+    for src in sources:
+        text = src.read_text(encoding="utf-8")
         for m in _SCRIPT_LITERAL.finditer(text):
-            found.append((str(py.relative_to(REPO_ROOT)), m.group(1)))
+            found.append((str(src.relative_to(REPO_ROOT)), m.group(1)))
     return found
 
 


### PR DESCRIPTION
Closes #852.

- `pre_push_check.sh` 3개 호출부 flat→`scripts/verify/` (2026-04-30 #557 이후 로컬 pre-push 게이트 §1 drift·§4 privacy 가 silent no-op — CI 가 실질 방어선이었음)
- `tests/test_script_path_lock.py` sweep 을 **scripts/*.sh 까지 확장** — 4번째 사례가 shell 출신, py-only 불충분 실증. 확장 후 잔존 drift 0 확인
- AGENTS.md 타이밍 1줄은 #851 과의 충돌 회피 위해 후속에 동승 예정

검증: sweep 2/2 · shellcheck clean · privacy scan ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)