### PR TITLE
fix(doc): revive sync-doc-counts and lock it to the gate that points at it

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Measured against `main` on 2026-07-28. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,417 collected across 284 files | |
+| **Backend tests** | 6,424 collected across 285 files | |
 | **Backend statement coverage** | 99.88% — 28 of 22,539 statements uncovered, across 9 files (Codecov `backend` flag) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,417 backend tests across 284 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-05-06)** — full closure verified via CI artifact combine of all 6 shards (4 fast + 2 slow).
+6,424 backend tests across 285 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99.88% (2026-07-28)** — 28 of 22,539 statements uncovered across 9 files, per the Codecov `backend` flag. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,417 tests, 284 files (statement coverage **100%**, 2026-05-06) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,424 tests, 285 files (statement coverage **99.88%** — 28/22,539 미커버, 2026-07-28) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -57,6 +57,13 @@ init_db(Path(_p))
 print(sqlite3.connect(_p).execute(\"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'\").fetchone()[0])
 " 2>/dev/null; }
 
+# verify_doc_counts.sh 와 동일 정의 — 두 스크립트의 claim 목록이 갈라지면
+# 게이트가 잡은 drift 를 이 스크립트가 못 고치는 상태가 된다 (#916 의 본질).
+# tests/verify/test_doc_claim_parity.py 가 두 목록의 포함관계를 잠근다.
+live_migrations()     { grep -cE '^        [0-9]+,$' nuri/core/db_migrations.py || true; }
+live_scheduler_jobs() { grep -cE '"cron":' nuri/scheduler.py || true; }
+live_rules_lines()    { wc -l < config/rules.yaml | tr -d ' '; }
+
 live_tests_be() {
     $PYTHON -m pytest tests/ --collect-only -q 2>/dev/null \
         | grep -oE '[0-9]+/[0-9]+ tests collected' \
@@ -82,7 +89,9 @@ update_claim() {
         warn "$file not found — skipped"
         return
     fi
-    current=$(grep -oE "$pattern" "$file" | head -1)
+    # `|| true` 없으면 set -e 가 여기서 스크립트를 죽여, 바로 아래 warn 분기가
+    # 영영 실행되지 않는다 (#916). 그 상태로 이 스크립트는 배너만 찍고 exit 1 했다.
+    current=$(grep -oE "$pattern" "$file" | head -1 || true)
     if [ -z "$current" ]; then
         warn "$file: pattern not found — $pattern"
         FAILED=$((FAILED + 1))
@@ -110,19 +119,21 @@ update_claim() {
 
 banner "Doc Count Sync"
 
-# Collectors (3 sites)
-update_claim live_collectors     CLAUDE.md                     '[0-9]+ collector modules'
+# Collectors (3 sites) — CLAUDE.md 가 .claude/rules/ 로 분할되며 이사함 (#916)
+update_claim live_collectors     .claude/rules/architecture.md '[0-9]+ collector modules'
 update_claim live_collectors     nuri/collectors/CLAUDE.md     '[0-9]+ Data Collectors'
 update_claim live_collectors     README.md                     '[0-9]+ collectors \(BaseCollector'
 
-# Endpoints (3 sites)
-update_claim live_endpoints      CLAUDE.md                     '\([0-9]+ endpoints, routes/'
+# Endpoints (4 sites)
+update_claim live_endpoints      .claude/rules/architecture.md '\([0-9]+ endpoints, routes/'
 update_claim live_endpoints      docs/ARCHITECTURE.md          '## API \([0-9]+ endpoints\)'
 update_claim live_endpoints      docs/ARCHITECTURE.md          '— [0-9]+ REST endpoints'
+update_claim live_endpoints      nuri/api/CLAUDE.md            'read surface \([0-9]+ endpoints\)'
 
 # Backend test files (2 sites)
 update_claim live_test_files_be  docs/ARCHITECTURE.md          'backend tests across [0-9]+ files'
 update_claim live_test_files_be  docs/STRATEGY.md              'Backend tests.*tests, [0-9]+ files'
+update_claim live_test_files_be  README.md                     'collected across [0-9]+ files'
 
 # Frontend test files (2 sites)
 update_claim live_test_files_fe  docs/ARCHITECTURE.md          'frontend vitest \([0-9]+ files\)'
@@ -133,6 +144,12 @@ update_claim live_e2e_specs      docs/ARCHITECTURE.md          'Playwright E2E \
 
 update_claim live_regimes        README.md                     '· [0-9]+ regimes'
 update_claim live_db_tables      README.md                     'SQLite WAL · [0-9]+ tables'
+
+# grep/wc 기반 — verify 가 하드 게이트하는데 sync 에는 없어서, 이 셋이 drift 하면
+# 게이트가 빨간불인 채 고칠 방법이 없었다 (#916).
+update_claim live_migrations     README.md                     '[0-9]+ forward-only migrations'
+update_claim live_scheduler_jobs docs/ARCHITECTURE.md          '[0-9]+ cron jobs in'
+update_claim live_rules_lines    config/CLAUDE.md              '\| [0-9]+ \| Investment rules'
 
 # Pytest collect count — runs pytest which is slow; do last so failures above
 # don't waste the call. Updates any "[0-9,]+ backend tests" / "[0-9,]+ tests,"
@@ -159,7 +176,7 @@ if [ -n "$TESTS_BE" ]; then
         local file="$1" pattern="$2"
         [ ! -f "$file" ] && return
         local current new
-        current=$(grep -oE "$pattern" "$file" | head -1)
+        current=$(grep -oE "$pattern" "$file" | head -1 || true)   # set -e 가드 (#916)
         [ -z "$current" ] && return
         new=$(echo "$current" | sed -E "s/[0-9,]+/$TESTS_DISPLAY/")
         if [ "$current" = "$new" ]; then
@@ -174,16 +191,24 @@ if [ -n "$TESTS_BE" ]; then
         CHANGED=$((CHANGED + 1))
     }
 
-    # STRATEGY.md Backend row also contains "1%" before "2,993 tests"; narrow
-    # pattern to the "X,YYY tests, NN files |" suffix so "1%" isn't clobbered.
+    # 패턴은 두 조건을 동시에 만족해야 한다: (a) 대상 행을 고유하게 집을 것,
+    # (b) 매치 문자열의 **첫** 숫자 런이 바꿀 숫자일 것 — sed 가 첫 런을 치환한다.
+    #   · 옛 '[0-9,]+ tests, [0-9]+ files \|' 은 (b)는 만족하나 (a) 실패:
+    #     바로 아래 Frontend 행에도 매치해 head -1 이 그쪽을 집었고, 프론트 수치를
+    #     백엔드 수치로 덮어썼다 (#916 복구 직후 실측: 1449 → 6,417).
+    #   · 'Backend tests.*[0-9,]+ tests' 로 넓히면 (a)는 되나 (b) 실패:
+    #     첫 숫자 런이 같은 행의 "Codecov 1%" 라 1% 가 파괴된다.
+    # 뒤따르는 '(statement' 로 Backend 행을 식별하면 둘 다 만족한다 (Frontend 행에는 없음).
     update_comma_number docs/ARCHITECTURE.md '[0-9,]+ backend tests across'
-    update_comma_number docs/STRATEGY.md     '[0-9,]+ tests, [0-9]+ files \|'
-    update_comma_number README.md            '\([0-9,]+ backend \+'
+    update_comma_number docs/STRATEGY.md     '[0-9,]+ tests, [0-9]+ files \(statement'
+    update_comma_number README.md            '[0-9,]+ collected across'
 fi
 
 echo ""
 if [ "$FAILED" -gt 0 ]; then
-    echo -e "${YELLOW}$FAILED claim(s) could not be processed. Manifest may be out of date.${NC}"
+    echo -e "${RED}$FAILED claim(s) could not be processed — the manifest above points at text that no longer exists.${NC}"
+    echo -e "${RED}Fix the target list in this script; a stale entry means that claim is no longer auto-synced.${NC}"
+    exit 1
 fi
 if [ "$CHANGED" -eq 0 ]; then
     echo -e "${CYAN}All doc counts already in sync.${NC}"

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -127,6 +127,7 @@ check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '— [0-9]+ RE
 check_claim "endpoints"      "$EP"   "nuri/api/CLAUDE.md"         'read surface \([0-9]+ endpoints\)' || true
 check_claim "test_files_be"  "$TFBE" "docs/ARCHITECTURE.md"       'backend tests across [0-9]+ files' || true
 check_claim "test_files_be"  "$TFBE" "docs/STRATEGY.md"           'Backend tests.*tests, [0-9]+ files' || true
+check_claim "test_files_be"  "$TFBE" "README.md"                  'collected across [0-9]+ files' || true
 check_claim "test_files_fe"  "$TFFE" "docs/ARCHITECTURE.md"       'frontend vitest \([0-9]+ files\)' || true
 check_claim "test_files_fe"  "$TFFE" "docs/STRATEGY.md"           'Frontend tests.*tests, [0-9]+ files' || true
 check_claim "e2e_specs"      "$E2E"  "docs/ARCHITECTURE.md"       'Playwright E2E \([0-9]+ spec files\)' || true

--- a/tests/verify/test_doc_claim_parity.py
+++ b/tests/verify/test_doc_claim_parity.py
@@ -1,0 +1,204 @@
+"""doc-count 게이트와 그 fixer 가 같은 클레임 목록을 본다 (#916).
+
+`verify_doc_counts.sh` 는 검사하고 `sync_doc_counts.sh` 는 고친다. 두 목록이
+갈라지면 **게이트가 잡은 drift 를 그 게이트가 안내하는 명령이 못 고치는** 상태가
+된다 — verify 는 빨간불, sync 는 "할 일 없음". 실제로 `CLAUDE.md` 가
+`.claude/rules/` 로 쪼개진 뒤 sync 가 첫 클레임에서 `set -e` 로 죽어 아무것도
+고치지 않았고, 그동안 verify 는 계속 그 명령을 해결책으로 안내했다.
+
+여기서 잠그는 것:
+  1. sync 가 배너만 찍고 죽지 않는다 (실제 고장 모드의 직접 재현)
+  2. verify 가 검사하는 (파일, 클레임) 을 sync 도 전부 다룬다
+  3. round-trip — 숫자를 망가뜨리면 sync 가 고치고 verify 가 통과한다
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFY = REPO_ROOT / "scripts" / "verify" / "verify_doc_counts.sh"
+SYNC = REPO_ROOT / "scripts" / "doc" / "sync_doc_counts.sh"
+
+# `update_claim <live_fn> <file> '<pattern>'` / `check_claim "<label>" "$X" "<file>" '<pattern>'`
+_SYNC_CALL = re.compile(r"^update_claim\s+(\S+)\s+(\S+)\s+'(.+)'\s*$", re.M)
+_VERIFY_CALL = re.compile(r"""check_claim\s+"[^"]+"\s+"[^"]+"\s+"([^"]+)"\s+'(.+?)'\s*(?:\|\||$)""", re.M)
+
+
+def _sync_targets() -> set[tuple[str, str]]:
+    return {(f, pat) for _fn, f, pat in _SYNC_CALL.findall(SYNC.read_text())}
+
+
+def _verify_targets() -> set[tuple[str, str]]:
+    return {(f, pat) for f, pat in _VERIFY_CALL.findall(VERIFY.read_text())}
+
+
+class TestSyncRuns:
+    def test_sync_does_more_than_print_its_banner(self):
+        """#916 의 고장 모드 그대로 — 배너만 찍고 종료하면 FAIL.
+
+        Gotcha-Test Pair: `current=$(grep ... || true)` 의 `|| true` 를 지우면
+        set -e 가 첫 클레임에서 스크립트를 죽여 이 테스트가 FAIL.
+        """
+        r = subprocess.run(["bash", str(SYNC)], cwd=REPO_ROOT, capture_output=True, text=True, timeout=300, check=False)
+        processed = [ln for ln in r.stdout.splitlines() if "already in sync" in ln or "→" in ln]
+        assert len(processed) >= 15, (
+            f"클레임을 {len(processed)}건만 처리했다 — 중간에 죽었을 가능성:\n{r.stdout}{r.stderr}"
+        )
+        assert r.returncode == 0, f"clean tree 인데 exit {r.returncode}:\n{r.stdout}{r.stderr}"
+
+
+class TestStaleTargetIsSurvivable:
+    """대상 문구가 이사가도 스크립트가 죽지 않고 나머지를 계속 처리한다.
+
+    건강한 레포에서는 모든 패턴이 존재하므로 `set -e` 가 발동할 일이 없다 — 즉
+    이 방어선은 **미래의 stale** 에만 작동하고, 그 상황을 여기서 인위적으로 만들지
+    않으면 `|| true` 를 지워도 아무 테스트가 반응하지 않는다. #916 이 정확히 그
+    "아직 아무도 밟지 않은 지뢰" 였다.
+    """
+
+    def test_missing_pattern_warns_and_continues(self, repo_copy):
+        """첫 클레임의 대상 문구를 지워도 나머지가 처리되고, 조용히 넘어가지 않는다.
+
+        Gotcha-Test Pair: `grep ... | head -1 || true` 의 `|| true` 를 지우면
+        set -e 가 첫 클레임에서 스크립트를 죽여 processed 가 0 이 되고 FAIL.
+        """
+        target = repo_copy / ".claude" / "rules" / "architecture.md"
+        target.write_text(target.read_text().replace("collector modules", "collector thingies"))
+
+        r = _run(SYNC, repo_copy)
+
+        processed = [ln for ln in r.stdout.splitlines() if "already in sync" in ln or "→" in ln]
+        assert len(processed) >= 10, f"stale 대상 하나에 스크립트가 멈췄다 ({len(processed)}건 처리):\n{r.stdout}"
+        assert "pattern not found" in r.stdout, f"누락을 알리지 않음:\n{r.stdout}"
+        assert r.returncode != 0, "manifest 가 깨졌는데 exit 0 — 조용히 넘어감"
+
+
+class TestClaimListParity:
+    def test_both_scripts_were_parsed(self):
+        """정규식이 조용히 눈이 멀면 아래 포함관계 테스트가 공허하게 통과한다."""
+        assert len(_sync_targets()) >= 15, _sync_targets()
+        assert len(_verify_targets()) >= 15, _verify_targets()
+
+    def test_every_verified_claim_is_also_syncable(self):
+        """verify 가 하드 게이트하는 클레임은 sync 도 고칠 수 있어야 한다.
+
+        Gotcha-Test Pair: verify 에 check_claim 을 추가하고 sync 에 대응 항목을
+        빼면 FAIL — 그 조합이 "빨간불인데 고칠 수단이 없는" 상태다.
+        """
+        missing = sorted(_verify_targets() - _sync_targets())
+        assert not missing, (
+            "verify 는 검사하는데 sync 는 안 고치는 클레임:\n"
+            + "\n".join(f"  {f}  {pat}" for f, pat in missing)
+            + "\nscripts/doc/sync_doc_counts.sh 에 update_claim 을 추가할 것"
+        )
+
+    def test_sync_targets_all_exist_in_their_files(self):
+        """sync 의 대상 문구가 실제로 그 파일에 있는가 — #916 의 직접 원인."""
+        stale = []
+        for f, pat in sorted(_sync_targets()):
+            p = REPO_ROOT / f
+            if not p.exists() or not re.search(pat, p.read_text()):
+                stale.append((f, pat))
+        assert not stale, "sync 대상이 이사갔거나 사라짐:\n" + "\n".join(f"  {f}  {pat}" for f, pat in stale)
+
+
+@pytest.fixture
+def repo_copy(tmp_path):
+    """검사 대상 문서만 복사한 얕은 사본 + `.venv` 심볼릭 링크.
+
+    round-trip 은 문서를 실제로 **쓰기** 때문에 레포에서 직접 돌리면 `-n auto`
+    병렬 실행 중 다른 워커가 손상된 중간 상태를 읽는다. `_common.sh` 의 REPO_ROOT
+    override 로 두 스크립트를 사본에 묶는다.
+    """
+    dst = tmp_path / "repo"
+    dst.mkdir()
+    for rel in (
+        "README.md",
+        "docs/ARCHITECTURE.md",
+        "docs/STRATEGY.md",
+        "config/CLAUDE.md",
+        "config/rules.yaml",
+        "nuri/api/CLAUDE.md",
+        "nuri/collectors/CLAUDE.md",
+        ".claude/rules/architecture.md",
+        "nuri/core/db_migrations.py",
+        "nuri/scheduler.py",
+    ):
+        out = dst / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / rel, out)
+    for pkg in ("nuri/collectors", "nuri/api/routes"):
+        (dst / pkg).mkdir(parents=True, exist_ok=True)
+        for f in (REPO_ROOT / pkg).glob("*.py"):
+            shutil.copy2(f, dst / pkg / f.name)
+    for sub in ("tests", "frontend/src", "frontend/e2e"):
+        (dst / sub).mkdir(parents=True, exist_ok=True)
+    (dst / "pyproject.toml").write_text("")  # _common.sh 의 레포 루트 마커
+    (dst / ".venv").symlink_to(REPO_ROOT / ".venv")
+    return dst
+
+
+def _run(script: Path, repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        env={**os.environ, "REPO_ROOT": str(repo)},
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+class TestRoundTrip:
+    def test_corrupted_count_is_repaired_and_then_verifies(self, repo_copy):
+        """망가뜨림 → sync → verify 통과. 게이트와 fixer 가 같은 걸 본다는 증명."""
+        readme = repo_copy / "README.md"
+        original = readme.read_text()
+        assert "SQLite WAL · 51 tables" in original
+        readme.write_text(original.replace("SQLite WAL · 51 tables", "SQLite WAL · 88 tables"))
+
+        before = _run(VERIFY, repo_copy)
+        assert "DRIFT" in before.stdout, f"손상시켰는데 verify 가 통과함:\n{before.stdout}"
+
+        sync = _run(SYNC, repo_copy)
+        assert sync.returncode == 0, sync.stdout + sync.stderr
+
+        after = _run(VERIFY, repo_copy)
+        assert "DRIFT" not in after.stdout, f"sync 후에도 drift 잔존:\n{after.stdout}"
+        assert "SQLite WAL · 51 tables" in readme.read_text()
+
+    def test_sync_leaves_neighbouring_numbers_alone(self, repo_copy):
+        """Backend 행 동기화가 같은 표의 다른 숫자를 건드리지 않는다.
+
+        Gotcha-Test Pair: STRATEGY 패턴을 'Backend tests.*[0-9,]+ tests' 로 넓히면
+        첫 숫자 런인 "Codecov 1%" 가 파괴되고, 옛 패턴 '[0-9,]+ tests, [0-9]+ files \\|'
+        로 되돌리면 바로 아래 Frontend 행이 백엔드 수치로 덮어써진다 — 둘 다 FAIL.
+        """
+        strategy = repo_copy / "docs" / "STRATEGY.md"
+        strategy.write_text(
+            re.sub(
+                r"[0-9,]+ tests, 284 files \(statement",
+                "9,999 tests, 284 files (statement",
+                strategy.read_text(),
+                count=1,
+            )
+        )
+
+        sync = _run(SYNC, repo_copy)
+        assert sync.returncode == 0, sync.stdout + sync.stderr
+
+        after = strategy.read_text()
+        assert "Codecov 1% relative" in after, "Backend 행의 1% 가 파괴됨"
+        # 사본의 tests/ 는 비어 있어 **파일 수**는 0 으로 동기화된다(fixture 아티팩트).
+        # 이 테스트가 지키는 건 그게 아니라 "이웃 숫자를 건드리지 않는가" 이므로
+        # Frontend 행의 **테스트 수**(1449)만 본다 — 옛 패턴이 덮어썼던 바로 그 값.
+        assert re.search(r"Frontend tests \|[^|]*\| 1449 tests,", after), "Frontend 테스트 수가 덮어써짐"
+        assert "9,999" not in after, "손상된 값이 복구되지 않음"


### PR DESCRIPTION
Closes #916.

## The failure

`make sync-doc-counts` printed its banner, exited 1, and synced nothing — since `CLAUDE.md` was split into `.claude/rules/`.

`verify_doc_counts.sh:168` names it as **the remedy** every time it detects drift. So the gate correctly reported a problem and sent the operator to a command that did nothing. Every doc-count fix since the refactor was hand-applied without anyone noticing the tool was gone.

The immediate cause is one missing `|| true`:

```bash
current=$(grep -oE "$pattern" "$file" | head -1)
if [ -z "$current" ]; then
    warn "$file: pattern not found — $pattern"   # <- unreachable
```

Its first target looks for `collector modules` in `CLAUDE.md`, which moved. Under `set -euo pipefail` the failing grep in a plain assignment kills the script **before** the `warn` branch below it can run. A graceful not-found path existed and `set -e` had turned it into dead code.

## Repairs

- Guard both grep assignments so a stale target warns instead of aborting, and **exit non-zero** when any claim could not be processed — a broken manifest should be loud, not a silent no-op
- Repoint the two claims that moved to `.claude/rules/architecture.md`
- Add the four claims verify hard-gates but sync never touched — API endpoints, migrations, scheduler jobs, `rules.yaml` lines. Without them, drift in any of the four left the gate red **with no way to fix it**
- Register the README backend-file count in **both** scripts. It was in neither, and had already drifted to 284 against a live 285 — sync now repairs it

## A corruption bug the dead script was hiding

Reviving it made this fire on the first live run:

```
✓ docs/STRATEGY.md: 1449 tests, 127 files | → 6,417 tests, 127 files |
```

The pattern `'[0-9,]+ tests, [0-9]+ files \|'` also matches the **Frontend** row directly below the Backend one, and `head -1` picks whichever comes first — so it overwrote the frontend count with the backend count.

Widening to anchor on `Backend tests` trades one bug for another: `sed` replaces the **first** digit run in the match, and that is the `Codecov 1%` on the same row (measured — it produced `Codecov 6,417% relative regression`).

Anchoring on the trailing `(statement` satisfies both constraints — unique to the Backend row, and the target is still the first number in the match.

## Tests

Three failure modes, not the happy path:

| Test | Locks |
|---|---|
| `test_sync_does_more_than_print_its_banner` | processes its whole list instead of dying at claim one |
| `test_every_verified_claim_is_also_syncable` | every claim verify checks is one sync can fix |
| `test_missing_pattern_warns_and_continues` | a deliberately stale target warns, keeps going, and fails the exit code |
| `test_sync_leaves_neighbouring_numbers_alone` | the `1%` and the Frontend row survive a Backend-row sync |

The third exists because **in a healthy repo no pattern is missing**, so nothing exercises the `set -e` guard — I removed `|| true` and every test still passed until I added it. #916 was a mine nobody had stepped on yet.

Round-trip tests run against a `tmp_path` copy via the `REPO_ROOT` override in `_common.sh`; they write files, so running them in-tree would corrupt other `-n auto` workers.

**Mutation-verified**: removing `|| true` fails `test_missing_pattern_warns_and_continues`; dropping a sync target fails `test_every_verified_claim_is_also_syncable`.

## Also

Corrects the coverage figure #915's audit turned up but left in the canonical docs — `docs/ARCHITECTURE.md` and `docs/STRATEGY.md` still claimed 100%. Backend statement coverage is **99.88%**, 28 of 22,539 statements across 9 files. 100% held on 2026-05-06 and regressed after.

## Verification

- `bash scripts/doc/sync_doc_counts.sh` → processes 20 claims, exit 0, `All doc counts already in sync`
- Corrupt → sync → verify round trip passes, with `1%` and the Frontend row intact
- `make verify-doc-counts` → 19/19
- `make test-fast` → 6,394 passed, 6 skipped · `make lint`, `make lint-sh`, privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)