### PR TITLE
fix(scheduler): read cron weekdays as crontab, not as APScheduler (#929)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,486 collected across 288 files | |
+| **Backend tests** | 6,505 collected across 289 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,486 backend tests across 288 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,505 backend tests across 289 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,486 tests, 288 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,505 tests, 289 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/CLAUDE.md
+++ b/nuri/agents/CLAUDE.md
@@ -56,7 +56,8 @@ Only 4 actors are reached from `SCHEDULES` today, and **only one of them is a re
 
 So **14 of the 15 registered actors have no cron** — they run from their `main()` CLI or another caller. **Do not assume an actor is running just because it exists and is registered.** Check `SCHEDULES` before claiming anything about live behaviour.
 
-⚠️ **APScheduler weekday ≠ crontab weekday.** `day_of_week` is Mon=0…Sun=6, so a crontab literal `1-5` fires **Tue–Sat**. Use explicit `mon-fri`.
+⚠️ **APScheduler weekday ≠ crontab weekday**, but `SCHEDULES` entries are written in **crontab** semantics (0=Sun) and `scheduler._make_trigger()` converts. Write `1-5` for Mon–Fri and `0` for Sunday, as you would in a crontab — do NOT pre-convert to `mon-fri`, and do NOT call `CronTrigger.from_crontab()` directly (it skips the conversion, which is how every non-`tz` job ran a day late until #929 — `stock_us_freshness` missed Tuesdays, leaving the §3.11 benchmark SPY stale each Mon/Tue).
+**Test:** `tests/test_scheduler_weekday.py::TestEverySchedulesJobFiresOnIntendedDays::test_all_jobs_match_crontab_semantics` — asks the registered triggers which weekdays they actually fire on and compares against a hand-written crontab table.
 
 ## Adding an actor
 

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -16,6 +16,7 @@ import os
 import signal
 import sys
 from pathlib import Path
+from typing import Any, Optional
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -766,45 +767,104 @@ def _write_heartbeat():
         pass
 
 
+def _make_trigger(cron: str, tz: Optional[str] = None) -> CronTrigger:
+    """crontab 문자열 → CronTrigger. 요일은 crontab 규약으로 해석한다.
+
+    `CronTrigger.from_crontab()` 은 요일 필드를 **변환 없이** APScheduler 의
+    `day_of_week`(Mon=0…Sun=6)로 넘긴다. crontab 은 0=Sun 이므로 그대로 쓰면 모든
+    job 이 하루씩 밀린다 — `1-5`(월–금)가 화–토로, `0`(일)이 월요일로 fire 된다.
+
+    이 함정은 #432 리뷰에서 이미 지적돼 주석으로 남아 있었지만 변환은 `tz` 있는
+    job 에만 걸려 있었다. 나머지 22 개는 밀린 채였고, 그 결과 `stock_us_freshness`
+    가 화요일에 안 돌아 §3.11 벤치마크(SPY)가 매주 월·화 stale 이었다 (#929).
+    `period=5d` 가 뒤늦게 메꿔 영구 결손이 아니었던 탓에 조용히 지나갔다.
+
+    변환을 한 곳에 두어 `tz` 유무와 무관하게 같은 의미가 되게 한다.
+    """
+    parts = cron.split()
+    if len(parts) != 5:
+        raise ValueError(f"cron 필드가 5개가 아님: {cron!r}")
+    minute, hour, day, month, dow = parts
+    kwargs: dict[str, Any] = {
+        "minute": minute,
+        "hour": hour,
+        "day": day,
+        "month": month,
+        "day_of_week": _crontab_dow(dow),
+    }
+    if tz:
+        import pytz
+
+        kwargs["timezone"] = pytz.timezone(tz)
+    return CronTrigger(**kwargs)
+
+
+# crontab 요일 숫자(0=일) → 이름. crontab 은 0 과 7 을 모두 일요일로 본다.
+_CRONTAB_DOW_NAMES = ("sun", "mon", "tue", "wed", "thu", "fri", "sat", "sun")
+_NAME_TO_CRONTAB_DOW = {n: i for i, n in enumerate(_CRONTAB_DOW_NAMES[:7])}
+
+
+def _crontab_dow(field: str) -> str:
+    """crontab 요일 필드 → APScheduler `day_of_week` 문자열.
+
+    치환이 아니라 **열거**한다. `mon-fri` 로 문자열만 바꾸면 `*/2` 같은 step 형식이
+    조용히 다른 요일 집합이 된다 — crontab `*/2` 는 0 부터라 일·화·목·토, APScheduler
+    `*/2` 는 월부터라 월·수·금·일이다. 이 이슈 자체가 그런 조용한 불일치였으므로
+    같은 함정을 함수 안에 남기지 않는다.
+    """
+    if field.strip() == "*":
+        return "*"
+    days = sorted(_parse_crontab_dow(field))  # crontab 번호 (0=일)
+    # APScheduler 는 이름을 Mon=0…Sun=6 로 읽으므로 월요일부터 정렬해 내보낸다.
+    ordered = sorted(days, key=lambda d: (d - 1) % 7)
+    return ",".join(_CRONTAB_DOW_NAMES[d] for d in ordered)
+
+
+def _parse_crontab_dow(field: str) -> set[int]:
+    """crontab 요일 필드 → {0..6} (0=일). 7 은 0 으로 정규화."""
+    out: set[int] = set()
+    for part in field.split(","):
+        part = part.strip()
+        step = 1
+        if "/" in part:
+            part, _, step_raw = part.partition("/")
+            step = int(step_raw)
+            if step < 1:
+                raise ValueError(f"crontab 요일 step 이 1 미만: {field!r}")
+        if part == "*":
+            lo, hi = 0, 6
+        elif "-" in part:
+            lo_raw, _, hi_raw = part.partition("-")
+            lo, hi = _dow_num(lo_raw), _dow_num(hi_raw)
+        else:
+            lo = hi = _dow_num(part)
+        # crontab 은 lo > hi 인 wrap 범위(fri-mon 등)를 표준으로 지원하지 않는다.
+        if lo > hi:
+            raise ValueError(f"crontab 요일 범위가 역순: {field!r}")
+        out.update(range(lo, hi + 1, step))
+    return out
+
+
+def _dow_num(token: str) -> int:
+    """요일 토큰 → crontab 번호(0=일). 숫자와 이름 모두 허용."""
+    token = token.strip().lower()
+    if token.isdigit():
+        n = int(token)
+        if not 0 <= n <= 7:
+            raise ValueError(f"crontab 요일 범위 밖: {token!r}")
+        return n % 7
+    if token not in _NAME_TO_CRONTAB_DOW:
+        raise ValueError(f"알 수 없는 요일 토큰: {token!r}")
+    return _NAME_TO_CRONTAB_DOW[token]
+
+
 def create_scheduler() -> BlockingScheduler:
     """스케줄러 생성 및 작업 등록."""
     scheduler = BlockingScheduler()
 
     for job in SCHEDULES:
-        # tz kwarg optional — CronTrigger.from_crontab 은 tz 를 직접 지원 안 함.
-        # tz 지정 job 은 CronTrigger() 직접 호출 (codex Plan: DST-aware).
-        # ⚠️ WEEKDAY SEMANTICS — APScheduler CronTrigger 는 `day_of_week="0-6"`
-        # 를 **Mon=0, Sun=6** 로 해석 (crontab standard 0=Sun 아님). 따라서
-        # crontab literal `1-5` 를 그대로 넘기면 Tue-Sat 로 fire 됨 (codex
-        # #432 Review). 안전하게 `mon-fri` 같은 명시적 literal 사용.
-        if "tz" in job:
-            import pytz
-
-            parts = job["cron"].split()
-            dow_raw = parts[4]
-            dow_map = {
-                "0": "sun",
-                "1": "mon",
-                "2": "tue",
-                "3": "wed",
-                "4": "thu",
-                "5": "fri",
-                "6": "sat",
-                "1-5": "mon-fri",
-                "0-6": "mon-sun",
-                "*": "*",
-            }
-            dow = dow_map.get(dow_raw, dow_raw)
-            trigger = CronTrigger(
-                minute=parts[0],
-                hour=parts[1],
-                day=parts[2],
-                month=parts[3],
-                day_of_week=dow,
-                timezone=pytz.timezone(job["tz"]),
-            )
-        else:
-            trigger = CronTrigger.from_crontab(job["cron"])
+        # 요일 규약 변환은 `_make_trigger` 안에 있다 (#929) — tz 유무로 갈리지 않는다.
+        trigger = _make_trigger(job["cron"], job.get("tz"))
         scheduler.add_job(
             job["func"],
             trigger=trigger,

--- a/tests/test_scheduler_weekday.py
+++ b/tests/test_scheduler_weekday.py
@@ -1,0 +1,173 @@
+"""스케줄러 요일 규약을 crontab 의미로 고정한다 (#929).
+
+`CronTrigger.from_crontab()` 은 요일 필드를 **변환 없이** APScheduler 의
+`day_of_week`(Mon=0…Sun=6)로 넘긴다. crontab 은 0=Sun 이라 그대로 쓰면 모든 job 이
+하루씩 밀린다. 이 함정은 #432 리뷰에서 이미 발견돼 `scheduler.py` 에 경고 주석까지
+있었는데, 변환은 `tz` 있는 job 1개에만 걸려 있었고 나머지 22개는 밀린 채였다.
+
+실제 피해 (2026-07-29 프로덕션 실측): `stock_us_freshness` 의 `2-6` 이 화–토가
+아니라 수–일로 fire → **화요일에 안 돌아** 미국 월요일 종가가 수요일에야 들어왔다.
+그 결과 §3.11 US 판정의 벤치마크인 SPY 가 매주 월·화 stale (07-24 금 → 07-28 화
+동안 갱신 없음, 같은 기간 KOSPI 는 정상). `period=5d` 가 뒤늦게 메꿔 영구 결손이
+아니었던 탓에 아무 알림도 울리지 않았다.
+
+여기서 두 가지를 잠근다:
+  1. 변환 함수가 crontab 의미를 정확히 옮긴다 (step 형식 포함)
+  2. SCHEDULES 의 **모든** job 이 crontab 의미대로 fire 한다 — tz 유무와 무관하게
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+
+from nuri.scheduler import SCHEDULES, _crontab_dow, create_scheduler
+
+KST = pytz.timezone("Asia/Seoul")
+
+# 손으로 적은 crontab 규약 표 — 검사 대상 코드와 독립적이어야 의미가 있다.
+_CRONTAB_DAY = {0: "Sun", 1: "Mon", 2: "Tue", 3: "Wed", 4: "Thu", 5: "Fri", 6: "Sat", 7: "Sun"}
+_ALL_DAYS = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}
+
+
+def _intended_weekdays(dow_field: str) -> set[str]:
+    """crontab 요일 필드가 **의도한** 요일 집합 (독립 참조 구현).
+
+    SCHEDULES 는 `*` / 단일 숫자 / 단순 범위만 쓴다. step 형식이 들어오면 이 참조가
+    조용히 틀리는 대신 실패하게 둔다 — 그때는 이 함수부터 고쳐야 한다.
+    """
+    dow_field = dow_field.strip()
+    if dow_field == "*":
+        return set(_ALL_DAYS)
+    out: set[str] = set()
+    for part in dow_field.split(","):
+        assert "/" not in part, f"참조 구현이 step 형식을 모른다: {dow_field!r}"
+        if "-" in part:
+            lo, _, hi = part.partition("-")
+            out |= {_CRONTAB_DAY[n] for n in range(int(lo), int(hi) + 1)}
+        else:
+            out.add(_CRONTAB_DAY[int(part)])
+    return out
+
+
+def _actual_weekdays(trigger) -> set[str]:
+    """트리거가 실제로 fire 하는 요일 — APScheduler 에게 직접 물어본다.
+
+    2주를 훑어 어느 요일에 한 번이라도 fire 하는지 모은다 (문서 해석이 아니라 실측).
+    """
+    now = KST.localize(datetime(2026, 6, 1))  # 월요일
+    end = now + timedelta(days=14)
+    days: set[str] = set()
+    while True:
+        nxt = trigger.get_next_fire_time(None, now)
+        if nxt is None or nxt > end:
+            return days
+        days.add(nxt.strftime("%a"))
+        now = nxt + timedelta(minutes=1)
+
+
+class TestCrontabDowConversion:
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            ("*", "*"),
+            ("0", "sun"),
+            ("7", "sun"),  # crontab 은 0 과 7 을 모두 일요일로 본다
+            ("6", "sat"),
+            ("1-5", "mon,tue,wed,thu,fri"),
+            ("2-6", "tue,wed,thu,fri,sat"),
+            ("0,6", "sat,sun"),
+            ("mon-fri", "mon,tue,wed,thu,fri"),  # 이름은 두 규약이 일치 — 통과만
+        ],
+    )
+    def test_field_conversion(self, field, expected):
+        assert _crontab_dow(field) == expected
+
+    def test_step_form_is_enumerated_not_rewritten(self):
+        """`*/2` 를 문자열 그대로 넘기면 조용히 다른 요일이 된다.
+
+        crontab `*/2` = 0,2,4,6 = 일·화·목·토. APScheduler 가 `*/2` 를 그대로 받으면
+        월부터 세어 월·수·금·일이 된다 — 겹치는 요일이 있어 더 알아채기 어렵다.
+
+        Gotcha-Test Pair: 열거를 문자열 치환으로 되돌리면 FAIL.
+        """
+        assert set(_crontab_dow("*/2").split(",")) == {"sun", "tue", "thu", "sat"}
+        assert set(_crontab_dow("0-6/3").split(",")) == {"sun", "wed", "sat"}
+
+    @pytest.mark.parametrize("bad", ["8", "-1", "fri-mon", "nonday", "1-5/0"])
+    def test_invalid_field_raises(self, bad):
+        """조용히 통과시키느니 기동 때 죽는 게 낫다 — 이 이슈가 조용해서 오래갔다."""
+        with pytest.raises(ValueError):
+            _crontab_dow(bad)
+
+
+def _registered_triggers() -> dict[str, object]:
+    """`create_scheduler()` 가 **실제로 등록한** 트리거.
+
+    helper 를 직접 부르면 배선을 못 잠근다 — `create_scheduler` 안의 호출을
+    `from_crontab` 으로 되돌려도 helper 테스트는 그대로 통과한다. 실측으로
+    확인한 구멍이라 등록 결과를 본다.
+    """
+    return {j.id: j.trigger for j in create_scheduler().get_jobs()}
+
+
+class TestEverySchedulesJobFiresOnIntendedDays:
+    def test_all_jobs_match_crontab_semantics(self):
+        """등록된 전 job 의 실제 fire 요일 == crontab 이 뜻하는 요일.
+
+        Gotcha-Test Pair: `create_scheduler` 의 트리거 생성을
+        `CronTrigger.from_crontab()` 으로 되돌리면 요일 필드가 `*` 가 아닌 22개
+        job 이 전부 하루씩 밀려 FAIL.
+        """
+        triggers = _registered_triggers()
+        drift = []
+        for job in SCHEDULES:
+            want = _intended_weekdays(job["cron"].split()[4])
+            got = _actual_weekdays(triggers[job["name"]])
+            if want != got:
+                drift.append(f"{job['name']} ({job['cron']}): 기대 {sorted(want)} != 실제 {sorted(got)}")
+        assert not drift, "요일이 밀린 job:\n  " + "\n  ".join(drift)
+
+    def test_every_scheduled_job_is_registered(self):
+        """SCHEDULES 항목이 전부 등록되는지 — 빠지면 위 sweep 이 그 job 을 못 본다.
+
+        `heartbeat` 는 SCHEDULES 밖에서 interval 트리거로 직접 등록되므로 cron
+        요일 검사 대상이 아니다 (초과분 1건 허용).
+        """
+        registered = set(_registered_triggers())
+        missing = {j["name"] for j in SCHEDULES} - registered
+        assert not missing, f"등록되지 않은 SCHEDULES job: {sorted(missing)}"
+        assert registered - {j["name"] for j in SCHEDULES} == {"heartbeat"}
+
+    def test_the_sweep_actually_covers_non_wildcard_jobs(self):
+        """요일 필드가 전부 `*` 면 위 테스트가 공허하게 통과한다."""
+        specific = [j for j in SCHEDULES if j["cron"].split()[4] != "*"]
+        assert len(specific) >= 20, f"요일 지정 job 이 {len(specific)}개뿐 — sweep 무력화 의심"
+
+
+class TestFreshnessJobRegression:
+    """#929 의 증상 자체 — SPY 수집이 화요일에 돌아야 한다."""
+
+    def _freshness_job(self):
+        jobs = [s for s in SCHEDULES if (s.get("kwargs") or {}).get("source") == "freshness"]
+        assert jobs, "source=freshness job 이 사라짐 (#860 회귀)"
+        return jobs[0]
+
+    def test_freshness_runs_on_tuesday(self):
+        """화요일 아침에 돌아야 미국 **월요일** 종가가 당일 들어온다.
+
+        Gotcha-Test Pair: 요일 변환을 되돌리면 화요일이 빠져 FAIL — 그게 SPY 가
+        월·화 stale 이던 이유다.
+        """
+        job = self._freshness_job()
+        days = _actual_weekdays(_registered_triggers()[job["name"]])
+        assert "Tue" in days, f"{job['name']} 이 화요일에 안 돈다 (실제 {sorted(days)})"
+
+    def test_freshness_covers_every_us_trading_day_plus_one(self):
+        """미국 월–금 종가는 KST 화–토 아침에 수집된다 — 하루도 비면 안 된다."""
+        job = self._freshness_job()
+        days = _actual_weekdays(_registered_triggers()[job["name"]])
+        missing = {"Tue", "Wed", "Thu", "Fri", "Sat"} - days
+        assert not missing, f"{job['name']} 이 {sorted(missing)} 에 안 돈다 — 그날 벤치마크가 stale"


### PR DESCRIPTION
Closes #929.

## 무엇이 문제였나

`CronTrigger.from_crontab()` 은 요일 필드를 **변환하지 않는다** — crontab 의 0=일요일 번호를 APScheduler 의 Mon=0…Sun=6 에 그대로 넘긴다. 이걸로 등록된 job 은 전부 하루씩 밀린다: `1-5` 는 화–토로, `0` 은 월요일로.

**이 함정은 이미 알려져 있었다.** #432 리뷰가 찾아냈고 코드 바로 위에 경고 주석까지 있었다. 그런데 대응은 `if "tz" in job:` 안에 들어갔고, 그 분기에 해당하는 job 은 48개 중 **1개**다. 나머지 22개는 그 버그를 설명하는 주석 밑에서 그대로 버그였다.

## 대가

프로덕션 실측 (2026-07-29):

```
SPY   최신 2026-07-24 (금)      ← 월·화 미국 거래일 두 개 결손
KOSPI 최신 2026-07-28 (화)      ← 정상
US 티커 수 — 07-24: 542 / 07-27: 10 / 07-28: 10   (10 = 보유 종목만)
```

`stock_us_freshness` (`2-6`) 가 화–토가 아니라 **수–일**로 fire → 화요일에 안 돌아 미국 월요일 종가가 수요일에야 들어왔다. SPY 는 §3.11 US 판정의 벤치마크라 그 구간 alpha 가 전부 부정확해진다 — #860 이 막으려던 바로 그 고장이, #860 이 넣은 job 이 배선된 채로 났다.

아무 알림도 안 울린 이유: `period=5d` 가 수요일에 뒤늦게 메꾼다. **영구 결손이 아니라 주기적 지연**이라 조용했다.

## 무엇을 했나

변환을 `_make_trigger()` 한 곳에 두고 `tz` 유무와 무관하게 적용한다.

**치환이 아니라 열거한다.** `mon-fri` 로 문자열만 바꾸면 step 형식이 조용히 다른 요일 집합이 된다 — crontab `*/2` 는 일·화·목·토, APScheduler `*/2` 는 월·수·금·일이다. 겹치는 요일이 있어 지금 고치는 버그보다 알아채기 더 어렵다. 같은 함정을 함수 안에 남기지 않는다.

범위 밖·역순 필드는 기동 시 raise 한다. 그럴듯해 보이는 스케줄을 조용히 등록하느니 죽는 게 낫다 — 이 이슈가 오래간 이유가 조용해서였다.

## 배포 후 달라지는 것

| | 이전 (실제) | 이후 (cron 이 뜻하던 대로) |
|---|---|---|
| `stock_us_night` `1-5` | 화–토 | **월–금** |
| `stock_us_dawn` · `technical` · `ark` · `postmarket_brief_us_*` · `stock_us_freshness` `2-6` | 수–일 | **화–토** |
| `stock_kr` `1-5` | 화–토 | **월–금** |
| 주간 job 12개 `0` (backfill · db_maintenance · dispatcher_rollout · 주간 collector) | 월요일 | **일요일** |

`premarket_brief` 은 유일한 `tz` job 이라 원래 정상이었고 그대로다.

## 테스트

**등록된 트리거**에게 실제 발화 요일을 물어 손으로 적은 crontab 표와 대조한다. helper 만 테스트하는 건 부족했다 — 실측으로 확인: `create_scheduler` 를 `from_crontab` 으로 되돌려도 helper 테스트는 초록이었다. 이 PR 이 고치는 결함(경고는 있는데 배선에 안 걸림)과 같은 모양이라 배선을 보게 고쳤다.

mutation 검증 4건 전부 FAIL 확인:

| mutation | FAIL |
|---|---|
| `create_scheduler` → `from_crontab` | 3건 |
| step 을 문자열 통과로 | 1건 |
| `0` 을 월요일로 매핑 | 11건 |
| 범위 역순 검증 제거 | 1건 |

`nuri/agents/CLAUDE.md` 의 gotcha 도 갱신 — "명시 literal 을 쓰라" 는 우회 권고에서 "crontab 으로 쓰면 변환된다 + `from_crontab` 직접 호출 금지" 로, Gotcha-Test Pair 인용 포함.

## 게이트

`make verify-all` 5/5 · `make lint` clean · `make verify-doc-counts` 19/19 · privacy clean · scheduler·alerts 439 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)