### PR TITLE
fix(scheduler): wire daily SPY benchmark freshness collection (§3.11)

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -516,6 +516,18 @@ SCHEDULES = [
         "kwargs": {"days": 365, "source": "all"},
         "cron": "30 5 * * 0",
     },
+    # 측정 모드 벤치마크(SPY) + SIEGE freshness 티커 일일 수집 (#457 도구 배선 — #860 fix).
+    # stock_us_night/dawn 은 source="portfolio"(held) 만 → SPY/TLT/GC=F(universe-only,
+    # 미보유 벤치마크)가 주간 backfill 에만 의존해 최대 1주 stale 이었음. §3.11 alpha 측정
+    # (forward_outcome_tracker, 매일 17:00) + 레짐 분류가 매일 SPY 를 필요로 한다.
+    # KST 화~토 06:10/06:40 — 미국 정규장 마감(서머 05:00 / 표준 06:00) 후 데이터 확정 창.
+    {
+        "name": "stock_us_freshness",
+        "func": _run_collector,
+        "args": ("stock",),
+        "kwargs": {"period": "5d", "source": "freshness"},
+        "cron": "10,40 6 * * 2-6",
+    },
     # 일일 자가 재시작 (#780) — KST 08:40, 모닝 배치(07-08) 종료 후·KR 개장(09:00) 전 idle
     # window. yfinance fd 누수를 fresh 프로세스 교체로 회수 (plist 4096 천장도 결국 고갈).
     {"name": "self_restart", "func": _self_restart, "args": (), "cron": "40 8 * * *"},

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -313,6 +313,30 @@ class TestScheduler_R2:
             assert "func" in s
             assert "cron" in s
 
+    def test_spy_benchmark_wired_to_daily_freshness(self):
+        """Gotcha-Test Pair (#860): §3.11 벤치마크(SPY) 일일 수집 배선 lock.
+
+        stock_us_night/dawn 은 source=portfolio(held)만 → SPY(universe-only 벤치마크)가
+        주간 backfill 에만 의존해 최대 1주 stale → forward_outcome_tracker(매일) alpha
+        부정확 + 레짐 분류 차단. daily freshness job 을 제거/변경하면 즉시 FAIL.
+        """
+        from nuri.collectors.stock import _load_freshness_tickers
+        from nuri.core.rules import RULES
+        from nuri.scheduler import SCHEDULES
+
+        # (a) scheduler 에 매일(요일 2-6) source=freshness 수집 job 이 있어야 함
+        fresh_jobs = [
+            s for s in SCHEDULES if s.get("kwargs", {}).get("source") == "freshness" and s["args"] == ("stock",)
+        ]
+        assert fresh_jobs, "source=freshness daily job 미배선 (#860 회귀)"
+        assert any("* * 2-6" in s["cron"] or "* * 1-5" in s["cron"] for s in fresh_jobs), (
+            "freshness job 이 주중 일일 cron 이 아님"
+        )
+
+        # (b) 측정 모드 벤치마크가 freshness 수집 대상에 실제로 포함되는지
+        benchmark = RULES["measurement_mode"]["benchmark"]
+        assert benchmark in _load_freshness_tickers(), f"{benchmark} 이 freshness 티커에 없음"
+
     def test_run_collector_unknown(self):
         """존재하지 않는 collector → 에러 로그만, 예외 없음."""
         from nuri.scheduler import _run_collector


### PR DESCRIPTION
Closes #860.

## Root cause (3중 확정)
1. daily stock 수집(`stock_us_night/dawn`)은 `source=portfolio`(held)만 — SPY 는 held 아님(universe-only)
2. SPY 는 주간 backfill(일요일)에만 의존 → **최대 1주 stale** (2026-07-08 실측: SPY 146h stale, 최신 07-02)
3. #457 이 `--source freshness`(SPY/TLT/GC=F 일일 수집) 도구를 만들었으나 **scheduler 배선 통째 누락** (wired≠validated)

**영향**: §3.11 측정 모드 벤치마크(SPY, forward_outcome_tracker 매일 17:00)가 구조적으로 stale → alpha 부정확 + 레짐 분류 차단 반복. **방금 만든 측정 시스템의 심장 결함.**

## Fix
- `stock_us_freshness` daily job 추가 (KST 화~토 06:10/06:40, 미국장 마감 후). `period=5d, source=freshness`
- Gotcha-Test Pair: `test_spy_benchmark_wired_to_daily_freshness` — scheduler job + SPY∈freshness 티커 동시 lock

## Verification
- scheduler 테스트 91 passed, ruff clean, privacy ✓
- **라이브 즉시 복구**: mini 에서 `stock --source freshness` 1회 → SPY 07-02 → **07-07** 최신화 확인 (측정 벤치마크 복구)

## Deploy note
머지 후 mini scheduler 재시작 필요 (새 job importlib 반영) — 다음 KST 08:40 self-restart 로도 자동.

발견 경로: #857 watchdog 디버깅 → SPY stale(#860) 근본 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)