### PR TITLE
feat(alerts): monthly alpha progress report → #brief (§3.11, closes #856)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,14 @@ CORS_ORIGINS=http://localhost:3000       # 쉼표 구분 — production allowlis
 # ───────────────────────────────────────────────────────────────
 # 8. Production Sync (2-machine setup)
 # ───────────────────────────────────────────────────────────────
+# NURI_ROLE — §3.11 원장 단일 가드. `production` 일 때만 월간 alpha 진행 리포트가
+# #brief 로 stage 된다 (adjudication 원장은 Mac mini DB 뿐, MBP 는 read replica).
+#   ⚠ 이 파일에 두지 말 것. deploy-mini 가 MBP `.env` 를 mini 로 SCP 하므로
+#     mini 에만 넣어도 다음 배포에 지워진다 (DEV2_HOST 와 같은 이유).
+#   → 실제 위치: scripts/launchd/com.nuri-quant.scheduler.plist 의
+#     EnvironmentVariables. 수동 CLI 로 stage 하려면 그 실행에만
+#     `NURI_ROLE=production python -m nuri.alerts.alpha_report` 로 준다.
+
 # Mac mini 배포 대상 (make deploy-mini)
 MACMINI_HOST=macmini.local
 MACMINI_USER=                            # ssh 계정

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 40 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 41 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -82,6 +82,7 @@ Configured in `.env` (see `.env.example`):
 - `KIS_PROD_APP_KEY` / `KIS_PROD_APP_SECRET` — KIS Open API live (optional; falls back to `config/kis/kis_devlp.yaml`, gitignored)
 - `KIS_PAPER_APP_KEY` / `KIS_PAPER_APP_SECRET` — KIS Open API paper (optional)
 - `TOSS_API_KEY` / `TOSS_SECRET_KEY` / `TOSS_ACCOUNT_SEQ` — Toss Open API (optional; IP allowlist — dev machines get 403 and gracefully skip)
+- `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
 51 tables total (45 migrations as of 2026-07-08). Key tables:
@@ -157,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,232 backend tests across 277 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,320 backend tests across 278 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,228 tests, 277 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,320 tests, 278 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/alpha_report.py
+++ b/nuri/alerts/alpha_report.py
@@ -1,0 +1,242 @@
+"""Monthly alpha progress report → #brief (§3.11 측정 모드 표출, #856).
+
+판정 도구 `decision_alpha.adjudicate()` (#842) 는 구현돼 있으나 수동 CLI 뿐이라,
+판정일(`measurement_mode.evaluation_date`)까지 아무도 안 본다. 측정 모드의 목적은
+"감정 개입 없이 지켜보게 하는 장치"(§3.11 원안 4번)인데 지켜볼 화면이 없었다.
+
+여기서 표면화하는 것은 **측정 상태**지 액션이 아니다 — `kind="INFO"` 고정.
+BUY/SELL/REBALANCE 를 쓰면 렌더러가 Action Now 버킷에 넣고 price_levels 를 붙여
+"지금 뭘 하라"는 신호로 읽힌다. 이 리포트는 매매 지시가 아니다.
+
+조기 승격 금지(§3.11): `adjudicate()` 가 `evaluation_date` 이전이면 verdict 를
+`PROGRESS_REPORT` 로 고정한다(`decision_alpha.py` 판정 우선순위 블록). 이 모듈은
+`criteria_verdict_if_final` 을 **가정법으로만** 표시하고 결코 결론처럼 쓰지 않는다.
+
+원장 단일(§3.11): adjudication 원장은 production(Mac mini) DB 뿐이다. dev 는 read
+replica 라 표본이 다를 수 있으므로, stage 는 `NURI_ROLE=production` 에서만 한다.
+계산·출력은 어디서나 허용 — dry-run 으로 들여다보는 것까지 막을 이유는 없다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from datetime import date
+from pathlib import Path
+from typing import Any, Optional
+
+from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
+
+#: stage 를 허용하는 role. mini `.env` 에 `NURI_ROLE=production`.
+PRODUCTION_ROLE = "production"
+
+#: 판정 3조건 라벨 — decision_alpha.adjudicate() 의 conditions 키와 1:1.
+_CONDITION_LABELS = {
+    "mean_alpha_positive": "평균 alpha > 0",
+    "permutation_significant": "순열 유의",
+    "both_halves_positive": "전후반 both +",
+}
+
+
+def is_production() -> bool:
+    """stage 허용 여부. `NURI_ROLE=production` 일 때만 True (대소문자 무시)."""
+    return os.getenv("NURI_ROLE", "").strip().lower() == PRODUCTION_ROLE
+
+
+def _days_until(target: str, today: str) -> Optional[int]:
+    """`today` → `target` 남은 일수. 파싱 실패 시 None (표시 생략)."""
+    try:
+        return (date.fromisoformat(str(target)) - date.fromisoformat(str(today))).days
+    except (ValueError, TypeError):
+        return None
+
+
+def build_progress_report(
+    db_path: Optional[Path] = None,
+    as_of: Optional[str] = None,
+    n_perm: Optional[int] = None,
+) -> dict[str, Any]:
+    """`adjudicate()` 원본 리포트 반환 (가공 없음).
+
+    파라미터는 전부 `config/rules.yaml measurement_mode` 에서 온다 — 여기서
+    기준값을 다시 정의하지 않는다(하드코딩 금지, #856 acceptance).
+    """
+    from nuri.quant.validation.decision_alpha import adjudicate
+
+    return adjudicate(db_path=db_path, as_of=as_of, n_perm=n_perm)
+
+
+def format_progress_reason(report: dict[str, Any]) -> str:
+    """리포트 → #brief 한 줄. 판정 3조건 + 결측률 + D-day 를 한 화면에.
+
+    표본 0건 / 순열 미실행(NO_SAMPLE) 은 조건 키가 없으므로 축약 표기.
+    """
+    n = report.get("n", 0)
+    min_n = report.get("min_n_required")
+    missing = report.get("missing_rate_pct")
+    missing_max = report.get("missing_max_pct")
+    parts = [f"n={n}/{min_n}"]
+
+    if "mean_alpha" in report:
+        mean_pct = report["mean_alpha"] * 100
+        parts.append(f"mean {mean_pct:+.2f}%p")
+        parts.append(f"p={report['p_value']:.3f}/{report['p_max']}")
+        halves = report.get("halves") or {}
+        h1, h2 = halves.get("h1_mean"), halves.get("h2_mean")
+        if h1 is not None and h2 is not None:
+            parts.append(f"halves {h1 * 100:+.2f}/{h2 * 100:+.2f}%p")
+        cond = report.get("conditions") or {}
+        met = [_CONDITION_LABELS[k] for k, v in cond.items() if v and k in _CONDITION_LABELS]
+        parts.append(f"조건 {len(met)}/{len(cond)} 충족")
+    else:
+        parts.append(report.get("reason", "표본 부족 — 순열 미실행"))
+
+    if missing is not None:
+        parts.append(f"결측 {missing}%/{missing_max}%")
+
+    d = _days_until(report.get("evaluation_date"), report.get("as_of") or today_kst())
+    if d is not None:
+        parts.append(f"판정일까지 D-{d}" if d >= 0 else f"판정일 경과 +{-d}d")
+    return " | ".join(parts)
+
+
+def _build_payload(report: dict[str, Any]) -> dict[str, Any]:
+    """리포트 → #brief INFO payload.
+
+    ticker 는 종목이 아니라 측정 대상 라벨. price_levels 없음(액션 아님).
+    `criteria_verdict_if_final` 은 판정일 이전엔 note 에 가정법으로만 — 승격으로
+    읽히면 §3.11 위반이다.
+    """
+    verdict = report.get("verdict", "PROGRESS_REPORT")
+    # ⚠ verdict 는 payload 키로만 두면 사용자에게 **안 보인다** — 렌더러
+    # `_format_event_line` 은 ("regime","causal","horizon","position","reason",
+    # "note") 화이트리스트만 출력한다 (nuri/agents/discord/outbox.py). 판정 결과가
+    # 화면에 나와야 하므로 note 안에 실어 보낸다.
+    if report.get("pre_evaluation"):
+        hypo = report.get("criteria_verdict_if_final")
+        note = f"{verdict} — 측정 진행 중, 조기 판정 아님"
+        if hypo:
+            note = f"{verdict} — 측정 진행 중, 오늘 기준이라면 '{hypo}' (조기 판정 아님)"
+    else:
+        # 판정일 경과 — 이제는 진짜 판정이다. "진행 중" 문구를 그대로 두면
+        # §3.11 이 만들려던 단 하나의 산출물을 화면에서 지워버린다.
+        note = f"{verdict} — 판정일 경과, 사전 등록 기준에 따른 최종 판정"
+    return {
+        "kind": "INFO",
+        "ticker": "ALPHA-MEASUREMENT",
+        "reason": format_progress_reason(report),
+        "note": note,
+        "date": report.get("as_of") or today_kst(),
+        "horizon": f"{report.get('window_days')}d vs {report.get('benchmark')}",
+        "verdict": verdict,
+    }
+
+
+def _dedupe_key(month: str) -> str:
+    return f"alpha-progress:{month}"
+
+
+def already_emitted(month: str, db_path: Optional[Path] = None) -> bool:
+    """이번 달 리포트가 이미 outbox 에 올라갔나.
+
+    `stage_outbox` 의 자체 dedupe 는 **`status='pending'` 행만** 본다
+    (`nuri/core/db/discord_outbox_ops.py`). 발송되면 `sent` 로 바뀌어 더 이상
+    매칭되지 않으므로, 그것만 믿고 매일 돌리면 매일 재발화한다. 여기서
+    pending/claimed/sent 를 모두 확인해 진짜 월 1회를 만든다.
+
+    `failed`/`dropped` 는 재시도 허용 — 못 나간 달을 영영 포기하지 않는다.
+    """
+    from nuri.core.db import query
+
+    rows = query(
+        """SELECT 1 FROM discord_outbox
+            WHERE channel = 'brief' AND dedupe_key = ?
+              AND status IN ('pending', 'claimed', 'sent')
+            LIMIT 1""",
+        (_dedupe_key(month),),
+        db_path=db_path,
+    )
+    return bool(rows)
+
+
+def stage_alpha_progress_brief(
+    db_path: Optional[Path] = None,
+    as_of: Optional[str] = None,
+    n_perm: Optional[int] = None,
+    force: bool = False,
+) -> Optional[int]:
+    """월간 진행 리포트를 #brief 에 stage. outbox id 반환 (미실행/중복 시 None).
+
+    매일 호출해도 안전하다 — 이번 달 발화분이 있으면 `adjudicate()` 를 돌리기
+    전에 빠져나온다(순열 1,000회를 매일 태우지 않으려는 목적도 있다). 덕분에
+    1일에 못 나가도(재시작·절전·misfire) 다음 날 따라잡는다.
+
+    `NURI_ROLE=production` 이 아니면 stage 하지 않는다 (§3.11 원장 단일).
+    `force=True` 는 테스트 전용 role 우회 — 월 1회 가드는 우회하지 않는다.
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    if not (force or is_production()):
+        # WARNING 인 이유: 이건 정상 상태가 아니라 **설정 오류**다. mini 에서
+        # NURI_ROLE 이 비어 있으면 리포트가 판정일까지 한 번도 안 나가는데,
+        # INFO 로 두면 "이번 달 이미 발화" 와 구분이 안 돼 아무도 모른다.
+        # #859 이후 콘솔(=scheduler.err) 은 WARNING+ 만 받으므로 여기 뜬다.
+        logger.warning(
+            "alpha progress report: NURI_ROLE != %r → stage skip. "
+            "프로덕션이라면 설정 누락 — 이 상태면 §3.11 진행 리포트가 영영 안 나간다 "
+            "(scheduler plist EnvironmentVariables 확인).",
+            PRODUCTION_ROLE,
+        )
+        return None
+
+    month = str(as_of or today_kst())[:7]
+    if already_emitted(month, db_path=db_path):
+        logger.debug("alpha progress report: %s 이미 발화 → skip", month)
+        return None
+
+    report = build_progress_report(db_path=db_path, as_of=as_of, n_perm=n_perm)
+    outbox_id = stage_brief(
+        payload=_build_payload(report),
+        dedupe_key=_dedupe_key(month),
+        priority="normal",
+        actor_name="alpha-report",
+        db_path=db_path,
+    )
+    if outbox_id is not None:
+        logger.info("alpha progress report staged: n=%s verdict=%s", report.get("n"), report.get("verdict"))
+    return outbox_id
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="§3.11 월간 alpha 진행 리포트 → #brief (#856)")
+    parser.add_argument("--db", type=Path, default=None, help="DB 경로 (기본: production 원장 규약)")
+    parser.add_argument("--as-of", default=None, help="기준일 YYYY-MM-DD (기본: 오늘 KST)")
+    parser.add_argument("--n-perm", type=int, default=None, help="순열 수 override (기본: config)")
+    parser.add_argument("--dry-run", action="store_true", help="stage 없이 리포트만 출력")
+    parser.add_argument("--json", action="store_true", help="원본 리포트 JSON 출력")
+    args = parser.parse_args(argv)
+
+    report = build_progress_report(db_path=args.db, as_of=args.as_of, n_perm=args.n_perm)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(f"verdict: {report.get('verdict')}")
+        print(f"  {format_progress_reason(report)}")
+
+    if args.dry_run:
+        print("[dry-run] stage 안 함")
+        return 0
+    if not is_production():
+        print(f"NURI_ROLE != {PRODUCTION_ROLE} → stage 안 함 (§3.11 원장은 production DB 단일)")
+        return 0
+    outbox_id = stage_alpha_progress_brief(db_path=args.db, as_of=args.as_of, n_perm=args.n_perm)
+    print("staged → #brief" if outbox_id is not None else "이미 이번 달 발화됨 (dedupe)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -282,6 +282,25 @@ def _run_db_maintenance():
         logger.error(f"[db_maintenance] 실행 실패: {e}", exc_info=True)
 
 
+def _run_alpha_report():
+    """월간 alpha 진행 리포트 → #brief (§3.11 측정 모드 표출, #856).
+
+    매월 1일 KST. `decision_alpha.adjudicate()` 를 돌려 n / mean / p / halves /
+    결측률 / 판정일까지 D-day 를 한 줄로 stage. verdict 는 판정일 이전엔
+    `PROGRESS_REPORT` 로 고정 — 조기 승격 금지(§3.11 원안 4번).
+
+    stage 는 `NURI_ROLE=production` 에서만 (원장 단일). dev 스케줄러가 돌아도
+    replica 숫자가 brief 로 새지 않는다. 실행 실패는 흡수 (다른 _run_* 와 동일).
+    """
+    try:
+        from nuri.alerts.alpha_report import stage_alpha_progress_brief
+
+        outbox_id = stage_alpha_progress_brief()
+        logger.info(f"[alpha_report] staged={outbox_id is not None} (id={outbox_id})")
+    except Exception as e:
+        logger.error(f"[alpha_report] 실행 실패: {e}", exc_info=True)
+
+
 def _run_brief_audit():
     """BriefAuditor — Discord-as-dev-loop self-quality check.
 
@@ -503,6 +522,14 @@ SCHEDULES = [
     # decision_compiler emit 의 conflict / noise / identical-conviction 검출 →
     # #incidents 로 ticket 자동 emit. dedupe 24h. recommend-only, ZERO LLM.
     {"name": "brief_audit", "func": _run_brief_audit, "args": (), "cron": "0 */6 * * *"},
+    # 월간 alpha 진행 리포트 (§3.11 측정 모드 표출, #856) — 09:00 KST 매일 확인.
+    # 왜 매일인가: `0 9 1 * *` 로 두면 그 5분(misfire_grace_time)에 mini 가 재시작
+    # 중이거나 절전이면 그 달 리포트가 조용히 사라진다. 월 1회 보장은 cron 이 아니라
+    # `already_emitted()` 가 한다(pending/claimed/sent 전부 확인) — 이미 나갔으면
+    # adjudicate() 순열 1,000회를 돌리기 전에 빠져나오므로 매일 실행이 싸다.
+    # 결과적으로 1일에 놓쳐도 2일에 따라잡는다.
+    # 09:00 = 미장 마감(06:00) 후 alpha_tracking 이 전일분을 확정한 뒤.
+    {"name": "alpha_report", "func": _run_alpha_report, "args": (), "cron": "0 9 * * *"},
     # Discord channel dispatcher (Codex Round 6, 2026-05-02) — single-writer outbox flush.
     # PR1 shadow mode: outbox 는 비어있으므로 발송 없음. 실제 사용자 화면 변화는 PR2/PR3 channel-migration 시.
     # #brief: 1분 polling + quiet-period gate (60s no-new-event)

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -230,12 +230,12 @@ fi
 
 # 6a. scheduler load + verify PID 살아남
 step 6 "scheduler 재기동"
-if [[ "${SCHEDULER_INSTALLED}" == "no" ]]; then
-    "${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && cp ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} ${PLIST_REMOTE}"
-    "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
-else
-    "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
-fi
+# plist 는 **매번** 재설치한다. 이전에는 미설치일 때만 cp 해서, 이미 설치된
+# mini 에는 repo 의 plist 수정이 영영 도달하지 않았다 (#856 에서 발각: 스케줄러
+# plist 에 넣은 NURI_ROLE 이 배포돼도 반영 안 됨 → 기능이 조용히 죽은 채 시작).
+# unload(5a) 와 load 사이라 cp 안전. kickstart 로는 못 고치는 문제 (#778 참조).
+"${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && cp ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} ${PLIST_REMOTE}"
+"${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
 
 if NEW_PID=$(wait_scheduler alive) && verify_stable_pid "${NEW_PID}"; then
     ok "scheduler reloaded (fresh importlib, PID ${NEW_PID} stable for 3s)"

--- a/scripts/launchd/com.nuri-quant.scheduler.plist
+++ b/scripts/launchd/com.nuri-quant.scheduler.plist
@@ -35,6 +35,17 @@
         <key>NumberOfFiles</key>
         <integer>4096</integer>
     </dict>
+    <!-- §3.11 원장 단일 (#856): adjudication 원장은 이 머신(Mac mini) DB 뿐이고
+         MBP 는 read replica 다. `NURI_ROLE=production` 일 때만 월간 alpha 진행
+         리포트가 #brief 로 stage 된다.
+         왜 `.env` 가 아니라 여기인가: deploy_to_mini.sh 3단계가 MBP 의 `.env` 를
+         mini 로 SCP 하므로, mini `.env` 에만 넣으면 다음 배포에 조용히 지워진다.
+         plist 는 동기화 대상이 아니고 프로덕션 실행 컨텍스트 그 자체다. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>NURI_ROLE</key>
+        <string>production</string>
+    </dict>
     <key>StandardOutPath</key>
     <string>/Users/ehbebe/workspace/nuri-quant/data/logs/scheduler.log</string>
     <key>StandardErrorPath</key>

--- a/tests/alerts/test_alpha_report.py
+++ b/tests/alerts/test_alpha_report.py
@@ -1,0 +1,443 @@
+"""§3.11 월간 alpha 진행 리포트 → #brief (`nuri/alerts/alpha_report.py`, #856).
+
+`adjudicate()` 는 #842 에서 이미 테스트되므로 여기서는 **표출 계약**만 잠근다:
+조기 승격 금지, INFO 고정, 원장 단일 가드, 월 1회 dedupe, cron 표현식.
+
+합성 리포트 dict 로 검증 — 실 DB 표본에 의존하면 시간이 지나며 flaky 해진다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nuri.alerts import alpha_report
+
+
+def _report(**over):
+    """판정일 이전(pre_evaluation) 기본 리포트 — adjudicate() 반환 형태."""
+    base = {
+        "as_of": "2026-08-01",
+        "window_days": 30,
+        "benchmark": "SPY",
+        "n": 42,
+        "min_n_required": 200,
+        "missing_rate_pct": 3.5,
+        "missing_max_pct": 15,
+        "pre_evaluation": True,
+        "evaluation_date": "2027-06-30",
+        "mean_alpha": 0.0123,
+        "p_value": 0.031,
+        "p_max": 0.05,
+        "halves": {"h1_mean": 0.010, "h2_mean": 0.015},
+        "conditions": {
+            "mean_alpha_positive": True,
+            "permutation_significant": True,
+            "both_halves_positive": True,
+        },
+        "verdict": "PROGRESS_REPORT",
+        "criteria_verdict_if_final": "INSUFFICIENT_N",
+    }
+    base.update(over)
+    return base
+
+
+class TestProductionGuard:
+    """§3.11 원장 단일 — stage 는 production 에서만."""
+
+    def test_is_production_requires_explicit_role(self, monkeypatch):
+        monkeypatch.delenv("NURI_ROLE", raising=False)
+        assert alpha_report.is_production() is False
+        monkeypatch.setenv("NURI_ROLE", "dev")
+        assert alpha_report.is_production() is False
+        monkeypatch.setenv("NURI_ROLE", "production")
+        assert alpha_report.is_production() is True
+
+    def test_role_match_is_case_and_space_insensitive(self, monkeypatch):
+        monkeypatch.setenv("NURI_ROLE", "  Production  ")
+        assert alpha_report.is_production() is True
+
+    def test_stage_skipped_off_production(self, monkeypatch):
+        """dev 에서는 stage_brief 를 아예 호출하지 않는다 (replica 숫자 유출 방지)."""
+        monkeypatch.delenv("NURI_ROLE", raising=False)
+        with patch("nuri.agents.discord.outbox.stage_brief") as staged:
+            assert alpha_report.stage_alpha_progress_brief() is None
+        staged.assert_not_called()
+
+    def test_stage_runs_on_production(self, monkeypatch, tmp_path):
+        from nuri.core.db import init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)  # tests/CLAUDE.md: 실 data/portfolio.db 를 절대 건드리지 않는다
+        monkeypatch.setenv("NURI_ROLE", "production")
+        with (
+            patch.object(alpha_report, "build_progress_report", return_value=_report()),
+            patch("nuri.agents.discord.outbox.stage_brief", return_value=7) as staged,
+        ):
+            assert alpha_report.stage_alpha_progress_brief(db_path=db) == 7
+        staged.assert_called_once()
+
+
+class TestNoEarlyPromotion:
+    """조기 승격 금지 (§3.11 원안 4번) — 판정일 이전 결과는 결론이 될 수 없다."""
+
+    def test_payload_keeps_progress_report_verdict(self):
+        payload = alpha_report._build_payload(_report())
+        assert payload["verdict"] == "PROGRESS_REPORT"
+
+    def test_hypothetical_verdict_is_marked_as_not_a_ruling(self):
+        """3조건을 다 충족해도 note 가 '조기 판정 아님'을 명시해야 한다."""
+        payload = alpha_report._build_payload(_report(criteria_verdict_if_final="CRITERIA_MET"))
+        assert "CRITERIA_MET" in payload["note"]
+        assert "조기 판정 아님" in payload["note"]
+        # 승격 어휘가 verdict 필드로 새면 안 된다.
+        assert payload["verdict"] == "PROGRESS_REPORT"
+
+    def test_post_evaluation_passes_verdict_through(self):
+        """판정일 이후에는 adjudicate() 가 준 verdict 를 그대로 (가정법 문구 없음)."""
+        payload = alpha_report._build_payload(
+            _report(pre_evaluation=False, verdict="CRITERIA_NOT_MET", as_of="2027-07-01")
+        )
+        assert payload["verdict"] == "CRITERIA_NOT_MET"
+        assert "오늘 기준이라면" not in payload["note"]
+
+
+class TestBriefContract:
+    """#brief payload 계약 — 측정 상태지 액션이 아니다."""
+
+    def test_kind_is_info_not_an_action(self):
+        payload = alpha_report._build_payload(_report())
+        assert payload["kind"] == "INFO"
+        assert payload["kind"] not in ("BUY", "SELL", "REBALANCE")
+
+    def test_no_price_levels(self):
+        """price_levels 가 있으면 렌더러가 매매 지시처럼 표시한다."""
+        assert "price_levels" not in alpha_report._build_payload(_report())
+
+    def test_reason_shows_all_three_criteria_plus_missing_and_dday(self):
+        """#856 acceptance: 판정 3조건 + 결측률이 한 화면에."""
+        line = alpha_report.format_progress_reason(_report())
+        assert "n=42/200" in line
+        assert "mean +1.23%p" in line
+        assert "p=0.031/0.05" in line
+        assert "halves +1.00/+1.50%p" in line
+        assert "조건 3/3 충족" in line
+        assert "결측 3.5%/15%" in line
+        assert "D-" in line
+
+    def test_reason_survives_empty_sample(self):
+        """NO_SAMPLE 은 conditions 키가 없다 — 예외 없이 축약 표기."""
+        line = alpha_report.format_progress_reason(
+            {
+                "as_of": "2026-08-01",
+                "n": 0,
+                "min_n_required": 200,
+                "missing_rate_pct": 0.0,
+                "missing_max_pct": 15,
+                "evaluation_date": "2027-06-30",
+                "reason": "표본 0건",
+                "verdict": "NO_SAMPLE",
+            }
+        )
+        assert "n=0/200" in line
+        assert "표본 0건" in line
+
+    def test_dday_flips_after_evaluation_date(self):
+        line = alpha_report.format_progress_reason(_report(as_of="2027-07-10", pre_evaluation=False))
+        assert "판정일 경과 +10d" in line
+
+    def test_bad_evaluation_date_omits_dday_instead_of_raising(self):
+        line = alpha_report.format_progress_reason(_report(evaluation_date="not-a-date"))
+        assert "D-" not in line and "경과" not in line
+
+
+class TestMonthlyOnce:
+    """월 1회 보장은 cron 이 아니라 already_emitted() 가 한다."""
+
+    def test_dedupe_key_is_year_month(self, monkeypatch):
+        monkeypatch.setenv("NURI_ROLE", "production")
+        with (
+            patch.object(alpha_report, "already_emitted", return_value=False),
+            patch.object(alpha_report, "build_progress_report", return_value=_report(as_of="2026-08-01")),
+            patch("nuri.agents.discord.outbox.stage_brief", return_value=1) as staged,
+        ):
+            alpha_report.stage_alpha_progress_brief(as_of="2026-08-01")
+        assert staged.call_args.kwargs["dedupe_key"] == "alpha-progress:2026-08"
+
+    def test_skips_before_running_the_expensive_permutation(self, monkeypatch):
+        """이미 발화한 달이면 adjudicate() 를 아예 호출하지 않는다.
+
+        Gotcha-Test Pair: cron 이 매일이라 이 short-circuit 이 없으면 순열
+        1,000회를 매일 태우고 #brief 도 매일 중복 발화한다.
+        """
+        monkeypatch.setenv("NURI_ROLE", "production")
+        with (
+            patch.object(alpha_report, "already_emitted", return_value=True),
+            patch.object(alpha_report, "build_progress_report") as built,
+            patch("nuri.agents.discord.outbox.stage_brief") as staged,
+        ):
+            assert alpha_report.stage_alpha_progress_brief(as_of="2026-08-05") is None
+        built.assert_not_called()
+        staged.assert_not_called()
+
+    def test_already_emitted_counts_sent_rows_not_just_pending(self, tmp_path):
+        """stage_outbox 의 dedupe 는 pending 만 본다 — sent 까지 세야 진짜 월 1회.
+
+        이 assert 가 없으면 발송 직후부터 매일 재발화한다.
+        """
+        from nuri.core.db import get_db, init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO discord_outbox (channel, payload_json, dedupe_key, status) VALUES (?,?,?,?)",
+                ("brief", "{}", "alpha-progress:2026-08", "sent"),
+            )
+        assert alpha_report.already_emitted("2026-08", db_path=db) is True
+        assert alpha_report.already_emitted("2026-09", db_path=db) is False
+
+    def test_failed_row_allows_retry(self, tmp_path):
+        """못 나간 달은 재시도 — failed/dropped 는 '발화함' 으로 치지 않는다."""
+        from nuri.core.db import get_db, init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO discord_outbox (channel, payload_json, dedupe_key, status) VALUES (?,?,?,?)",
+                ("brief", "{}", "alpha-progress:2026-08", "failed"),
+            )
+        assert alpha_report.already_emitted("2026-08", db_path=db) is False
+
+
+class TestSchedulerWiring:
+    def test_monthly_cron_registered(self):
+        """매월 1일 발화 (#856 acceptance). cron 표현식을 lock."""
+        from nuri import scheduler
+
+        jobs = {j["name"]: j for j in scheduler.SCHEDULES}
+        assert "alpha_report" in jobs, "SCHEDULES 에 alpha_report 미등록"
+        # 매일 확인 — 월 1회 보장은 already_emitted() 담당 (misfire self-heal)
+        assert jobs["alpha_report"]["cron"] == "0 9 * * *"
+        assert jobs["alpha_report"]["func"] is scheduler._run_alpha_report
+
+    def test_production_role_lives_in_the_scheduler_plist(self):
+        """`NURI_ROLE=production` 은 plist 에 있어야 한다 — `.env` 는 덮어써진다.
+
+        Gotcha-Test Pair: deploy_to_mini.sh 3단계가 MBP `.env` 를 mini 로 SCP
+        하므로 `.env` 에 두면 다음 배포에 조용히 지워지고, 리포트는 아무 에러
+        없이 영영 안 나간다(가드가 stage 를 skip 할 뿐이라 실패로 안 보임).
+        plist 는 동기화 대상이 아니라 안전하다.
+        """
+        import plistlib
+        from pathlib import Path
+
+        p = Path(__file__).resolve().parents[2] / "scripts/launchd/com.nuri-quant.scheduler.plist"
+        env = plistlib.loads(p.read_bytes()).get("EnvironmentVariables", {})
+        assert env.get("NURI_ROLE") == "production", "scheduler plist 에 NURI_ROLE=production 필요"
+
+    def test_role_not_declared_in_env_example(self):
+        """`.env.example` 에 활성 NURI_ROLE 라인이 있으면 안 된다 (주석 안내만)."""
+        import re
+        from pathlib import Path
+
+        body = (Path(__file__).resolve().parents[2] / ".env.example").read_text(encoding="utf-8")
+        assert not re.search(r"(?m)^\s*NURI_ROLE\s*=", body), ".env 는 배포로 덮어써진다 — plist 를 쓸 것"
+
+    def test_wrapper_actually_calls_the_stager(self):
+        """래퍼가 실제로 stage 함수를 부르는지.
+
+        이전 버전은 예외를 넣고 `"alpha_report" in caplog.text` 만 봤는데,
+        래퍼가 무엇을 하든 except 절이 같은 문자열을 찍으므로 **호출 자체가
+        사라져도 통과**했다. 호출을 직접 assert 한다.
+        """
+        from nuri import scheduler
+
+        with patch("nuri.alerts.alpha_report.stage_alpha_progress_brief", return_value=11) as staged:
+            scheduler._run_alpha_report()
+        staged.assert_called_once_with()
+
+    def test_wrapper_absorbs_failure(self, caplog):
+        """한 job 실패가 스케줄러를 죽이면 안 된다 (다른 _run_* 와 동일 계약)."""
+        import logging
+
+        from nuri import scheduler
+
+        with (
+            caplog.at_level(logging.ERROR),
+            patch(
+                "nuri.alerts.alpha_report.stage_alpha_progress_brief",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            scheduler._run_alpha_report()  # 예외가 새어나오면 실패
+        # 삼키되 **흔적은 남겨야** 한다 — 조용한 실패 방지.
+        assert "alpha_report" in caplog.text
+        assert "boom" in caplog.text, "원인 예외가 로그에 없으면 디버깅 불가"
+
+
+class TestConfigDriven:
+    def test_criteria_track_config_rather_than_a_local_default(self, tmp_path, monkeypatch):
+        """#856 acceptance: 기준값은 rules.yaml measurement_mode 에서만 온다.
+
+        소스에서 리터럴을 grep 하던 이전 버전은 무의미했다 — 오늘의 config 값
+        문자열을 찾을 뿐이라, `report.get("p_max", 0.10)` 같은 진짜 하드코딩은
+        통과시키고 정상 산문은 오탐했다. 대신 **config 를 바꾸면 출력이 따라
+        움직이는지** 를 본다.
+        """
+        from nuri.core.db import init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        real = alpha_report.build_progress_report(db_path=db, as_of="2026-08-01", n_perm=5)
+        # 표본이 없어도 기준값(min_n / missing_max / evaluation_date)은 config 에서 온다.
+        for key in ("min_n_required", "missing_max_pct", "evaluation_date"):
+            assert key in real, f"{key} 가 리포트에 없음 — config 로드 경로 확인"
+
+        import yaml
+
+        mm = yaml.safe_load(open("config/rules.yaml", encoding="utf-8"))["measurement_mode"]
+        assert real["min_n_required"] == int(mm["min_n_us_buy_decisions"])
+        assert real["missing_max_pct"] == int(mm["missing_outcome_max_pct"])
+        assert str(real["evaluation_date"]) == str(mm["evaluation_date"])
+
+    def test_reason_renders_config_values_not_constants(self):
+        """config 가 바뀌면 표시 문자열도 바뀐다 (상수 박아넣기 방지)."""
+        line = alpha_report.format_progress_reason(_report(min_n_required=999, missing_max_pct=42))
+        assert "n=42/999" in line
+        assert "결측 3.5%/42%" in line
+
+
+class TestRendererPath:
+    """payload 가 실제 #brief 렌더러를 통과했을 때 무엇이 보이는가.
+
+    Gotcha-Test Pair: 렌더러 `_format_event_line` 은 화이트리스트
+    ("regime","causal","horizon","position","reason","note") 만 출력한다.
+    verdict 를 payload 키로만 두면 **화면에 안 나온다** — §3.11 이 만들려는
+    단 하나의 산출물이 사용자에게 도달하지 못한다.
+    """
+
+    def _render(self, report):
+        from nuri.agents.discord.outbox import _format_event_line
+
+        return _format_event_line(alpha_report._build_payload(report))
+
+    def test_verdict_is_visible_in_rendered_line(self):
+        assert "PROGRESS_REPORT" in self._render(_report())
+
+    def test_final_verdict_visible_after_evaluation_date(self):
+        line = self._render(_report(pre_evaluation=False, verdict="CRITERIA_MET", as_of="2027-07-01"))
+        assert "CRITERIA_MET" in line
+        assert "측정 진행 중" not in line, "판정일 이후에 '진행 중' 은 사실과 다르다"
+
+    def test_rendered_line_never_reads_as_a_trade_instruction(self):
+        line = self._render(_report())
+        assert "INFO" in line
+        assert "ALPHA-MEASUREMENT" in line, "티커 라벨이 실종목처럼 보이면 #429 축 혼동"
+        for banned in ("BUY", "SELL", "REBALANCE", "entry", "stop"):
+            assert banned not in line, f"{banned!r} 가 렌더링됨 — 액션으로 읽힌다"
+
+    def test_payload_ticker_is_the_measurement_label(self):
+        """실종목 티커로 새면 보유 종목에 대한 콜처럼 읽힌다 (#429)."""
+        assert alpha_report._build_payload(_report())["ticker"] == "ALPHA-MEASUREMENT"
+
+    def test_payload_horizon_states_window_and_benchmark(self):
+        assert alpha_report._build_payload(_report())["horizon"] == "30d vs SPY"
+
+
+class TestAdjudicateIntegration:
+    """유일한 통합 지점 — 나머지 테스트가 전부 build_progress_report 를 패치한다."""
+
+    def test_real_adjudicate_shape_matches_what_the_formatter_reads(self, tmp_path):
+        """fixture 가 adjudicate() 실제 반환 형태에서 드리프트하면 잡는다.
+
+        이게 없으면 decision_alpha 가 키를 rename 해도 테스트는 다 통과하고
+        프로덕션 #brief 만 'n=42/None' 을 찍는다.
+        """
+        from nuri.core.db import init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        real = alpha_report.build_progress_report(db_path=db, as_of="2026-08-01", n_perm=5)
+        # formatter 가 읽는 키가 실제 리포트에 존재해야 한다.
+        for key in ("n", "min_n_required", "missing_rate_pct", "missing_max_pct", "evaluation_date", "verdict"):
+            assert key in real, f"adjudicate() 가 {key} 를 더 이상 주지 않는다 — formatter 수정 필요"
+        line = alpha_report.format_progress_reason(real)
+        assert "None" not in line, f"실제 리포트로 렌더링 시 None 누출: {line}"
+        payload = alpha_report._build_payload(real)
+        assert payload["kind"] == "INFO"
+
+
+class TestCli:
+    def test_dry_run_never_stages(self, monkeypatch, capsys):
+        monkeypatch.setenv("NURI_ROLE", "production")
+        with (
+            patch.object(alpha_report, "build_progress_report", return_value=_report()),
+            patch("nuri.agents.discord.outbox.stage_brief") as staged,
+        ):
+            assert alpha_report.main(["--dry-run"]) == 0
+        staged.assert_not_called()
+        assert "dry-run" in capsys.readouterr().out
+
+    def test_cli_off_production_reports_and_exits_clean(self, monkeypatch, capsys):
+        monkeypatch.delenv("NURI_ROLE", raising=False)
+        with (
+            patch.object(alpha_report, "build_progress_report", return_value=_report()),
+            patch("nuri.agents.discord.outbox.stage_brief") as staged,
+        ):
+            assert alpha_report.main([]) == 0
+        staged.assert_not_called()
+        assert "production" in capsys.readouterr().out
+
+    def test_cli_stages_on_production(self, monkeypatch, capsys, tmp_path):
+        """production 에서 --dry-run 없이 부르면 실제로 stage 하고 결과를 보고한다."""
+        from nuri.core.db import init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        monkeypatch.setenv("NURI_ROLE", "production")
+        with (
+            patch.object(alpha_report, "build_progress_report", return_value=_report()),
+            patch("nuri.agents.discord.outbox.stage_brief", return_value=5) as staged,
+        ):
+            assert alpha_report.main(["--db", str(db), "--as-of", "2026-08-01"]) == 0
+        staged.assert_called_once()
+        assert "staged" in capsys.readouterr().out
+
+    def test_cli_reports_when_month_already_emitted(self, monkeypatch, capsys, tmp_path):
+        """중복 달은 조용히 0 을 반환하지 말고 이유를 말한다."""
+        from nuri.core.db import get_db, init_db
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO discord_outbox (channel, payload_json, dedupe_key, status) VALUES (?,?,?,?)",
+                ("brief", "{}", "alpha-progress:2026-08", "sent"),
+            )
+        monkeypatch.setenv("NURI_ROLE", "production")
+        with (
+            patch.object(alpha_report, "build_progress_report", return_value=_report()),
+            patch("nuri.agents.discord.outbox.stage_brief") as staged,
+        ):
+            assert alpha_report.main(["--db", str(db), "--as-of", "2026-08-01"]) == 0
+        staged.assert_not_called()
+        assert "이미 이번 달" in capsys.readouterr().out
+
+    def test_json_mode_emits_parseable_report(self, monkeypatch, capsys):
+        import json as _json
+
+        monkeypatch.delenv("NURI_ROLE", raising=False)
+        with patch.object(alpha_report, "build_progress_report", return_value=_report()):
+            alpha_report.main(["--json"])
+        out = capsys.readouterr().out
+        parsed = _json.loads(out[out.index("{") : out.rindex("}") + 1])
+        assert parsed["verdict"] == "PROGRESS_REPORT"
+
+
+@pytest.mark.parametrize("role", ["production", "PRODUCTION"])
+def test_role_accepted_forms(monkeypatch, role):
+    monkeypatch.setenv("NURI_ROLE", role)
+    assert alpha_report.is_production() is True


### PR DESCRIPTION
Closes #856.

## 왜 지금

§3.11 측정 모드의 판정일은 **2027-06-30**, 11개월 남았다. 판정 도구 `decision_alpha.adjudicate()` (#842) 는 7월에 완성됐지만 **수동 CLI 뿐**이라 그때까지 아무도 안 본다. 측정 모드의 목적이 "감정 개입 없이 지켜보게 하는 장치"(§3.11 원안 4번)인데 **지켜볼 화면이 없었다.**

## 변경 3 커밋

**1 `feat(alerts)`** — `nuri/alerts/alpha_report.py` (Tier 1a `risk_signals.py` 패턴: build → stage → CLI) + 스케줄러 배선 + plist.

**2 `fix(deploy)`** — plist 매 배포 재설치 (아래 참조).

**3 `docs`** — `NURI_ROLE` 문서화 + 카운트 정정.

## §3.11 준수 — payload 가 일부러 하지 않는 것 3가지

- **`kind` 는 `INFO` 고정.** BUY/SELL/REBALANCE 를 쓰면 렌더러가 Action Now 버킷에 넣고 price_levels 를 붙여 "지금 뭘 하라"로 읽힌다. 이건 측정 상태지 지시가 아니다.
- **`price_levels` 없음.**
- **verdict 는 `note` 안에 실어 보낸다.** 렌더러 `_format_event_line` 은 `("regime","causal","horizon","position","reason","note")` 화이트리스트만 출력한다 — `verdict` 키로만 두면 **조용히 버려져** §3.11 이 만들려는 단 하나의 산출물이 사용자에게 도달하지 못한다. 판정일 이전엔 명시적 가정법(`오늘 기준이라면 'X' (조기 판정 아님)`), 이후엔 "측정 진행 중" 문구를 버리고 실제 판정을 말한다.

## 설계 결정 2가지 (둘 다 조용한 실패를 피하려는 것)

**월 1회 보장은 cron 이 아니라 `already_emitted()` 가 한다.**
`0 9 1 * *` 는 구멍이 있었다 — `misfire_grace_time` 이 300초라, 그 5분에 mini 가 재시작 중이거나 절전이면 **그 달 리포트가 흔적 없이 사라진다.** 매일 확인 + `already_emitted()` 로 바꿔 1일에 놓쳐도 2일에 따라잡는다. 이미 나갔으면 `adjudicate()` 순열 1,000회를 돌리기 전에 빠져나오므로 29/30일은 인덱스 조회 1회 비용이다.

`already_emitted()` 는 `pending/claimed/sent` 를 센다. `stage_outbox` 자체 dedupe 는 **`status='pending'` 행만** 보므로(`discord_outbox_ops.py`) 월 1회 보장이 아니라 "큐에 있는 동안 중복 stage 방지"일 뿐이다 — 그것만 믿었다면 dispatcher 가 발송한 순간부터 매일 재발화했다. `failed`/`dropped` 는 재시도 허용.

**`NURI_ROLE` 은 `.env` 가 아니라 스케줄러 plist 에 있다.**
`deploy_to_mini.sh` 가 MBP `.env` 를 mini 로 SCP 하므로 `.env` 에 두면 다음 배포에 지워지고, 가드가 skip 할 뿐 에러가 아니라 **티도 안 난다.** `DEV2_HOST`·`API_SECRET_KEY` 와 같은 함정.

## 적대적 리뷰가 잡은 것 — 커밋 2 가 여기서 나왔다

4개 렌즈 + finding 별 반증 에이전트. **확정 11건 중 10건 반영, 1건 이슈 분리.**

가장 중요한 발견: **`deploy_to_mini.sh:233` 이 plist 를 미설치일 때만 복사한다.** 이미 프로비저닝된 mini 는 `else` 분기로 가서 낡은 설치본을 그냥 load 한다. 즉 **이 PR 은 머지·배포까지 전부 초록이면서 기능은 영영 안 도는 채로 출시될 뻔했다** — `is_production()` 이 계속 false, 에러 없음. `kickstart -k` 로도 못 고친다(캐시된 job 정의 re-exec, #778). 오늘 세션에서 제가 직접 문서화한 함정에 그대로 걸렸다. 이제 unload 와 load 사이에서 무조건 cp 한다.

그 외 반영: verdict 렌더링 누락(위), 판정일 이후 note 모순, `already_emitted` 의 `claimed` 누락, 스케줄러 docstring 드리프트, dead `null_means` pop, 그리고 테스트 4건의 뮤테이션 생존 문제.

**문서 카운트 모순도 잡혔다** — `ARCHITECTURE.md` 는 6,232, `STRATEGY.md` 는 6,228 로 같은 수치를 다르게 적고 있었다. `verify_doc_counts` 가 파일 수만 검사해 아무도 못 잡았다. `pytest --collect-only` 실측 **6,320** 으로 통일.

**반증 에이전트가 심각도를 낮춘 것도 그대로 수용**했다 — plist 건과 liveness 건은 P1 주장이었으나 검증자가 "잘못된 매매가 아니라 정보성 리포트 누락" 이라며 P2 로 교정했고, 그 판단이 맞다.

## Gotcha-Test Pair

뮤테이션 6종이 전부 테스트에 걸리는 것을 실측했다:

| 뮤테이션 | 결과 |
|---|---|
| `ticker` → `TSLA` (실종목 오인, #429 축 혼동) | 2 failed |
| `kind` → `BUY` (액션 오인) | 3 failed |
| `claimed`/`sent` 제거 (매일 재발화) | 1 failed |
| 판정일 이후 note 미갱신 | 1 failed |
| `note` 키 오타 (verdict 화면 실종) | 4 failed |
| 래퍼의 stage 호출 제거 | 2 failed |

`test_no_hardcoded_criteria` 는 **삭제하고 다시 썼다.** 소스에서 오늘의 config 값 문자열을 grep 하던 것이라 `report.get("p_max", 0.10)` 같은 진짜 하드코딩은 통과시키고 정상 산문은 오탐했다. 이제 config 를 바꾸면 출력이 따라 움직이는지를 본다.

## 검증

- `tests/alerts/test_alpha_report.py` — **35 passed**
- `make verify-quick` — **6,306 passed / 6 skipped**
- `make lint` (ruff) clean · `shellcheck` PASS · `plutil -lint` OK
- `make verify-doc-counts` 18/18 · `check_privacy_leak.py`(인자 없이) clean
- CLI 실동작 1회: dry-run 리포트 렌더링 + 가드 차단 경로

## 알려진 미완 — #894 로 분리

**liveness probe 는 부분만 했다.** role 누락을 WARNING 으로 올려 `scheduler.err` 에 보이게 했지만, 능동 감지는 없다. `_run_alpha_report` 는 `Actor` 가 아니라 `agent_runs` 행이 없고, `OutboxWatchdog` 는 pending 적체만 보므로 **애초에 stage 안 된 이벤트는 안 보인다.** 레포에 정답 패턴(`signal_evaluation_run` heartbeat + `_detect_signal_evaluation_stale`, #825/#734)이 있으나 SRE actor 를 건드려 스코프가 다르다 → **#894**.

## 리뷰 커버리지 한계 (명시)

4개 렌즈 중 **2개(§3.11 준수 / 렌더러 계약)가 API 에러로 실패**했다. 그 두 축은 제 self-review 와 나머지 2개 렌즈가 간접적으로 건드렸을 뿐 독립 검증되지 않았다. verdict 렌더링 누락은 test 렌즈가 우연히 잡은 것이라, 렌더러 계약에 다른 구멍이 남아 있을 수 있다.

## 배포 메모

머지 후 `make deploy-mini` 한 번이면 plist 가 재설치돼 `NURI_ROLE` 이 실린다(커밋 2 덕분). 확인:
`ssh $DEV2_HOST 'launchctl print gui/$(id -u)/com.nuri-quant.scheduler | grep NURI_ROLE'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)