### PR TITLE
fix(measurement): exclude KOSDAQ from the US adjudication sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,505 collected across 289 files | |
+| **Backend tests** | 6,508 collected across 289 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,505 backend tests across 289 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,508 backend tests across 289 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -245,7 +245,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,505 tests, 289 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,508 tests, 289 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/validation/decision_alpha.py
+++ b/nuri/quant/validation/decision_alpha.py
@@ -44,6 +44,7 @@ import numpy as np
 
 from nuri.core.db import query
 from nuri.core.rules import RULES
+from nuri.core.ticker_names import is_kr_ticker
 from nuri.core.timezone import today_kst
 
 # 순열 null 오염 방지 — 지수/선물 pseudo-ticker 는 universe 에서 제외.
@@ -136,7 +137,6 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
         LEFT JOIN decision_outcomes o
                ON o.decision_id = 'rec_' || r.id AND o.observation_window = ?
         WHERE ad.action = 'BUY'
-          AND r.ticker NOT LIKE '%.KS'
           AND r.date >= ? AND r.date <= ?
         ORDER BY r.date, r.id
         """,
@@ -147,6 +147,10 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
     sample = Sample()
     for raw in rows:
         r = dict(raw)
+        # §3.11 판정은 US-only 고정 — KR(.KS + .KQ) 은 별도 사전등록 전까지 진단 전용.
+        # SQL `NOT LIKE '%.KS'` 는 .KQ 를 통과시켰다 (#925). 판별은 canonical helper 로만.
+        if is_kr_ticker(r["ticker"]):
+            continue
         if r["alpha"] is not None:
             sample.decisions.append(
                 {
@@ -194,11 +198,12 @@ def _eligible_substitutes(
     """블록별 치환 후보 — 해당 블록의 모든 emit 일자에서 placebo alpha 계산 가능한
     US ticker (원 ticker·benchmark·pseudo 제외). 결정론 보장 위해 정렬 유지."""
     rows = query(
-        "SELECT DISTINCT ticker FROM prices WHERE ticker NOT LIKE '%.KS' ORDER BY ticker",
+        "SELECT DISTINCT ticker FROM prices ORDER BY ticker",
         db_path=db_path,
     )
     universe = [dict(r)["ticker"] for r in rows]
-    universe = [t for t in universe if t not in PSEUDO_TICKERS and t != benchmark]
+    # 치환 universe 도 표본과 같은 시장이어야 null 이 유효 — KR(.KS + .KQ) 제외 (#925).
+    universe = [t for t in universe if not is_kr_ticker(t) and t not in PSEUDO_TICKERS and t != benchmark]
 
     eligible: dict[str, list[str]] = {}
     for ticker, dates in blocks.items():

--- a/tests/quant/validation/test_decision_alpha.py
+++ b/tests/quant/validation/test_decision_alpha.py
@@ -13,6 +13,7 @@ from datetime import date, timedelta
 import pytest
 
 from nuri.core.db import get_db, init_db
+from nuri.core.ticker_names import is_kr_ticker
 from nuri.quant.validation import decision_alpha as da
 
 # ─── 합성 원장 픽스처 ───────────────────────────────────
@@ -113,6 +114,31 @@ class TestFetchSample:
         assert s.n == 4
         assert all(not d["ticker"].endswith(".KS") for d in s.decisions)
 
+    def test_kosdaq_excluded_from_us_sample(self, seeded):
+        """`.KQ`(KOSDAQ) 도 US 표본에서 빠진다 (#925).
+
+        Gotcha lock: `.KS` 만 배제하던 SQL LIKE 필터는 `.KQ` 를 통과시켰다.
+        #833 착륙 후 `.KQ` 결정의 원장 alpha 는 **KOSPI 기준**으로 기록되므로,
+        통과하면 벤치마크가 다른 행이 SPY 기준 mean alpha 와 순열 null 에 섞인다.
+        판별은 canonical `is_kr_ticker` 로만 — 접미사를 다시 손으로 적으면 재발한다.
+        """
+        _seed_decision(seeded, 30, "247540.KQ", EMIT_1, alpha=0.5)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n == 4
+        assert not any(is_kr_ticker(d["ticker"]) for d in s.decisions)
+
+    def test_kr_not_counted_as_missing(self, seeded):
+        """KR 배제는 결측 분모보다 **앞**이다 (#925).
+
+        결측률은 15% 초과 시 판정을 무효화하는 사전등록 기준이다 (§3.11). KR 이
+        결측으로 세어지면 US 판정이 KR 추적 실패로 무효화될 수 있다.
+        """
+        _seed_decision(seeded, 31, "247540.KQ", EMIT_1, alpha=None)
+        _seed_decision(seeded, 32, "005930.KS", EMIT_2, alpha=None)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n_missing_closed == 0
+        assert s.missing_rate_pct == 0.0
+
     def test_missing_only_when_window_closed(self, seeded):
         # 창 닫힘 + alpha 없음 → 결측 / 창 미도래 → 결측 아님 (lookahead)
         _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # closed, missing
@@ -145,6 +171,20 @@ class TestTickerBlockPlacebo:
         assert "TSLA" not in eligible["TSLA"]
         assert "SPY" not in eligible["TSLA"]
         assert set(eligible["TSLA"]) <= {"AAA", "BBB", "CCC", "NVDA"}
+
+    def test_placebo_universe_excludes_kr(self, seeded):
+        """치환 universe 에서도 KR 이 빠진다 (#925).
+
+        Gotcha lock: universe 쿼리도 `.KS` 만 배제했다. KR 종목이 US 표본의 치환
+        후보가 되면 null 분포에 FX·시장 스타일이 섞여 p 자체가 무의미해진다
+        (§3.11: "동일 시장 eligible universe 에서 ticker 치환").
+        """
+        _seed_prices(seeded, "247540.KQ", "2026-07-01", 60, 40.0, 0.001)
+        _seed_prices(seeded, "005930.KS", "2026-07-01", 60, 70.0, 0.001)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        book = da.PriceBook(db_path=seeded)
+        eligible = da._eligible_substitutes(book, da._blocks(s.decisions), 30, "SPY", db_path=seeded)
+        assert not any(is_kr_ticker(t) for cands in eligible.values() for t in cands)
 
     def test_deterministic_p_with_same_seed(self, seeded):
         s = da.fetch_sample(db_path=seeded, as_of=AS_OF)


### PR DESCRIPTION
The §3.11 adjudication sample excluded Korea with `NOT LIKE '%.KS'`, so `.KQ` (KOSDAQ) passed through into the US population. The canonical discriminator is `nuri.core.ticker_names.is_kr_ticker`, whose docstring already warns that checking `.KS` alone split-brains `.KQ` holdings (#764).

Harmless while no `.KQ` row exists (measured: 0 rows in `recommendations` / `prices`), but #833 changed what the defect means: a `.KQ` decision is now measured against KOSPI (`forward_outcome_tracker.py` routes on `is_kr_ticker`) while the adjudication query still counts it as US. One row benchmarked against a different index would land in the SPY mean alpha and in the permutation null.

## Why this is a bug fix, not a pre-registration amendment

§3.11 defines the population as **US BUY** decisions and states "본 판정은 US-only 로 고정". `.KQ` is KOSDAQ, so excluding it makes the code match the table that was locked on 2026-07-08. Nothing in the criteria moves.

The alternative in the issue — defining the sample by `decision_outcomes.benchmark_ticker = 'SPY'` — was rejected on structural grounds, independent of pre-registration. `fetch_sample` LEFT JOINs outcomes so untracked decisions survive as `n_missing_closed`; a benchmark predicate drops exactly those rows and deflates the missing rate to zero. The missing rate is itself a pre-registered invalidation criterion (>15% voids the verdict), so that alternative would disable the bias check it was meant to strengthen.

## Changes

- `fetch_sample` — SQL suffix filter replaced by `is_kr_ticker`, placed **ahead** of the missing-outcome branch so a KR tracking failure cannot void a US verdict.
- `_eligible_substitutes` — same fix for the placebo universe. §3.11 requires substitutes from the same market; a KR substitute mixes FX and market style into the null.
- `PSEUDO_TICKERS` needs no cleanup (acceptance item 2): `{KOSDAQ, KOSPI, GC=F, TESTAA}` are suffixless index pseudo-tickers, disjoint from `is_kr_ticker`.

## Verification

Three regression tests, each confirmed by mutation:

| Mutation | Test killed |
|---|---|
| revert `fetch_sample` filter | `test_kosdaq_excluded_from_us_sample`, `test_kr_not_counted_as_missing` |
| revert universe filter | `test_placebo_universe_excludes_kr` |
| move KR skip inside the alpha branch | `test_kr_not_counted_as_missing` |

`make verify-quick`: 6493 passed / 6 skipped. Doc counts re-synced (6,505 → 6,508 backend tests).

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)