### PR TITLE
chore(ci): drop the dead universe paths-filter

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -58,7 +58,6 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
-      universe: ${{ steps.filter.outputs.universe }}
       # ── Policy outputs (Stage 2c) ──
       # Collapse the repeated `X == 'true' || !pull_request` pattern into
       # single booleans. Skip-notice steps use the inverse (`run_X != 'true'`),
@@ -88,10 +87,6 @@ jobs:
               - 'frontend/**'
               - '.github/workflows/**'
               - '.github/actions/**'
-            universe:
-              - 'config/universe.yaml'
-              - 'scripts/validate_universe.py'
-              - '.github/workflows/main-ci-cd.yml'
 
   # ─── Frontend ───
 
@@ -332,7 +327,7 @@ jobs:
   # Validates universe.yaml ↔ upstream sync. CI 에서는 universe.yaml 의 ticker
   # count sanity check 만 수행 (DB 부재). 5-table coverage 검증 (prices /
   # fundamentals / analyst / insider / superinvestors) 은 로컬 또는 Mac mini
-  # scheduler 가 수행하며 `scripts/validate_universe.py --no-fetch` 로 5/5 PASS
+  # scheduler 가 수행하며 `scripts/doc/validate_universe.py --no-fetch` 로 5/5 PASS
   # 가 유지되어야 함 (2026-04-16 마지막 실측 99/99/97/97/97%).
   #
   # **Required gate** — TODO.md Tier 2 P2 #7 에 따라 promotion 됨. universe.yaml


### PR DESCRIPTION
## Why

Dead-code sweep found a paths-filter output in `main-ci-cd.yml` that nothing consumes.

`needs.<job>.outputs.<name>` is the only syntax that reads a job output, and the repo has zero occurrences of `outputs.universe` outside its own declaration. The reason is PR #343: `universe-check` was promoted to an **unconditional required gate**, so the conditional it was built to drive was removed but the filter was left behind.

Second defect in the same block: it listed `scripts/validate_universe.py`, which moved to `scripts/doc/validate_universe.py` in #557. So the filter would not have fired on changes to the real script even if something had read it — and the `universe-check` comment pointed at the same dead path.

## What changed

- Removed `universe: ${{ steps.filter.outputs.universe }}` from the `changes` job outputs
- Removed the 4-line `universe:` filter block
- Fixed the stale `scripts/validate_universe.py` → `scripts/doc/validate_universe.py` reference in the `universe-check` comment

`universe-check` itself is untouched and still runs on every PR.

## Verification

- `yaml.safe_load` parses; 15 jobs, `changes` outputs now `backend / frontend / run_backend / run_frontend / run_security`
- `grep -rn "outputs\.universe" .github/` → no hits
- `universe-check` job body unchanged (`git diff` touches only the two locations above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)