### PR TITLE
docs(readme): restructure to standard-readme section order

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,36 @@
 
 Every BUY / SELL recommendation runs through a 5-phase pipeline — **collect → analyze → consensus → certify → track**. Each decision records its market context and per-agent reasoning, then scores itself against the realized outcome at 30 / 60 / 90 days. Agent weights adjust from the 30-day hit rate, bounded to ±30% of their configured base.
 
-## What this system claims — and what it does not
+## Table of Contents
+
+- [Security](#security)
+- [Background](#background)
+- [Install](#install)
+- [Usage](#usage)
+- [Investment Rules](#investment-rules)
+- [LLM Integration](#llm-integration)
+- [Deployment](#deployment)
+- [Tech Stack](#tech-stack)
+- [Project Stats](#project-stats)
+- [Documentation](#documentation)
+- [Maintainers](#maintainers)
+- [Acknowledgements](#acknowledgements)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Security
+
+The repository is public and the platform reads a real portfolio. Two controls follow — one mechanical, one not, and the difference matters.
+
+**Personal financial data cannot reach the repo — mechanically.** `scripts/verify/check_privacy_leak.py` runs as a pre-push hook and as the required `Privacy Leak Scan` CI job. It blocks Korean broker names and their romanized variants, monetary literals of 7 digits or more sitting near keys like `total_invested` or `cash_balance`, and ticker-with-signed-percentage combinations. `config/portfolio.yaml` is gitignored and never scanned; fixtures use placeholders (`Brokerage Alpha`, round-million values).
+
+**Portfolio data reaching an external model is blocked by convention, not by a hook.** `nuri/llm/openai_client.py` is the single external-LLM entry point, and everything enforced there is real: each call is logged to `external_llm_calls` (timestamp / model / tokens, never content), portfolio-bearing prompts require `OPENAI_ZDR_APPROVED=1`, and `NURI_DISABLE_EXTERNAL_LLM=1` raises before any request leaves the process. But nothing stops a new module from importing `openai` directly — unlike the `sqlite3` sole-importer rule, which an AST sweep in CI enforces, a stray `import openai` passes CI silently and is caught only in review.
+
+In production the API binds `127.0.0.1`, not `0.0.0.0`. The Next.js proxy is the only reachable surface and sits behind a password gate. Reporting, accepted risks, and the full control list: [`SECURITY.md`](SECURITY.md).
+
+## Background
+
+### What this system claims — and what it does not
 
 The point of the project is that a recommendation is auditable, not that it is right. Two constraints follow, and both are enforced rather than aspirational:
 
@@ -21,26 +50,7 @@ The point of the project is that a recommendation is auditable, not that it is r
 
 If you are looking for a backtested strategy with a published Sharpe ratio, this is not that. It is the measurement apparatus you would need before you could honestly publish one.
 
-## Quick Start
-
-```bash
-# Prerequisites: Python 3.12, uv, ta-lib, Node 22
-brew install uv ta-lib fnm && fnm install 22
-
-git clone https://github.com/researcherhojin/nuri-quant.git && cd nuri-quant
-make setup                                              # backend deps + DB init + git hooks
-cd frontend && npm ci && cd ..                          # frontend
-cp .env.example .env                                    # API keys (all optional)
-cp config/portfolio.example.yaml config/portfolio.yaml  # your holdings (gitignored)
-
-make start          # API on :8001 + Dashboard on :3000
-```
-
-Visit **`:3000`** for the Action-First dashboard or **`:8001/docs`** for OpenAPI.
-
-Every API key is optional. Collectors whose credentials are absent skip themselves and log the skip; the pipeline completes without them.
-
-## How It Works
+### How it works
 
 ```mermaid
 flowchart TB
@@ -86,7 +96,7 @@ Two signal registries exist and are deliberately not merged. The 22 in `config/s
 
 Detail: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Certification spec: [`docs/CERTIFICATION_SPEC.md`](docs/CERTIFICATION_SPEC.md).
 
-## Two decision axes, never conflated
+### Two decision axes, never conflated
 
 A rule that fires because a position is too large is not the same as a rule that fires because a thesis broke. Mixing them is what produces a panicked sale of a good position, so the distinction is structural (`nuri/core/axis.py`):
 
@@ -97,7 +107,46 @@ A rule that fires because a position is too large is not the same as a rule that
 
 The risk veto triggers on `alpha_action == FLAT`. A portfolio-axis violation cannot trigger it.
 
-## Dashboard
+## Install
+
+```bash
+# Prerequisites: Python 3.12, uv, ta-lib, Node 22
+brew install uv ta-lib fnm && fnm install 22
+
+git clone https://github.com/researcherhojin/nuri-quant.git && cd nuri-quant
+make setup                                              # backend deps + DB init + git hooks
+cd frontend && npm ci && cd ..                          # frontend
+cp .env.example .env                                    # API keys (all optional)
+cp config/portfolio.example.yaml config/portfolio.yaml  # your holdings (gitignored)
+
+make start          # API on :8001 + Dashboard on :3000
+```
+
+Visit **`:3000`** for the Action-First dashboard or **`:8001/docs`** for OpenAPI.
+
+Every API key is optional. Collectors whose credentials are absent skip themselves and log the skip; the pipeline completes without them.
+
+## Usage
+
+### Daily commands
+
+```bash
+make full-scan      # 5-phase pipeline end-to-end
+make consensus      # 10-agent analysis + decision recording
+make certify        # Certification (3-D gates)
+make scan           # Daily swing scan (us_core, 85 tickers)
+make scan-extended  # Weekly swing scan (us_core + S&P 500 extension, 543 tickers)
+
+make test-fast      # backend, slow tests excluded — 111s on an 18-core M5 Max
+make test           # full backend suite (adds 24 slow-marked tests)
+make ci-cov         # combine CI shard artifacts — ground-truth coverage
+
+make verify-quick   # pre-commit smoke gate
+make verify-all     # pre-push gate: tests + lint + frontend
+make help           # full target list with categories
+```
+
+### Dashboard
 
 The dashboard at `:3000/` answers **"what should I do today?"** — Action-First design that surfaces actionable intelligence ahead of raw data. Pension / IRP holdings are filtered out, since a monthly rebalance is not a daily decision.
 
@@ -129,7 +178,7 @@ Take-profit ladders sit on top: growth takes +20% / +40% then trails at -15%; va
 
 Rule changes follow an escalation ladder rather than landing at full strength: **surface** evidence → **soft penalty** (deterministic downgrade) → **hard veto** (action block on downside risk) → **symmetric amplifier**. Promotion between rungs requires a STRATEGY PR with backtest evidence, and a rung has been walked back before — a 50-day-MA leader exit was disabled in #800 after a 197-ticker walk-forward failed to reproduce the 17-ticker result it was built on.
 
-## LLM Integration (optional, off by default)
+## LLM Integration
 
 LLM integrations are **wired but inactive** unless you set the corresponding env var. The system runs without any LLM and falls back to regex / rule-based logic. Egress policy: [`docs/STRATEGY.md §4.4.3`](docs/STRATEGY.md).
 
@@ -141,6 +190,12 @@ LLM integrations are **wired but inactive** unless you set the corresponding env
 | **Ollama** (local) | Daily LLM report fallback | `OLLAMA_HOST` | Tier 2 — local only |
 
 `nuri/llm/openai_client.py` is the only module permitted to import `openai`. Every external call is logged to the `external_llm_calls` table (timestamp / model / tokens — **never content**), portfolio-bearing prompts require the explicit ZDR flag, and `NURI_DISABLE_EXTERNAL_LLM=1` raises before any request leaves the process.
+
+## Deployment
+
+The reference operator setup is two Apple Silicon Macs — a MacBook Pro for development, a Mac mini as a 24/7 receiver — synced by `make deploy-mini` in one command. The receiver is the sole writer; the development machine treats its database as a read replica, so adjudication records have exactly one ledger of record.
+
+Production binds the API to `127.0.0.1`. The dashboard proxy is the only public surface and sits behind a password gate.
 
 ## Tech Stack
 
@@ -183,7 +238,7 @@ Measured against `main` on 2026-07-28. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,424 collected across 285 files | |
+| **Backend tests** | 6,433 collected across 286 files | |
 | **Backend statement coverage** | 99.88% — 28 of 22,539 statements uncovered, across 9 files (Codecov `backend` flag) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -199,30 +254,6 @@ Measured against `main` on 2026-07-28. Counts marked ✅ are verified on every P
 | **DB tables** | SQLite WAL · 51 tables (47 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
-## Common Commands
-
-```bash
-make full-scan      # 5-phase pipeline end-to-end
-make consensus      # 10-agent analysis + decision recording
-make certify        # Certification (3-D gates)
-make scan           # Daily swing scan (us_core, 85 tickers)
-make scan-extended  # Weekly swing scan (us_core + S&P 500 extension, 543 tickers)
-
-make test-fast      # backend, slow tests excluded — 111s on an 18-core M5 Max
-make test           # full backend suite (adds 24 slow-marked tests)
-make ci-cov         # combine CI shard artifacts — ground-truth coverage
-
-make verify-quick   # pre-commit smoke gate
-make verify-all     # pre-push gate: tests + lint + frontend
-make help           # full target list with categories
-```
-
-## Deployment
-
-The reference operator setup is two Apple Silicon Macs — a MacBook Pro for development, a Mac mini as a 24/7 receiver — synced by `make deploy-mini` in one command. The receiver is the sole writer; the development machine treats its database as a read replica, so adjudication records have exactly one ledger of record.
-
-Production binds the API to `127.0.0.1`. The dashboard proxy is the only public surface and sits behind a password gate.
-
 ## Documentation
 
 - [`docs/STRATEGY.md`](docs/STRATEGY.md) — project philosophy, architectural decisions, investment rules. Canonical when documents disagree.
@@ -233,7 +264,11 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 - [`SECURITY.md`](SECURITY.md) — security policy, LLM egress rules
 - [`CLAUDE.md`](CLAUDE.md) / [`AGENTS.md`](AGENTS.md) — agent guides (Claude Code / Cursor / Copilot)
 
-## References
+## Maintainers
+
+[@researcherhojin](https://github.com/researcherhojin) — sole maintainer. This is a personal investment platform; the contribution rules exist mainly because coding agents work in this repo and need mechanical guardrails.
+
+## Acknowledgements
 
 | Source | Usage |
 |--------|-------|
@@ -247,6 +282,14 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 | [López de Prado](https://www.wiley.com/en-us/Advances+in+Financial+Machine+Learning-p-9781119482086) · [Riskfolio-Lib](https://riskfolio-lib.readthedocs.io/) · [OpenBB](https://docs.openbb.co/) | Walk-forward null-safe gate · optimization · data |
 
 Academic foundations: O'Neil _CAN SLIM_, Minervini _SEPA_, Shefrin & Statman 1985 (disposition effect), Markowitz, Damodaran, Bernstein.
+
+## Contributing
+
+Open an issue before writing code so scope can be agreed first — read [`docs/STRATEGY.md`](docs/STRATEGY.md) before proposing any non-trivial change, since it is canonical when documents disagree. PRs are accepted.
+
+CI gates every PR on `Commit count gate (≤ 3)`, `Privacy Leak Scan`, `Doc Count Drift Check`, `codecov/patch`, CodeQL, and Trivy. One issue per PR and English Conventional Commit subjects are conventions the review enforces, not jobs — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow.
+
+Changing an investment rule, or promoting an escalation-ladder rung, additionally requires a `docs/STRATEGY.md` amendment with backtest evidence. A code change alone is not sufficient, and rungs have been walked back on evidence before.
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,424 backend tests across 285 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99.88% (2026-07-28)** — 28 of 22,539 statements uncovered across 9 files, per the Codecov `backend` flag. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,433 backend tests across 286 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99.88% (2026-07-28)** — 28 of 22,539 statements uncovered across 9 files, per the Codecov `backend` flag. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,424 tests, 285 files (statement coverage **99.88%** — 28/22,539 미커버, 2026-07-28) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,433 tests, 286 files (statement coverage **99.88%** — 28/22,539 미커버, 2026-07-28) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/verify/test_readme_structure.py
+++ b/tests/verify/test_readme_structure.py
@@ -1,0 +1,119 @@
+"""README 가 standard-readme 규격 구조를 유지한다.
+
+규격: https://github.com/RichardLitt/standard-readme/blob/main/spec.md
+
+순서는 취향이 아니라 계약이다 — 처음 온 사람이 Install 다음에 Usage 를, 맨 끝에서
+License 를 찾는다는 전제로 씌어 있다. 이 레포의 README 는 한때 Usage(`Common
+Commands`)가 14개 중 10번째에 있어 Install 과 7개 섹션 떨어져 있었고, 253줄인데
+목차가 없었으며, 필수인 Contributing 이 다른 섹션 안 링크 한 줄로만 존재했다.
+
+ToC 는 특히 조용히 썩는다 — 섹션을 하나 추가하고 목차를 잊어도 렌더링은 멀쩡하다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+
+# spec 이 요구하는 상대 순서. 사이에 커스텀(Extra) 섹션이 끼는 건 허용되므로
+# 동등성이 아니라 **부분순서**로 검사한다.
+REQUIRED_ORDER = [
+    "Table of Contents",
+    "Background",
+    "Install",
+    "Usage",
+    "Maintainers",
+    "Acknowledgements",
+    "Contributing",
+    "License",
+]
+
+# spec 이 필수로 못박은 섹션 (문서 저장소가 아니므로 Install/Usage 도 필수)
+REQUIRED_SECTIONS = {"Table of Contents", "Install", "Usage", "Contributing", "License"}
+
+
+def _headings() -> list[str]:
+    return [m.group(1).strip() for m in re.finditer(r"^## (.+)$", README.read_text(), re.M)]
+
+
+def _github_anchor(heading: str) -> str:
+    a = re.sub(r"[^\w\s-]", "", heading.lower())
+    return re.sub(r"\s+", "-", a.strip())
+
+
+def _toc_links() -> list[tuple[str, str]]:
+    body = README.read_text()
+    start = body.index("## Table of Contents")
+    end = body.index("\n## ", start + 1)
+    return re.findall(r"^- \[([^\]]+)\]\(#([^)]+)\)$", body[start:end], re.M)
+
+
+class TestRequiredSections:
+    def test_all_required_sections_present(self):
+        missing = REQUIRED_SECTIONS - set(_headings())
+        assert not missing, f"standard-readme 필수 섹션 누락: {sorted(missing)}"
+
+    def test_license_is_last(self):
+        """spec: License must be last section."""
+        assert _headings()[-1] == "License", _headings()[-1]
+
+    def test_toc_is_required_because_readme_exceeds_100_lines(self):
+        """spec: ToC 는 100줄 넘는 README 에서 필수. 짧아졌다면 이 테스트를 지워도 된다."""
+        n = len(README.read_text().splitlines())
+        assert n > 100, f"README 가 {n}줄로 줄었다 — ToC 필수 조건 재검토"
+        assert "## Table of Contents" in README.read_text()
+
+
+class TestSectionOrder:
+    def test_spec_sections_appear_in_prescribed_order(self):
+        """Extra 섹션이 사이에 끼는 건 허용, 상대 순서가 뒤집히면 FAIL.
+
+        Gotcha-Test Pair: Usage 를 Install 앞으로 옮기거나 License 를 위로 올리면 FAIL.
+        """
+        present = [h for h in _headings() if h in REQUIRED_ORDER]
+        expected = [h for h in REQUIRED_ORDER if h in present]
+        assert present == expected, f"섹션 순서가 규격과 다름:\n  실제   {present}\n  기대   {expected}"
+
+    def test_usage_directly_follows_install_ignoring_nothing_between(self):
+        """spec 순서상 Install → Usage 사이에는 다른 spec 섹션이 없어야 한다.
+
+        과거 이 둘 사이에 7개 섹션이 있었다 — 설치한 사람이 다음에 뭘 치는지 찾으려면
+        Tech Stack 과 Project Stats 를 지나쳐야 했다.
+        """
+        heads = _headings()
+        gap = heads[heads.index("Install") + 1 : heads.index("Usage")]
+        assert not gap, f"Install 과 Usage 사이에 {gap}"
+
+
+class TestTableOfContents:
+    def test_every_toc_link_resolves_to_a_heading(self):
+        anchors = {_github_anchor(h) for h in _headings()}
+        broken = [(t, a) for t, a in _toc_links() if a not in anchors]
+        assert not broken, f"가리키는 헤딩이 없는 ToC 링크: {broken}"
+
+    def test_every_section_is_listed_in_the_toc(self):
+        """섹션을 추가하고 목차를 잊는 게 가장 흔한 부패 경로 — 렌더링은 멀쩡하다.
+
+        Gotcha-Test Pair: `## ` 섹션을 추가하고 ToC 에 안 넣으면 FAIL.
+        """
+        listed = {a for _, a in _toc_links()}
+        missing = [h for h in _headings() if h != "Table of Contents" and _github_anchor(h) not in listed]
+        assert not missing, f"ToC 에 없는 섹션: {missing}"
+
+    def test_toc_order_matches_document_order(self):
+        """목차 순서가 본문 순서와 다르면 목차가 지도 역할을 못 한다."""
+        listed = [a for _, a in _toc_links()]
+        doc = [_github_anchor(h) for h in _headings() if h != "Table of Contents"]
+        assert listed == doc, f"ToC 순서 불일치:\n  ToC  {listed}\n  본문 {doc}"
+
+
+class TestShortDescription:
+    def test_short_description_is_under_120_chars(self):
+        """spec: short description 은 120자 미만, 자기 줄에."""
+        body = README.read_text()
+        m = re.search(r"^\*\*(.+?)\*\*$", body, re.M)
+        assert m, "굵은 한 줄 요약을 찾지 못함"
+        assert len(m.group(1)) < 120, f"{len(m.group(1))}자: {m.group(1)}"


### PR DESCRIPTION
The README's section order was ad hoc. Checked against the [standard-readme spec](https://github.com/RichardLitt/standard-readme/blob/main/spec.md), six things did not hold.

## What was wrong

| # | Deviation | Spec |
|---|---|---|
| 1 | **`Common Commands` sat 10th of 14** — seven sections after Quick Start, behind Tech Stack and Project Stats | Usage comes **directly after Install** |
| 2 | **No Table of Contents** | Required past 100 lines. This was **253** |
| 3 | **No Contributing section** | **Required.** Existed only as a link line inside Documentation |
| 4 | **Background (`How It Works`) came after Install** | Background → Install → Usage |
| 5 | No Security section | Optional, but the spec allows placing it early "if important" — `SECURITY.md` exists and the project has a real egress policy |
| 6 | No Maintainers | Optional |

The first is the one that actually costs a reader something: the section telling you what to type after installing was seven sections away from the install instructions.

## New order

```
Title / badges / short description / long description
→ Table of Contents → Security → Background → Install → Usage
→ Investment Rules · LLM Integration · Deployment · Tech Stack
  · Project Stats · Documentation          (extra sections)
→ Maintainers → Acknowledgements → Contributing → License
```

Existing prose moved **verbatim**. A line-level diff of the body shows **0 content lines lost** and 21 added — all of them the four new sections.

## A claim that needed walking back before shipping

The first draft of the Security section said both controls are "enforced mechanically". Only one is:

- **Privacy scanner** — yes. Pre-push hook plus the required `Privacy Leak Scan` CI job.
- **External-LLM rule** — no. `.claude/rules/invariants.md` records it as *review-enforced* and notes that a stray `import openai` **passes CI silently**, unlike the `sqlite3` sole-importer rule which an AST sweep does cover.

The section now states which is which, because that difference is the useful part for anyone auditing this. Contributing had the same problem — it claimed CI enforces "one issue per PR" and commit-message format; it now names the jobs that actually run (`Commit count gate (≤ 3)`, `Privacy Leak Scan`, `Doc Count Drift Check`, `codecov/patch`, CodeQL, Trivy) and marks the rest as review conventions.

## Tests

`tests/verify/test_readme_structure.py` — 9 tests:

- required sections present; License last; ToC required past 100 lines
- spec sections in prescribed relative order (extra sections may interleave)
- **nothing between Install and Usage**
- every ToC entry resolves to a real heading, every section is listed, and ToC order matches document order

The ToC tests exist because a ToC rots silently — add a section, forget the entry, and the page still renders fine.

**Mutation-verified**: swapping Install/Usage fails 2 tests; deleting one ToC entry fails 2 tests.

## Side effect worth noting

Adding the test file drifted the backend test-file count, `Doc Count Drift Check` caught it, and **`make sync-doc-counts` repaired all 6 sites automatically** — the first real use of the tooling revived in #917, which until today exited 1 and fixed nothing.

## Verification

- `make verify-doc-counts` → 19/19 · `make test-fast` → 6,403 passed, 6 skipped
- `make lint`, privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)