### PR TITLE
fix(sre): close incidents when their condition clears, without trusting silence

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,570 collected across 292 files | |
+| **Backend tests** | 6,571 collected across 292 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,537 collected across 291 files | |
+| **Backend tests** | 6,541 collected across 291 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,537 backend tests across 291 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,541 backend tests across 291 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,570 backend tests across 292 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,571 backend tests across 292 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,570 tests, 292 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,571 tests, 292 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,537 tests, 291 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,541 tests, 291 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -73,6 +73,24 @@ FRESHNESS_FAIL_CRIT = 3
 # 시그널 평가 heartbeat 공백 (#825) — 영업일 단위 (KST 화~토, technical cron '0 7 * * 2-6')
 SIGNAL_EVAL_WARN_DAYS = 2
 SIGNAL_EVAL_CRIT_DAYS = 4
+
+# 자동 해소 grace (#944) — 마지막 감지가 이보다 최근이면 닫지 않는다. 스캔 주기가
+# 1시간(launchd StartInterval 3600)이므로 3h = 연속 3회 미감지에 해당한다.
+AUTO_RESOLVE_GRACE_HOURS = 3.0
+
+# detector → 그 detector 가 낼 수 있는 incident_type. 자동 해소가 **죽은 detector 의
+# 침묵을 '해소됨' 으로 오독하지 않도록** 쓰인다. 새 detector 를 추가하면 여기도 등록할 것
+# — 누락 시 그 타입은 detector 가 죽어도 닫혀버린다.
+_DETECTOR_INCIDENT_TYPES: dict[str, tuple[str, ...]] = {
+    "_detect_orphan_runs": ("orphan_run",),
+    "_detect_disk_full": ("disk_full",),
+    "_detect_db_lock": ("db_lock",),
+    "_detect_scheduler_heartbeat": ("scheduler_heartbeat",),
+    "_detect_actor_failure_streak": ("actor_failure_streak",),
+    "_detect_data_freshness_critical": ("data_freshness_critical",),
+    "_detect_signal_evaluation_stale": ("signal_evaluation_stale",),
+    "_detect_alpha_report_stale": ("alpha_report_stale",),
+}
 # 당일은 이 시각(KST) 이후부터 미실행으로 계상 — 07:00 cron 전 새벽 scan false positive 방지
 SIGNAL_EVAL_GRACE_HOUR = 12
 # 평가 예정 요일 (Mon=0 기준 화~토 — 미국 거래일 마감 다음 날 아침 KST)
@@ -133,6 +151,8 @@ class SREIncidentAgent(Actor):
         """8 detector 실행 → 발견된 incident 목록 반환."""
         detected: list[dict[str, Any]] = []
 
+        failed_detectors: set[str] = set()
+
         for detector in (
             self._detect_orphan_runs,
             self._detect_disk_full,
@@ -146,6 +166,7 @@ class SREIncidentAgent(Actor):
             try:
                 detected.extend(detector(ctx))
             except Exception as exc:  # noqa: BLE001 — detector 실패는 다른 detector 진행
+                failed_detectors.add(detector.__name__)
                 detected.append(
                     {
                         "incident_type": "db_lock",  # detector 실패 = infra 의심
@@ -156,6 +177,8 @@ class SREIncidentAgent(Actor):
                     }
                 )
 
+        auto_resolved = self._auto_resolve(detected, failed_detectors)
+
         # 요약 (severity 분포)
         severity_counts = {"critical": 0, "warning": 0, "info": 0}
         for inc in detected:
@@ -164,8 +187,10 @@ class SREIncidentAgent(Actor):
         return ActorResult(
             output={
                 "incidents": detected,
+                "auto_resolved": auto_resolved,
                 "summary": {
                     "total": len(detected),
+                    "auto_resolved": len(auto_resolved),
                     **severity_counts,
                 },
             },
@@ -173,9 +198,57 @@ class SREIncidentAgent(Actor):
             sample_n=len(detected),
             input_summary=(
                 f"scan → {len(detected)} incidents "
-                f"(crit={severity_counts['critical']}, warn={severity_counts['warning']})"
+                f"(crit={severity_counts['critical']}, warn={severity_counts['warning']}, "
+                f"auto-resolved={len(auto_resolved)})"
             ),
         )
+
+    # ─── auto-resolve ────────────────────────────────────────
+
+    def _auto_resolve(self, detected: list[dict[str, Any]], failed_detectors: set[str]) -> list[dict[str, Any]]:
+        """이번 스캔에서 감지되지 않은 open incident 를 닫는다 (#944).
+
+        열기만 하고 닫지 않으면 두 가지가 망가진다. open 목록이 단조 증가해
+        "지금 무엇이 고장인가" 를 답하지 못하게 되고, 더 나쁘게는 dedupe 가
+        `UNIQUE(incident_type, target, status='open')` 이라 **닫히지 않은 incident 가
+        같은 target 의 재발화를 계속 흡수해** 재발 알림이 영영 안 나간다.
+
+        안전 장치 둘:
+          1. **detector 가 죽었으면 그 타입은 건드리지 않는다.** 안 보이는 것과
+             사라진 것은 다르다 — 고장난 detector 가 진짜 incident 를 닫아버리면
+             감시 자체가 거짓말이 된다.
+          2. **grace 기간** — 마지막 감지가 `AUTO_RESOLVE_GRACE_HOURS` 보다 최근이면
+             닫지 않는다. 간헐 조건이 매 스캔 열고 닫으며 알림 폭풍을 내는 걸 막는다.
+             (`last_detected_at` 은 재감지마다 갱신되므로 별도 상태가 필요 없다.)
+        """
+        blocked_types = {t for name in failed_detectors for t in _DETECTOR_INCIDENT_TYPES.get(name, ())}
+        still_open = {(d["incident_type"], d["target"]) for d in detected}
+
+        rows = query(
+            """SELECT incident_id, incident_type, target, last_detected_at
+                 FROM incidents
+                WHERE status IN ('open', 'acknowledged')
+                  AND datetime(last_detected_at) < datetime('now', ?)""",
+            (f"-{int(AUTO_RESOLVE_GRACE_HOURS * 60)} minutes",),
+        )
+
+        resolved: list[dict[str, Any]] = []
+        for raw in rows:
+            r = dict(raw)
+            if (r["incident_type"], r["target"]) in still_open:
+                continue
+            if r["incident_type"] in blocked_types:
+                continue  # detector 가 죽어서 안 보이는 것일 수 있다
+            if db_resolve_incident(r["incident_id"]):
+                resolved.append(
+                    {
+                        "incident_id": r["incident_id"],
+                        "incident_type": r["incident_type"],
+                        "target": r["target"],
+                        "last_detected_at": r["last_detected_at"],
+                    }
+                )
+        return resolved
 
     # ─── 8 detectors ─────────────────────────────────────────
 

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -1186,3 +1186,96 @@ class TestHumanIncidentSummary:
     def test_unknown_type_falls_back_gracefully(self):
         s = _human_incident_summary("brand_new_type", "x", {})
         assert "brand_new_type" in s and "x" in s
+
+
+# ═══════════════════════════════════════════════════════
+# 자동 해소 (#944)
+# ═══════════════════════════════════════════════════════
+
+
+def _seed_open_incident(db_path, incident_type: str, target: str, *, hours_ago: float):
+    """open incident 1건 + last_detected_at 백데이트."""
+    log_incident(
+        incident_type=incident_type,
+        severity="warning",
+        target=target,
+        evidence={"seeded": True},
+        db_path=db_path,
+    )
+    with get_db(db_path) as conn:
+        conn.execute(
+            """UPDATE incidents SET last_detected_at = datetime('now', ?)
+                WHERE incident_type = ? AND target = ? AND status = 'open'""",
+            (f"-{int(hours_ago * 60)} minutes", incident_type, target),
+        )
+
+
+def _open_rows(db_path):
+    return [
+        dict(r)
+        for r in query("SELECT incident_type, target, status FROM incidents WHERE status='open'", db_path=db_path)
+    ]
+
+
+class TestIncidentAutoResolve:
+    """열기만 하고 닫지 않으면 dedupe 가 재발 알림을 영원히 흡수한다 (#944)."""
+
+    def _scan_all(self, now=_EVAL_FIXED_NOW):
+        actor = SREIncidentAgent()
+        with (
+            patch("nuri.agents.actors.sre_incident_agent.kst_now", return_value=now),
+            patch("nuri.core.freshness.check_all_freshness", return_value=[]),
+            patch(
+                "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
+                return_value=MagicMock(total=1000, used=100, free=900),
+            ),
+        ):
+            return actor.run({"action": "scan"}).output
+
+    def test_undetected_incident_past_grace_is_resolved(self, patched_db, no_publish):
+        """조건이 사라졌고 grace 도 지났으면 닫힌다."""
+        _seed_open_incident(patched_db, "orphan_run", "ghost-actor", hours_ago=48)
+        out = self._scan_all()
+        assert any(r["target"] == "ghost-actor" for r in out["auto_resolved"])
+        assert not [r for r in _open_rows(patched_db) if r["target"] == "ghost-actor"]
+
+    def test_within_grace_is_kept(self, patched_db, no_publish):
+        """Gotcha lock: grace 안이면 안 닫는다 — 간헐 조건의 열고-닫기 폭풍 방지."""
+        _seed_open_incident(patched_db, "orphan_run", "flappy-actor", hours_ago=0.5)
+        out = self._scan_all()
+        assert not out["auto_resolved"]
+        assert [r for r in _open_rows(patched_db) if r["target"] == "flappy-actor"]
+
+    def test_dead_detector_does_not_resolve_its_types(self, patched_db, no_publish):
+        """Gotcha lock: **안 보이는 것과 사라진 것은 다르다.**
+
+        detector 가 죽어 조용해진 걸 '해소됨' 으로 읽으면, 고장난 감시자가 진짜
+        incident 를 닫아버린다 — 감시 자체가 거짓말이 되는 경로다.
+        """
+        _seed_open_incident(patched_db, "orphan_run", "ghost-actor", hours_ago=48)
+        actor = SREIncidentAgent()
+        with (
+            patch("nuri.agents.actors.sre_incident_agent.kst_now", return_value=_EVAL_FIXED_NOW),
+            patch("nuri.core.freshness.check_all_freshness", return_value=[]),
+            patch(
+                "nuri.agents.actors.sre_incident_agent.shutil.disk_usage",
+                return_value=MagicMock(total=1000, used=100, free=900),
+            ),
+            patch.object(
+                SREIncidentAgent, "_detect_orphan_runs", autospec=True, side_effect=RuntimeError("detector down")
+            ),
+        ):
+            out = actor.run({"action": "scan"}).output
+
+        assert not [r for r in out["auto_resolved"] if r["incident_type"] == "orphan_run"]
+        assert [r for r in _open_rows(patched_db) if r["target"] == "ghost-actor"]
+
+    def test_every_detector_is_mapped(self):
+        """map 누락 = 그 타입이 detector 사망 중에도 닫힌다 — 조용한 구멍."""
+        from nuri.agents.actors.sre_incident_agent import _DETECTOR_INCIDENT_TYPES
+
+        detectors = {n for n in dir(SREIncidentAgent) if n.startswith("_detect_")}
+        assert detectors, "detector 스윕이 아무것도 못 찾았다 — 캐너리"
+        assert detectors == set(_DETECTOR_INCIDENT_TYPES), (
+            f"매핑 누락/잉여: {detectors ^ set(_DETECTOR_INCIDENT_TYPES)}"
+        )

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -1279,3 +1279,19 @@ class TestIncidentAutoResolve:
         assert detectors == set(_DETECTOR_INCIDENT_TYPES), (
             f"매핑 누락/잉여: {detectors ^ set(_DETECTOR_INCIDENT_TYPES)}"
         )
+
+    def test_still_detected_incident_is_not_resolved(self, patched_db, no_publish):
+        """Gotcha lock: 이번 스캔에서 감지된 인시던트는 오래됐어도 닫지 않는다.
+
+        통상 경로에서는 `_record_incident` 가 재감지 시 `last_detected_at` 을 갱신해
+        grace 쿼리가 먼저 걸러낸다. 그래서 `_auto_resolve` 를 직접 불러 계약을 검증한다
+        — 갱신 경로가 바뀌어도(로그 실패, 쿼리 변경) **발화 중인 장애가 조용히 resolved
+        로 사라지지 않아야** 한다.
+        """
+        _seed_open_incident(patched_db, "orphan_run", "stuck-actor", hours_ago=48)
+        detected = [{"incident_type": "orphan_run", "target": "stuck-actor"}]
+
+        resolved = SREIncidentAgent()._auto_resolve(detected, failed_detectors=set())
+
+        assert not [r for r in resolved if r["target"] == "stuck-actor"]
+        assert [r for r in _open_rows(patched_db) if r["target"] == "stuck-actor"]


### PR DESCRIPTION
`SREIncidentAgent` opened incidents and never closed them. `resolve_incident` existed, but its only callers were the CLI and tests — so closing was a manual step nobody took. Before today the open list held two `orphan_run` incidents from a June outage, and clearing the underlying rows (#942) left them open anyway; I closed them by hand.

## The real cost is dedupe, not tidiness

`_record_incident` keys on `UNIQUE(incident_type, target, status='open')`. A stale open incident **absorbs every later detection for that target**. A genuinely new failure on an actor that already has an unclosed incident produces **no alert at all**.

So "the list is untidy" is the visible symptom; "the monitor stops alerting" is the actual defect.

## Two guards, and they are the point

**A detector that raised this scan blocks resolution of the types it owns.** Not seeing something is not the same as it being gone. A broken watcher that closes real incidents is worse than one that stays quiet — it reports all-clear. `_DETECTOR_INCIDENT_TYPES` maps that ownership, and a test asserts the map covers **every** `_detect_*` method, because a missing entry is precisely the silent hole this guard exists to prevent.

**Resolution waits out `AUTO_RESOLVE_GRACE_HOURS` (3h ≈ 3 scans) since last detection,** so an intermittent condition cannot open and close on alternating scans. `last_detected_at` already advances on every re-detection, so this needs **no new state and no schema change**.

## Verification

| Mutation | Tests killed |
|---|---|
| remove the grace window | `test_within_grace_is_kept` |
| remove the dead-detector guard | `test_dead_detector_does_not_resolve_its_types` |
| drop one `_DETECTOR_INCIDENT_TYPES` entry | that one **+** `test_every_detector_is_mapped` |

The third mutation is the interesting one: dropping a map entry silently re-opens the exact failure mode the second guard closes, and only the coverage test names it.

`make verify-quick`: 6526 passed / 6 skipped.

## Not included

Resolution is not published to Discord. Whether a "recovered" message is wanted is a notification-policy question, not part of making the ledger honest — say the word and it is a small follow-up.

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)