### PR TITLE
feat(alerts): surface concentration drift as REBALANCE in #brief

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,232 backend tests across 275 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,232 backend tests across 276 files + 1383 frontend vitest (126 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,228 tests, 275 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,228 tests, 276 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1383 tests, 126 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/discord/outbox.py
+++ b/nuri/agents/discord/outbox.py
@@ -368,7 +368,7 @@ def bucket_brief_digest(
             "footer": {"text": "manual execute only"},
         }
 
-    counts = {"BUY": 0, "SELL": 0, "BLOCK": 0, "CONFLICT": 0, "HOLD": 0, "INFO": 0}
+    counts = {"BUY": 0, "SELL": 0, "BLOCK": 0, "CONFLICT": 0, "HOLD": 0, "INFO": 0, "REBALANCE": 0}
     buckets: dict[str, list[str]] = {
         "Action Now": [],
         "Blocked / Conflict": [],
@@ -385,7 +385,7 @@ def bucket_brief_digest(
     title = f"{title_prefix} | {today_kst()} {kst_now().strftime('%H:%M')} KST | {n} opinions"
 
     desc_parts = []
-    for kind in ("BUY", "SELL", "BLOCK", "CONFLICT", "HOLD"):
+    for kind in ("BUY", "SELL", "BLOCK", "CONFLICT", "HOLD", "REBALANCE"):
         if counts[kind]:
             desc_parts.append(f"{kind} {counts[kind]}")
     desc = " | ".join(desc_parts) + " | manual execute only" if desc_parts else "manual execute only"

--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -1,0 +1,132 @@
+"""Mechanical portfolio-axis signals → #brief (Tier 1b: 집중도 드리프트 → REBALANCE).
+
+Tier 1a(risk_signals) 가 alpha 축(손절선 이탈 → urgent SELL) 을 표면화했다면,
+여기는 **portfolio 축**(#429): 종목 비중이 계좌별 `max_single_position` 한도를
+넘으면 REBALANCE 로 surface. 결정론적 룰(예측 아님).
+
+#429 축 분리 (엄밀): 집중도/드리프트는 `portfolio_action=REBALANCE` — **절대
+urgent SELL 아님**(alpha_action=FLAT 은 손절선만). 따라서 여기 payload 는
+kind="REBALANCE"(렌더러 Lower Priority 버킷) + **매도/청산 동사 금지 + entry/
+stop/target price_levels 금지**(REBALANCE 는 alpha exit 가 아님). 문구는 "비중
+조절 권고 — 수단·타이밍 사용자 판단".
+
+검출은 재구현하지 않고 canonical `rebalance_advisor.detect_violations()` 를
+재사용(per-account, 통화정확, 팩터정렬). 손절/레버리지 위반은 여기서 제외
+(손절 = Tier 1a alpha 축, 중복 방지).
+
+Privacy: Discord private 채널이므로 ticker+비중 노출 OK. 테스트는 합성 티커만.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
+
+# pension 계좌 라벨 판별 — actions.py/decision_compiler.py 와 동일한 canonical
+# 키워드 게이트. (get_account_strategy_name 은 Tier 1a #868 에만 있어 여기서 재정의
+# 하면 머지 충돌 → 정착된 substring 패턴 재사용.)
+_PENSION_KEYWORDS = ("연금", "pension", "irp")
+
+
+def _is_pension_account(account: Optional[str]) -> bool:
+    return any(kw in (account or "").lower() for kw in _PENSION_KEYWORDS)
+
+
+def scan_concentration_drift(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
+    """계좌별 단일종목 비중 한도 초과(집중도 드리프트) 목록.
+
+    `detect_violations()` 중 `position_limit_exceeded` 만 필터 — 손절(alpha 축,
+    Tier 1a)·레버리지·섹터는 제외. pension 계좌는 daily action 대상 아니므로 제외
+    (postmarket brief 가 pension holdings 를 이미 숨기는데 pension REBALANCE 를
+    매일 emit 하면 자기모순 — Tier 1a·_filter_actionable_accounts 와 동일 정책).
+    반환 dict 는 rebalance_advisor 원본 (ticker/account/current_value/limit_value/...).
+    """
+    from nuri.analysis.rebalance_advisor import detect_violations
+
+    violations = detect_violations(db_path=db_path)
+    return [
+        v
+        for v in violations
+        if v.get("violation_type") == "position_limit_exceeded" and not _is_pension_account(v.get("account"))
+    ]
+
+
+def _build_rebalance_payload(violation: dict[str, Any], date: str) -> dict[str, Any]:
+    """집중도 위반 1건 → #brief REBALANCE payload.
+
+    kind="REBALANCE" → 렌더러 `.get(kind, 2)` 로 Lower Priority 버킷(비긴급).
+    price_levels 없음(alpha exit 아님), reason 은 매도 동사 없이 비중 조절 권고.
+
+    Privacy: detect_violations 원본 reason 은 account 키(로마자 broker name)를
+    포함하므로 재사용하지 않고 numeric 필드로 재구성한다. stage_brief 는 요약
+    경로의 _privacy_gate_payload 를 안 거치므로 여기서 broker name egress 를 원천
+    차단 (계좌는 dedupe_key 에만, 사용자 노출 X).
+    """
+    return {
+        "kind": "REBALANCE",
+        "ticker": violation["ticker"],
+        "reason": (
+            f"비중 {violation['current_value']:.1f}% > 한도 {violation['limit_value'] * 100:.0f}%"
+            " — 비중 조절 권고 (수단·타이밍 사용자 판단)"
+        ),
+        "date": date,
+    }
+
+
+def stage_concentration_briefs(date: Optional[str] = None, db_path: Optional[Path] = None) -> int:
+    """집중도 드리프트를 #brief outbox 에 REBALANCE 로 stage. staged 건수 반환.
+
+    dedupe_key=`rebalance:position:{ticker}:{account}:{date}` — (ticker, account)
+    × 하루 1건. priority="normal"(비긴급 — 손절 SELL 의 high 와 구분).
+    non-None 만 카운트(dedupe skip → None).
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    d = date or today_kst()
+    drifts = scan_concentration_drift(db_path=db_path)
+    staged = 0
+    for v in drifts:
+        payload = _build_rebalance_payload(v, d)
+        outbox_id = stage_brief(
+            payload=payload,
+            dedupe_key=f"rebalance:position:{v['ticker']}:{v.get('account', '')}:{d}",
+            priority="normal",
+            actor_name="portfolio-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("concentration REBALANCE briefs staged: %d", staged)
+    return staged
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="집중도 드리프트 → #brief REBALANCE (Tier 1b)")
+    parser.add_argument("--dry-run", action="store_true", help="stage 없이 위반 목록만 출력")
+    args = parser.parse_args(argv)
+
+    drifts = scan_concentration_drift()
+    if not drifts:
+        print("집중도 한도 초과 없음")
+        return 0
+    for v in drifts:
+        print(
+            f"  {v['ticker']} [{v.get('account', '?')}] {v['current_value']:.1f}% > 한도 {v['limit_value'] * 100:.0f}%"
+        )
+    if args.dry_run:
+        print(f"[dry-run] {len(drifts)}건 — stage 안 함")
+        return 0
+    staged = stage_concentration_briefs()
+    print(f"staged {staged}건 → #brief (REBALANCE)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -632,6 +632,18 @@ def write_brief(
     if outbox_id is None:
         logger.info("Post-market brief Discord publish 미발행 (gate 차단 또는 outbox 미작동)")
 
+    # Tier 1b — 집중도 드리프트를 digest 에 REBALANCE 로 표면화 (portfolio 축, #429).
+    # 집중도는 portfolio-wide → US 세션에서만 stage (US-heavy 포트폴리오 · US 종장
+    # 직후 타이밍). kr/us 양 세션 호출 시 dispatcher 가 US 행을 sent 처리 후 KR 이
+    # 재삽입(dedupe 는 pending 만 매칭)해 하루 2건 나던 것을 단일 세션으로 차단.
+    if session == "us":
+        try:
+            from nuri.alerts.portfolio_signals import stage_concentration_briefs
+
+            stage_concentration_briefs(d, db_path=db_path)
+        except Exception:
+            logger.warning("concentration REBALANCE brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+
     return path
 
 

--- a/nuri/analysis/rebalance_advisor.py
+++ b/nuri/analysis/rebalance_advisor.py
@@ -198,6 +198,7 @@ def detect_violations(db_path: Optional[Path] = None) -> list[dict]:
         violations.append(
             {
                 "ticker": ticker,
+                "account": account,
                 "violation_type": "position_limit_exceeded",
                 "priority": _PRIORITY_MAP.get("position_limit_exceeded", 4),
                 "current_value": weight_pct,

--- a/tests/agents/test_discord_outbox.py
+++ b/tests/agents/test_discord_outbox.py
@@ -268,6 +268,21 @@ def test_bucket_brief_digest_groups_by_actionability():
     assert "BLOCK 1" in embed["description"]
 
 
+def test_bucket_brief_digest_counts_rebalance():
+    """Tier 1b — REBALANCE 는 Lower Priority 버킷 + 헤더 요약에 집계 (undercount 방지)."""
+    events = [
+        {"kind": "BUY", "ticker": "TST_A", "conviction": 0.81},
+        {"kind": "REBALANCE", "ticker": "TST_B", "reason": "비중 24.4% > 한도 15%"},
+        {"kind": "REBALANCE", "ticker": "TST_C", "reason": "비중 40.0% > 한도 35%"},
+    ]
+    embed = bucket_brief_digest(events)
+    assert "REBALANCE 2" in embed["description"]  # 헤더 집계
+    assert "3 opinions" in embed["title"]
+    # REBALANCE 는 Lower Priority 필드에 렌더 (Action Now 아님)
+    lower = next(f for f in embed["fields"] if "Lower Priority" in f["name"])
+    assert "TST_B" in lower["value"] and "TST_C" in lower["value"]
+
+
 def test_bucket_brief_digest_empty_returns_no_op_embed():
     embed = bucket_brief_digest([])
     assert embed["fields"] == []

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -1,0 +1,233 @@
+"""Tier 1b — 집중도 드리프트 → #brief REBALANCE (`nuri/alerts/portfolio_signals.py`).
+
+합성 티커 TST_* + placeholder 계좌만(privacy). 단위 테스트는 detect_violations 를
+mock 하고, 통합 테스트 1건은 실제 detect_violations 경로를 seed 로 검증.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from nuri.alerts import portfolio_signals
+from nuri.core.db import init_db, query, upsert_macro, upsert_portfolio, upsert_prices
+from nuri.core.timezone import today_kst
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    # analyze_portfolio()/analyze_sector() 는 db_path 인자 없이 전역 DB_PATH 사용 →
+    # monkeypatch 필수 (seeded_db 관례).
+    import nuri.core.db as db_mod
+
+    path = tmp_path / "port.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+def _violation(ticker, account, weight, limit=0.15):
+    return {
+        "ticker": ticker,
+        "account": account,
+        "violation_type": "position_limit_exceeded",
+        "current_value": weight,
+        "limit_value": limit,
+        "reason": f"{account} 비중 {weight:.1f}% > 한도 {limit * 100:.0f}%",
+    }
+
+
+# ─── scan_concentration_drift (filter) ───────────────────────────────────────
+
+
+def test_scan_filters_to_position_only(db_path):
+    """손절/섹터/레버리지 위반은 제외, position_limit_exceeded 만."""
+    fake = [
+        _violation("TST_A", "Brokerage Alpha", 24.4),
+        {"ticker": "TST_B", "violation_type": "stop_loss_exceeded", "reason": "손절"},
+        {"ticker": "TST_C", "violation_type": "sector_limit_exceeded", "reason": "섹터"},
+        {"ticker": "TST_D", "violation_type": "leverage_etf", "reason": "레버리지"},
+    ]
+    with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=fake):
+        out = portfolio_signals.scan_concentration_drift(db_path=db_path)
+    assert [v["ticker"] for v in out] == ["TST_A"]  # position only
+
+
+def test_scan_empty_when_no_violations(db_path):
+    with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]):
+        assert portfolio_signals.scan_concentration_drift(db_path=db_path) == []
+
+
+# ─── _build_rebalance_payload (#429 axis 룰) ──────────────────────────────────
+
+
+def test_payload_is_rebalance_no_price_levels_no_sell_verb():
+    p = portfolio_signals._build_rebalance_payload(_violation("TST_A", "Brokerage Alpha", 24.4), "2026-07-08")
+    assert p["kind"] == "REBALANCE"
+    assert p["ticker"] == "TST_A"
+    assert "price_levels" not in p  # REBALANCE 는 alpha exit 아님 → 가격레벨 금지
+    for verb in ("매도", "SELL", "청산"):
+        assert verb not in p["reason"]  # #429: 집중도는 urgent SELL 아님
+    assert "비중 조절 권고" in p["reason"]
+    # privacy: reason 은 numeric 재구성 — account 키(broker name) 미노출
+    assert "Brokerage Alpha" not in p["reason"]
+    assert "비중 24.4% > 한도 15%" in p["reason"]
+
+
+def test_pension_account_excluded_from_scan(db_path):
+    """pension 계좌 집중도는 REBALANCE 로 안 뜸 (brief 가 pension 을 숨기는 정책과 일치)."""
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations",
+        return_value=[
+            _violation("TST_A", "pension", 95.0, limit=0.40),  # pension 95% > 40% 이지만 제외
+            _violation("TST_B", "Brokerage Alpha", 24.4),
+        ],
+    ):
+        out = portfolio_signals.scan_concentration_drift(db_path=db_path)
+    assert [v["ticker"] for v in out] == ["TST_B"]  # pension 제외, 일반 계좌만
+
+
+def test_payload_renders_lower_priority_bucket():
+    """kind=REBALANCE → 렌더러 Lower Priority 버킷 (urgent Action Now 아님)."""
+    from nuri.agents.discord.outbox import _classify_event, _format_event_line
+
+    p = portfolio_signals._build_rebalance_payload(_violation("TST_A", "Brokerage Alpha", 24.4), "2026-07-08")
+    assert _classify_event(p) == "Lower Priority"  # #429: 비긴급
+    line = _format_event_line(p)
+    assert line.startswith("TST_A | REBALANCE")
+    assert "↳" not in line  # price_levels 라인 없음
+
+
+# ─── stage_concentration_briefs ──────────────────────────────────────────────
+
+
+def test_staging_writes_rebalance_events(db_path):
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations", return_value=[_violation("TST_A", "Brokerage Alpha", 24.4)]
+    ):
+        staged = portfolio_signals.stage_concentration_briefs(date="2026-07-08", db_path=db_path)
+    assert staged == 1
+
+    rows = query("SELECT priority, dedupe_key, payload_json FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "normal"  # 손절 high 와 구분
+    assert rows[0]["dedupe_key"] == "rebalance:position:TST_A:Brokerage Alpha:2026-07-08"
+    assert json.loads(rows[0]["payload_json"])["kind"] == "REBALANCE"
+
+
+def test_staging_dedupes_same_ticker_account_day(db_path):
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations", return_value=[_violation("TST_A", "Brokerage Alpha", 24.4)]
+    ):
+        portfolio_signals.stage_concentration_briefs(date="2026-07-08", db_path=db_path)
+        portfolio_signals.stage_concentration_briefs(date="2026-07-08", db_path=db_path)  # 재실행
+    rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert rows[0]["c"] == 1
+
+
+def test_staging_multi_account_same_ticker_distinct(db_path):
+    """같은 티커가 두 계좌에서 집중되면 각각 별개 REBALANCE (account-scoped dedupe)."""
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations",
+        return_value=[
+            _violation("TST_A", "Brokerage Alpha", 24.4),
+            _violation("TST_A", "Brokerage Beta", 18.0),
+        ],
+    ):
+        staged = portfolio_signals.stage_concentration_briefs(date="2026-07-08", db_path=db_path)
+    assert staged == 2
+    rows = query("SELECT dedupe_key FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert {r["dedupe_key"] for r in rows} == {
+        "rebalance:position:TST_A:Brokerage Alpha:2026-07-08",
+        "rebalance:position:TST_A:Brokerage Beta:2026-07-08",
+    }
+
+
+def test_no_breach_stages_nothing(db_path):
+    with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]):
+        assert portfolio_signals.stage_concentration_briefs(date="2026-07-08", db_path=db_path) == 0
+
+
+# ─── 통합 — 실제 detect_violations (mock 없이) ────────────────────────────────
+
+
+def test_integration_real_detect_violations_finds_concentration(db_path):
+    """rebalance_advisor.detect_violations 실경로 + 신규 account 필드 노출 검증."""
+    upsert_portfolio(
+        [
+            {
+                "account": "Brokerage Alpha",
+                "ticker": "TST_A",
+                "quantity": 90,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "Brokerage Alpha",
+                "ticker": "TST_B",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Energy",
+            },
+        ],
+        db_path,
+    )
+    rows = []
+    for t in ("TST_A", "TST_B"):
+        rows.append(
+            {
+                "ticker": t,
+                "date": today_kst(),
+                "open": 100,
+                "high": 100,
+                "low": 100,
+                "close": 100,
+                "volume": 1_000_000,
+                "adj_close": 100,
+            }
+        )
+    upsert_prices(pd.DataFrame(rows), db_path)
+    # analyze_portfolio 이 get_exchange_rate() 호출 → usd_krw 신선(today 앵커) 필요
+    upsert_macro([{"indicator": "usd_krw", "date": today_kst(), "value": 1380.0, "source": "test"}], db_path)
+
+    drifts = portfolio_signals.scan_concentration_drift(db_path=db_path)
+    tickers = [v["ticker"] for v in drifts]
+    assert "TST_A" in tickers  # 90% > core 15%
+    assert "TST_B" not in tickers  # 10% < 15%
+    # 신규 account 필드 (dedupe 용) 노출 확인
+    assert drifts[0]["account"] == "Brokerage Alpha"
+
+
+# ─── main() CLI ──────────────────────────────────────────────────────────────
+
+
+def test_cli_dry_run(db_path, capsys):
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations", return_value=[_violation("TST_A", "Brokerage Alpha", 24.4)]
+    ):
+        rc = portfolio_signals.main(["--dry-run"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "TST_A" in out and "dry-run" in out
+    rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert rows[0]["c"] == 0  # dry-run → stage 안 함
+
+
+def test_cli_stages_when_not_dry_run(db_path, capsys):
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations", return_value=[_violation("TST_A", "Brokerage Alpha", 24.4)]
+    ):
+        rc = portfolio_signals.main([])
+    out = capsys.readouterr().out
+    assert rc == 0 and "staged 1" in out
+
+
+def test_cli_no_breach(db_path, capsys):
+    with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]):
+        rc = portfolio_signals.main([])
+    assert rc == 0 and "없음" in capsys.readouterr().out

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -200,6 +200,20 @@ def test_write_brief_stages_concentration_rebalance_us_only(seeded_db, portfolio
     assert args[0] == "2026-05-01"  # date 전달
 
 
+def test_write_brief_survives_concentration_staging_error(seeded_db, portfolio_yaml):
+    """집중도 staging 이 raise 해도 write_brief 는 브리프 생성 후 정상 반환 (best-effort)."""
+    from nuri.alerts.postmarket_brief import write_brief
+
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", side_effect=RuntimeError("boom")),
+    ):
+        path = write_brief("us", date="2026-05-01")  # 예외 전파 안 함
+
+    assert path.exists()  # 브리프 자체는 생성됨
+
+
 def test_us_session_dst_aware_cron_dispatch():
     """NYSE 16:30 ET window — EDT (KST 05:30) / EST (KST 06:30) 양쪽 검증.
 

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -176,6 +176,30 @@ def test_pension_excluded_from_postmarket(seeded_db, portfolio_yaml, tmp_path):
     assert "NVDA" in md
 
 
+def test_write_brief_stages_concentration_rebalance_us_only(seeded_db, portfolio_yaml):
+    """Tier 1b wiring lock — write_brief('us') 만 집중도 REBALANCE 를 stage.
+
+    배선 제거 시 FAIL. US-only 게이트(P2-2): kr/us 양 세션 호출 시 dispatcher 가
+    US 행 sent 처리 후 KR 재삽입해 하루 2건 나던 것을 단일 세션으로 차단.
+    """
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    spy = MagicMock(return_value=0)
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", spy),
+    ):
+        write_brief("us", date="2026-05-01")
+        write_brief("kr", date="2026-05-01")
+
+    spy.assert_called_once()  # US 만 — KR 은 호출 안 함
+    args, _ = spy.call_args
+    assert args[0] == "2026-05-01"  # date 전달
+
+
 def test_us_session_dst_aware_cron_dispatch():
     """NYSE 16:30 ET window — EDT (KST 05:30) / EST (KST 06:30) 양쪽 검증.
 


### PR DESCRIPTION
## Why

Tier 1a(#868)가 alpha 축(손절선 이탈 → urgent SELL)을 `#brief`에 표면화했다. 이 PR은 그 **portfolio 축 짝**(#429): 종목 비중이 계좌별 `max_single_position` 한도를 넘는 **집중도 드리프트**를 REBALANCE로 surface한다. 사용자 실 포트폴리오에 단일 종목이 24%까지 집중된 상태가 있어도 브리프가 침묵했다 — 리밸런싱 판단 근거가 표면에 없었다.

결정론적 룰(config `position_limits` / 계좌별 `max_single_position`)이므로 Tier 1(rigorous). 예측 아님.

## What

- **`nuri/alerts/portfolio_signals.py`** (신규)
  - `scan_concentration_drift(db_path)` — canonical `rebalance_advisor.detect_violations()`를 **재사용**(재구현 금지)하고 `position_limit_exceeded`만 필터. 손절(alpha 축, Tier 1a)·섹터·레버리지는 제외(중복 방지).
  - `stage_concentration_briefs(date, db_path)` — REBALANCE payload를 `#brief`에 stage. `dedupe_key=rebalance:position:{ticker}:{account}:{date}`, `priority="normal"`(손절 SELL의 high와 구분).
  - `main()` CLI — `--dry-run`.
- **`nuri/analysis/rebalance_advisor.py`** — position violation dict에 `"account"` 필드 1줄 노출(다계좌 dedupe/구분용, backward-compatible).
- **`nuri/alerts/postmarket_brief.py`** — `write_brief`에 best-effort 1줄 wiring(집중도는 portfolio-wide라 session 무관, dedupe로 하루 1건).

## #429 축 준수 (엄밀)

- 집중도 = `portfolio_action=REBALANCE`, **절대 urgent SELL 아님**(alpha_action=FLAT은 손절선만).
- `kind="REBALANCE"` → 렌더러 `_classify_event`의 `.get(kind, 2)`로 **Lower Priority 버킷**(비긴급). 렌더러(outbox.py) 미변경 — #571 계약 보존.
- payload에 **매도/SELL/청산 동사 금지 + entry/stop price_levels 금지**(REBALANCE는 alpha exit 아님). 문구: "비중 조절 권고 — 수단·타이밍 사용자 판단".

## 렌더링 예시 (합성 값)

```
TST_A | REBALANCE | reason: Brokerage Alpha 비중 24.4% > 한도 15% — 비중 조절 권고 (수단·타이밍 사용자 판단)
```
(price_levels 없음, Lower Priority 버킷)

## Review (3-lens 적대적 워크플로우 → 4건 confirm·전부 수정)

병렬 3렌즈(axis 정합/재사용 정확성/엣지) + 각 finding 적대적 재검증. verified real 4건 전부 fold:
- **P2 pension 미제외**: postmarket이 pension holdings를 숨기면서(_filter_actionable_accounts) pension REBALANCE는 매일 emit하는 자기모순 → `scan`에서 pension 계좌 제외(canonical 연금/pension/irp 키워드).
- **P2 kr/us 이중 stage**: dispatcher가 US행을 sent 처리 후 KR이 재삽입(dedupe는 pending만 매칭) → 하루 2건 → **US 세션만 stage**로 게이트.
- **P3 broker name egress**: reason의 raw account 키(로마자 broker name)가 gate 없이 Discord로 → reason을 numeric 재구성(account는 dedupe_key에만).
- **P3 렌더러 count 헤더**: REBALANCE 미집계 → `bucket_brief_digest` counts에 추가(2줄).

## Test

- `tests/alerts/test_portfolio_signals.py` (14): position-only 필터/**pension 제외**/no-price-levels·no-SELL-verb/**broker-name 부재**/Lower-Priority-버킷/staging/dedupe/multi-account/**실 detect_violations 통합(account 필드 노출)**/CLI. **100% branch**.
- `tests/alerts/test_postmarket_brief.py` (+1): wiring lock — write_brief('us')만 호출, ('kr')은 미호출.
- `tests/agents/test_discord_outbox.py` (+1): REBALANCE 헤더 집계 + Lower Priority 렌더.
- rebalance_advisor 회귀 0 (account 필드 additive). 광범위 회귀 1,466 passed.

## 스코프 노트 (follow-up)

- **섹터 드리프트 → Tier 1c**: `detect_violations` 섹터 위반은 종목당 1건이라 per-sector collapse가 필요 + `analyze_sector`와 스케일 불일치 → 별도 clean slice로 분리.

## 관계

Tier 1a #868(alpha 축 stop-breach SELL)의 portfolio 축 짝. main 기반 병렬 브랜치라 write_brief wiring이 #868과 인접(trivial sequential rebase). 배포는 mini(§3.11 프로덕션)라 사용자 명시 승인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)