### PR TITLE
chore(verify): gate migrations/jobs/rules-lines + merge-conflict guard in doc-count check

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,12 +156,8 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-<<<<<<< HEAD
-6,228 backend tests across 275 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,232 backend tests across 275 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
-=======
-**Slow marker**: 11 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
->>>>>>> origin/main
 @pytest.fixture
 def db_path(tmp_path):
     path = tmp_path / "test.db"

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -53,6 +53,13 @@ print(sqlite3.connect(_p).execute(\"SELECT COUNT(*) FROM sqlite_master WHERE typ
 " 2>/dev/null || echo ""
 }
 
+# 2026-07-08: migrations / scheduler jobs / rules.yaml lines — previously
+# manual-tracked (silent drift; migration 44→45 slipped through #863). grep/wc
+# based (no Python) so they HARD-GATE in CI, unlike regimes/db_tables above.
+live_migrations()     { grep -cE '^        [0-9]+,$' nuri/core/db_migrations.py || true; }
+live_scheduler_jobs() { grep -cE '"cron":' nuri/scheduler.py || true; }
+live_rules_lines()    { wc -l < config/rules.yaml | tr -d ' '; }
+
 # Extract the target integer from a file.
 # Strategy: match the claim's context substring (must be unique in the file),
 # then take the LAST [0-9]+ in that substring. Target numbers are consistently
@@ -92,6 +99,9 @@ TFFE=$(live_test_files_fe)
 E2E=$(live_e2e_specs)
 REGIMES=$(live_regimes)
 DBT=$(live_db_tables)
+MIG=$(live_migrations)
+JOBS=$(live_scheduler_jobs)
+RULES=$(live_rules_lines)
 
 # Claim checks: pattern must uniquely identify the phrase containing the target
 # number. Target is always the LAST [0-9]+ in the matched substring.
@@ -117,11 +127,26 @@ if [ -n "$DBT" ]; then
 else
     info "db_tables: skipped (no .venv/bin/python)"
 fi
+# grep/wc-based (no Python) — always run, including CI
+check_claim "migrations"       "$MIG"   "README.md"            '[0-9]+ forward-only migrations' || true
+check_claim "scheduler_jobs"   "$JOBS"  "docs/ARCHITECTURE.md" '[0-9]+ cron jobs in' || true
+check_claim "rules_yaml_lines" "$RULES" "config/CLAUDE.md"     '\| [0-9]+ \| Investment rules' || true
 
 # Note: agent count + pytest collect count intentionally excluded from hard
 # verify. Agent count has no single stable grep pattern across docs (multiple
 # phrasings "10-agent", "10 agents", "10개"), and pytest collect takes 30+s
 # which would slow PR CI. Those are covered by sync_doc_counts.sh best-effort.
+
+# 2026-07-08: doc integrity guard. Merge conflict markers were committed into
+# docs/ARCHITECTURE.md and sat undetected — the count greps above still matched
+# inside the conflict block, so this check stayed green. Hard-fail if any tracked
+# .md carries a git conflict marker. (git grep = tracked files only; no git → skip.)
+CONFLICTS=$(git grep -lE '^(<<<<<<<|>>>>>>>)' -- '*.md' 2>/dev/null || true)
+if [ -n "$CONFLICTS" ]; then
+    fail "merge conflict markers in tracked .md: $(echo "$CONFLICTS" | tr '\n' ' ')"
+else
+    pass "no merge conflict markers in tracked .md"
+fi
 
 summary
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Why

세션 검증 중 `verify-doc-counts`가 3종 카운트(migrations·scheduler jobs·rules.yaml 줄수)를 **기계 검사하지 않아** 수동 추적으로만 잡히는 걸 발견 (이번에도 migration 44→45가 #863에서 silent drift). 그 3종을 게이트에 편입하던 중, **docs/ARCHITECTURE.md에 머지 컨플릭트 마커가 커밋된 채 방치**된 것도 발견 — count grep이 마커 안에서도 매칭돼 CI가 계속 green이었음.

## What

**`scripts/verify/verify_doc_counts.sh`** (CI "Doc Count Drift Check")
- +3 count checks — migrations(45)·scheduler cron jobs(40)·rules.yaml lines(474). 전부 grep/wc 기반이라 Python 없는 CI에서도 **하드 게이트** (regimes/db_tables처럼 skip 안 함).
- +conflict-marker guard — tracked `*.md`에 git 컨플릭트 마커 있으면 hard-fail.

**`docs/ARCHITECTURE.md`**
- Testing 섹션의 커밋된 `<<<<<<< HEAD` … `>>>>>>> origin/main` 마커 해소. 정확한 side 채택 (실측: slow 24 tests, 6,228→6,232 backend). origin side의 "11 slow"는 stale.

## Verification

- `make verify-doc-counts` → **17 checks pass** (16 counts + guard)
- guard break-test: 마커 재주입 시 `✗ merge conflict markers in tracked .md: docs/ARCHITECTURE.md` FAIL 확인
- shellcheck clean (SC1091 info 제외), privacy scan clean
- 실측 대조: migrations `len(_MIGRATIONS)`=45, `"cron":`×40, `wc -l rules.yaml`=474, `pytest --collect-only`=6,232 / slow 24

## Out of scope (별도 이슈)

`sync_doc_counts.sh` (mutator)는 pre-existing 완전-dead였고 (set -e+pipefail 하 첫 호출 abort + frontend-count clobbering 버그) **손대지 않음**. `docs/TODO.md` Tier 3에 재작성/폐기 항목으로 등록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)