### PR TITLE
fix(alerts): stop watchdog false-positive api DOWN — recheck + no kickstart on KeepAlive

### DIFF
--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -52,11 +52,20 @@ STALE_THRESHOLD_MIN = 30.0
 SCHEDULER_LABEL = "com.nuri-quant.scheduler"
 
 # 표출 계층 포트 감시 대상 (#826) — launchd 에 로드된 머신(production)에서만 검사.
-# KeepAlive 는 크래시만 복구; 살아있되 hung/포트 미바인딩 상태는 kickstart -k 로 회수.
+# api/dashboard 는 KeepAlive=true → launchd 가 크래시 자동복구. watchdog 은 kickstart
+# 하지 않고 알림만 한다 (#857): kickstart -k 는 부팅 중 정상 프로세스까지 죽였고
+# (2026-07-08 02:39 오탐), crash-loop 는 kickstart 로도 해결 안 되며, uvicorn/next 에
+# 실질적 hung(포트 미바인딩 좀비)은 발생하지 않는다. scheduler 는 heartbeat 경로라
+# fd 누수 hung 대비 kickstart 유지(별도).
 SERVICE_PORTS: dict[str, int] = {
     "com.nuri-quant.api": int(os.getenv("API_PORT", "8001")),
     "com.nuri-quant.dashboard": int(os.getenv("FRONTEND_PORT", "3000")),
 }
+
+# 포트 down 판정 전 재확인 간격 (초) — 부팅/일시 미바인딩 흡수 (#857).
+# 최초 launchd 설치 직후 uvicorn 부팅(SPY freshness 체크 등)이 수십초 걸려
+# 단발 체크가 DOWN 오판하던 문제. 15분 주기 watchdog 에 재확인 sleep 은 무해.
+SERVICE_RECHECK_DELAY_S = 15.0
 
 
 def _kickstart(label: str) -> bool:
@@ -113,22 +122,35 @@ def _port_open(port: int, timeout_s: float = 3.0) -> bool:
         return False
 
 
-def check_services() -> list[str]:
-    """로드돼 있는데 포트가 닫힌 표출 서비스 → kickstart + 알림 라인 반환 (#826).
+def check_services(recheck_delay_s: float = SERVICE_RECHECK_DELAY_S) -> list[str]:
+    """로드된 표출 서비스의 포트가 재확인에도 닫혀 있으면 알림 라인 반환 (#826/#857).
 
     heartbeat 감시와 동일 철학: launchctl + socket 만 사용 (DB 무의존).
     launchd 미설치 머신(dev MBP)은 label 미로드로 자동 skip — 환경 분기 불필요.
+
+    KeepAlive 서비스이므로 kickstart 하지 않는다 (launchd 가 크래시 복구 담당).
+    부팅/일시 미바인딩 오탐 방지 위해 `recheck_delay_s` 후 재확인 — 그 사이 포트가
+    열리면(부팅 중이었음) 알림 없음. 재확인에도 닫혀 있으면 launchd 도 못 살리는
+    상태(crash-loop 등)이므로 수동 확인을 안내한다.
     """
+    down = [(label, port) for label, port in SERVICE_PORTS.items() if _label_loaded(label) and not _port_open(port)]
+    if not down:
+        return []
+
+    # 부팅/일시 미바인딩 흡수 — 재확인 전 대기 (테스트는 0 주입).
+    if recheck_delay_s > 0:
+        time.sleep(recheck_delay_s)
+
     problems: list[str] = []
-    for label, port in SERVICE_PORTS.items():
-        if not _label_loaded(label):
-            continue
+    for label, port in down:
         if _port_open(port):
-            continue
-        restarted = _kickstart(label)
+            continue  # 재확인 시 복구 = 부팅 중이었음 (오탐 아님)
         short = label.removeprefix("com.nuri-quant.")
-        note = "🔄 자동 재시작 시도 완료 — 포트 곧 복구." if restarted else "⚠️ 자동 재시작 실패 — 수동 확인 필요."
-        problems.append(f"🔴 **{short} DOWN** — 127.0.0.1:{port} 응답 없음 (launchd 로드 상태). {note}")
+        problems.append(
+            f"🔴 **{short} DOWN** — 127.0.0.1:{port} {recheck_delay_s:.0f}s 재확인에도 무응답 "
+            f"(launchd 로드 상태, KeepAlive 자동복구 실패 의심). "
+            f"수동 확인: `launchctl kickstart -k gui/$(id -u)/{label}`"
+        )
     return problems
 
 

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -129,25 +129,52 @@ class TestMain:
 
 
 class TestServiceCheck:
-    """#826 표출 계층 포트 감시 — 로드+포트닫힘 → kickstart+알림, 미설치 → skip.
+    """#826/#857 표출 계층 포트 감시 — 재확인 후에도 닫히면 알림만 (kickstart X).
 
-    Gotcha-Test Pair: 2026-07-07 실측 — mini 의 API/dashboard 가 launchd 밖에서
-    (`make start` nohup) 돌다 죽은 채 기간 불명 방치. KeepAlive 만으로는 hung/
-    미바인딩 상태 복구 불가 → 포트 감시 계약을 고정.
+    Gotcha-Test Pair: 2026-07-08 02:39 오탐 — launchd api 최초 설치 직후 부팅 중
+    포트 미개방을 DOWN 오판하고 KeepAlive 서비스에 kickstart -k → 부팅 중 정상
+    프로세스 kill + 30s timeout. 계약 고정: (1) 재확인으로 부팅/일시 미바인딩 흡수
+    (2) KeepAlive 서비스는 kickstart 미호출 (launchd 가 크래시 복구 담당).
     """
 
-    def test_loaded_and_port_closed_kickstarts_and_alerts(self, monkeypatch):
+    def test_transient_down_recovers_on_recheck_no_alert(self, monkeypatch):
+        # 첫 체크 down → 재확인 시 open = 부팅 중이었음 → 알림 없음 (오탐 방지 핵심).
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.api": 18001})
+        calls = iter([False, True])  # 1차 closed, 재확인 open
+        with (
+            patch.object(hw, "_label_loaded", return_value=True),
+            patch.object(hw, "_port_open", side_effect=lambda *a, **k: next(calls)),
+            patch.object(hw, "_kickstart") as kick,
+        ):
+            problems = hw.check_services(recheck_delay_s=0)
+        assert problems == []
+        kick.assert_not_called()  # KeepAlive 서비스는 절대 kickstart 안 함
+
+    def test_persistent_down_alerts_without_kickstart(self, monkeypatch):
+        # 재확인에도 down → 알림 (kickstart 미호출, 수동 안내).
         monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.api": 18001})
         with (
             patch.object(hw, "_label_loaded", return_value=True),
             patch.object(hw, "_port_open", return_value=False),
-            patch.object(hw, "_kickstart", return_value=True) as kick,
+            patch.object(hw, "_kickstart") as kick,
         ):
-            problems = hw.check_services()
-        kick.assert_called_once_with("com.nuri-quant.api")
+            problems = hw.check_services(recheck_delay_s=0)
         assert len(problems) == 1
         assert "api DOWN" in problems[0]
-        assert "자동 재시작 시도 완료" in problems[0]
+        assert "KeepAlive 자동복구 실패" in problems[0]
+        assert "launchctl kickstart" in problems[0]  # 수동 안내
+        kick.assert_not_called()
+
+    def test_recheck_delay_sleeps_when_positive(self, monkeypatch):
+        # recheck_delay_s > 0 이면 재확인 전 sleep (부팅 흡수). 기본 15s 경로 커버.
+        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.api": 18001})
+        with (
+            patch.object(hw, "_label_loaded", return_value=True),
+            patch.object(hw, "_port_open", return_value=False),
+            patch.object(hw.time, "sleep") as slept,
+        ):
+            hw.check_services(recheck_delay_s=15.0)
+        slept.assert_called_once_with(15.0)
 
     def test_not_loaded_skips_silently(self, monkeypatch):
         # dev 머신 (launchd 미설치) — 검사·재시작 모두 없음.
@@ -156,7 +183,7 @@ class TestServiceCheck:
             patch.object(hw, "_label_loaded", return_value=False),
             patch.object(hw, "_kickstart") as kick,
         ):
-            problems = hw.check_services()
+            problems = hw.check_services(recheck_delay_s=0)
         kick.assert_not_called()
         assert problems == []
 
@@ -167,19 +194,9 @@ class TestServiceCheck:
             patch.object(hw, "_port_open", return_value=True),
             patch.object(hw, "_kickstart") as kick,
         ):
-            problems = hw.check_services()
+            problems = hw.check_services(recheck_delay_s=0)
         kick.assert_not_called()
         assert problems == []
-
-    def test_kickstart_failure_reports_manual_step(self, monkeypatch):
-        monkeypatch.setattr(hw, "SERVICE_PORTS", {"com.nuri-quant.dashboard": 13000})
-        with (
-            patch.object(hw, "_label_loaded", return_value=True),
-            patch.object(hw, "_port_open", return_value=False),
-            patch.object(hw, "_kickstart", return_value=False),
-        ):
-            problems = hw.check_services()
-        assert "자동 재시작 실패" in problems[0]
 
     def test_main_combines_service_alert_with_fresh_heartbeat(self, tmp_path, monkeypatch):
         # heartbeat 정상이어도 서비스 down 이면 rc=2 + 알림 발송.

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -29,6 +29,7 @@ class TestHeartbeatAge:
         p = tmp_path / "hb"
         _write_heartbeat(p, age_minutes=40.0)
         age = hw.heartbeat_age_minutes(path=p, now_epoch=time.time())
+        assert age is not None  # float | None 타입 좁히기 (파일 존재 → non-None)
         assert 39.0 < age < 41.0
 
 


### PR DESCRIPTION
Closes #857.

## Root cause (로그 실증)
2026-07-08 02:39 `🔴 api DOWN / 자동 재시작 실패` 알림 — 실제 api 정상. `heartbeat_watchdog.err`: `kickstart -k ... timed out after 30s`. launchd api 최초 설치 직후 uvicorn 부팅 중 포트 미개방을 DOWN 오판 → KeepAlive 서비스에 kickstart -k(부팅 중 프로세스 kill) → timeout → 오탐. launchd KeepAlive 가 자동 복구.

## Fix
- `check_services`: 포트 down 시 `SERVICE_RECHECK_DELAY_S`(15s) 후 **재확인** — 부팅/일시 미바인딩 흡수 (열리면 알림 없음)
- **KeepAlive 서비스 kickstart 제거** — launchd 가 크래시 복구 담당. crash-loop 는 kickstart 로 해결 안 되고 uvicorn/next 는 hung(포트 미바인딩 좀비) 안 남. 지속 down 시 알림 + 수동 안내만
- scheduler heartbeat 경로 kickstart 유지 (fd 누수 hung 대비)

## Verification
- 24 tests (transient→no-alert / persistent→alert-no-kickstart / recheck sleep), patch cov 100%, ruff clean
- watchdog 은 launchd StartInterval 15분 새 프로세스 실행 → autopull 코드 갱신 시 **다음 실행부터 자동 반영** (데몬 재시작 불요)

## 별개 발견 (본 PR 스코프 밖, 이슈 분리 예정)
- 🔴 `data/logs/scheduler.err` **189MB** — launchd stderr 로테이션 부재 무한성장 (디스크 위협)
- 🟡 SPY 데이터 146h stale (max 120h) → 레짐 분류 차단 반복 (수집 갭)

🤖 Generated with [Claude Code](https://claude.com/claude-code)