### PR TITLE
test(coverage): execute the 34 statements that only run when something breaks (#926)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,12 +268,12 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 
 ## Project Stats
 
-Measured against `main` on 2026-07-28. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
+Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,461 collected across 288 files | |
-| **Backend statement coverage** | 99.88% — 28 of 22,539 statements uncovered, across 9 files (Codecov `backend` flag) | |
+| **Backend tests** | 6,486 collected across 288 files | |
+| **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,461 backend tests across 288 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99.88% (2026-07-28)** — 28 of 22,539 statements uncovered across 9 files, per the Codecov `backend` flag. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,486 backend tests across 288 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,461 tests, 288 files (statement coverage **99.88%** — 28/22,539 미커버, 2026-07-28) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,486 tests, 288 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -438,7 +438,12 @@ class SREIncidentAgent(Actor):
                 reason = "already_emitted"
             else:
                 reason = "staged"
-        except (json.JSONDecodeError, TypeError, KeyError):
+        # pragma 이유(#927): 이 except 는 도달 불가하다. 위 집계 쿼리가 같은 payload 에
+        # `json_extract` 를 걸므로 깨진 JSON 은 SQLite 단계에서 먼저 죽고, 객체가 아닌
+        # 유효 JSON('null'/'[]'/'"x"')은 `.get` 에서 AttributeError 라 이 튜플에 안 걸린다.
+        # payload 컬럼은 TEXT affinity 라 TypeError 도 안 난다. 즉 실제 두 고장 모드는
+        # 여기를 통과해 버린다 — 교정은 #927 (동작 변경이라 별도 PR).
+        except (json.JSONDecodeError, TypeError, KeyError):  # pragma: no cover
             payload = {}
 
         evidence = {

--- a/nuri/alerts/heartbeat_watchdog.py
+++ b/nuri/alerts/heartbeat_watchdog.py
@@ -242,5 +242,5 @@ def main() -> int:
     return 2
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/nuri/quant/validation/decision_alpha.py
+++ b/nuri/quant/validation/decision_alpha.py
@@ -376,5 +376,5 @@ def main(argv: Optional[list[str]] = None) -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -606,13 +606,25 @@ class TestMissedEvalDays:
 # ═══════════════════════════════════════════════════════
 
 
-def _seed_alpha_run(db_path, ts_utc: str, *, staged: bool, role_ok: bool = True, error: str | None = None):
-    """pipeline_events 에 alpha_report_run heartbeat 1행 (payload 는 scheduler 와 동일 스키마)."""
-    payload = json.dumps(
+def _seed_alpha_run(
+    db_path,
+    ts_utc: str,
+    *,
+    staged: bool,
+    role_ok: bool = True,
+    error: str | None = None,
+    already_emitted: bool = False,
+    raw_payload: str | None = None,
+):
+    """pipeline_events 에 alpha_report_run heartbeat 1행 (payload 는 scheduler 와 동일 스키마).
+
+    `raw_payload` 는 스키마를 벗어난 payload 를 그대로 넣기 위한 탈출구 (파싱 실패 경로 검증용).
+    """
+    payload = raw_payload or json.dumps(
         {
             "month": ts_utc[:7],
             "role_ok": role_ok,
-            "already_emitted": False,
+            "already_emitted": already_emitted,
             "staged": staged,
             "error": error,
         },
@@ -702,6 +714,32 @@ class TestAlphaReportStaleDetector:
         out = self._scan()
         assert out[0]["evidence"]["last_skip_reason"] == "error"
         assert out[0]["evidence"]["last_error"] == "boom"
+
+    def test_already_emitted_skip_reason_is_distinguished(self, patched_db, no_publish):
+        """이번 달 리포트가 '이미 나갔다' 고 주장하는데 35일째 성공 stage 가 없다.
+
+        role 누락이나 예외와 조치가 다르다 — 중복 방지 키가 잘못 잡혀 매번 스스로를
+        skip 하는 상태이므로, evidence 가 이걸 뭉뚱그리면 엉뚱한 곳을 보게 된다.
+        """
+        for offset in range(40):
+            day = datetime(2026, 5, 30) + timedelta(days=offset)
+            _seed_alpha_run(patched_db, day.strftime("%Y-%m-%d 00:00:00"), staged=False, already_emitted=True)
+        out = self._scan()
+        assert out[0]["evidence"]["last_skip_reason"] == "already_emitted"
+        assert out[0]["evidence"]["last_error"] is None
+
+    def test_claims_staged_but_nothing_landed(self, patched_db, no_publish):
+        """heartbeat 가 '역할 정상·예외 없음·중복 아님' 이라 말하는데 stage 는 0건.
+
+        가장 위험한 조합이다 — 모든 지표가 초록인데 리포트만 안 나간다 (outbox 가
+        None 을 돌려주는 경우). reason 이 'staged' 로 남아야 heartbeat 를 믿지 말고
+        outbox 를 보라는 뜻이 전달된다.
+        """
+        for offset in range(40):
+            day = datetime(2026, 5, 30) + timedelta(days=offset)
+            _seed_alpha_run(patched_db, day.strftime("%Y-%m-%d 00:00:00"), staged=False)
+        out = self._scan()
+        assert out[0]["evidence"]["last_skip_reason"] == "staged"
 
     def test_summary_names_the_cause_not_just_the_type(self):
         """알림 한 줄이 cryptic 코드가 아니라 원인+조치를 담는다 (알림 가독성)."""

--- a/tests/alerts/test_alpha_report.py
+++ b/tests/alerts/test_alpha_report.py
@@ -326,6 +326,32 @@ class TestSchedulerWiring:
         assert payload["role_ok"] is False
         assert payload["staged"] is False
 
+    def test_heartbeat_write_failure_does_not_kill_the_job(self, caplog):
+        """heartbeat **기록** 이 실패해도 job 은 조용히 끝나야 한다.
+
+        읽기만 조심하면 되는 게 아니다 — 관측용 write 도 본 작업과 같은 위험이다.
+        여기서 예외가 새면 스케줄러 래퍼가 이미 stage 를 마친 뒤인데도 job 이
+        실패로 기록되고, 다음 잡까지 영향을 준다
+        ([[feedback_observability_must_not_gate]]).
+
+        Gotcha-Test Pair: heartbeat 의 try/except 를 지우면 예외가 새어 FAIL.
+        """
+        import logging
+
+        from nuri import scheduler
+
+        with (
+            caplog.at_level(logging.ERROR),
+            patch("nuri.alerts.alpha_report.stage_alpha_progress_brief", return_value=11) as staged,
+            patch("nuri.alerts.alpha_report.already_emitted", return_value=False),
+            patch("nuri.core.events.emit_event", side_effect=RuntimeError("no such table: pipeline_events")),
+        ):
+            scheduler._run_alpha_report()  # 예외가 새어나오면 실패
+
+        staged.assert_called_once_with()  # 본 작업이 heartbeat 실패에 말려들면 안 된다
+        assert "heartbeat" in caplog.text, "조용히 넘어가면 heartbeat 부재 원인을 못 찾는다"
+        assert "no such table" in caplog.text
+
     def test_wrapper_absorbs_failure(self, caplog):
         """한 job 실패가 스케줄러를 죽이면 안 된다 (다른 _run_* 와 동일 계약)."""
         import logging

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -731,6 +731,30 @@ def test_write_brief_postmortem_failure_does_not_break_brief(seeded_db, portfoli
     assert path.exists()  # markdown still written
 
 
+def test_write_brief_survives_stop_breach_staging_failure(seeded_db, portfolio_yaml, monkeypatch):
+    """손절 신호 staging 이 죽어도 브리프 자체는 나가야 한다.
+
+    Tier 1a 는 브리프에 얹는 **부가** 신호다. 여기서 예외가 새면 손절 신호 하나
+    때문에 그날 브리프가 통째로 사라진다 — 신호를 잃는 것과 브리프를 잃는 것은
+    피해 규모가 다르다.
+
+    Gotcha-Test Pair: 이 try/except 를 지우면 예외가 새어 FAIL.
+    """
+    import nuri.alerts.risk_signals as rs
+    from nuri.alerts.postmarket_brief import write_brief
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated staging failure")
+
+    monkeypatch.setattr(rs, "stage_stop_breach_briefs", _boom)
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+    ):
+        path = write_brief("us", date="2026-05-01")
+    assert path.exists(), "부가 신호 실패가 브리프를 통째로 죽였다"
+
+
 # ─── _load_5d helpers — empty / coerce-error / zero-divisor branches ─────
 
 

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -166,3 +166,48 @@ class TestAuth:
 
         assert _constant_time_compare("abc", "abc")
         assert not _constant_time_compare("abc", "def")
+
+
+class TestSecretKeyStartupWarning:
+    """`API_SECRET_KEY` 부재는 import 시점에 경고로 표면화된다 (`nuri/api/main.py`).
+
+    이 키는 JWT 서명 키다. 없으면 재시작마다 발급된 토큰이 전부 무효화되는데,
+    증상은 "가끔 로그아웃됨" 이라 원인까지 도달하기 어렵다. 경고 한 줄이 그
+    거리를 없앤다 — 그러니 그 한 줄이 실제로 나오는지 확인한다.
+    """
+
+    def _exec_main_fresh(self, env: dict, caplog):
+        """`nuri/api/main.py` 를 **다른 모듈 이름으로** 새로 실행한다.
+
+        `importlib.reload` 를 쓰면 `sys.modules["nuri.api.main"]` 의 app 객체가
+        교체돼 같은 워커의 다른 테스트가 옛 app 을 들고 있게 된다. 별칭으로 로드하면
+        모듈 본문(=검사 대상)은 그대로 실행되면서 캐시는 건드리지 않는다.
+        `load_dotenv` 는 no-op 으로 막는다 — 안 그러면 개발 머신의 `.env` 가 방금
+        지운 키를 되살려 로컬에서만 통과한다.
+        """
+        import importlib.util
+        import logging
+
+        import dotenv
+
+        path = Path(__file__).resolve().parents[2] / "nuri" / "api" / "main.py"
+        spec = importlib.util.spec_from_file_location("nuri_api_main_probe", path)
+        module = importlib.util.module_from_spec(spec)
+        with (
+            patch.dict("os.environ", env, clear=False),
+            patch.object(dotenv, "load_dotenv", lambda *a, **kw: False),
+            caplog.at_level(logging.WARNING, logger="nuri.api"),
+        ):
+            spec.loader.exec_module(module)
+        assert hasattr(module, "app"), "모듈 본문이 끝까지 실행되지 않음 — 아래 assert 가 공허해진다"
+        return caplog.text
+
+    def test_warns_when_secret_key_is_absent(self, caplog, monkeypatch):
+        monkeypatch.delenv("API_SECRET_KEY", raising=False)
+        text = self._exec_main_fresh({}, caplog)
+        assert "API_SECRET_KEY" in text
+        assert "JWT" in text
+
+    def test_silent_when_secret_key_is_set(self, caplog):
+        text = self._exec_main_fresh({"API_SECRET_KEY": "x" * 32}, caplog)
+        assert "API_SECRET_KEY 미설정" not in text

--- a/tests/api/test_ticker_search.py
+++ b/tests/api/test_ticker_search.py
@@ -151,6 +151,39 @@ class TestTickerSearch:
         data = resp.json()
         assert data["count"] <= 8
 
+    def test_korean_name_search_stops_at_eight(self, client, monkeypatch):
+        """라인 182-183: **한글 이름** 매칭 루프의 8건 상한.
+
+        위 `q=0` 은 ticker **코드** 매칭 루프(160-161)의 상한을 친다. 한글 루프는
+        별도 상한이고, 그쪽이 안 끊기면 KOSPI200 전체를 순회하며 종목당 가격
+        쿼리를 한 번씩 날린다 — 검색 한 번이 수백 쿼리가 된다.
+
+        기존에는 개발 머신의 `config/kr_ticker_names.json` (gitignored) 덕에
+        로컬에서만 이 분기가 밟혔고 CI 에서는 한 번도 실행되지 않았다. 이름을
+        직접 주입해 환경 의존을 없앤다.
+
+        Gotcha-Test Pair: 183 의 `break` 를 지우면 count 가 8 을 넘어 FAIL.
+        """
+        # `search_tickers` 는 함수 본문에서 import 하므로 **원 모듈**을 패치해야 한다.
+        # conftest 의 autouse fixture 가 teardown 에서 `cache_clear()` 를 부르므로
+        # 스텁도 lru_cache 로 감싼다 (맨 lambda 면 teardown 이 AttributeError).
+        from functools import lru_cache
+
+        import nuri.core.ticker_names as tn
+
+        monkeypatch.setattr(
+            tn,
+            "get_ticker_name",
+            lru_cache(maxsize=None)(lambda t: "테스트종목" if t.endswith((".KS", ".KQ")) else None),
+        )
+        # "테스트" 는 어떤 ticker 코드에도 없다 → 코드 매칭 루프는 0건 → 한글 루프가 8건을 채운다.
+        resp = client.get("/api/tickers/search?q=테스트")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 8, f"한글 매칭 루프가 상한에서 안 끊겼다 (count={data['count']})"
+        assert all(r["ticker"].endswith((".KS", ".KQ")) for r in data["results"])
+
     def test_search_empty_query_rejected(self, client):
         """빈 쿼리는 422 에러."""
         resp = client.get("/api/tickers/search?q=")

--- a/tests/core/test_ticker_names.py
+++ b/tests/core/test_ticker_names.py
@@ -117,3 +117,45 @@ class TestGetTickerName:
             patch("pykrx.stock.get_market_ticker_name", return_value="맵외종목"),
         ):
             assert ticker_names.get_ticker_name("999000.KS") == "맵외종목"
+
+
+class TestKrNameMapLoad:
+    """`_load_kr_name_map` — 정적 맵 파일이 없거나 깨져도 이름 해석이 멈추면 안 된다."""
+
+    def setup_method(self) -> None:
+        ticker_names._load_kr_name_map.cache_clear()
+
+    def teardown_method(self) -> None:
+        # lru_cache(maxsize=1) 라 여기서 안 비우면 빈 dict 가 다른 테스트로 샌다.
+        ticker_names._load_kr_name_map.cache_clear()
+
+    def test_map_loads_when_the_file_exists(self, tmp_path) -> None:
+        """정상 경로 — 이 assert 가 깨지면 아래 실패 경로 테스트가 공허해진다.
+
+        실제 `config/kr_ticker_names.json` 을 읽지 않는다: 그 파일은 gitignored
+        (로컬 생성물)이라 CI 와 새 클론에는 아예 없다. 즉 **부재가 프로덕션의
+        기본 상태**이고, 그래서 아래 degradation 테스트가 이 모듈의 실질 경로다.
+        """
+        good = tmp_path / "kr_ticker_names.json"
+        good.write_text(json.dumps({"005930.KS": "TestCo"}), encoding="utf-8")
+        with patch.object(ticker_names, "_KR_NAMES_PATH", good):
+            assert ticker_names._load_kr_name_map() == {"005930.KS": "TestCo"}
+
+    def test_missing_file_degrades_to_empty_map(self, tmp_path) -> None:
+        """라인 30-32: 파일 부재 → 빈 dict.
+
+        이 맵은 pykrx 를 안 부르기 위한 캐시일 뿐이다. 없다고 예외를 내면
+        `get_ticker_name` 을 부르는 모든 경로(검색 API·브리프·리포트)가 같이
+        죽는다 — 성능 최적화의 부재가 기능 정지가 되면 안 된다.
+
+        Gotcha-Test Pair: except 를 지우면 FileNotFoundError 가 새어 FAIL.
+        """
+        with patch.object(ticker_names, "_KR_NAMES_PATH", tmp_path / "does_not_exist.json"):
+            assert ticker_names._load_kr_name_map() == {}
+
+    def test_corrupt_file_degrades_to_empty_map(self, tmp_path) -> None:
+        """깨진 JSON 도 같은 취급 — 파싱 실패가 조회 경로를 막지 않는다."""
+        bad = tmp_path / "kr_ticker_names.json"
+        bad.write_text("{not json", encoding="utf-8")
+        with patch.object(ticker_names, "_KR_NAMES_PATH", bad):
+            assert ticker_names._load_kr_name_map() == {}

--- a/tests/quant/validation/test_decision_alpha.py
+++ b/tests/quant/validation/test_decision_alpha.py
@@ -197,3 +197,134 @@ class TestAdjudicate:
         assert rc == 0
         out = capsys.readouterr().out
         assert '"verdict"' in out
+
+
+# ═══════════════════════════════════════════════════════
+# 열화 경로 — 설정 부재 / 가격 결측 / 치환 불가
+# ═══════════════════════════════════════════════════════
+
+
+class TestCriteriaSource:
+    def test_missing_measurement_mode_raises_instead_of_defaulting(self):
+        """판정 파라미터가 없으면 **멈춘다** — 기본값으로 조용히 판정하지 않는다.
+
+        §3.11 의 요체는 기준이 사전 고정돼 있다는 것이다. 설정이 사라졌는데
+        코드 기본값으로 리포트를 내면 그 리포트는 무엇을 기준으로 한 판정인지
+        아무도 모른다. 여기서 raise 하는 게 유일하게 정직한 동작이다.
+        """
+        from unittest.mock import patch
+
+        with patch.dict(da.RULES, {}, clear=True), pytest.raises(RuntimeError, match="measurement_mode"):
+            da._criteria()
+
+
+class TestPriceBookMisses:
+    """가격 조회는 없을 때 None 을 돌려줘야 한다 — 예외도, 이웃 값도 아니다."""
+
+    def test_exact_date_miss_returns_none(self, seeded):
+        book = da.PriceBook(db_path=seeded)
+        assert book.close("AAA", "2020-01-01") is None, "시계열 시작 전인데 값이 나왔다"
+        assert book.close("AAA", "2099-01-01") is None, "시계열 끝 이후인데 값이 나왔다"
+
+    def test_on_or_after_past_the_end_returns_none(self, seeded):
+        """창 끝이 시계열 밖 — 미래 창은 '아직 모른다' 이지 0 이 아니다."""
+        book = da.PriceBook(db_path=seeded)
+        assert book.close_on_or_after("AAA", "2099-01-01") is None
+
+    def test_unknown_ticker_is_empty_not_an_error(self, seeded):
+        book = da.PriceBook(db_path=seeded)
+        assert book.close("NOPRICE", EMIT_1) is None
+        assert book.close_on_or_after("NOPRICE", EMIT_1) is None
+
+
+class TestPlaceboAlphaGuards:
+    def test_missing_price_yields_none(self, seeded):
+        """가격이 없으면 placebo alpha 는 None — 이게 치환 후보 필터의 근거다."""
+        book = da.PriceBook(db_path=seeded)
+        assert da._placebo_alpha(book, "NOPRICE", EMIT_1, 30, "SPY") is None
+
+    def test_zero_entry_price_yields_none(self, seeded):
+        """entry=0 은 수익률 정의 불가 — ZeroDivisionError 대신 None."""
+        with get_db(seeded) as conn:
+            for d in _business_dates(EMIT_1, 40):
+                conn.execute("INSERT OR REPLACE INTO prices (ticker, date, close) VALUES ('ZEROP', ?, 0.0)", (d,))
+            conn.commit()
+        book = da.PriceBook(db_path=seeded)
+        assert da._placebo_alpha(book, "ZEROP", EMIT_1, 30, "SPY") is None
+
+
+class TestSkippedBlocks:
+    def test_block_without_substitutes_keeps_observed_alpha(self, db_path):
+        """라인 250-257: 치환 후보가 없는 블록은 null 에서도 실측 alpha 를 그대로 쓴다.
+
+        치환할 종목이 없다고 그 블록을 표본에서 빼면 null 이 실측보다 유리해져
+        p 가 anti-conservative 해진다. 실측을 그대로 넣으면 null 이 실측 쪽으로
+        끌려가 p 가 **보수적** 으로 나온다 — 틀리더라도 엣지를 과대평가하지 않는
+        방향으로 틀린다. 그리고 그 사실은 `skipped_blocks` 로 공시된다.
+
+        Gotcha-Test Pair: `continue` 대신 블록을 건너뛰면 count 가 0 이 되어
+        ZeroDivisionError, 실측 유지를 빼면 p 가 1.0 미만이 되어 FAIL.
+        """
+        _seed_prices(db_path, "SPY", "2026-07-01", 60, 100.0, 0.001)
+        _seed_prices(db_path, "ONLY", "2026-07-01", 60, 50.0, 0.002)
+        _seed_decision(db_path, 1, "ONLY", EMIT_1, alpha=0.05)
+        _seed_decision(db_path, 2, "ONLY", EMIT_2, alpha=0.07)
+
+        s = da.fetch_sample(db_path=db_path, as_of=AS_OF)
+        r = da.ticker_block_placebo(s, n_perm=20, seed=828, db_path=db_path)
+
+        assert r.skipped_blocks == ["ONLY"], "치환 불가 사실이 공시되지 않음"
+        assert r.null_means == [pytest.approx(r.observed_mean)] * 20
+        assert r.p_value == 1.0, "치환 불가 블록이 p 를 보수적으로 만들지 않았다"
+
+
+class TestVerdictBranches:
+    """라인 352-359: 판정 우선순위 — 결측 무효 > 표본 미달 > 3조건.
+
+    n≥200 은 판정일(2027-06-30)에나 도달할 표본이라, 이 두 분기는 그때까지 한
+    번도 실행되지 않는다. 판정 당일에 처음 돌아가는 코드를 남겨두지 않기 위해
+    `min_n_us_buy_decisions` 만 낮춰 분기 자체를 미리 실행한다 — 낮추는 건 이
+    테스트 안에서만이고, 실제 사전등록값은 `tests/core/test_rules.py` 의
+    `test_adjudication_params_locked` 가 그대로 잠근다.
+    """
+
+    def _adjudicate_with_small_n(self, db_path, **kw):
+        from unittest.mock import patch
+
+        with patch.dict(da.RULES["measurement_mode"], {"min_n_us_buy_decisions": 2}):
+            return da.adjudicate(db_path=db_path, n_perm=20, as_of=AS_OF, **kw)
+
+    def test_criteria_not_met_when_permutation_is_insignificant(self, seeded):
+        """평균 alpha 는 양수이고 반기 분할도 통과하지만 p 가 못 미친다.
+
+        가장 흔할 결과이며 §3.11 이 경고한 함정이다 — "평균이 +니까 엣지가 있다"
+        는 결론을 순열이 막는다.
+        """
+        report = self._adjudicate_with_small_n(seeded)
+
+        assert report["criteria_verdict_if_final"] == "CRITERIA_NOT_MET"
+        assert report["conditions"]["mean_alpha_positive"] is True
+        assert report["conditions"]["both_halves_positive"] is True
+        assert report["conditions"]["permutation_significant"] is False
+        assert report["verdict"] == "PROGRESS_REPORT", "판정일 전인데 최종 판정이 표출됐다"
+
+    def test_criteria_met_requires_all_three(self, db_path):
+        """3조건 동시 충족 → CRITERIA_MET. 승격 경로가 실제로 존재하는지 확인.
+
+        실측 alpha 를 모든 placebo 보다 크게 두어 p = 1/(20+1) = 0.0476 < 0.05.
+        이 분기가 죽어 있으면 판정일에 '통과인데 통과가 안 나오는' 상태가 된다.
+        """
+        _seed_prices(db_path, "SPY", "2026-07-01", 60, 100.0, 0.001)
+        for t, base, drift in (("AAA", 50.0, 0.002), ("BBB", 80.0, 0.0), ("TSLA", 200.0, 0.004)):
+            _seed_prices(db_path, t, "2026-07-01", 60, base, drift)
+        for rec_id, emit in ((1, EMIT_1), (2, EMIT_2), (3, EMIT_3)):
+            _seed_decision(db_path, rec_id, "TSLA", emit, alpha=0.5)
+        _seed_decision(db_path, 4, "AAA", EMIT_1, alpha=0.5)
+
+        report = self._adjudicate_with_small_n(db_path)
+
+        assert report["criteria_verdict_if_final"] == "CRITERIA_MET"
+        assert all(report["conditions"].values())
+        assert report["p_value"] < report["p_max"]
+        # 통과해도 판정일 전이면 표출은 진행 리포트 — 조기 승격 금지 (§3.11 원안 4번)
+        assert report["verdict"] == "PROGRESS_REPORT"

--- a/tests/trading/agents/test_wallstreet_branches.py
+++ b/tests/trading/agents/test_wallstreet_branches.py
@@ -149,3 +149,51 @@ class TestWallStreetBranches:
         v = WallStreetAgent().analyze("ZERO_REC", db_path=db_path)
         # 컨센서스 메시지 없음 (total=0)
         assert "컨센서스" not in v.reasoning
+
+    def test_mixed_rating_changes_are_reported_without_scoring(self, db_path, monkeypatch):
+        """라인 89: 업/다운이 둘 다 있으나 어느 쪽도 margin(2)을 못 넘김.
+
+        점수는 0 이지만 "등급변경이 있었다" 는 사실은 근거에 남아야 한다 — 여기가
+        비면 애널리스트 활동이 활발한 종목과 아무 커버리지 없는 종목이 같은 얼굴이
+        된다 (후자는 아래 `if not reasons` 로 '데이터 부족' HOLD).
+        """
+        ud = pd.DataFrame(
+            [
+                {"Action": "up", "priceTargetAction": "", "currentPriceTarget": float("nan")},
+                {"Action": "down", "priceTargetAction": "", "currentPriceTarget": float("nan")},
+            ],
+            index=[datetime.now()] * 2,
+        )
+        _patch_ticker(monkeypatch, ud=ud)
+
+        from nuri.trading.agents.wallstreet import WallStreetAgent
+
+        v = WallStreetAgent().analyze("MIXED", db_path=db_path)
+        assert "등급변경 혼조(1↑/1↓)" in v.reasoning
+        assert v.action == "HOLD", "점수 0 인데 방향이 잡혔다"
+        assert "데이터 부족" not in v.reasoning
+
+    def test_strong_signals_reach_the_buy_branch(self, db_path, monkeypatch):
+        """라인 189: score >= score_buy(3) → BUY + confidence 공식.
+
+        업그레이드 우세(+2) + 실적 서프라이즈(+2) = 4. BUY 분기는 이 에이전트가
+        낼 수 있는 유일한 매수 신호라, 한 번도 실행되지 않은 채로 두면 confidence
+        공식이 cap 을 넘기거나 normalize 에서 깨져도 아무도 모른다.
+        """
+        ud = pd.DataFrame(
+            [{"Action": "up", "priceTargetAction": "raises", "currentPriceTarget": float("nan")}] * 2,
+            index=[datetime.now()] * 2,
+        )
+        eh = pd.DataFrame([{"surprisePercent": 0.20, "epsActual": 1.2, "epsEstimate": 1.0}])
+        _patch_ticker(monkeypatch, ud=ud, eh=eh)
+
+        from nuri.trading.agents.wallstreet import WallStreetAgent
+
+        v = WallStreetAgent().analyze("STRONG", db_path=db_path)
+        assert v.action == "BUY"
+        # raw = min(buy_cap 85, buy_base 45 + score 4 × 10 = 85) = 85 → cap 에 정확히 걸림.
+        # 표출값은 base.normalize_confidence 가 agents.yaml 스케일로 재매핑한 결과다.
+        from nuri.trading.agents.wallstreet import WallStreetAgent as _W
+
+        assert v.confidence == pytest.approx(round(_W().normalize_confidence(85.0), 1))
+        assert 0 <= v.confidence <= 100

--- a/tests/trading/recommend/test_buy_candidate_emitter_branches.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter_branches.py
@@ -65,3 +65,40 @@ class TestCooldownTickerAccumulation:
         result = _get_cooldown_tickers_by_type(cfg)
         assert "AAA" in result  # type-aware path (line 154)
         assert "BBB" in result  # legacy fallback path (line 174)
+
+
+class TestRegimeAndVixDegradation:
+    """`_get_regime` 는 조회가 죽어도 값을 돌려줘야 한다 — 부르는 쪽이 게이트다."""
+
+    def test_vix_query_failure_falls_back_to_neutral_reading(self, monkeypatch):
+        """라인 251-252: VIX 조회 실패 → 20.0.
+
+        VIX 는 신규 매수 차단(>30) / 반포지션(25-30) 게이트의 입력이다. 조회가
+        실패했을 때 예외가 새면 후보 산출 전체가 멈추고, 반대로 30 같은 값으로
+        떨어지면 조회 실패가 조용히 '공포장' 으로 둔갑해 매수가 전면 차단된다.
+        20.0 은 어느 게이트도 건드리지 않는 중립값이라 '모름' 을 가장 정직하게
+        표현한다.
+
+        Gotcha-Test Pair: fallback 값을 25 이상으로 바꾸면 두 번째 assert 가 FAIL.
+        """
+        from nuri.core.rules import VIX_BLOCK_ABOVE, VIX_CAUTION_ABOVE
+        from nuri.trading.recommend import buy_candidate_emitter as bce
+
+        calls = []
+
+        def _selective_boom(sql, *a, **kw):
+            calls.append(sql)
+            if "macro" in sql:
+                raise RuntimeError("simulated DB failure")
+            import pandas as pd
+
+            return pd.DataFrame()
+
+        monkeypatch.setattr(bce, "query_df", _selective_boom)
+
+        regime, vix = bce._get_regime()
+
+        assert vix == 20.0
+        assert vix < VIX_CAUTION_ABOVE < VIX_BLOCK_ABOVE, "조회 실패가 공포장으로 둔갑하면 안 된다"
+        assert regime == "neutral"
+        assert any("macro" in s for s in calls), "VIX 조회 자체가 일어나지 않았다"

--- a/tests/trading/recommend/test_leader_exit.py
+++ b/tests/trading/recommend/test_leader_exit.py
@@ -121,6 +121,15 @@ class TestLeaderTrail:
         _seed(db_path, "GRW", 100.0, [140.0] * 49 + [125.0], sector="AI")
         assert check_leader_trail_signals(db_path=db_path) == []
 
+    def test_empty_portfolio_returns_empty(self, db_path):
+        """라인 507-508: 보유가 없으면 조회할 대상도 없다 — 빈 리스트.
+
+        `enabled=True` 인데 portfolio 가 비어 있는 조합은 신규 배포/빈 DB 에서
+        그대로 나온다. 아래 루프가 빈 DataFrame 을 만나면 iterrows 는 무해하지만,
+        이 early return 이 사라져도 아무도 모르므로 계약으로 고정한다.
+        """
+        assert check_leader_trail_signals(db_path=db_path) == []
+
     def test_skips_zero_entry_price(self, db_path):
         """avg_price=0 보유는 손익 계산 불가 → skip (크래시 없음)."""
         _seed(db_path, "ZERO", 0.0, [140.0] * 49 + [125.0], sector="AI")

--- a/tests/trading/recommend/test_recommend_branch_coverage_v2.py
+++ b/tests/trading/recommend/test_recommend_branch_coverage_v2.py
@@ -70,6 +70,41 @@ class TestBuyCandidateEmitterPriceSignalsEmpty:
         assert isinstance(result, dict)
 
 
+class TestBuyCandidateEmitterShortSeries:
+    """Line 202-203: `if len(grp) < 6: continue` — 45일 창 안에 6행 미만인 종목 skip.
+
+    `ret_5d` 가 `closes[-6]` 을 읽으므로 6행 미만이면 IndexError 다. 이 skip 이
+    사라지면 신규 상장·수집 재개 직후 종목 하나가 후보 산출 전체를 크래시시킨다.
+
+    이 분기는 **CI 에서만 미커버였다** — 개발 머신 DB 에는 짧은 시계열 종목이
+    우연히 있어서 로컬 실측이 100% 로 보였다. 필요한 데이터를 테스트가 직접
+    시드해야 어느 환경에서든 실행된다.
+    """
+
+    def test_ticker_with_fewer_than_six_rows_is_skipped(self, fresh_db, monkeypatch):
+        import nuri.core.db as db_mod
+
+        monkeypatch.setattr(db_mod, "DB_PATH", fresh_db)
+        from nuri.core.timezone import today_kst
+        from nuri.trading.recommend.buy_candidate_emitter import _get_price_signals
+
+        # 창(45일) 안에 들도록 today 기준 앵커링 — 고정 리터럴 날짜는 시한폭탄 (#721).
+        end = date.fromisoformat(today_kst())
+        with get_db(fresh_db) as conn:
+            for i in range(10):  # 충분한 종목 — 정상 처리
+                d = (end - timedelta(days=i)).isoformat()
+                conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('TESTLONG', ?, ?)", (d, 100.0 + i))
+            for i in range(3):  # 6행 미만 — skip 대상
+                d = (end - timedelta(days=i)).isoformat()
+                conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('TESTSHORT', ?, ?)", (d, 50.0 + i))
+            conn.commit()
+
+        out = _get_price_signals()
+
+        assert "TESTLONG" in out, "정상 종목까지 사라졌다 — 시드 자체가 창 밖일 수 있음"
+        assert "TESTSHORT" not in out, "6행 미만 종목이 skip 되지 않았다 (closes[-6] IndexError 위험)"
+
+
 class TestBuyCandidateEmitterRegimeFallbacks:
     """Lines 256-257, 264-265: regime/VIX query exceptions → defaults 'neutral'/20.0."""
 

--- a/tests/trading/recommend/test_tracker_branches.py
+++ b/tests/trading/recommend/test_tracker_branches.py
@@ -35,3 +35,34 @@ class TestTrackerEmptyByAction:
         # tracked > 0 → "Hit rate" 출력. by_action 빈 → "Action" 헤더 미출력.
         assert "Hit rate" in out
         assert "Action" not in out
+
+
+class TestRegimeClassifyDegradation:
+    def test_classify_failure_leaves_regime_null_and_still_saves(self, tmp_path, monkeypatch):
+        """라인 80-81: regime 분류가 죽어도 추천 저장은 계속되고 라벨은 NULL 로 남는다.
+
+        두 가지를 동시에 지킨다:
+        1. **저장이 막히면 안 된다.** regime 라벨은 사후 분석용 메타데이터지
+           추천의 성립 조건이 아니다 ([[feedback_observability_must_not_gate]]).
+        2. **'unknown' 같은 가짜 라벨을 쓰면 안 된다** (#832). 분류 실패와 실제
+           regime 을 구분할 수 없게 되면 라벨 커버리지 통계 자체가 거짓이 된다.
+
+        Gotcha-Test Pair: except 를 지우면 저장이 통째로 죽어 FAIL. NULL 대신
+        'unknown' 을 넣어도 FAIL.
+        """
+        from nuri.core.db import init_db, query
+        from nuri.trading.recommend.candidates import Candidate
+        from nuri.trading.recommend.tracker import save_recommendations
+
+        p = tmp_path / "tr_regime.db"
+        init_db(p)
+
+        import nuri.quant.regime.classifier as clf
+
+        monkeypatch.setattr(clf, "classify_regime", lambda **kw: (_ for _ in ()).throw(RuntimeError("no price data")))
+
+        candidates = [Candidate("TESTAA", "rsi_oversold", "2026-03-01", "BUY", 75.0, 0.6, 2.0, True, 100.0, "test")]
+        assert save_recommendations(candidates, db_path=p) == 1
+
+        rows = query("SELECT regime FROM recommendations WHERE ticker = 'TESTAA'", db_path=p)
+        assert rows[0]["regime"] is None, "분류 실패가 가짜 라벨로 저장됐다"


### PR DESCRIPTION
Closes #926.

## 결과

**statement 미커버 34 → 0** (22,560 statements, full local suite `-m "not integration"`). partial branch 는 부수적으로 69 → 57.

## 왜 이게 숫자놀음이 아닌가

남아 있던 34줄이 **거의 전부 실패/열화 경로**였다. 우연이 아니라 구조다 — 정상 경로는 기능 테스트가 자연히 밟으므로, 남는 건 "이미 뭔가 잘못됐을 때만 실행되는 코드" 다. 이 레포는 정확히 그 층에서 세 번 다쳤다:

- **#894** — 관측용 조회가 본 작업과 같은 `try` 에 있어 DB 하나로 job 이 죽음
- **#910/#911** — pre-push 테스트 단계가 `rc=127` 로 3.5개월 no-op
- **FD exhaustion** — 6일 silent outage, 헬스는 전부 초록

셋 다 "실패하면 어떻게 되는가" 가 한 번도 실행된 적 없어서 늦게 발견됐다. 그래서 이 테스트들은 라인을 밟는 게 아니라 **동작을 못 박는다**:

| 대상 | 무엇을 잠갔나 |
|---|---|
| `scheduler` | heartbeat **쓰기** 실패가 job 을 데려가지 않는다 — #894 는 *읽기* 만 다뤘다. 쓰기도 똑같이 위험하다 |
| `buy_candidate_emitter` | VIX 조회 실패 → 20.0. **두 VIX 게이트(25/30) 아래**임을 assert — 조회 실패가 공포장으로 둔갑해 신규 매수를 전면 차단하는 일이 없도록 |
| `tracker` | regime 분류 실패 → NULL 유지 ('unknown' 금지, #832). 그리고 저장은 계속된다 |
| `ticker_names` | 이름 맵 부재/파손 → `{}`. pykrx 캐시를 잃는 게 이름 조회 경로 전체를 죽이면 안 된다 |
| `postmarket_brief` | 손절 신호 staging 실패 = 신호 1건 손실이지 브리프 전체 손실이 아니다 |
| `sre_incident_agent` | `already_emitted` / `staged` skip 사유 — 운영자가 어디를 먼저 볼지 결정하는 값 |
| `decision_alpha` | 설정 부재 시 기본값 판정 대신 raise · 가격 결측 None · 치환 불가 블록이 p 를 **보수적**으로 유지 · 두 verdict 분기 |
| `api/main` | `API_SECRET_KEY` 경고 — 없으면 증상이 "가끔 로그아웃됨" 이라 원인까지 도달이 어렵다 |
| `wallstreet` | BUY 분기(이 에이전트의 유일한 매수 신호) + 등급변경 혼조 |

### `decision_alpha` 두 verdict 분기가 특히 중요한 이유

`min_n_us_buy_decisions = 200` 은 판정일(2027-06-30)에나 닿는 표본이다. 즉 `CRITERIA_MET` / `CRITERIA_NOT_MET` 는 **판정 당일에 처음 실행될 코드**였다. 테스트 안에서만 n 임계를 낮춰 지금 실행해 둔다 — 사전등록값 자체는 `test_adjudication_params_locked` 가 그대로 잠근다.

## pragma 3곳

- `__main__` 본문 2곳 (`heartbeat_watchdog`, `decision_alpha`) — in-process 도달 불가, 레포 내 동일 형태 31곳.
- `sre_incident_agent` payload `except` 1곳 — **관행이 아니라 발견이다.** 이 except 는 도달 불가한데 정작 실제 고장 모드 둘은 그냥 통과한다:

  | payload | 집계 쿼리의 `json_extract` | 실제 결과 |
  |---|---|---|
  | `{not json` | **OperationalError** | detector 통째로 사망 |
  | `null` / `[]` / `"x"` | 통과 | `.get` → AttributeError → 예외 전파 |

  감시자를 감시 대상이 죽이는 구조 — **#927** 로 분리(동작 변경). pragma 주석이 그 이슈를 인용한다.

## 문서

커버리지 클레임이 "28/22,539 미커버, 9개 파일" 로 낡아 있어 함께 갱신했다. 값은 로컬 full-suite 실측이며 출처를 명시했다 — `make ci-cov` / Codecov `backend` 가 CI ground truth라, 이 PR 의 CI 결과로 재대조할 것.

## 게이트

`make verify-all` 5/5 · `make lint` clean · `make verify-doc-counts` 19/19 · privacy scan clean · 6,462 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)