### PR TITLE
fix(scripts): land in the repo root, not scripts/, after the #557 move

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,537 collected across 291 files | |
+| **Backend tests** | 6,566 collected across 292 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,537 backend tests across 291 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,566 backend tests across 292 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,537 tests, 291 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,566 tests, 292 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/autopull_receiver.sh
+++ b/scripts/deploy/autopull_receiver.sh
@@ -25,7 +25,9 @@
 
 set -u   # set -e 사용 안 함 — 한 단계 실패가 launchd 전체를 멈추게 하면 안 됨
 
-REPO="${NURI_REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+# NURI_REPO 미설정 시 폴백 — scripts/deploy/ 이므로 두 단계 (#946).
+# git 은 하위 디렉터리에서도 워크트리 전체에 작동해 여태 운으로 동작했다.
+REPO="${NURI_REPO:-$(cd "$(dirname "$0")/../.." && pwd)}"
 LOG="$HOME/Library/Logs/nuri-quant-autopull.log"
 
 mkdir -p "$(dirname "$LOG")"

--- a/scripts/deploy/dev_sync.sh
+++ b/scripts/deploy/dev_sync.sh
@@ -20,7 +20,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# scripts/deploy/ 에 있으므로 두 단계 (#946 — 구조적 테스트가 잡아냈다).
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${PROJECT_ROOT}"
 

--- a/scripts/deploy/state_replicator.sh
+++ b/scripts/deploy/state_replicator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/state_replicator.sh — State-Replicator-DR actor (#529 Phase 1).
+# scripts/deploy/state_replicator.sh — State-Replicator-DR actor (#529 Phase 1).
 #
 # Codex Round 5 mandatory #1: Mac mini = single writer (PRIMARY).
 # MBP = read-only replica.
@@ -23,7 +23,8 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# scripts/deploy/ 에 있으므로 두 단계 올라가야 repo root (#946 — #557 이동 때 안 고쳐졌다).
+cd "$(dirname "$0")/../.."
 
 MODE="${1:-verify}"
 HOSTNAME=$(hostname -s)

--- a/scripts/deploy/sync_dev.sh
+++ b/scripts/deploy/sync_dev.sh
@@ -72,7 +72,8 @@ if [[ "$DIRECTION" != "push" && "$DIRECTION" != "pull" ]]; then
     exit 1
 fi
 
-LOCAL_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# scripts/deploy/ 에 있으므로 두 단계 (#946).
+LOCAL_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
 echo "=== Sync ($DIRECTION) — ${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_PATH} ==="
 

--- a/scripts/ops/health_check.sh
+++ b/scripts/ops/health_check.sh
@@ -13,7 +13,8 @@
 # Exit codes: 0 OK / 1 WARN / 2 FAIL.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# scripts/ops/ 에 있으므로 두 단계 (#946).
+cd "$(dirname "$0")/../.."
 
 DB="${NURI_DB_PATH:-data/portfolio.db}"
 HOSTNAME=$(hostname -s 2>/dev/null || hostname)

--- a/tests/scripts/test_script_root_resolution.py
+++ b/tests/scripts/test_script_root_resolution.py
@@ -1,0 +1,97 @@
+"""`scripts/` 하위 셸 스크립트가 repo root 를 올바로 계산하는지 검증 (#946).
+
+Gotcha-Test Pair:
+#557 이 스크립트를 `scripts/` → `scripts/<subdir>/` 로 옮기면서 (커밋 메시지가
+"no rename" 이다) 내부의 `cd "$(dirname "$0")/.."` 를 안 고쳤다. 한 단계만 올라가
+**repo root 가 아니라 `scripts/` 에 착지**한 채로 4개가 남았고, 실패 방식이 전부
+조용했다:
+
+  - `state_replicator.sh` — `.venv/bin/python` 못 찾고 launchd exit 1
+  - `health_check.sh`     — `❌ DB missing`, python 검사가 `|| echo 0` 폴백으로
+                            빠져 **실패를 0 으로 보고** (검사 미실행 = 검사 통과)
+  - `sync_dev.sh`         — 파일 목록이 전부 `[[ -e ]] || continue` 로 탈락, no-op
+  - `autopull_receiver.sh`— git 이 하위 디렉터리에서도 작동해 **운으로** 동작
+
+launchd 에 미설치라(#939) 안 도는 동안은 아무도 몰랐다. 다음 이동 때 같은 일이
+반복되지 않도록, 중첩 깊이와 `..` 개수를 기계적으로 대조한다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path("scripts")
+
+# **root 해석만** 잡는다. `source "$(dirname "$0")/../_common.sh"` 같은 형제 디렉터리
+# 참조는 대상이 아니다 — `scripts/dev/` → `scripts/` 로 한 단계가 정답이라 같이 잡으면
+# 오탐이 된다. root 해석은 두 형태뿐이고 둘 다 모호하지 않다:
+#   (a) 문장 맨 앞의 bare `cd "$(dirname "$0")/../.."`
+#   (b) `ROOT/REPO 이름의 변수 = "$(cd "$(dirname "$0")/../.." && pwd)"`
+_ROOT_EXPRS = (
+    re.compile(r'^\s*cd\s+"\$\(dirname\s+"\$(?:0|\{BASH_SOURCE\[0\]\})"\)((?:/\.\.)+)"', re.MULTILINE),
+    # `LOCAL_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"` 와
+    # `REPO="${NURI_REPO:-$(cd "$(dirname "$0")/../.." && pwd)}"` 를 모두 받는다.
+    re.compile(
+        r'\w*(?:ROOT|REPO)\w*=\s*"(?:\$\{[^"\n]*?:-)?'
+        r'\$\(cd\s+"\$\(dirname\s+"\$(?:0|\{BASH_SOURCE\[0\]\})"\)((?:/\.\.)+)"\s*&&\s*pwd\)',
+    ),
+    # SCRIPT_DIR 2-step 패턴: SCRIPT_DIR 로 스크립트 위치를 잡은 뒤 거기서 올라간다.
+    re.compile(r'\w*(?:ROOT|REPO)\w*=\s*"\$\(cd\s+"\$\{SCRIPT_DIR\}((?:/\.\.)+)"\s*&&\s*pwd\)"'),
+)
+
+
+def _shell_scripts() -> list[Path]:
+    return sorted(p for p in SCRIPTS_DIR.rglob("*.sh"))
+
+
+def _root_expr_depths(path: Path) -> list[int]:
+    """스크립트 안의 root 해석식들이 올라가는 단계 수."""
+    text = path.read_text(encoding="utf-8")
+    out = []
+    for pattern in _ROOT_EXPRS:
+        for m in pattern.finditer(text):
+            out.append(m.group(1).count(".."))
+    return out
+
+
+def _nesting_depth(path: Path) -> int:
+    """`scripts/` 기준 중첩 깊이 = repo root 까지 올라가야 하는 단계 수."""
+    # scripts/x.sh        → 1  (scripts → root)
+    # scripts/deploy/x.sh → 2
+    return len(path.parts) - 1
+
+
+class TestScriptRootResolution:
+    def test_sweep_is_not_blind(self):
+        """캐너리 — 스윕이 아무 스크립트도 못 찾으면 아래 검사가 공짜로 통과한다."""
+        scripts = _shell_scripts()
+        assert len(scripts) >= 8, f"scripts/ 하위 .sh 를 {len(scripts)}개만 찾았다 — 스윕이 고장난 것"
+        assert any(_root_expr_depths(p) for p in scripts), "root 해석식을 하나도 못 찾았다 — 정규식이 눈멀었다"
+
+    @pytest.mark.parametrize("script", _shell_scripts(), ids=lambda p: str(p))
+    def test_root_expression_matches_nesting(self, script: Path):
+        """`..` 개수가 실제 중첩 깊이와 일치해야 repo root 에 착지한다."""
+        expected = _nesting_depth(script)
+        for depth in _root_expr_depths(script):
+            assert depth == expected, (
+                f"{script} 의 root 해석식이 {depth}단계만 올라간다 (필요: {expected}단계).\n"
+                f"실제 착지: {(script.parent / ('../' * depth)).resolve()}\n"
+                "#557 처럼 스크립트를 옮기고 경로를 안 고치면 조용히 잘못된 곳에서 실행된다 (#946)."
+            )
+
+    def test_known_broken_scripts_are_fixed(self):
+        """#946 이 고친 4개를 이름으로 고정 — 회귀 시 무엇이 깨졌는지 바로 보인다."""
+        for name in (
+            "scripts/deploy/state_replicator.sh",
+            "scripts/ops/health_check.sh",
+            "scripts/deploy/sync_dev.sh",
+            "scripts/deploy/autopull_receiver.sh",
+        ):
+            p = Path(name)
+            assert p.exists(), f"{name} 이 사라졌다 — 이 테스트를 갱신할 것"
+            depths = _root_expr_depths(p)
+            assert depths, f"{name} 에서 root 해석식을 못 찾았다 — 형태가 바뀌었으면 정규식을 갱신할 것"
+            assert all(d == 2 for d in depths), f"{name}: {depths} (전부 2여야 한다)"


### PR DESCRIPTION
#557 moved shell scripts from `scripts/` into `scripts/<subdir>/` — its commit message says **"no rename"** — and left their root resolution at one level. `cd "$(dirname "$0")/.."` now lands in `scripts/`, so every repo-relative path inside pointed at a directory with no `data/`, `.venv/` or `config/`.

## Five scripts, every failure silent

| script | how it failed |
|---|---|
| `deploy/state_replicator.sh` | `.venv/bin/python: No such file or directory`, launchd exit 1 |
| `ops/health_check.sh` | `❌ DB missing` for a DB in the right place; five python probes fell through `\|\| echo 0`, so **a check that never ran reported zero orphans** — indistinguishable from healthy |
| `deploy/sync_dev.sh` | WAL checkpoint skipped behind `[[ -f ]]`; transfer list emptied by `[[ -e "$f" ]] \|\| continue`. A no-op that exits 0 |
| `deploy/dev_sync.sh` | same bug in the `${SCRIPT_DIR}` two-step form |
| `deploy/autopull_receiver.sh` | **worked by luck** — git operates on the whole worktree from any subdirectory |

Nobody noticed because `state_replicator` and `health_check` were never installed in launchd (#939) and `sync_dev` is manual. **Nothing has run these correctly since #557.**

`health_check.sh` is the worst of them: it is the thing that tells you whether the system is healthy, and it was answering "0 problems" because it could not run its own probes. Same shape as #910/#911.

## The test finds the next one

It derives the expected depth from each file's own nesting and compares it to the `..` count, covering **8 scripts**. A canary fails if the sweep matches nothing, so a blind regex cannot pass.

It earned its keep immediately: **it found `dev_sync.sh`**, which my initial grep sweep missed because it resolves the root through `${SCRIPT_DIR}` rather than inline. The issue said four scripts; there were five.

It matches only genuine root resolution. An earlier version also matched `source "$(dirname "$0")/../_common.sh"` and produced **fourteen false positives** — that is a sibling reference where one level is correct.

Mutation-verified:

| Mutation | Tests killed |
|---|---|
| revert `health_check.sh` to one level | `test_root_expression_matches_nesting[...health_check.sh]` + `test_known_broken_scripts_are_fixed` |
| revert `dev_sync.sh` (`${SCRIPT_DIR}` form) | `test_root_expression_matches_nesting[...dev_sync.sh]` |

## Verified by running them, not just by reading

`health_check.sh` before → `❌ DB missing: data/portfolio.db`. After → `✅ schema version: 48 (>=40)` and every table found.

`state_replicator.sh` before → dead at `.venv/bin/python`. After → snapshot, digest (`schema=48 tables=54`), push.

The push then failed for an **unrelated** reason: the rsync destination is relative, so it resolves against the receiver's home. Filed as **#947**, not fixed here.

`make verify-quick`: 6551 passed / 6 skipped. `make lint-sh` clean.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)