### PR TITLE
docs(core): retire the 6-step vocabulary and write down the payload guarantees

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,11 +43,11 @@ Special regimes (priority order, override base `regime` field): euphoria, stagfl
 `nuri/trading/engine/` — Gated Execution + Conflict Detection + Learning Memory. Confidence scoring in `candidates.py` combines regime win rate, profit factor, learning memory drift, conflict penalties, and regime fit.
 Full certification architecture + 3-dimensional certification specification: **[`docs/CERTIFICATION_SPEC.md`](CERTIFICATION_SPEC.md)** (canonical). Confidence scoring formula: [`docs/STRATEGY.md` §3.3](STRATEGY.md). Gate policy: [`docs/STRATEGY.md` §6](STRATEGY.md).
 ## Pipeline Observability
-`nuri/core/events.py` — Append-only event journal. `emit_event()` records state transitions. `get_pipeline_status()` returns 6-step status. `get_timeline()` returns history with `causation_id` for chain tracing.
+`nuri/core/events.py` — Append-only event journal. `emit_event()` records state transitions and always writes **valid JSON** to `payload` (#935). `get_pipeline_status()` returns 5-stage status. `get_timeline()` returns history with `causation_id` for chain tracing.
 `nuri/core/freshness.py` — Data freshness SLA. `FRESHNESS_POLICIES` defines warn/fail thresholds. `check_freshness(key)` returns PASS/WARN/FAIL. Sources: prices (48h/120h), VIX (24h/72h), F&G (24h/48h), consensus (24h/48h), certification (24h/48h).
-`nuri/core/pipeline.py` — Pipeline orchestration. `STEP_DEPENDENCIES` defines 6-step DAG. `run_step()` enforces dependency completion + records events.
+`nuri/core/pipeline.py` — Pipeline orchestration. `STEP_DEPENDENCIES` defines the 5-stage DAG (`collect → analyze → consensus → certify → track`). `run_step()` enforces dependency completion + records events.
 Pipeline control API (`nuri/api/routes/pipeline.py`):
-- `GET /api/pipeline/status` — 6-step status + record counts
+- `GET /api/pipeline/status` — 5-stage status + record counts
 - `POST /api/pipeline/{step}/run` — Execute step (background)
 - `GET /api/pipeline/timeline` — Event log
 - `GET /api/freshness` — Data freshness report

--- a/nuri/core/CLAUDE.md
+++ b/nuri/core/CLAUDE.md
@@ -27,13 +27,20 @@ DB stores dates as `YYYY-MM-DD` strings.
 
 Append-only. `emit_event()` records state transitions (step_started/completed/failed/blocked). `causation_id` for chain tracing. Never delete events.
 
+Two guarantees hold here, and both are load-bearing for readers elsewhere:
+
+- **`payload` is always valid JSON.** Twelve queries read that column through `json_extract()`, and SQLite raises `OperationalError: malformed JSON` instead of skipping the row — and those queries *scan* the table rather than filtering to their own rows, so one poisoned row kills every unrelated lookup (holdings dedupe, trim age, eight BUY-candidate predicates). All sit under scheduler wrappers that catch and log, so it surfaces as a quiet no-op. `emit_event` therefore `json.dumps()` **every** payload shape, with `default=str` so a non-serializable value cannot raise inside the writer and abort the caller's real work (#935/#894).
+- **`emit_event()` is the only writer.** The guarantee above rests on it. Never `INSERT INTO pipeline_events` directly from `nuri/`.
+
+**Test:** `tests/core/test_pipeline_events.py::TestEmitEventAlwaysWritesValidJson::test_json_extract_scan_survives_every_payload_shape` (the per-row `json_valid` check is not enough — the real failure is a query looking for *something else* dying as it passes a poisoned row) and `::TestPipelineEventsSingleWriter::test_only_events_module_inserts` (AST sweep + a canary, since a sweep that silently matches nothing passes as happily as one that matches everything).
+
 ## freshness.py — Data Freshness SLA
 
 `FRESHNESS_POLICIES` per data source (prices 48h/120h, VIX 24h/72h, etc.). `check_freshness(key)` returns PASS/WARN/FAIL.
 
 ## pipeline.py — Orchestration
 
-`STEP_DEPENDENCIES` defines the 6-step DAG. `run_step()` enforces dependency completion.
+`STEP_DEPENDENCIES` defines the 5-stage DAG (`collect → analyze → consensus → certify → track`). `run_step()` enforces dependency completion.
 
 ## rules.py / signal_config.py / agent_config.py
 

--- a/nuri/core/events.py
+++ b/nuri/core/events.py
@@ -155,7 +155,7 @@ def get_step_status(step: str, db_path: Optional[Path] = None) -> dict:
 
 
 def get_pipeline_status(db_path: Optional[Path] = None) -> dict:
-    """전체 6-step 파이프라인 상태 조회."""
+    """전체 5-stage 파이프라인 상태 조회 (#921 — 예전 6-step 어휘 폐기)."""
     result = {}
     for step in PIPELINE_STEPS:
         result[step] = get_step_status(step, db_path)

--- a/nuri/core/pipeline.py
+++ b/nuri/core/pipeline.py
@@ -1,7 +1,10 @@
 """파이프라인 스텝 의존성 + 실행 래퍼.
 
-6-step 파이프라인: Collect → Validate → Classify → Diagnose → Recommend → Track
+5-stage 파이프라인: Collect → Analyze → Consensus → Certify → Track
 각 스텝은 의존성 충족 시에만 실행 가능.
+
+⚠️ 예전 6-step 어휘(Collect/Validate/Classify/Diagnose/Recommend/Track)는 #921 에서
+폐기됐다 — 그 이름들은 더 이상 어디에도 존재하지 않는다. `STEP_DEPENDENCIES` 가 canonical.
 """
 
 import logging

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ scripts/
 | Script | Purpose | Use |
 |---|---|---|
 | `deploy_remote.sh` | generic SSH push (rsync) | `make deploy` |
-| `deploy_to_mini.sh` | MBP → Mac mini 1-command (6 steps) | `make deploy-mini` |
+| `deploy_to_mini.sh` | MBP → Mac mini 1-command (7 steps) | `make deploy-mini` |
 | `autopull_receiver.sh` | Mac mini receiver (5min cron, NOT push) | launchd `com.nuri-quant.autopull` |
 | `pre_deploy_check.sh` | safety check before deploy | `make pre-deploy` |
 | `sync_dev.sh` | low-level rsync state (push/pull) | `bash scripts/deploy/sync_dev.sh push` |


### PR DESCRIPTION
Same pattern as #932: #921 fixed the code and locked it with a test, and the documents describing that code stayed behind.

## 1. The `6-step` vocabulary #921 retired

Measured on `main`:

```
PIPELINE_STEPS             : ('collect','analyze','consensus','certify','track')  → 5
STEP_DEPENDENCIES keys     : same 5
get_pipeline_status() keys : same 5
```

The lock already exists — `tests/core/test_pipeline_events.py:159`: *"5개 스테이지 전체 상태 반환 (#921 — 예전 6-step 어휘 폐기)"*. Six places still said otherwise:

| Location | Was |
|---|---|
| `docs/ARCHITECTURE.md:46` | "`get_pipeline_status()` returns **6-step** status" |
| `docs/ARCHITECTURE.md:48` | "`STEP_DEPENDENCIES` defines **6-step** DAG" |
| `docs/ARCHITECTURE.md:50` | "`GET /api/pipeline/status` — **6-step** status" |
| `nuri/core/CLAUDE.md` | "`STEP_DEPENDENCIES` defines the **6-step** DAG" |
| `nuri/core/events.py:158` docstring | `"""전체 6-step 파이프라인 상태 조회."""` |
| **`nuri/core/pipeline.py:3`** module header | **"6-step 파이프라인: Collect → Validate → Classify → Diagnose → Recommend → Track"** |

**The module header is the one that mattered.** It didn't just miscount — it *named* the steps, and `Validate` / `Classify` / `Diagnose` have not existed since #921. The first file a reader opens to understand the pipeline handed them three identifiers that match nothing in the codebase.

Remaining `6-step` matches are deliberate and were left alone: two say the vocabulary was retired, one in the long/short backtest refers to an unrelated six-call sequence.

## 2. `emit_event`'s guarantees were undocumented

`nuri/core/CLAUDE.md` described it only as "records state transitions". The two properties readers elsewhere depend on were missing:

- **`payload` is always valid JSON** (#935) — twelve queries `json_extract()` that column, and they scan rather than filter, so one malformed row kills unrelated lookups
- **`emit_event()` is the only writer** — the premise the first guarantee rests on

Both now stated with the Gotcha-Test Pair citation (§5.3.1), including *why* the load-bearing test is the `json_extract` scan rather than the per-row `json_valid` check.

## 3. Swept up along the way

`scripts/README.md` called `deploy_to_mini.sh` a 6-step script. It has seven (`# 1.`–`# 7.` in the source), and `.claude/rules/architecture.md`, `.claude/commands/nuri-deploy.md`, and `.claude/skills/nuri-deploy/SKILL.md` all already said seven.

## Verification

- `grep -rn "6-step\|6 steps"` over `*.md` + `*.py` → only the three intentional mentions remain
- `make verify-doc-counts` 19/19 · `tests/core/` 495 passed · ruff clean · `make lint-sh` clean · privacy scan clean

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)