### PR TITLE
fix(verify): verify-all File Integrity 게이트를 드리프트하지 않는 검사로 교체 (closes #902)

### DIFF
--- a/.claude/skills/nuri-verify/SKILL.md
+++ b/.claude/skills/nuri-verify/SKILL.md
@@ -20,7 +20,7 @@ make verify-all
 ## Manual checklist
 
 - [ ] `make lint` passes (ruff check)
-- [ ] `make test` passes (6,341 tests — integration 9건은 addopts 로 제외, xdist parallel)
+- [ ] `make test` passes (6,355 tests — integration 9건은 addopts 로 제외, xdist parallel)
 - [ ] Numbers changed? → `grep -ri "old_value"` across CLAUDE.md, README.md, STRATEGY.md
 - [ ] New rule or threshold? → Added to `config/rules.yaml` or `config/agents.yaml`, not hardcoded
 - [ ] New feature? → "이 기능이 실패하면 어떻게 알 수 있는가?" 답할 것

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every BUY / SELL recommendation runs through a 5-phase pipeline — **collect �
 - 🔁 **Self-correcting** — agent weights adjust based on actual prediction accuracy, not hand-tuning.
 - 🛡️ **3-D certification** — gates apply per `Account × Asset Class × Market`. One error-grade fail → REJECTED, no manual override.
 - 🔓 **Open data flow** — phases coupled only via SQLite tables. Re-run any phase, downstream consumers refresh automatically.
-- ✅ **Tested rigorously** — 6,350 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
+- ✅ **Tested rigorously** — 6,364 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
 
 ## Quick Start
 
@@ -157,7 +157,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 
 | Metric | Value |
 |--------|-------|
-| **Backend tests** | 6,350 (280 files) — **100% statement coverage** |
+| **Backend tests** | 6,364 (281 files) — **100% statement coverage** |
 | **Frontend tests** | 1,449 (127 files) |
 | **E2E tests** | 57 (Playwright, 8 specs) |
 | **Pipeline phases** | 5 (collect / analyze / consensus / certify / track) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,350 backend tests across 280 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,364 backend tests across 281 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,350 tests, 280 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,364 tests, 281 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/verify/check_orphan_imports.py
+++ b/scripts/verify/check_orphan_imports.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""첫째-party import 가 실제로 존재하는 모듈을 가리키는지 검사 (#902).
+
+이전 구현은 `verify_all.sh` 안의 grep 한 줄이었고, **옛 경로 목록을 하드코딩**하고
+제외 목록으로 예외를 뺐다. 그 뒤 새로 생긴 1급 패키지(`nuri/agents/` actor fleet,
+`nuri/quant/backtest` 등)가 제외 목록에 없어 정당한 import 353건이 전부 orphan 으로
+잡혔다 — `make verify-all` 이 **구조적으로 통과 불가**였고, 그래서 1~4단계(테스트·
+백엔드·엔드포인트)의 진짜 신호까지 같이 무시됐다.
+
+접근을 뒤집는다: "옛 경로인가" 가 아니라 **"이 모듈이 존재하는가"** 를 묻는다.
+목록이 없으므로 패키지가 추가/이동돼도 드리프트하지 않는다.
+
+해석은 파일시스템으로만 한다 — `importlib.util.find_spec` 은 부모 패키지를 실제로
+import 해서 `__init__` 부작용(로깅 설정 등)을 일으킬 수 있다. 검증 스크립트가
+프로덕션 모듈을 실행하면 안 된다.
+
+사용:
+    python scripts/verify/check_orphan_imports.py          # 개수만 stdout
+    python scripts/verify/check_orphan_imports.py -v       # 위반 목록도 stderr
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_ROOTS = ("nuri", "tests", "scripts")
+FIRST_PARTY = "nuri"
+
+
+def _resolve(dotted: str) -> bool:
+    """`nuri.a.b` → `nuri/a/b.py` 또는 `nuri/a/b/__init__.py` 존재 여부."""
+    rel = Path(*dotted.split("."))
+    return (REPO_ROOT / rel).with_suffix(".py").is_file() or (REPO_ROOT / rel / "__init__.py").is_file()
+
+
+def _imported_modules(tree: ast.AST) -> set[str]:
+    """절대 import 된 모듈명. 상대 import(`from . import x`)는 제외."""
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            mods |= {a.name for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            mods.add(node.module)
+    return mods
+
+
+def find_orphans() -> list[str]:
+    """존재하지 않는 첫째-party 모듈을 import 하는 지점 목록."""
+    orphans: list[str] = []
+    for root in SCAN_ROOTS:
+        base = REPO_ROOT / root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except SyntaxError:
+                # 문법 오류는 lint/test 가 잡는다 — 여기서 중복 실패시키지 않는다.
+                continue
+            for mod in sorted(_imported_modules(tree)):
+                if mod != FIRST_PARTY and not mod.startswith(FIRST_PARTY + "."):
+                    continue
+                if not _resolve(mod):
+                    orphans.append(f"{path.relative_to(REPO_ROOT)}: {mod}")
+    return orphans
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="존재하지 않는 nuri.* import 검사")
+    parser.add_argument("-v", "--verbose", action="store_true", help="위반 목록을 stderr 로 출력")
+    args = parser.parse_args(argv)
+
+    orphans = find_orphans()
+    print(len(orphans))
+    if args.verbose:
+        for o in orphans:
+            print(f"  {o}", file=sys.stderr)
+    return 1 if orphans else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Nuri-Quant System Verification — 커밋 전 필수
-# 주: pipefail 미사용 — 아래 5/5 integrity 체크가 여러 `grep -v` 체인을 쓰는데,
-# 중간에 match가 0개면 grep이 exit 1을 반환해 pipefail 하에서 전체 subshell
-# 실패. tolerance 위해 pipefail 생략.
+# 주: pipefail 미사용 — 1~4단계가 `| tail -1` 로 요약을 뽑는데, 앞 단계가 조기
+# 종료하면 pipefail 하에서 subshell 전체가 실패한다. tolerance 위해 생략.
+# (5/5 의 grep 체인은 #902 에서 python 검사로 대체됐다.)
 set -eu
 
 # Source shared helpers (colors, PYTHON, REPO_ROOT cd, counters).
@@ -110,10 +110,12 @@ check "Heavy Endpoints"
 
 # 5. Integrity
 echo ""; echo "━━━ 5/5. File Integrity ━━━"
-# 체인된 `grep -v`가 여러 개라 마지막만 `grep -vc`로 치환하면 의미가 달라짐 (이전
-# 단계 중 하나라도 all-excluded 결과면 exit 1). 의도적으로 `| wc -l` 유지.
-# shellcheck disable=SC2126
-old=$(grep -rn "from nuri\.regime\.\|from nuri\.agents\.\|from nuri\.strategy\.\|from nuri\.recommend\.\|from nuri\.swing\.\|from nuri\.quant\." nuri/ tests/ scripts/ --include="*.py" 2>/dev/null | grep -v __pycache__ | grep -v "nuri.quant.regime" | grep -v "nuri.quant.validation" | grep -v "nuri.analysis.factors" | grep -v "nuri.trading" | wc -l | tr -d ' ')
+# 예전에는 여기서 **옛 경로를 하드코딩**한 grep 에 제외 목록을 덧대는 방식이었다.
+# 그 뒤 생긴 1급 패키지(`nuri/agents/` actor fleet, `nuri/quant/backtest` 등)가 제외
+# 목록에 없어 정당한 import 353 건이 orphan 으로 잡혔고, 이 게이트는 **통과 불가**
+# 상태로 오래 방치됐다 — 5단계가 항상 빨간불이라 1~4단계의 진짜 신호까지 묻혔다 (#902).
+# 이제 "옛 경로인가" 대신 **"그 모듈이 존재하는가"** 를 묻는다. 목록이 없으니 드리프트도 없다.
+old=$($PYTHON "$(dirname "$0")/check_orphan_imports.py" -v)
 echo "  Orphan imports: $old"
 test "$old" -eq "0"
 check "File Integrity"

--- a/tests/verify/test_check_orphan_imports.py
+++ b/tests/verify/test_check_orphan_imports.py
@@ -1,0 +1,104 @@
+"""`scripts/verify/check_orphan_imports.py` 계약 (#902).
+
+이전 구현(옛 경로 하드코딩 grep)은 `nuri/agents/` actor fleet 처럼 나중에 생긴 1급
+패키지를 제외 목록에 못 넣어 정당한 import 353 건을 orphan 으로 잡았고, 그 결과
+`make verify-all` 이 **구조적으로 통과 불가**였다 — 5단계가 항상 빨간불이라 1~4단계의
+진짜 신호까지 함께 묻혔다.
+
+그래서 두 방향을 다 잠근다: 진짜 orphan 을 잡는가(민감도) + 현재 레포를 통과시키는가
+(특이도). 특이도 쪽이 원래 결함이므로 그게 핵심이다.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "verify" / "check_orphan_imports.py"
+
+sys.path.insert(0, str(SCRIPT.parent))
+import check_orphan_imports as coi  # noqa: E402
+
+
+class TestResolution:
+    """`_resolve` — dotted name → 파일시스템. import 를 실행하지 않는다."""
+
+    @pytest.mark.parametrize(
+        "mod",
+        [
+            "nuri",  # 패키지 __init__
+            "nuri.scheduler",  # 단일 모듈
+            "nuri.core.db",  # 서브패키지 __init__
+            "nuri.core.db.connection",  # 서브패키지 내 모듈
+            "nuri.agents.actors.sre_incident_agent",  # 예전 구현이 orphan 으로 오탐하던 경로
+            "nuri.quant.factors.composite",  # 마찬가지
+        ],
+    )
+    def test_existing_modules_resolve(self, mod):
+        assert coi._resolve(mod), f"{mod} 는 실존하는데 미해석"
+
+    @pytest.mark.parametrize(
+        "mod",
+        ["nuri.regime.classifier", "nuri.strategy.longshort", "nuri.does_not_exist"],
+    )
+    def test_moved_or_absent_modules_do_not_resolve(self, mod):
+        assert not coi._resolve(mod), f"{mod} 는 없는데 해석됨"
+
+
+class TestRepoIsClean:
+    def test_no_orphans_in_current_tree(self):
+        """현재 레포는 통과해야 한다 — 이게 #902 의 본질(오탐 353건).
+
+        Gotcha-Test Pair: 옛 하드코딩 grep 으로 되돌리면 353 을 반환해 FAIL.
+        """
+        orphans = coi.find_orphans()
+        assert orphans == [], f"orphan import {len(orphans)}건:\n" + "\n".join(orphans[:10])
+
+    def test_cli_exits_zero_and_prints_count(self):
+        r = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True, timeout=120, check=False)
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "0"
+
+
+class TestDetectsRealOrphans:
+    def test_import_of_missing_module_is_flagged(self, tmp_path, monkeypatch):
+        """존재하지 않는 `nuri.*` 를 import 하면 잡힌다 (민감도)."""
+        root = tmp_path
+        (root / "nuri").mkdir()
+        (root / "nuri" / "__init__.py").write_text("")
+        (root / "nuri" / "real.py").write_text("X = 1\n")
+        (root / "scripts").mkdir()
+        (root / "scripts" / "bad.py").write_text(
+            "from nuri.real import X\nfrom nuri.ghost import Y\nimport nuri.also_missing\n"
+        )
+        monkeypatch.setattr(coi, "REPO_ROOT", root)
+
+        orphans = coi.find_orphans()
+        found = {o.split(": ")[1] for o in orphans}
+        assert found == {"nuri.ghost", "nuri.also_missing"}, orphans
+
+    def test_relative_and_thirdparty_imports_are_ignored(self, tmp_path, monkeypatch):
+        """상대 import 와 서드파티는 검사 대상이 아니다 (오탐 방지)."""
+        root = tmp_path
+        (root / "nuri").mkdir()
+        (root / "nuri" / "__init__.py").write_text("")
+        (root / "nuri" / "mod.py").write_text(
+            "from . import sibling\nfrom .deep import thing\nimport pandas\nfrom yfinance import Ticker\n"
+        )
+        monkeypatch.setattr(coi, "REPO_ROOT", root)
+
+        assert coi.find_orphans() == []
+
+    def test_syntax_error_file_does_not_crash_the_check(self, tmp_path, monkeypatch):
+        """문법 오류는 lint/test 담당 — 여기서 중복 실패시키지 않는다."""
+        root = tmp_path
+        (root / "nuri").mkdir()
+        (root / "nuri" / "__init__.py").write_text("")
+        (root / "nuri" / "broken.py").write_text("def f(:\n")
+        monkeypatch.setattr(coi, "REPO_ROOT", root)
+
+        assert coi.find_orphans() == []


### PR DESCRIPTION
## 증상 — 통과가 구조적으로 불가능한 게이트

```
━━━ 5/5. File Integrity ━━━
  Orphan imports: 353
make: *** [verify-all] Error 1
```

`test "$old" -eq "0"` 인데 353 이라 **어떤 상태에서도 통과 못 한다.**

## Root cause

`verify_all.sh` 가 **모듈 이동 당시의 옛 경로를 하드코딩**한 grep 에 제외 목록을 덧대는 방식이었다. 그 뒤 생긴 1급 패키지가 제외 목록에 없어 정당한 import 가 전부 orphan 으로 잡혔다.

| 경로 | 건수 | 실체 |
|---|---|---|
| `nuri.agents.actors` / `.discord` / `.base` | 250 | top-level actor fleet |
| `nuri.quant.backtest` / `.factors` / `.exits` / `.chart_analysis` | 103 | 실존 패키지 |

## 왜 중요한가

**통과할 수 없는 게이트는 아무도 안 본다.** 1~4단계(테스트 · 백엔드 스모크 · 엔드포인트 프로브)의 진짜 신호가 5단계 오탐과 함께 버려진다.

2026-07-28 배포 중 실제로 마주쳤고, 선택지는 "게이트를 건너뛴다" 또는 "353건이 노이즈임을 증명하는 데 시간을 쓴다" 둘뿐이었다.

## Fix — 질문을 뒤집는다

"옛 경로인가" → **"이 모듈이 존재하는가"**.

목록이 없으므로 패키지가 추가·이동돼도 드리프트하지 않는다. **진짜 버그는 353이라는 숫자가 아니라 유지보수해야 하는 목록이 있다는 구조**였다.

해석은 **파일시스템으로만** 한다. `importlib.util.find_spec` 은 부모 패키지를 실제 import 해서 `__init__` 부작용(로깅 설정 등)을 일으킨다 — 검증 스크립트가 검사 대상 코드를 실행해선 안 된다.

## 테스트 — 양방향

원 결함이 한쪽으로만 틀렸으므로 둘 다 잠근다.

| 방향 | 테스트 |
|---|---|
| 특이도 (**원 결함**) | `test_no_orphans_in_current_tree` — 현재 레포 통과 |
| 민감도 | `test_import_of_missing_module_is_flagged` — 없는 모듈 잡음 |
| 오탐 방지 | 상대 import · 서드파티 무시 |
| 책임 분리 | 문법 오류는 lint/test 담당 — 여기서 중복 실패 안 시킴 |

`nuri.agents.actors.sre_incident_agent` · `nuri.quant.factors.composite` 를 해석 테스트에 명시했다 — 예전 구현이 오탐하던 바로 그 경로다.

## Verification

```
━━━ 5/5. File Integrity ━━━
  Orphan imports: 0
  ✓ File Integrity
  ✓ ALL 5/5 PASSED
```

`tests/verify/` 14 passed · `make lint` clean · `make lint-sh` clean · `make verify-doc-counts` 18/18

## 관련

같은 클래스 (검증·자동화 장치가 조용히 무효화): #897(#898) · #899(#903) · #900(#905)

Closes #902