### PR TITLE
fix(deploy): push replicas into the repo, not the receiver's home

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,566 collected across 292 files | |
+| **Backend tests** | 6,572 collected across 293 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,566 backend tests across 292 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,572 backend tests across 293 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,566 tests, 292 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,572 tests, 293 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/state_replicator.sh
+++ b/scripts/deploy/state_replicator.sh
@@ -31,6 +31,13 @@ HOSTNAME=$(hostname -s)
 HOSTNAME_LC=$(echo "$HOSTNAME" | tr '[:upper:]' '[:lower:]')
 DB_PATH="${NURI_DB_PATH:-data/portfolio.db}"
 REPLICAS_DIR="data/replicas"
+
+# 원격 수신 경로 (#947). `host:relative/path` 는 **수신 측 홈** 기준으로 풀린다 —
+# 보내는 쪽 cwd 와 무관하다. 그래서 예전 `$DEV2_HOST:$REPLICAS_DIR/...` 은 레포가 아니라
+# `~/data/replicas/` 로 떨어졌다. 홈 기준 상대경로로 정규화해 레포 안에 착지시킨다.
+REMOTE_REPO="${DEV2_PATH:-~/workspace/nuri-quant}"
+REMOTE_REPO="${REMOTE_REPO#\~/}"  # 패턴의 ~ 를 escape — 안 하면 bash 가 홈으로 확장해 매칭 실패
+REMOTE_REPLICAS="${REMOTE_REPO}/${REPLICAS_DIR}"
 SNAPSHOTS_DIR="data/backups"
 TS=$(date +%Y%m%d_%H%M%S)
 
@@ -98,7 +105,13 @@ c.close()
         DIGEST=$(db_digest "$SNAP")
         echo "[primary] digest: $DIGEST"
         echo "[primary] pushing to $DEV2_HOST"
-        rsync -avz --partial "$SNAP" "$DEV2_HOST:$REPLICAS_DIR/portfolio_${HOSTNAME}.db" || {
+        # 수신 측 디렉터리를 먼저 만든다 — macOS openrsync 는 목적지 디렉터리를
+        # 자동 생성하지 않는다. 없으면 `open: No such file or directory` 로 죽는다 (#947).
+        ssh -o BatchMode=yes "$DEV2_HOST" "mkdir -p '$REMOTE_REPLICAS'" || {
+            echo " ❌ 원격 $REMOTE_REPLICAS 생성 실패 — SSH/권한 확인"
+            exit 2
+        }
+        rsync -avz --partial "$SNAP" "$DEV2_HOST:$REMOTE_REPLICAS/portfolio_${HOSTNAME}.db" || {
             echo " ❌ rsync push failed"
             exit 2
         }

--- a/tests/scripts/test_state_replicator_remote_path.py
+++ b/tests/scripts/test_state_replicator_remote_path.py
@@ -1,0 +1,69 @@
+r"""state_replicator 의 원격 수신 경로 검증 (#947).
+
+Gotcha-Test Pair (두 개, 둘 다 조용히 틀리는 종류):
+
+1. **`host:relative/path` 는 수신 측 홈 기준으로 풀린다.** 보내는 쪽 cwd 와 무관하다.
+   예전 코드는 `$DEV2_HOST:data/replicas/...` 라 스냅샷이 레포가 아니라
+   `~/data/replicas/` 로 떨어졌다 (2026-07-29 실측: 136MB 가 홈에 쌓였다).
+   rsync 는 성공을 보고하므로 아무도 몰랐다.
+
+2. **`${VAR#~/}` 는 `~` 를 안 지운다.** bash 가 **패턴 쪽 물결표를 홈으로 확장**해
+   `/Users/<user>/` 와 비교하므로 매칭이 실패한다. `\~/` 로 escape 해야 한다.
+   이걸 놓치면 원격 경로가 `~/workspace/...` 리터럴이 되어 또 엉뚱한 곳에 만들어진다.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path("scripts/deploy/state_replicator.sh")
+
+
+def _bash(snippet: str) -> str:
+    return subprocess.run(["bash", "-c", snippet], capture_output=True, text=True, check=True).stdout.strip()
+
+
+class TestRemotePathIsRepoRelativeNotHome:
+    def test_rsync_destination_uses_remote_repo_path(self):
+        """rsync 목적지가 `$REMOTE_REPLICAS` 여야 한다 — `$REPLICAS_DIR` 이면 홈에 떨어진다."""
+        text = SCRIPT.read_text(encoding="utf-8")
+        m = re.search(r'rsync[^\n]*"\$DEV2_HOST:([^"]+)"', text)
+        assert m, "rsync push 라인을 못 찾았다 — 형태가 바뀌었으면 이 테스트를 갱신할 것"
+        dest = m.group(1)
+        assert dest.startswith("$REMOTE_REPLICAS"), (
+            f"rsync 목적지가 {dest!r} — 홈 기준으로 풀려 레포 밖에 떨어진다 (#947)"
+        )
+
+    def test_remote_directory_is_created_before_push(self):
+        """macOS openrsync 는 목적지 디렉터리를 안 만든다 — 선행 mkdir 필수."""
+        text = SCRIPT.read_text(encoding="utf-8")
+        mkdir_at = text.find("mkdir -p '$REMOTE_REPLICAS'")
+        rsync_at = text.find('rsync -avz --partial "$SNAP"')
+        assert mkdir_at != -1, "원격 mkdir 이 없다 — 신규 머신에서 rsync 가 죽는다 (#947)"
+        assert mkdir_at < rsync_at, "mkdir 이 rsync 뒤에 있으면 소용없다"
+
+
+class TestTildeStripping:
+    """`${VAR#~/}` 함정 — 패턴의 `~` 가 확장돼 매칭이 조용히 실패한다."""
+
+    def test_bare_tilde_pattern_does_not_strip(self):
+        """이 테스트는 **bash 동작 자체**를 고정한다 — 함정이 실재함을 증명."""
+        assert _bash('D="~/workspace/nuri-quant"; echo "${D#~/}"') == "~/workspace/nuri-quant"
+
+    def test_escaped_tilde_pattern_strips(self):
+        assert _bash(r'D="~/workspace/nuri-quant"; echo "${D#\~/}"') == "workspace/nuri-quant"
+
+    def test_script_uses_escaped_form(self):
+        text = SCRIPT.read_text(encoding="utf-8")
+        assert r"${REMOTE_REPO#\~/}" in text, (
+            r"`${REMOTE_REPO#~/}` 는 `~` 를 안 지운다 — `\~/` 로 escape 해야 한다 (#947)"
+        )
+
+    def test_normalisation_result(self):
+        """세 가지 입력 모두 홈 기준 상대경로로 정규화된다."""
+        norm = r'REMOTE_REPO="${DEV2_PATH:-~/workspace/nuri-quant}"; echo "${REMOTE_REPO#\~/}"'
+        assert _bash(norm) == "workspace/nuri-quant"
+        assert _bash(f'DEV2_PATH="~/workspace/nuri-quant"; {norm}') == "workspace/nuri-quant"
+        assert _bash(f'DEV2_PATH="workspace/nuri-quant"; {norm}') == "workspace/nuri-quant"


### PR DESCRIPTION
With #946 fixed, `state_replicator` got far enough to actually push — and put the snapshot in the wrong directory. **rsync reported success both times.**

## Two defects, both silent

**`host:relative/path` resolves against the receiver's home**, not the sender's working directory. `$DEV2_HOST:data/replicas/...` wrote to `~/data/replicas/` instead of the repo. Measured: 136 MB landed in the home directory.

That broke the DR pair without any error. `replica` mode reads `<repo>/data/replicas`, so primary wrote one place and replica looked in another — and neither said anything.

**The push assumed the destination directory existed.** macOS openrsync does not create it, so on a machine that has never received a snapshot the transfer dies with `open: No such file or directory`. Both earlier "successes" only happened because I had made the directory by hand.

## Fix

Remote path derives from `DEV2_PATH` (the same variable `deploy_to_mini.sh` uses), normalised to a home-relative form, and an `ssh mkdir -p` runs before the transfer.

## The normalisation cost a second bug worth recording

`${VAR#~/}` **does not strip the tilde.** bash expands the tilde in the *pattern* to `/Users/<user>/`, which never matches, so the variable passes through unchanged and the remote path becomes a literal `~/workspace/...` — a third wrong directory. It needs `\~/`.

```
${D#~/}   → ~/workspace/nuri-quant     (unchanged — trap)
${D#\~/}  → workspace/nuri-quant       (correct)
```

The test pins **bash's own behaviour**, not just the script text, so the trap is documented by a comparison that would fail if the assumption were wrong — rather than by a comment nobody rereads.

## Verified end to end, from a clean slate

Deleted this machine's `data/replicas/` **first**, so nothing could pass by accident:

```
mini   → ✅ primary push OK (sha=93297befc70db337 schema=48 tables=54)
MBP    → data/replicas/portfolio_Ehbebeui-Macmini.db   (136 MB, in the repo)
replica→ ✅ replica verify OK   sha=93297befc70db337
```

Same digest on both sides — the DR cycle closes for the first time. The stray copy my earlier diagnosis left in `~/data` was removed.

`make verify-quick`: 6557 passed / 6 skipped. `make lint-sh` clean.

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)