### PR TITLE
feat(alerts): surface stop-loss breach as SELL in #brief digest

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,232 backend tests across 275 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,232 backend tests across 276 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,228 tests, 275 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,228 tests, 276 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -632,6 +632,15 @@ def write_brief(
     if outbox_id is None:
         logger.info("Post-market brief Discord publish 미발행 (gate 차단 또는 outbox 미작동)")
 
+    # Tier 1a — 손절선 이탈 종목을 같은 digest 에 SELL 로 표면화 (mechanical rule
+    # signal, 예측 아님). aggregate summary 만 보였던 통증(행동 가능 신호 부재) 해소.
+    try:
+        from nuri.alerts.risk_signals import stage_stop_breach_briefs
+
+        stage_stop_breach_briefs(session, d, db_path=db_path)
+    except Exception:
+        logger.warning("stop-breach brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+
     return path
 
 

--- a/nuri/alerts/risk_signals.py
+++ b/nuri/alerts/risk_signals.py
@@ -1,0 +1,174 @@
+"""Mechanical risk signals → #brief (Tier 1a: stop-loss breach).
+
+브리프가 지금까지 aggregate INFO summary 1건만 stage 해 "행동 가능한 신호가
+안 보인다"는 통증(늦은 손절 = 처분효과, Shefrin & Statman 1985)의 첫 해소.
+
+여기서 표면화하는 것은 **결정론적 룰 신호**(예측 아님): row PnL 이 계좌별
+`config/rules.yaml` stop_loss threshold 를 이탈하면 SELL 로 stage. 예측 alpha
+(consensus BUY/SELL) 는 §3.11 측정 진행 중이라 Tier 2 로 분리 — 여기 미포함.
+
+Axis (#429): stop-loss breach 는 유일한 mechanical `alpha_action=FLAT` → 정당한
+urgent SELL. 집중도/드리프트(REBALANCE) 는 alpha 축이 아니므로 여기 없음.
+
+Privacy: Discord 는 사용자 private 채널이므로 ticker+PnL 노출 OK (DecisionCompiler
+`_publish_brief` 선례와 동일). repo 로는 절대 안 감(mini gitignored DB). 테스트는
+합성 티커(TST_*)만.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from nuri.core.db import query
+from nuri.core.rules import get_account_strategy_name, get_stop_loss_for_account
+from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
+
+Session = Literal["kr", "us"]
+
+
+def scan_stop_breaches(
+    session: Optional[Session] = None,
+    db_path: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    """보유 종목 중 손절선 이탈(row PnL < 계좌 threshold) 목록.
+
+    Args:
+        session: "kr" → `.KS` only, "us" → non-`.KS` only, None → 전체.
+        db_path: 테스트 격리용.
+
+    Returns:
+        [{ticker, account, avg, current, pnl_pct, threshold}] — worst 우선 정렬.
+        pension 계좌(장기 buy-and-hold, daily action 대상 아님)는 제외.
+    """
+    rows = query(
+        """
+        SELECT p.account, p.ticker, p.avg_price, p.quantity, pr.close AS current
+        FROM portfolio p
+        LEFT JOIN (
+            SELECT ticker, close FROM prices
+            WHERE (ticker, date) IN (SELECT ticker, MAX(date) FROM prices GROUP BY ticker)
+        ) pr ON p.ticker = pr.ticker
+        WHERE p.quantity > 0
+        """,
+        db_path=db_path,
+    )
+
+    breaches: list[dict[str, Any]] = []
+    for r in rows:
+        ticker = str(r["ticker"])
+        if session == "kr" and not ticker.endswith(".KS"):
+            continue
+        if session == "us" and ticker.endswith(".KS"):
+            continue
+        if get_account_strategy_name(r["account"]) == "pension":
+            continue
+
+        avg = r["avg_price"]
+        current = r["current"]
+        # avg/current 0·None → 손절 계산 무의미. current==0 (상장폐지/거래정지/
+        # 불량 price) 을 걸러야 (0-avg)/avg = -100% false SELL 방지 (risk_agent
+        # 와 동일하게 truthiness 가드).
+        if not avg or not current:
+            continue
+
+        pnl_pct = (current - avg) / avg * 100
+        threshold = get_stop_loss_for_account(r["account"])
+        if pnl_pct < threshold:
+            breaches.append(
+                {
+                    "ticker": ticker,
+                    "account": r["account"],
+                    "avg": float(avg),
+                    "current": float(current),
+                    "pnl_pct": pnl_pct,
+                    "threshold": threshold,
+                }
+            )
+
+    breaches.sort(key=lambda b: b["pnl_pct"])  # 가장 깊은 손실 우선
+    return breaches
+
+
+def _build_breach_payload(breach: dict[str, Any], date: str) -> dict[str, Any]:
+    """손절 이탈 1건 → #brief SELL payload (DecisionCompiler `_publish_brief` 형식).
+
+    price_levels: entry=평단, stop=이탈한 손절가(평단×(1+threshold%)). TP 는
+    cut 신호엔 무의미하므로 생략(렌더러가 present 키만 표시).
+    """
+    avg = breach["avg"]
+    threshold = breach["threshold"]
+    stop_level = avg * (1 + threshold / 100)
+    return {
+        "kind": "SELL",
+        "ticker": breach["ticker"],
+        # note → 렌더러가 표시. 같은 티커가 여러 계좌에 있을 때 어느 계좌인지 구분
+        # (계좌별 avg 가 달라 entry/stop 도 다름).
+        "note": breach["account"],
+        "reason": f"손절선 돌파 ({breach['pnl_pct']:+.1f}% < {threshold}%)",
+        "date": date,
+        "price_levels": {"entry": round(avg, 2), "stop": round(stop_level, 2)},
+    }
+
+
+def stage_stop_breach_briefs(
+    session: Optional[Session] = None,
+    date: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """손절선 이탈 종목을 #brief outbox 에 SELL 로 stage. staged 건수 반환.
+
+    dedupe_key=`stop-breach:{ticker}:{account}:{date}` — (ticker, account) × 하루
+    1건(같은 이탈이 이틀 지속되면 매일 재알림: 처분효과 방어 = 자를 때까지 상기).
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    d = date or today_kst()
+    breaches = scan_stop_breaches(session, db_path=db_path)
+    staged = 0
+    for b in breaches:
+        payload = _build_breach_payload(b, d)
+        # dedupe_key 에 account 포함 — 같은 티커가 여러 계좌에서 이탈해도 각각
+        # 별개 brief (계좌별 avg 다름). non-None 만 카운트(dedupe skip → None).
+        outbox_id = stage_brief(
+            payload=payload,
+            dedupe_key=f"stop-breach:{b['ticker']}:{b['account']}:{d}",
+            priority="high",
+            actor_name="risk-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("stop-breach briefs staged: %d (session=%s)", staged, session or "all")
+    return staged
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Stop-loss breach → #brief (Tier 1a)")
+    parser.add_argument("--session", choices=("kr", "us"), default=None, help="세션 필터 (기본: 전체)")
+    parser.add_argument("--dry-run", action="store_true", help="stage 없이 이탈 목록만 출력")
+    args = parser.parse_args(argv)
+
+    breaches = scan_stop_breaches(args.session)
+    if not breaches:
+        print("stop-loss breach 없음")
+        return 0
+    for b in breaches:
+        print(
+            f"  {b['ticker']} [{b['account']}] {b['pnl_pct']:+.1f}% < {b['threshold']}% (avg {b['avg']:.2f} → {b['current']:.2f})"
+        )
+    if args.dry_run:
+        print(f"[dry-run] {len(breaches)}건 — stage 안 함")
+        return 0
+    staged = stage_stop_breach_briefs(args.session)
+    print(f"staged {staged}건 → #brief")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -122,6 +122,26 @@ def get_account_strategy(account: str) -> dict:
         return _DEFAULT_STRATEGY
 
 
+def get_account_strategy_name(account: str | None) -> str:
+    """계좌명 → 전략 이름 반환 ('core'|'swing'|'pension'|...). 매칭 실패 → 'core'.
+
+    `get_account_strategy()` 는 rules dict(stop_loss/max_position/...)만 반환해
+    이름이 소실된다 — pension 판별(daily action 제외)엔 이름이 authoritative 하므로
+    yaml 의 strategy 필드를 직접 노출.
+    """
+    if not account:
+        return "core"
+    import yaml
+
+    _portfolio_path = Path(__file__).parent.parent.parent / "config" / "portfolio.yaml"
+    try:
+        with open(_portfolio_path, encoding="utf-8") as f:
+            portfolio = yaml.safe_load(f) or {}
+        return portfolio.get("accounts", {}).get(account, {}).get("strategy", "core")
+    except Exception:
+        return "core"
+
+
 def get_stop_loss_for_account(account: str | None) -> int:
     """계좌명 → stop_loss threshold (정수 %). 계좌 미지정/매칭 실패 → global fallback.
 

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -176,6 +176,30 @@ def test_pension_excluded_from_postmarket(seeded_db, portfolio_yaml, tmp_path):
     assert "NVDA" in md
 
 
+def test_write_brief_stages_stop_breach(seeded_db, portfolio_yaml):
+    """Tier 1a wiring lock — write_brief 가 손절 이탈 종목을 SELL 로 stage.
+
+    배선을 되돌리면(write_brief 의 stage_stop_breach_briefs 호출 제거) FAIL.
+    """
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    spy = MagicMock(return_value=1)
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.risk_signals.stage_stop_breach_briefs", spy),
+    ):
+        write_brief("us", date="2026-05-01")
+
+    # write_brief 가 세션/날짜/db_path 를 그대로 전달해 호출
+    spy.assert_called_once()
+    args, kwargs = spy.call_args
+    assert args[0] == "us"  # session
+    assert args[1] == "2026-05-01"  # date
+
+
 def test_us_session_dst_aware_cron_dispatch():
     """NYSE 16:30 ET window — EDT (KST 05:30) / EST (KST 06:30) 양쪽 검증.
 

--- a/tests/alerts/test_risk_signals.py
+++ b/tests/alerts/test_risk_signals.py
@@ -1,0 +1,386 @@
+"""Tier 1a — stop-loss breach → #brief (`nuri/alerts/risk_signals.py`).
+
+합성 티커 TST_* 만 사용(privacy: 사용자 실보유/실티커 금지). breach 판정은
+가격에서 유도(소스에 signed-% 리터럴 미포함).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+import yaml
+
+from nuri.alerts import risk_signals
+from nuri.core.db import init_db, query, upsert_portfolio, upsert_prices
+
+
+def _seed_price(path, ticker, close):
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": ticker,
+                    "date": "2026-07-08",
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": 1_000_000,
+                    "adj_close": close,
+                }
+            ]
+        ),
+        path,
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "risk.db"
+    init_db(path)
+    return path
+
+
+def _seed(path, *, ticker, account, avg, current):
+    upsert_portfolio(
+        [{"account": account, "ticker": ticker, "quantity": 10, "avg_price": avg, "currency": "USD", "sector": "Tech"}],
+        path,
+    )
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": ticker,
+                    "date": "2026-07-08",
+                    "open": current,
+                    "high": current,
+                    "low": current,
+                    "close": current,
+                    "volume": 1_000_000,
+                    "adj_close": current,
+                }
+            ]
+        ),
+        path,
+    )
+
+
+# ─── scan_stop_breaches ──────────────────────────────────────────────────────
+
+
+def test_breach_detected_when_below_threshold(db_path, monkeypatch):
+    # core stop_loss = -7% → avg 100, current 90 = -10% → breach
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=90.0)
+
+    breaches = risk_signals.scan_stop_breaches(db_path=db_path)
+
+    assert len(breaches) == 1
+    b = breaches[0]
+    assert b["ticker"] == "TST_A"
+    assert b["threshold"] == -7
+    assert b["pnl_pct"] == pytest.approx(-10.0)
+
+
+def test_no_breach_when_above_threshold(db_path, monkeypatch):
+    # avg 100, current 95 = -5% > -7% → no breach
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=95.0)
+
+    assert risk_signals.scan_stop_breaches(db_path=db_path) == []
+
+
+def test_pension_account_excluded(db_path, monkeypatch):
+    # 깊은 손실이라도 pension 은 daily action 대상 아님 → 제외
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "pension")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -30)
+    _seed(db_path, ticker="TST_A", account="Pension Gamma", avg=100.0, current=50.0)
+
+    assert risk_signals.scan_stop_breaches(db_path=db_path) == []
+
+
+def test_session_filter_kr_vs_us(db_path, monkeypatch):
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=88.0)
+    _seed(db_path, ticker="005930.KS", account="Brokerage Alpha", avg=100.0, current=88.0)
+
+    us = risk_signals.scan_stop_breaches(session="us", db_path=db_path)
+    kr = risk_signals.scan_stop_breaches(session="kr", db_path=db_path)
+    all_ = risk_signals.scan_stop_breaches(db_path=db_path)
+
+    assert [b["ticker"] for b in us] == ["TST_A"]
+    assert [b["ticker"] for b in kr] == ["005930.KS"]
+    assert len(all_) == 2
+
+
+def test_missing_price_skipped(db_path, monkeypatch):
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    # 보유만 있고 prices 없음 → current None → skip (KeyError/crash 없이)
+    upsert_portfolio(
+        [
+            {
+                "account": "Brokerage Alpha",
+                "ticker": "TST_A",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Tech",
+            }
+        ],
+        db_path,
+    )
+    assert risk_signals.scan_stop_breaches(db_path=db_path) == []
+
+
+def test_zero_price_skipped_no_false_breach(db_path, monkeypatch):
+    """P1 regression — current==0 (상장폐지/거래정지/불량 price) 은 -100% false
+    SELL 을 내면 안 됨. risk_agent 와 동일한 truthiness 가드.
+    """
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=0.0)
+
+    assert risk_signals.scan_stop_breaches(db_path=db_path) == []  # -100% false breach 없음
+
+
+def test_breaches_sorted_worst_first(db_path, monkeypatch):
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=90.0)  # -10%
+    _seed(db_path, ticker="TST_B", account="Brokerage Alpha", avg=100.0, current=80.0)  # -20%
+
+    breaches = risk_signals.scan_stop_breaches(db_path=db_path)
+    assert [b["ticker"] for b in breaches] == ["TST_B", "TST_A"]  # 깊은 손실 우선
+
+
+# ─── _build_breach_payload ───────────────────────────────────────────────────
+
+
+def test_payload_shape_is_actionable_sell():
+    breach = {
+        "ticker": "TST_A",
+        "account": "Brokerage Alpha",
+        "avg": 100.0,
+        "current": 90.0,
+        "pnl_pct": -10.0,
+        "threshold": -7,
+    }
+    payload = risk_signals._build_breach_payload(breach, "2026-07-08")
+
+    assert payload["kind"] == "SELL"  # → priority 0 "Action Now" + price_levels 노출
+    assert payload["ticker"] == "TST_A"
+    assert payload["note"] == "Brokerage Alpha"  # 다계좌 구분
+    assert "손절선 돌파" in payload["reason"]
+    assert payload["price_levels"]["entry"] == 100.0
+    assert payload["price_levels"]["stop"] == 93.0  # 100 × (1 + -7/100)
+
+
+def test_payload_renders_actionable_line():
+    # 렌더러 계약: "TST_A | SELL | reason: ...\n  ↳ entry $.. / stop $.."
+    from nuri.agents.discord.outbox import _format_event_line
+
+    breach = {
+        "ticker": "TST_A",
+        "account": "Brokerage Alpha",
+        "avg": 100.0,
+        "current": 90.0,
+        "pnl_pct": -10.0,
+        "threshold": -7,
+    }
+    line = _format_event_line(risk_signals._build_breach_payload(breach, "2026-07-08"))
+
+    assert line.startswith("TST_A | SELL")
+    assert "손절선 돌파" in line
+    assert "entry $100" in line and "stop $93" in line
+
+
+# ─── stage_stop_breach_briefs ────────────────────────────────────────────────
+
+
+def test_staging_writes_sell_events_to_brief_outbox(db_path, monkeypatch):
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=90.0)
+
+    staged = risk_signals.stage_stop_breach_briefs(date="2026-07-08", db_path=db_path)
+    assert staged == 1
+
+    rows = query(
+        "SELECT channel, priority, dedupe_key, payload_json FROM discord_outbox WHERE channel='brief'",
+        db_path=db_path,
+    )
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "high"
+    assert rows[0]["dedupe_key"] == "stop-breach:TST_A:Brokerage Alpha:2026-07-08"
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["kind"] == "SELL" and payload["ticker"] == "TST_A"
+
+
+def test_staging_dedupes_same_ticker_same_day(db_path, monkeypatch):
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=90.0)
+
+    risk_signals.stage_stop_breach_briefs(date="2026-07-08", db_path=db_path)
+    risk_signals.stage_stop_breach_briefs(date="2026-07-08", db_path=db_path)  # 재실행
+
+    rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert rows[0]["c"] == 1  # dedupe_key 로 1건만
+
+
+def test_multi_account_same_ticker_distinct_briefs(db_path, monkeypatch):
+    """P2-B — 같은 티커가 두 계좌에서 이탈하면 각각 별개 brief (dedupe 로 collapse
+    안 됨). 계좌별 avg 가 달라 entry/stop 도 다르므로 하나로 합치면 안 됨.
+    """
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    upsert_portfolio(
+        [
+            {
+                "account": "Brokerage Alpha",
+                "ticker": "TST_A",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "Brokerage Beta",
+                "ticker": "TST_A",
+                "quantity": 5,
+                "avg_price": 120.0,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ],
+        db_path,
+    )
+    _seed_price(db_path, "TST_A", 90.0)  # Alpha -10%, Beta -25% — 둘 다 이탈
+
+    assert len(risk_signals.scan_stop_breaches(db_path=db_path)) == 2
+
+    staged = risk_signals.stage_stop_breach_briefs(date="2026-07-08", db_path=db_path)
+    assert staged == 2  # collapse 안 됨 + non-None 카운트 정확
+
+    rows = query("SELECT dedupe_key FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert {r["dedupe_key"] for r in rows} == {
+        "stop-breach:TST_A:Brokerage Alpha:2026-07-08",
+        "stop-breach:TST_A:Brokerage Beta:2026-07-08",
+    }
+
+
+def test_e2e_pension_excluded_via_real_helper(db_path):
+    """P2-D — mock 없이 실제 get_account_strategy_name(portfolio.yaml 읽기) 경로로
+    pension 제외를 검증. helper 를 monkeypatch 하는 다른 테스트가 못 잡는 통합 갭.
+    """
+    portfolio_yaml = db_path.parent / "portfolio.yaml"
+    portfolio_yaml.write_text(
+        yaml.dump(
+            {
+                "accounts": {
+                    "Pension Gamma": {"strategy": "pension"},
+                    "Brokerage Alpha": {"strategy": "core"},
+                }
+            }
+        )
+    )
+    real_open = open
+
+    def mock_open(path, **kwargs):
+        if str(path).endswith("portfolio.yaml"):
+            return real_open(portfolio_yaml, **kwargs)
+        return real_open(path, **kwargs)
+
+    upsert_portfolio(
+        [
+            {
+                "account": "Pension Gamma",
+                "ticker": "TST_P",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "ETF",
+            },
+            {
+                "account": "Brokerage Alpha",
+                "ticker": "TST_A",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+        ],
+        db_path,
+    )
+    _seed_price(db_path, "TST_P", 50.0)  # -50% (pension stop -30 이탈이지만 제외)
+    _seed_price(db_path, "TST_A", 90.0)  # -10% (core stop -7 이탈)
+
+    with patch("builtins.open", side_effect=mock_open):
+        breaches = risk_signals.scan_stop_breaches(db_path=db_path)
+
+    assert [b["ticker"] for b in breaches] == ["TST_A"]  # pension 제외, core 만
+
+
+def test_no_breach_stages_nothing(db_path, monkeypatch):
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=99.0)
+
+    assert risk_signals.stage_stop_breach_briefs(date="2026-07-08", db_path=db_path) == 0
+
+
+# ─── main() CLI ──────────────────────────────────────────────────────────────
+
+
+def test_cli_dry_run_scans_without_staging(db_path, monkeypatch, capsys):
+    import nuri.core.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=90.0)
+
+    rc = risk_signals.main(["--dry-run"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "TST_A" in out and "dry-run" in out
+    rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert rows[0]["c"] == 0  # dry-run → stage 안 함
+
+
+def test_cli_stages_when_breach_and_not_dry_run(db_path, monkeypatch, capsys):
+    import nuri.core.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=90.0)
+
+    rc = risk_signals.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "staged 1" in out
+    rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert rows[0]["c"] == 1
+
+
+def test_cli_no_breach_reports_clean(db_path, monkeypatch, capsys):
+    import nuri.core.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+    monkeypatch.setattr(risk_signals, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(risk_signals, "get_stop_loss_for_account", lambda a: -7)
+    _seed(db_path, ticker="TST_A", account="Brokerage Alpha", avg=100.0, current=99.0)
+
+    rc = risk_signals.main([])
+    assert rc == 0
+    assert "없음" in capsys.readouterr().out

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -161,6 +161,35 @@ class TestAccountStrategies:
             result = get_account_strategy("test_acct")
             assert result["stop_loss"] == -7  # core default
 
+    def test_get_account_strategy_name_reads_yaml_name(self, tmp_path):
+        """이름(dict 아닌 name string) 반환 — pension 판별용."""
+        from nuri.core.rules import get_account_strategy_name
+
+        portfolio_yaml = tmp_path / "portfolio.yaml"
+        portfolio_yaml.write_text(yaml.dump({"accounts": {"P_acct": {"strategy": "pension"}}}))
+
+        real_open = open
+
+        def mock_open(path, **kwargs):
+            if str(path).endswith("portfolio.yaml"):
+                return real_open(portfolio_yaml, **kwargs)
+            return real_open(path, **kwargs)
+
+        with patch("builtins.open", side_effect=mock_open):
+            assert get_account_strategy_name("P_acct") == "pension"
+            assert get_account_strategy_name("unknown_acct") == "core"  # 매칭 실패 → core
+
+    def test_get_account_strategy_name_none_returns_core(self):
+        from nuri.core.rules import get_account_strategy_name
+
+        assert get_account_strategy_name(None) == "core"
+
+    def test_get_account_strategy_name_exception_returns_core(self):
+        from nuri.core.rules import get_account_strategy_name
+
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            assert get_account_strategy_name("any") == "core"
+
 
 # ═══════════════════════════════════════════════════════
 # §3.11 측정 모드 — 사전 고정 판정 기준 lock


### PR DESCRIPTION
## Why

`#brief` 다이제스트가 지금까지 aggregate INFO summary 1건(`? | INFO | 1 opinion`)만 표면화해, "이 화면만으로 무슨 의사결정을 하나"라는 통증이 있었다. 실제로는 손절선을 이탈한 보유 종목이 있어도 브리프에 뜨지 않았다 — 늦은 손절(처분효과, Shefrin & Statman 1985)로 이어지는 구조.

이 PR은 그 첫 slice(**Tier 1a**): **결정론적 룰 신호**인 손절선 이탈만 `#brief`에 SELL로 표면화한다. 예측 alpha(consensus BUY/SELL)는 §3.11 측정 진행 중이라 **의도적으로 제외**(Tier 2에서 "unproven/측정중" 라벨과 함께 별도).

## What

- **`nuri/alerts/risk_signals.py`** (신규)
  - `scan_stop_breaches(session, db_path)` — 보유 종목 중 row PnL < 계좌별 `config/rules.yaml` `stop_loss` threshold 이탈 목록 (worst 우선). pension 계좌 제외(monthly rebalance 대상), session 필터(`.KS` vs non-`.KS`).
  - `stage_stop_breach_briefs(session, date, db_path)` — 이탈 건을 `stage_brief`로 `#brief` outbox에 SELL로 stage. `dedupe_key=stop-breach:{ticker}:{date}`(하루 1건, 자를 때까지 매일 재알림 = 처분효과 방어).
  - `main()` CLI — `--session` / `--dry-run`(read-only 스캔).
- **`nuri/core/rules.py`** — `get_account_strategy_name(account)` public helper(pension 판별용 strategy name 반환).
- **`nuri/alerts/postmarket_brief.py`** — `write_brief`에 best-effort 1줄 wiring. 같은 post-market digest에 실려 발송(별도 스케줄러 job 불필요).

## 설계 준수 (invariants)

- **#429 alpha/portfolio 축** — stop-loss breach는 유일한 mechanical `alpha_action=FLAT` = 정당한 urgent SELL. `kind=SELL` → renderer "Action Now" 버킷 + price_levels 노출. 집중도/드리프트(REBALANCE)는 미포함(Tier 1b).
- **§3.11 측정 모드** — 예측 신호 미표면화. 결정론적 룰만.
- **payload 형식** — DecisionCompiler `_publish_brief` 선례와 동일(`kind`/`ticker`/`reason`/`price_levels{entry,stop}`). 발송 경로(`bucket_brief_digest`→`publish_embed`)에 privacy gate 없음 → 사용자 private Discord로 정상 도달.
- **privacy** — 테스트는 합성 티커 `TST_*` + placeholder broker만.

## 렌더링 예시 (합성 값)

```
TST_A | SELL | note: Brokerage Alpha | reason: 손절선 돌파 (-10.0% < -7%)
  ↳ entry $100.00 / stop $93.00
```

## Test

- `tests/alerts/test_risk_signals.py` (17): breach/no-breach/session-filter/pension-exclusion/missing-price/**zero-price(P1 regression)**/sort/payload-shape/renderer-contract/staging/dedupe/**multi-account distinct briefs(P2-B)**/**E2E pension via real helper(P2-D)**/CLI. **100% branch**.
- `tests/core/test_rules.py` (+3): `get_account_strategy_name` name/None/exception.
- `tests/alerts/test_postmarket_brief.py` (+1): wiring lock — write_brief가 stage_stop_breach_briefs를 (session, date) 전달해 호출(배선 되돌리면 FAIL).
- 전체 회귀: 6,217 passed (실패는 무관 — 로컬 `.env` env-leak 2 + macOS xdist flake 8, 모두 격리 통과).

## Review (self + local LLM 2차, Codex CLI 부재)

Codex CLI 미설치 → Flow fallback(self-review + 로컬 Qwen 2차). **P1 (수정 완료)**: `current==0` → -100% false SELL 가드(risk_agent truthiness 패턴 정렬) + regression. **P2-B/D (fold)**: 다계좌 dedupe collapse + mock-only 통합 → account-scoped dedupe_key + non-None 카운트 + E2E pension 테스트.

**Follow-up (별도, 미포함)**: P2-C — `get_account_strategy_name`/`get_stop_loss_for_account` 가 `portfolio.yaml` 읽기 실패 시 fail-OPEN(pension 제외 무력화). recommend-only(§7.1)라 청산 없음 + config 안정이라 즉시 위험은 낮음. name-substring(`연금`/`pension`/`irp`) fail-safe 가드는 후속 hardening.

## 배포

머지 후 mini prod 배포 필요(config/코드 변경). 배포 후 실 포트폴리오로 dry-run 재확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)