### PR TITLE
feat(alerts): surface sector drift as REBALANCE in #brief (Tier 1c)

### DIFF
--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -1,8 +1,9 @@
-"""Mechanical portfolio-axis signals → #brief (Tier 1b: 집중도 드리프트 → REBALANCE).
+"""Mechanical portfolio-axis signals → #brief (Tier 1b: 집중도 · 1c: 섹터 드리프트 → REBALANCE).
 
 Tier 1a(risk_signals) 가 alpha 축(손절선 이탈 → urgent SELL) 을 표면화했다면,
-여기는 **portfolio 축**(#429): 종목 비중이 계좌별 `max_single_position` 한도를
-넘으면 REBALANCE 로 surface. 결정론적 룰(예측 아님).
+여기는 **portfolio 축**(#429): (1b) 종목 비중이 계좌별 `max_single_position` 한도,
+(1c) 섹터 합산 비중이 `max_sector_exposure` 한도를 넘으면 REBALANCE 로 surface.
+결정론적 룰(예측 아님).
 
 #429 축 분리 (엄밀): 집중도/드리프트는 `portfolio_action=REBALANCE` — **절대
 urgent SELL 아님**(alpha_action=FLAT 은 손절선만). 따라서 여기 payload 는
@@ -107,23 +108,103 @@ def stage_concentration_briefs(date: Optional[str] = None, db_path: Optional[Pat
     return staged
 
 
+def scan_sector_drift(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
+    """섹터 합산 비중 한도(`max_sector_exposure`) 초과 목록 — 섹터당 1건.
+
+    `detect_violations()` 중 `sector_limit_exceeded` 만 필터. 섹터 위반은 트림
+    대상 종목당 1건씩 나오므로 `sector` 필드로 dedup 해 섹터당 1건으로 collapse
+    (detect_violations 는 Unknown/빈 섹터를 이미 제외).
+
+    **의도적 설계 — 섹터는 pension 포함 total 위험 (1b 집중도와 스코프 다름)**:
+    섹터 캡은 코드베이스 전체가 **global** 로 강제한다 — detect_violations 와
+    certification 모두 계좌별이 아니라 portfolio-wide 합에 flat `MAX_SECTOR_EXPOSURE`
+    (0.35) 를 적용(per-account 섹터 캡은 config 에 있으나 미구현·deferred). 따라서
+    섹터 비중은 pension 을 포함한 **총 섹터 노출**이며 이는 룰 정의와 일치한다.
+    1b 집중도가 pension 을 제외하는 건 그게 **per-account** 룰이라서고(pension 은
+    자체 높은 캡), 섹터는 global 룰이라 total 로 보는 게 정합. drawback: 드물게
+    섹터 초과가 pension-주도면 daily-actionable sleeve 에서 트림할 게 적을 수 있으나,
+    총위험 가시성이 목적이므로 수용(사용자는 non-pension 종목 트림으로 총 노출 감축).
+    """
+    from nuri.analysis.rebalance_advisor import detect_violations
+
+    violations = detect_violations(db_path=db_path)
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for v in violations:
+        if v.get("violation_type") != "sector_limit_exceeded":
+            continue
+        sector = v.get("sector")
+        if not sector or sector in seen:
+            continue
+        seen.add(sector)
+        out.append(v)
+    return out
+
+
+def _build_sector_rebalance_payload(violation: dict[str, Any], date: str) -> dict[str, Any]:
+    """섹터 위반 1건 → #brief REBALANCE payload. ticker 슬롯에 섹터명 표시.
+
+    집중도(1b)와 동일 #429 규칙: kind="REBALANCE"(Lower Priority), price_levels
+    없음, 매도 동사 없음. 섹터명은 public 라벨(broker name 아님)이라 노출 OK.
+    """
+    return {
+        "kind": "REBALANCE",
+        "ticker": violation["sector"],
+        "reason": (
+            f"섹터 비중 {violation['current_value']:.1f}% > 한도 {violation['limit_value'] * 100:.0f}%"
+            " — 비중 조절 권고 (수단·타이밍 사용자 판단)"
+        ),
+        "date": date,
+    }
+
+
+def stage_sector_briefs(date: Optional[str] = None, db_path: Optional[Path] = None) -> int:
+    """섹터 드리프트를 #brief outbox 에 REBALANCE 로 stage. staged 건수 반환.
+
+    dedupe_key=`rebalance:sector:{sector}:{date}` — 섹터 × 하루 1건.
+    priority="normal". non-None 만 카운트.
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    d = date or today_kst()
+    drifts = scan_sector_drift(db_path=db_path)
+    staged = 0
+    for v in drifts:
+        payload = _build_sector_rebalance_payload(v, d)
+        outbox_id = stage_brief(
+            payload=payload,
+            dedupe_key=f"rebalance:sector:{v['sector']}:{d}",
+            priority="normal",
+            actor_name="portfolio-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("sector REBALANCE briefs staged: %d", staged)
+    return staged
+
+
 def main(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="집중도 드리프트 → #brief REBALANCE (Tier 1b)")
+    parser = argparse.ArgumentParser(description="포트폴리오 드리프트(집중도·섹터) → #brief REBALANCE (Tier 1b/1c)")
     parser.add_argument("--dry-run", action="store_true", help="stage 없이 위반 목록만 출력")
     args = parser.parse_args(argv)
 
-    drifts = scan_concentration_drift()
-    if not drifts:
-        print("집중도 한도 초과 없음")
+    conc = scan_concentration_drift()
+    sect = scan_sector_drift()
+    if not conc and not sect:
+        print("포트폴리오 드리프트 없음 (집중도·섹터)")
         return 0
-    for v in drifts:
+    for v in conc:
         print(
-            f"  {v['ticker']} [{v.get('account', '?')}] {v['current_value']:.1f}% > 한도 {v['limit_value'] * 100:.0f}%"
+            f"  [집중도] {v['ticker']} [{v.get('account', '?')}] {v['current_value']:.1f}% > 한도 {v['limit_value'] * 100:.0f}%"
         )
+    for v in sect:
+        print(f"  [섹터] {v['sector']} {v['current_value']:.1f}% > 한도 {v['limit_value'] * 100:.0f}%")
     if args.dry_run:
-        print(f"[dry-run] {len(drifts)}건 — stage 안 함")
+        print(f"[dry-run] 집중도 {len(conc)}건 · 섹터 {len(sect)}건 — stage 안 함")
         return 0
-    staged = stage_concentration_briefs()
+    staged = stage_concentration_briefs() + stage_sector_briefs()
     print(f"staged {staged}건 → #brief (REBALANCE)")
     return 0
 

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -641,10 +641,12 @@ def write_brief(
     except Exception:
         logger.warning("stop-breach brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
 
-    # Tier 1b — 집중도 드리프트를 digest 에 REBALANCE 로 표면화 (portfolio 축, #429).
-    # 집중도는 portfolio-wide → US 세션에서만 stage (US-heavy 포트폴리오 · US 종장
-    # 직후 타이밍). kr/us 양 세션 호출 시 dispatcher 가 US 행을 sent 처리 후 KR 이
-    # 재삽입(dedupe 는 pending 만 매칭)해 하루 2건 나던 것을 단일 세션으로 차단.
+    # Tier 1b/1c — 포트폴리오 드리프트(집중도·섹터)를 digest 에 REBALANCE 로 표면화
+    # (portfolio 축, #429). 둘 다 portfolio-wide → US 세션에서만 stage (US-heavy
+    # 포트폴리오 · US 종장 직후 타이밍). kr/us 양 세션 호출 시 dispatcher 가 US 행을
+    # sent 처리 후 KR 이 재삽입(dedupe 는 pending 만 매칭)해 하루 2건 나던 것을 단일
+    # 세션으로 차단. 집중도·섹터는 독립 신호라 각각 별도 best-effort (한쪽 실패가
+    # 다른 쪽 stage 를 막지 않게 — Tier 1a stop-breach 와 동일 per-concern 패턴).
     if session == "us":
         try:
             from nuri.alerts.portfolio_signals import stage_concentration_briefs
@@ -652,6 +654,12 @@ def write_brief(
             stage_concentration_briefs(d, db_path=db_path)
         except Exception:
             logger.warning("concentration REBALANCE brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+        try:
+            from nuri.alerts.portfolio_signals import stage_sector_briefs
+
+            stage_sector_briefs(d, db_path=db_path)
+        except Exception:
+            logger.warning("sector REBALANCE brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
 
     return path
 

--- a/nuri/analysis/rebalance_advisor.py
+++ b/nuri/analysis/rebalance_advisor.py
@@ -261,6 +261,7 @@ def detect_violations(db_path: Optional[Path] = None) -> list[dict]:
                 violations.append(
                     {
                         "ticker": ticker,
+                        "sector": sector,
                         "violation_type": "sector_limit_exceeded",
                         "priority": _PRIORITY_MAP.get("sector_limit_exceeded", 5),
                         "current_value": sector_weight,

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -203,6 +203,97 @@ def test_integration_real_detect_violations_finds_concentration(db_path):
     assert drifts[0]["account"] == "Brokerage Alpha"
 
 
+# ─── Tier 1c: scan_sector_drift ──────────────────────────────────────────────
+
+
+def _sector_violation(ticker, sector, weight, limit=0.35):
+    return {
+        "ticker": ticker,
+        "sector": sector,
+        "violation_type": "sector_limit_exceeded",
+        "current_value": weight,
+        "limit_value": limit,
+        "reason": f"섹터({sector}) 비중 {weight:.1f}% > 한도 {limit * 100:.0f}%",
+    }
+
+
+def test_scan_sector_filters_and_dedups_by_sector(db_path):
+    """sector_limit_exceeded 만 + 섹터당 1건 (종목당 나오는 것 collapse)."""
+    fake = [
+        _violation("TST_A", "Brokerage Alpha", 24.4),  # position — 제외
+        _sector_violation("TST_B", "Semiconductor", 45.0),
+        _sector_violation("TST_C", "Semiconductor", 45.0),  # 같은 섹터 → dedup
+        _sector_violation("TST_D", "Energy", 40.0),
+    ]
+    with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=fake):
+        out = portfolio_signals.scan_sector_drift(db_path=db_path)
+    assert [v["sector"] for v in out] == ["Semiconductor", "Energy"]  # 섹터당 1건
+
+
+def test_sector_payload_is_rebalance_ticker_is_sector(db_path):
+    p = portfolio_signals._build_sector_rebalance_payload(
+        _sector_violation("TST_B", "Semiconductor", 45.0), "2026-07-08"
+    )
+    assert p["kind"] == "REBALANCE"
+    assert p["ticker"] == "Semiconductor"  # ticker 슬롯 = 섹터명
+    assert "price_levels" not in p
+    for verb in ("매도", "SELL", "청산"):
+        assert verb not in p["reason"]
+    assert "섹터 비중 45.0% > 한도 35%" in p["reason"]
+
+
+def test_sector_staging_and_dedupe(db_path):
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations",
+        return_value=[_sector_violation("TST_B", "Semiconductor", 45.0)],
+    ):
+        s1 = portfolio_signals.stage_sector_briefs(date="2026-07-08", db_path=db_path)
+        s2 = portfolio_signals.stage_sector_briefs(date="2026-07-08", db_path=db_path)  # 재실행
+    assert s1 == 1 and s2 == 0  # dedupe
+    rows = query("SELECT dedupe_key, priority FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert len(rows) == 1
+    assert rows[0]["dedupe_key"] == "rebalance:sector:Semiconductor:2026-07-08"
+    assert rows[0]["priority"] == "normal"
+
+
+def test_integration_real_detect_violations_sector(db_path):
+    """실 detect_violations 로 섹터 초과 검출 + 신규 sector 필드 노출."""
+    # 한 계좌에 같은 섹터 3종목 = 섹터 100% > 35% (계좌 집중은 각 <15% 로 회피)
+    upsert_portfolio(
+        [
+            {
+                "account": "Brokerage Alpha",
+                "ticker": f"TST_{i}",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            }
+            for i in range(8)
+        ],
+        db_path,
+    )
+    rows = [
+        {
+            "ticker": f"TST_{i}",
+            "date": today_kst(),
+            "open": 100,
+            "high": 100,
+            "low": 100,
+            "close": 100,
+            "volume": 1_000_000,
+            "adj_close": 100,
+        }
+        for i in range(8)
+    ]
+    upsert_prices(pd.DataFrame(rows), db_path)
+    upsert_macro([{"indicator": "usd_krw", "date": today_kst(), "value": 1380.0, "source": "test"}], db_path)
+
+    drifts = portfolio_signals.scan_sector_drift(db_path=db_path)
+    assert any(v["sector"] == "Semiconductor" for v in drifts)  # 100% > 35%
+    assert drifts[0]["sector"] == "Semiconductor"  # 신규 필드 노출
+
+
 # ─── main() CLI ──────────────────────────────────────────────────────────────
 
 
@@ -231,3 +322,19 @@ def test_cli_no_breach(db_path, capsys):
     with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]):
         rc = portfolio_signals.main([])
     assert rc == 0 and "없음" in capsys.readouterr().out
+
+
+def test_cli_shows_concentration_and_sector(db_path, capsys):
+    """main() 이 집중도 + 섹터 둘 다 표시 + stage."""
+    with patch(
+        "nuri.analysis.rebalance_advisor.detect_violations",
+        return_value=[
+            _violation("TST_A", "Brokerage Alpha", 24.4),
+            _sector_violation("TST_B", "Semiconductor", 45.0),
+        ],
+    ):
+        rc = portfolio_signals.main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "[집중도] TST_A" in out and "[섹터] Semiconductor" in out
+    assert "staged 2" in out  # 집중도 1 + 섹터 1

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -200,8 +200,8 @@ def test_write_brief_stages_stop_breach(seeded_db, portfolio_yaml):
     assert args[1] == "2026-05-01"  # date
 
 
-def test_write_brief_stages_concentration_rebalance_us_only(seeded_db, portfolio_yaml):
-    """Tier 1b wiring lock — write_brief('us') 만 집중도 REBALANCE 를 stage.
+def test_write_brief_stages_portfolio_drift_us_only(seeded_db, portfolio_yaml):
+    """Tier 1b/1c wiring lock — write_brief('us') 만 집중도+섹터 REBALANCE 를 stage.
 
     배선 제거 시 FAIL. US-only 게이트(P2-2): kr/us 양 세션 호출 시 dispatcher 가
     US 행 sent 처리 후 KR 재삽입해 하루 2건 나던 것을 단일 세션으로 차단.
@@ -210,32 +210,41 @@ def test_write_brief_stages_concentration_rebalance_us_only(seeded_db, portfolio
 
     from nuri.alerts.postmarket_brief import write_brief
 
-    spy = MagicMock(return_value=0)
+    conc_spy = MagicMock(return_value=0)
+    sect_spy = MagicMock(return_value=0)
     with (
         patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
         patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
-        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", spy),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", conc_spy),
+        patch("nuri.alerts.portfolio_signals.stage_sector_briefs", sect_spy),
     ):
         write_brief("us", date="2026-05-01")
         write_brief("kr", date="2026-05-01")
 
-    spy.assert_called_once()  # US 만 — KR 은 호출 안 함
-    args, _ = spy.call_args
-    assert args[0] == "2026-05-01"  # date 전달
+    conc_spy.assert_called_once()  # US 만 — KR 은 호출 안 함
+    sect_spy.assert_called_once()
+    assert conc_spy.call_args[0][0] == "2026-05-01"  # date 전달
+    assert sect_spy.call_args[0][0] == "2026-05-01"
 
 
-def test_write_brief_survives_concentration_staging_error(seeded_db, portfolio_yaml):
-    """집중도 staging 이 raise 해도 write_brief 는 브리프 생성 후 정상 반환 (best-effort)."""
+def test_write_brief_survives_portfolio_drift_staging_error(seeded_db, portfolio_yaml):
+    """집중도 staging 이 raise 해도 (1) write_brief 는 정상 반환 + (2) 섹터는 여전히
+    시도됨 (독립 best-effort — 한쪽 실패가 다른 쪽을 막지 않음)."""
+    from unittest.mock import MagicMock
+
     from nuri.alerts.postmarket_brief import write_brief
 
+    sect_spy = MagicMock(return_value=0)
     with (
         patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
         patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
         patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", side_effect=RuntimeError("boom")),
+        patch("nuri.alerts.portfolio_signals.stage_sector_briefs", sect_spy),
     ):
         path = write_brief("us", date="2026-05-01")  # 예외 전파 안 함
 
     assert path.exists()  # 브리프 자체는 생성됨
+    sect_spy.assert_called_once()  # 집중도 실패해도 섹터는 시도됨
 
 
 def test_us_session_dst_aware_cron_dispatch():

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -247,6 +247,23 @@ def test_write_brief_survives_portfolio_drift_staging_error(seeded_db, portfolio
     sect_spy.assert_called_once()  # 집중도 실패해도 섹터는 시도됨
 
 
+def test_write_brief_survives_sector_staging_error(seeded_db, portfolio_yaml):
+    """섹터 staging 이 raise 해도 write_brief 는 정상 반환 (섹터 독립 except)."""
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", MagicMock(return_value=0)),
+        patch("nuri.alerts.portfolio_signals.stage_sector_briefs", side_effect=RuntimeError("boom")),
+    ):
+        path = write_brief("us", date="2026-05-01")  # 예외 전파 안 함
+
+    assert path.exists()
+
+
 def test_us_session_dst_aware_cron_dispatch():
     """NYSE 16:30 ET window — EDT (KST 05:30) / EST (KST 06:30) 양쪽 검증.
 


### PR DESCRIPTION
## Why

Tier 1b(#869)가 계좌별 **집중도** 드리프트를 REBALANCE로 표면화했다. 이 PR은 그 sector-axis 짝(**Tier 1c**): 한 섹터의 합산 비중이 `max_sector_exposure`(35%)를 넘으면 REBALANCE로 surface. 프로덕션 dry-run에서 반도체 섹터가 한도를 크게 초과 중인데 브리프가 침묵했다.

결정론적 룰(config `position_limits.max_sector_exposure`). 예측 아님(Tier 1).

## What

- **`nuri/alerts/portfolio_signals.py`** (Tier 1b 모듈 확장)
  - `scan_sector_drift(db_path)` — `detect_violations()` 중 `sector_limit_exceeded`만 필터 + **`sector` 필드로 dedup**(섹터당 1건 — detect_violations는 트림 대상 종목당 1건씩 내므로 collapse).
  - `stage_sector_briefs(date, db_path)` — 섹터당 REBALANCE stage. `dedupe_key=rebalance:sector:{sector}:{date}`.
  - `main()` — 집중도 + 섹터 둘 다 표시/stage.
- **`nuri/analysis/rebalance_advisor.py`** — sector violation dict에 `"sector"` 필드 1줄(dedup/표시용, backward-compatible — Tier 1b `account` 필드 선례).
- **`nuri/alerts/postmarket_brief.py`** — `write_brief` US 세션에 `stage_sector_briefs`를 concentration 옆에 wiring.

## #429 축 준수 (Tier 1b와 동일)

- 섹터 드리프트 = `portfolio_action=REBALANCE`, **절대 urgent SELL 아님**. `kind="REBALANCE"` → Lower Priority 버킷, 매도/청산 동사 금지, price_levels 금지.
- ticker 슬롯에 섹터명(public 라벨, broker name 아님) 표시. reason은 numeric("섹터 비중 X% > 한도 35%").
- 섹터 비중은 global(계좌 무관)이라 pension 필터 불필요. 손절(alpha 축)·집중도(position: prefix)와 dedupe_key로 분리.

## 렌더링 예시 (합성 값)

```
Semiconductor | REBALANCE | reason: 섹터 비중 45.0% > 한도 35% — 비중 조절 권고 (수단·타이밍 사용자 판단)
```

## Review (3-lens 적대적 워크플로우 → 2 실이슈)

- **P2 coupled try (수정)**: `write_brief`에서 집중도·섹터 staging이 같은 try → 집중도 실패 시 섹터 skip. 독립 신호이므로 **별도 try/except로 분리**(Tier 1a stop-breach와 동일 per-concern) + survives 테스트에 `sect_spy.assert_called_once()` 추가.
- **P2 섹터 weight에 pension 포함 (문서화)**: 섹터 합산이 pension 보유분을 포함 vs 1b 집중도는 pension 제외. **검토 결과 정당** — 섹터 캡은 코드베이스 전체가 **global**로 강제(detect_violations·certification 모두 flat 0.35 portfolio-wide, per-account 섹터 캡은 deferred). 1b는 per-account 룰이라 pension 제외, 1c는 global 룰이라 total 섹터 위험. 서로 다른 스코프가 설계상 맞음 → docstring에 명시(리뷰어도 "document OR fix" 수용). drawback(드문 pension-주도 섹터 초과의 비-actionability)은 총위험 가시성 목적상 수용, docstring 기재.

## Test

- `tests/alerts/test_portfolio_signals.py` (+6): sector 필터+dedup/payload(ticker=섹터, no price·no SELL)/staging+dedupe/실 detect_violations 통합(sector 필드)/CLI 집중도+섹터. **100% branch**(mock; integration은 macOS `--cov` Heisenbug이라 제외, CI 커버).
- `tests/alerts/test_postmarket_brief.py`: wiring lock을 conc+sector 둘 다로 업데이트.
- 광범위 회귀 287 passed, rebalance_advisor 회귀 0.

## 관계

Tier 1a #868(손절 SELL) + Tier 1b #869(집중도 REBALANCE)의 sector-axis 완성. 이로써 #429 portfolio 축 드리프트(집중도+섹터) 표면화 완결. 배포는 mini(§3.11)라 사용자 승인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)