### PR TITLE
test(agents): cover forward_outcome_tracker defensive fall-through (468->exit)

### DIFF
--- a/tests/agents/test_forward_outcome_tracker.py
+++ b/tests/agents/test_forward_outcome_tracker.py
@@ -450,6 +450,23 @@ class TestStatusMachineLockTest:
         )
         assert dict(rows[0])["status"] == "rejected"  # 변동 X
 
+    def test_non_pass_reject_validation_is_noop(self, patched_db):
+        """468->exit 방어 분기: validation ∉ {pass, reject} (예: insufficient_data) 면
+        if/elif 둘 다 미매치 → fall-through, open hypothesis 미변경.
+
+        공개 경로(_trigger_forward_validation L380 guard)는 pass/reject 만 이 메서드에
+        넘기므로 도달 불가한 방어 분기 — staticmethod 직접 호출로 커버.
+        Regression: 예상 밖 validation 값에 else 를 잘못 달면 open hypothesis 를 오변경.
+        """
+        _seed_hypothesis(patched_db, "h-insuf", "claim-insuf")
+        ForwardOutcomeTracker._trigger_hypothesis_update("h-insuf", "insufficient_data", 7, 0.01, None, "run-insuf")
+        rows = query(
+            "SELECT status FROM hypotheses WHERE hypothesis_id=?",
+            ("h-insuf",),
+            db_path=patched_db,
+        )
+        assert dict(rows[0])["status"] == "open"  # pass/reject 아님 → 변동 없음
+
 
 class TestHoldSkipLockTest:
     """LOCK-TEST: HOLD action → tracking skip (의미 없음)."""


### PR DESCRIPTION
## Why

Residual actor-coverage gap after #865: `forward_outcome_tracker.py` sat at 99% on the full suite — the only real gap was branch `468->exit`.

## What

`_trigger_hypothesis_update`'s `if validation == "pass" / elif validation == "reject"` has an unreachable fall-through when `validation` is neither (e.g. `insufficient_data`). The public path (`_trigger_forward_validation`, L380 guard `validation in ("pass","reject")`) only ever passes pass/reject, so the branch is defensive-only.

Covered by calling the staticmethod directly with `insufficient_data` on an open hypothesis and asserting it's left unchanged (matches the direct-call pattern used for `decision_compiler._publish_brief` in #865). No source change.

## Verification

- `forward_outcome_tracker.py`: **99% → 100%** on the full coverer set (test_forward_outcome_tracker + test_actors_branch_gaps + test_main_runpy + test_alpha + test_scheduler + test_rules), branch partial 0
- `test_forward_outcome_tracker.py`: 40 passed (no `--cov`), ruff + privacy clean

(The 3 unrelated failures seen when measuring locally are the known macOS-arm64 numpy-under-`--cov` Heisenbug from hmmlearn-importing sibling tests — CI on ubuntu is unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)