### PR TITLE
fix(tracking): prior-trading-day close for entry price (weekend as_of → 34% missing)

### DIFF
--- a/nuri/agents/actors/forward_outcome_tracker.py
+++ b/nuri/agents/actors/forward_outcome_tracker.py
@@ -316,9 +316,9 @@ class ForwardOutcomeTracker(Actor):
             }
 
         # ─── 가격 조회 ───
-        entry = self._fetch_close(ticker, as_of_date)
+        entry = self._fetch_close_on_or_before(ticker, as_of_date)
         exit_p = self._fetch_close_on_or_after(ticker, target_date)
-        bench_entry = self._fetch_close(DEFAULT_BENCHMARK_TICKER, as_of_date)
+        bench_entry = self._fetch_close_on_or_before(DEFAULT_BENCHMARK_TICKER, as_of_date)
         bench_exit = self._fetch_close_on_or_after(DEFAULT_BENCHMARK_TICKER, target_date)
 
         if entry is None or exit_p is None:
@@ -408,9 +408,15 @@ class ForwardOutcomeTracker(Actor):
         return start + timedelta(days=n)
 
     @staticmethod
-    def _fetch_close(ticker: str, date_str: str) -> Optional[float]:
+    def _fetch_close_on_or_before(ticker: str, date_str: str) -> Optional[float]:
+        """as_of_date 이전(포함) 마지막 거래일의 close — 주말/휴장 진입일 흡수.
+
+        PIT: `date <= as_of` 만 조회하므로 미래 정보 미사용 (lookahead 아님).
+        exit 의 `_fetch_close_on_or_after` 와 대칭 — 진입은 직전 거래일, 청산은 직후 거래일.
+        (기존 exact-date 조회는 주말/휴장 as_of 에서 None → insufficient_data 대량 발생 버그.)
+        """
         rows = query(
-            "SELECT close FROM prices WHERE ticker = ? AND date = ? LIMIT 1",
+            "SELECT close FROM prices WHERE ticker = ? AND date <= ? AND close IS NOT NULL ORDER BY date DESC LIMIT 1",
             (ticker, date_str),
         )
         if not rows:
@@ -420,9 +426,12 @@ class ForwardOutcomeTracker(Actor):
 
     @staticmethod
     def _fetch_close_on_or_after(ticker: str, date_str: str) -> Optional[float]:
-        """target_date 이후 첫 거래일의 close (주말/휴장 자동 흡수)."""
+        """target_date 이후 첫 거래일의 close (주말/휴장 자동 흡수).
+
+        `close IS NOT NULL` 로 stale NULL 행이 유효 close 를 가리는 것 방지 (entry 헬퍼와 대칭).
+        """
         rows = query(
-            "SELECT close FROM prices WHERE ticker = ? AND date >= ? ORDER BY date LIMIT 1",
+            "SELECT close FROM prices WHERE ticker = ? AND date >= ? AND close IS NOT NULL ORDER BY date LIMIT 1",
             (ticker, date_str),
         )
         if not rows:

--- a/tests/agents/test_actors_branch_gaps.py
+++ b/tests/agents/test_actors_branch_gaps.py
@@ -289,7 +289,7 @@ class TestForwardOutcomeTrackerBranches:
 
         monkeypatch.setattr(
             fot.ForwardOutcomeTracker,
-            "_fetch_close",
+            "_fetch_close_on_or_before",
             lambda self, t, d: prices.get(t, {}).get(d),
         )
         monkeypatch.setattr(

--- a/tests/agents/test_forward_outcome_tracker.py
+++ b/tests/agents/test_forward_outcome_tracker.py
@@ -330,6 +330,41 @@ class TestTrackOnePass:
         assert result.output["realized_return"] == pytest.approx(0.08)
 
 
+class TestWeekendEntryLockTest:
+    """LOCK-TEST: 주말/휴장 as_of_date 진입은 직전 거래일 close 로 흡수 (on_or_before).
+
+    시스템이 매일(주말 포함) 스캔하며 BUY 를 재발행하므로 as_of 가 토/일인 결정이
+    다수 생긴다. entry 를 exact-date 로 조회하면 그날 시세가 없어 insufficient_data →
+    prod 원장에서 성숙 US BUY 결정의 34% 결측(전부 주말) 발생 → §3.11 결측 게이트(15%)
+    초과로 판정 무효 위험. Regression: entry 가 exact-date 로 되돌아가면 이 테스트 FAIL.
+    """
+
+    def test_weekend_entry_uses_prior_trading_close(self, patched_db):
+        _seed_hypothesis(patched_db, "h-wk", "claim-wk")
+        # as_of = 2026-05-09(토). 당일 시세 없음(주말) — 직전 금(05-08)만 seed.
+        _seed_decision(patched_db, decision_id="dc-wk", ticker="TESTWK", as_of_date="2026-05-09", hypothesis_id="h-wk")
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTWK", "2026-05-08", 100.0),  # 금 — entry on_or_before 흡수
+                ("TESTWK", "2026-05-18", 108.0),  # 월 — target(05-16) 이후 첫 거래일, exit on_or_after
+                ("SPY", "2026-05-08", 500.0),
+                ("SPY", "2026-05-18", 505.0),
+            ],
+        )
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-wk", "observation_window": 7})
+        # insufficient 아님 — entry=100(금 close), exit=108 → +8%
+        assert result.output["validation"] == "pass"
+        assert result.output["realized_return"] == pytest.approx(0.08)
+        out = query(
+            "SELECT realized_return, benchmark_return FROM decision_outcomes "
+            "WHERE decision_id='dc-wk' AND observation_window=7",
+            db_path=patched_db,
+        )
+        assert out[0]["realized_return"] is not None
+        assert out[0]["benchmark_return"] is not None
+
+
 # ═══════════════════════════════════════════════════════
 # Anti-pattern lock-tests
 # ═══════════════════════════════════════════════════════


### PR DESCRIPTION
## Why (rigor check of §3.11 measurement mode)

Diagnosing whether the measurement experiment can even yield a valid verdict, I found the prod ledger had **34% missing outcomes on mature US BUY decisions** — over the §3.11 gate (15%), which would invalidate the 2027 verdict. Root cause: the tracker fetched the **entry** price with an exact-date lookup while the **exit** used on-or-after. The system scans daily including weekends, so Sat/Sun `as_of_date` decisions had no market price that day → `insufficient_data`. All 32 missing were weekends.

## What

- `_fetch_close` (exact-date) → `_fetch_close_on_or_before` (`date <= ? ORDER BY date DESC`), used for entry + benchmark-entry. PIT-safe (past closes only, no lookahead), symmetric with exit's on-or-after.
- Both helpers now filter `close IS NOT NULL` (stale NULL can't mask a valid close).

## Verification

- **Prod projection (read-only, no write)**: missing **34% → 9%** (24/32 recovered), under the 15% gate ✅. Residual 8 = separate TSM/BAC price-history gap (de-universed tickers), not this bug.
- **Regression proof**: `TestWeekendEntryLockTest` fails if entry reverts to exact-date (stashed source → test FAILs).
- Superset property: weekday outcomes byte-identical (`prices` has `UNIQUE(ticker,date)`); only weekends newly resolve.
- `tests/agents/`: **987 passed**, ruff + privacy clean.
- Adversarial review (independent agent): PIT-safe ✅, superset ✅; caught a stale `_fetch_close` monkeypatch in `test_actors_branch_gaps.py` (fixed) + the NULL-close gap (fixed).

## Deploy note

After merge, mini autopulls the code; re-running the tracker will populate the 24 recovered historical outcomes. Go-forward: weekend decisions (post-declared 2026-07-08) now track correctly.

## Not in scope (flagged)

- Unbounded lookback distance in both helpers (fine for 1-3 day weekend absorption; a cap would be a design call).
- The residual 8 TSM/BAC gaps (de-universed ticker price coverage) — separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)