### PR TITLE
docs: sync doc-count drift after freshness job + migration + measurement follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 | **Trading signals** | 22 (20 actionable + 2 shadow) |
 | **API endpoints** | 72 (FastAPI on `:8001`) |
 | **Frontend routes** | 18 (Next.js on `:3000`) |
-| **DB tables** | 51 (44 forward-only migrations) |
+| **DB tables** | 51 (45 forward-only migrations) |
 | **DB submodules** | 11 (sole `sqlite3` importer in `nuri/core/db/`) |
 
 ## Common Commands

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 473 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 474 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 39 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors.
+`nuri/scheduler.py` — 40 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -239,7 +239,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 | regime 축 | 내부 10-regime 분류는 진단 Surface 전용, 판정 비사용 — 원장 라벨 커버리지 3% (12/383, #828 코멘트 쿼리), 2026-04 이후 transition 1회 (판정 교착 위험), 자기 분류기 순환성 | 실측 2026-07-07 (production 원장) |
 | 오염 방지 | `decision_id` 없는 ad-hoc 체결은 표본 제외 (#715 사전등록 원칙의 자본 버전). missing outcome (추적 실패/가격 결측) 은 제외하되 비율을 판정 리포트에 공시 — **15% 초과 시 판정 무효 (측정 연장)** | Shefrin & Statman (1985) — ad-hoc 개입이 처분효과 재유입 경로. 결측 편향 (탈락은 나쁜 outcome 과 상관 가능) |
 **판정 결과 처리**: 3조건 통과 → **US 집행분 슬리브에 한해** 상한 상향 STRATEGY PR (새 상한도 본 표 개정으로 사전 고정). 미달 → 슬리브 유지/축소 + 측정 연장 또는 §3.10 passive 로 수렴 — "조금만 더" 없이 본 표가 답이다. 사전등록 대상은 판정 **기준**이지 상한 초기값이 아니다 — 슬리브 초기값은 판정 표본에 영향이 없으므로 최초 사용자 확정 PR 까지 placeholder 로 두며 일반 PR 로 정정 가능. 확정 이후부터 상향-sticky 발효.
-**미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 (진단용) ② 순열 판정 도구 — #842 구현 완료 (`nuri/quant/validation/decision_alpha.py`, 설계는 본 표에 사전 고정; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall) ⑥ 원장 스냅샷/백업 정책.
+**미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 — #832 구현 완료 (`scripts/ops/backfill_regime_labels.py` + emit 경로 canonical-or-NULL, 진단용) ② 순열 판정 도구 — #842 구현 완료 (`nuri/quant/validation/decision_alpha.py`, 설계는 본 표에 사전 고정; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 (#833) ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall, #834) ⑥ 원장 스냅샷/백업 정책 (#835). 월간 알파 진행 리포트 표출 = #856.
 **참조**: `config/rules.yaml measurement_mode` (canonical 값), `nuri/agents/actors/forward_outcome_tracker.py` (측정 파이프라인, 매일 17:00 KST), `docs/SOURCE_OF_TRUTH.md` (원장 매핑, local-only).
 ## 4. 개발 품질 기준
 PR 전 확인.

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -77,7 +77,7 @@ ThreadPoolExecutor caveat: `.result(timeout=)` cancels FUTURE only — underlyin
 
 SIEGE freshness gate (`certification.py::_check_freshness_for_class`) reads **`prices` only**. `--source freshness` (#457) feeds SPY/TLT/GC=F into `prices` daily. Two known redundancies:
 
-- **`gold` lives in two tables**: `macro.indicator='gold'` (~5Y backfill, 304 rows as of 2026-07-08 — grows daily) AND `prices."GC=F"` (1mo, ~20 rows after each daily refresh). Same yfinance source, separate writers (`macro.py` vs `stock.py --source freshness`). No current historical consumer of `prices."GC=F"` beyond the gate, so single-source-of-truth not enforced — accept as debt.
-- **TLT shallow history**: `prices.TLT` is 1mo only (freshness pass period). If a future backtest/analysis needs TLT 5Y, add TLT to `universe.yaml` (don't promote freshness gate to dual-source — drift risk per #454 codex consult 2026-04-28).
+- **`gold` lives in two tables**: `macro.indicator='gold'` (~5Y backfill, 304 rows as of 2026-07-08 — grows daily) AND `prices."GC=F"` (`period=5d` freshness pass, accumulates daily via upsert). Same yfinance source, separate writers (`macro.py` vs `stock.py --source freshness`, wired daily as `stock_us_freshness` in `scheduler.py` #860). No current historical consumer of `prices."GC=F"` beyond the gate, so single-source-of-truth not enforced — accept as debt.
+- **TLT shallow history**: `prices.TLT` comes only from the `period=5d` freshness pass. If a future backtest/analysis needs TLT 5Y, add TLT to `universe.yaml` (don't promote freshness gate to dual-source — drift risk per #454 codex consult 2026-04-28).
 
 **Why not dual-source the gate** (option A in #454, rejected): if gate accepts `macro.gold` 37h-fresh while a downstream consumer reads stale `prices."GC=F"`, gate PASS but downstream gets stale data → silent split-brain. Single-source gate = single truth.


### PR DESCRIPTION
## Why

세션 종료 시점 doc drift 정합. 오늘 착륙한 코드 변경(#860 freshness job, 45번째 migration, §3.11 측정 follow-up 이슈들)이 5개 문서의 정량 클레임과 어긋나 있었음. 전부 실측 후 정정.

## What (6 lines, 5 files — 순수 문서)

| File | Change | 실측 근거 |
|------|--------|-----------|
| `README.md` | 44→45 forward-only migrations | `len(_MIGRATIONS)` = 45 |
| `config/CLAUDE.md` | rules.yaml 473→474 lines | `wc -l config/rules.yaml` = 474 |
| `docs/ARCHITECTURE.md` | scheduler 39→40 cron jobs + `stock_us_freshness` note | `sum('cron' in j for j in SCHEDULES)` = 40 |
| `docs/STRATEGY.md` §3.11 | ① regime backfill(#832) 완료 표기 + follow-up 이슈 #833/#834/#835/#856 주석 | — |
| `nuri/collectors/CLAUDE.md` | freshness pass 1mo→`period=5d` + scheduler wiring(#860) | mini 실측 GC=F/TLT accumulate |

## Verification

- `make verify-doc-counts` → 13/13 passed
- `check_privacy_leak.py` (diff mode) → clean
- migration/rules.yaml/job 카운트 3종 live 코드 대조 완료 (verify-doc-counts 미커버 카운트라 수동 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)