### PR TITLE
docs: sync .claude/rules with AGENTS.md hard rules + dedup Flow guidance

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,6 +2,8 @@
 
 ## Code layout
 
+**Pipeline** (5 phases, DB-coupled only — see Cross-phase isolation in `invariants.md`): `collect → analyze → consensus → certify → track`.
+
 `nuri/core` (sole sqlite3 importer) / `nuri/collectors` (27 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm` / `agents` (top-level actor fleet: 18 `actors/` — SRE incident · drift sentinel · forward outcome tracker · walkforward validator · execution firewall · … — plus `discord/` bot layer, wired by `nuri/scheduler.py`). Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
 
 ## Commands
@@ -12,6 +14,7 @@
 - Reactive: `make recommend` (BUY candidates + tracker) / `/nuri-thesis <T>` skill (`nuri/llm/thesis_query.py`) / `make earnings-preview ticker=<T>`
 - LLM consult dual-archive: `make llm-consult slug=<kebab> prompt=<file>`
 - Lint+Test: `make lint` / `make test-fast` / `.venv/bin/python -m pytest <path>::<test> -v`
+- Gates: `make verify-quick` (~10s pre-commit smoke) / `make verify-all` (~30s pre-push: tests + lint + frontend)
 - Deploy: `make start` (API :8001 + Dashboard :3000) / `make deploy-mini` (MBP → Mac mini 6단계 동기화)
 
 Frontend-only commands → `frontend/CLAUDE.md`.

--- a/.claude/rules/flow.md
+++ b/.claude/rules/flow.md
@@ -1,6 +1,6 @@
 # 7-phase Flow
 
-`docs/STRATEGY.md §2.7` is canonical. 7 phases, no skipping. Failed gate → regress prior phase. Trivial chores may inline Think+Plan; Build onward is mandatory. Codex unavailable → self-review + recover in next PR.
+`docs/STRATEGY.md §2.7` is canonical. 7 phases, no skipping. Failed gate → regress prior phase. Trivial chores may inline Think+Plan; Build onward is mandatory.
 
 | # | Phase | Output gate (must answer YES to advance) |
 |---|-------|-----------------------------------------|

--- a/.claude/rules/invariants.md
+++ b/.claude/rules/invariants.md
@@ -1,9 +1,11 @@
 # Always-on Invariants
 
-Mechanically enforced (hooks/CI/code). Violating any means a hook block, CI fail, or design regression. `docs/STRATEGY.md` is canonical — load it on demand for the "why" / full spec.
+Mechanically enforced (hooks/CI/code) unless marked *(convention — review-enforced)*. Violating any means a hook block, CI fail, or design regression. `docs/STRATEGY.md` is canonical — load it on demand for the "why" / full spec.
 
 - **DB sole importer**: `nuri/core/db/` is the ONLY `sqlite3` importer (PreToolUse hook blocks). All other modules use `query()` / `query_df()` / `upsert_*()` / `get_db()` with optional `db_path=` for test isolation.
 - **Timezone**: always `kst_now()` / `today_kst()` from `nuri.core.timezone` — `datetime.now()` blocked by hook.
+- **External LLM gateway** (STRATEGY §4.4.3) *(convention — review-enforced)*: `nuri/llm/openai_client.py` is the ONLY external-LLM entry point; `import openai` elsewhere is forbidden. ZDR + audit-log enforced there. This is the single choke point where the no-portfolio-data-egress rule actually holds — unlike the sqlite3 rule there is no hook, so a stray import passes CI silently.
+- **Cross-phase isolation** *(convention — review-enforced)*: the 5 pipeline phases (`collect → analyze → consensus → certify → track`) couple through DB tables / CSV only — never direct cross-phase imports (same-phase imports are fine). This is what lets any single phase be re-run with downstream consumers refreshing on their own.
 - **Conventional commits (English)** + **PR discipline**: 1 issue = 1 PR, ≤ 3 commits, scope = what was asked. New findings → separate issue. Format: `(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(scope)?: msg`. Korean comments in code, English variable/function names.
 - **Escalation Ladder** (STRATEGY §2.6 summary): **Surface** exposes evidence only (no action change) → **Soft penalty** deterministic downgrade/cap (config-tunable) → **Hard veto** action-block on downside (risk-of-ruin) → **Symmetric amplifier** post-veto upside sizing (multi-condition, never single-trigger). Promotion between rungs requires STRATEGY PR + evidence/backtest.
 - **Alpha vs portfolio axis** (PR A #429): `alpha_action ∈ {LONG, SHORT, FLAT}` ≠ `portfolio_action ∈ {REBALANCE, TRIM, HEDGE}`. Concentration / sector-cap → `portfolio_action=REBALANCE` only (never urgent SELL). Stop-loss breach is the **only** mechanical → `alpha_action=FLAT`. Veto fires on `alpha_action==FLAT`, not portfolio violations. See `nuri/core/axis.py`.

--- a/.claude/skills/nuri-flow/SKILL.md
+++ b/.claude/skills/nuri-flow/SKILL.md
@@ -9,9 +9,9 @@ description: STRATEGY §2.7 7-phase Flow (Think→Plan→Build→Review→Test�
 
 ## 운영 원칙
 
-- **자동 chain 절대 금지** — 사용자 명시 지시 없이 다음 phase 자동 진행 X. STRATEGY §7.1 Auto trading deferred 정신.
+- **자동 chain 절대 금지** — 사용자 명시 지시 없이 다음 phase 자동 진행 X (`gh pr merge` 자동 호출 포함). STRATEGY §7.1 Auto trading deferred 정신.
 - **추천만, 실행 X** — 다음 phase 적합 skill / Make target 권고만. invoke 는 사용자 또는 다른 skill 이.
-- **Trivial chore = inline 압축 OK** (typo, README 배지, gitignored 파일) — Build 이상은 모든 단계 준수.
+- **추정 틀려도 강제 회귀 X** — phase 추정은 권고일 뿐.
 
 ## 도구 매핑 (STRATEGY §2.7 phase 별)
 
@@ -45,13 +45,7 @@ description: STRATEGY §2.7 7-phase Flow (Think→Plan→Build→Review→Test�
 
 PR merged + NEXT_SESSION.md 마지막 편집 < PR merge 시각 → **Reflect 필요**. 갱신 항목 권고: 산출물 1줄 / 신규 gotcha / 다음 P0.
 
-## Anti-patterns
-
-자동 `gh pr merge` 호출 X. 사용자 의도 없이 다음 phase 자동 진입 X. Phase 추정 틀려도 강제 회귀 X — 추정은 권고일 뿐.
-
 ## Reference
 
-- `.claude/rules/flow.md` — 7-phase Gate 표 (always-on)
-- `docs/STRATEGY.md §2.7` — canonical 정의
 - `docs/STRATEGY.md §5.8` — 7 Harness Principles (gate 근거)
 - `~/.claude/projects/-Users-ehbebe-workspace-nuri-quant/memory/feedback_dev_flow.md`


### PR DESCRIPTION
## 왜 지금

`AGENTS.md` 상단은 `.claude/rules/invariants.md` 와의 동기화 계약을 선언한다.

> `DRIFT SYNC: 본 파일 (cross-tool fallback) ↔ .claude/rules/invariants.md (Claude Code always-on) — 변경 시 두 곳 동시 갱신`

그런데 Hard Rule 2건이 AGENTS.md 에만 있었다. `.claude/rules/gotchas.md` 가 "AGENTS.md 는 Claude Code 가 auto-load 하지 않음" 이라고 명시하므로, 이 두 규칙은 **Claude Code 세션에서 사실상 부재** 상태였다.

`/doctor` + `/init` 진단 중 발견.

## 변경

### 1. Flow 중복 제거 (`0a3d50a`)

`flow.md`(always-on, gate 기준) 와 `nuri-flow` skill(lazy, phase 추정 + 도구 매핑) 은 역할이 다르지만 일부가 겹쳤다. 역할 분리는 유지하고 중복만 제거:

- `flow.md` intro 의 Codex-unavailable fallback 삭제 → 판단이 실제로 일어나는 Review gate 행에만 존치
- `nuri-flow` SKILL: trivial-chore 룰 삭제(always-on `flow.md` 가 보유), `Anti-patterns` 섹션을 `운영 원칙` 으로 흡수(같은 2개 룰 재진술이었음), Source 줄과 중복되던 Reference 2줄 삭제

### 2. Drift-sync parity 복구 (`6ce8533`)

- `invariants.md` + **External LLM gateway** (AGENTS.md #9) — `nuri/llm/openai_client.py` 유일 진입점, 타 모듈 `import openai` 금지
- `invariants.md` + **Cross-phase isolation** (AGENTS.md #4) — 5 phase 는 DB/CSV 로만 결합
- 두 룰 모두 hook/CI 강제가 **없다**. 헤더의 "Mechanically enforced" 가 거짓이 되지 않도록 `*(convention — review-enforced)*` 마커로 범위를 좁혔다. 지키는 척하는 문서보다 정직한 문서가 낫다.
- `architecture.md` + 5-phase pipeline 한 줄 (DB-coupling 큰 그림이 README/AGENTS.md 에만 있었음) + `verify-quick` / `verify-all` gate

## 검증

- `make verify-quick` — 6,269 passed / 6 skipped (124s)
- `make verify-doc-counts` — 18/18 (신규 numeric claim 없음)
- `check_privacy_leak.py` (인자 없이, CI parity) — clean
- `import openai` 실측: `nuri/llm/openai_client.py` 1곳뿐 — 문서화만 빠져 있었고 규칙 자체는 지켜지고 있었음

## Scope

`AGENTS.md` 는 수정 없음 — 이미 4건 모두 보유. 이 PR 은 Claude Code 쪽을 parity 로 올린다.

상시 컨텍스트 순증 약 +100 est. tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)