### PR TITLE
feat(tracking): measure KR decisions against KOSPI, not SPY (#833)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-28. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,454 collected across 288 files | |
+| **Backend tests** | 6,461 collected across 288 files | |
 | **Backend statement coverage** | 99.88% — 28 of 22,539 statements uncovered, across 9 files (Codecov `backend` flag) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -285,7 +285,7 @@ Measured against `main` on 2026-07-28. Counts marked ✅ are verified on every P
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 51 tables (47 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 51 tables (48 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 474 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 481 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -219,6 +219,13 @@ measurement_mode:
   evaluation_date: "2027-06-30"  # 판정일. 조기 승격 금지, 하향은 상시 (prudential)
   emit_cutoff_date: "2027-05-15" # 표본 emit 마감 — 판정일까지 30d 창 완결 보장
   benchmark: SPY                 # forward_outcome_tracker DEFAULT_BENCHMARK_TICKER 와 일치 (#675)
+                                 # ⚠️ 이 값은 **US 판정 기준**이며 2026-07-08 사전등록으로 잠겼다.
+                                 # 아래 map 을 늘리는 것과 달리 이 줄을 바꾸는 건 사전등록 개정이다.
+  benchmark_by_market:           # 기록용 시장별 벤치마크 (#833). 판정 기준이 아니라 측정 인프라.
+                                 # KR 결정을 SPY 로 재던 FX/스타일 불일치를 제거한다. KR 판정 자체는
+                                 # 별도 사전등록 대상 (§3.11 벤치마크 행) — 여기서 승격하지 않는다.
+    us: SPY                      # us 값은 위 benchmark 와 항상 같아야 한다 (lock test)
+    kr: KOSPI                    # siege_gates.kr_equity.freshness_primary 와 동일 — 이미 매일 수집됨
   primary_window_days: 30        # 판정 창 (7/14d 는 진단용, §3.11 표 — 파일럿 기반 선택 경위 명시)
   min_n_us_buy_decisions: 200    # US BUY 결정만 (KR/SELL 은 진단 전용 — §3.11 표본 규약), distinct decision_id
   permutation_p_max: 0.05        # one-sided. scheme 은 아래 사전 고정 (구현만 follow-up — §3.11 미구축 ②)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,454 backend tests across 288 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99.88% (2026-07-28)** — 28 of 22,539 statements uncovered across 9 files, per the Codecov `backend` flag. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,461 backend tests across 288 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99.88% (2026-07-28)** — 28 of 22,539 statements uncovered across 9 files, per the Codecov `backend` flag. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -234,18 +234,18 @@ base = regime_win_rate × 60% + profit_factor × 40%
 |---|---|---|
 | 판정일 | 2027-06-30. 조기 승격 금지 (하향은 상시). 표본 emit cutoff = 2027-05-15 (30d 창 완결 보장) | pre-registration — Harvey, Liu & Zhu (2016) multiple testing / p-hacking |
 | 표본 규약 | `declared_date` (2026-07-08) ~ emit cutoff 에 emit 된 **US BUY** 결정만 (distinct `decision_id`). 30d window 단일 판정 창 — 7/14d 는 진단용 (30d 는 파일럿 #675 탐색 결과 기반 선택, 판정 표본은 declared_date 이후 disjoint). n ≥ 200. SELL 은 진단 전용 (원장 alpha 는 방향 보정 저장 — tracker 부호 반전) | 원장 실측 σ≈25.0%p (US BUY 30d, n=62, #828 코멘트 쿼리): n=200 의 검출 하한 ≈ +4.4%p/30d (one-sided α=0.05, 80% power), accrual 실측 ~43건/월 → 판정 시점 기대 n≈400 → ≈ +3.1%p. **미검출 ≠ 엣지 부재** (power 한계 명시). §2.1 30-trade 는 per-signal tier, 본 n 은 system-level (별개 축) |
-| 벤치마크 | SPY (`forward_outcome_tracker.py` `DEFAULT_BENCHMARK_TICKER`). **본 판정은 US-only 로 고정** — KR 결정은 KR benchmark (#675 명시 follow-up, 미구축 ④) 착륙 후 **별도 사전등록** 을 거쳐야 판정 대상, 그 전까지 진단 전용 | #675 caveat: SPY 는 growth 대비 과대평가 |
+| 벤치마크 | SPY (`forward_outcome_tracker.py` `DEFAULT_BENCHMARK_TICKER` = `measurement_mode.benchmark`). **본 판정은 US-only 로 고정.** #833 착륙 후 KR 결정의 **기록 기준**은 KOSPI (`measurement_mode.benchmark_by_market`, 매 outcome 행의 `benchmark_ticker` 에 자기기술) — 기록 기준이 바뀌었을 뿐 **판정 대상 여부는 그대로**이며, KR 은 **별도 사전등록** 전까지 진단 전용 | #675 caveat: SPY 는 growth 대비 과대평가. KR 을 SPY 로 재면 FX + 시장 스타일이 alpha 에 섞여 부호까지 뒤집힘 |
 | 승격 조건 (3개 동시) | mean 30d alpha > 0 · 순열 p < 0.05 (**ticker-block placebo**: 실 표본의 ticker→emit일 구조 유지, 동일 시장 eligible universe 에서 ticker 치환, N=1000, 통계량 = mean 30d alpha, one-sided — 중첩 창·동일일 배치·반복 종목 의존성을 null 이 상속) · **median-decision-date 등분 2분할** 모두 mean alpha > 0 (반기 n 균형 보장) | López de Prado (2018) PBO/deflated-Sharpe 정신 — 단일 통계 아닌 강건성 요구. naive iid 순열은 클러스터링으로 anti-conservative |
 | regime 축 | 내부 10-regime 분류는 진단 Surface 전용, 판정 비사용 — 원장 라벨 커버리지 3% (12/383, #828 코멘트 쿼리), 2026-04 이후 transition 1회 (판정 교착 위험), 자기 분류기 순환성 | 실측 2026-07-07 (production 원장) |
 | 오염 방지 | `decision_id` 없는 ad-hoc 체결은 표본 제외 (#715 사전등록 원칙의 자본 버전). missing outcome (추적 실패/가격 결측) 은 제외하되 비율을 판정 리포트에 공시 — **15% 초과 시 판정 무효 (측정 연장)** | Shefrin & Statman (1985) — ad-hoc 개입이 처분효과 재유입 경로. 결측 편향 (탈락은 나쁜 outcome 과 상관 가능) |
 **판정 결과 처리**: 3조건 통과 → **US 집행분 슬리브에 한해** 상한 상향 STRATEGY PR (새 상한도 본 표 개정으로 사전 고정). 미달 → 슬리브 유지/축소 + 측정 연장 또는 §3.10 passive 로 수렴 — "조금만 더" 없이 본 표가 답이다. 사전등록 대상은 판정 **기준**이지 상한 초기값이 아니다 — 슬리브 초기값은 판정 표본에 영향이 없으므로 최초 사용자 확정 PR 까지 placeholder 로 두며 일반 PR 로 정정 가능. 확정 이후부터 상향-sticky 발효.
-**미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 — #832 구현 완료 (`scripts/ops/backfill_regime_labels.py` + emit 경로 canonical-or-NULL, 진단용) ② 순열 판정 도구 — #842 구현 완료 (`nuri/quant/validation/decision_alpha.py`, 설계는 본 표에 사전 고정; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 (#833) ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall, #834) ⑥ 원장 스냅샷/백업 정책 (#835). 월간 알파 진행 리포트 표출 = #856.
+**미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 — #832 구현 완료 (`scripts/ops/backfill_regime_labels.py` + emit 경로 canonical-or-NULL, 진단용) ② 순열 판정 도구 — #842 구현 완료 (`nuri/quant/validation/decision_alpha.py`, 설계는 본 표에 사전 고정; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 — #833 구현 완료 (`benchmark_by_market` + `decision_outcomes.benchmark_ticker`, 기록 기준만; KR 판정 사전등록은 미착수) ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall, #834) ⑥ 원장 스냅샷/백업 정책 (#835). 월간 알파 진행 리포트 표출 = #856.
 **참조**: `config/rules.yaml measurement_mode` (canonical 값), `nuri/agents/actors/forward_outcome_tracker.py` (측정 파이프라인, 매일 17:00 KST), `docs/SOURCE_OF_TRUTH.md` (원장 매핑, local-only).
 ## 4. 개발 품질 기준
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,454 tests, 288 files (statement coverage **99.88%** — 28/22,539 미커버, 2026-07-28) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,461 tests, 288 files (statement coverage **99.88%** — 28/22,539 미커버, 2026-07-28) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/forward_outcome_tracker.py
+++ b/nuri/agents/actors/forward_outcome_tracker.py
@@ -39,6 +39,8 @@ from nuri.core.db import (
     reject_hypothesis,
     validate_hypothesis,
 )
+from nuri.core.rules import RULES
+from nuri.core.ticker_names import is_kr_ticker
 from nuri.core.timezone import today_kst
 
 # ─── window 별 validation 임계값 (Codex consult 합의) ─────────
@@ -48,7 +50,24 @@ WINDOW_THRESHOLDS: dict[int, tuple[float, float]] = {
     30: (0.10, -0.10),  # ±10% within 30 days
 }
 SUPPORTED_WINDOWS: tuple[int, ...] = (7, 14, 30)
-DEFAULT_BENCHMARK_TICKER = "SPY"  # 시장 베타 — alpha 산출 baseline
+DEFAULT_BENCHMARK_TICKER = "SPY"  # 시장 베타 — alpha 산출 baseline (US, §3.11 사전등록 판정 기준)
+
+
+def benchmark_for(ticker: str) -> str:
+    """티커가 속한 시장의 벤치마크 (#833).
+
+    KR 결정을 SPY 로 재면 alpha 에 환율 + 시장 스타일 차이가 통째로 섞인다 —
+    KOSPI 가 -3%, SPY 가 +1% 인 날 KR 종목의 -2% 는 SPY 기준 -3% alpha 지만
+    실제로는 시장 대비 +1% 다. 부호까지 뒤집히므로 KR 표본은 SPY 기준으로는
+    해석 불가다.
+
+    `benchmark_by_market` 이 없거나 시장이 미등재면 US 기준으로 폴백한다 —
+    조용히 틀린 값을 쓰는 게 아니라, 어느 쪽을 썼는지는 매 outcome row 의
+    `benchmark_ticker` 컬럼에 그대로 기록되므로 사후 판별이 된다.
+    """
+    by_market = (RULES.get("measurement_mode") or {}).get("benchmark_by_market") or {}
+    market = "kr" if is_kr_ticker(ticker) else "us"
+    return str(by_market.get(market) or DEFAULT_BENCHMARK_TICKER)
 
 
 def backfill_agent_decisions_from_recommendations() -> int:
@@ -318,8 +337,9 @@ class ForwardOutcomeTracker(Actor):
         # ─── 가격 조회 ───
         entry = self._fetch_close_on_or_before(ticker, as_of_date)
         exit_p = self._fetch_close_on_or_after(ticker, target_date)
-        bench_entry = self._fetch_close_on_or_before(DEFAULT_BENCHMARK_TICKER, as_of_date)
-        bench_exit = self._fetch_close_on_or_after(DEFAULT_BENCHMARK_TICKER, target_date)
+        benchmark = benchmark_for(ticker)
+        bench_entry = self._fetch_close_on_or_before(benchmark, as_of_date)
+        bench_exit = self._fetch_close_on_or_after(benchmark, target_date)
 
         if entry is None or exit_p is None:
             log_decision_outcome(
@@ -368,6 +388,7 @@ class ForwardOutcomeTracker(Actor):
             exit_price=exit_p,
             realized_return=realized,
             benchmark_return=bench_return,
+            benchmark_ticker=benchmark,
             alpha=alpha,
             hit_threshold=hit_threshold,
             hypothesis_validation=validation,

--- a/nuri/core/db/execution_ops.py
+++ b/nuri/core/db/execution_ops.py
@@ -129,6 +129,7 @@ def log_decision_outcome(
     exit_price: Optional[float] = None,
     realized_return: Optional[float] = None,
     benchmark_return: Optional[float] = None,
+    benchmark_ticker: Optional[str] = None,
     alpha: Optional[float] = None,
     hit_threshold: bool = False,
     notes: Optional[str] = None,
@@ -151,15 +152,16 @@ def log_decision_outcome(
         conn.execute(
             """INSERT INTO decision_outcomes
                (decision_id, observation_window, tracked_as_of_date,
-                entry_price, exit_price, realized_return, benchmark_return, alpha,
+                entry_price, exit_price, realized_return, benchmark_return, benchmark_ticker, alpha,
                 hit_threshold, hypothesis_validation, notes, run_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(decision_id, observation_window) DO UPDATE SET
                  tracked_as_of_date = excluded.tracked_as_of_date,
                  entry_price = excluded.entry_price,
                  exit_price = excluded.exit_price,
                  realized_return = excluded.realized_return,
                  benchmark_return = excluded.benchmark_return,
+                 benchmark_ticker = excluded.benchmark_ticker,
                  alpha = excluded.alpha,
                  hit_threshold = excluded.hit_threshold,
                  hypothesis_validation = excluded.hypothesis_validation,
@@ -173,6 +175,7 @@ def log_decision_outcome(
                 exit_price,
                 realized_return,
                 benchmark_return,
+                benchmark_ticker,
                 alpha,
                 int(hit_threshold),
                 hypothesis_validation,

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1504,4 +1504,21 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_blocks_run ON execution_blocks(run_id);
     """,
     ),
+    (
+        48,
+        "decision_outcomes.benchmark_ticker — 행이 어느 벤치마크로 잰 alpha 인지 자기기술 (#833)",
+        # KR 결정이 SPY 대비로 측정되던 것을 시장별 벤치마크로 바꾸면, 같은 테이블에
+        # 서로 다른 기준으로 잰 alpha 가 섞인다. 어느 행이 어느 기준인지 모르면 §3.11
+        # 판정 표본을 나눌 수 없다 — 컬럼 하나로 모든 행을 자기기술하게 만든다.
+        #
+        # 기존 행 backfill 은 추정이 아니라 사실이다: DEFAULT_BENCHMARK_TICKER 는
+        # 도입(e9495aa) 이래 "SPY" 뿐이었고 다른 경로가 없었다. 단 benchmark_return
+        # 이 NULL 인 행은 벤치마크가 아예 적용되지 않은 행(insufficient_data)이므로
+        # NULL 로 남긴다 — "SPY 로 쟀다" 가 거짓이 되기 때문.
+        """
+        ALTER TABLE decision_outcomes ADD COLUMN benchmark_ticker TEXT;
+        CREATE INDEX IF NOT EXISTS idx_outcomes_benchmark ON decision_outcomes(benchmark_ticker);
+        UPDATE decision_outcomes SET benchmark_ticker = 'SPY' WHERE benchmark_return IS NOT NULL;
+    """,
+    ),
 ]

--- a/tests/agents/test_forward_outcome_tracker.py
+++ b/tests/agents/test_forward_outcome_tracker.py
@@ -258,6 +258,78 @@ class TestRecommendationBackfill:
 # ═══════════════════════════════════════════════════════
 
 
+class TestPerMarketBenchmark:
+    """KR 결정은 KOSPI, US 결정은 SPY 로 잰다 (#833).
+
+    KR 종목을 SPY 로 재면 alpha 에 환율과 시장 스타일 차이가 통째로 섞여 부호까지
+    뒤집힌다. 아래 첫 테스트가 그 상황을 그대로 만든다 — 두 벤치마크가 반대로
+    움직여서, 잘못된 쪽을 쓰면 alpha 가 +0.02 가 아니라 +0.13 이 된다.
+    """
+
+    def _outcome_row(self, db_path, decision_id):
+        rows = query(
+            "SELECT alpha, benchmark_return, benchmark_ticker FROM decision_outcomes WHERE decision_id=?",
+            (decision_id,),
+            db_path=db_path,
+        )
+        return dict(rows[0])
+
+    def test_kr_decision_is_measured_against_kospi(self, patched_db):
+        """Gotcha-Test Pair: `benchmark_for(ticker)` 를 상수로 되돌리면 alpha 가
+        0.13 이 되어 FAIL."""
+        _seed_decision(patched_db, decision_id="dc-kr", ticker="TESTKR.KS", hypothesis_id=None)
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTKR.KS", "2026-04-20", 100.0),
+                ("TESTKR.KS", "2026-04-27", 108.0),  # +8%
+                ("KOSPI", "2026-04-20", 2500.0),
+                ("KOSPI", "2026-04-27", 2650.0),  # +6%
+                ("SPY", "2026-04-20", 500.0),
+                ("SPY", "2026-04-27", 475.0),  # -5% — 반대 방향
+            ],
+        )
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-kr", "observation_window": 7})
+
+        assert result.output["alpha"] == pytest.approx(0.02, abs=1e-6), "KR alpha 가 SPY 기준으로 계산됨"
+        row = self._outcome_row(patched_db, "dc-kr")
+        assert row["benchmark_ticker"] == "KOSPI"
+        assert row["benchmark_return"] == pytest.approx(0.06, abs=1e-6)
+
+    def test_us_decision_still_uses_spy(self, patched_db):
+        """회귀 방지 — US 경로는 §3.11 사전등록 기준 그대로여야 한다."""
+        _seed_decision(patched_db, decision_id="dc-us", ticker="TESTAA", hypothesis_id=None)
+        _seed_prices(
+            patched_db,
+            [
+                ("TESTAA", "2026-04-20", 100.0),
+                ("TESTAA", "2026-04-27", 108.0),
+                ("KOSPI", "2026-04-20", 2500.0),
+                ("KOSPI", "2026-04-27", 2650.0),
+                ("SPY", "2026-04-20", 500.0),
+                ("SPY", "2026-04-27", 505.0),  # +1%
+            ],
+        )
+        result = ForwardOutcomeTracker().run({"action": "track_one", "decision_id": "dc-us", "observation_window": 7})
+
+        assert result.output["alpha"] == pytest.approx(0.07, abs=1e-6)
+        assert self._outcome_row(patched_db, "dc-us")["benchmark_ticker"] == "SPY"
+
+    def test_kosdaq_routes_to_the_kr_benchmark(self):
+        """`.KQ` 도 KR — `.KS` 만 보면 KOSDAQ 종목이 US 벤치마크로 새어나간다 (#764)."""
+        from nuri.agents.actors.forward_outcome_tracker import benchmark_for
+
+        assert benchmark_for("TESTKR.KQ") == benchmark_for("TESTKR.KS") == "KOSPI"
+        assert benchmark_for("TESTAA") == "SPY"
+
+    def test_unmapped_market_falls_back_to_the_us_benchmark(self):
+        """map 이 비어도 죽지 않고 US 기준으로 폴백한다 — 단 그 사실이 행에 남는다."""
+        from nuri.agents.actors import forward_outcome_tracker as fot
+
+        with patch.dict(fot.RULES["measurement_mode"], {"benchmark_by_market": {}}):
+            assert fot.benchmark_for("TESTKR.KS") == fot.DEFAULT_BENCHMARK_TICKER
+
+
 class TestTrackOnePass:
     def test_pass_validation_8pct_return(self, patched_db):
         """7d window, +8% realized → pass + hypothesis auto-validated."""

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,13 +29,14 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_47(self, db_path):
+    def test_schema_version_at_48(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
         incidents alpha_report_stale enum 확장 (#894) +
-        execution_blocks sleeve_cap enum 확장 (#834) → 47."""
-        assert get_schema_version(db_path) == 47
+        execution_blocks sleeve_cap enum 확장 (#834) +
+        decision_outcomes.benchmark_ticker (#833) → 48."""
+        assert get_schema_version(db_path) == 48
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -224,6 +224,47 @@ class TestMeasurementMode:
 
         assert RULES["measurement_mode"]["benchmark"] == DEFAULT_BENCHMARK_TICKER
 
+    def test_benchmark_by_market_us_equals_the_locked_criterion(self):
+        """시장별 map 의 us 항목은 사전등록된 판정 기준과 **같은 값**이어야 한다 (#833).
+
+        map 은 기록용 측정 인프라이고 `benchmark` 는 §3.11 판정 기준이다. 둘이
+        갈라지면 US 표본이 판정 기준과 다른 벤치마크로 측정되면서 아무 게이트도
+        울리지 않는다 — 사전등록의 조용한 개정.
+
+        Gotcha-Test Pair: `benchmark_by_market.us` 를 SPY 아닌 값으로 바꾸면 FAIL.
+        """
+        from nuri.agents.actors.forward_outcome_tracker import DEFAULT_BENCHMARK_TICKER
+        from nuri.core.rules import RULES
+
+        mm = RULES["measurement_mode"]
+        assert mm["benchmark_by_market"]["us"] == mm["benchmark"] == DEFAULT_BENCHMARK_TICKER
+
+    def test_benchmark_by_market_covers_every_market_the_classifier_emits(self):
+        """`benchmark_for` 는 모든 티커를 us/kr 둘 중 하나로 보낸다 — map 도 딱 그 둘.
+
+        키가 빠지면 폴백이 US 벤치마크를 조용히 쓰고, 남는 키는 아무도 안 읽는
+        죽은 설정이 된다.
+        """
+        from nuri.core.rules import RULES
+
+        assert set(RULES["measurement_mode"]["benchmark_by_market"]) == {"us", "kr"}
+
+    def test_every_market_benchmark_is_actually_collected(self):
+        """벤치마크가 수집 배선에 없으면 alpha 가 영구 NULL 이 된다 (#860 과 같은 고장).
+
+        `069500.KS`(KODEX 200) 는 prices 에 단 한 행도 없어 KR 벤치마크로 쓰면
+        모든 KR alpha 가 NULL 이 된다. 실제 수집되는 식별자만 등재되어야 한다.
+
+        Gotcha-Test Pair: 수집 배선에 없는 티커를 map 에 넣으면 FAIL.
+        """
+        from nuri.collectors.stock import _load_freshness_tickers
+        from nuri.collectors.stock_kr import StockKRCollector
+        from nuri.core.rules import RULES
+
+        collected = set(_load_freshness_tickers()) | set(StockKRCollector.INDEX_TICKERS.values())
+        for market, ticker in RULES["measurement_mode"]["benchmark_by_market"].items():
+            assert ticker in collected, f"{market} 벤치마크 {ticker} 가 일일 수집 대상에 없음"
+
     def test_primary_window_supported_by_tracker(self):
         """판정 창은 tracker 가 실제 측정하는 window 여야 함."""
         from nuri.agents.actors.forward_outcome_tracker import SUPPORTED_WINDOWS


### PR DESCRIPTION
Closes #833 (§3.11 미구축 ④).

## 무엇이 문제였나

모든 `decision_outcomes` 행이 SPY 대비로 측정되고 있었다. KR 종목에는 환율과 시장 스타일이 alpha 에 통째로 섞이고, **부호까지 뒤집힌다** — KOSPI 가 -3%, SPY 가 +1% 인 날 KR 보유의 -2% 는 SPY 기준 -3% alpha 지만 실제로는 자기 시장을 +1% 이겼다. §3.11 이 KR 을 판정에서 제외한 이유가 이것이다.

## 무엇을 했나 (측정 인프라만)

| | |
|---|---|
| `config/rules.yaml` | `measurement_mode.benchmark_by_market: {us: SPY, kr: KOSPI}` 추가. **`benchmark: SPY` 는 그대로** — 사전등록된 US 판정 기준이라 손대지 않는다 |
| `forward_outcome_tracker.benchmark_for()` | 티커 → 시장 → 벤치마크. `.KS`/`.KQ` 둘 다 KR (`is_kr_ticker`) |
| migration 48 | `decision_outcomes.benchmark_ticker` — 행마다 어느 기준으로 잰 alpha 인지 자기기술 |

KR **판정** 은 여전히 별도 사전등록 대상이다. 이 PR 은 기록 기준만 바꾼다.

## 벤치마크 선택 — 이슈가 제안한 KODEX 200 이 아니다

`069500.KS` 는 `prices` 에 **단 한 행도 없다**. 그대로 배선했으면 모든 KR alpha 가 영구 NULL 이 됐을 것이다 (#860 과 같은 고장 모드). `KOSPI` 는 `stock_kr` 이 `^KS11` 로 매일 수집 중이고 이미 `siege_gates.kr_equity.freshness_primary` 다. 테스트가 "map 의 모든 벤치마크는 실제 수집 경로에 있어야 한다" 를 잠근다.

## 기존 행 backfill = 추정이 아니라 사실

`DEFAULT_BENCHMARK_TICKER` 는 도입(e9495aa) 이래 `"SPY"` 뿐이었고 다른 경로가 없었다. 단 `benchmark_return IS NULL` 인 행은 벤치마크가 아예 적용되지 않은 행이라 NULL 로 남긴다.

dev DB 사본 실측: **507행 보존, 376행 'SPY' 라벨, 131행 NULL, 라벨 오부착 0건.**

## Gotcha-Test Pair (mutation 검증 완료)

| mutation | FAIL 하는 테스트 |
|---|---|
| `benchmark_for(ticker)` → 상수 복귀 | `test_kr_decision_is_measured_against_kospi` (alpha 0.02 → 0.13) |
| `kr: KOSPI` → `069500.KS` | `test_every_market_benchmark_is_actually_collected` |
| `us: SPY` → `QQQ` | `test_benchmark_by_market_us_equals_the_locked_criterion` |

US 회귀 없음: `test_us_decision_still_uses_spy` + 기존 SSoT lock 유지.

## 게이트

`make verify-all` 5/5 · `make verify-doc-counts` 19/19 · privacy scan clean · `tests/agents tests/core tests/quant` 2232 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)