### PR TITLE
fix(portfolio): stop importing fixture accounts into production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,8 @@ data/*.db
 data/*.db-wal
 data/*.db-shm
 data/backups/
+# state_replicator 가 push 하는 prod DB 사본 — #947 이후 실제로 생성된다
+data/replicas/
 data/exports/
 data/reports/
 data/.bfg-reports/

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,566 collected across 292 files | |
+| **Backend tests** | 6,571 collected across 293 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,566 backend tests across 292 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,571 backend tests across 293 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,566 tests, 292 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,571 tests, 293 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -521,24 +521,10 @@ def _get_targets_status() -> dict[str, dict]:
 
 
 def _get_real_accounts() -> set[str]:
-    """portfolio.yaml accounts 중 substantive metadata (label/name/strategy/holdings/balance)
-    가 있는 키만 반환. test/sample 같은 stub 계좌의 stale DB row 가
-    portfolio aggregation 을 오염시키는 것을 차단 (#527 root cause)."""
-    from pathlib import Path
+    """실계좌 집합 — 판별은 `nuri.core.rules.get_real_accounts()` 가 canonical."""
+    from nuri.core.rules import get_real_accounts
 
-    import yaml
-
-    portfolio_path = Path(__file__).parent.parent.parent.parent / "config" / "portfolio.yaml"
-    try:
-        portfolio = yaml.safe_load(portfolio_path.read_text(encoding="utf-8"))
-    except Exception:
-        return set()
-    real: set[str] = set()
-    for acc, info in (portfolio.get("accounts") or {}).items():
-        info = info or {}
-        if any(info.get(k) for k in ("label", "name", "strategy", "holdings", "balance")):
-            real.add(acc)
-    return real
+    return get_real_accounts()
 
 
 def _get_portfolio_map() -> dict[str, dict]:

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -142,6 +142,47 @@ def get_account_strategy_name(account: str | None) -> str:
         return "core"
 
 
+_REAL_ACCOUNT_KEYS = ("broker", "name", "label", "strategy", "balance")
+
+
+def is_real_account(info: dict | None) -> bool:
+    """계좌 블록 하나가 실계좌인지 — **이미 파싱된 dict 로** 판정한다.
+
+    `get_real_accounts()` 와 달리 파일을 다시 읽지 않는다. 다른 yaml 을 로드한
+    호출자(`import_portfolio.load_holdings_by_account(config_path=...)`)가 기본 경로를
+    재독해 **엉뚱한 파일 기준으로 판정하는 사고**를 막는다.
+    """
+    return any((info or {}).get(k) for k in _REAL_ACCOUNT_KEYS)
+
+
+def get_real_accounts() -> set[str]:
+    """실제 증권계좌만 — `portfolio.yaml` 의 픽스처/stub 계좌를 배제한다.
+
+    판별은 **계좌를 설명하는 메타데이터**(`broker`/`name`/`label`/`strategy`/`balance`)
+    선언 여부다. 픽스처(`test`/`sample`/`main`)는 `currency` + `holdings` 뿐이다.
+
+    이전 기준은 여기에 **`holdings` 가 포함돼 있었고, 그래서 픽스처도 전부 통과했다** —
+    "test/sample stub 차단" 이라 적힌 방어선이 실제로는 열려 있었다 (#527 의도 무산).
+    2026-07-29 실측: 8개 계좌 전부가 real 로 판정됐고, import 가 픽스처 9행을
+    프로덕션에 넣었다.
+
+    ⚠️ 기준을 더 좁히지 말 것 (예: `broker` 만). `strategy` 만 선언한 실계좌를 조용히
+    누락시키면 **보유가 통째로 사라진다** — 픽스처가 섞이는 것보다 나쁜 실패다.
+    지운 건 `holdings` 하나뿐이고, 그 하나가 구멍이었다.
+
+    호출자는 DB row 를 이 집합으로 걸러 stale 픽스처 행이 집계를 오염시키지 않게 한다.
+    """
+    import yaml
+
+    _portfolio_path = Path(__file__).parent.parent.parent / "config" / "portfolio.yaml"
+    try:
+        with open(_portfolio_path, encoding="utf-8") as f:
+            portfolio = yaml.safe_load(f) or {}
+    except Exception:
+        return set()
+    return {acc for acc, info in (portfolio.get("accounts") or {}).items() if is_real_account(info)}
+
+
 def get_stop_loss_for_account(account: str | None) -> int:
     """계좌명 → stop_loss threshold (정수 %). 계좌 미지정/매칭 실패 → global fallback.
 

--- a/nuri/trading/recommend/held_add.py
+++ b/nuri/trading/recommend/held_add.py
@@ -133,22 +133,10 @@ def is_in_earnings_blackout(
 
 
 def _get_real_accounts() -> set[str]:
-    """portfolio.yaml accounts 중 substantive metadata 가진 계좌만 — #527 패턴.
+    """실계좌 집합 — 판별은 `nuri.core.rules.get_real_accounts()` 가 canonical."""
+    from nuri.core.rules import get_real_accounts
 
-    test/sample/legacy stale row 가 shadow 데이터에 노이즈 안 들어가도록.
-    """
-    portfolio_path = Path(__file__).parent.parent.parent.parent / "config" / "portfolio.yaml"
-    try:
-        with open(portfolio_path, encoding="utf-8") as f:
-            portfolio = yaml.safe_load(f) or {}
-    except FileNotFoundError:
-        return set()
-    real: set[str] = set()
-    for acc, info in (portfolio.get("accounts") or {}).items():
-        info = info or {}
-        if any(info.get(k) for k in ("label", "name", "strategy", "holdings", "balance")):
-            real.add(acc)
-    return real
+    return get_real_accounts()
 
 
 def _get_held_positions() -> list[dict[str, Any]]:

--- a/scripts/ops/import_portfolio.py
+++ b/scripts/ops/import_portfolio.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import yaml
 
 from nuri.core.db import init_db, query, replace_portfolio_account
+from nuri.core.rules import is_real_account
 
 _KNOWN_FIELDS = {"ticker", "qty", "avg", "sector"}
 
@@ -48,6 +49,12 @@ def load_holdings_by_account(
     for account_id, account_info in accounts.items():
         # holdings 키가 없는 계좌는 sync 대상이 아님 (DB 보존)
         if "holdings" not in account_info:
+            continue
+        # 픽스처/stub 계좌는 DB 로 넘기지 않는다. 2026-07-29 실측: 필터가 없어
+        # `test`/`sample`/`main` 9행이 프로덕션 portfolio 에 들어갔고, 가짜 티커(BBB)로
+        # #515 auto-consensus 까지 돌아 추천 3건이 생성됐다. 판정은 **지금 읽은 data**
+        # 기준 — 기본 경로를 재독하면 config_path 를 넘긴 호출자가 엉뚱한 파일로 판정된다.
+        if not is_real_account(account_info):
             continue
 
         currency = account_info.get("currency", "USD")

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -1678,10 +1678,15 @@ class TestActionsEdgeFallbacks:
     """Lock-tests for missing actions.py branches."""
 
     def test_get_real_accounts_yaml_missing(self, monkeypatch, tmp_path):
-        """portfolio.yaml read 실패 → set() (lines 505-506)."""
-        import nuri.api.routes.actions as act_mod
+        """portfolio.yaml read 실패 → set().
 
-        monkeypatch.setattr(act_mod, "__file__", str(tmp_path / "fake_actions.py"))
+        판별은 `nuri.core.rules.get_real_accounts()` 로 위임됐으므로 경로를 푸는
+        모듈도 그쪽이다 — actions.__file__ 를 패치해도 더는 영향이 없다.
+        """
+        import nuri.api.routes.actions as act_mod
+        import nuri.core.rules as rules_mod
+
+        monkeypatch.setattr(rules_mod, "__file__", str(tmp_path / "fake_rules.py"))
         result = act_mod._get_real_accounts()
         assert result == set()
 

--- a/tests/api/test_portfolio.py
+++ b/tests/api/test_portfolio.py
@@ -746,6 +746,8 @@ class TestMetadata:
         yaml_content = {
             "accounts": {
                 "test": {
+                    # 실계좌 메타데이터 — 없으면 import 필터가 픽스처로 보고 건너뛴다.
+                    "name": "Metadata fixture",
                     "currency": "USD",
                     "holdings": [
                         {"ticker": "BBB", "qty": 96, "avg": 20.0, "sector": "SectorB", "flag": "SELL"},

--- a/tests/core/test_portfolio_sync.py
+++ b/tests/core/test_portfolio_sync.py
@@ -668,6 +668,7 @@ class TestMetadata:
         yaml_content = {
             "accounts": {
                 "test": {
+                    "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                     "currency": "USD",
                     "holdings": [
                         {"ticker": "BBB", "qty": 96, "avg": 20.0, "sector": "SectorB", "flag": "SELL"},
@@ -786,6 +787,7 @@ class TestImportScriptSync:
             {
                 "accounts": {
                     "test": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "USD",
                         "holdings": [
                             {"ticker": "TSLA", "qty": 10, "avg": 300.0, "sector": "SectorA"},
@@ -793,6 +795,7 @@ class TestImportScriptSync:
                         ],
                     },
                     "sample": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "KRW",
                         "holdings": [
                             {"ticker": "005930.KS", "qty": 1, "avg": 55000.0, "sector": "Semi"},
@@ -819,6 +822,7 @@ class TestImportScriptSync:
                     "irp": {"currency": "KRW", "balance": 1000000},  # holdings 키 없음
                     "demo": {"currency": "USD"},  # holdings 키 없음
                     "test": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "USD",
                         "holdings": [{"ticker": "AAA", "qty": 10, "avg": 100.0}],
                     },
@@ -838,7 +842,7 @@ class TestImportScriptSync:
             yaml_path,
             {
                 "accounts": {
-                    "test": {"currency": "USD", "holdings": []},
+                    "test": {"name": "Account fixture", "currency": "USD", "holdings": []},
                 },
             },
         )
@@ -856,12 +860,14 @@ class TestImportScriptSync:
             {
                 "accounts": {
                     "test": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "USD",
                         "holdings": [
                             {"ticker": "TSLA", "qty": 10, "avg": 300.0, "sector": "SectorA"},
                         ],
                     },
                     "sample": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "KRW",
                         "holdings": [
                             {"ticker": "005930.KS", "qty": 1, "avg": 55000.0, "sector": "Semi"},
@@ -926,6 +932,7 @@ class TestImportScriptSync:
             {
                 "accounts": {
                     "test": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "USD",
                         "holdings": [
                             {"ticker": "TSLA", "qty": 33, "avg": 200.0, "sector": "SectorA"},
@@ -982,6 +989,7 @@ class TestImportScriptSync:
             {
                 "accounts": {
                     "test": {
+                        "name": "Account fixture",  # 실계좌 메타데이터 — 없으면 import 필터가 stub 으로 본다
                         "currency": "USD",
                         "holdings": [
                             {"ticker": "TSLA", "qty": 33, "avg": 200.0, "sector": "SectorA"},
@@ -1030,7 +1038,7 @@ class TestImportScriptSync:
         self._write_yaml(
             yaml_path,
             {
-                "accounts": {"test": {"currency": "USD", "holdings": []}},
+                "accounts": {"test": {"name": "Account fixture", "currency": "USD", "holdings": []}},
             },
         )
 

--- a/tests/core/test_real_accounts.py
+++ b/tests/core/test_real_accounts.py
@@ -1,0 +1,109 @@
+"""실계좌 판별 + import 필터 회귀 테스트.
+
+Gotcha-Test Pair (2026-07-29 프로덕션 사고):
+
+`config/portfolio.yaml` 에는 실제 증권계좌와 함께 픽스처 계좌(`test`/`sample`/
+`main`)가 섞여 있었고, `import_portfolio.py` 에 계좌 필터가 없어 **한 번의 import
+실행으로 픽스처 9행이 프로덕션 portfolio 에 들어갔다.** 가짜 티커(`BBB`)까지
+#515 auto-consensus 를 타 추천 3건이 오늘 날짜로 생성됐다.
+
+방어선은 있다고 적혀 있었다 — `_get_real_accounts()` docstring 이 "test/sample
+stub 차단 (#527 root cause)". 그런데 판정 기준이
+`("label","name","strategy","holdings","balance")` 중 하나라도 있으면 실계좌라
+**픽스처도 `holdings` 를 가져 전부 통과했다.** 8개 계좌 전부가 real 로 나왔다.
+
+그래서 여기서 잠그는 건 두 가지다: 판별이 실제로 픽스처를 걸러내는가, 그리고
+import 가 그 판별을 쓰는가.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from nuri.core import rules as rules_mod
+from scripts.ops.import_portfolio import load_holdings_by_account
+
+_YAML = textwrap.dedent(
+    """
+    accounts:
+      kakaopay:
+        name: 실계좌 (Main)
+        broker: Brokerage Alpha
+        currency: USD
+        strategy: core
+        holdings:
+        - {ticker: AAA, qty: 10.0, avg: 100.0}
+      pension:
+        name: 연금
+        broker: Brokerage Beta
+        currency: KRW
+        strategy: pension
+        holdings:
+        - {ticker: 005930.KS, qty: 5.0, avg: 70000.0}
+      test:
+        currency: USD
+        holdings:
+        - {ticker: BBB, qty: 1.0, avg: 1.0}
+      sample:
+        currency: USD
+        holdings:
+        - {ticker: VOO, qty: 2.0, avg: 500.0}
+      main:
+        currency: USD
+        holdings:
+        - {ticker: AAPL, qty: 1.0, avg: 100.0}
+    """
+).strip()
+
+
+@pytest.fixture
+def yaml_path(tmp_path: Path, monkeypatch) -> Path:
+    p = tmp_path / "portfolio.yaml"
+    p.write_text(_YAML, encoding="utf-8")
+    # rules.get_real_accounts 는 repo 상대경로를 직접 읽는다 — 테스트용으로 치환.
+    real_open = open
+
+    def fake_open(path, *a, **kw):
+        if str(path).endswith("config/portfolio.yaml"):
+            return real_open(p, *a, **kw)
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    return p
+
+
+class TestGetRealAccounts:
+    def test_fixture_accounts_are_excluded(self, yaml_path):
+        """`holdings` 만 있는 stub 은 실계좌가 아니다 — 이게 뚫려 있어서 사고가 났다."""
+        assert rules_mod.get_real_accounts() == {"kakaopay", "pension"}
+
+    def test_holdings_alone_is_not_enough(self, yaml_path):
+        """옛 기준(`holdings` 포함)으로 되돌리면 픽스처가 통과한다."""
+        real = rules_mod.get_real_accounts()
+        for stub in ("test", "sample", "main"):
+            assert stub not in real, f"{stub} 은 broker/name 이 없으므로 실계좌가 아니다"
+
+    def test_missing_file_is_empty_not_crash(self, tmp_path, monkeypatch):
+        """yaml 을 못 읽어도 예외 대신 빈 집합 — 호출자가 필터를 건너뛰게 둔다."""
+
+        def boom(*a, **kw):
+            raise FileNotFoundError
+
+        monkeypatch.setattr("builtins.open", boom)
+        assert rules_mod.get_real_accounts() == set()
+
+
+class TestImportSkipsFixtureAccounts:
+    def test_only_real_accounts_are_synced(self, yaml_path):
+        """import 가 픽스처를 DB 로 넘기지 않는다 (#515 auto-consensus 도 안 탄다)."""
+        by_account = load_holdings_by_account(yaml_path)
+        assert set(by_account) == {"kakaopay", "pension"}
+
+    def test_fake_tickers_never_reach_the_record_set(self, yaml_path):
+        """`BBB` / `VOO` / `AAPL` 은 실제로 프로덕션에 들어갔던 티커다."""
+        tickers = {r["ticker"] for records in load_holdings_by_account(yaml_path).values() for r in records}
+        assert tickers == {"AAA", "005930.KS"}
+        assert not tickers & {"BBB", "VOO", "AAPL"}

--- a/tests/core/test_real_accounts.py
+++ b/tests/core/test_real_accounts.py
@@ -29,7 +29,7 @@ from scripts.ops.import_portfolio import load_holdings_by_account
 _YAML = textwrap.dedent(
     """
     accounts:
-      kakaopay:
+      brokerage_alpha:
         name: 실계좌 (Main)
         broker: Brokerage Alpha
         currency: USD
@@ -78,7 +78,7 @@ def yaml_path(tmp_path: Path, monkeypatch) -> Path:
 class TestGetRealAccounts:
     def test_fixture_accounts_are_excluded(self, yaml_path):
         """`holdings` 만 있는 stub 은 실계좌가 아니다 — 이게 뚫려 있어서 사고가 났다."""
-        assert rules_mod.get_real_accounts() == {"kakaopay", "pension"}
+        assert rules_mod.get_real_accounts() == {"brokerage_alpha", "pension"}
 
     def test_holdings_alone_is_not_enough(self, yaml_path):
         """옛 기준(`holdings` 포함)으로 되돌리면 픽스처가 통과한다."""
@@ -100,7 +100,7 @@ class TestImportSkipsFixtureAccounts:
     def test_only_real_accounts_are_synced(self, yaml_path):
         """import 가 픽스처를 DB 로 넘기지 않는다 (#515 auto-consensus 도 안 탄다)."""
         by_account = load_holdings_by_account(yaml_path)
-        assert set(by_account) == {"kakaopay", "pension"}
+        assert set(by_account) == {"brokerage_alpha", "pension"}
 
     def test_fake_tickers_never_reach_the_record_set(self, yaml_path):
         """`BBB` / `VOO` / `AAPL` 은 실제로 프로덕션에 들어갔던 티커다."""

--- a/tests/quant/regime/test_strategy_map_branches.py
+++ b/tests/quant/regime/test_strategy_map_branches.py
@@ -192,8 +192,6 @@ class TestGetRealAccountsActionsCI:
     """actions.py L507-512: yaml load + iter (uses Path.read_text)."""
 
     def test_real_accounts_via_read_text_patch(self, monkeypatch):
-        from pathlib import Path
-
         yaml_text = (
             "accounts:\n"
             "  main:\n"
@@ -204,18 +202,24 @@ class TestGetRealAccountsActionsCI:
             "    holdings:\n"
             "      AAA: 10\n"
         )
-        original_read_text = Path.read_text
+        import io
 
-        def _mock_read_text(self, *args, **kwargs):
-            if str(self).endswith("portfolio.yaml"):
-                return yaml_text
-            return original_read_text(self, *args, **kwargs)
+        real_open = open
 
-        monkeypatch.setattr("pathlib.Path.read_text", _mock_read_text)
+        def _opener(path, *args, **kwargs):
+            if str(path).endswith("portfolio.yaml"):
+                return io.StringIO(yaml_text)
+            return real_open(path, *args, **kwargs)
+
+        # 판별이 core 로 위임되며 read_text → open 으로 바뀌었다.
+        monkeypatch.setattr("builtins.open", _opener)
 
         from nuri.api.routes.actions import _get_real_accounts
 
         result = _get_real_accounts()
         assert "main" in result
-        assert "long_term" in result
+        # `holdings` 만 있는 계좌는 실계좌가 아니다. 이전에는 real 로 판정돼
+        # 픽스처(test/sample)가 그대로 통과했고, 2026-07-29 프로덕션 오염의 원인이었다.
+        assert "long_term" not in result
+        assert "shell" not in result
         assert "shell" not in result

--- a/tests/scripts/test_import_portfolio_consensus.py
+++ b/tests/scripts/test_import_portfolio_consensus.py
@@ -205,6 +205,7 @@ def test_main_no_consensus_flag_skips_trigger(db, tmp_path, monkeypatch):
         """
 accounts:
   main:
+    name: 실계좌 픽스처   # 없으면 import 필터가 stub 으로 보고 건너뛴다
     currency: USD
     holdings:
       - { ticker: NEWCO, qty: 1, avg: 100 }
@@ -232,6 +233,7 @@ def test_main_default_calls_trigger_for_new_tickers(db, tmp_path, monkeypatch):
         """
 accounts:
   main:
+    name: 실계좌 픽스처   # 없으면 import 필터가 stub 으로 보고 건너뛴다
     currency: USD
     holdings:
       - { ticker: NEWCO, qty: 1, avg: 100 }
@@ -263,6 +265,7 @@ def test_main_no_new_tickers_skips_trigger(db, tmp_path, monkeypatch):
         """
 accounts:
   main:
+    name: 실계좌 픽스처   # 없으면 import 필터가 stub 으로 보고 건너뛴다
     currency: USD
     holdings:
       - { ticker: AAPL, qty: 1, avg: 100 }


### PR DESCRIPTION
Running `import_portfolio.py` today put **nine rows** from the `test`, `sample` and `main` accounts into the production `portfolio` table, and the fake tickers they carry went on to trigger #515 auto-consensus, which wrote **three recommendations dated today**. `AAPL`, `BBB` and `VOO` are not holdings.

## It was not a one-off mistake

The importer had **no account filter at all** — it syncs every account in `portfolio.yaml`, and `portfolio.yaml` carries three fixture accounts. **Any run does this.** It had simply not been run since those fixtures were added, so nothing surfaced.

## The guard that was supposed to stop it

`_get_real_accounts()` says it blocks "test/sample stub" accounts as the #527 root cause. It treats an account as real if it declares any of `label`, `name`, `strategy`, `holdings`, `balance` — and **fixtures declare `holdings`**. Measured:

```
real accounts: ['irp','kakaopay','kakaopay_sub','main','pension','sample','test','toss']   ← all 8
```

The defence was inert, and had been for as long as it existed.

## Fix: remove exactly one key

Dropping `holdings` from that list is the whole fix. The others stay deliberately — **an account declaring only `strategy` is a real account with sparse metadata, and dropping it would silently lose live positions.** That is a worse failure than the one being fixed, so the reasoning is in the docstring: the tempting next change is to tighten to `broker` only, and that would be wrong.

The predicate moves to `nuri/core/rules.py`; `actions.py` and `held_add.py` each had their own copy of the same broken criterion and now delegate.

It is exposed **twice on purpose**:

- `is_real_account(info)` — judges an already-parsed block
- `get_real_accounts()` — reads the default file

The importer takes the first. Otherwise a caller passing `config_path=` is judged against a *different file* than the one it loaded — I wrote that bug first, and the API-boundary tests caught it.

## Verification

| Mutation | Tests killed |
|---|---|
| put `holdings` back in the criterion | 4 |
| remove the importer's filter | 2 |

Two defences, independently locked. `make verify-quick`: 6556 passed / 6 skipped.

Test fixtures that relied on holdings-only accounts now declare a `name`. **One assertion changed meaning rather than shape**: the actions test asserted a holdings-only account *was* real — that assertion was the defect, written down.

## Also

`data/replicas/` is now gitignored. `data/*.db` only matches direct children, so the replica #947 started producing sat **untracked — a copy of the production portfolio DB inside the repo**.

## Production, cleaned separately

Nine portfolio rows and three recommendations deleted; `kakaopay 8 / pension 7 / toss 4` remain. `agent_decisions` had no matching rows, so the §3.11 adjudication sample — which requires that join — **was never contaminated**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)