### PR TITLE
fix(api): stop returning raw exception text from the ticker consensus fallback

### DIFF
--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -1,12 +1,15 @@
 """종목 상세 API — 모든 데이터를 한 번에."""
 
 import json
+import logging
 import time
 from dataclasses import asdict
 
 from fastapi import APIRouter, Query
 
 from nuri.core.db import query
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["ticker"])
 
@@ -94,8 +97,12 @@ def _get_consensus(ticker: str) -> dict:
             "dissent": consensus.dissent,
             "as_of": today_kst(),
         }
-    except Exception as e:
-        return {"error": str(e)}
+    except Exception:
+        # 예외 문자열을 응답에 실으면 스택 트레이스·내부 경로가 외부로 나간다
+        # (CodeQL py/stack-trace-exposure). 진단은 로그, 클라이언트에는 generic 메시지
+        # — `nuri/api/CLAUDE.md` "Error handling" 의 soft 패턴.
+        logger.exception("live consensus 계산 실패: %s", ticker)
+        return {"error": "consensus unavailable"}
 
 
 def _get_signals(ticker: str) -> list:

--- a/tests/api/test_ticker.py
+++ b/tests/api/test_ticker.py
@@ -88,16 +88,25 @@ class TestTicker:
         assert r.json()["trend"] is None
 
     def test_ticker_consensus_db_miss_falls_back_to_live(self, client, monkeypatch):
-        """recommendations 행 없음 → live analyze_ticker fallback, raise 시 error 필드."""
+        """recommendations 행 없음 → live analyze_ticker fallback, raise 시 error 필드.
+
+        error 메시지는 **generic** 이어야 한다 — 예외 문자열을 그대로 실으면 스택
+        트레이스·내부 경로가 외부로 나간다 (CodeQL py/stack-trace-exposure, alert #28).
+        읽기 엔드포인트는 인증이 없어 이 응답은 대시보드에 닿는 누구에게나 보인다.
+
+        Gotcha-Test Pair: `return {"error": str(e)}` 로 되돌리면 FAIL.
+        """
 
         def boom(t):
-            raise RuntimeError("consensus down")
+            raise RuntimeError("secret-internal-detail /Users/someone/nuri/x.py")
 
         monkeypatch.setattr("nuri.trading.agents.consensus.analyze_ticker", boom)
         r = client.get("/api/ticker/AAPL")
         assert r.status_code == 200
         data = r.json()
         assert "error" in data["consensus"]
+        assert "secret-internal-detail" not in r.text, "예외 문자열이 응답으로 새어 나감"
+        assert "/Users/" not in r.text, "내부 경로가 응답으로 새어 나감"
 
     def test_ticker_consensus_read_from_db_no_live_call(self, client, tmp_path, monkeypatch):
         """recommendations 행 존재(fresh) → DB read 로 복원, analyze_ticker 미호출.


### PR DESCRIPTION
Resolves the only open **code scanning** alert — #28 `py/stack-trace-exposure`, live on `main` since 2026-07-12.

## The leak

`nuri/api/routes/ticker.py::_get_consensus` falls back to a live `analyze_ticker` when `recommendations` has no fresh row. On failure it returned:

```python
except Exception as e:
    return {"error": str(e)}
```

That value lands in `result["consensus"]` and is serialized straight out of `GET /api/ticker/{symbol}` (CodeQL flags the `return result` at line 306 as the sink). **Read endpoints carry no auth** (`API_AUTH_ENABLED=false`), so the exception text reaches anyone who can reach the dashboard — and for an import or file error that text carries absolute filesystem paths.

`nuri/api/CLAUDE.md` already documents the rule:

> Always `logger.exception(...)` first and keep the client message **generic** — never interpolate the exception (CodeQL `py/stack-trace-exposure`).

This file predates that convention. Now it matches `coverage.py` / `actions.py` / `alpha.py`: `logger.exception` for diagnosis, generic `consensus unavailable` for the client.

## Test

The existing test asserted only that an `error` key exists — it passes with **either** implementation, which is why the leak survived. It now raises with an identifiable marker plus an absolute path and asserts neither appears in the response body.

**Mutation-verified**: restoring `return {"error": str(e)}` makes `test_ticker_consensus_db_miss_falls_back_to_live` FAIL.

## Verification

- `pytest tests/api/test_ticker.py` → 14 passed
- `make lint` clean

Dependabot alerts are handled separately — 37 open across two ecosystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)