### PR TITLE
fix(scheduler): recommendation outcome tracker를 스케줄에 배선 (closes #899)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 41 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 42 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -168,6 +168,20 @@ def _run_collector(name: str, **kwargs):
 
             n = track_decision_outcomes()
             logger.info(f"[decision_pnl] {n}건 업데이트")
+        elif name == "recommendation_outcomes":
+            # recommendations 테이블의 7/14/21/30/60/90d forward return 갱신.
+            # NOTE: decisions 테이블이 아님 — 그쪽은 바로 위 decision_pnl.
+            #
+            # 이 호출은 `make recommend` CLI(tracker.main) 에만 있었다. 스케줄러에는
+            # 없어서 프로덕션 `recommendations.outcome_*` 1,170행이 **전부 NULL** 이었고
+            # (창이 닫힌 550행 포함), learning_memory 의 canonical(outcome_30d) /
+            # provisional(outcome_21d) 가중치가 표본 0 으로 DEFAULT_WEIGHTS 에 영구
+            # 고정돼 있었다. dev 에서는 사람이 `make recommend` 를 돌려 채워지므로
+            # 학습이 도는 것처럼 보였다 — 그게 3.5개월 안 들킨 이유다 (#899).
+            from nuri.trading.recommend.tracker import track_outcomes
+
+            n = track_outcomes()
+            logger.info(f"[recommendation_outcomes] {n}건 업데이트")
         elif name == "alpha_tracking":
             # ForwardOutcomeTracker: emit 된 추천 vs SPY benchmark → realized alpha 를
             # decision_outcomes 테이블에 기록 (recommendations → agent_decisions 백필 포함).
@@ -531,6 +545,16 @@ SCHEDULES = [
     {"name": "memory_snapshot", "func": _run_collector, "args": ("memory_snapshot",), "cron": "0 4 * * 0"},
     # decisions 테이블 raw P&L 갱신 (매일 07:00 — 시장 개장 전). NOT alpha (아래 alpha_tracking).
     {"name": "decision_pnl", "func": _run_collector, "args": ("decision_pnl",), "cron": "0 7 * * *"},
+    # recommendations forward return 갱신 (매일 07:02 — decision_pnl 직후, consensus 07:05 **전**).
+    # 순서가 계약이다: consensus 의 learning_memory 가 같은 날 갱신된 outcome 으로 가중치를
+    # 계산해야 한다. 07:00 대인 이유는 stock_us_dawn(00~06:59, 5분 간격)이 미국 종가를
+    # 이미 넣어둔 시각이기 때문 — decision_pnl 이 같은 근거로 07:00 이다 (#899).
+    {
+        "name": "recommendation_outcomes",
+        "func": _run_collector,
+        "args": ("recommendation_outcomes",),
+        "cron": "2 7 * * *",
+    },
     # 실현 alpha 추적 (매일 17:00 — 한국장 마감 후). ForwardOutcomeTracker scan →
     # decision_outcomes (realized vs SPY benchmark). 과거 launchd track-forward.plist 를 scheduler 로 흡수.
     {"name": "alpha_tracking", "func": _run_collector, "args": ("alpha_tracking",), "cron": "0 17 * * *"},

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -785,6 +785,44 @@ class TestSchedulerDecisions:
             _run_collector("agent_accuracy")
         mock_fn.assert_called_once()
 
+    def test_run_collector_recommendation_outcomes(self):
+        """_run_collector dispatches to tracker.track_outcomes (#899)."""
+        from nuri.scheduler import _run_collector
+
+        with patch("nuri.trading.recommend.tracker.track_outcomes", return_value=12) as mock_fn:
+            _run_collector("recommendation_outcomes")
+        mock_fn.assert_called_once_with()
+
+    def test_recommendation_outcomes_runs_before_consensus(self):
+        """`recommendation_outcomes` 는 반드시 `consensus` **보다 먼저** 돈다.
+
+        Gotcha-Test Pair: consensus 의 learning_memory 가 `recommendations.outcome_30d`
+        (canonical) / `outcome_21d` (provisional) 를 읽어 에이전트 가중치를 만든다.
+        순서가 뒤집히면 매일 하루 묵은 outcome 으로 가중치를 계산하게 되는데, 값이
+        그럴듯해서 **틀린 걸 알아차릴 방법이 없다**. 순서 자체가 계약이라 잠근다.
+
+        원 결함(#899)은 이 job 이 `make recommend` CLI 에만 있고 SCHEDULES 에는 아예
+        없어서, 프로덕션 outcome_* 1,170행이 전부 NULL → 가중치가 DEFAULT 로 영구
+        고정된 것이었다. dev 는 사람이 CLI 를 돌려 채워지므로 정상으로 보였다.
+        """
+        from nuri.scheduler import SCHEDULES
+
+        jobs = {j["name"]: j for j in SCHEDULES}
+        assert "recommendation_outcomes" in jobs, "SCHEDULES 에 recommendation_outcomes 미등록"
+
+        def _minute_of_day(cron: str) -> int:
+            minute, hour = cron.split()[0], cron.split()[1]
+            return int(hour) * 60 + int(minute)
+
+        outcomes_at = _minute_of_day(jobs["recommendation_outcomes"]["cron"])
+        consensus_at = _minute_of_day(jobs["consensus"]["cron"])
+        assert outcomes_at < consensus_at, (
+            f"recommendation_outcomes({jobs['recommendation_outcomes']['cron']}) 가 "
+            f"consensus({jobs['consensus']['cron']}) 보다 먼저 돌아야 한다"
+        )
+        # 미국 종가가 들어온 뒤여야 한다 — stock_us_dawn 은 06:59 에 끝난다.
+        assert outcomes_at >= 7 * 60, "미국 종가 수집(00~06:59) 완료 후여야 함"
+
     def test_run_collector_consensus(self):
         """_run_collector dispatches to analyze_portfolio + save_to_recommendations + record_decisions.
 


### PR DESCRIPTION
## Problem

`track_outcomes()` 가 `recommendations.outcome_7d~90d` 를 채우고, `learning_memory` 가 `outcome_30d`(canonical) / `outcome_21d`(provisional) 를 읽어 10-agent 가중치를 만든다. 그런데 **`SCHEDULES` 에 이 job 이 없다.** 호출자는 `make recommend` CLI 와 API 엔드포인트뿐.

## 왜 3.5개월간 안 들켰나

| | recommendations | `outcome_30d` 채워짐 |
|---|---|---|
| **로컬 dev** | 340 | **188** |
| **프로덕션 (mini)** | 1,170 | **0** (550행은 30일 창 이미 닫힘) |

dev 에서는 사람이 `make recommend` 를 돌려 채워진다. **확인하러 가는 곳에서는 루프가 살아있고, 정작 중요한 곳에서만 죽어 있었다.** `agent_verdicts` 는 프로덕션에도 1,138행 정상 축적돼 있어서 겉보기엔 더욱 멀쩡했다.

결과: `compute_canonical_weights` 가 사용 가능한 행 0 → 매번 `DEFAULT_WEIGHTS` 폴백. **가중치 학습이 한 번도 작동한 적 없다.**

## Fix

07:02 배선 — `decision_pnl`(07:00, `decisions` 테이블의 동일 역할 job)과 `consensus`(07:05) **사이**.

순서가 계약이다: consensus 의 learning_memory 가 같은 날 아침 갱신된 outcome 으로 가중치를 계산해야 한다. 07시대인 이유는 `stock_us_dawn`(00~06:59, 5분 간격)이 미국 종가를 이미 넣어둔 시각이기 때문 — `decision_pnl` 이 07:00 인 근거와 동일하다.

테스트는 cron 리터럴이 아니라 **순서 자체**를 단언한다 (뒤집히면 매일 하루 묵은 outcome 으로 계산하는데, 값이 그럴듯해서 틀린 걸 알아차릴 방법이 없다).

## ⚠️ 배포 시 실제 변화 — 프로덕션 원장 사본에서 측정

첫 실행이 **981건 처리 → 528행 `outcome_30d` 확정**. 그 결과 10개 중 **9개 에이전트의 가중치가 이동**:

| agent | before | after | delta |
|---|---|---|---|
| **risk** | 0.1900 | 0.1554 | **−0.0346** |
| **wallstreet** | 0.1050 | 0.0707 | **−0.0343** |
| macro | 0.1140 | 0.1426 | +0.0286 |
| options | 0.0760 | 0.0951 | +0.0191 |
| technical | 0.1520 | 0.1665 | +0.0145 |
| smart_money | 0.0760 | 0.0827 | +0.0067 |
| fundamental | 0.1140 | 0.1183 | +0.0043 |
| retail | 0.0500 | 0.0481 | −0.0019 |
| crypto | 0.0470 | 0.0452 | −0.0018 |
| korean_market | 0.0760 | 0.0753 | −0.0007 |

합계 1.0000 유지.

**hard veto 는 영향 없음.** `scoring.py:35` 가 `risk_v.confidence >= 80` 으로 발화하므로 risk 의 가중치 하락이 veto 를 약화시키지 않는다. 바뀌는 것은 **가중 투표 점수**뿐 — 설계상 원래 일어났어야 했으나 한 번도 일어나지 않은 동작이다.

> 측정은 프로덕션 원장을 건드리지 않고 `src.backup()` 사본에서 수행했다.

## Verification

- 변이 검증 2건 (§5.3.1 Gotcha-Test Pair):
  - cron 을 `30 7`(consensus 이후)로 → `test_recommendation_outcomes_runs_before_consensus` **FAIL**
  - dispatch 분기 제거 → `test_run_collector_recommendation_outcomes` **FAIL**
- `tests/test_scheduler.py` 96 passed, `make lint` clean

## 관련

같은 drift 클래스: #897(머지 #898) · #900 · #902

Closes #899