### PR TITLE
fix(sre): reap the orphan runs that kept orphan_run permanently critical

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,529 collected across 290 files | |
+| **Backend tests** | 6,537 collected across 291 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,529 backend tests across 290 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,537 backend tests across 291 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,529 tests, 290 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,537 tests, 291 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/ops/reap_orphan_runs.py
+++ b/scripts/ops/reap_orphan_runs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""고아 agent run 정리 — `started` 인 채 완료를 보고하지 않은 원장 행 (#942).
+
+프로세스가 kill 되면 `finish_agent_run()` 이 호출되지 못해 `agent_run_ledger` 에
+`status='started' AND finished_at IS NULL` 행이 남는다. 2026-06 FD exhaustion
+사태(#778/#779) 때 63 행이 그렇게 남았다.
+
+이 행들은 **늙기만 한다.** `SREIncidentAgent._detect_orphan_run` 은 나이만 보므로
+매 스캔마다 critical 을 재발화하고, dedupe 가 target 단위라 같은 actor 에 진짜
+orphan 이 새로 생겨도 묻힌다 — 알림이 상시 켜져 있으면 아무도 안 본다.
+
+정리 원칙:
+  - **삭제하지 않는다.** 그때 완료를 못 한 건 사실이므로 기록으로 남긴다.
+  - status 는 `timeout` — 실패했다는 증거는 없고, 완료를 보고하지 않았을 뿐이다.
+  - `finished_at` 은 **`started_at` 그대로** 둔다. `datetime('now')` 로 찍으면
+    40일짜리 duration 이 생겨 원장이 거짓말을 한다.
+
+Usage:
+    python scripts/ops/reap_orphan_runs.py                # dry-run (기본)
+    python scripts/ops/reap_orphan_runs.py --apply
+    python scripts/ops/reap_orphan_runs.py --older-than 24 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from nuri.core.db import get_db, query  # noqa: E402
+
+DEFAULT_OLDER_THAN_HOURS = 24
+REAP_REASON = "reaped by scripts/ops/reap_orphan_runs.py (#942) — 프로세스가 완료를 보고하지 않음"
+
+
+def find_orphans(older_than_hours: int, db_path: Optional[Path] = None) -> list[dict]:
+    """`started` + `finished_at IS NULL` + 지정 시간 초과 행."""
+    rows = query(
+        """SELECT run_id, actor_name, started_at,
+                  (julianday('now') - julianday(started_at)) * 24.0 AS age_hours
+             FROM agent_run_ledger
+            WHERE status = 'started' AND finished_at IS NULL
+              AND datetime(started_at) < datetime('now', ?)
+            ORDER BY started_at""",
+        (f"-{int(older_than_hours * 60)} minutes",),
+        db_path=db_path,
+    )
+    return [dict(r) for r in rows]
+
+
+def reap(orphans: list[dict], db_path: Optional[Path] = None) -> int:
+    """timeout 으로 마감. finished_at = started_at (duration 을 날조하지 않는다)."""
+    if not orphans:
+        return 0
+    with get_db(db_path) as conn:
+        for o in orphans:
+            conn.execute(
+                """UPDATE agent_run_ledger
+                      SET status = 'timeout',
+                          finished_at = started_at,
+                          error_message = ?
+                    WHERE run_id = ? AND status = 'started' AND finished_at IS NULL""",
+                (REAP_REASON, o["run_id"]),
+            )
+    return len(orphans)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="고아 agent run 정리 (#942)")
+    ap.add_argument("--apply", action="store_true", help="실제 반영 (기본은 dry-run)")
+    ap.add_argument("--older-than", type=int, default=DEFAULT_OLDER_THAN_HOURS, help="시간 (기본 24)")
+    ap.add_argument("--db-path", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    orphans = find_orphans(args.older_than, db_path=args.db_path)
+    if not orphans:
+        print(f"고아 run 없음 ({args.older_than}h 초과 기준)")
+        return 0
+
+    by_actor: dict[str, int] = {}
+    for o in orphans:
+        by_actor[o["actor_name"]] = by_actor.get(o["actor_name"], 0) + 1
+    print(f"고아 run {len(orphans)}건 ({args.older_than}h 초과):")
+    for actor, n in sorted(by_actor.items()):
+        print(f"  {actor}: {n}건")
+    print(f"  가장 오래된: {orphans[0]['started_at']} ({orphans[0]['age_hours']:.1f}h)")
+    print(f"  가장 최근  : {orphans[-1]['started_at']} ({orphans[-1]['age_hours']:.1f}h)")
+
+    if not args.apply:
+        print("\ndry-run — 반영하려면 --apply")
+        return 0
+
+    n = reap(orphans, db_path=args.db_path)
+    print(f"\n✓ {n}건 timeout 으로 마감 (삭제 아님, finished_at = started_at)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_reap_orphan_runs.py
+++ b/tests/scripts/test_reap_orphan_runs.py
@@ -1,0 +1,113 @@
+"""고아 agent run 정리 테스트 (#942).
+
+Gotcha-Test Pair:
+정리의 목적은 **알림을 끄는 것이 아니라 원장을 사실대로 만드는 것**이다. 그래서
+두 가지를 잠근다.
+
+1. `finished_at` 은 `started_at` 이어야 한다. `datetime('now')` 로 찍으면 40일 전에
+   죽은 run 이 40일짜리 duration 을 가진 것처럼 보인다 — 알림은 꺼지고 원장은
+   거짓말을 하게 된다. 정확히 이게 "고쳤다" 와 "숨겼다" 의 차이다.
+2. 행은 남아야 한다 (DELETE 금지). 그때 완료를 못 한 건 사실이고, 지우면 왜
+   비었는지 아무도 모른다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nuri.core.db import get_db, init_db, query
+from scripts.ops.reap_orphan_runs import REAP_REASON, find_orphans, main, reap
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "reap.db"
+    init_db(path)
+    return path
+
+
+def _seed_run(db_path: Path, run_id: str, actor: str, *, hours_ago: float, finished: bool):
+    with get_db(db_path) as conn:
+        conn.execute(
+            """INSERT INTO agent_run_ledger (run_id, actor_name, status, started_at, finished_at)
+               VALUES (?, ?, ?, datetime('now', ?), ?)""",
+            (
+                run_id,
+                actor,
+                "finished" if finished else "started",
+                f"-{int(hours_ago * 60)} minutes",
+                "2026-01-01 00:00:00" if finished else None,
+            ),
+        )
+
+
+class TestFindOrphans:
+    def test_only_stale_unfinished_rows(self, db_path):
+        _seed_run(db_path, "old-orphan", "dispatcher", hours_ago=100, finished=False)
+        _seed_run(db_path, "fresh-running", "dispatcher", hours_ago=0.5, finished=False)
+        _seed_run(db_path, "completed", "dispatcher", hours_ago=100, finished=True)
+
+        found = {o["run_id"] for o in find_orphans(24, db_path=db_path)}
+        assert found == {"old-orphan"}
+
+
+class TestReapKeepsTheLedgerHonest:
+    def test_finished_at_is_started_at_not_now(self, db_path):
+        """duration 을 날조하지 않는다 — 이게 '고쳤다' 와 '숨겼다' 의 차이다."""
+        _seed_run(db_path, "r1", "dispatcher", hours_ago=960, finished=False)
+        reap(find_orphans(24, db_path=db_path), db_path=db_path)
+
+        row = dict(
+            query("SELECT started_at, finished_at, status FROM agent_run_ledger WHERE run_id='r1'", db_path=db_path)[0]
+        )
+        assert row["status"] == "timeout"
+        assert row["finished_at"] == row["started_at"], (
+            "finished_at 이 now() 로 찍히면 40일짜리 duration 이 생겨 원장이 거짓말을 한다"
+        )
+
+    def test_row_is_kept_not_deleted(self, db_path):
+        _seed_run(db_path, "r1", "dispatcher", hours_ago=960, finished=False)
+        reap(find_orphans(24, db_path=db_path), db_path=db_path)
+
+        rows = query("SELECT error_message FROM agent_run_ledger WHERE run_id='r1'", db_path=db_path)
+        assert len(rows) == 1, "행을 지우면 왜 비었는지 아무도 모른다"
+        assert REAP_REASON in dict(rows[0])["error_message"]
+
+    def test_status_is_timeout_not_failed(self, db_path):
+        """실패했다는 증거는 없다 — 완료를 보고하지 않았을 뿐이다."""
+        _seed_run(db_path, "r1", "dispatcher", hours_ago=960, finished=False)
+        reap(find_orphans(24, db_path=db_path), db_path=db_path)
+        assert (
+            dict(query("SELECT status FROM agent_run_ledger WHERE run_id='r1'", db_path=db_path)[0])["status"]
+            == "timeout"
+        )
+
+    def test_running_job_is_untouched(self, db_path):
+        """지금 돌고 있는 run 을 마감해 버리면 진짜 실행을 죽은 것으로 만든다."""
+        _seed_run(db_path, "live", "dispatcher", hours_ago=0.5, finished=False)
+        reap(find_orphans(24, db_path=db_path), db_path=db_path)
+
+        row = dict(query("SELECT status, finished_at FROM agent_run_ledger WHERE run_id='live'", db_path=db_path)[0])
+        assert row["status"] == "started" and row["finished_at"] is None
+
+
+class TestCli:
+    def test_dry_run_does_not_write(self, db_path, capsys):
+        _seed_run(db_path, "r1", "dispatcher", hours_ago=960, finished=False)
+        assert main(["--db-path", str(db_path)]) == 0
+        assert "dry-run" in capsys.readouterr().out
+        assert (
+            dict(query("SELECT status FROM agent_run_ledger WHERE run_id='r1'", db_path=db_path)[0])["status"]
+            == "started"
+        )
+
+    def test_apply_writes(self, db_path, capsys):
+        _seed_run(db_path, "r1", "dispatcher", hours_ago=960, finished=False)
+        assert main(["--db-path", str(db_path), "--apply"]) == 0
+        assert "1건 timeout" in capsys.readouterr().out
+
+    def test_no_orphans_is_clean_exit(self, db_path, capsys):
+        assert main(["--db-path", str(db_path)]) == 0
+        assert "고아 run 없음" in capsys.readouterr().out


### PR DESCRIPTION
Installing `sre-scan` on the mini (#939) made its first real scan open two **critical** `orphan_run` incidents — `channel-dispatcher` and `outbox-watchdog`, both aged 958 hours.

## Neither actor is broken

| actor | finished | stuck at `started` | stuck window | last run |
|---|---|---|---|---|
| channel-dispatcher | 112,270 | **46** | 2026-05-08 → 2026-06-19 | today 12:51 |
| outbox-watchdog | 9,312 | **17** | 2026-05-08 → 2026-06-19 | today 12:50 |

63 ledger rows sit at `status='started'` with `finished_at NULL`, **all** inside one window that ends 2026-06-19 and none after — the FD exhaustion outage (#778/#779), where the process was killed before `finish_agent_run` could run.

`_detect_orphan_run` reads age only, so those rows can only get older. They would have re-fired critical on every hourly scan forever. Worse: dedupe is `UNIQUE(incident_type, target, status='open')`, so **a real new orphan on either actor would have been absorbed by the standing incident and never alerted.** An alert that is always on is an alert nobody reads.

## The fix is to the data, not the detector

`scripts/ops/reap_orphan_runs.py`, dry-run by default. Two choices are deliberate, and the tests lock both:

**`finished_at = started_at`, not `datetime('now')`.** Stamping now would silence the alert while making the ledger claim the run took forty days. That distinction — fixed versus hidden — is the whole point.

**UPDATE, never DELETE; status `timeout`, not `failed`.** There is no evidence these runs failed. They never reported completion, which is a different fact. The reap reason goes into `error_message` so the row explains itself later.

Mutation-verified:

| Mutation | Tests killed |
|---|---|
| `finished_at = datetime('now')` | `test_finished_at_is_started_at_not_now` |
| `DELETE` instead of `UPDATE` | that one + `test_row_is_kept_not_deleted` + `test_status_is_timeout_not_failed` |

`test_running_job_is_untouched` guards the other direction — a reaper that closes live runs would turn real executions into corpses.

## Applied to production

```
dry-run  → 63건 (channel-dispatcher 46 / outbox-watchdog 17), 1967.0h ~ 959.0h
--apply  → ✓ 63건 timeout 으로 마감
re-check → 고아 run 없음
rescan   → critical: 0, warning: 1   (남은 1건은 portfolio freshness = #943)
```

Sample reaped row: `started_at == finished_at == 2026-05-08 14:00:00`, `status=timeout`, `error_message` carries the reason.

## Found while doing this, filed separately

The two incidents **stayed open** after the condition cleared — nothing auto-resolves them, so I closed them by hand. That is a lifecycle gap, not a reaper bug: **#944**.

`make verify-quick`: 6522 passed / 6 skipped.

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)