### PR TITLE
feat(risk): wire sleeve_max_equity_pct into REBALANCE surface + ExecutionFirewall (#834)

### DIFF
--- a/.claude/skills/nuri-verify/SKILL.md
+++ b/.claude/skills/nuri-verify/SKILL.md
@@ -20,7 +20,7 @@ make verify-all
 ## Manual checklist
 
 - [ ] `make lint` passes (ruff check)
-- [ ] `make test` passes (6,367 tests — integration 9건은 addopts 로 제외, xdist parallel)
+- [ ] `make test` passes (6,381 tests — integration 9건은 addopts 로 제외, xdist parallel)
 - [ ] Numbers changed? → `grep -ri "old_value"` across CLAUDE.md, README.md, STRATEGY.md
 - [ ] New rule or threshold? → Added to `config/rules.yaml` or `config/agents.yaml`, not hardcoded
 - [ ] New feature? → "이 기능이 실패하면 어떻게 알 수 있는가?" 답할 것

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every BUY / SELL recommendation runs through a 5-phase pipeline — **collect �
 - 🔁 **Self-correcting** — agent weights adjust based on actual prediction accuracy, not hand-tuning.
 - 🛡️ **3-D certification** — gates apply per `Account × Asset Class × Market`. One error-grade fail → REJECTED, no manual override.
 - 🔓 **Open data flow** — phases coupled only via SQLite tables. Re-run any phase, downstream consumers refresh automatically.
-- ✅ **Tested rigorously** — 6,376 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
+- ✅ **Tested rigorously** — 6,390 backend tests, **100% statement coverage** (CI verified, 2026-05-06).
 
 ## Quick Start
 
@@ -157,7 +157,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 
 | Metric | Value |
 |--------|-------|
-| **Backend tests** | 6,376 (282 files) — **100% statement coverage** |
+| **Backend tests** | 6,390 (283 files) — **100% statement coverage** |
 | **Frontend tests** | 1,449 (127 files) |
 | **E2E tests** | 57 (Playwright, 8 specs) |
 | **Pipeline phases** | 5 (collect / analyze / consensus / certify / track) |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The egress policy is enforced by `nuri/llm/openai_client.py`: a single wrapper l
 | **Trading signals** | 22 (20 actionable + 2 shadow) |
 | **API endpoints** | 72 (FastAPI on `:8001`) |
 | **Frontend routes** | 18 (Next.js on `:3000`) |
-| **DB tables** | 51 (46 forward-only migrations) |
+| **DB tables** | 51 (47 forward-only migrations) |
 | **DB submodules** | 11 (sole `sqlite3` importer in `nuri/core/db/`) |
 
 ## Common Commands

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,376 backend tests across 282 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,390 backend tests across 283 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,376 tests, 282 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,390 tests, 283 files (statement coverage **100%**, 2026-05-06) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/execution_firewall.py
+++ b/nuri/agents/actors/execution_firewall.py
@@ -18,6 +18,7 @@ Hard rules (모두 우회 불가):
 - post-trade cash < 20% → cash_reserve
 - total long exposure / cash > 1.5x → leverage_cap
 - 일일 portfolio loss > -10% → max_daily_loss
+- post-trade 실험 슬리브 > 계좌 전략 상한 → sleeve_cap (§3.11, `account` 제공 시)
 
 Soft rule:
 - VIX 25-30 + BUY → 'caution' warn (emit 허용 + 사용자에게 경고)
@@ -65,6 +66,7 @@ class ExecutionFirewall(Actor):
         ticker: str
         trade_action: 'BUY' | 'SELL' | 'HOLD'  — 매매 방향 (key 충돌 회피)
         proposed_position_value: float — emit 시 매매 금액 (USD or KRW)
+        account: str (optional) — §3.11 슬리브 게이트용 계좌 키. 없으면 슬리브 미검사
         portfolio_state: dict — 현재 포트폴리오
             {
               total_value, cash, positions: {ticker: {value, sector}},
@@ -284,6 +286,35 @@ class ExecutionFirewall(Actor):
                                 "cash": cash,
                                 "ratio": leverage_ratio,
                                 "cap": MAX_LEVERAGE,
+                            },
+                        }
+                    )
+
+            # 7) §3.11 실험 슬리브 상한 — 이 매수가 계좌의 슬리브 여력을 넘는가
+            #
+            # `account` 가 없으면 검사하지 않는다. 다른 게이트(vix / sector / daily_pnl)와
+            # 같은 "입력 있으면 검사" 규약이고, 슬리브는 **계좌별** 룰이라 계좌 없이는
+            # 판정 자체가 불가능하다 (portfolio_state 는 계좌 구분을 담지 않는다).
+            #
+            # headroom 계산이 터지면 잡지 않는다 — 고장난 게이트가 통과한 게이트처럼
+            # 보이면 안 된다. run() 이 실패로 기록하고 caller 가 처리한다. 빈 포트폴리오는
+            # headroom=None 이라 예외가 아니라 "상한 없음"으로 조용히 통과한다 (CI 안전).
+            account = input_data.get("account")
+            if account:
+                from nuri.analysis.sleeve import sleeve_headroom
+
+                headroom = sleeve_headroom(str(account))
+                if headroom is not None and proposed_value > headroom:
+                    hard_blocks.append(
+                        {
+                            "type": "sleeve_cap",
+                            "reason": (
+                                f"§3.11 실험 슬리브 여력 {headroom:,.0f} < 신규 매수 {proposed_value:,.0f}"
+                                " — 사전등록 상한 초과 (상한 인상은 판정 통과 + STRATEGY PR 필요)"
+                            ),
+                            "evidence": {
+                                "headroom": headroom,
+                                "proposed_value": proposed_value,
                             },
                         }
                     )

--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -1,9 +1,9 @@
-"""Mechanical portfolio-axis signals → #brief (Tier 1b: 집중도 · 1c: 섹터 드리프트 → REBALANCE).
+"""Mechanical portfolio-axis signals → #brief (Tier 1b 집중도 · 1c 섹터 · 1d 슬리브 → REBALANCE).
 
 Tier 1a(risk_signals) 가 alpha 축(손절선 이탈 → urgent SELL) 을 표면화했다면,
 여기는 **portfolio 축**(#429): (1b) 종목 비중이 계좌별 `max_single_position` 한도,
-(1c) 섹터 합산 비중이 `max_sector_exposure` 한도를 넘으면 REBALANCE 로 surface.
-결정론적 룰(예측 아님).
+(1c) 섹터 합산 비중이 `max_sector_exposure` 한도, (1d) §3.11 실험 슬리브가 계좌
+전략별 `sleeve_max_equity_pct` 상한을 넘으면 REBALANCE 로 surface. 결정론적 룰(예측 아님).
 
 #429 축 분리 (엄밀): 집중도/드리프트는 `portfolio_action=REBALANCE` — **절대
 urgent SELL 아님**(alpha_action=FLAT 은 손절선만). 따라서 여기 payload 는
@@ -185,15 +185,79 @@ def stage_sector_briefs(date: Optional[str] = None, db_path: Optional[Path] = No
     return staged
 
 
+def scan_sleeve_breach(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
+    """§3.11 실험 슬리브 상한 초과 계좌 목록 (Tier 1d).
+
+    `sleeve_utilization()` 이 canonical 계산이고 여기는 필터만 한다 — 상한은
+    `rules.yaml measurement_mode.sleeve_max_equity_pct` 단일 출처.
+
+    1b/1c 와 달리 **pension 을 제외하지 않는다**: pension/long_term 의 상한은 0 이라
+    "시스템 추천 자본이 한 푼도 들어가면 안 되는 계좌"라는 뜻이고, 그 위반은 daily
+    action 대상이 아니라 사전등록 위반이다. 조용히 감추면 판정일에 표본이 오염된
+    채로 발견된다.
+    """
+    from nuri.analysis.sleeve import sleeve_utilization
+
+    return [row for row in sleeve_utilization(db_path=db_path) if row["over"]]
+
+
+def _build_sleeve_rebalance_payload(row: dict[str, Any], date: str) -> dict[str, Any]:
+    """슬리브 초과 1건 → #brief REBALANCE payload.
+
+    1b/1c 와 동일 #429 규칙: kind="REBALANCE", price_levels 없음, 매도 동사 없음.
+    §3.11 은 "cap-breach resolution surfaces as portfolio_action=REBALANCE only" 로
+    이 축을 명시 고정한다 — 슬리브 초과를 청산 신호로 승격하면 사전등록 위반이다.
+
+    Privacy: ticker 슬롯에 계좌 키(로마자 broker name) 대신 **전략 라벨**(core/active/
+    swing)을 넣는다. 전략명은 config public 라벨이고 계좌는 dedupe_key 에만 남는다.
+    """
+    return {
+        "kind": "REBALANCE",
+        "ticker": f"실험슬리브({row['strategy']})",
+        "reason": (
+            f"슬리브 {row['used_pct']:.1f}% > 상한 {row['cap_pct']:.0f}%"
+            " — 비중 조절 권고 (수단·타이밍 사용자 판단). 여력 회복까지 신규 시스템 추천 집행 보류"
+        ),
+        "date": date,
+    }
+
+
+def stage_sleeve_briefs(date: Optional[str] = None, db_path: Optional[Path] = None) -> int:
+    """슬리브 상한 초과를 #brief outbox 에 REBALANCE 로 stage. staged 건수 반환.
+
+    dedupe_key=`rebalance:sleeve:{account}:{date}` — 계좌 × 하루 1건. priority="normal".
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    d = date or today_kst()
+    staged = 0
+    for row in scan_sleeve_breach(db_path=db_path):
+        outbox_id = stage_brief(
+            payload=_build_sleeve_rebalance_payload(row, d),
+            dedupe_key=f"rebalance:sleeve:{row['account']}:{d}",
+            priority="normal",
+            actor_name="portfolio-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("sleeve REBALANCE briefs staged: %d", staged)
+    return staged
+
+
 def main(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="포트폴리오 드리프트(집중도·섹터) → #brief REBALANCE (Tier 1b/1c)")
+    parser = argparse.ArgumentParser(
+        description="포트폴리오 드리프트(집중도·섹터·슬리브) → #brief REBALANCE (Tier 1b/1c/1d)"
+    )
     parser.add_argument("--dry-run", action="store_true", help="stage 없이 위반 목록만 출력")
     args = parser.parse_args(argv)
 
     conc = scan_concentration_drift()
     sect = scan_sector_drift()
-    if not conc and not sect:
-        print("포트폴리오 드리프트 없음 (집중도·섹터)")
+    sleeve = scan_sleeve_breach()
+    if not conc and not sect and not sleeve:
+        print("포트폴리오 드리프트 없음 (집중도·섹터·슬리브)")
         return 0
     for v in conc:
         print(
@@ -201,10 +265,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         )
     for v in sect:
         print(f"  [섹터] {v['sector']} {v['current_value']:.1f}% > 한도 {v['limit_value'] * 100:.0f}%")
+    for v in sleeve:
+        print(f"  [슬리브] {v['strategy']} {v['used_pct']:.1f}% > 상한 {v['cap_pct']:.0f}%")
     if args.dry_run:
-        print(f"[dry-run] 집중도 {len(conc)}건 · 섹터 {len(sect)}건 — stage 안 함")
+        print(f"[dry-run] 집중도 {len(conc)}건 · 섹터 {len(sect)}건 · 슬리브 {len(sleeve)}건 — stage 안 함")
         return 0
-    staged = stage_concentration_briefs() + stage_sector_briefs()
+    staged = stage_concentration_briefs() + stage_sector_briefs() + stage_sleeve_briefs()
     print(f"staged {staged}건 → #brief (REBALANCE)")
     return 0
 

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -641,7 +641,7 @@ def write_brief(
     except Exception:
         logger.warning("stop-breach brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
 
-    # Tier 1b/1c — 포트폴리오 드리프트(집중도·섹터)를 digest 에 REBALANCE 로 표면화
+    # Tier 1b/1c/1d — 포트폴리오 드리프트(집중도·섹터·슬리브)를 digest 에 REBALANCE 로 표면화
     # (portfolio 축, #429). 둘 다 portfolio-wide → US 세션에서만 stage (US-heavy
     # 포트폴리오 · US 종장 직후 타이밍). kr/us 양 세션 호출 시 dispatcher 가 US 행을
     # sent 처리 후 KR 이 재삽입(dedupe 는 pending 만 매칭)해 하루 2건 나던 것을 단일
@@ -660,6 +660,12 @@ def write_brief(
             stage_sector_briefs(d, db_path=db_path)
         except Exception:
             logger.warning("sector REBALANCE brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+        try:
+            from nuri.alerts.portfolio_signals import stage_sleeve_briefs
+
+            stage_sleeve_briefs(d, db_path=db_path)
+        except Exception:
+            logger.warning("sleeve REBALANCE brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
 
     return path
 

--- a/nuri/analysis/sleeve.py
+++ b/nuri/analysis/sleeve.py
@@ -1,0 +1,138 @@
+"""§3.11 측정 모드 실험 슬리브 — 소속 판별 + 계좌별 사용률 (#834).
+
+`config/rules.yaml measurement_mode.sleeve_max_equity_pct` 는 선언만 되어 있고
+읽는 코드가 없었다. 이 모듈이 그 유일한 소비 지점이며, `rebalance_advisor`(초과 →
+REBALANCE 권고)와 `ExecutionFirewall`(잔여 소진 → 신규 BUY 차단) 둘 다 여기서
+계산을 가져간다. 두 곳에 각자 구현하면 오늘 종일 본 drift 가 그대로 재현된다.
+
+**소속 판별이 이 모듈의 핵심이자 유일한 함정이다.**
+슬리브는 "측정 모드 이후 시스템 추천을 **실행해** 투입된 자본"이다. 티커가 BUY 추천에
+등장했다는 사실만으로는 부족하다 — 실측(2026-07-28) 상 사전등록일 이후 BUY 추천 종목이
+**전부 이미 보유 중**이었고, 다수는 측정 모드보다 한참 앞서 열린 포지션이었다. 등장만으로
+판정하면 기존 보유가 통째로 슬리브로 오분류돼 사용률이 허구가 되고, 그 숫자가 신규
+매수를 차단한다.
+
+그래서 **두 조건을 모두** 요구한다:
+  1. `portfolio.first_buy_date >= declared_date` — 측정 모드 이후 새로 연 포지션
+  2. 그 창 안에서 해당 티커에 BUY 추천 이력 존재 — 시스템 추천에 기인
+
+#848 위임 결정 "기존보유 제외" 가 (1) 이다. 실측상 현재 슬리브는 비어 있다(사용률 0%).
+
+축(#429): 초과는 **portfolio_action=REBALANCE** 로만 표면화한다. 슬리브 초과는
+alpha 신호가 아니므로 SELL/청산으로 승격하지 않는다 (STRATEGY §3.11 "cap-breach
+resolution surfaces as portfolio_action=REBALANCE only").
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from nuri.core.db import query
+from nuri.core.rules import RULES
+
+logger = logging.getLogger(__name__)
+
+# 슬리브 상한이 적용되지 않는 자산군 — 상한은 주식(us_equity + kr_equity) 대비 비율이다.
+_EQUITY_CURRENCIES = ("USD", "KRW")
+
+
+def _measurement_mode() -> dict[str, Any]:
+    mm = RULES.get("measurement_mode")
+    if not mm:
+        raise RuntimeError("config/rules.yaml 에 measurement_mode 블록 없음 (§3.11)")
+    return mm
+
+
+def sleeve_caps() -> dict[str, float]:
+    """account_strategy → 상한 %. canonical 소스는 rules.yaml 뿐이다."""
+    caps = _measurement_mode().get("sleeve_max_equity_pct") or {}
+    return {str(k): float(v) for k, v in caps.items()}
+
+
+def sleeve_members(db_path: Optional[Path] = None) -> set[tuple[str, str]]:
+    """슬리브 소속 `(account, ticker)` 집합.
+
+    두 조건 **모두** 만족해야 한다 — 모듈 docstring 의 오분류 함정 참조.
+    """
+    mm = _measurement_mode()
+    declared = str(mm["declared_date"])
+
+    recommended = {
+        row["ticker"]
+        for row in query(
+            """SELECT DISTINCT r.ticker
+               FROM recommendations r
+               JOIN agent_decisions ad ON ad.decision_id = ? || r.id
+               WHERE ad.action = ? AND r.date >= ?""",
+            ("rec_", "BUY", declared),
+            db_path=db_path,
+        )
+    }
+    if not recommended:
+        return set()
+
+    return {
+        (str(row["account"]), str(row["ticker"]))
+        for row in query(
+            "SELECT account, ticker FROM portfolio WHERE ticker <> ? AND first_buy_date >= ?",
+            ("", declared),
+            db_path=db_path,
+        )
+        if str(row["ticker"]) in recommended
+    }
+
+
+def sleeve_utilization(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
+    """계좌별 슬리브 사용률.
+
+    Returns: `[{account, strategy, cap_pct, sleeve_usd, equity_usd, used_pct, over}]`
+    상한이 정의되지 않은 전략은 건너뛴다(판정 대상 아님).
+    """
+    from nuri.analysis.portfolio import analyze_portfolio
+    from nuri.core.rules import get_account_strategy_name
+
+    # analyze_portfolio() 는 db_path 를 받지 않는다 (기본 DB 고정). 테스트는
+    # 이 함수를 patch 하거나 sleeve_members/caps 를 직접 검증한다.
+    df = analyze_portfolio()
+    if df.empty:
+        return []
+
+    members = sleeve_members(db_path=db_path)
+    caps = sleeve_caps()
+    out: list[dict[str, Any]] = []
+
+    for account, grp in df.groupby("account"):
+        strategy = get_account_strategy_name(str(account))
+        if strategy not in caps:
+            continue
+        equity = float(grp["current_value_usd"].sum())
+        if equity <= 0:
+            continue
+        sleeve = float(grp[grp["ticker"].isin([t for a, t in members if a == str(account)])]["current_value_usd"].sum())
+        used = sleeve / equity * 100.0
+        cap = caps[strategy]
+        out.append(
+            {
+                "account": str(account),
+                "strategy": strategy,
+                "cap_pct": cap,
+                "sleeve_usd": round(sleeve, 2),
+                "equity_usd": round(equity, 2),
+                "used_pct": round(used, 2),
+                "over": used > cap,
+            }
+        )
+    return out
+
+
+def sleeve_headroom(account: str, db_path: Optional[Path] = None) -> Optional[float]:
+    """해당 계좌의 잔여 슬리브 여력(USD). 상한 미정의 전략이면 None(=제한 없음).
+
+    ExecutionFirewall 이 신규 BUY 를 판단할 때 쓴다. 0 이하면 여력 소진.
+    """
+    for row in sleeve_utilization(db_path=db_path):
+        if row["account"] == account:
+            return round(row["equity_usd"] * row["cap_pct"] / 100.0 - row["sleeve_usd"], 2)
+    return None

--- a/nuri/api/routes/alpha.py
+++ b/nuri/api/routes/alpha.py
@@ -28,6 +28,41 @@ WINDOWS = (7, 14, 30)
 SUSPECT_ABS_RETURN = 0.5
 
 
+def _sleeve_block() -> dict:
+    """§3.11 실험 슬리브 사용률 — 계좌별 상한 대비 (#834).
+
+    이 엔드포인트의 alpha 숫자가 **어떤 자본으로** 만들어졌는지가 슬리브다. 사용률
+    없이 alpha 만 보이면 "상한 안에서 난 결과"인지 판단할 수 없어서 같은 응답에 둔다.
+
+    실패해도 alpha 헤드라인을 죽이지 않는다(soft error) — 슬리브는 부가 맥락이고,
+    이 엔드포인트의 본 계약은 tracking-completeness 다.
+    """
+    try:
+        from nuri.analysis.sleeve import sleeve_utilization
+
+        rows = sleeve_utilization()
+    except Exception:
+        logger.exception("sleeve utilization 계산 실패")
+        return {"accounts": [], "count": 0, "error": "sleeve utilization unavailable"}
+
+    # account 는 broker name 이라 응답에 넣지 않는다 (전략 라벨만 노출).
+    accounts = [
+        {
+            "strategy": r["strategy"],
+            "cap_pct": r["cap_pct"],
+            "used_pct": r["used_pct"],
+            "over": r["over"],
+        }
+        for r in rows
+    ]
+    return {
+        "accounts": accounts,
+        "count": len(accounts),
+        "any_over": any(a["over"] for a in accounts),
+        "note": "실험 슬리브 = 사전등록일 이후 시스템 BUY 추천을 실행해 새로 연 포지션. 초과는 REBALANCE 권고이며 매도 신호가 아니다 (§3.11 · #429).",
+    }
+
+
 def _median(values: list[float]) -> float | None:
     n = len(values)
     if n == 0:
@@ -95,6 +130,8 @@ def alpha_summary() -> dict:
         "windows": windows_out,
         # clean alpha 의 distinct 결정 수 — median 의 실제 표본 크기 (coverage 아님).
         "effective_bets": len(clean_decisions),
+        # 이 alpha 가 어떤 자본으로 만들어졌는지 (§3.11 슬리브 사용률).
+        "sleeve": _sleeve_block(),
         "data_quality": {
             "suspect_rows": suspect,
             "suspect_threshold_pct": int(SUSPECT_ABS_RETURN * 100),

--- a/nuri/core/db/execution_ops.py
+++ b/nuri/core/db/execution_ops.py
@@ -29,6 +29,7 @@ _BLOCK_TYPES = (
     "cash_reserve",
     "leverage_cap",
     "max_daily_loss",
+    "sleeve_cap",  # §3.11 실험 슬리브 상한 (#834) — migration 47 의 CHECK 와 짝
 )
 _BLOCK_SEVERITIES = ("hard", "soft")
 _INCIDENT_TYPES = (

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1467,4 +1467,41 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_incidents_type ON incidents(incident_type, last_detected_at);
     """,
     ),
+    (
+        47,
+        "execution_blocks block_type enum 확장 — sleeve_cap (#834)",
+        # §3.11 실험 슬리브 상한(rules.yaml measurement_mode.sleeve_max_equity_pct)이
+        # ExecutionFirewall 의 hard block 으로 승격된다. block_type CHECK 에 없으면
+        # log_execution_block 이 IntegrityError 로 죽어 firewall 자체가 무너지므로
+        # 게이트 코드보다 이 migration 이 먼저다. migration 45/46 과 동일 재생성 패턴.
+        """
+        CREATE TABLE execution_blocks_new (
+            block_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            decision_id TEXT NOT NULL,
+            block_type TEXT NOT NULL CHECK(block_type IN (
+                'vix_too_high','banned_leverage_etf','position_cap',
+                'sector_concentration','cash_reserve','leverage_cap','max_daily_loss',
+                'sleeve_cap'
+            )),
+            severity TEXT NOT NULL CHECK(severity IN ('hard','soft')),
+            block_reason TEXT NOT NULL,
+            evidence_json TEXT NOT NULL,
+            run_id TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (decision_id) REFERENCES agent_decisions(decision_id)
+        );
+        INSERT INTO execution_blocks_new
+            (block_id, decision_id, block_type, severity, block_reason,
+             evidence_json, run_id, created_at)
+            SELECT block_id, decision_id, block_type, severity, block_reason,
+                   evidence_json, run_id, created_at
+              FROM execution_blocks;
+        DROP TABLE execution_blocks;
+        ALTER TABLE execution_blocks_new RENAME TO execution_blocks;
+        CREATE INDEX IF NOT EXISTS idx_blocks_decision ON execution_blocks(decision_id);
+        CREATE INDEX IF NOT EXISTS idx_blocks_type ON execution_blocks(block_type, created_at);
+        CREATE INDEX IF NOT EXISTS idx_blocks_severity ON execution_blocks(severity, created_at);
+        CREATE INDEX IF NOT EXISTS idx_blocks_run ON execution_blocks(run_id);
+    """,
+    ),
 ]

--- a/tests/agents/test_execution_firewall.py
+++ b/tests/agents/test_execution_firewall.py
@@ -415,6 +415,89 @@ class TestMaxDailyLossLockTest:
         assert all(b["type"] != "max_daily_loss" for b in result.output["blocks"])
 
 
+class TestSleeveCapLockTest:
+    """LOCK-TEST: §3.11 실험 슬리브 여력 초과 + BUY → BLOCK (#834).
+
+    게이트는 **opt-in** 이다 — `account` 없이는 계좌별 상한을 판정할 수 없고
+    (portfolio_state 는 계좌 구분을 담지 않는다), 조용히 아무 계좌나 골라 판정하면
+    엉뚱한 매수를 막는다. 그래서 account 부재 = 미검사가 정답이다.
+    """
+
+    def test_no_account_means_no_sleeve_lookup_at_all(self, patched_db):
+        """account 없으면 headroom 계산 자체를 하지 않는다.
+
+        Gotcha-Test Pair: `if account:` 가드를 없애면 호출이 일어나 FAIL.
+        """
+        _seed_decision(patched_db, "dc-sleeve-noacct")
+        with patch("nuri.analysis.sleeve.sleeve_headroom") as mock_headroom:
+            result = ExecutionFirewall().run(_check_payload("dc-sleeve-noacct", "NVDA"))
+        mock_headroom.assert_not_called()
+        assert all(b["type"] != "sleeve_cap" for b in result.output["blocks"])
+
+    def test_buy_exceeding_headroom_blocks(self, patched_db):
+        _seed_decision(patched_db, "dc-sleeve-over")
+        with patch("nuri.analysis.sleeve.sleeve_headroom", return_value=500.0):
+            result = ExecutionFirewall().run(
+                _check_payload("dc-sleeve-over", "NVDA", account="Brokerage Alpha", proposed_position_value=3000.0)
+            )
+        assert result.outcome == Outcome.BLOCK
+        assert any(b["type"] == "sleeve_cap" for b in result.output["blocks"])
+
+    def test_buy_within_headroom_passes(self, patched_db):
+        _seed_decision(patched_db, "dc-sleeve-ok")
+        with patch("nuri.analysis.sleeve.sleeve_headroom", return_value=5000.0):
+            result = ExecutionFirewall().run(
+                _check_payload("dc-sleeve-ok", "NVDA", account="Brokerage Alpha", proposed_position_value=3000.0)
+            )
+        assert all(b["type"] != "sleeve_cap" for b in result.output["blocks"])
+
+    def test_undefined_cap_means_no_limit(self, patched_db):
+        """상한이 정의되지 않은 전략(headroom=None)은 슬리브 판정 대상이 아니다."""
+        _seed_decision(patched_db, "dc-sleeve-none")
+        with patch("nuri.analysis.sleeve.sleeve_headroom", return_value=None):
+            result = ExecutionFirewall().run(
+                _check_payload("dc-sleeve-none", "NVDA", account="Brokerage Alpha", proposed_position_value=99_000.0)
+            )
+        assert all(b["type"] != "sleeve_cap" for b in result.output["blocks"])
+
+    def test_sell_is_not_sleeve_gated(self, patched_db):
+        """슬리브는 신규 투입 자본 상한 — 회수(SELL)를 막으면 상한 복구가 불가능해진다."""
+        _seed_decision(patched_db, "dc-sleeve-sell", action="SELL")
+        with patch("nuri.analysis.sleeve.sleeve_headroom", return_value=0.0) as mock_headroom:
+            result = ExecutionFirewall().run(
+                _check_payload(
+                    "dc-sleeve-sell",
+                    "NVDA",
+                    trade_action="SELL",
+                    account="Brokerage Alpha",
+                    proposed_position_value=3000.0,
+                )
+            )
+        mock_headroom.assert_not_called()
+        assert all(b["type"] != "sleeve_cap" for b in result.output["blocks"])
+
+    def test_block_persists_and_evidence_carries_no_account_name(self, patched_db):
+        """block_type='sleeve_cap' 가 CHECK 를 통과해 기록된다 + evidence 에 broker name 없음.
+
+        Gotcha-Test Pair: migration 47 (또는 `_BLOCK_TYPES` 의 'sleeve_cap') 을 되돌리면
+        log_execution_block 이 죽어 FAIL — 게이트만 넣고 스키마를 빼먹는 조합을 잠근다.
+        """
+        _seed_decision(patched_db, "dc-sleeve-audit")
+        with patch("nuri.analysis.sleeve.sleeve_headroom", return_value=0.0):
+            ExecutionFirewall().run(
+                _check_payload("dc-sleeve-audit", "NVDA", account="Brokerage Alpha", proposed_position_value=1000.0)
+            )
+        rows = query(
+            "SELECT block_type, severity, evidence_json FROM execution_blocks WHERE decision_id=?",
+            ("dc-sleeve-audit",),
+            db_path=patched_db,
+        )
+        sleeve_rows = [dict(r) for r in rows if dict(r)["block_type"] == "sleeve_cap"]
+        assert len(sleeve_rows) == 1
+        assert sleeve_rows[0]["severity"] == "hard"
+        assert "Brokerage Alpha" not in sleeve_rows[0]["evidence_json"]
+
+
 # ═══════════════════════════════════════════════════════
 # Persistence
 # ═══════════════════════════════════════════════════════

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -338,3 +338,88 @@ def test_cli_shows_concentration_and_sector(db_path, capsys):
     assert rc == 0
     assert "[집중도] TST_A" in out and "[섹터] Semiconductor" in out
     assert "staged 2" in out  # 집중도 1 + 섹터 1
+
+
+# ═══════════════════════════════════════════════════════
+# Tier 1d — §3.11 실험 슬리브 상한 (#834)
+# ═══════════════════════════════════════════════════════
+
+
+def _sleeve_row(strategy="core", used=25.0, cap=10.0, account="Brokerage Alpha"):
+    return {
+        "account": account,
+        "strategy": strategy,
+        "cap_pct": cap,
+        "sleeve_usd": 2500.0,
+        "equity_usd": 10_000.0,
+        "used_pct": used,
+        "over": used > cap,
+    }
+
+
+def test_sleeve_scan_keeps_only_over_cap(db_path):
+    rows = [_sleeve_row(used=25.0), _sleeve_row(strategy="active", used=5.0, cap=20.0, account="Brokerage Beta")]
+    with patch("nuri.analysis.sleeve.sleeve_utilization", return_value=rows):
+        got = portfolio_signals.scan_sleeve_breach(db_path=db_path)
+    assert [r["strategy"] for r in got] == ["core"]
+
+
+def test_sleeve_scan_does_not_exclude_pension(db_path):
+    """1b/1c 와 달리 pension 을 감추지 않는다 — 상한 0 위반은 사전등록 위반이다.
+
+    Gotcha-Test Pair: `_is_pension_account` 필터를 1b/1c 처럼 복사해 넣으면 FAIL.
+    """
+    rows = [_sleeve_row(strategy="pension", used=3.0, cap=0.0, account="연금저축")]
+    with patch("nuri.analysis.sleeve.sleeve_utilization", return_value=rows):
+        got = portfolio_signals.scan_sleeve_breach(db_path=db_path)
+    assert len(got) == 1, "pension 슬리브 침범이 조용히 사라짐"
+
+
+def test_sleeve_payload_is_rebalance_without_sell_verb_or_price_levels():
+    """#429 축 — 슬리브 초과는 REBALANCE 만. 매도 동사·price_levels 금지.
+
+    Gotcha-Test Pair: kind 를 SELL 로 바꾸거나 price_levels 를 붙이면 FAIL.
+    """
+    payload = portfolio_signals._build_sleeve_rebalance_payload(_sleeve_row(), "2026-07-08")
+    assert payload["kind"] == "REBALANCE"
+    assert "price_levels" not in payload
+    for verb in ("매도", "청산", "손절", "SELL"):
+        assert verb not in payload["reason"], f"REBALANCE payload 에 매도 동사({verb})"
+
+
+def test_sleeve_payload_hides_account_name(db_path):
+    """계좌 키(broker name)는 사용자 노출 텍스트에 들어가면 안 된다 — 전략 라벨만.
+
+    Gotcha-Test Pair: ticker 슬롯에 row['account'] 를 쓰면 FAIL.
+    """
+    row = _sleeve_row(account="Brokerage Alpha")
+    payload = portfolio_signals._build_sleeve_rebalance_payload(row, "2026-07-08")
+    assert "Brokerage Alpha" not in json.dumps(payload, ensure_ascii=False)
+    assert "core" in payload["ticker"]
+
+
+def test_sleeve_staging_writes_normal_priority_and_dedupes(db_path):
+    with patch("nuri.analysis.sleeve.sleeve_utilization", return_value=[_sleeve_row()]):
+        s1 = portfolio_signals.stage_sleeve_briefs(date="2026-07-08", db_path=db_path)
+        s2 = portfolio_signals.stage_sleeve_briefs(date="2026-07-08", db_path=db_path)  # 재실행
+    assert (s1, s2) == (1, 0)
+    rows = query("SELECT priority, dedupe_key FROM discord_outbox WHERE channel='brief'", db_path=db_path)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "normal"
+    assert rows[0]["dedupe_key"] == "rebalance:sleeve:Brokerage Alpha:2026-07-08"
+
+
+def test_sleeve_within_cap_stages_nothing(db_path):
+    with patch("nuri.analysis.sleeve.sleeve_utilization", return_value=[_sleeve_row(used=5.0)]):
+        assert portfolio_signals.stage_sleeve_briefs(date="2026-07-08", db_path=db_path) == 0
+
+
+def test_cli_shows_sleeve_breach(db_path, capsys):
+    with (
+        patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]),
+        patch("nuri.analysis.sleeve.sleeve_utilization", return_value=[_sleeve_row()]),
+    ):
+        rc = portfolio_signals.main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "[슬리브] core" in out and "staged 1" in out

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -264,6 +264,49 @@ def test_write_brief_survives_sector_staging_error(seeded_db, portfolio_yaml):
     assert path.exists()
 
 
+def test_write_brief_stages_sleeve_breach_us_only(seeded_db, portfolio_yaml):
+    """Tier 1d wiring lock — §3.11 슬리브 초과도 US 세션에서만 stage (#834).
+
+    배선 제거 시 FAIL. `nuri/analysis/sleeve.py` 가 존재해도 여기 호출이 없으면
+    사용자는 상한 초과를 영영 못 본다 — 오늘 하루 반복해서 나온 "wired ≠ live" 패턴.
+    """
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    sleeve_spy = MagicMock(return_value=0)
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", MagicMock(return_value=0)),
+        patch("nuri.alerts.portfolio_signals.stage_sector_briefs", MagicMock(return_value=0)),
+        patch("nuri.alerts.portfolio_signals.stage_sleeve_briefs", sleeve_spy),
+    ):
+        write_brief("us", date="2026-05-01")
+        write_brief("kr", date="2026-05-01")
+
+    sleeve_spy.assert_called_once()
+    assert sleeve_spy.call_args[0][0] == "2026-05-01"
+
+
+def test_write_brief_survives_sleeve_staging_error(seeded_db, portfolio_yaml):
+    """슬리브 staging 이 raise 해도 write_brief 는 정상 반환 (독립 best-effort)."""
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", MagicMock(return_value=0)),
+        patch("nuri.alerts.portfolio_signals.stage_sector_briefs", MagicMock(return_value=0)),
+        patch("nuri.alerts.portfolio_signals.stage_sleeve_briefs", side_effect=RuntimeError("boom")),
+    ):
+        path = write_brief("us", date="2026-05-01")  # 예외 전파 안 함
+
+    assert path.exists()
+
+
 def test_us_session_dst_aware_cron_dispatch():
     """NYSE 16:30 ET window — EDT (KST 05:30) / EST (KST 06:30) 양쪽 검증.
 

--- a/tests/analysis/test_sleeve.py
+++ b/tests/analysis/test_sleeve.py
@@ -1,0 +1,201 @@
+"""§3.11 실험 슬리브 소속·사용률 (#834).
+
+핵심은 **소속 판별**이다. 티커가 BUY 추천에 등장했다는 사실만으로 슬리브로 보면
+기존 보유가 통째로 오분류된다 — 실측(2026-07-28) 상 사전등록일 이후 BUY 추천 종목이
+전부 이미 보유 중이었고, 다수는 측정 모드보다 한참 앞서 열린 포지션이었다. 사용률이
+허구가 되고 그 숫자가 신규 매수를 차단하므로, 오분류는 조용한 오작동이다.
+
+합성 티커 TST_* + placeholder 계좌만 (privacy — `tests/CLAUDE.md`).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from nuri.analysis import sleeve
+from nuri.core.db import get_db, init_db
+
+DECLARED = "2026-07-08"
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "sleeve.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, *, holdings, buy_recs):
+    """holdings: [(account, ticker, first_buy_date)] · buy_recs: [(ticker, date)]"""
+    with get_db(db_path) as conn:
+        for account, ticker, fbd in holdings:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, first_buy_date) "
+                "VALUES (?, ?, 10, 100.0, 'USD', ?)",
+                (account, ticker, fbd),
+            )
+        for i, (ticker, date) in enumerate(buy_recs, start=1):
+            conn.execute(
+                "INSERT INTO recommendations (id, date, ticker, action) VALUES (?, ?, ?, 'BUY')",
+                (i, date, ticker),
+            )
+            conn.execute(
+                "INSERT INTO agent_decisions "
+                "(decision_id, ticker, as_of_date, action, conviction, inputs_json, rationale_json, status) "
+                "VALUES (?, ?, ?, 'BUY', 50, '{}', '{}', 'emitted')",
+                (f"rec_{i}", ticker, date),
+            )
+
+
+class TestSleeveCaps:
+    def test_caps_come_from_rules_yaml_only(self):
+        """상한의 canonical 소스는 rules.yaml 뿐 — 하드코딩 금지 (§3.11 lock)."""
+        caps = sleeve.sleeve_caps()
+        assert set(caps) >= {"core", "active", "swing", "long_term", "pension"}
+        assert caps["pension"] == 0, "연금은 실험 슬리브 대상이 아니다"
+        assert caps["long_term"] == 0
+
+
+class TestMembership:
+    def test_preexisting_holding_is_not_sleeve_even_if_recommended(self, db_path):
+        """**핵심 회귀** — 측정 모드 이전부터 보유한 종목은 BUY 추천이 있어도 슬리브가 아니다.
+
+        Gotcha-Test Pair: `first_buy_date >= declared_date` 조건을 빼면 이 테스트가 FAIL.
+        실측상 그 조건이 없으면 보유 20건 중 10건이 슬리브로 잡힌다.
+        """
+        _seed(
+            db_path,
+            holdings=[("Brokerage Alpha", "TST_A", "2025-01-15")],  # 측정 모드보다 한참 앞섬
+            buy_recs=[("TST_A", "2026-07-20")],
+        )
+        assert sleeve.sleeve_members(db_path=db_path) == set()
+
+    def test_new_position_with_recommendation_is_sleeve(self, db_path):
+        _seed(
+            db_path,
+            holdings=[("Brokerage Alpha", "TST_B", "2026-07-20")],
+            buy_recs=[("TST_B", "2026-07-15")],
+        )
+        assert sleeve.sleeve_members(db_path=db_path) == {("Brokerage Alpha", "TST_B")}
+
+    def test_new_position_without_recommendation_is_not_sleeve(self, db_path):
+        """추천 없이 산 종목은 시스템 자본이 아니다 — 사용자 재량 매수."""
+        _seed(db_path, holdings=[("Brokerage Alpha", "TST_C", "2026-07-20")], buy_recs=[])
+        assert sleeve.sleeve_members(db_path=db_path) == set()
+
+    def test_recommendation_before_declared_date_does_not_qualify(self, db_path):
+        """사전등록일 이전 추천은 판정 창 밖이다."""
+        _seed(
+            db_path,
+            holdings=[("Brokerage Alpha", "TST_D", "2026-07-20")],
+            buy_recs=[("TST_D", "2026-06-01")],
+        )
+        assert sleeve.sleeve_members(db_path=db_path) == set()
+
+
+class TestUtilization:
+    def _fake_portfolio(self, rows):
+        return pd.DataFrame(rows)
+
+    def test_over_cap_is_flagged_without_any_sell_action(self, db_path):
+        """상한 초과는 `over=True` 로만 표면화된다 — SELL/청산 필드가 없어야 한다 (#429 축).
+
+        Gotcha-Test Pair: 초과를 alpha 신호로 승격시키면 이 테스트가 FAIL.
+        """
+        _seed(
+            db_path,
+            holdings=[("Brokerage Alpha", "TST_B", "2026-07-20")],
+            buy_recs=[("TST_B", "2026-07-15")],
+        )
+        df = self._fake_portfolio(
+            [
+                {"account": "Brokerage Alpha", "ticker": "TST_B", "current_value_usd": 5000.0},
+                {"account": "Brokerage Alpha", "ticker": "TST_A", "current_value_usd": 5000.0},
+            ]
+        )
+        with (
+            patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df),
+            patch("nuri.core.rules.get_account_strategy_name", return_value="core"),  # cap 10%
+        ):
+            rows = sleeve.sleeve_utilization(db_path=db_path)
+
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["used_pct"] == 50.0, "5000/10000"
+        assert r["over"] is True, "cap 10% 를 초과했는데 미표시"
+        for forbidden in ("action", "sell_shares", "sell_value_usd", "alpha_action"):
+            assert forbidden not in r, f"슬리브 초과가 alpha/매도 필드({forbidden})를 노출하면 안 된다"
+
+    def test_empty_sleeve_reports_zero_not_missing(self, db_path):
+        """슬리브가 비면 0% 로 보고한다 — 행 자체가 사라지면 대시보드가 침묵한다."""
+        _seed(db_path, holdings=[("Brokerage Alpha", "TST_A", "2025-01-15")], buy_recs=[])
+        df = self._fake_portfolio([{"account": "Brokerage Alpha", "ticker": "TST_A", "current_value_usd": 1000.0}])
+        with (
+            patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df),
+            patch("nuri.core.rules.get_account_strategy_name", return_value="core"),
+        ):
+            rows = sleeve.sleeve_utilization(db_path=db_path)
+        assert len(rows) == 1
+        assert rows[0]["used_pct"] == 0.0
+        assert rows[0]["over"] is False
+
+    def test_strategy_without_cap_is_skipped(self, db_path):
+        """상한이 정의되지 않은 전략은 판정 대상이 아니다."""
+        df = self._fake_portfolio([{"account": "misc", "ticker": "X", "current_value_usd": 100.0}])
+        with (
+            patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df),
+            patch("nuri.core.rules.get_account_strategy_name", return_value="__undefined__"),
+        ):
+            assert sleeve.sleeve_utilization(db_path=db_path) == []
+
+
+class TestHeadroom:
+    def test_headroom_is_cap_minus_used(self, db_path):
+        _seed(db_path, holdings=[("Brokerage Alpha", "TST_B", "2026-07-20")], buy_recs=[("TST_B", "2026-07-15")])
+        df = pd.DataFrame(
+            [
+                {"account": "Brokerage Alpha", "ticker": "TST_B", "current_value_usd": 500.0},
+                {"account": "Brokerage Alpha", "ticker": "TST_A", "current_value_usd": 9500.0},
+            ]
+        )
+        with (
+            patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df),
+            patch("nuri.core.rules.get_account_strategy_name", return_value="core"),  # 10% of 10000 = 1000
+        ):
+            assert sleeve.sleeve_headroom("Brokerage Alpha", db_path=db_path) == 500.0
+
+    def test_unknown_account_has_no_limit(self, db_path):
+        df = pd.DataFrame([{"account": "Brokerage Alpha", "ticker": "X", "current_value_usd": 100.0}])
+        with (
+            patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df),
+            patch("nuri.core.rules.get_account_strategy_name", return_value="core"),
+        ):
+            assert sleeve.sleeve_headroom("Brokerage Beta", db_path=db_path) is None
+
+
+class TestDegenerateInputs:
+    def test_empty_portfolio_yields_no_rows(self, db_path):
+        """빈 포트폴리오(CI · 신규 설치)는 예외가 아니라 빈 결과다 — 게이트가 조용히 통과."""
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=pd.DataFrame()):
+            assert sleeve.sleeve_utilization(db_path=db_path) == []
+            assert sleeve.sleeve_headroom("Brokerage Alpha", db_path=db_path) is None
+
+    def test_zero_equity_account_is_skipped_not_divided_by_zero(self, db_path):
+        df = pd.DataFrame([{"account": "Brokerage Alpha", "ticker": "X", "current_value_usd": 0.0}])
+        with (
+            patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df),
+            patch("nuri.core.rules.get_account_strategy_name", return_value="core"),
+        ):
+            assert sleeve.sleeve_utilization(db_path=db_path) == []
+
+    def test_missing_measurement_mode_block_is_loud(self):
+        """§3.11 블록이 사라지면 조용히 상한 없음으로 통과하지 않고 즉시 터진다.
+
+        Gotcha-Test Pair: `raise` 를 `return {}` 로 바꾸면 상한이 사라져 FAIL.
+        """
+        with patch.dict("nuri.core.rules.RULES", {"measurement_mode": {}}, clear=False):
+            with pytest.raises(RuntimeError, match="measurement_mode"):
+                sleeve.sleeve_caps()

--- a/tests/api/test_alpha.py
+++ b/tests/api/test_alpha.py
@@ -71,3 +71,69 @@ def test_alpha_empty(client):
     assert data["effective_bets"] == 0
     assert data["edge_status"] == "NOT_MEASURABLE"
     assert all(w["n_completed"] == 0 and w["n_pending"] == 0 for w in data["windows"])
+
+
+# ─── §3.11 실험 슬리브 사용률 (#834) ──────────────────────────────────────────
+
+
+def test_alpha_exposes_sleeve_utilization(client):
+    """alpha 헤드라인 옆에 "어떤 자본으로 낸 결과인가"가 같이 나온다.
+
+    Gotcha-Test Pair: 응답에서 `sleeve` 를 빼면 FAIL — 백엔드에 계산이 있어도
+    노출 지점이 없으면 사용자는 상한 초과를 못 본다.
+    """
+    from unittest.mock import patch
+
+    rows = [
+        {
+            "account": "Brokerage Alpha",
+            "strategy": "core",
+            "cap_pct": 10.0,
+            "sleeve_usd": 2500.0,
+            "equity_usd": 10_000.0,
+            "used_pct": 25.0,
+            "over": True,
+        }
+    ]
+    with patch("nuri.analysis.sleeve.sleeve_utilization", return_value=rows):
+        r = client.get("/api/alpha")
+    assert r.status_code == 200
+    sleeve = r.json()["sleeve"]
+    assert sleeve["count"] == 1
+    assert sleeve["any_over"] is True
+    assert sleeve["accounts"][0]["used_pct"] == 25.0
+
+
+def test_alpha_sleeve_never_leaks_account_name(client):
+    """계좌 키(broker name)는 응답에 들어가면 안 된다 — 전략 라벨만 (public repo/dashboard).
+
+    Gotcha-Test Pair: row 를 통째로 응답에 실으면 FAIL.
+    """
+    from unittest.mock import patch
+
+    rows = [
+        {
+            "account": "Brokerage Alpha",
+            "strategy": "core",
+            "cap_pct": 10.0,
+            "sleeve_usd": 2500.0,
+            "equity_usd": 10_000.0,
+            "used_pct": 25.0,
+            "over": True,
+        }
+    ]
+    with patch("nuri.analysis.sleeve.sleeve_utilization", return_value=rows):
+        r = client.get("/api/alpha")
+    assert "Brokerage Alpha" not in r.text
+
+
+def test_alpha_survives_sleeve_failure(client):
+    """슬리브 계산이 터져도 alpha 헤드라인은 살아야 한다 (soft error, shape 유지)."""
+    from unittest.mock import patch
+
+    with patch("nuri.analysis.sleeve.sleeve_utilization", side_effect=RuntimeError("boom")):
+        r = client.get("/api/alpha")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["edge_status"] == "NOT_MEASURABLE"  # 본 계약 유지
+    assert data["sleeve"]["accounts"] == [] and "error" in data["sleeve"]

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,12 +29,36 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_46(self, db_path):
+    def test_schema_version_at_47(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
-        incidents alpha_report_stale enum 확장 (#894) → 46."""
-        assert get_schema_version(db_path) == 46
+        incidents alpha_report_stale enum 확장 (#894) +
+        execution_blocks sleeve_cap enum 확장 (#834) → 47."""
+        assert get_schema_version(db_path) == 47
+
+    def test_block_type_allowlist_matches_sql_check(self, db_path):
+        """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.
+
+        #834 에서 실제로 갈렸다 — CHECK 에 'sleeve_cap' 을 넣고 `_BLOCK_TYPES` 를
+        빼먹으면 `log_execution_block` 이 ValueError 로 죽는다. 반대 방향(파이썬만
+        확장)은 IntegrityError 로 죽는다. 둘 다 firewall 이 통째로 멈추는 고장이라
+        한쪽만 고치는 조합을 여기서 잠근다.
+
+        Gotcha-Test Pair: 어느 한쪽에만 block_type 을 추가하면 FAIL.
+        """
+        import re
+
+        from nuri.core.db.execution_ops import _BLOCK_TYPES
+
+        sql = query(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='execution_blocks'",
+            db_path=db_path,
+        )[0]["sql"]
+        check_body = re.search(r"block_type TEXT NOT NULL CHECK\(block_type IN \((.*?)\)\)", sql, re.S)
+        assert check_body, "execution_blocks CHECK 파싱 실패 — 스키마 형태가 바뀜"
+        in_sql = set(re.findall(r"'([a-z_]+)'", check_body.group(1)))
+        assert in_sql == set(_BLOCK_TYPES), f"SQL CHECK {sorted(in_sql)} != _BLOCK_TYPES {sorted(_BLOCK_TYPES)}"
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
Closes #834.

## Why

`measurement_mode.sleeve_max_equity_pct` has been declared in `config/rules.yaml` since §3.11 was locked, with **zero code reading it**. The §3.11 invariant says capital executing system recommendations *stays inside* the sleeve sub-cap — but nothing measured it and nothing enforced it.

## What

**1. `nuri/analysis/sleeve.py`** — the single calculation both consumers share (`sleeve_caps` / `sleeve_members` / `sleeve_utilization` / `sleeve_headroom`).

Membership is the whole problem. "The ticker appears in a BUY recommendation" does **not** mean the position is sleeve capital. Measured against production: every ticker recommended for buying since the declared date is already held, and most of those positions predate the measurement window entirely. Counting them would report a fabricated utilization figure — and that figure gates new buying.

So membership requires **both**:
1. `portfolio.first_buy_date >= declared_date` (the "exclude existing holdings" call recorded in #848)
2. a BUY recommendation for that ticker inside the window

On production today that yields an **empty sleeve** — utilization 0%, nothing gated yet.

**2. Enforcement — `ExecutionFirewall` gains a `sleeve_cap` hard block.** A BUY exceeding the account's remaining headroom is refused.

- Opt-in on an `account` input: the cap is per-account and `portfolio_state` carries no account distinction, so guessing one would refuse the wrong purchase.
- SELL is never gated — blocking a sale would make an exhausted sleeve unrecoverable.
- `headroom is None` (no declared cap, or empty portfolio) → no limit. This is what keeps CI and fresh installs from blocking every buy.

**Migration 47** had to land with it: `sleeve_cap` was rejected by *both* the SQL CHECK and the `_BLOCK_TYPES` allowlist, and either one alone kills `log_execution_block` and takes the whole firewall down. A new test asserts the two lists are equal — I broke exactly that pair while writing this.

**3. Surfacing — `portfolio_signals` Tier 1d**, staged from the same US post-market path as 1b/1c.

Unlike 1b/1c it does **not** exclude pension accounts: their declared cap is `0`, so a breach there is a pre-registration violation rather than routine drift. Hiding it means discovering a contaminated sample on the evaluation date.

Payload is `kind="REBALANCE"`, no sell verb, no `price_levels` — per §3.11 *"cap-breach resolution surfaces as portfolio_action=REBALANCE only"* and the #429 axis split.

**4. Reading — `GET /api/alpha` carries a `sleeve` block.** That endpoint reports alpha; without utilization beside it there is no way to tell whether the number came from inside the declared bound. Fails soft, so a sleeve error can't take down the alpha headline.

Account keys are broker names, so **neither** the Discord payload **nor** the API response contains one — both label by strategy; the account survives only in the dedupe key.

## Deviation from the issue text

The issue said "rebalance_advisor: 슬리브 사용률 계산 + 초과 시 REBALANCE 권고". I put the surfacing in `portfolio_signals.py` instead. `detect_violations()` is a **sell-quantity calculator** — every row it returns carries `action` / `sell_shares` / `sell_value_usd`, and its three consumers read those fields. A sleeve row there would either have to lie (emit sell quantities) or break the uniform schema. `portfolio_signals.py` is the canonical REBALANCE-only path and already enforces the no-sell-verb contract, so it satisfies the issue's *intent* more faithfully.

## Verification

- `make test-fast` — 6379 passed, 6 skipped
- Coverage on touched modules: `sleeve.py` 100% · `execution_firewall.py` 100% · `portfolio_signals.py` 100% · `routes/alpha.py` 100% · `execution_ops.py` 100%
- Migration 47 applied to a **copy of the production DB**: `46 → 47`, rows preserved, indexes intact, `sleeve_cap` accepted end-to-end through `log_execution_block`
- **Mutation-verified** each Gotcha-Test Pair: removing the `if account:` guard, dropping `sleeve_cap` from `_BLOCK_TYPES`, copying the pension filter into the sleeve scan, and substituting `account` for `strategy` in the payload each make the paired test FAIL
- `make lint` clean · `check_privacy_leak.py` clean on files *and* unpushed commit messages

## Note

Local `pytest --cov` on a *subset* of these files reproduces the known macOS-arm64 numpy `_NoValueType` poisoning (memo: local coverage heisenbug) — it also fails two pre-existing tests untouched here. The full-suite run is green; coverage numbers above are from the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)