### PR TITLE
fix(verify): repair the pre-push gate's dead invocations and lock unquoted paths

### DIFF
--- a/scripts/deploy/autopull_receiver.sh
+++ b/scripts/deploy/autopull_receiver.sh
@@ -93,9 +93,9 @@ if echo "$CHANGED" | grep -qE "^frontend/package(-lock)?\.json$"; then
     log "  cd $REPO/frontend && npm ci"
 fi
 
-if echo "$CHANGED" | grep -qE "^(nuri/core/db\.py|scripts/migrate_db\.py)$"; then
+if echo "$CHANGED" | grep -qE "^(nuri/core/db/.*\.py|nuri/core/db_migrations\.py|scripts/db/migrate\.py)$"; then
     log "WARN: DB schema may have changed. Run manually:"
-    log "  cd $REPO && .venv/bin/python scripts/migrate.py"
+    log "  cd $REPO && .venv/bin/python scripts/db/migrate.py"
 fi
 
 if echo "$CHANGED" | grep -qE "^config/"; then

--- a/scripts/deploy/dev_sync.sh
+++ b/scripts/deploy/dev_sync.sh
@@ -38,7 +38,7 @@ fi
 
 usage() {
     cat <<EOF
-사용법: bash scripts/dev_sync.sh {start|end|status} [options]
+사용법: bash scripts/deploy/dev_sync.sh {start|end|status} [options]
 
   start   다른 머신 → 이 머신 (작업 시작 시)
   end     이 머신 → 다른 머신 (작업 종료 시)

--- a/scripts/dev/ci_local.sh
+++ b/scripts/dev/ci_local.sh
@@ -57,7 +57,7 @@ case "$mode" in
 
     *)
         echo -e "${RED}Unknown mode: $mode${NC}"
-        echo "Usage: bash scripts/ci_local.sh [--lint | --quick | full]"
+        echo "Usage: bash scripts/dev/ci_local.sh [--lint | --quick | full]"
         exit 1
         ;;
 esac

--- a/scripts/dev/demo.sh
+++ b/scripts/dev/demo.sh
@@ -42,8 +42,8 @@ ok "Python venv found"
 
 if [ ! -f "data/portfolio.db" ]; then
     warn "DB not found. Initializing..."
-    $PYTHON scripts/migrate.py
-    $PYTHON scripts/import_portfolio.py
+    $PYTHON scripts/db/migrate.py
+    $PYTHON scripts/ops/import_portfolio.py
 fi
 ok "Database ready"
 

--- a/scripts/verify/pre_push_check.sh
+++ b/scripts/verify/pre_push_check.sh
@@ -68,11 +68,11 @@ fi
 # live code (collectors/endpoints/test files/e2e specs) before push. Fast
 # (<1s, find + grep only).
 echo -e "${YELLOW}━━━ 2c. Doc Count Drift ━━━${NC}"
-if bash scripts/verify_doc_counts.sh > /dev/null 2>&1; then
+if bash scripts/verify/verify_doc_counts.sh > /dev/null 2>&1; then
     echo -e "${GREEN}✓ Doc counts match live code${NC}\n"
 else
     echo -e "${RED}✗ Doc drift detected — run \`make sync-doc-counts\` then amend commit${NC}"
-    bash scripts/verify_doc_counts.sh 2>&1 | grep -E "✗|DRIFT" | head -5
+    bash scripts/verify/verify_doc_counts.sh 2>&1 | grep -E "✗|DRIFT" | head -5
     echo ""
     fail=1
 fi
@@ -82,7 +82,7 @@ if [ "$mode" != "--skip-tests" ]; then
     echo -e "${YELLOW}━━━ 3. Tests (CI parity) ━━━${NC}"
     if [ "$mode" == "--quick" ]; then
         echo -e "  ${YELLOW}Mode: quick (smoke only)${NC}"
-        if bash scripts/ci_local.sh --quick; then
+        if bash scripts/dev/ci_local.sh --quick; then
             echo -e "${GREEN}✓ Smoke tests pass${NC}\n"
         else
             echo -e "${RED}✗ Smoke tests failed${NC}\n"
@@ -90,7 +90,7 @@ if [ "$mode" != "--skip-tests" ]; then
         fi
     else
         echo -e "  ${YELLOW}Mode: full (~2 min, exact CI command)${NC}"
-        if bash scripts/ci_local.sh; then
+        if bash scripts/dev/ci_local.sh; then
             echo -e "${GREEN}✓ Full test parity passed${NC}\n"
         else
             echo -e "${RED}✗ Tests failed — fix before pushing${NC}\n"

--- a/tests/test_script_path_lock.py
+++ b/tests/test_script_path_lock.py
@@ -1,13 +1,22 @@
-"""스크립트 경로 drift 클래스 킬러 (#846/#852, Gotcha-Test Pair).
+"""스크립트 경로 drift 클래스 킬러 (#846/#852/#910, Gotcha-Test Pair).
 
-#557 scripts/ 7-subdir 리팩터가 만든 silent 고장 — 실증 3건:
+#557 scripts/ 7-subdir 리팩터가 만든 silent 고장 — 실증 4건:
 - scheduler backup (scripts/backup.sh → db/) — 2개월 무백업 (#836)
 - discord /health (scripts/health_check.sh → ops/) — rc=127 (#846)
 - pre_push_check.sh 의 flat 경로 호출 — 로컬 pre-push 게이트 일부 무력화 (#852)
+- pre_push_check.sh 의 **따옴표 없는** 호출 — 테스트 단계가 통째로 no-op (#910)
 
-개별 상수 lock 대신, nuri/ 전체 .py + scripts/ 전체 .sh 의 "scripts/…" 리터럴을
-전수 수집해 실존을 검증한다 — 다음 리팩터가 어떤 스크립트를 옮겨도 즉시 FAIL.
-mock-only 테스트 (subprocess patch) 로는 경로 drift 를 못 잡는다 (§5.3).
+개별 상수 lock 대신 "scripts/…" 참조를 전수 수집해 실존을 검증한다 — 다음 리팩터가
+어떤 스크립트를 옮겨도 즉시 FAIL. mock-only 테스트 (subprocess patch) 로는 경로
+drift 를 못 잡는다 (§5.3).
+
+**두 문법을 모두 본다.** #852 는 따옴표 친 리터럴만 스캔해서 `bash scripts/x.sh`
+같은 셸 호출 라인을 통째로 놓쳤고, 그래서 #853 이 "pre-push 경로 수리"를 하고도
+`scripts/ci_local.sh` 를 남겨 테스트 단계가 rc=127 로 계속 죽었다 — 게이트가 빨간불인
+것과 테스트가 실패한 것이 구분되지 않아 아무도 눈치채지 못했다.
+
+주석 라인은 제외한다. docstring 의 usage 예시(`python scripts/foo.py`)는 실행되지
+않는 문서라 여기 대상이 아니다 (문서 drift 는 별개 관심사).
 """
 
 import re
@@ -18,6 +27,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # "scripts/foo/bar.sh" / 'scripts/x.py' 형태의 문자열 리터럴
 _SCRIPT_LITERAL = re.compile(r"""["'](scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))["']""")
 
+# 따옴표 없는 셸/파이썬 호출 — `bash scripts/x.sh`, `if $PYTHON scripts/y.py --flag`,
+# `... && python3 scripts/z.py`. 인터프리터 토큰 직후의 경로만 잡는다.
+_SCRIPT_INVOCATION = re.compile(
+    r"(?:bash|sh|source|\$PYTHON|\$\{PYTHON\}|python3?)\s+(scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))"
+)
+
 
 def _collect_script_literals() -> list[tuple[str, str]]:
     """(참조 위치, 스크립트 경로) 목록 — nuri/ .py + scripts/ .sh 스캔 (#852 확장)."""
@@ -27,6 +42,18 @@ def _collect_script_literals() -> list[tuple[str, str]]:
         text = src.read_text(encoding="utf-8")
         for m in _SCRIPT_LITERAL.finditer(text):
             found.append((str(src.relative_to(REPO_ROOT)), m.group(1)))
+    return found
+
+
+def _collect_script_invocations() -> list[tuple[str, int, str]]:
+    """(참조 위치, 줄번호, 스크립트 경로) — scripts/ .sh 의 실행 라인만 (#910)."""
+    found: list[tuple[str, int, str]] = []
+    for src in sorted((REPO_ROOT / "scripts").rglob("*.sh")):
+        for lineno, line in enumerate(src.read_text(encoding="utf-8").splitlines(), 1):
+            if line.lstrip().startswith("#"):  # usage 주석은 실행 경로가 아님
+                continue
+            for m in _SCRIPT_INVOCATION.finditer(line):
+                found.append((str(src.relative_to(REPO_ROOT)), lineno, m.group(1)))
     return found
 
 
@@ -47,3 +74,27 @@ class TestScriptPathLock:
         assert "scripts/db/backup.sh" in scripts  # nuri/scheduler.py (#836)
         assert "scripts/ops/health_check.sh" in scripts  # nuri/agents/discord/bot.py (#846)
         assert "scripts/dev/llm_consult.py" in scripts  # nuri/llm/thesis_query.py
+
+
+class TestShellInvocationPathLock:
+    """따옴표 없는 셸 호출 (#910) — pre-push 테스트 단계가 죽어 있던 실제 경로."""
+
+    def test_all_invoked_scripts_exist(self):
+        found = _collect_script_invocations()
+        assert found, "scripts/ .sh 에서 셸 호출을 하나도 못 찾음 — sweep 정규식 확인"
+        missing = [(src, ln, script) for src, ln, script in found if not (REPO_ROOT / script).is_file()]
+        assert not missing, (
+            f"셸 호출 경로 drift (#910): {missing} — 존재하지 않는 스크립트를 실행하면 "
+            "rc=127 이 '해당 단계 실패' 와 구분되지 않는다"
+        )
+
+    def test_pre_push_gate_invocations_are_covered(self):
+        """pre-push 게이트의 두 호출이 sweep 에 잡히는지 — canary.
+
+        Gotcha-Test Pair: `_SCRIPT_INVOCATION` 을 지우거나 따옴표 필수로 되돌리면
+        여기서 FAIL — #852 가 이걸 못 봐서 #910 이 생겼다.
+        """
+        invoked = {(src, script) for src, _, script in _collect_script_invocations()}
+        gate = "scripts/verify/pre_push_check.sh"
+        assert (gate, "scripts/verify/verify_doc_counts.sh") in invoked
+        assert (gate, "scripts/dev/ci_local.sh") in invoked


### PR DESCRIPTION
Closes #910.

## The finding

The local pre-push gate (`scripts/verify/pre_push_check.sh`) has been structurally red since the #557 `scripts/` reorg. Two steps invoke files that do not exist:

| Step | Invoked | Actual |
|---|---|---|
| 2c Doc Count Drift | `scripts/verify_doc_counts.sh` | `scripts/verify/verify_doc_counts.sh` |
| **3 Tests (CI parity)** | `scripts/ci_local.sh` | `scripts/dev/ci_local.sh` |

**Step 3 is the reason the gate exists, and it has not run a test since #557.** The shell returns 127; the script records `fail=1`; that is indistinguishable from a genuine test failure. A red gate looked like red tests, so nobody investigated.

After the repair the script emits `✓ ALL CHECKS PASSED` — the first time in that window:

```
━━━ 2c. Doc Count Drift ━━━     ✓ Doc counts match live code
━━━ 3. Tests (CI parity) ━━━    ✓ Smoke tests pass
  ✓ ALL CHECKS PASSED — safe to push
```

## Why the class killer missed it

`tests/test_script_path_lock.py` was added in #852 to kill exactly this class, and #853 repaired the paths it could see. Neither caught these, because the sweep requires quotes:

```python
_SCRIPT_LITERAL = re.compile(r"""["'](scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))["']""")
```

Shell invocations are unquoted (`bash scripts/ci_local.sh`), so **every executed path inside a `.sh` file was invisible to the class killer built to find them.**

This adds a second sweep over unquoted interpreter invocations (`bash|sh|source|$PYTHON|python`) in `scripts/**/*.sh`, skipping comment lines so docstring usage examples stay out of scope, plus a canary asserting the two pre-push invocations are covered.

## What the new sweep found

Three more, all operator-facing rather than executed:

- **`autopull_receiver.sh`'s DB-schema warning is dead in both directions.** Its trigger matches `nuri/core/db.py` and `scripts/migrate_db.py` — the first became a package in #566, the second never existed under that name — so **it has never fired**; and the remedy it would print names `scripts/migrate.py`, also gone. Trigger now matches `nuri/core/db/**`, `db_migrations.py`, and `scripts/db/migrate.py`; remedy points at `scripts/db/migrate.py`.
  Migrations still apply automatically through `init_db()`, so this was a lost **signal**, not lost migrations.
- `dev_sync.sh` and `ci_local.sh` print usage lines naming their own pre-#557 paths.

## Verification

- `bash scripts/verify/pre_push_check.sh --quick` → ALL CHECKS PASSED (every step green, including 2c and 3)
- `pytest tests/test_script_path_lock.py` → 4 passed
- **Mutation-verified**: reverting `_SCRIPT_INVOCATION` to require quotes makes `test_pre_push_gate_invocations_are_covered` FAIL; restoring any one stale path makes `test_all_invoked_scripts_exist` FAIL
- `make lint` + `make lint-sh` clean

## Out of scope

~22 stale `scripts/…` paths in module **docstrings / usage comments** (`python scripts/check_privacy_leak.py` etc). Not executed — documentation drift, tracked separately in #910's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)