### PR TITLE
test(agents): close actor branch-coverage gaps + pragma unreachable retry arc

### DIFF
--- a/nuri/agents/actors/collector_orchestrator.py
+++ b/nuri/agents/actors/collector_orchestrator.py
@@ -145,7 +145,9 @@ class CollectorOrchestrator(Actor):
         last_error: Optional[str] = None
         rows_collected = 0
         # attempt 0 + retry 회수 = max_retries+1 회 시도.
-        for attempt_idx in range(max_retries + 1):
+        # 마지막 시도는 성공→return(174)/실패→break(212)로만 종료하므로 for 자연 소진 arc(148->218)은
+        # max_retries>=0(L136) 불변식상 도달 불가 → pragma: no branch 로 partial-branch 제외.
+        for attempt_idx in range(max_retries + 1):  # pragma: no branch
             start_ms = time.monotonic()
             try:
                 result_value = collector_fn()

--- a/tests/agents/test_decision_compiler_branches.py
+++ b/tests/agents/test_decision_compiler_branches.py
@@ -339,6 +339,41 @@ class TestPositionState:
 
 
 # ════════════════════════════════════════════════════════════
+# L416 (416->473 false branch) — non-BUY/SELL action skips price levels
+# ════════════════════════════════════════════════════════════
+
+
+class TestBriefNonDirectionalAction:
+    def test_non_buy_sell_action_stages_brief_without_price_levels(self, patched_db):
+        """L416 false branch (416->473): action ∉ {BUY,SELL} → price/horizon/position
+        블록 전체 skip 후 곧장 stage_brief.
+
+        `.run()` 경로는 proposed_action 을 VALID_ACTIONS_INPUT=("BUY","SELL") 로 강제하므로
+        이 분기는 non-directional action (예: HOLD) 으로 직접 호출해야만 도달.
+        Regression: 분기 inversion 시 HOLD brief 에 무의미한 price_levels 가 붙는다.
+        """
+        from nuri.core.db import claim_pending_outbox
+
+        DecisionCompiler._publish_brief(
+            decision_id="dec-hold-1",
+            ticker="TST_A",
+            action="HOLD",
+            conviction=0.55,
+            rationale={"regime_top_prob": 0.80, "causal_certainty": 0.90, "top2_margin": 0.50},
+            run_id="run-hold-1",
+        )
+
+        _, rows = claim_pending_outbox("brief", db_path=patched_db)
+        assert len(rows) == 1
+        p = rows[0]["payload"]
+        assert p["kind"] == "HOLD"
+        # price-level 블록 전체 skip.
+        assert "price_levels" not in p
+        assert "horizon" not in p
+        assert "position" not in p
+
+
+# ════════════════════════════════════════════════════════════
 # L501-502 — _publish_block exception swallow
 # ════════════════════════════════════════════════════════════
 

--- a/tests/agents/test_drift_sentinel_branches.py
+++ b/tests/agents/test_drift_sentinel_branches.py
@@ -4,16 +4,20 @@
 - 208→221: `if baseline.size and np.std(baseline) > 0:` False (degenerate baseline)
 - 211→221: `if len(edges) >= 2:` False (n_bins=0 → quantile edges 1 element)
 - 417→419: `if severity in severity_counts:` False (sub_result error → severity None)
+
++ line 128: scipy 성공 return — `--cov` numpy double-init Heisenbug 우회 (stub).
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
 
 from nuri.agents.actors.drift_sentinel import (
     DriftSentinel,
+    _compute_ks,
     _distribution_summary,
 )
 from nuri.agents.base import Outcome, RunContext
@@ -90,3 +94,30 @@ class TestScanFeaturesUnknownSeverity:
         assert "error" in result.output["alerts"][0]
         # 모두 None severity → BLOCK 도 critical 도 아님 → PASS
         assert result.outcome == Outcome.PASS
+
+
+# ═══════════════════════════════════════════════════════
+# _compute_ks — line 128 (scipy 성공 return)
+# ═══════════════════════════════════════════════════════
+
+
+class TestComputeKsScipySuccessPath:
+    def test_scipy_success_returns_statistic(self):
+        """line 128 `return float(result.statistic)` — scipy 정상 경로.
+
+        실 scipy.stats.ks_2samp 는 `--cov` 계측 시 numpy double-init 로
+        `numpy.dtypes.VoidDType` 가 사라져 AttributeError 를 던지고 fallback
+        (131-134) 으로 빠진다 — 측정 행위 자체가 경로를 바꾸는 Heisenbug.
+        프로덕션/비계측 런에서는 128 이 정상 실행되므로, 취약한 외부 호출만
+        stub 으로 격리해 128 을 실제로 태운다.
+        """
+        baseline = np.array([1.0, 2.0, 3.0, 4.0])
+        current = np.array([2.0, 3.0, 4.0, 5.0])
+
+        def stub_ks(_a, _b):
+            return SimpleNamespace(statistic=0.42, pvalue=0.1)
+
+        with patch("scipy.stats.ks_2samp", stub_ks):
+            result = _compute_ks(baseline, current)
+
+        assert result == 0.42

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -967,6 +967,14 @@ class TestHumanIncidentSummary:
         s = _human_incident_summary("actor_failure_streak", "consensus", {"consecutive_failures": 5})
         assert "consensus" in s and "5회 연속 실패" in s
 
+    def test_signal_evaluation_stale_shows_missed_days_and_last_utc(self):
+        s = _human_incident_summary(
+            "signal_evaluation_stale",
+            "signal-eval",
+            {"missed_eval_days": 3, "last_evaluated_at_utc": "2026-07-04 22:00:00"},
+        )
+        assert "signal-eval" in s and "3영업일째" in s and "2026-07-04 22:00:00" in s
+
     def test_unknown_type_falls_back_gracefully(self):
         s = _human_incident_summary("brand_new_type", "x", {})
         assert "brand_new_type" in s and "x" in s


### PR DESCRIPTION
## Why

Codecov (`nuri/agents/actors` tree) showed coverage gaps. Investigation: all 18 actor modules already have comprehensive tests; the real gaps are a handful of uncovered branches/lines in the non-numeric modules.

## What (test-only + 1 source pragma)

| Module | Gap | Fix |
|--------|-----|-----|
| `decision_compiler` | `416->473` false branch (non-directional action skips price-levels block) | test `_publish_brief(action="HOLD")` — real branch, reachable by direct callers |
| `sre_incident_agent` | line 594 (`signal_evaluation_stale` summary arm) | test the untested incident_type |
| `drift_sentinel` | line 128 (`_compute_ks` scipy-success return) | test via `scipy.stats.ks_2samp` stub |
| `collector_orchestrator` | branch `148->218` | `# pragma: no branch` — natural loop-exhaustion is unreachable (`max_retries>=0` → always exits via return/break) |

## Key finding: regime_posterior / walkforward_validator are NOT real gaps

Their low **local** coverage is a **macOS-arm64-only Heisenbug**: under `--cov`, numpy is re-loaded twice → `numpy.dtypes.VoidDType` disappears → `scipy.stats.ks_2samp` / hmmlearn raise `AttributeError`, corrupting fixture data to `numpy._NoValue`. The measurement act itself changes the code path. **CI runs on `ubuntu-latest` and is unaffected**, so codecov measures these modules correctly. No new tests needed for them.

(Residual: `forward_outcome_tracker` may have small gaps but a clean full-suite measurement is blocked locally by the same Heisenbug — deferred.)

## Verification

- `tests/agents/`: **985 passed** (no `--cov`), +3 new tests, 0 regressions
- Each targeted branch/line confirmed covered locally (non-numeric modules measure cleanly under `--cov`)
- `ruff` clean, privacy scan clean
- No production behavior change (1 pragma comment only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)