### PR TITLE
docs: add scoped CLAUDE.md for nuri/agents and nuri/api

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -10,4 +10,4 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 
 ## .claude/ 4-Layer Architecture (STRATEGY §5.10)
 
-L1 CLAUDE.md (11 scoped + global) → L2 Skills (`.claude/skills/nuri-*/`, 6) → L3 Hooks (`.claude/settings.json` PreToolUse + PostToolUse) → L4 Agents (`.claude/agents/nuri-*.md`, 2). Slash commands: `.claude/commands/nuri-*.md` (8). Path-scoped + always-on rules: `.claude/rules/*.md`. `nuri-` prefix 만 git tracked — 머신별 개인 설치는 `.gitignore` 로 자동 ignored.
+L1 CLAUDE.md (13 scoped + global) → L2 Skills (`.claude/skills/nuri-*/`, 6) → L3 Hooks (`.claude/settings.json` PreToolUse + PostToolUse) → L4 Agents (`.claude/agents/nuri-*.md`, 2). Slash commands: `.claude/commands/nuri-*.md` (8). Path-scoped + always-on rules: `.claude/rules/*.md`. `nuri-` prefix 만 git tracked — 머신별 개인 설치는 `.gitignore` 로 자동 ignored.

--- a/.claude/rules/load-triggers.md
+++ b/.claude/rules/load-triggers.md
@@ -13,8 +13,8 @@
 | `config/rules.yaml`, `config/agents.yaml`, `config/signals.yaml` | `config/CLAUDE.md` + `docs/STRATEGY.md §2.6, §3.4-§3.5` |
 | `frontend/` | `frontend/CLAUDE.md` (Next.js 16 breaking changes — read `node_modules/next/dist/docs/` first) |
 | `tests/` | `tests/CLAUDE.md` (DB isolation, mock pitfalls, privacy in fixtures) |
-| `nuri/agents/` (actor fleet + discord bot) | `nuri/agents/base.py` (actor contract) + `nuri/scheduler.py` (wiring) — no scoped CLAUDE.md yet |
-| `nuri/api/` (FastAPI routes) | `docs/ARCHITECTURE.md` §"Dashboard API" + `.claude/rules/architecture.md` "API Access Pattern" + source convention from existing `nuri/api/routes/` |
+| `nuri/agents/` (actor fleet + discord bot) | `nuri/agents/CLAUDE.md` — actor contract (Layer A/B/C), `CANONICAL_15` roster, single-writer Discord invariant, `SCHEDULES` wiring |
+| `nuri/api/` (FastAPI routes) | `nuri/api/CLAUDE.md` — router registration, no-`response_model` convention, error-handling split, cache TTL gotchas |
 | `scripts/` (shell automation, no scoped CLAUDE.md) | source docstring; `make lint-sh` (shellcheck); `scripts/verify/pre_push_check.sh` for safety contract |
 | DB migrations / schema changes | `nuri/core/CLAUDE.md` + `_MIGRATIONS` list in `nuri/core/db_migrations.py` (forward-only, never edit existing migration) |
 | Investment-rule / strategy / regime decisions | `docs/STRATEGY.md` §2 (principles) + §3 (decisions) |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -337,7 +337,7 @@ Deferred (필요 시점에 추가):
 ### 5.7 하네스 구성 요소
 | 레이어 | 역할 | 구현 |
 |--------|------|------|
-| **Context Files** | 프로젝트 규칙 | `CLAUDE.md` 루트 + 11 scoped + `AGENTS.md` + `docs/STRATEGY.md` |
+| **Context Files** | 프로젝트 규칙 | `CLAUDE.md` 루트 + 13 scoped + `AGENTS.md` + `docs/STRATEGY.md` |
 | **MCP Servers** | 외부 도구 연결 | `.mcp.json` → SQLite DB. 필요 최소. |
 | **Skill Files** | 반복 작업 | `scripts/deploy/deploy_remote.sh`, `scripts/verify/verify.py`, `scripts/db/migrate.py` |
 | **Mechanical Enforcement** | 시스템 강제 | ruff · main-ci-cd.yml · pr-checks.yml · `make verify-*` · SIEGE `gate_check.py` |
@@ -349,7 +349,7 @@ Deferred (필요 시점에 추가):
 | Schema drift | `schema_version` + `_MIGRATIONS` | `init_db()` 자동 |
 | Config drift | `config/*.yaml` 중앙 | 하드코딩 금지 |
 | Number drift | `grep -ri` 전수 | 커밋 메시지 숫자 명시 |
-**Context Files 설계**: 거대 단일 파일 ✕ → 디렉토리별 scoped ✓ (루트 + 11개). 코드에서 유추 가능한 정보 ✕ → 결정의 "왜" 만. `STRATEGY.md` 는 작업 전 읽도록 `CLAUDE.md` 에 지시.
+**Context Files 설계**: 거대 단일 파일 ✕ → 디렉토리별 scoped ✓ (루트 + 13개). 코드에서 유추 가능한 정보 ✕ → 결정의 "왜" 만. `STRATEGY.md` 는 작업 전 읽도록 `CLAUDE.md` 에 지시.
 ### 5.8 하네스 원칙 요약 (2026-04-14 #272 반영, 7개)
 1. 모르면 읽는다              — 가정하지 않는다
 2. 2번 실패하면 접근을 바꾼다  — 같은 시도 3회 금지. 같은 fix 3회 부분 해결 시 root cause 의심

--- a/nuri/agents/CLAUDE.md
+++ b/nuri/agents/CLAUDE.md
@@ -1,0 +1,92 @@
+# nuri/agents/ — Actor Fleet + Discord Layer
+
+## Scope
+
+The autonomous operating layer: long-lived actors that observe the system, record verdicts to an audit ledger, and surface findings to Discord. Distinct from `nuri/trading/agents/` (the 10-agent *consensus* pipeline that scores tickers) — an actor here is an **operational unit with a run ledger**, not a signal contributor.
+
+`actors/` holds **18 files: 15 registered actors + 3 unregistered infra helpers** (`brief_auditor`, `channel_dispatcher`, `outbox_watchdog` — deliberately outside the canonical roster).
+
+## The actor contract (`base.py`)
+
+`Actor(ABC)`. Subclass declares three class attributes and implements one method:
+
+```python
+name: str = ""          # DB key — must be in ActorRegistry.CANONICAL_15
+version: str = "0.0.0"  # semver, recorded in every audit row
+layer: Layer = Layer.B
+
+def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult: ...
+```
+
+**Callers invoke `run()`, never `execute()`.** `run()` is the lifecycle wrapper: `start_agent_run` → `execute` → `finish_agent_run` → `log_agent_audit`. Calling `execute()` directly produces an unaudited run — the ledger is the point of this layer.
+
+| Layer | Meaning | Hard constraint |
+|---|---|---|
+| **A** | Enforcement — pure rule | **Zero LLM** (`_uses_llm=True` → `RuntimeError` at `__init__`) and **must return an `outcome`** (`None` → run marked failed + `ValueError`). Both enforced at runtime in `base.py`, not by convention. |
+| **B** | Computation — statistical / deterministic | — |
+| **C** | Interpretation — LLM essential | Async enrichment only; never in the decision path. |
+
+`ActorResult(output, outcome=None, sample_n=None, input_summary=None, llm_narrative=None)`; `Outcome ∈ {PASS, BLOCK, WARN, ERROR}`.
+
+**`execute()` may raise** — `run()` records the failure (`status="failed"` + an `ERROR` audit row) and then **re-raises**. Failure isolation is the *caller's* responsibility: every `_run_*` wrapper in `nuri/scheduler.py` try/excepts, which is why one actor dying doesn't take the fleet down.
+
+**`ActorRegistry.CANONICAL_15` is a closed roster.** `@REGISTRY.register` raises if `name` isn't in that tuple — adding a 16th actor means editing the tuple deliberately, not incidentally. Registration is idempotent for the same `module:qualname` so the `python -m` double-import (`__main__` reload) doesn't blow up.
+
+## Invariants
+
+- **Single-writer Discord.** Actors stage to the outbox — they never publish. Only `channel_dispatcher.py` (the writer) and `outbox_watchdog.py` (recursion break: if the dispatcher is dead, staging its own alarm would never be delivered) may touch `DiscordPublisher`. Everything else calls `nuri.agents.discord.outbox.stage_*` lazily inside the method. Breaking this breaks digest bucketing, the quiet-period gate, and dedupe at once.
+- **No DB connections here.** Zero `sqlite3` in this directory. Reads go through `query()`; writes go through the named helpers (`log_decision`, `log_incident`, `register_hypothesis`, `stage_outbox`, …) — `query()` is read-only by contract.
+- **Actors do not use `nuri/alerts/`.** That package is a separate scheduler-driven briefing path. The two never call each other; don't bridge them.
+- **Mac mini is the sole writer; MBP is a read replica** (`nuri/agents/__init__.py`). An actor that writes must be safe to run in exactly one place.
+- **Every actor module ships a `main(argv)` CLI** — `python -m nuri.agents.actors.<module> <action> ...`. Universal across all 18.
+- Most actors dispatch on `input_data["action"]` against a class-level `VALID_ACTIONS` and return `ActorResult({"error": ...})` for an unknown action rather than raising.
+
+## Scheduling
+
+There is **no schedule declaration on the actor**. Cron lives entirely in `nuri/scheduler.py`'s module-level `SCHEDULES` list; jobs run **in-process** under APScheduler `BlockingScheduler` with `misfire_grace_time=300`.
+
+Only 4 actors are reached from `SCHEDULES` today, and **only one of them is a registered actor**:
+
+| Wrapper | Actor | Registered? |
+|---|---|---|
+| `_run_collector("alpha_tracking")` | `ForwardOutcomeTracker` | ✅ (of the 15) |
+| `_run_brief_audit` | `BriefAuditor` | — helper |
+| `_run_channel_dispatcher` | `ChannelDispatcher` | — helper |
+| `_run_outbox_watchdog` | `OutboxWatchdog` | — helper |
+
+So **14 of the 15 registered actors have no cron** — they run from their `main()` CLI or another caller. **Do not assume an actor is running just because it exists and is registered.** Check `SCHEDULES` before claiming anything about live behaviour.
+
+⚠️ **APScheduler weekday ≠ crontab weekday.** `day_of_week` is Mon=0…Sun=6, so a crontab literal `1-5` fires **Tue–Sat**. Use explicit `mon-fri`.
+
+## Adding an actor
+
+1. `nuri/agents/actors/<snake>.py`; subclass `Actor`, set `name` / `version` / `layer`.
+2. Add `name` to `ActorRegistry.CANONICAL_15`, then decorate with `@REGISTRY.register`. (Order matters — registration validates against the tuple.)
+3. Implement `execute()`. Layer A must always set `outcome`.
+4. Add a module-level `main(argv)` CLI.
+5. Export from `actors/__init__.py`.
+6. To schedule: add a `_run_<x>()` wrapper in `scheduler.py` that try/excepts + logs `exc_info=True`, then append to `SCHEDULES`.
+7. Discord output: `stage_*` only. Never import `DiscordPublisher`.
+
+## Gotchas
+
+- **Dedupe channel must match emit channel.** `brief_auditor.py` sets `_AUDIT_CHANNEL = "ops"` and uses it for *both* `stage_ops()` and `_dedupe_recent()`. If the two drift apart, the dedupe lookup queries the wrong channel, finds nothing, and re-emits the same incident every 6 hours.
+- **Quiet period is `#brief`-only** (`QUIET_PERIOD_SECONDS = 60`). `#ops` / `#incidents` / `#rollout` bypass the gate — don't "fix" their apparent lack of throttling.
+- **`outbox_watchdog` exists because silent failure is the default.** Scheduler wrappers swallow exceptions, so a dead dispatcher looks identical to an idle one. The watchdog measures outbox backlog (`>30 min` oldest pending, `>100` pending) and alerts `#ops` **directly via webhook**. Any new "quiet by design" component needs an equivalent liveness probe.
+- **`forward_outcome_tracker` accepts only `SUPPORTED_WINDOWS = (7, 14, 30)`** — other horizons return an error result, not an exception.
+
+## Tests
+
+`tests/agents/` — no `conftest.py`; fixtures are duplicated per file (canonical form in `test_base.py`, `test_freshness_gatekeeper.py`):
+
+1. `db_path(tmp_path)` → `init_db(path)`.
+2. `patched_db(db_path)` → patch **`nuri.agents.base.log_agent_audit` / `start_agent_run` / `finish_agent_run`** with `side_effect` wrappers that `kwargs.setdefault("db_path", db_path)`.
+
+**Patch the `nuri.agents.base` namespace, not `nuri.core.db`** — `base.py` imports those names directly, so patching the source module misses. Discord side effects: patch `nuri.agents.discord.outbox.stage_*` at its source module. See `tests/CLAUDE.md`.
+
+## References
+
+- `nuri/scheduler.py` — `SCHEDULES` wiring, heartbeat, launchd self-restart
+- `nuri/agents/discord/outbox.py` — payload schema + single-writer invariant statement
+- `docs/STRATEGY.md §3.11` — measurement mode (what these actors adjudicate)
+- `nuri/trading/agents/CLAUDE.md` — the *other* agents (consensus pipeline), not this fleet

--- a/nuri/api/CLAUDE.md
+++ b/nuri/api/CLAUDE.md
@@ -1,0 +1,57 @@
+# nuri/api/ — FastAPI Read Layer
+
+## Scope
+
+The dashboard's read surface (72 endpoints). This layer **queries and renders — it never computes strategy**. Anything that decides, scores, or certifies lives in `nuri/trading/` · `nuri/quant/` · `nuri/analysis/` and is imported *lazily inside the handler body* (keeps startup fast; top-level heavy imports are the one convention every file follows).
+
+Backend `:8001`, Next.js `:3000` proxies `/api/*` — see `.claude/rules/architecture.md` "API Access Pattern" before touching frontend call sites.
+
+## App composition (`main.py` — sole app factory)
+
+- **`/api` prefix lives only in `main.py`.** Route files declare `APIRouter(tags=[...])` with **no prefix** and spell the full sub-path in the decorator (`@router.get("/pipeline/status")`). Sole exception: `routes/learning_memory.py` declares `prefix="/learning-memory"`.
+- `routes/__init__.py` is **empty by design** — no registry. A new router needs two edits in `main.py`: the import block and an `app.include_router(mod.router, prefix="/api")` line. Miss the second and the endpoint 404s while router-level tests still pass — `tests/api/test_routes.py` smoke tests assert the router object exists, not that it is mounted.
+- No lifespan / startup hooks. Only registered exception handler is slowapi's `RateLimitExceeded`.
+- Global limit `60/minute`; `pipeline.py` declares its **own** `Limiter` (`2/minute`) because its endpoints run real work.
+- `X-Frame-Options: SAMEORIGIN` (not DENY) is deliberate — `/evidence` iframes Plotly HTML. Changing it breaks charts (2026-04-20 Playwright audit).
+
+## Conventions for a new route
+
+| Concern | Convention |
+|---|---|
+| Response model | **None.** Zero `response_model=` in the directory. Return plain `dict`; serialize dataclasses with `dataclasses.asdict()`. |
+| Request body | Pydantic **only for writes** (`portfolio.py`, `trades.py`, `external.py`), with `field_validator` normalizers (`ticker.upper()`, regex, range). |
+| DB access | Direct `from nuri.core.db import query` + inline SQL. No service layer. Mutations use `upsert_*()` / `get_db()`. `query_df` is unused here — keep it that way (DataFrames leak numpy into JSON). |
+| `def` vs `async def` | **Sync.** Work is blocking SQLite + pandas; FastAPI threadpools it. `async` only for SSE (`stream.py`, `agents.py` consensus stream). |
+| Writes | `user=Depends(require_write_auth)` + `audit_log(OP, table, key, detail, user_id=user.get("sub","unknown"))`. Reads are deliberately unauthenticated (public dashboard read). |
+| Filtering | `limit: int = Query(N, ge=1, le=M)`; enum-ish params use `pattern=` (`Query("us", pattern="^(us\|kr)$")`). Build WHERE from a `where: list[str]` / `params: list` pair. No cursor pagination anywhere. |
+| List responses | Always carry a sibling `"count": len(...)`. |
+
+## Error handling — pick by intent
+
+- **Soft** (`return {"error": "<generic>"}`, HTTP 200) when the frontend should degrade gracefully. Always `logger.exception(...)` first and keep the client message **generic** — never interpolate the exception (CodeQL `py/stack-trace-exposure`).
+- **Hard** (`raise HTTPException`) — 404 for a missing single resource, 400 for invalid enum-ish input.
+- **Shape-preserving fallback**: an endpoint whose response is destructured by the frontend must return its full empty shape on failure, not `{}` (`actions.py` returns `{"urgent":[],"check":[],"hold":[],"portfolio":[]}`). A collapsed shape makes UI buckets silently vanish.
+
+## Gotchas
+
+- **`GET /api/evidence/report` is unreachable** — `/evidence/{chart_id}` is declared first, so FastAPI binds `chart_id="report"` → 400. Definition order is load-bearing; declare literal paths before parameterized ones.
+  **Test:** `tests/api/test_evidence.py::test_get_evidence_report_not_found`
+- **`/api/pipeline/status` `steps` must stay an array.** It was once a dict — the frontend couldn't iterate it and silently fell back to hardcoded `DEFAULT_NODES`, so the DAG rendered fake data with no error.
+- **Module-level in-memory caches (5 min TTL) are process-local and write-blind** — `actions.py`, `dashboard.py`, `agents.py`, `targets.py`, `ticker.py`, `learning_memory.py`, `swing.py`, `stream.py` (60 s). A POST that mutates portfolio state will **not** refresh `/api/dashboard` or `/api/actions` for up to 5 minutes. Budget for this when QA-ing a write flow.
+- **numpy leaks into JSON.** Handlers returning pandas/numpy-derived values must JSON-round-trip with a `default=` coercer (`swing.py`, `portfolio.py`); `signals.py` additionally maps `inf`/`NaN` → `None`.
+- **Auth is off by default** (`API_AUTH_ENABLED=false`) — `require_auth` returns an anonymous principal, so every write endpoint is open in dev. Unset `API_SECRET_KEY` regenerates a random key each boot (JWTs die on restart).
+- **Legitimately empty responses**: `/api/research/*` (no writer yet), `/api/signals/*` (needs `make validate`), `/api/evidence` (needs `make evidence`). Empty ≠ broken — check the upstream producer before debugging the route.
+- **`/api/alpha` always returns `edge_status: "NOT_MEASURABLE"`** with a `caveat` string. This is a deliberate honesty guard per STRATEGY §3.11 — do not "fix" it into a positive verdict.
+- **CORS `allow_methods` must track the route surface.** The frontend reaches the API same-origin through the Next rewrite, so preflight never fires in normal use — a missing method fails **only** on cross-origin calls, and never in tests that use `TestClient`. Adding a route with a new HTTP verb means updating `main.py`.
+  **Test:** `tests/api/test_main.py::TestApiMain::test_cors_allows_every_mutating_method`
+- **Heavy endpoints run in-process**: `POST /api/pipeline/{step}/run` (backtest / regime / 10-agent consensus), `GET /api/certify`, `GET /api/backtest`.
+
+## Tests
+
+`tests/api/` — one module per route file. `fastapi.testclient.TestClient`, fixtures in `tests/api/conftest.py`. **DB isolation = monkeypatching `nuri.core.db.DB_PATH` to a `tmp_path` DB**, not transaction rollback; the `client` fixture imports `nuri.api.main.app` lazily *inside* the fixture so the patch lands first. Helpers in `tests/api/_helpers.py` must be imported explicitly (conftest only auto-loads fixtures). See `tests/CLAUDE.md`.
+
+## References
+
+- `docs/ARCHITECTURE.md` §"Dashboard API" — endpoint-by-endpoint table
+- `.claude/rules/architecture.md` — Server vs Client Component access pattern
+- `frontend/next.config.ts` — `/api/*` rewrite + CSP `connect-src` / `frame-src` allowlist

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -111,6 +111,7 @@ check_claim "collectors"     "$COLL" "README.md"                  '[0-9]+ collec
 check_claim "endpoints"      "$EP"   ".claude/rules/architecture.md" '\([0-9]+ endpoints, routes/' || true
 check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '## API \([0-9]+ endpoints\)' || true
 check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '— [0-9]+ REST endpoints' || true
+check_claim "endpoints"      "$EP"   "nuri/api/CLAUDE.md"         'read surface \([0-9]+ endpoints\)' || true
 check_claim "test_files_be"  "$TFBE" "docs/ARCHITECTURE.md"       'backend tests across [0-9]+ files' || true
 check_claim "test_files_be"  "$TFBE" "docs/STRATEGY.md"           'Backend tests.*tests, [0-9]+ files' || true
 check_claim "test_files_fe"  "$TFFE" "docs/ARCHITECTURE.md"       'frontend vitest \([0-9]+ files\)' || true


### PR DESCRIPTION
Closes the last two load-trigger gaps. `load-triggers.md` routed `nuri/agents/` to raw source with the comment *"no scoped CLAUDE.md yet"*, and `nuri/api/` to `ARCHITECTURE.md` plus "source convention from existing `nuri/api/routes/`". Both are now covered.

Content is limited to what requires reading several files to discover. Anything greppable in one shot was left out.

## `nuri/agents/CLAUDE.md`

Opens by separating this fleet from `nuri/trading/agents/` (the 10-agent consensus pipeline) — same word, different thing.

- **Actor contract**: `run()` is the lifecycle wrapper; calling `execute()` directly produces an unaudited run.
- **Layer A is runtime-enforced**, not conventional — `_uses_llm=True` raises at `__init__`, and a `None` outcome marks the run failed and raises.
- **`CANONICAL_15` is a closed roster** — `@REGISTRY.register` raises for any name outside the tuple.
- **Single-writer Discord**, with the two sanctioned exceptions (`channel_dispatcher` is the writer; `outbox_watchdog` breaks recursion so a dead dispatcher can still raise the alarm).
- **14 of the 15 registered actors have no cron.** Only `ForwardOutcomeTracker` is in `SCHEDULES`; the other three scheduled actors are unregistered helpers. Existence is not liveness.
- APScheduler `day_of_week` is Mon=0, so a crontab literal `1-5` fires Tue–Sat.
- Tests patch the **`nuri.agents.base`** namespace, not `nuri.core.db` — `base.py` imports those names directly.

## `nuri/api/CLAUDE.md`

- The `/api` prefix lives **only** in `main.py`; route files declare no prefix (`learning_memory.py` is the sole exception).
- `routes/__init__.py` is empty by design — registration is two edits in `main.py`, and missing the second yields a 404 while `tests/api/test_routes.py` smoke tests still pass (they assert the router object exists, not that it is mounted).
- Zero `response_model=` in the directory; plain dicts and `dataclasses.asdict()`.
- Error handling splits three ways: soft (`{"error": ...}` + 200), hard (`HTTPException`), and shape-preserving fallback for responses the frontend destructures.
- Module-level 5-minute caches are process-local and write-blind — a POST does not refresh `/api/dashboard`.
- `/api/evidence/report` is unreachable (shadowed by `/evidence/{chart_id}`), locked by an existing test.

## Drift guard

`nuri/api/CLAUDE.md` states "72 endpoints", so the claim is registered in `verify_doc_counts.sh` rather than left unguarded. `enforcement.md` and `STRATEGY.md` §5.7 move 11 → 13 scoped files.

## Verification

- `make verify-doc-counts` — **18/18** (was 17/17; the new endpoint claim is the 18th)
- `check_privacy_leak.py` (no args, CI parity) — clean
- Scoped file count verified by `find`: 13 + root

Every quantitative and behavioural claim was confirmed by direct read or by running it. One error caught in self-review and corrected before commit: an early draft said 5 scheduler wrappers reach actors; the measured number is 4, which is what surfaced the "14 of 15 have no cron" point.

## Merge order

Prefer merging #884 first. `nuri/api/CLAUDE.md` cites `test_cors_allows_every_mutating_method`, which is added there. Not a blocker — the citation is a doc reference, not a code dependency.