### PR TITLE
fix(deploy): bounce every resident python service, not just the scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,522 collected across 289 files | |
+| **Backend tests** | 6,529 collected across 290 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,522 backend tests across 289 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,529 backend tests across 290 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,522 tests, 289 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,529 tests, 290 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -229,7 +229,7 @@ else
 fi
 
 # 6a. scheduler load + verify PID 살아남
-step 6 "scheduler 재기동"
+step 6 "scheduler + 상주 python 서비스 재기동"
 # plist 는 **매번** 재설치한다. 이전에는 미설치일 때만 cp 해서, 이미 설치된
 # mini 에는 repo 의 plist 수정이 영영 도달하지 않았다 (#856 에서 발각: 스케줄러
 # plist 에 넣은 NURI_ROLE 이 배포돼도 반영 안 됨 → 기능이 조용히 죽은 채 시작).
@@ -242,6 +242,33 @@ if NEW_PID=$(wait_scheduler alive) && verify_stable_pid "${NEW_PID}"; then
 else
     fail "scheduler load 실패 또는 crash-loop — 20초 안에 stable PID 못 찾음. import error 가능성. 'ssh ${REMOTE} tail data/logs/scheduler.err' 확인 + 'launchctl load ${PLIST_REMOTE}' 수동 실행"
 fi
+
+# 6b. scheduler 외 **상주 python 서비스**도 bounce (#940).
+# 이것들은 레포의 python 을 상주 실행하므로 배포마다 stale 이 된다. 2026-07-29 실측:
+# deploy 정상 완료 직후에도 api 가 06:03 기동분으로 남아 방금 배포한 #936 emit_event 를
+# 못 들고 있었다 (`nuri/api/routes/pipeline.py` 가 emit_event 를 import). OPERATIONS.md
+# 복구표에 이미 적혀 있던 함정인데 문서로는 못 막았다 — 그래서 스크립트가 직접 한다.
+# dashboard 는 여기 없다: npm 빌드 산출물을 서빙하므로 4단계에서 **빌드가 바뀔 때만** 바운스가 맞다.
+# periodic(StartInterval) 서비스도 없다 — 매 실행이 새 프로세스라 자동으로 새 코드다.
+# scheduler 는 여기 없다 — plist 재설치가 필요해 위에서 unload/load 경로를 쓴다 (#778/#856).
+# 이 배열은 tests/scripts/test_deploy_bounces_resident_services.py 가 plist 실측과 대조한다.
+RESIDENT_SERVICES=(com.nuri-quant.api com.nuri-quant.discord-bot)
+
+for RESIDENT in "${RESIDENT_SERVICES[@]}"; do
+    # 미설치는 정상 상태일 수 있다 (#939) — skip 하되 침묵하지 않는다.
+    if ! "${SSH}" "${REMOTE}" "launchctl list 2>/dev/null | grep -q '${RESIDENT}\$'"; then
+        warn "${RESIDENT}: 미설치 — skip"
+        continue
+    fi
+    "${SSH}" "${REMOTE}" "launchctl kickstart -k gui/\$(id -u)/${RESIDENT}" >/dev/null 2>&1 \
+        || warn "${RESIDENT}: kickstart 실패 — 구코드로 계속 돌 수 있다. 수동 확인 필요"
+    RESIDENT_PID=$("${SSH}" "${REMOTE}" "launchctl list 2>/dev/null | awk -v l='${RESIDENT}' '\$3==l && \$1 ~ /^[0-9]+\$/ { print \$1; exit }'" 2>/dev/null || echo "")
+    if [[ -n "${RESIDENT_PID}" ]]; then
+        ok "${RESIDENT} bounced (PID ${RESIDENT_PID})"
+    else
+        warn "${RESIDENT}: 재기동 후 PID 없음 — crash 가능성"
+    fi
+done
 
 # ── 6. 최종 검증 ──
 step 7 "최종 검증"
@@ -263,6 +290,14 @@ fi
 
 AUTOPULL_STATUS=$("${SSH}" "${REMOTE}" "launchctl list | grep autopull | awk '{print \$1}'" 2>/dev/null || echo "-")
 ok "autopull: ${AUTOPULL_STATUS:-active}"
+
+# API 는 PID 존재가 아니라 **실제 응답**으로 확인한다 (#940). PID 만 보면 구코드로 돌고 있는
+# 프로세스도 초록으로 통과한다 — 배포 검증은 사용자 실경로로.
+if "${SSH}" "${REMOTE}" "curl -sf -o /dev/null -m 5 http://127.0.0.1:8001/api/health" 2>/dev/null; then
+    ok "API 응답 정상 (127.0.0.1:8001/api/health)"
+else
+    warn "API 무응답 — 미설치이거나 재기동 실패. 'ssh ${REMOTE} tail data/logs/api.err' 확인"
+fi
 
 echo ""
 echo -e "${GREEN}═══ deploy 완료 ═══${NC}"

--- a/tests/scripts/test_deploy_bounces_resident_services.py
+++ b/tests/scripts/test_deploy_bounces_resident_services.py
@@ -1,0 +1,112 @@
+"""배포가 **상주 python 서비스를 전부 재기동**하는지 검증 (#940).
+
+Gotcha-Test Pair:
+`deploy_to_mini.sh` 는 오랫동안 `com.nuri-quant.scheduler` 만 bounce 했다. `api` 와
+`discord-bot` 도 레포의 python 을 상주 실행하는데 어디서도 재기동되지 않아, 배포가
+초록으로 끝난 뒤에도 구코드를 들고 있었다 (2026-07-29 실측: deploy 직후 api PID 가
+06:03 기동분 — 그날 오후 머지한 `emit_event` 수정을 못 들고 있었다).
+
+이 함정은 `docs/OPERATIONS.md` 복구표에 **이미 문서화돼 있었는데도 재발했다.** 문서로
+두 번 실패했으므로 테스트로 잠근다. 새 상주 서비스를 추가하면 이 테스트가 먼저 걸린다.
+
+판정 기준은 plist 자체에서 뽑는다 (하드코딩한 목록이 아니라):
+  상주 = `StartInterval` / `StartCalendarInterval` 없음 (periodic 은 매 실행이 새 프로세스)
+  python = `ProgramArguments` 가 `.venv/bin/python` 실행
+"""
+
+from __future__ import annotations
+
+import plistlib
+import re
+from pathlib import Path
+
+import pytest
+
+LAUNCHD_DIR = Path("scripts/launchd")
+DEPLOY_SCRIPT = Path("scripts/deploy/deploy_to_mini.sh")
+
+# dashboard 는 상주지만 npm 빌드 산출물을 서빙한다 — 빌드가 바뀔 때만 바운스하는 게 맞고,
+# 그 조건부 처리는 4단계에 이미 있다. python 판정에서 자연히 빠지지만 의도를 명시해 둔다.
+_NOT_PYTHON_BY_DESIGN = {"com.nuri-quant.dashboard"}
+
+
+def _plists() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(LAUNCHD_DIR.glob("*.plist")):
+        out.append((path.stem, plistlib.loads(path.read_bytes())))
+    return out
+
+
+def _is_resident(spec: dict) -> bool:
+    """periodic 트리거가 없으면 상주 데몬."""
+    return not ("StartInterval" in spec or "StartCalendarInterval" in spec)
+
+
+def _runs_repo_python(spec: dict) -> bool:
+    argv = " ".join(str(a) for a in spec.get("ProgramArguments", []))
+    return ".venv/bin/python" in argv
+
+
+def resident_python_labels() -> list[str]:
+    return [label for label, spec in _plists() if _is_resident(spec) and _runs_repo_python(spec)]
+
+
+def _declared_resident_services() -> set[str]:
+    """`deploy_to_mini.sh` 가 선언한 bounce 대상 (`RESIDENT_SERVICES=(...)`)."""
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    m = re.search(r"RESIDENT_SERVICES=\(([^)]*)\)", script)
+    return set(m.group(1).split()) if m else set()
+
+
+class TestDeployBouncesEveryResidentPythonService:
+    def test_sweep_is_not_blind(self):
+        """캐너리 — plist 파싱이 조용히 빈 결과를 내면 아래 테스트가 공짜로 통과한다.
+
+        (#910/#911 계열: 검사 미실행과 검사 통과가 구분 불가한 상태를 배제한다.)
+        """
+        labels = resident_python_labels()
+        assert labels, "plist 스윕이 상주 python 서비스를 하나도 못 찾았다 — 스윕이 고장난 것"
+        assert "com.nuri-quant.scheduler" in labels, "known 상주 서비스(scheduler)를 못 찾았다"
+
+    @pytest.mark.parametrize("label", resident_python_labels())
+    def test_deploy_script_bounces_it(self, label):
+        """상주 python 서비스는 배포 때 재기동돼야 한다 — kickstart 또는 unload/load."""
+        script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+        if label == "com.nuri-quant.scheduler":
+            # plist 재설치가 필요해 kickstart 가 아니라 unload/load 경로를 쓴다 (#778/#856).
+            assert "launchctl unload" in script and "launchctl load" in script, (
+                "scheduler 의 unload/load 재기동 경로가 사라졌다"
+            )
+            return
+
+        assert label in _declared_resident_services(), (
+            f"{label} 은 상주 python 서비스인데 {DEPLOY_SCRIPT} 의 RESIDENT_SERVICES 에 없다.\n"
+            "배포 후에도 구코드를 들고 도는 상태가 되고, 검증은 초록으로 끝난다 (#940)."
+        )
+
+    def test_declared_list_is_actually_bounced(self):
+        """선언만 하고 안 부르는 상태를 배제 — 배열이 실제 kickstart 루프에 쓰여야 한다."""
+        script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+        assert 'for RESIDENT in "${RESIDENT_SERVICES[@]}"' in script
+        assert re.search(r"launchctl kickstart[^\n]*\$\{RESIDENT\}", script), (
+            "RESIDENT_SERVICES 를 순회하지만 kickstart 하지 않는다"
+        )
+
+    def test_dashboard_stays_conditional(self):
+        """dashboard 는 이 규칙 대상이 아니다 — 빌드 산출물 서빙이라 조건부가 맞다."""
+        assert not any(label in _NOT_PYTHON_BY_DESIGN for label in resident_python_labels())
+
+
+class TestDeployVerifiesApiLiveness:
+    def test_final_step_checks_api_response_not_just_pid(self):
+        """7단계 검증이 API **응답**을 본다 (#940).
+
+        PID 존재만 보면 구코드로 도는 프로세스도 통과한다 — 실제로 그렇게 통과했다.
+        """
+        script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+        # 부분문자열 검사로는 부족하다 — 같은 URL 이 성공 메시지에도 들어 있어서, 실제
+        # curl 을 지워도 통과했다 (이 테스트를 mutation 걸다 발견). **호출 자체**를 본다.
+        assert re.search(r"curl[^\n]*127\.0\.0\.1:8001/api/health", script), (
+            "7단계 검증에 API 라이브 curl 이 없다 — PID 존재만 보면 구코드로 도는 프로세스도 통과한다"
+        )


### PR DESCRIPTION
`deploy_to_mini.sh` restarted `com.nuri-quant.scheduler`, and `com.nuri-quant.dashboard` when the frontend had been rebuilt. **`com.nuri-quant.api` was never touched.** It runs uvicorn out of the same repo, so every deploy left it holding whatever code it loaded at its last start.

## Measured today

A deploy finished green at 19:47 with:

```
scheduler   PID=67798   Wed Jul 29 19:47:23   ← bounced
api         PID=47106   Wed Jul 29 06:03:13   ← 13 hours stale
```

`nuri/api/routes/pipeline.py:140` imports `emit_event`, so the API was serving the **old `str(payload)` path** while the scheduler ran the fixed one from #936. Step 7 did not catch it: it checks the scheduler PID and nothing else.

`docs/OPERATIONS.md` already documented this exact trap. Documenting it was not enough — which is why this is a script change plus a test, not another line of prose.

## Changes

**Step 6** iterates `RESIDENT_SERVICES` and kickstarts each. Not-installed is skipped **with a warning** rather than failing — four of nine plists are legitimately absent on the mini right now (#939) — but it says so out loud instead of passing in silence.

- scheduler keeps its unload/load path: `kickstart` cannot pick up changes to the plist *file* (#778/#856)
- dashboard stays conditional: it serves a build artifact, so bouncing an unchanged build is noise
- periodic services are excluded by construction — each run is a fresh process

**Step 7** curls `/api/health` through the remote. A PID proves a process exists, not that it runs the code you just shipped. That distinction is the whole bug.

**Step count stays 7** — `scripts/README.md`, `.claude/rules/architecture.md`, `.claude/commands/nuri-deploy.md` and `.claude/skills/nuri-deploy/SKILL.md` all say seven, so adding a step would create doc drift in four places.

## Test derives its expectations from the plists

`tests/scripts/test_deploy_bounces_resident_services.py` parses `scripts/launchd/*.plist`, selects **resident** (no `StartInterval`/`StartCalendarInterval`) **and** `.venv/bin/python`, and asserts the deploy script bounces each. Add a resident service and the test fails until the deploy script handles it. A canary asserts the sweep found something, so a parser that silently returns nothing cannot pass.

Mutation-verified:

| Mutation | Test killed |
|---|---|
| drop `api` from `RESIDENT_SERVICES` | `test_deploy_script_bounces_it[com.nuri-quant.api]` |
| keep the array, gut the kickstart loop | `test_declared_list_is_actually_bounced` |
| disable the health curl | `test_final_step_checks_api_response_not_just_pid` |

**The third mutation initially passed.** The assertion looked for the URL as a substring and the success message mentions the same URL, so removing the `curl` left it satisfied — the exact blindness this repo keeps getting bitten by (#910/#911). It now matches the `curl` invocation itself.

## Verified live, not just in tests

Ran the modified script against production:

```
[6/7] scheduler + 상주 python 서비스 재기동
  ✓ scheduler reloaded (PID 71395 stable for 3s)
  ✓ com.nuri-quant.api bounced (PID 71424)
  ⚠ com.nuri-quant.discord-bot: 미설치 — skip
[7/7] 최종 검증
  ✓ git HEAD 일치: 8b52398
  ✓ API 응답 정상 (127.0.0.1:8001/api/health)
```

Both processes start at 21:44:4x, after the commit landed on disk at 21:41:33.

`make verify-quick`: 6514 passed / 6 skipped. `make lint-sh` clean.

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)