### PR TITLE
fix(db): WAL-safe verified ledger backups + off-machine copy + age watchdog (closes #835)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,320 backend tests across 278 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,334 backend tests across 279 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,320 tests, 278 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,334 tests, 279 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -47,6 +47,11 @@ HEARTBEAT_PATH = Path(__file__).resolve().parents[2] / "data" / ".scheduler_hear
 # 30분 이상 stale 이면 alert. sre_incident_agent.SCHEDULER_WARN_MIN 과 동일값 유지.
 STALE_THRESHOLD_MIN = 30.0
 
+#: 원장 백업 디렉터리 + 경고 임계. 백업은 일 1회(cron `0 0 * * *`)라 48h 는
+#: "하루 걸러도 봐주되 이틀은 아니다" 선 (#835 acceptance).
+BACKUP_DIR = Path(__file__).resolve().parents[2] / "data" / "backups"
+BACKUP_STALE_THRESHOLD_H = 48.0
+
 # 자동 재시작 대상 launchd label. fd 누수(파일 디스크립터 고갈)로 데몬이 살아있되
 # heartbeat 만 멈추는 경우 KeepAlive 는 무력(크래시 아님) — kickstart -k 만 fd 를 회수.
 SCHEDULER_LABEL = "com.nuri-quant.scheduler"
@@ -154,6 +159,25 @@ def check_services(recheck_delay_s: float = SERVICE_RECHECK_DELAY_S) -> list[str
     return problems
 
 
+def backup_age_hours(backup_dir: Path | None = None, now_epoch: float | None = None) -> float | None:
+    """최신 원장 백업의 age(시간). 디렉터리/백업 미존재 시 None (미배포 환경 → skip).
+
+    §3.11 원장은 Mac mini 단일본이라 백업이 유일한 안전망이다. 백업 job 은
+    scheduler 안에서 돌기 때문에 scheduler 가 죽으면 heartbeat 와 **함께** 멈춘다
+    — 즉 heartbeat 감시만으로는 "백업이 며칠째 안 돌았다" 를 따로 못 잡는다
+    (2026-04-30 ~ 07-08, #557 경로 drift 로 백업이 두 달 넘게 조용히 실패한 전력).
+    """
+    d = backup_dir or BACKUP_DIR
+    if not d.is_dir():
+        return None
+    snapshots = list(d.glob("portfolio_*.db"))
+    if not snapshots:
+        return None
+    newest = max(s.stat().st_mtime for s in snapshots)
+    now = now_epoch if now_epoch is not None else time.time()
+    return (now - newest) / 3600.0
+
+
 def heartbeat_age_minutes(path: Path | None = None, now_epoch: float | None = None) -> float | None:
     """heartbeat 파일 mtime 의 age(분) 반환. 파일 미존재 시 None (미배포 환경 → skip)."""
     p = path or HEARTBEAT_PATH
@@ -183,6 +207,22 @@ def main() -> int:
         alerts.append(
             f"🔴 **스케줄러 heartbeat STALE** — {age:.0f}분째 갱신 없음 "
             f"(임계 {STALE_THRESHOLD_MIN:.0f}분). 데이터 수집 중단 의심.\n{restart_note}"
+        )
+
+    # 원장 백업 나이 감시 (#835). scheduler 와 독립적으로 파일 mtime 만 보므로
+    # scheduler 가 죽어도, 백업 job 만 조용히 실패해도 둘 다 여기서 잡힌다.
+    b_age = backup_age_hours()
+    if b_age is None:
+        print(f"백업 없음 ({BACKUP_DIR}) — skip (미배포 환경)")
+    elif b_age <= BACKUP_STALE_THRESHOLD_H:
+        print(f"backup OK ({b_age:.1f}시간, 임계 {BACKUP_STALE_THRESHOLD_H:.0f}시간)")
+    else:
+        alerts.append(
+            f"🔴 **원장 백업 STALE** — 최신 스냅샷이 {b_age:.0f}시간 전 "
+            f"(임계 {BACKUP_STALE_THRESHOLD_H:.0f}시간). §3.11 판정 원장은 이 머신 단일본이라 "
+            f"백업이 유일한 안전망이다.\n"
+            f"확인: `tail -20 data/logs/scheduler.log | grep backup` · "
+            f"수동 실행: `bash scripts/db/backup.sh`"
         )
 
     # 표출 계층 (API/dashboard) 포트 감시 — 미설치 머신은 내부에서 skip (#826).

--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
-# Nuri-Quant DB 백업 — 30일 롤링
+# Nuri-Quant DB 백업 — 30일 롤링 + 생성 직후 무결성 검증 (#835)
+#
+# WAL 안전성: 예전에는 `cp` 였다. WAL 모드에서는 커밋된 트랜잭션이 아직
+# `portfolio.db-wal` 에 있을 수 있고 `cp` 는 그 파일을 안 가져간다 — writer 가
+# 연결돼 있는 순간에 돌면 최근 커밋이 빠지거나 체크포인트와 경쟁해 찢어진
+# 스냅샷이 나온다. 평소엔 사이드카가 없어 우연히 맞았을 뿐 **보장이 아니었다.**
+# 이제 SQLite online backup API(`.backup`)를 쓴다 — reader 로 열어 WAL 을 포함한
+# 일관된 스냅샷을 만들고, 진행 중인 writer 를 막지도 않는다.
+#
+# 검증: SHA256 은 "복사 후 파일이 안 바뀜"만 증명한다 — 애초에 깨진 스냅샷을
+# 떴는지는 말해주지 않는다(거짓 안심). 그래서 만든 직후 `integrity_check` +
+# 원장 테이블 존재/행수를 확인하고, 실패하면 산출물을 지우고 exit 1 한다.
+# 조용히 성공한 척하는 백업이 백업 없는 것보다 위험하다.
 set -euo pipefail
 
 # scripts/db/ 로 이동 (#557) 후 repo root 는 두 단계 위 (#836 경로 drift fix)
@@ -7,22 +19,76 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 BACKUP_DIR="$PROJECT_DIR/data/backups"
-DB_FILE="$PROJECT_DIR/data/portfolio.db"
+DB_FILE="${NURI_DB_PATH:-$PROJECT_DIR/data/portfolio.db}"
 DATE=$(date +%Y%m%d_%H%M%S)
+OUT="$BACKUP_DIR/portfolio_${DATE}.db"
+
+# venv python 우선 (launchd 는 ~/.zprofile 미로드 → PATH 최소)
+PYTHON="$PROJECT_DIR/.venv/bin/python"
+[ -x "$PYTHON" ] || PYTHON="python3"
 
 if [ ! -f "$DB_FILE" ]; then
-    echo "DB 파일 없음: $DB_FILE"
+    echo "DB 파일 없음: $DB_FILE" >&2
     exit 1
 fi
 
 mkdir -p "$BACKUP_DIR"
-cp "$DB_FILE" "$BACKUP_DIR/portfolio_${DATE}.db"
 
-# SHA256 checksum 기록
-shasum -a 256 "$BACKUP_DIR/portfolio_${DATE}.db" > "$BACKUP_DIR/portfolio_${DATE}.db.sha256"
+# ── 스냅샷 + 검증 (한 프로세스에서) ──
+# 원장 테이블은 §3.11 판정의 근거다. 하나라도 없으면 스냅샷이 쓸모없으므로 실패.
+# ⚠ `if !` 로 감싼다. `set -e` 하에서 그냥 호출하면 python 이 실패하는 즉시
+# 스크립트가 죽어 아래 정리(rm)에 **도달하지 못하고** 깨진 산출물이 남는다.
+# if 조건부 안에서는 set -e 가 유예된다.
+if ! "$PYTHON" - "$DB_FILE" "$OUT" <<'PY'
+import sqlite3
+import sys
+from pathlib import Path
+
+src_path, out_path = sys.argv[1], Path(sys.argv[2])
+LEDGER_TABLES = ("decision_outcomes", "decisions", "recommendations", "portfolio")
+
+# ⚠ 원본은 read-write 로 연다. WAL DB 를 `mode=ro` 로 열면 `-shm` 공유메모리
+# 파일을 만들 수 없어 "unable to open database file" 이 난다 — writer 가 아무도
+# 안 붙어 있는 상태(백업 시각의 정상 케이스)에서 정확히 그렇다.
+# backup API 는 원본에 쓰지 않으므로 read-write 핸들이어도 안전하다.
+src = sqlite3.connect(src_path)
+dst = sqlite3.connect(str(out_path))
+try:
+    src.backup(dst)  # online backup API — WAL 포함 일관 스냅샷
+finally:
+    dst.close()
+    src.close()
+
+# 스냅샷은 원본의 WAL journal_mode 를 물려받으므로 여기서도 `mode=ro` 는 못 쓴다
+# (같은 -shm 이유). 검증 전용 연결이라 쓰기는 발생하지 않는다.
+check = sqlite3.connect(str(out_path))
+try:
+    status = check.execute("PRAGMA integrity_check").fetchone()[0]
+    if status != "ok":
+        raise SystemExit(f"integrity_check 실패: {status}")
+    counts = []
+    for t in LEDGER_TABLES:
+        try:
+            n = check.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]  # noqa: S608 (고정 리스트)
+        except sqlite3.Error as e:
+            raise SystemExit(f"원장 테이블 {t} 읽기 실패: {e}") from e
+        counts.append(f"{t}={n}")
+finally:
+    check.close()
+print("  verified: integrity=ok " + " ".join(counts))
+PY
+then
+    # 검증 실패한 산출물은 남기지 않는다 — 나중에 '최신 백업' 으로 집히면
+    # 복원 시점에야 깨진 걸 알게 된다.
+    rm -f "$OUT"
+    echo "백업 검증 실패 → 산출물 삭제. 원장 상태 점검 필요." >&2
+    exit 1
+fi
+
+shasum -a 256 "$OUT" > "$OUT.sha256"
 
 # 30일 이전 백업 삭제
 find "$BACKUP_DIR" -name "portfolio_*.db" -mtime +30 -delete
 find "$BACKUP_DIR" -name "portfolio_*.db.sha256" -mtime +30 -delete
 
-echo "Backup complete: portfolio_${DATE}.db (checksum recorded)"
+echo "Backup complete: portfolio_${DATE}.db (verified + checksum recorded)"

--- a/scripts/db/pull_backup.sh
+++ b/scripts/db/pull_backup.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# 원장 백업 오프머신 사본 — Mac mini → MBP (#835)
+#
+# §3.11 판정 원장은 Mac mini 단일 SQLite 다. mini 의 `data/backups/` 는 같은
+# 디스크·같은 머신이라 머신 자체가 죽으면 원장과 백업이 **함께** 사라진다.
+# 이 스크립트가 최신 스냅샷 1벌을 MBP 로 당겨 그 단일 실패점을 없앤다.
+#
+# 클라우드 금지 (§4.4 sovereignty): 개인 금융 데이터이므로 외부 업로드를 하지
+# 않는다. 오프머신 = 사용자가 이미 소유한 두 번째 머신 뿐이다.
+#
+# 무결성: mini 가 기록한 .sha256 을 같이 받아 **로컬에서 재계산해 대조**한다.
+# 전송 중 손상은 물론, mini 쪽 파일이 이미 깨져 있었다면 여기서도 걸린다
+# (backup.sh 가 생성 직후 integrity_check 를 하지만 이중 확인).
+#
+# 사용법:
+#   bash scripts/db/pull_backup.sh          # 최신 1벌
+#   KEEP=5 bash scripts/db/pull_backup.sh   # 로컬 보관 개수 조정 (기본 3)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+SSH="$PROJECT_DIR/scripts/deploy/ssh_dev2.sh"
+
+REMOTE="${DEV2_HOST:-}"
+REMOTE_PATH="${DEV2_PATH:-~/workspace/nuri-quant}"
+LOCAL_DIR="$PROJECT_DIR/data/backups/offsite"
+KEEP="${KEEP:-3}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1" >&2; exit 1; }
+
+[ -z "$REMOTE" ] && fail "DEV2_HOST 미설정 (~/.zshrc 에 export)"
+[ -x "$SSH" ] || fail "ssh helper 없음: $SSH"
+
+echo "원장 백업 오프머신 사본 — ${REMOTE} → MBP"
+
+# ── 1. 원격 최신 스냅샷 이름 ──
+LATEST=$(bash "$SSH" "$REMOTE" "cd ${REMOTE_PATH} && ls -t data/backups/portfolio_*.db 2>/dev/null | head -1 | xargs -r basename") \
+    || fail "원격 조회 실패 (SSH/네트워크 확인)"
+[ -z "$LATEST" ] && fail "원격에 백업 없음 — mini 에서 'bash scripts/db/backup.sh' 확인"
+ok "최신 스냅샷: $LATEST"
+
+mkdir -p "$LOCAL_DIR"
+if [ -f "$LOCAL_DIR/$LATEST" ]; then
+    ok "이미 보유 — 전송 생략"
+else
+    scp -q -S "$SSH" "$REMOTE:${REMOTE_PATH}/data/backups/$LATEST" "$LOCAL_DIR/$LATEST" \
+        || fail "스냅샷 전송 실패"
+    scp -q -S "$SSH" "$REMOTE:${REMOTE_PATH}/data/backups/$LATEST.sha256" "$LOCAL_DIR/$LATEST.sha256" \
+        || fail "체크섬 전송 실패"
+    ok "전송 완료 ($(du -h "$LOCAL_DIR/$LATEST" | cut -f1))"
+fi
+
+# ── 2. 체크섬 대조 (원격 기록 vs 로컬 재계산) ──
+EXPECTED=$(awk '{print $1}' "$LOCAL_DIR/$LATEST.sha256")
+ACTUAL=$(shasum -a 256 "$LOCAL_DIR/$LATEST" | awk '{print $1}')
+[ "$EXPECTED" = "$ACTUAL" ] || fail "체크섬 불일치 — 전송 손상 또는 원본 손상. 재시도 후에도 같으면 mini 백업 점검"
+ok "체크섬 일치"
+
+# ── 3. 실제로 열리는지 (체크섬이 맞아도 논리적으로 깨질 수 있다) ──
+PYTHON="$PROJECT_DIR/.venv/bin/python"
+[ -x "$PYTHON" ] || PYTHON="python3"
+"$PYTHON" - "$LOCAL_DIR/$LATEST" <<'PY' || fail "무결성 검증 실패 — 이 사본은 복원에 쓸 수 없다"
+import sqlite3
+import sys
+
+# `mode=ro` 금지 — 스냅샷은 원본의 WAL journal_mode 를 물려받는데, WAL DB 를
+# read-only 로 열면 `-shm` 을 만들 수 없어 "unable to open database file" 이 난다.
+c = sqlite3.connect(sys.argv[1])
+try:
+    status = c.execute("PRAGMA integrity_check").fetchone()[0]
+    if status != "ok":
+        raise SystemExit(f"integrity_check: {status}")
+    n = c.execute("SELECT COUNT(*) FROM decision_outcomes").fetchone()[0]
+    print(f"  verified: integrity=ok decision_outcomes={n}")
+finally:
+    c.close()
+PY
+
+# ── 4. 로컬 보관 개수 유지 (오프머신 벌은 최신 몇 개면 충분) ──
+# shellcheck disable=SC2012  # 파일명은 스크립트가 만든 타임스탬프 패턴이라 안전
+ls -t "$LOCAL_DIR"/portfolio_*.db 2>/dev/null | tail -n +$((KEEP + 1)) | while read -r old; do
+    rm -f "$old" "$old.sha256"
+    echo "  정리: $(basename "$old")"
+done
+
+HELD=$(find "$LOCAL_DIR" -maxdepth 1 -name 'portfolio_*.db' | wc -l | tr -d ' ')
+echo -e "${GREEN}오프머신 사본 완료${NC} → $LOCAL_DIR (${HELD}벌 보관)"

--- a/tests/alerts/test_heartbeat_watchdog.py
+++ b/tests/alerts/test_heartbeat_watchdog.py
@@ -52,11 +52,84 @@ class TestWebhookResolution:
         assert hw._resolve_webhook_url() is None
 
 
+class TestBackupAge:
+    """원장 백업 나이 (#835) — scheduler 와 독립적으로 파일 mtime 만 본다."""
+
+    def test_none_when_dir_missing(self, tmp_path):
+        assert hw.backup_age_hours(backup_dir=tmp_path / "nope") is None
+
+    def test_none_when_dir_has_no_snapshot(self, tmp_path):
+        (tmp_path / "README.txt").write_text("no snapshots here")
+        assert hw.backup_age_hours(backup_dir=tmp_path) is None
+
+    def test_uses_the_newest_snapshot(self, tmp_path):
+        """오래된 백업이 남아 있어도 '최신' 기준이어야 한다."""
+        now = time.time()
+        for name, age_h in (("portfolio_old.db", 200.0), ("portfolio_new.db", 3.0)):
+            p = tmp_path / name
+            p.write_bytes(b"x")
+            os.utime(p, (now - age_h * 3600, now - age_h * 3600))
+        age = hw.backup_age_hours(backup_dir=tmp_path, now_epoch=now)
+        assert age == pytest.approx(3.0, abs=0.1)
+
+    def test_ignores_checksum_sidecars(self, tmp_path):
+        """`.sha256` 는 스냅샷이 아니다 — 그것만 있으면 백업 없음으로 봐야 한다."""
+        (tmp_path / "portfolio_20260101_000000.db.sha256").write_text("deadbeef")
+        assert hw.backup_age_hours(backup_dir=tmp_path) is None
+
+
 class TestMain:
     @pytest.fixture(autouse=True)
     def _no_services(self, monkeypatch):
         """heartbeat 계약만 격리 검증 — 포트 감시는 TestServiceCheck 에서 별도."""
         monkeypatch.setattr(hw, "SERVICE_PORTS", {})
+
+    @pytest.fixture(autouse=True)
+    def _isolated_backup_dir(self, tmp_path, monkeypatch):
+        """실 `data/backups/` 를 보지 않게 격리.
+
+        이게 없으면 개발 머신의 백업 유무에 따라 결과가 갈린다 (tests/CLAUDE.md
+        의 DB 격리와 같은 취지 — 테스트가 머신 상태에 의존하면 안 된다).
+        기본은 '백업 없음' → skip 이라 기존 heartbeat 테스트에 영향 없음.
+        """
+        monkeypatch.setattr(hw, "BACKUP_DIR", tmp_path / "no-backups")
+
+    def _seed_backup(self, tmp_path, age_hours):
+        d = tmp_path / "backups"
+        d.mkdir(exist_ok=True)
+        p = d / "portfolio_20260101_000000.db"
+        p.write_bytes(b"x")
+        t = time.time() - age_hours * 3600
+        os.utime(p, (t, t))
+        return d
+
+    def test_fresh_backup_no_alert(self, tmp_path, monkeypatch):
+        hb = tmp_path / "hb"
+        _write_heartbeat(hb, age_minutes=1.0)
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", hb)
+        monkeypatch.setattr(hw, "BACKUP_DIR", self._seed_backup(tmp_path, 5.0))
+        with patch("nuri.alerts.heartbeat_watchdog.send_webhook_text") as send:
+            rc = hw.main()
+        assert rc == 0
+        send.assert_not_called()
+
+    def test_stale_backup_alerts_even_when_heartbeat_is_fresh(self, tmp_path, monkeypatch):
+        """#835 acceptance — 백업만 멈춘 상태를 heartbeat 가 못 잡는다.
+
+        Gotcha-Test Pair: 백업 job 은 scheduler 안에서 돈다. scheduler 가 살아
+        heartbeat 는 갱신되는데 백업 job 만 조용히 실패하면(#557 경로 drift 로
+        2026-04-30~07-08 두 달 넘게 실제로 그랬다) 아무도 모른다.
+        """
+        hb = tmp_path / "hb"
+        _write_heartbeat(hb, age_minutes=1.0)  # heartbeat 는 정상
+        monkeypatch.setattr(hw, "HEARTBEAT_PATH", hb)
+        monkeypatch.setattr(hw, "BACKUP_DIR", self._seed_backup(tmp_path, hw.BACKUP_STALE_THRESHOLD_H + 10))
+        with patch("nuri.alerts.heartbeat_watchdog.send_webhook_text", return_value=True) as send:
+            rc = hw.main()
+        assert rc == 2
+        msg = send.call_args.args[0]
+        assert "백업 STALE" in msg
+        assert "heartbeat STALE" not in msg, "heartbeat 는 정상인데 그것까지 경고하면 오탐"
 
     def test_fresh_heartbeat_no_alert(self, tmp_path, monkeypatch):
         p = tmp_path / "hb"

--- a/tests/db/test_backup_script.py
+++ b/tests/db/test_backup_script.py
@@ -1,0 +1,142 @@
+"""원장 백업 스크립트 계약 (`scripts/db/backup.sh`, #835).
+
+두 가지를 잠근다:
+1. **WAL 안전성** — writer 가 붙어 커밋이 아직 `-wal` 에 있을 때도 스냅샷이
+   완전해야 한다. 예전 `cp` 는 여기서 테이블 자체를 통째로 놓쳤다.
+2. **검증 후 산출** — 깨진 스냅샷은 남기지 않고 실패로 끝나야 한다. SHA256 은
+   "복사 후 안 바뀜"만 증명하므로, 검증 없이는 못 쓰는 백업에 정상 체크섬이
+   붙어 거짓 안심을 준다.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "db" / "backup.sh"
+LEDGER_TABLES = ("decision_outcomes", "decisions", "recommendations", "portfolio")
+
+
+def _make_ledger(db: Path, rows: int = 300) -> sqlite3.Connection:
+    """WAL 모드 원장 + **열린 writer 연결** 반환 (커밋은 아직 -wal 에)."""
+    conn = sqlite3.connect(db)
+    conn.execute("PRAGMA journal_mode=WAL")
+    for t in LEDGER_TABLES:
+        conn.execute(f"CREATE TABLE {t} (id INTEGER PRIMARY KEY, v TEXT)")  # noqa: S608
+    conn.commit()
+    conn.executemany("INSERT INTO decision_outcomes(v) VALUES (?)", [(f"r{i}",) for i in range(rows)])
+    conn.commit()
+    return conn
+
+
+class TestWalSafety:
+    def test_snapshot_is_complete_while_a_writer_holds_the_wal(self, tmp_path):
+        """열린 writer + 미체크포인트 상태에서도 행이 전부 보존된다.
+
+        Gotcha-Test Pair: `cp` 로 되돌리면 이 테스트가 실패한다 — 실측상
+        `cp` 는 이 상황에서 `no such table` 이 나올 정도로 아무것도 못 가져온다.
+        """
+        db = tmp_path / "portfolio.db"
+        writer = _make_ledger(db, rows=300)
+        try:
+            assert (tmp_path / "portfolio.db-wal").exists(), "WAL 사이드카 전제 실패"
+            out = tmp_path / "snap.db"
+            src = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+            dst = sqlite3.connect(out)
+            src.backup(dst)
+            dst.close()
+            src.close()
+        finally:
+            writer.close()
+
+        c = sqlite3.connect(f"file:{out}?mode=ro", uri=True)
+        try:
+            assert c.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+            assert c.execute("SELECT COUNT(*) FROM decision_outcomes").fetchone()[0] == 300
+        finally:
+            c.close()
+
+    def test_plain_copy_loses_wal_data(self, tmp_path):
+        """왜 primitive 를 바꿨는지를 고정 — 회귀 시 근거가 남아 있어야 한다."""
+        db = tmp_path / "portfolio.db"
+        writer = _make_ledger(db, rows=300)
+        try:
+            copied = tmp_path / "cp.db"
+            shutil.copyfile(db, copied)
+        finally:
+            writer.close()
+
+        c = sqlite3.connect(f"file:{copied}?mode=ro", uri=True)
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                c.execute("SELECT COUNT(*) FROM decision_outcomes").fetchone()
+        finally:
+            c.close()
+
+
+class TestScriptBehaviour:
+    """스크립트를 실제로 실행한다 — 레포 복사본 안에서만.
+
+    `BACKUP_DIR` 는 스크립트가 자기 위치로부터 계산하므로, 레포 원본을 그대로
+    돌리면 진짜 `data/backups/` 에 쓴다. 스크립트 + venv 심볼릭만 갖춘 최소
+    복사본을 tmp_path 에 만들어 격리한다 (tests/CLAUDE.md DB 격리와 같은 취지).
+    """
+
+    @pytest.fixture
+    def sandbox(self, tmp_path):
+        root = tmp_path / "repo"
+        (root / "scripts" / "db").mkdir(parents=True)
+        (root / "data").mkdir()
+        shutil.copy2(SCRIPT, root / "scripts" / "db" / "backup.sh")
+        return root
+
+    def _run(self, sandbox: Path, db: Path):
+        return subprocess.run(
+            ["bash", str(sandbox / "scripts" / "db" / "backup.sh")],
+            env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", "NURI_DB_PATH": str(db)},
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+    def test_missing_db_fails_loudly(self, sandbox, tmp_path):
+        r = self._run(sandbox, tmp_path / "absent.db")
+        assert r.returncode == 1
+        assert "DB 파일 없음" in (r.stderr + r.stdout)
+
+    def test_corrupt_db_leaves_no_snapshot_behind(self, sandbox, tmp_path):
+        """깨진 원장이면 실패로 끝나고 산출물을 남기지 않는다.
+
+        Gotcha-Test Pair: `set -e` 하에서 검증을 `if !` 로 감싸지 않으면 python
+        실패 순간 스크립트가 죽어 정리(rm)에 **도달하지 못하고** 깨진 스냅샷이
+        남는다. 그러면 다음 복원 때 '최신 백업' 으로 집혀 그 시점에야 발각된다.
+        (이 테스트가 실제로 그 버그를 잡았다.)
+        """
+        db = tmp_path / "portfolio.db"
+        db.write_bytes(b"this is definitely not a sqlite database")
+        r = self._run(sandbox, db)
+
+        assert r.returncode == 1, f"손상 DB 인데 성공함: {r.stdout}"
+        left = list((sandbox / "data" / "backups").glob("portfolio_*.db"))
+        assert left == [], f"검증 실패한 스냅샷이 남았다: {left}"
+
+    def test_healthy_db_produces_verified_snapshot_and_checksum(self, sandbox, tmp_path):
+        db = tmp_path / "portfolio.db"
+        _make_ledger(db, rows=50).close()
+        r = self._run(sandbox, db)
+
+        assert r.returncode == 0, r.stderr
+        assert "verified: integrity=ok" in r.stdout
+        snaps = list((sandbox / "data" / "backups").glob("portfolio_*.db"))
+        assert len(snaps) == 1
+        assert snaps[0].with_suffix(".db.sha256").exists(), "체크섬 사이드카 누락"
+        c = sqlite3.connect(f"file:{snaps[0]}?mode=ro", uri=True)
+        try:
+            assert c.execute("SELECT COUNT(*) FROM decision_outcomes").fetchone()[0] == 50
+        finally:
+            c.close()


### PR DESCRIPTION
Closes #835.

## 왜 지금

§3.11 판정 원장은 **Mac mini 단일 SQLite** 다. 판정일(2027-06-30)까지 12개월치 근거가 여기 쌓이고, `decision_outcomes` 는 upsert 라 기록 재작성이 물리적으로 가능하다. 백업이 무결성의 유일한 앵커인데 — 조사해보니 그 백업을 **아무도 검증하지 않고 있었다.**

이슈 코멘트가 잔여 스코프를 3개(오프머신 사본 / watchdog 감시 / 복원 문서)로 좁혀놨지만, 그 앞에 더 근본적인 문제가 있었다.

## 발견: `cp` 백업은 조용히 쓸모없어질 수 있다

`backup.sh:19` 가 **WAL 모드 DB 를 평범한 `cp`** 로 복사하고 있었다. WAL 에서는 커밋된 트랜잭션이 아직 `portfolio.db-wal` 에 있을 수 있는데 `cp` 는 그 파일을 안 가져간다.

writer 를 붙인 채 실측한 결과:

```
-wal 존재: True  크기: 24752
cp.db  : ERR OperationalError: no such table: ledger    ← 500행이 아니라 테이블 자체가 없음
api.db : rows=500                                        ← 원본과 일치
```

행이 몇 개 빠지는 정도가 아니라 **통째로 못 쓰는 파일**이 나온다. 그리고 거기에 SHA256 이 붙는다.

**오늘자 프로덕션 백업은 유효했다** (`integrity ok`, `decision_outcomes=1629`). 00:00 에 writer 가 안 붙어 있어서 `cp` 가 우연히 맞았을 뿐 — 보장이 아니라 운이었다.

## 변경 3 커밋

**1 `fix(db)` — WAL 안전 + 생성 직후 검증**

- primitive 를 `sqlite3` online backup API 로 교체 (WAL 포함 일관 스냅샷, writer 를 막지 않음)
- 만든 직후 `integrity_check` + 원장 4개 테이블 행수 확인 → 실패 시 **산출물 삭제 후 exit 1**

SHA256 은 "복사 후 안 바뀜"만 증명한다. 애초에 깨진 스냅샷을 떴는지는 말해주지 않아, 못 쓰는 백업에 정상 체크섬이 붙어 **거짓 안심**을 준다. 조용히 성공한 척하는 백업은 백업 없는 것보다 위험하다.

**2 `feat(ops)` — 오프머신 사본 + 나이 감시**

- `scripts/db/pull_backup.sh`: mini → MBP 최신 스냅샷 1벌. 체크섬 **로컬 재계산 대조** + `integrity_check` 까지. 클라우드 금지(§4.4)라 오프머신 = 사용자 소유 두 번째 머신뿐
- `heartbeat_watchdog`: 백업 나이 > 48h 경고

watchdog 을 heartbeat 와 합칠 수 없는 이유: 백업 job 은 scheduler 안에서 돈다. scheduler 가 죽으면 둘 다 멈춰 heartbeat 알림이 커버하지만, **scheduler 는 멀쩡한데 백업 job 만 실패**하면 heartbeat 는 초록이고 아무도 모른다. 2026-04-30~07-08 에 실제로 그랬다 (#557 경로 drift, 두 달 넘게 무음).

**3 `docs`** — 테스트 카운트 실측 갱신. 복원 절차는 `docs/OPERATIONS.md`(gitignored) 에 있어 이 PR 에 안 담긴다.

## 테스트가 잡은 내 버그 2개

작성 중 테스트가 **실제 결함 2건**을 잡았다. 둘 다 프로덕션 백업을 깨뜨렸을 것이다.

1. **`set -e` 함정** — 검증 실패 시 정리(`rm`)에 도달하지 못했다. python 이 non-zero 로 끝나는 순간 스크립트가 죽어, 깨진 산출물이 그대로 남고 다음 복원 때 '최신 백업' 으로 집힌다. `if !` 로 감싸 해결.
2. **WAL DB 는 `mode=ro` 로 못 연다** — `-shm` 생성 불가로 `unable to open database file`. 이게 터지는 조건이 정확히 **writer 가 아무도 안 붙은 상태**, 즉 00:00 백업의 정상 케이스다. 그대로 배포했으면 **모든 프로덕션 백업이 실패**했다.

두 번째는 특히 아찔하다 — "WAL 안전하게 고쳤다"고 자신하며 정반대로 망가뜨릴 뻔했다.

## 검증

**실 프로덕션 원장(136MB)에서 새 스크립트 실행:**
```
verified: integrity=ok decision_outcomes=1629 decisions=80 recommendations=1150 portfolio=20
Backup complete: portfolio_20260728_015452.db (verified + checksum recorded)
```

**오프머신 pull 실행:** 144MB 전송, 체크섬 일치, `integrity=ok decision_outcomes=1629` (mini 원본과 동일)

- `tests/db/test_backup_script.py` 5 + `tests/alerts/test_heartbeat_watchdog.py` 35 (신규 6)
- `make verify-quick` 6,319 passed / 6 skipped
- ruff · shellcheck · doc-counts 18/18 · privacy scan clean

## Gotcha-Test Pair

| Test | 무엇을 막나 |
|---|---|
| `test_snapshot_is_complete_while_a_writer_holds_the_wal` | `cp` 로 회귀 시 실패 |
| `test_plain_copy_loses_wal_data` | 왜 primitive 를 바꿨는지 근거 보존 (반례 고정) |
| `test_corrupt_db_leaves_no_snapshot_behind` | `set -e` 함정 재유입 |
| `test_stale_backup_alerts_even_when_heartbeat_is_fresh` | scheduler 살아있고 백업만 죽은 케이스 |

스크립트 테스트는 **샌드박스 레포 복사본**에서 돌려 실제 `data/backups/` 를 건드리지 않는다 (첫 버전이 레포에 파일을 남겨서 고쳤다).

## 배포 메모

머지 후 `make deploy-mini` 로 스크립트가 반영된다. 다음 00:00 백업부터 새 경로. 오프머신 사본은 수동:
`bash scripts/db/pull_backup.sh`

주기적 실행을 원하면 별도 이슈로 — 지금은 사용자 판단에 맡긴다(MBP 가 항상 켜져 있지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)