### PR TITLE
feat(sre): alpha_report liveness probe — 무기록이 '정상'인지 '고장'인지 구분 (closes #894)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 | **Trading signals** | 22 (20 actionable + 2 shadow) |
 | **API endpoints** | 72 (FastAPI on `:8001`) |
 | **Frontend routes** | 18 (Next.js on `:3000`) |
-| **DB tables** | 51 (45 forward-only migrations) |
+| **DB tables** | 51 (46 forward-only migrations) |
 | **DB submodules** | 11 (sole `sqlite3` importer in `nuri/core/db/`) |
 
 ## Common Commands

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -5,10 +5,10 @@
 Layer A 설계 (Codex Round 5):
 - 100% rule-based — threshold 비교 (LLM 추론 X)
 - ZERO LLM
-- 7 detector 모두 결정적 (DB query + filesystem stat)
+- 8 detector 모두 결정적 (DB query + filesystem stat)
 - 모든 incident → audit_ledger + incidents 테이블 영구 기록
 
-7 Detector:
+8 Detector:
     1. orphan_run         — agent_run_ledger started + finished_at IS NULL + >1h
                             warning (1h+) / critical (3h+)
     2. disk_full          — shutil.disk_usage() percent_used > 80 (warn) / > 90 (crit)
@@ -21,6 +21,10 @@ Layer A 설계 (Codex Round 5):
                             ≥1 (warn) / ≥3 (crit)
     7. signal_evaluation_stale — pipeline_events 'signal_evaluation_run'
                             heartbeat 공백 영업일 (#825): ≥2 (warn) / ≥4 (crit)
+    8. alpha_report_stale — pipeline_events 'alpha_report_run' 의 **마지막 성공
+                            stage** 공백 (#894): ≥35일 (warn). heartbeat 공백이
+                            아니라 성공 공백 — cron 이 매일이라 role 누락 상태도
+                            heartbeat 는 계속 찍힌다.
 
 Idempotent semantics:
 - 동일 (incident_type, target) 의 open incident 는 단일 row → log_incident() 가
@@ -36,6 +40,7 @@ Discord routing:
 
 from __future__ import annotations
 
+import json
 import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -72,6 +77,10 @@ SIGNAL_EVAL_CRIT_DAYS = 4
 SIGNAL_EVAL_GRACE_HOUR = 12
 # 평가 예정 요일 (Mon=0 기준 화~토 — 미국 거래일 마감 다음 날 아침 KST)
 SIGNAL_EVAL_WEEKDAYS = (1, 2, 3, 4, 5)
+# §3.11 월간 alpha 리포트 미발화 임계 (#894). 월 1회 발화라 한 달(31일)로는
+# 정상 주기와 구분이 안 된다 — 한 주기를 통째로 놓친 게 확실해지는 35일.
+# pipeline_events 보존 90일(scripts/db/maintenance.py)이라 이 창은 안전하다.
+ALPHA_REPORT_STALE_DAYS = 35
 
 HEARTBEAT_PATH = Path(__file__).resolve().parents[3] / "data" / ".scheduler_heartbeat"
 
@@ -81,7 +90,7 @@ class SREIncidentAgent(Actor):
     """Operational incident detection + lifecycle management — Layer A.
 
     Actions (input_data['action']):
-        scan        — 7 detector 모두 실행 → log_incident + Discord publish.
+        scan        — 8 detector 모두 실행 → log_incident + Discord publish.
         acknowledge — incident_id 사용자 확인 (audit-only).
         resolve     — incident_id 종료 (status='resolved').
         list_open   — open incident 목록 (severity 필터 optional).
@@ -121,7 +130,7 @@ class SREIncidentAgent(Actor):
     # ─── scan ────────────────────────────────────────────────
 
     def _scan(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
-        """7 detector 실행 → 발견된 incident 목록 반환."""
+        """8 detector 실행 → 발견된 incident 목록 반환."""
         detected: list[dict[str, Any]] = []
 
         for detector in (
@@ -132,6 +141,7 @@ class SREIncidentAgent(Actor):
             self._detect_actor_failure_streak,
             self._detect_data_freshness_critical,
             self._detect_signal_evaluation_stale,
+            self._detect_alpha_report_stale,
         ):
             try:
                 detected.extend(detector(ctx))
@@ -167,7 +177,7 @@ class SREIncidentAgent(Actor):
             ),
         )
 
-    # ─── 6 detectors ─────────────────────────────────────────
+    # ─── 8 detectors ─────────────────────────────────────────
 
     def _detect_orphan_runs(self, ctx: RunContext) -> list[dict[str, Any]]:
         """agent_run_ledger 에서 started + finished_at NULL + age 검사."""
@@ -375,6 +385,76 @@ class SREIncidentAgent(Actor):
                 incident_type="signal_evaluation_stale",
                 severity=severity,
                 target="signals",
+                evidence=evidence,
+                ctx=ctx,
+            )
+        ]
+
+    def _detect_alpha_report_stale(self, ctx: RunContext) -> list[dict[str, Any]]:
+        """pipeline_events 'alpha_report_run' 의 **마지막 성공 stage** 공백 검사 (#894).
+
+        heartbeat 공백이 아니라 *성공* 공백을 재는 게 핵심이다. cron 이 매일
+        ('0 9 * * *') 이라 `NURI_ROLE` 이 비어 있어도 heartbeat 는 매일 찍힌다 —
+        공백만 보면 설정 오류를 영영 못 잡는데, 그게 #894 가 잡으라는 바로 그
+        케이스다 (리포트가 판정일까지 한 번도 안 나가는 상태).
+
+        한 번도 stage 된 적 없으면 최초 heartbeat 를 기준으로 잰다 — 신규 배포에서
+        role 이 처음부터 누락된 경우가 정확히 여기 걸린다. heartbeat 가 전무하면
+        skip (미배포 / 신규 DB — scheduler_heartbeat 와 동일한 취급).
+        """
+        rows = query(
+            """SELECT MIN(timestamp) AS first_run,
+                      MAX(timestamp) AS last_run,
+                      MAX(CASE WHEN json_extract(payload, '$.staged') = 1
+                               THEN timestamp END) AS last_staged
+               FROM pipeline_events
+               WHERE event_type = 'alpha_report_run'"""
+        )
+        if not rows or not rows[0]["first_run"]:
+            return []
+        row = rows[0]
+        last_staged = row["last_staged"]
+        # 성공분이 없으면 '언제부터 성공 없이 돌고 있나' = 최초 heartbeat 이후 경과.
+        anchor = last_staged or row["first_run"]
+        anchor_dt = datetime.strptime(str(anchor)[:19].replace("T", " "), "%Y-%m-%d %H:%M:%S")
+        days = (kst_now().date() - to_kst(anchor_dt).date()).days
+        if days < ALPHA_REPORT_STALE_DAYS:
+            return []
+
+        # 마지막 실행의 skip 사유를 붙여 조치가 바로 나오게 한다 (역할 누락인지 예외인지).
+        last_rows = query(
+            """SELECT payload FROM pipeline_events
+               WHERE event_type = 'alpha_report_run'
+               ORDER BY timestamp DESC LIMIT 1"""
+        )
+        reason = "unknown"
+        try:
+            payload = json.loads(last_rows[0]["payload"]) if last_rows and last_rows[0]["payload"] else {}
+            if payload.get("error"):
+                reason = "error"
+            elif not payload.get("role_ok"):
+                reason = "role_missing"
+            elif payload.get("already_emitted"):
+                reason = "already_emitted"
+            else:
+                reason = "staged"
+        except (json.JSONDecodeError, TypeError, KeyError):
+            payload = {}
+
+        evidence = {
+            "last_staged_at_utc": str(last_staged) if last_staged else None,
+            "never_staged": last_staged is None,
+            "days_since_staged": days,
+            "threshold_days": ALPHA_REPORT_STALE_DAYS,
+            "last_run_at_utc": str(row["last_run"]),
+            "last_skip_reason": reason,
+            "last_error": payload.get("error"),
+        }
+        return [
+            self._record_incident(
+                incident_type="alpha_report_stale",
+                severity="warning",
+                target="alpha_report",
                 evidence=evidence,
                 ctx=ctx,
             )
@@ -595,6 +675,14 @@ def _human_incident_summary(incident_type: str, target: str, evidence: dict[str,
             f"{target} — {e.get('missed_eval_days', 0)}영업일째 시그널 평가 미실행 "
             f"(마지막 {e.get('last_evaluated_at_utc', '?')} UTC)"
         )
+    if incident_type == "alpha_report_stale":
+        cause = {
+            "role_missing": "NURI_ROLE 미설정 — scheduler plist EnvironmentVariables 확인",
+            "error": f"실행 예외: {e.get('last_error') or '?'}",
+            "already_emitted": "중복 판정이 계속 True — dedupe 로직 점검",
+        }.get(str(e.get("last_skip_reason")), "원인 미상")
+        when = "한 번도 발화 없음" if e.get("never_staged") else f"마지막 {e.get('last_staged_at_utc', '?')} UTC"
+        return f"§3.11 월간 alpha 리포트 — {e.get('days_since_staged', 0)}일째 미발화 ({when}). {cause}"
     return f"{incident_type} on {target}"
 
 

--- a/nuri/core/db/execution_ops.py
+++ b/nuri/core/db/execution_ops.py
@@ -39,6 +39,7 @@ _INCIDENT_TYPES = (
     "actor_failure_streak",
     "data_freshness_critical",
     "signal_evaluation_stale",
+    "alpha_report_stale",
 )
 _INCIDENT_SEVERITIES = ("critical", "warning", "info")
 _INCIDENT_STATUSES = ("open", "acknowledged", "resolved")

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1430,4 +1430,41 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_incidents_type ON incidents(incident_type, last_detected_at);
     """,
     ),
+    (
+        46,
+        "incidents incident_type enum 확장 — alpha_report_stale (#894)",
+        # §3.11 월간 alpha 진행 리포트(#856)는 "안 나가는 상태"와 "이번 달 이미 나간
+        # 상태"가 관측상 동일했다 — NURI_ROLE 누락이면 판정일까지 영영 안 나가는데
+        # 아무 신호가 없다. pipeline_events 'alpha_report_run' heartbeat 를 근거로
+        # SRE detector 가 stale 을 잡는다. migration 45 와 동일한 재생성 패턴.
+        """
+        CREATE TABLE incidents_new (
+            incident_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            incident_type TEXT NOT NULL CHECK(incident_type IN (
+                'orphan_run','disk_full','db_lock','scheduler_heartbeat',
+                'actor_failure_streak','data_freshness_critical','signal_evaluation_stale',
+                'alpha_report_stale'
+            )),
+            severity TEXT NOT NULL CHECK(severity IN ('critical','warning','info')),
+            target TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('open','acknowledged','resolved')),
+            first_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+            last_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+            resolved_at TEXT,
+            evidence_json TEXT NOT NULL,
+            run_id TEXT,
+            UNIQUE(incident_type, target, status)
+        );
+        INSERT INTO incidents_new
+            (incident_id, incident_type, severity, target, status,
+             first_detected_at, last_detected_at, resolved_at, evidence_json, run_id)
+            SELECT incident_id, incident_type, severity, target, status,
+                   first_detected_at, last_detected_at, resolved_at, evidence_json, run_id
+              FROM incidents;
+        DROP TABLE incidents;
+        ALTER TABLE incidents_new RENAME TO incidents;
+        CREATE INDEX IF NOT EXISTS idx_incidents_status ON incidents(status, severity);
+        CREATE INDEX IF NOT EXISTS idx_incidents_type ON incidents(incident_type, last_detected_at);
+    """,
+    ),
 ]

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -316,7 +316,13 @@ def _run_alpha_report():
 
         role_ok = is_production()
         # stage **이전** 상태를 찍어야 skip 사유가 구분된다 (stage 후엔 항상 True).
-        already = already_emitted(month)
+        # ⚠️ 자체 try — 이건 관측용 부가 정보다. 여기서 실패했다고 본 작업(stage)까지
+        # 막으면 observability 가 관측 대상을 죽인다. DB 가 없는 CI 에서 실제로 그랬고,
+        # 프로덕션에서도 일시적 DB 잠금이 리포트를 통째로 건너뛰게 만들 수 있었다.
+        try:
+            already = already_emitted(month)
+        except Exception:  # noqa: BLE001 — 관측 실패는 본 작업과 무관
+            already = None
         outbox_id = stage_alpha_progress_brief()
         logger.info(f"[alpha_report] staged={outbox_id is not None} (id={outbox_id})")
     except Exception as e:

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -291,14 +291,49 @@ def _run_alpha_report():
 
     stage 는 `NURI_ROLE=production` 에서만 (원장 단일). dev 스케줄러가 돌아도
     replica 숫자가 brief 로 새지 않는다. 실행 실패는 흡수 (다른 _run_* 와 동일).
-    """
-    try:
-        from nuri.alerts.alpha_report import stage_alpha_progress_brief
 
+    실행할 때마다 `pipeline_events` 에 `alpha_report_run` heartbeat 를 **반드시**
+    한 행 남긴다 (#894). 없으면 "안 나감(정상: 이번 달 이미 발화)" 과 "안 나감
+    (고장: role 누락 / 예외 / mini 다운)" 이 관측상 완전히 동일하다 — NURI_ROLE 이
+    비어 있으면 판정일까지 한 번도 안 나가는데 아무 신호가 없다.
+    `SREIncidentAgent._detect_alpha_report_stale` 가 이 heartbeat 를 읽는다.
+    """
+    from nuri.core.timezone import today_kst
+
+    month = str(today_kst())[:7]
+    role_ok = False
+    already: bool | None = None
+    outbox_id = None
+    error = None
+    try:
+        from nuri.alerts.alpha_report import already_emitted, is_production, stage_alpha_progress_brief
+
+        role_ok = is_production()
+        # stage **이전** 상태를 찍어야 skip 사유가 구분된다 (stage 후엔 항상 True).
+        already = already_emitted(month)
         outbox_id = stage_alpha_progress_brief()
         logger.info(f"[alpha_report] staged={outbox_id is not None} (id={outbox_id})")
     except Exception as e:
+        error = str(e)[:200]
         logger.error(f"[alpha_report] 실행 실패: {e}", exc_info=True)
+
+    # heartbeat 는 위 성공/실패와 무관하게 남긴다 — 무기록 = 'job 자체가 안 돌았다'.
+    try:
+        from nuri.core.events import emit_event
+
+        emit_event(
+            "alpha_report_run",
+            step="alpha_report",
+            payload={
+                "month": month,
+                "role_ok": role_ok,
+                "already_emitted": already,
+                "staged": outbox_id is not None,
+                "error": error,
+            },
+        )
+    except Exception as e:
+        logger.error(f"[alpha_report] heartbeat 기록 실패: {e}", exc_info=True)
 
 
 def _run_brief_audit():

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -3,8 +3,9 @@
 검증 (Codex Round 5 Layer A):
 - Layer A enforcement (outcome 필수, ZERO LLM)
 - 4 actions: scan / acknowledge / resolve / list_open
-- 7 detector 각각 (orphan_run / disk_full / db_lock / scheduler_heartbeat /
-  actor_failure_streak / data_freshness_critical / signal_evaluation_stale)
+- 8 detector 각각 (orphan_run / disk_full / db_lock / scheduler_heartbeat /
+  actor_failure_streak / data_freshness_critical / signal_evaluation_stale /
+  alpha_report_stale)
 - Idempotent UNIQUE(incident_type,target,status='open') — 재detection 시 신규 row X
 - resolve 후 재발 시 신규 incident_id (status 가 UNIQUE 의 일부)
 - Discord publish — critical=INCIDENTS, warning=OPS, 재detection 시 publish 차단
@@ -15,13 +16,15 @@
 
 from __future__ import annotations
 
+import json
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nuri.agents.actors.sre_incident_agent import (
+    ALPHA_REPORT_STALE_DAYS,
     DISK_CRIT_PCT,
     DISK_WARN_PCT,
     FAILURE_STREAK_CRIT,
@@ -596,6 +599,119 @@ class TestMissedEvalDays:
     def test_weekday_streak_counted(self):
         """평일 연속 공백은 하루 1씩 계상."""
         assert _missed_eval_days("2026-06-30 22:00:00", _EVAL_FIXED_NOW) == 5
+
+
+# ═══════════════════════════════════════════════════════
+# Detector: alpha_report_stale (#894)
+# ═══════════════════════════════════════════════════════
+
+
+def _seed_alpha_run(db_path, ts_utc: str, *, staged: bool, role_ok: bool = True, error: str | None = None):
+    """pipeline_events 에 alpha_report_run heartbeat 1행 (payload 는 scheduler 와 동일 스키마)."""
+    payload = json.dumps(
+        {
+            "month": ts_utc[:7],
+            "role_ok": role_ok,
+            "already_emitted": False,
+            "staged": staged,
+            "error": error,
+        },
+        ensure_ascii=False,
+    )
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO pipeline_events (event_type, timestamp, payload) VALUES ('alpha_report_run', ?, ?)",
+            (ts_utc, payload),
+        )
+
+
+class TestAlphaReportStaleDetector:
+    """#894 Gotcha-Test Pair — '월간 alpha 리포트가 안 나가는데 아무도 모른다'.
+
+    핵심은 heartbeat 공백이 **아니라** 마지막 *성공 stage* 공백을 잰다는 것.
+    cron 이 매일이라 `NURI_ROLE` 누락 상태에서도 heartbeat 는 매일 찍히므로,
+    공백만 재는 구현으로 되돌리면 `test_role_missing_alerts_even_though_heartbeats_are_daily`
+    가 FAIL 한다 — 그게 이슈가 잡으라고 한 바로 그 시나리오다.
+    """
+
+    def _scan(self, now=_EVAL_FIXED_NOW):
+        actor = SREIncidentAgent()
+        with (
+            patch("nuri.agents.actors.sre_incident_agent.kst_now", return_value=now),
+            patch("nuri.core.freshness.check_all_freshness", return_value=[]),
+            patch(
+                "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
+                return_value=MagicMock(total=1000, used=100, free=900),
+            ),
+        ):
+            result = actor.run({"action": "scan"})
+        return [i for i in result.output["incidents"] if i["incident_type"] == "alpha_report_stale"]
+
+    def test_no_alert_when_no_heartbeat_rows(self, patched_db, no_publish):
+        """heartbeat 전무 → skip (미배포/신규 DB false positive 방지)."""
+        assert self._scan() == []
+
+    def test_no_alert_on_healthy_monthly_cadence(self, patched_db, no_publish):
+        """정상 운영: 매일 heartbeat + 이번 달 1일 성공 stage → 오탐 0.
+
+        acceptance '정상 월간 발화는 알림 없음'.
+        """
+        _seed_alpha_run(patched_db, "2026-07-01 00:00:00", staged=True)
+        for day in range(2, 9):  # 이후 매일 heartbeat (이미 발화 → staged=False)
+            _seed_alpha_run(patched_db, f"2026-07-{day:02d} 00:00:00", staged=False)
+        assert self._scan() == []
+
+    def test_role_missing_alerts_even_though_heartbeats_are_daily(self, patched_db, no_publish):
+        """`NURI_ROLE` 누락 — heartbeat 는 매일 찍히지만 성공 stage 가 한 번도 없다.
+
+        acceptance 'role 누락 상태를 35일 안에 #incidents 가 잡는다'. heartbeat
+        공백 기준 구현으로 되돌리면 공백이 0 이라 영영 안 잡히고 이 테스트가 FAIL.
+        """
+        for offset in range(40):  # 2026-05-30 부터 40일치 daily heartbeat, 전부 미발화
+            day = datetime(2026, 5, 30) + timedelta(days=offset)
+            _seed_alpha_run(patched_db, day.strftime("%Y-%m-%d 00:00:00"), staged=False, role_ok=False)
+        out = self._scan()
+        assert len(out) == 1
+        assert out[0]["severity"] == "warning"
+        assert out[0]["target"] == "alpha_report"
+        e = out[0]["evidence"]
+        assert e["never_staged"] is True
+        assert e["days_since_staged"] >= ALPHA_REPORT_STALE_DAYS
+        assert e["last_skip_reason"] == "role_missing"
+
+    def test_stale_since_last_successful_stage(self, patched_db, no_publish):
+        """예전에 성공한 적은 있으나 그 뒤 35일 넘게 미발화 → 알림."""
+        _seed_alpha_run(patched_db, "2026-05-01 00:00:00", staged=True)
+        _seed_alpha_run(patched_db, "2026-07-08 00:00:00", staged=False, role_ok=False)
+        out = self._scan()
+        assert len(out) == 1
+        assert out[0]["evidence"]["never_staged"] is False
+        assert out[0]["evidence"]["last_staged_at_utc"].startswith("2026-05-01")
+
+    def test_recent_success_suppresses_alert_despite_old_failures(self, patched_db, no_publish):
+        """오래된 미발화가 남아 있어도 최근 성공이 있으면 알림 없음."""
+        _seed_alpha_run(patched_db, "2026-05-01 00:00:00", staged=False, role_ok=False)
+        _seed_alpha_run(patched_db, "2026-07-01 00:00:00", staged=True)
+        assert self._scan() == []
+
+    def test_error_skip_reason_surfaces_the_exception(self, patched_db, no_publish):
+        """예외로 못 나간 경우 evidence 가 role 누락과 구분된다 (조치가 다르다)."""
+        for offset in range(40):
+            day = datetime(2026, 5, 30) + timedelta(days=offset)
+            _seed_alpha_run(patched_db, day.strftime("%Y-%m-%d 00:00:00"), staged=False, error="boom")
+        out = self._scan()
+        assert out[0]["evidence"]["last_skip_reason"] == "error"
+        assert out[0]["evidence"]["last_error"] == "boom"
+
+    def test_summary_names_the_cause_not_just_the_type(self):
+        """알림 한 줄이 cryptic 코드가 아니라 원인+조치를 담는다 (알림 가독성)."""
+        line = _human_incident_summary(
+            "alpha_report_stale",
+            "alpha_report",
+            {"days_since_staged": 41, "never_staged": True, "last_skip_reason": "role_missing"},
+        )
+        assert "41일째 미발화" in line
+        assert "NURI_ROLE" in line
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/agents/test_state_replicator_dr.py
+++ b/tests/agents/test_state_replicator_dr.py
@@ -24,7 +24,7 @@ from nuri.agents.actors.state_replicator_dr import (
     main,
 )
 from nuri.agents.base import Layer, Outcome
-from nuri.core.db import init_db, query, upsert_dr_replica
+from nuri.core.db import get_schema_version, init_db, query, upsert_dr_replica
 
 
 @pytest.fixture
@@ -218,7 +218,10 @@ class TestVerifyAction:
             role="replica",
             hostname="mbp-test",
             last_sync_at="2026-05-01 12:00:00",
-            last_sync_schema_version=45,  # 현행 schema version (#825 migration 45)
+            # 이 테스트의 관심사는 'replica 가 동기 상태인가' 지 특정 버전이 아니다.
+            # 리터럴로 두면 migration 이 추가될 때마다 무관한 이 테스트가 깨진다 (#894 에서 실제로 깨짐).
+            # 버전 자체의 lock 은 tests/core/test_agent_infra.py::test_schema_version_at_46 담당.
+            last_sync_schema_version=get_schema_version(patched_db),
             sync_lag_seconds=120,
             status="healthy",
             db_path=patched_db,

--- a/tests/alerts/test_alpha_report.py
+++ b/tests/alerts/test_alpha_report.py
@@ -259,6 +259,49 @@ class TestSchedulerWiring:
             scheduler._run_alpha_report()
         staged.assert_called_once_with()
 
+    def test_heartbeat_written_on_every_path(self, caplog):
+        """발화/미발화/예외 **모두** `alpha_report_run` heartbeat 1행을 남긴다 (#894).
+
+        Gotcha-Test Pair: heartbeat 가 없으면 '이번 달 이미 발화(정상)' 와
+        'NURI_ROLE 누락(고장, 판정일까지 영영 안 나감)' 이 관측상 동일해진다.
+        `emit_event` 호출을 지우면 세 케이스 모두 FAIL.
+        """
+        from nuri import scheduler
+
+        cases = {
+            "staged": (11, None),
+            "skipped": (None, None),
+            "raised": (None, RuntimeError("boom")),
+        }
+        for label, (ret, exc) in cases.items():
+            kw = {"side_effect": exc} if exc else {"return_value": ret}
+            with (
+                patch("nuri.alerts.alpha_report.stage_alpha_progress_brief", **kw),
+                patch("nuri.alerts.alpha_report.already_emitted", return_value=False),
+                patch("nuri.core.events.emit_event") as emitted,
+            ):
+                scheduler._run_alpha_report()
+            assert emitted.call_count == 1, f"{label}: heartbeat 누락"
+            assert emitted.call_args.args[0] == "alpha_report_run"
+            payload = emitted.call_args.kwargs["payload"]
+            assert payload["staged"] is (ret is not None), label
+            assert (payload["error"] is not None) is (exc is not None), label
+
+    def test_heartbeat_records_role_state_for_the_detector(self):
+        """`role_ok` 가 payload 에 들어가야 detector 가 설정 오류를 지목할 수 있다."""
+        from nuri import scheduler
+
+        with (
+            patch("nuri.alerts.alpha_report.is_production", return_value=False),
+            patch("nuri.alerts.alpha_report.stage_alpha_progress_brief", return_value=None),
+            patch("nuri.alerts.alpha_report.already_emitted", return_value=False),
+            patch("nuri.core.events.emit_event") as emitted,
+        ):
+            scheduler._run_alpha_report()
+        payload = emitted.call_args.kwargs["payload"]
+        assert payload["role_ok"] is False
+        assert payload["staged"] is False
+
     def test_wrapper_absorbs_failure(self, caplog):
         """한 job 실패가 스케줄러를 죽이면 안 된다 (다른 _run_* 와 동일 계약)."""
         import logging

--- a/tests/alerts/test_alpha_report.py
+++ b/tests/alerts/test_alpha_report.py
@@ -287,6 +287,30 @@ class TestSchedulerWiring:
             assert payload["staged"] is (ret is not None), label
             assert (payload["error"] is not None) is (exc is not None), label
 
+    def test_observability_probe_failure_does_not_block_staging(self):
+        """heartbeat 용 `already_emitted` 조회가 죽어도 stage 는 그대로 시도된다.
+
+        Gotcha-Test Pair: #894 최초 구현이 `already_emitted` 를 stage 와 **같은 try
+        앞자리**에 뒀다. 그 조회가 실패하면(테이블 없음/DB 잠금) except 로 빠져
+        stage 를 아예 안 부른다 — 관측을 붙이려다 관측 대상을 죽인 것. 로컬은 dev DB
+        가 있어 통과했고 CI(빈 DB)에서만 터졌으므로, DB 상태와 무관하게 결정적으로
+        재현되도록 예외를 직접 주입해 잠근다.
+        """
+        from nuri import scheduler
+
+        with (
+            patch("nuri.alerts.alpha_report.already_emitted", side_effect=RuntimeError("db locked")),
+            patch("nuri.alerts.alpha_report.stage_alpha_progress_brief", return_value=7) as staged,
+            patch("nuri.core.events.emit_event") as emitted,
+        ):
+            scheduler._run_alpha_report()
+
+        staged.assert_called_once_with()
+        payload = emitted.call_args.kwargs["payload"]
+        assert payload["staged"] is True
+        assert payload["already_emitted"] is None, "관측 실패는 None 으로 남아야 (False 로 위장 금지)"
+        assert payload["error"] is None, "본 작업은 성공했으므로 error 가 없어야"
+
     def test_heartbeat_records_role_state_for_the_detector(self):
         """`role_ok` 가 payload 에 들어가야 detector 가 설정 오류를 지목할 수 있다."""
         from nuri import scheduler

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,11 +29,12 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_45(self, db_path):
+    def test_schema_version_at_46(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
-        incidents signal_evaluation_stale enum 확장 (#825) → 45."""
-        assert get_schema_version(db_path) == 45
+        incidents signal_evaluation_stale enum 확장 (#825) +
+        incidents alpha_report_stale enum 확장 (#894) → 46."""
+        assert get_schema_version(db_path) == 46
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
## Problem

#856 이 §3.11 월간 진행 리포트를 배선했으나 **안 나가는 상태와 정상 상태가 관측상 동일**하다.

cron 이 매일이라 `_run_alpha_report` 는 한 달에 29일 정도 정상적으로 아무것도 stage 하지 않는다. 그런데 다음 넷이 전부 같은 로그를 남긴다:

- `NURI_ROLE` 누락 → **판정일(2027-06-30)까지 영영 안 나감**
- mini 가 재시도 창 내내 다운
- `adjudicate()` 예외
- dispatcher 발행 실패

## Fix

**1. heartbeat — 모든 경로에서 기록**

`_run_alpha_report` 가 skip·예외 포함 **항상** `pipeline_events` 에 `alpha_report_run` 1행을 남긴다. payload: `{month, role_ok, already_emitted, staged, error}`.

`already_emitted` 는 **stage 이전에** 샘플링한다 — 이후에 읽으면 항상 True 라 skip 사유가 사라진다.

**2. detector — 8번째**

`SREIncidentAgent._detect_alpha_report_stale` 가 그 heartbeat 를 읽는다.

> ⚠️ **이슈 스펙에서 의도적으로 벗어남.** 스펙은 "heartbeat 공백 >35일"이라 썼는데, cron 이 매일이라 **role 누락 상태에서도 heartbeat 는 매일 찍힌다** — 공백 기준으로는 acceptance("role 누락을 35일 안에 잡는다")를 절대 만족할 수 없다.
>
> 그래서 **마지막 성공 stage** 기준으로 잰다. 성공 이력이 없으면 최초 heartbeat 기준 (배포 시점부터 role 이 누락된 경우가 정확히 여기 걸린다). heartbeat 전무면 skip (미배포).
>
> 스펙대로 되돌리면 테스트 3개가 FAIL 한다 — 실측 확인:
> ```
> FAILED ...::test_role_missing_alerts_even_though_heartbeats_are_daily
> FAILED ...::test_stale_since_last_successful_stage
> FAILED ...::test_error_skip_reason_surfaces_the_exception
> ```

임계 35일 — 월 1회 발화라 31일로는 정상 주기와 구분이 안 된다. `pipeline_events` 보존 90일이라 안전.

**3. 알림 한 줄이 원인+조치를 담는다**

```
§3.11 월간 alpha 리포트 — 41일째 미발화 (한 번도 발화 없음).
NURI_ROLE 미설정 — scheduler plist EnvironmentVariables 확인
```

cryptic `alpha_report_stale warning on alpha_report` 대신 (알림 가독성 원칙).

**4. 마이그레이션 45→46 (이슈에 없던 필수 작업)**

`incidents.incident_type` 은 Python tuple 이자 **DB CHECK 제약**이다. 새 타입 추가에 테이블 재생성이 필요하다 (#825 migration 45 와 동일 패턴).

빠뜨렸다면 mini 에서 INSERT 가 CHECK 위반으로 죽고, detector-level `except` 가 그걸 **`db_lock` incident 로 둔갑**시켜 엉뚱한 곳을 가리켰을 것이다.

## Acceptance (전부 테스트로 lock)

| 기준 | 테스트 |
|---|---|
| role 누락을 35일 안에 잡는다 | `test_role_missing_alerts_even_though_heartbeats_are_daily` |
| 정상 월간 발화는 알림 없음 (오탐 0) | `test_no_alert_on_healthy_monthly_cadence` |
| skip 사유 구분 (role_missing / error / already_emitted) | `test_error_skip_reason_surfaces_the_exception` |
| 모든 경로에서 heartbeat | `test_heartbeat_written_on_every_path` |

## 부수 수정

`tests/agents/test_state_replicator_dr.py` 가 `last_sync_schema_version=45` 를 리터럴로 박아 마이그레이션에 깨졌다. 라이브 값을 읽게 고쳤다 — 그 테스트의 관심사는 'replica 가 동기 상태인가' 지 특정 버전이 아니고, 버전 lock 은 `test_schema_version_at_46` 이 담당한다. 리터럴로 두면 앞으로 모든 migration 이 무관한 이 테스트를 깬다.

`sre_incident_agent` 의 detector 개수 언급(7 → 8) 동기화. 섹션 헤더는 #825 때부터 `6` 으로 어긋나 있어 함께 정정했다.

## Verification

- `make test-fast` — **6,313 passed / 6 skipped**
- `make lint` — clean
- `make verify-doc-counts` — 18/18 (README migrations 45 → 46)
- 스펙-그대로 변이 → acceptance 3건 FAIL 확인 (§5.3.1 Gotcha-Test Pair)

Closes #894