### PR TITLE
fix(scheduler): record consensus results to the decisions table (closes #897)

### DIFF
--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -189,10 +189,16 @@ def _run_collector(name: str, **kwargs):
             # 10-agent 합의 결과를 recommendations 에 저장 → Learning Memory 자동 학습 input.
             # decision_outcomes 가 30 일 후 outcome_30d 채우면 _compute_weights 가 가중치 조정.
             from nuri.trading.agents.consensus import analyze_portfolio, save_to_recommendations
+            from nuri.trading.engine.decisions import record_decisions
 
             results = analyze_portfolio()
             saved = save_to_recommendations(results)
-            logger.info(f"[consensus] {len(results)}건 분석, {saved}건 저장")
+            # decisions 기록은 CLI(`python -m nuri.trading.agents.consensus`) 에만 있었다.
+            # 자동화(#363, 2026-04-17)가 수동 실행을 대체하면서 이 호출이 빠져 decisions 가
+            # 2026-04-14 이후 3.5 개월 동결됐다 — /decisions 대시보드가 4월 데이터를 서빙
+            # 했는데 헬스 지표는 전부 초록이었다 (#897).
+            recorded = record_decisions(results)
+            logger.info(f"[consensus] {len(results)}건 분석, recommendations {saved}건, decisions {recorded}건")
         elif name == "holdings_monitor":
             # Holdings post-entry technical-divergence monitor (07:10 KST, after consensus 07:05).
             # JKHY-class entry-stage defenses (PR #303) cover before-buy; this covers after-buy

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -786,7 +786,7 @@ class TestSchedulerDecisions:
         mock_fn.assert_called_once()
 
     def test_run_collector_consensus(self):
-        """_run_collector dispatches to analyze_portfolio + save_to_recommendations.
+        """_run_collector dispatches to analyze_portfolio + save_to_recommendations + record_decisions.
 
         Phase 2 A-1a 의 read path fix 가 의미 있으려면 input 이 꾸준히 쌓여야 함 —
         이 job 이 매일 07:05 에 agent_verdicts 를 recommendations 테이블에 저장.
@@ -794,13 +794,86 @@ class TestSchedulerDecisions:
         """
         from nuri.scheduler import _run_collector
 
+        # 비어있지 않은 sentinel — `return_value=[]` 로 두면 `record_decisions([])`,
+        # `record_decisions(saved)` 같은 인자 변이가 전부 green 으로 통과한다.
+        # `saved` 는 바로 윗줄 변수라 실제로 있을 법한 오타이고, 그 경우 production
+        # 에서 `for r in 0` → TypeError 를 blanket except 가 삼켜 #897 과 **같은
+        # 방식**으로 다시 동결된다. 그래서 호출 여부가 아니라 payload 를 잠근다.
+        results = [object()]
         with (
-            patch("nuri.trading.agents.consensus.analyze_portfolio", return_value=[]) as m_analyze,
+            patch("nuri.trading.agents.consensus.analyze_portfolio", return_value=results) as m_analyze,
             patch("nuri.trading.agents.consensus.save_to_recommendations", return_value=0) as m_save,
+            patch("nuri.trading.engine.decisions.record_decisions", return_value=0) as m_record,
         ):
             _run_collector("consensus")
         m_analyze.assert_called_once()
-        m_save.assert_called_once()
+        m_save.assert_called_once_with(results)
+        m_record.assert_called_once_with(results)
+
+    def test_scheduler_and_cli_persist_to_the_same_tables(self):
+        """자동(scheduler) 경로와 수동(CLI) 경로가 **같은 테이블 집합**에 쓴다.
+
+        Gotcha-Test Pair (§5.3.1): PR #363 이 consensus 를 스케줄러로 자동화하면서
+        CLI 에만 있던 `record_decisions()` 를 빠뜨렸다. 마지막 수동 실행(2026-04-14)
+        이후 3.5 개월간 `decisions` 가 80 행에 동결됐고 /decisions 대시보드는 계속
+        4 월 데이터를 서빙했다 — 헬스 지표는 전부 초록 (#897).
+
+        위 `test_run_collector_consensus` 는 당시 두 함수만 단언해서 **불완전한
+        동작을 lock-in** 했다. 그래서 개별 호출이 아니라 두 경로의 **동등성**을
+        잠근다. 어느 한쪽에서 persistence 를 빼면 집합이 갈라지며 fail.
+
+        기록하는 값은 호출 여부가 아니라 **전달된 payload** 다 — 호출 여부만 보면
+        `record_decisions(saved)` 같은 인자 변이가 통과해버린다 (production 에서는
+        TypeError 가 blanket except 에 삼켜져 같은 동결로 되돌아간다).
+        """
+        from nuri.scheduler import _run_collector
+        from nuri.trading.agents.consensus import __main__ as cli
+
+        results = [object()]
+
+        # CLI 는 `from . import analyze_portfolio` 로 이름을 미리 바인딩하므로
+        # 패키지 속성 patch 가 안 먹는다 → 모듈 속성을 직접 patch (tests/CLAUDE.md mock 함정).
+        def _scheduler_path() -> dict[str, object]:
+            seen: dict[str, object] = {}
+            with (
+                patch("nuri.trading.agents.consensus.analyze_portfolio", return_value=results),
+                patch(
+                    "nuri.trading.agents.consensus.save_to_recommendations",
+                    side_effect=lambda r, *a, **k: seen.__setitem__("recommendations", r) or 0,
+                ),
+                patch(
+                    "nuri.trading.engine.decisions.record_decisions",
+                    side_effect=lambda r, *a, **k: seen.__setitem__("decisions", r) or 0,
+                ),
+            ):
+                _run_collector("consensus")
+            return seen
+
+        def _cli_path() -> dict[str, object]:
+            seen: dict[str, object] = {}
+            with (
+                patch.object(cli, "analyze_portfolio", return_value=results),
+                patch.object(cli, "print_consensus"),
+                patch.object(
+                    cli,
+                    "save_to_recommendations",
+                    side_effect=lambda r, *a, **k: seen.__setitem__("recommendations", r) or 0,
+                ),
+                patch(
+                    "nuri.trading.engine.decisions.record_decisions",
+                    side_effect=lambda r, *a, **k: seen.__setitem__("decisions", r) or 0,
+                ),
+                patch("sys.argv", ["consensus"]),
+            ):
+                cli.main()
+            return seen
+
+        scheduler_writes, cli_writes = _scheduler_path(), _cli_path()
+        assert scheduler_writes == cli_writes, (
+            f"자동/수동 경로 persistence 불일치 — scheduler={sorted(scheduler_writes)} cli={sorted(cli_writes)}"
+        )
+        # 두 경로 모두 두 테이블에 **consensus 결과 그 자체**를 전달해야 한다.
+        assert scheduler_writes == {"recommendations": results, "decisions": results}
 
     def test_schedules_include_consensus_job(self):
         """SCHEDULES 리스트에 consensus job entry 존재 — cron 스펙 lock-in."""


### PR DESCRIPTION
## Problem

프로덕션 `decisions` 테이블이 **80행, 2026-04-14 이후 정지**. 3.5개월간 새 행 0건.

사용자 경로 실측 — `/api/decisions` 최신 레코드가 아직도 `2026-04-14` AVGO:
```
{"decisions":[{"id":135,"date":"2026-04-14","ticker":"AVGO","action":"BUY",...
```
대시보드가 4월 데이터를 서빙하는 동안 **헬스 지표는 전부 초록**이었다.

## Root cause

PR #363 (2026-04-17) 이 consensus 를 스케줄러로 자동화하면서 CLI 경로를 **부분 재구현**했다.

| | CLI (`python -m ...consensus`) | Scheduler (매일 07:05) |
|---|---|---|
| `analyze_portfolio()` | ✅ | ✅ |
| `save_to_recommendations()` | ✅ | ✅ |
| `record_decisions()` | ✅ | ❌ |

마지막 수동 실행 2026-04-14 → 자동화 도착 2026-04-17. cron 이 습관을 대체하면서 누락분이 묻혔다.

## Blast radius (실측)

| 소비자 | 상태 |
|---|---|
| `/decisions` + `/decisions/[id]` | 4월 데이터 서빙 |
| `decision_pnl` (매일 07:00) | pending 3건 반복 |
| `agent_accuracy` 스냅샷 (주간) | frozen 80행에서 상수 재계산 |
| 라이브 consensus 가중치 | **영향 없음** — `recommendations.agent_verdicts` 사용 |
| §3.11 측정 모드 | **영향 없음** — 표본은 `recommendations` ⋈ `agent_decisions` (`decision_alpha.py:131`) |

## Design note

공용 함수를 추출하지 **않았다**. `consensus`(phase 3) → `engine`(phase 4) 직접 import 가 cross-phase isolation 위반이 된다. 스케줄러와 CLI 는 orchestrator 라 phase 조합이 허용된다. 재발 방지는 추상화가 아니라 테스트가 한다.

## Tests (§5.3.1 Gotcha-Test Pair)

기존 `test_run_collector_consensus` 는 두 함수만 단언하면서 *"Revert 시 fail"* 이라 적혀 있어 **불완전한 동작을 lock-in** 하고 있었다 — 버그가 3.5개월 산 이유.

호출 여부가 아니라 **payload** 를 잠근다. 호출만 보면 `record_decisions(saved)` 같은 인자 변이가 통과하는데(`saved` 는 바로 윗줄 변수), production 에서는 `for r in 0` → TypeError 를 blanket except 가 삼켜 **같은 방식으로 다시 동결**된다.

검증된 변이 (전부 fail 확인):
- fix revert → 2 fail
- `record_decisions(saved)` → 2 fail
- `record_decisions([])` / HOLD 필터 / 다른 `db_path` → fail

신규 `test_scheduler_and_cli_persist_to_the_same_tables` 는 자동/수동 두 경로가 같은 테이블에 같은 payload 를 전달하는지 **동등성**을 잠근다.

## Verification

- `make test-fast` — 6,305 passed / 6 skipped (99% coverage)
- `make lint` — clean
- `make verify-doc-counts` — 18/18
- 적대적 리뷰 10 에이전트 / 4 렌즈 — 7건 제기, **전부 pre-existing 으로 반박**

`make verify-all` 은 로컬에서 실패하나 **본 변경과 무관**: `verify_all.sh:86` `assert r is not None` 이 로컬 dev DB 의 SPY 514h staleness 로 `classify_regime()` 이 차단되어 발생. `make collect` 미실행 환경 조건.

## Out of scope (별도 이슈 예정)

리뷰가 같은 drift 클래스로 지목한 것들 — 전부 pre-existing:
- `track_outcomes()` 가 SCHEDULES 에 없음 → `recommendations.outcome_*` 1,170행 전부 NULL (550행은 30일 창 이미 닫힘). Learning Memory 가중치 학습이 한 번도 작동한 적 없음
- `make collect` 의 6개 collector 가 스케줄러 미배선: cboe / coingecko / finviz / fred_calendar / kis_realtime / reddit
- 4~7월 `recommendations` → `decisions` 백필

Closes #897