### PR TITLE
chore: fix inert permission rules + add PUT to CORS allow_methods

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,6 @@
   "permissions": {
     "allow": [
       "Read(**)",
-      "Glob(**)",
       "Grep(**)",
       "Bash(make *)",
       "Bash(.venv/bin/* *)",
@@ -22,18 +21,7 @@
       "Bash(curl -s http://127.0.0.1*)",
       "Bash(uv sync*)",
       "Bash(uv run*)",
-      "Edit(**)",
-      "Write(**/*.md)",
-      "Write(**/*.py)",
-      "Write(**/*.yaml)",
-      "Write(**/*.yml)",
-      "Write(**/*.json)",
-      "Write(**/*.toml)",
-      "Write(**/*.ts)",
-      "Write(**/*.tsx)",
-      "Write(**/*.sh)",
-      "Write(/tmp/**)",
-      "Write(/private/tmp/**)"
+      "Edit(**)"
     ],
     "deny": [
       "Bash(git push --force *)",
@@ -58,9 +46,9 @@
       "Read(**/id_rsa*)",
       "Read(**/id_ed25519*)",
       "Read(config/kis/*)",
-      "Write(**/.env)",
-      "Write(**/credentials*)",
-      "Write(**/secrets*)"
+      "Edit(**/.env)",
+      "Edit(**/credentials*)",
+      "Edit(**/secrets*)"
     ]
   },
   "hooks": {

--- a/nuri/api/main.py
+++ b/nuri/api/main.py
@@ -81,7 +81,9 @@ _cors_origins = [o.strip() for o in _cors_origins_str.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
-    allow_methods=["GET", "POST", "DELETE"],
+    # PUT 포함 필수 — portfolio/trades 수정 엔드포인트가 PUT. 목록은 3/27 작성,
+    # PUT 엔드포인트는 #60 (3/31) 추가되며 미갱신 → cross-origin preflight 400.
+    allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["Authorization", "Content-Type"],
     allow_credentials=True,
 )

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -33,6 +33,24 @@ class TestApiMain:
         assert resp.headers.get("X-Content-Type-Options") == "nosniff"
         assert resp.headers.get("X-Frame-Options") == "SAMEORIGIN"  # A2 fix: /evidence iframe
 
+    @pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+    def test_cors_allows_every_mutating_method(self, client, method):
+        """CORS allow_methods 는 실제 라우트가 쓰는 메서드를 전부 덮어야 한다.
+
+        PUT 이 빠져 있으면 cross-origin preflight 가 400 (Disallowed CORS method).
+        프론트는 Next rewrite 로 same-origin 이라 preflight 가 안 떠서 이 결함이
+        브라우저 cross-origin 에서만 드러남 — TestClient 로 직접 잠근다.
+        """
+        resp = client.options(
+            "/api/portfolio/main/AAPL",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": method,
+            },
+        )
+        assert resp.status_code == 200, f"{method} preflight rejected"
+        assert method in resp.headers.get("access-control-allow-methods", "")
+
     def test_login_no_password_env(self, client, monkeypatch):
         monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
         resp = client.post("/api/auth/token", json={"password": "test"})


### PR DESCRIPTION
Two unrelated-to-features housekeeping fixes, both of which were silently inert.

## 1. `.claude/settings.json` — permission rules that never matched

Claude Code logged 15 warnings at every startup. `Write(...)` and `Glob(**)` patterns are not evaluated by file permission checks — only `Read(path)` and `Edit(path)` are.

The allow rules were merely redundant, but the **deny rules were inert**: `Write(**/.env)`, `Write(**/credentials*)`, and `Write(**/secrets*)` blocked nothing. Converted to `Edit(...)`, which is what actually gates file writes.

- drop `Glob(**)` — `Read(**)` already covers all file-reading tools
- drop 11 redundant `Write(...)` allow rules — `Edit(**)` covers file writes
- convert the 3 `Write(...)` deny rules to `Edit(...)`

Permission scope is unchanged; secrets-write denial now actually applies.

## 2. `nuri/api/main.py` — CORS `allow_methods` missing PUT

`allow_methods` was written 2026-03-27 as `["GET", "POST", "DELETE"]`. The `portfolio` and `trades` PUT endpoints landed in #60 on 2026-03-31 without updating it.

Measured (`TestClient` preflight against `/api/portfolio/main/AAPL`):

| Method | Preflight |
|---|---|
| GET / POST / DELETE | 200 |
| **PUT** | **400 Disallowed CORS method** |

**Not reachable today** — the frontend calls PUT with a relative URL through the Next rewrite, so it is same-origin and preflight never fires. This is a latent inconsistency, not a live bug.

Fixing rather than documenting-as-intended, because the list already contains POST and DELETE. Anyone reading it reasonably concludes cross-origin mutations are supported; an absolute-URL PUT would then fail **only** in a browser, cross-origin, and never in a `TestClient` test. That is the silent-failure class this repo keeps getting bitten by.

Origin remains constrained by `CORS_ORIGINS`, so this does not widen the surface beyond what POST/DELETE already allow.

### Gotcha-Test Pair (STRATEGY §5.3.1)

**Test:** `tests/api/test_main.py::TestApiMain::test_cors_allows_every_mutating_method`

Parametrized over GET/POST/PUT/DELETE. Verified it fails when the fix is reverted — PUT fails, the other three still pass.

## Verification

- `make test-fast` — 6254 passed, 6 skipped, 99% coverage
- `ruff check` — clean
- `make verify-doc-counts` — 17/17
- `check_privacy_leak.py` (no args, CI parity) — clean

## Scope note

Docs work from the same session (2 new scoped `CLAUDE.md` files) is deliberately **not** in this PR — it follows as a separate one.