### PR TITLE
fix(scheduler): make collect 전용이던 collector 4종 배선 (closes #900)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 42 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 46 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -136,6 +136,22 @@ def _run_collector(name: str, **kwargs):
             from nuri.collectors.fundamental import FundamentalCollector
 
             FundamentalCollector().run()
+        elif name == "cboe":
+            from nuri.collectors.cboe import CBOECollector
+
+            CBOECollector().run()
+        elif name == "coingecko":
+            from nuri.collectors.coingecko import CoinGeckoCollector
+
+            CoinGeckoCollector().run()
+        elif name == "reddit":
+            from nuri.collectors.reddit import RedditCollector
+
+            RedditCollector().run()
+        elif name == "fred_calendar":
+            from nuri.collectors.fred_calendar import FREDCalendarCollector
+
+            FREDCalendarCollector().run()
         elif name == "kis_analyst_opinion":
             from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
 
@@ -515,6 +531,19 @@ SCHEDULES = [
     {"name": "ark", "func": _run_collector, "args": ("ark",), "cron": "30 7 * * 2-6"},
     # 이벤트 캘린더 (매일 07:00)
     {"name": "events", "func": _run_collector, "args": ("events",), "cron": "0 7 * * *"},
+    # ── `make collect` 에는 있었으나 SCHEDULES 에 없던 4종 (#900) ──────────────
+    # 2026-04-14 이후 한 행도 안 쌓였다 — 그날이 마지막 수동 `make collect` 이고,
+    # 자동화가 이 넷을 안 가져갔다. consensus(07:05) **전**에 배치해 같은 날 데이터로
+    # 투표하게 한다. 특히 reddit 은 retail_agent 의 유일한 입력이라, 없으면 10-agent
+    # 중 하나가 3.5 개월 묵은 값으로 표를 던진다.
+    #   cboe          → macro.put_call_ratio  (공포/과열)
+    #   coingecko     → macro.btc_dominance
+    #   reddit        → macro.wsb_post_count / wsb_mention_<ticker>  → retail_agent
+    #   fred_calendar → events (경제지표 발표 일정 — 실적/FOMC 는 위 events collector 담당, 상보적)
+    {"name": "cboe", "func": _run_collector, "args": ("cboe",), "cron": "20 6 * * *"},
+    {"name": "coingecko", "func": _run_collector, "args": ("coingecko",), "cron": "25 6 * * *"},
+    {"name": "reddit", "func": _run_collector, "args": ("reddit",), "cron": "35 6 * * *"},
+    {"name": "fred_calendar", "func": _run_collector, "args": ("fred_calendar",), "cron": "45 6 * * *"},
     # 뉴스 (1시간 — SaveTicker 대체)
     {"name": "news", "func": _run_collector, "args": ("news",), "cron": "0 * * * *"},
     # 매크로 뉴스 (KST 08:00, 14:00, 20:00 — 시장 영향 큰 이벤트만)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1259,3 +1259,64 @@ class TestSchedulerBootstrap:
         sched_mod.main()
 
         mock_init_db.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════
+# TestOrphanCollectorsWired — #900
+# ═══════════════════════════════════════════════════════
+
+
+class TestOrphanCollectorsWired:
+    """`make collect` 에만 있고 SCHEDULES 에 없던 collector 4종 (#900).
+
+    2026-04-14 이후 프로덕션에 한 행도 안 쌓였다 — 그날이 마지막 수동 `make collect`
+    이고 자동화가 이 넷을 안 가져갔다. `decisions` 동결(#897)·outcome 미기록(#899)과
+    같은 날짜, 같은 drift 클래스.
+    """
+
+    ORPHANS = {
+        "cboe": "nuri.collectors.cboe.CBOECollector",
+        "coingecko": "nuri.collectors.coingecko.CoinGeckoCollector",
+        "reddit": "nuri.collectors.reddit.RedditCollector",
+        "fred_calendar": "nuri.collectors.fred_calendar.FREDCalendarCollector",
+    }
+
+    @pytest.mark.parametrize("job_name", sorted(ORPHANS))
+    def test_dispatch_reaches_the_collector(self, job_name):
+        """`_run_collector(name)` 이 해당 Collector.run() 을 부른다."""
+        from nuri.scheduler import _run_collector
+
+        mock = MagicMock()
+        with patch(self.ORPHANS[job_name], return_value=mock):
+            _run_collector(job_name)
+        mock.run.assert_called_once()
+
+    @pytest.mark.parametrize("job_name", sorted(ORPHANS))
+    def test_registered_in_schedules(self, job_name):
+        from nuri.scheduler import SCHEDULES
+
+        jobs = [j for j in SCHEDULES if j["name"] == job_name]
+        assert len(jobs) == 1, f"{job_name} job 이 정확히 1개여야 함"
+        assert jobs[0]["args"] == (job_name,)
+
+    def test_all_run_before_consensus(self):
+        """네 job 모두 consensus(07:05) **보다 먼저** 돈다.
+
+        Gotcha-Test Pair: reddit 은 `retail_agent` 의 유일한 입력이다
+        (`retail_agent.py` 가 `macro.wsb_mention_<ticker>` / `wsb_post_count` 를 읽는다).
+        consensus 뒤로 밀리면 10-agent 중 하나가 매일 하루 묵은 값으로 표를 던지는데,
+        값이 그럴듯해서 틀린 걸 알아차릴 방법이 없다. 나머지 셋도 같은 이유로 선행.
+        """
+        from nuri.scheduler import SCHEDULES
+
+        jobs = {j["name"]: j["cron"] for j in SCHEDULES}
+
+        def _minute_of_day(cron: str) -> int:
+            minute, hour = cron.split()[0], cron.split()[1]
+            return int(hour) * 60 + int(minute)
+
+        consensus_at = _minute_of_day(jobs["consensus"])
+        for name in self.ORPHANS:
+            assert _minute_of_day(jobs[name]) < consensus_at, (
+                f"{name}({jobs[name]}) 가 consensus({jobs['consensus']}) 보다 늦다"
+            )


### PR DESCRIPTION
## 실측 — 전부 2026-04-14 에 멈춰 있다

| 시리즈 | 마지막 | 행수 |
|---|---|---|
| `macro.put_call_ratio` (cboe) | **2026-04-14** | 5 |
| `macro.btc_dominance` (coingecko) | **2026-04-14** | 5 |
| `macro.wsb_post_count` (reddit) | **2026-04-14** | 5 |
| `macro.wsb_mention_<ticker>` (reddit) | **2026-04-14** | 17 |

`decisions` 동결(#897)·outcome 미기록(#899)과 **같은 날짜**다. 그날이 마지막 수동 `make collect` 이고, 자동화가 이 넷을 안 가져갔다.

## 매매 판단에 닿는 갭

`retail_agent` 는 `macro.wsb_mention_<ticker>` 와 `wsb_post_count` **만** 읽는다 (`retail_agent.py:22,26`). 즉 **10-agent 중 하나가 3.5개월간 4월 데이터로 표를 던져 왔다.** 아무 에러 없이.

`put_call_ratio` 는 사용자 매매 체크리스트의 CBOE 항목이다.

## Fix

consensus(07:05) **전**에 배치 — 당일 합의가 당일 데이터를 보게. 외부 API 4개가 한 분에 몰리지 않도록 06:20부터 분산:

| job | cron | 대상 |
|---|---|---|
| `cboe` | `20 6 * * *` | `macro.put_call_ratio` |
| `coingecko` | `25 6 * * *` | `macro.btc_dominance` |
| `reddit` | `35 6 * * *` | `macro.wsb_*` → **retail_agent** |
| `fred_calendar` | `45 6 * * *` | `events` (경제지표 발표) |

테스트는 cron 리터럴이 아니라 **순서**를 단언한다. consensus 뒤로 밀리면 매일 하루 묵은 값으로 투표하는데, 값이 그럴듯해서 알아차릴 방법이 없다.

## 배선하지 않은 2종 — 의도적

| collector | 판정 근거 |
|---|---|
| `kis_realtime` | 독립 job 아님. `kis_analyst_opinion` / `institutional` / `fundamental` 이 **라이브러리로 import** 하며 그 셋은 이미 스케줄됨 |
| `finviz` | 자기 모듈 밖 **호출자 0**. 배선도 삭제도 이 PR 스코프 아니라 그대로 둠 (별건) |

`fred_calendar` 는 배선 대상 — `events` collector 는 실적/FOMC/배당 담당이고 이쪽은 경제지표 발표 일정이라 **상보적**이다 (중복 아님, `events.py:114` docstring 대조).

## Verification

- 변이 검증: `reddit` cron 을 `35 8`(consensus 이후)로 → `test_all_run_before_consensus` **FAIL** (`reddit(35 8 * * *) 가 consensus(5 7 * * *) 보다 늦다`)
- `tests/test_scheduler.py` 105 passed · `make lint` clean · `make verify-doc-counts` 18/18 (jobs 42 → 46)

## 관련

같은 drift 클래스: #897(#898) · #899(#903) · #902

Closes #900