### PR TITLE
feat(sre): absorb health_check's unique checks into detectors that alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,582 collected across 294 files | |
+| **Backend tests** | 6,591 collected across 294 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -285,7 +285,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 51 tables (48 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 51 tables (49 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,582 backend tests across 294 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,591 backend tests across 294 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (46 migrations as of 2026-07-28). Key tables:
+51 tables total (49 migrations as of 2026-07-30). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,582 tests, 294 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,591 tests, 294 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -5,10 +5,10 @@
 Layer A 설계 (Codex Round 5):
 - 100% rule-based — threshold 비교 (LLM 추론 X)
 - ZERO LLM
-- 8 detector 모두 결정적 (DB query + filesystem stat)
+- 11 detector 모두 결정적 (DB query + filesystem stat)
 - 모든 incident → audit_ledger + incidents 테이블 영구 기록
 
-8 Detector:
+11 Detector:
     1. orphan_run         — agent_run_ledger started + finished_at IS NULL + >1h
                             warning (1h+) / critical (3h+)
     2. disk_full          — shutil.disk_usage() percent_used > 80 (warn) / > 90 (crit)
@@ -21,6 +21,9 @@ Layer A 설계 (Codex Round 5):
                             ≥1 (warn) / ≥3 (crit)
     7. signal_evaluation_stale — pipeline_events 'signal_evaluation_run'
                             heartbeat 공백 영업일 (#825): ≥2 (warn) / ≥4 (crit)
+    9. schema_version_drift — DB schema_version < 코드 _MIGRATIONS 최신본 (#939)
+   10. required_table_missing — #529 Phase 1+2 필수 테이블 누락 (#939)
+   11. writer_role       — writer actor 가 primary(Mac mini) 밖에서 실행 (#939)
     8. alpha_report_stale — pipeline_events 'alpha_report_run' 의 **마지막 성공
                             stage** 공백 (#894): ≥35일 (warn). heartbeat 공백이
                             아니라 성공 공백 — cron 이 매일이라 role 누락 상태도
@@ -42,6 +45,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import socket
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -78,10 +82,45 @@ SIGNAL_EVAL_CRIT_DAYS = 4
 # 1시간(launchd StartInterval 3600)이므로 3h = 연속 3회 미감지에 해당한다.
 AUTO_RESOLVE_GRACE_HOURS = 3.0
 
+# #529 Phase 1+2 이후 반드시 존재해야 하는 테이블. `health_check.sh` 에서 이식했다 (#939) —
+# 그쪽은 알림 경로가 없어 로그로만 남았고, 그 로그를 읽는 코드는 없었다.
+REQUIRED_TABLES: tuple[str, ...] = (
+    "agent_audit_ledger",
+    "feature_flags",
+    "agent_run_ledger",
+    "agent_messages",
+    "walkforward_runs",
+    "regime_posteriors",
+    "hypotheses",
+    "causal_audits",
+    "agent_decisions",
+    "decision_outcomes",
+    "execution_blocks",
+    "incidents",
+    "dr_replicas",
+    "collector_runs",
+    "drift_alerts",
+    "foundation_benchmarks",
+)
+
+
+def _machine_role() -> str:
+    """hostname → 'primary' | 'replica' | 'unknown' (단일 writer 불변식 판정)."""
+    host = socket.gethostname().split(".")[0].lower()
+    if "macmini" in host:
+        return "primary"
+    if "macbook" in host or "mbp" in host:
+        return "replica"
+    return "unknown"
+
+
 # detector → 그 detector 가 낼 수 있는 incident_type. 자동 해소가 **죽은 detector 의
 # 침묵을 '해소됨' 으로 오독하지 않도록** 쓰인다. 새 detector 를 추가하면 여기도 등록할 것
-# — 누락 시 그 타입은 detector 가 죽어도 닫혀버린다.
+# — 누락 시 그 타입은 detector 가 죽어도 닫혀버린다 (test_every_detector_is_mapped 가 강제).
 _DETECTOR_INCIDENT_TYPES: dict[str, tuple[str, ...]] = {
+    "_detect_schema_version_drift": ("schema_version_drift",),
+    "_detect_required_tables_missing": ("required_table_missing",),
+    "_detect_writer_role": ("writer_role",),
     "_detect_orphan_runs": ("orphan_run",),
     "_detect_disk_full": ("disk_full",),
     "_detect_db_lock": ("db_lock",),
@@ -108,7 +147,7 @@ class SREIncidentAgent(Actor):
     """Operational incident detection + lifecycle management — Layer A.
 
     Actions (input_data['action']):
-        scan        — 8 detector 모두 실행 → log_incident + Discord publish.
+        scan        — 11 detector 모두 실행 → log_incident + Discord publish.
         acknowledge — incident_id 사용자 확인 (audit-only).
         resolve     — incident_id 종료 (status='resolved').
         list_open   — open incident 목록 (severity 필터 optional).
@@ -148,12 +187,15 @@ class SREIncidentAgent(Actor):
     # ─── scan ────────────────────────────────────────────────
 
     def _scan(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
-        """8 detector 실행 → 발견된 incident 목록 반환."""
+        """11 detector 실행 → 발견된 incident 목록 반환 + 조건 해소분 자동 종료."""
         detected: list[dict[str, Any]] = []
 
         failed_detectors: set[str] = set()
 
         for detector in (
+            self._detect_schema_version_drift,
+            self._detect_required_tables_missing,
+            self._detect_writer_role,
             self._detect_orphan_runs,
             self._detect_disk_full,
             self._detect_db_lock,
@@ -251,6 +293,78 @@ class SREIncidentAgent(Actor):
         return resolved
 
     # ─── 8 detectors ─────────────────────────────────────────
+
+    def _detect_schema_version_drift(self, ctx: RunContext) -> list[dict[str, Any]]:
+        """DB schema_version 이 코드의 마이그레이션 최신본보다 낮은가 (#939).
+
+        기대값을 상수로 박지 않고 `_MIGRATIONS` 에서 도출한다 — 코드는 배포됐는데
+        마이그레이션이 안 돈 상태를 잡는 게 목적이라, 기대값은 **코드가 정의**해야 한다.
+        (`health_check.sh` 는 `>= 40` 하드코딩이라 41~49 누락을 못 잡았다.)
+        """
+        from nuri.core.db_migrations import _MIGRATIONS
+
+        expected = max(v for v, _, _ in _MIGRATIONS)
+        # `get_schema_version()` 대신 `query()` — 다른 detector 와 같은 경로를 타야
+        # db_path 주입(테스트 격리)이 먹는다. 직접 호출하면 기본 DB 를 읽어버린다.
+        rows = query("SELECT MAX(version) AS v FROM schema_version")
+        actual = int(dict(rows[0])["v"] or 0) if rows else 0
+        if actual >= expected:
+            return []
+        return [
+            self._record_incident(
+                incident_type="schema_version_drift",
+                severity="critical",
+                target="db_schema",
+                evidence={
+                    "actual_version": actual,
+                    "expected_version": expected,
+                    "missing_migrations": expected - actual,
+                    "hint": "배포는 됐으나 마이그레이션 미적용 — init_db() 또는 배포 절차 확인",
+                },
+                ctx=ctx,
+            )
+        ]
+
+    def _detect_required_tables_missing(self, ctx: RunContext) -> list[dict[str, Any]]:
+        """#529 Phase 1+2 필수 테이블 존재 확인 (#939)."""
+        rows = query("SELECT name FROM sqlite_master WHERE type = 'table'")
+        present = {dict(r)["name"] for r in rows}
+        missing = [t for t in REQUIRED_TABLES if t not in present]
+        if not missing:
+            return []
+        return [
+            self._record_incident(
+                incident_type="required_table_missing",
+                severity="critical",
+                target="db_schema",
+                evidence={"missing": missing, "required_count": len(REQUIRED_TABLES)},
+                ctx=ctx,
+            )
+        ]
+
+    def _detect_writer_role(self, ctx: RunContext) -> list[dict[str, Any]]:
+        """단일 writer 불변식 — 이 액터는 쓰기를 하므로 primary 에서만 돌아야 한다 (#939).
+
+        Mac mini = sole writer, MBP = read replica (`nuri/agents/__init__.py`).
+        replica/unknown 에서 도는 걸 알아채지 못하면 두 원장이 갈라지고, §3.11 은
+        "원장은 production DB 단일" 위에 서 있다.
+        """
+        role = _machine_role()
+        if role == "primary":
+            return []
+        return [
+            self._record_incident(
+                incident_type="writer_role",
+                severity="warning",
+                target=f"machine:{role}",
+                evidence={
+                    "role": role,
+                    "hostname_matched": role != "unknown",
+                    "hint": "writer actor 는 Mac mini(primary)에서만 실행 — 원장 분기 위험",
+                },
+                ctx=ctx,
+            )
+        ]
 
     def _detect_orphan_runs(self, ctx: RunContext) -> list[dict[str, Any]]:
         """agent_run_ledger 에서 started + finished_at NULL + age 검사."""

--- a/nuri/core/db/execution_ops.py
+++ b/nuri/core/db/execution_ops.py
@@ -41,6 +41,10 @@ _INCIDENT_TYPES = (
     "data_freshness_critical",
     "signal_evaluation_stale",
     "alpha_report_stale",
+    # health_check.sh 에서 이식 (#939) — 그쪽은 알림 경로가 없어 로그로만 남았다.
+    "schema_version_drift",
+    "required_table_missing",
+    "writer_role",
 )
 _INCIDENT_SEVERITIES = ("critical", "warning", "info")
 _INCIDENT_STATUSES = ("open", "acknowledged", "resolved")

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1521,4 +1521,43 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         UPDATE decision_outcomes SET benchmark_ticker = 'SPY' WHERE benchmark_return IS NOT NULL;
     """,
     ),
+    (
+        49,
+        "incidents incident_type enum 확장 — health_check.sh 흡수 3종 (#939)",
+        # `scripts/ops/health_check.sh` 의 고유 검사 3종(schema version / 필수 테이블 /
+        # 단일 writer role)을 SRE detector 로 이식한다. 그 스크립트는 echo 만 하고
+        # 알림 경로가 없어 시간마다 로그만 쌓였고, plist 주석이 "SRE-Incident-Agent 가
+        # 이 로그를 watch 한다" 고 적어뒀으나 그런 코드는 없었다 — 광고된 배선이 허구.
+        # SQLite 는 CHECK 제약 변경 미지원 → migration 45/46 과 동일한 재생성 패턴.
+        """
+        CREATE TABLE incidents_new (
+            incident_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            incident_type TEXT NOT NULL CHECK(incident_type IN (
+                'orphan_run','disk_full','db_lock','scheduler_heartbeat',
+                'actor_failure_streak','data_freshness_critical','signal_evaluation_stale',
+                'alpha_report_stale','schema_version_drift','required_table_missing',
+                'writer_role'
+            )),
+            severity TEXT NOT NULL CHECK(severity IN ('critical','warning','info')),
+            target TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('open','acknowledged','resolved')),
+            first_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+            last_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+            resolved_at TEXT,
+            evidence_json TEXT NOT NULL,
+            run_id TEXT,
+            UNIQUE(incident_type, target, status)
+        );
+        INSERT INTO incidents_new
+            (incident_id, incident_type, severity, target, status,
+             first_detected_at, last_detected_at, resolved_at, evidence_json, run_id)
+            SELECT incident_id, incident_type, severity, target, status,
+                   first_detected_at, last_detected_at, resolved_at, evidence_json, run_id
+              FROM incidents;
+        DROP TABLE incidents;
+        ALTER TABLE incidents_new RENAME TO incidents;
+        CREATE INDEX IF NOT EXISTS idx_incidents_status ON incidents(status, severity);
+        CREATE INDEX IF NOT EXISTS idx_incidents_type ON incidents(incident_type, last_detected_at);
+    """,
+    ),
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,7 +60,7 @@ scripts/
 
 | Script | Purpose | Use |
 |---|---|---|
-| `health_check.sh` | schema version + table existence | hourly launchd cron |
+| `health_check.sh` | schema version + table existence | Discord `/health` on-demand (cron 미설치 — #939) |
 | `import_portfolio.py` | YAML → DB portfolio import | `make setup` 내부 (`$(PYTHON) scripts/ops/import_portfolio.py`) |
 | `notify_scan_result.py` | Discord scan result publish | `make full-scan` 마지막 단계 |
 | `ports.sh` | check + kill running services | `bash scripts/ops/ports.sh [kill]` |
@@ -122,7 +122,7 @@ PR/이슈 단위로 한 번 실행한 backfill / counterfactual / amplifier repl
 | `com.nuri-quant.api.plist` | continuous (KeepAlive) | FastAPI :8001 (#838) |
 | `com.nuri-quant.dashboard.plist` | continuous (KeepAlive) | Next.js dashboard :3000 (#838) |
 | `com.nuri-quant.discord-bot.plist` | continuous | Discord bot daemon |
-| `com.nuri-quant.health-check.plist` | hourly | health_check.sh |
+| `com.nuri-quant.health-check.plist` | hourly | health_check.sh — **prod 미설치** (#939: 고유 검사는 SRE detector 로 이식) |
 | `com.nuri-quant.heartbeat-watchdog.plist` | 15min | scheduler heartbeat watchdog + 자동 재시작 (#778/#779) |
 | `com.nuri-quant.state-replicator.plist` | daily | state_replicator.sh |
 | `com.nuri-quant.sre-scan.plist` | hourly | SREIncidentAgent.scan |

--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -148,6 +148,8 @@ update_claim live_db_tables      README.md                     'SQLite WAL · [0
 # grep/wc 기반 — verify 가 하드 게이트하는데 sync 에는 없어서, 이 셋이 drift 하면
 # 게이트가 빨간불인 채 고칠 방법이 없었다 (#916).
 update_claim live_migrations     README.md                     '[0-9]+ forward-only migrations'
+# ARCHITECTURE 도 같은 수치를 적는데 등록이 안 돼 있었다 — 2026-07-30 실측 46 vs 실제 49.
+update_claim live_migrations     docs/ARCHITECTURE.md          '\([0-9]+ migrations as of'
 update_claim live_scheduler_jobs docs/ARCHITECTURE.md          '[0-9]+ cron jobs in'
 update_claim live_rules_lines    config/CLAUDE.md              '\| [0-9]+ \| Investment rules'
 

--- a/scripts/launchd/com.nuri-quant.health-check.plist
+++ b/scripts/launchd/com.nuri-quant.health-check.plist
@@ -5,7 +5,12 @@
   com.nuri-quant.health-check (#529 Phase 1, SRE-Incident-Agent precursor)
 
   매시간 health_check.sh 실행. exit code 1/2 시 stderr 로그가
-  data/logs/health_check.err 에 남음. SRE-Incident-Agent (Phase 6) 가 이 로그 watch.
+  data/logs/health_check.err 에 남음.
+  ⚠️ 이 plist 는 **설치하지 않는다** (#939). 고유 검사 3종(schema version / 필수 테이블 /
+  writer role)은 SREIncidentAgent detector 로 이식됐고 그쪽이 log_incident + Discord
+  publish 경로를 탄다. 예전 주석은 'SRE-Incident-Agent 가 이 로그를 watch' 라고 적었으나
+  그런 코드는 존재한 적이 없다 — 광고된 배선이 허구였다. 스크립트 자체는 Discord /health
+  슬래시 명령의 on-demand 실행 경로로 남는다.
 
   설치:
     cp scripts/launchd/com.nuri-quant.health-check.plist ~/Library/LaunchAgents/

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -144,6 +144,8 @@ else
 fi
 # grep/wc-based (no Python) — always run, including CI
 check_claim "migrations"       "$MIG"   "README.md"            '[0-9]+ forward-only migrations' || true
+# ARCHITECTURE 도 같은 수치를 적는데 게이트가 없어 조용히 갈렸다 (2026-07-30 실측 46 vs 49).
+check_claim "migrations"       "$MIG"   "docs/ARCHITECTURE.md" '\([0-9]+ migrations as of' || true
 check_claim "scheduler_jobs"   "$JOBS"  "docs/ARCHITECTURE.md" '[0-9]+ cron jobs in' || true
 check_claim "rules_yaml_lines" "$RULES" "config/CLAUDE.md"     '\| [0-9]+ \| Investment rules' || true
 

--- a/tests/agents/test_sre_incident_agent.py
+++ b/tests/agents/test_sre_incident_agent.py
@@ -1295,3 +1295,75 @@ class TestIncidentAutoResolve:
 
         assert not [r for r in resolved if r["target"] == "stuck-actor"]
         assert [r for r in _open_rows(patched_db) if r["target"] == "stuck-actor"]
+
+
+# ═══════════════════════════════════════════════════════
+# health_check.sh 흡수 detector 3종 (#939)
+# ═══════════════════════════════════════════════════════
+
+
+class TestAbsorbedHealthChecks:
+    """`health_check.sh` 의 고유 검사를 알림 경로가 있는 detector 로 이식 (#939).
+
+    그 스크립트는 `echo` 만 하고 DB/Discord 쓰기가 0건이라, 시간마다 로그만 쌓였다.
+    게다가 plist 주석은 "SRE-Incident-Agent 가 이 로그를 watch 한다" 고 적어뒀는데
+    그런 코드는 없었다 — 광고된 배선이 허구였다. 여기 옮겨야 `log_incident` +
+    Discord publish 를 탄다.
+    """
+
+    def _detect(self, name: str, **patches):
+        actor = SREIncidentAgent()
+        ctx = MagicMock(run_id="test-run")
+        with patch.object(SREIncidentAgent, "_publish_alert"):
+            return getattr(actor, name)(ctx)
+
+    def test_schema_drift_expected_version_comes_from_code(self, patched_db, no_publish):
+        """기대값은 `_MIGRATIONS` 에서 도출 — 상수를 박으면 이후 마이그레이션을 못 잡는다.
+
+        `health_check.sh` 는 `>= 40` 하드코딩이라 41~49 누락을 통과시켰다.
+        """
+        from nuri.core.db_migrations import _MIGRATIONS
+
+        expected = max(v for v, _, _ in _MIGRATIONS)
+        # schema_version 테이블을 실제로 되돌려 detector 가 읽는 경로 그대로 검증한다.
+        with get_db(patched_db) as conn:
+            conn.execute("DELETE FROM schema_version WHERE version > ?", (expected - 3,))
+        out = self._detect("_detect_schema_version_drift")
+        assert len(out) == 1
+        e = out[0]["evidence"]
+        assert e["expected_version"] == expected and e["missing_migrations"] == 3
+        assert out[0]["severity"] == "critical"
+
+    def test_schema_drift_silent_when_current(self, patched_db, no_publish):
+        assert self._detect("_detect_schema_version_drift") == []
+
+    def test_missing_table_is_reported(self, patched_db, no_publish):
+        with patch(
+            "nuri.agents.actors.sre_incident_agent.REQUIRED_TABLES",
+            ("incidents", "definitely_not_a_table"),
+        ):
+            out = self._detect("_detect_required_tables_missing")
+        assert len(out) == 1
+        assert out[0]["evidence"]["missing"] == ["definitely_not_a_table"]
+        assert out[0]["severity"] == "critical"
+
+    def test_all_required_tables_present_is_silent(self, patched_db, no_publish):
+        """init_db() 가 만든 스키마는 필수 테이블을 전부 갖춰야 한다."""
+        assert self._detect("_detect_required_tables_missing") == []
+
+    @pytest.mark.parametrize(
+        ("hostname", "expect_incident", "role"),
+        [
+            ("Ehbebeui-Macmini", False, "primary"),
+            ("Ehbebeui-MacBookPro", True, "replica"),
+            ("some-random-host", True, "unknown"),
+        ],
+    )
+    def test_writer_role(self, patched_db, no_publish, hostname, expect_incident, role):
+        """writer actor 가 primary 밖에서 돌면 원장이 갈라진다 (§3.11 단일 원장)."""
+        with patch("nuri.agents.actors.sre_incident_agent.socket.gethostname", return_value=hostname):
+            out = self._detect("_detect_writer_role")
+        assert bool(out) is expect_incident
+        if expect_incident:
+            assert out[0]["evidence"]["role"] == role
+            assert out[0]["severity"] == "warning"

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,14 +29,15 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_48(self, db_path):
+    def test_schema_version_at_49(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
         incidents alpha_report_stale enum 확장 (#894) +
         execution_blocks sleeve_cap enum 확장 (#834) +
-        decision_outcomes.benchmark_ticker (#833) → 48."""
-        assert get_schema_version(db_path) == 48
+        decision_outcomes.benchmark_ticker (#833) +
+        incidents enum 확장 — health_check.sh 흡수 3종 (#939) → 49."""
+        assert get_schema_version(db_path) == 49
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.
@@ -60,6 +61,44 @@ class TestSchemaMigrations:
         assert check_body, "execution_blocks CHECK 파싱 실패 — 스키마 형태가 바뀜"
         in_sql = set(re.findall(r"'([a-z_]+)'", check_body.group(1)))
         assert in_sql == set(_BLOCK_TYPES), f"SQL CHECK {sorted(in_sql)} != _BLOCK_TYPES {sorted(_BLOCK_TYPES)}"
+
+    def test_incident_type_allowlist_matches_sql_check(self, db_path):
+        """`_INCIDENT_TYPES`(파이썬 검증) 와 incidents CHECK(스키마) 는 같아야 한다.
+
+        block_type 과 완전히 같은 실패 모드인데 여기엔 잠금이 없었다 — #939 에서
+        detector 3종을 추가하며 양쪽을 손으로 맞췄고, 한쪽만 고치면 `log_incident`
+        가 ValueError(파이썬만 좁음) 또는 IntegrityError(스키마만 좁음)로 죽는다.
+        둘 다 **감시자가 통째로 멈추는** 고장이라 조합을 여기서 잠근다.
+
+        Gotcha-Test Pair: 어느 한쪽에만 incident_type 을 추가하면 FAIL.
+        """
+        import re
+
+        from nuri.core.db.execution_ops import _INCIDENT_TYPES
+
+        sql = query(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='incidents'",
+            db_path=db_path,
+        )[0]["sql"]
+        check_body = re.search(r"incident_type TEXT NOT NULL CHECK\(incident_type IN \((.*?)\)\)", sql, re.S)
+        assert check_body, "incidents CHECK 파싱 실패 — 스키마 형태가 바뀜"
+        in_sql = set(re.findall(r"'([a-z_]+)'", check_body.group(1)))
+        assert in_sql == set(_INCIDENT_TYPES), (
+            f"SQL CHECK {sorted(in_sql)} != _INCIDENT_TYPES {sorted(_INCIDENT_TYPES)}"
+        )
+
+    def test_every_sre_detector_type_is_allowed(self, db_path):
+        """detector 가 낼 수 있는 타입은 전부 DB 가 받아줘야 한다 (#939).
+
+        `_DETECTOR_INCIDENT_TYPES` 는 자동 해소 가드용이지만, 그 값이 곧 detector 가
+        `log_incident` 에 넘기는 타입이다. allowlist 에 없으면 스캔 중 그 detector 가
+        예외로 죽고 scan 루프가 db_lock 으로 바꿔 담는다 — 원인이 가려진다.
+        """
+        from nuri.agents.actors.sre_incident_agent import _DETECTOR_INCIDENT_TYPES
+        from nuri.core.db.execution_ops import _INCIDENT_TYPES
+
+        emitted = {t for types in _DETECTOR_INCIDENT_TYPES.values() for t in types}
+        assert emitted <= set(_INCIDENT_TYPES), f"allowlist 누락: {sorted(emitted - set(_INCIDENT_TYPES))}"
 
     def test_audit_ledger_table_exists(self, db_path):
         """agent_audit_ledger 테이블이 생성되었는지 확인."""


### PR DESCRIPTION
`health-check` was the last of the four uninstalled plists (#939). Codex was asked install-or-not and returned **`ABSORB_INTO_SRE`** — neither of the two options I was weighing.

## My objection was right in direction, wrong in substance

I argued against installing on the grounds that the SRE agent already covers the same ground. **It does not.** Schema version, table existence and the single-writer role check exist nowhere in the eight detectors — the only overlap is orphan runs. Those three are exactly the silent-corruption class this repo keeps getting caught by, so "just don't install it" would have left the blind spot in place.

## But installing as-is is worse

`health_check.sh` only echoes — **no DB write, no Discord, no incident row** (measured: 0 matches). An hourly log with no reader.

Two claims made it worse than neutral:

- `com.nuri-quant.health-check.plist:8` said *"SRE-Incident-Agent (Phase 6) 가 이 로그 watch"* — **no such code has ever existed.**
- `scripts/README.md:63` described it as an installed `hourly launchd cron` — it is not installed.

The repo was claiming a control it did not have. Installing would have entrenched that rather than corrected it. Codex framed this as governance rather than mechanics, and that is the part I had missed.

## What moved

Three detectors that reach `log_incident` + Discord routing:

| detector | severity | note |
|---|---|---|
| `schema_version_drift` | critical | **not a port** — `health_check` hardcoded `>= 40`, which passes a DB missing migrations 41–49. Expectation now derives from `_MIGRATIONS`, so it measures *code deployed without its migrations* |
| `required_table_missing` | critical | 16 tables from #529 Phase 1+2 |
| `writer_role` | warning | primary/replica/unknown — §3.11 rests on a single ledger |

Migration **49** widens the `incidents` CHECK, following the table-rebuild pattern of 45 and 46.

## Two lock tests fell out of it

`_BLOCK_TYPES` has had a test tying it to its SQL CHECK since they diverged in #834. **`_INCIDENT_TYPES` had none** — and I had just edited both sides by hand. Added, plus one asserting every type a detector can emit is accepted by the allowlist: otherwise the detector dies mid-scan and the loop relabels it `db_lock`, hiding the cause.

## A bug I introduced and the tests caught

The detector first called `get_schema_version()` directly, which **bypasses the `db_path` injection** the other detectors go through — it read the default database during tests. Now goes through `query()` like the rest.

## Verification

| Mutation | Test killed |
|---|---|
| hardcode expected version to 40 | `test_schema_drift_expected_version_comes_from_code` |
| empty the missing-table list | `test_missing_table_is_reported` |
| treat replica as primary | `test_writer_role[replica]`, `[unknown]` |
| drop a detector from the type map | `test_every_detector_is_mapped` |
| narrow only the python allowlist | `test_incident_type_allowlist_matches_sql_check` + `test_every_sre_detector_type_is_allowed` |

`make verify-quick`: 6576 passed / 6 skipped. Schema lock test updated 48 → 49.

## Not installed, and now it says so

The plist header records why. The script stays as the Discord `/health` on-demand path.

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)