### PR TITLE
fix(harness): make the PreToolUse guards actually fire

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -11,9 +11,14 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 > 이 한 단어 때문에 sqlite3 / privacy 훅 2개가 #229(2026-04-13)부터 **3.5개월간 무력**이었고,
 > 그동안 이 문서의 "blocks" 문장은 거짓이었다 (2026-07-29 `/doctor` 발견). 나머지 훅 3개는
 > stdin 을 jq 로 직접 파이프해 왕복이 없어 영향 없었다.
-> **Test:** `tests/test_hook_guard_execution.py` — 훅 명령을 grep 하지 않고 `sh -c` + stdin JSON 으로
-> **실행**해 exit code 를 본다(위반 2 / 허용 0). 카나리아는 *개행을 품은* payload 다 — 단행
-> payload 는 `echo` 로도 살아남아 회귀가 조용히 통과한다 (mutation 실측: 단행 PASS, 개행 FAIL).
+> 같은 이유로 훅 본문은 **POSIX sh 만** 쓴다 — `[[ ]]` 는 dash 에서 조건절째 죽어 또 조용히
+> exit 0 이 된다. 파일 매칭은 `case ... in` 으로. (macOS `/bin/sh` 는 bash 라 로컬에선 안 터지고
+> Linux 에서만 터진다.)
+> **Test:** `tests/test_hook_guard_execution.py` — 훅 명령을 grep 하지 않고 **셸로 실행**해 exit
+> code 를 본다(위반 2 / 허용 0). 셸 2종을 돌린다: `bash -O xpg_echo`(macOS `/bin/sh` 등가 —
+> `echo` 회귀 축)와 `dash`(bashism 축). 카나리아는 *개행을 품은* payload 다 — 단행 payload 는
+> `echo` 로도 살아남아 회귀가 조용히 통과한다. mutation 실측: `printf`→`echo` 4 FAIL,
+> `case`→`[[ ]]` 3 FAIL, 단행 payload 는 양쪽 mutant 에서 PASS.
 
 **PostToolUse**: `datetime.now()` block (exit 1 surfaces to Claude), ruff advisory.
 

--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -4,6 +4,17 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 
 **PreToolUse hook** blocks: `import sqlite3` outside `nuri/core/db/connection.py`, `git push --force` / `reset --hard` / `clean -f`, privacy ticker+PnL inline writes (`scripts/verify/check_privacy_leak.py --message --quiet`).
 
+> ⚠️ 훅 안에서 stdin payload 를 다시 뱉을 땐 **`printf '%s' "$INPUT"` 만** — `echo` 금지.
+> macOS `/bin/sh` 는 `xpg_echo` 가 켜진 bash 3.2 라 `echo` 가 **JSON 안의 `\n` 을 실제
+> 개행으로 펼친다**. `new_string` 은 거의 항상 여러 줄이므로 JSON 이 깨지고 → jq 실패 →
+> 변수 공백 → 가드가 **exit 0 으로 통과**한다. 차단이 아니라 침묵이라 아무 신호가 없다:
+> 이 한 단어 때문에 sqlite3 / privacy 훅 2개가 #229(2026-04-13)부터 **3.5개월간 무력**이었고,
+> 그동안 이 문서의 "blocks" 문장은 거짓이었다 (2026-07-29 `/doctor` 발견). 나머지 훅 3개는
+> stdin 을 jq 로 직접 파이프해 왕복이 없어 영향 없었다.
+> **Test:** `tests/test_hook_guard_execution.py` — 훅 명령을 grep 하지 않고 `sh -c` + stdin JSON 으로
+> **실행**해 exit code 를 본다(위반 2 / 허용 0). 카나리아는 *개행을 품은* payload 다 — 단행
+> payload 는 `echo` 로도 살아남아 회귀가 조용히 통과한다 (mutation 실측: 단행 PASS, 개행 FAIL).
+
 **PostToolUse**: `datetime.now()` block (exit 1 surfaces to Claude), ruff advisory.
 
 **CI gates** (every PR): `privacy-scan`, `pr-discipline` (commits ≤ 3 — escape `scope-expand-approved` label), test regression + Codecov 1% relative, `security-scan` (Trivy CRITICAL), `Doc Count Drift Check` (`make verify-doc-counts`).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,13 +69,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // \"\"'); if [[ \"$FILE\" == */nuri/*.py && \"$FILE\" != */core/db.py && \"$FILE\" != */core/db/connection.py ]]; then CONTENT=$(echo \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); if echo \"$CONTENT\" | grep -q 'import sqlite3'; then echo '{\"decision\":\"block\",\"reason\":\"sqlite3는 nuri/core/db/connection.py만 import 가능 (PR #566 stage 2). query()/query_df()/upsert_*() 사용.\"}'; exit 2; fi; fi",
+            "command": "INPUT=$(cat); FILE=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.file_path // \"\"'); if [[ \"$FILE\" == */nuri/*.py && \"$FILE\" != */core/db.py && \"$FILE\" != */core/db/connection.py ]]; then CONTENT=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); if echo \"$CONTENT\" | grep -q 'import sqlite3'; then echo '{\"decision\":\"block\",\"reason\":\"sqlite3는 nuri/core/db/connection.py만 import 가능 (PR #566 stage 2). query()/query_df()/upsert_*() 사용.\"}'; exit 2; fi; fi",
             "timeout": 5,
             "statusMessage": "sqlite3 import guard..."
           },
           {
             "type": "command",
-            "command": "INPUT=$(cat); [ -x .venv/bin/python ] && [ -f scripts/verify/check_privacy_leak.py ] || exit 0; CONTENT=$(echo \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); [ -z \"$CONTENT\" ] && exit 0; OUT=$(echo \"$CONTENT\" | .venv/bin/python scripts/verify/check_privacy_leak.py --message --quiet 2>&1); if [ $? -ne 0 ]; then printf '{\"decision\":\"block\",\"reason\":\"Privacy ticker+PnL leak detected (PR #202 signature). Findings: %s. See scripts/verify/check_privacy_leak.py + STRATEGY §4.4.1. Use placeholders or round values.\"}' \"$(echo \"$OUT\" | head -3 | tr '\\n' ' ' | sed 's/\"/\\\\\"/g')\"; exit 2; fi",
+            "command": "INPUT=$(cat); [ -x .venv/bin/python ] && [ -f scripts/verify/check_privacy_leak.py ] || exit 0; CONTENT=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); [ -z \"$CONTENT\" ] && exit 0; OUT=$(echo \"$CONTENT\" | .venv/bin/python scripts/verify/check_privacy_leak.py --message --quiet 2>&1); if [ $? -ne 0 ]; then printf '{\"decision\":\"block\",\"reason\":\"Privacy ticker+PnL leak detected (PR #202 signature). Findings: %s. See scripts/verify/check_privacy_leak.py + STRATEGY §4.4.1. Use placeholders or round values.\"}' \"$(echo \"$OUT\" | head -3 | tr '\\n' ' ' | sed 's/\"/\\\\\"/g')\"; exit 2; fi",
             "timeout": 5,
             "statusMessage": "privacy ticker+pnl check..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,13 +69,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); FILE=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.file_path // \"\"'); if [[ \"$FILE\" == */nuri/*.py && \"$FILE\" != */core/db.py && \"$FILE\" != */core/db/connection.py ]]; then CONTENT=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); if echo \"$CONTENT\" | grep -q 'import sqlite3'; then echo '{\"decision\":\"block\",\"reason\":\"sqlite3는 nuri/core/db/connection.py만 import 가능 (PR #566 stage 2). query()/query_df()/upsert_*() 사용.\"}'; exit 2; fi; fi",
+            "command": "INPUT=$(cat); FILE=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.file_path // \"\"'); case \"$FILE\" in */core/db.py|*/core/db/connection.py) ;; */nuri/*.py) CONTENT=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); if printf '%s\\n' \"$CONTENT\" | grep -q 'import sqlite3'; then echo '{\"decision\":\"block\",\"reason\":\"sqlite3는 nuri/core/db/connection.py만 import 가능 (PR #566 stage 2). query()/query_df()/upsert_*() 사용.\"}'; exit 2; fi ;; esac",
             "timeout": 5,
             "statusMessage": "sqlite3 import guard..."
           },
           {
             "type": "command",
-            "command": "INPUT=$(cat); [ -x .venv/bin/python ] && [ -f scripts/verify/check_privacy_leak.py ] || exit 0; CONTENT=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); [ -z \"$CONTENT\" ] && exit 0; OUT=$(echo \"$CONTENT\" | .venv/bin/python scripts/verify/check_privacy_leak.py --message --quiet 2>&1); if [ $? -ne 0 ]; then printf '{\"decision\":\"block\",\"reason\":\"Privacy ticker+PnL leak detected (PR #202 signature). Findings: %s. See scripts/verify/check_privacy_leak.py + STRATEGY §4.4.1. Use placeholders or round values.\"}' \"$(echo \"$OUT\" | head -3 | tr '\\n' ' ' | sed 's/\"/\\\\\"/g')\"; exit 2; fi",
+            "command": "INPUT=$(cat); [ -x .venv/bin/python ] && [ -f scripts/verify/check_privacy_leak.py ] || exit 0; CONTENT=$(printf '%s' \"$INPUT\" | jq -r '.tool_input.new_string // .tool_input.content // \"\"'); [ -z \"$CONTENT\" ] && exit 0; OUT=$(printf '%s\\n' \"$CONTENT\" | .venv/bin/python scripts/verify/check_privacy_leak.py --message --quiet 2>&1); if [ $? -ne 0 ]; then printf '{\"decision\":\"block\",\"reason\":\"Privacy ticker+PnL leak detected (PR #202 signature). Findings: %s. See scripts/verify/check_privacy_leak.py + STRATEGY §4.4.1. Use placeholders or round values.\"}' \"$(echo \"$OUT\" | head -3 | tr '\\n' ' ' | sed 's/\"/\\\\\"/g')\"; exit 2; fi",
             "timeout": 5,
             "statusMessage": "privacy ticker+pnl check..."
           }
@@ -88,13 +88,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if [[ \"$f\" == *.py ]]; then .venv/bin/ruff check \"$f\" --no-fix 2>&1 | head -10; fi; }",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.py) .venv/bin/ruff check \"$f\" --no-fix 2>&1 | head -10 ;; esac; }",
             "timeout": 15,
             "statusMessage": "ruff check..."
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; if [[ \"$f\" == */nuri/*.py ]] && grep -qn 'datetime\\.now()' \"$f\" 2>/dev/null; then echo '{\"decision\":\"block\",\"reason\":\"datetime.now() 금지 — kst_now() 또는 today_kst() 사용. See nuri/core/timezone.py\"}'; exit 1; fi; }",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in */nuri/*.py) if grep -qn 'datetime\\.now()' \"$f\" 2>/dev/null; then echo '{\"decision\":\"block\",\"reason\":\"datetime.now() 금지 — kst_now() 또는 today_kst() 사용. See nuri/core/timezone.py\"}'; exit 1; fi ;; esac; }",
             "timeout": 5,
             "statusMessage": "datetime.now() check..."
           }

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,597 collected across 295 files | |
+| **Backend tests** | 6,603 collected across 295 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,591 collected across 294 files | |
+| **Backend tests** | 6,597 collected across 295 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,597 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,603 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,591 backend tests across 294 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,597 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,597 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,603 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,591 tests, 294 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,597 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -50,6 +50,10 @@ conftest 전역 mock 은 **yfinance 만** 커버. `MacroCollector.collect()` 는
 코드가 `date('now', '-N days')` 윈도우 + 최소 행 수 임계값으로 필터하면(예: `buy_candidate_emitter._get_price_signals`, 45일 윈도우 + `len(grp) < 6` skip), **고정 절대일로 seed한 fixture 는 wall-clock 이 지나며 윈도우 밖으로 밀려 silent 하게 누락**된다. 합성 가격/날짜 fixture 의 `end` 는 항상 `today_kst()` 로 앵커링 — 리터럴 날짜 금지. (#721: `end="2026-04-30"` → 39일 후 scored=0 회귀)
 **Test:** `tests/trading/recommend/test_buy_candidate_emitter.py::test_vix_caution_halves_allocation` (+`test_emit_above_threshold`, `test_allocation_split_by_score`) — 고정일로 되돌리면 즉시 FAIL.
 
+### Privacy 가드를 테스트하는 픽스처는 런타임 조립
+가드가 차단하는 패턴 자체를 **리터럴로** 적으면 파일을 저장하는 순간 PreToolUse 훅과 CI `privacy-scan` 이 그 테스트 파일을 차단한다 (2026-07-29 실측: `TS`+`LA` 를 리터럴로 쓴 Write 가 막혔다). `ticker = "TS" + "LA"` 처럼 조립해 리터럴이 파일에 남지 않게 할 것 — 스캐너는 정규식이라 이걸로 충분하다.
+**Test:** `tests/test_hook_guard_execution.py::TestPrivacyGuard::test_blocks_ticker_pnl_across_newlines` — 리터럴로 되돌리면 커밋 자체가 CI 에서 막힌다.
+
 ## Privacy in Test Data
 
 Never use real broker names, holdings, prices, or account identifiers. Use placeholders: `Brokerage Alpha`, `Brokerage Beta`, round-million values like `1_000_000`.

--- a/tests/test_hook_guard_execution.py
+++ b/tests/test_hook_guard_execution.py
@@ -51,21 +51,27 @@ def _hook_command(status_message: str) -> str:
     )
 
 
-def _run(command: str, payload: dict) -> int:
-    """훅을 **macOS `/bin/sh` 등가 셸** + stdin JSON 으로 실행.
+# 훅이 돌아야 하는 셸 두 종. 하나만으로는 각각 다른 실패를 못 본다.
+#
+# - `bash -O xpg_echo` — macOS `/bin/sh` 등가(이스케이프 펼치는 echo + `[[` 지원).
+#   `echo` 회귀(원래 버그)를 잡는 축. 평범한 `bash` 로 돌리면 escape 가 안 펼쳐져
+#   **mutation 검출력이 0** 이 된다.
+# - dash — bashism(`[[ ]]`) 을 잡는 축. dash 는 `[[` 를 모르므로 조건절이 통째로
+#   죽고 훅이 조용히 exit 0 한다 — 차단 실패와 구분되지 않는다 (PR #954 1차 푸시에서
+#   Linux CI 가 실제로 이걸 뱉었다). **`/bin/sh` 를 쓰면 안 된다**: Linux 에선 dash
+#   지만 macOS 에선 bash 라, 개발 머신에서 이 축이 조용히 no-op 이 되고 bashism 회귀가
+#   로컬 green 인 채 CI 에서만 터진다. dash 를 명시하면 양쪽에서 같은 걸 본다.
+_POSIX_SH = shutil.which("dash") or "/bin/sh"
 
-    셸 선택이 이 테스트의 전부다. 세 후보 중 하나만 맞다:
+_SHELLS = [
+    pytest.param(["/bin/bash", "-O", "xpg_echo", "-c"], id="macos-sh-equivalent"),
+    pytest.param([_POSIX_SH, "-c"], id="posix-sh"),
+]
 
-    - `/bin/sh` — macOS 에선 정확하지만 **Linux 에선 dash** 라 훅의 `[[ ]]` 가
-      죽어 조건절이 통째로 건너뛰어진다. CI 에서 rc=0 이 나와 "가드 무력"으로
-      오판한다 (2026-07-29 PR #954 에서 실제로 밟았다).
-    - `bash` — `[[` 는 되지만 `echo` 가 이스케이프를 **안** 펼친다. 그래서
-      `printf`→`echo` 회귀가 **통과해버린다** — mutation 검출력이 0 이 된다.
-    - `bash -O xpg_echo` — 둘 다 만족. macOS `/bin/sh` 는 xpg_echo 가 켜진
-      bash 이므로 이게 등가이고, 플랫폼과 무관하게 결정론적이다.
-    """
+
+def _run(shell: list[str], command: str, payload: dict) -> int:
     proc = subprocess.run(
-        ["/bin/bash", "-O", "xpg_echo", "-c", command],
+        [*shell, command],
         input=json.dumps(payload),
         capture_output=True,
         text=True,
@@ -74,7 +80,10 @@ def _run(command: str, payload: dict) -> int:
     return proc.returncode
 
 
-pytestmark = pytest.mark.skipif(shutil.which("jq") is None, reason="훅이 jq 에 의존 — 미설치 환경에선 판정 불가")
+pytestmark = [
+    pytest.mark.skipif(shutil.which("jq") is None, reason="훅이 jq 에 의존 — 미설치 환경에선 판정 불가"),
+    pytest.mark.parametrize("shell", _SHELLS),
+]
 
 
 class TestSqlite3ImportGuard:
@@ -84,14 +93,15 @@ class TestSqlite3ImportGuard:
     def command(self) -> str:
         return _hook_command("sqlite3 import guard...")
 
-    def test_blocks_import_in_nuri_module(self, command):
+    def test_blocks_import_in_nuri_module(self, shell, command):
         rc = _run(
+            shell,
             command,
             {"tool_input": {"file_path": f"{REPO_ROOT}/nuri/analysis/foo.py", "new_string": "import sqlite3"}},
         )
         assert rc == 2, "nuri/ 안의 `import sqlite3` 가 안 막혔다 — 가드가 무력하다"
 
-    def test_blocks_when_payload_contains_newlines(self, command):
+    def test_blocks_when_payload_contains_newlines(self, shell, command):
         r"""원래 버그의 카나리아 — `echo` 가 `\n` 을 펼쳐 JSON 을 깨뜨렸다.
 
         위 단행 테스트만으로는 부족하다: 개행 없는 payload 는 `echo` 로도 살아남아
@@ -99,13 +109,15 @@ class TestSqlite3ImportGuard:
         """
         content = 'import os\nimport sqlite3\n\ndef f():\n    return "tab\there"\n'
         rc = _run(
+            shell,
             command,
             {"tool_input": {"file_path": f"{REPO_ROOT}/nuri/analysis/foo.py", "new_string": content}},
         )
         assert rc == 2, "여러 줄 payload 에서 가드가 통과했다 — `echo` 회귀 (2026-07-29 실측 형태)"
 
-    def test_allows_the_sole_importer(self, command):
+    def test_allows_the_sole_importer(self, shell, command):
         rc = _run(
+            shell,
             command,
             {
                 "tool_input": {
@@ -116,8 +128,9 @@ class TestSqlite3ImportGuard:
         )
         assert rc == 0, "유일한 허용 모듈이 차단됐다"
 
-    def test_allows_non_nuri_file(self, command):
+    def test_allows_non_nuri_file(self, shell, command):
         rc = _run(
+            shell,
             command,
             {"tool_input": {"file_path": f"{REPO_ROOT}/scripts/ops/x.py", "new_string": "import sqlite3\n"}},
         )
@@ -137,15 +150,16 @@ class TestPrivacyGuard:
         if not (REPO_ROOT / ".venv" / "bin" / "python").exists():
             pytest.skip(".venv 부재 — 훅이 no-op 로 빠져 판정 불가")
 
-    def test_blocks_ticker_pnl_across_newlines(self, command):
+    def test_blocks_ticker_pnl_across_newlines(self, shell, command):
         """개행 포함 — 이게 `echo` 회귀를 잡는 축이다."""
         ticker = "TS" + "LA"  # 리터럴 금지 — 위 docstring ⚠️ 참조
         content = f"## holdings\n\n- {ticker} +47.3%\n"
-        rc = _run(command, {"tool_input": {"file_path": f"{REPO_ROOT}/docs/x.md", "new_string": content}})
+        rc = _run(shell, command, {"tool_input": {"file_path": f"{REPO_ROOT}/docs/x.md", "new_string": content}})
         assert rc == 2, "ticker+PnL 조합이 안 막혔다 — privacy 가드가 무력하다"
 
-    def test_allows_clean_content(self, command):
+    def test_allows_clean_content(self, shell, command):
         rc = _run(
+            shell,
             command,
             {"tool_input": {"file_path": f"{REPO_ROOT}/docs/x.md", "new_string": "# 제목\n\n평범한 문장.\n"}},
         )

--- a/tests/test_hook_guard_execution.py
+++ b/tests/test_hook_guard_execution.py
@@ -14,7 +14,7 @@ macOS `/bin/sh` 는 `xpg_echo` 가 켜진 bash 3.2 다 — `echo` 가 **JSON 안
 `printf '%s'` 는 이스케이프를 해석하지 않는다. 그게 유일한 수정이고, 그래서
 누군가 "`echo` 랑 같잖아" 하며 되돌리기 쉽다. 이 테스트가 그걸 막는다.
 
-훅을 **문자열로 grep 하지 않고 `sh` 로 실행**한다 — grep 은 `printf` 존재만 보고
+훅을 **문자열로 grep 하지 않고 셸로 실행**한다 — grep 은 `printf` 존재만 보고
 "통과"라 말하지만, 파이프라인이 다른 이유로 깨져도 똑같이 통과한다 (#910 의 rc=127
 = 실패와 구분 불가 교훈). 여기서 유일하게 믿는 신호는 **exit code** 다.
 
@@ -52,9 +52,20 @@ def _hook_command(status_message: str) -> str:
 
 
 def _run(command: str, payload: dict) -> int:
-    """훅을 Claude Code 와 동일하게 `sh -c` + stdin JSON 으로 실행."""
+    """훅을 **macOS `/bin/sh` 등가 셸** + stdin JSON 으로 실행.
+
+    셸 선택이 이 테스트의 전부다. 세 후보 중 하나만 맞다:
+
+    - `/bin/sh` — macOS 에선 정확하지만 **Linux 에선 dash** 라 훅의 `[[ ]]` 가
+      죽어 조건절이 통째로 건너뛰어진다. CI 에서 rc=0 이 나와 "가드 무력"으로
+      오판한다 (2026-07-29 PR #954 에서 실제로 밟았다).
+    - `bash` — `[[` 는 되지만 `echo` 가 이스케이프를 **안** 펼친다. 그래서
+      `printf`→`echo` 회귀가 **통과해버린다** — mutation 검출력이 0 이 된다.
+    - `bash -O xpg_echo` — 둘 다 만족. macOS `/bin/sh` 는 xpg_echo 가 켜진
+      bash 이므로 이게 등가이고, 플랫폼과 무관하게 결정론적이다.
+    """
     proc = subprocess.run(
-        ["/bin/sh", "-c", command],
+        ["/bin/bash", "-O", "xpg_echo", "-c", command],
         input=json.dumps(payload),
         capture_output=True,
         text=True,

--- a/tests/test_hook_guard_execution.py
+++ b/tests/test_hook_guard_execution.py
@@ -1,0 +1,141 @@
+r"""PreToolUse 훅이 **실제로 차단하는지** 실행으로 검증 (Gotcha-Test Pair).
+
+2026-07-29 실측: `.claude/settings.json` 의 sqlite3 / privacy 훅 2개가 도입
+(#229, 2026-04-13) 이래 3.5개월간 **무력**이었다. 원인은 등가로 보이는 한 단어:
+
+    INPUT=$(cat); FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+
+macOS `/bin/sh` 는 `xpg_echo` 가 켜진 bash 3.2 다 — `echo` 가 **JSON 안의 `\n`
+이스케이프를 실제 개행으로 펼친다**. 훅 payload 의 `new_string` 은 거의 항상 개행을
+품으므로 JSON 이 깨지고, jq 가 실패하고, `$FILE` 이 빈 문자열이 되고, 가드는
+**exit 0 으로 통과**한다. 차단이 아니라 침묵이다 — `.claude/rules/enforcement.md`
+가 "PreToolUse hook blocks ..." 라고 적어둔 내내 아무것도 안 막고 있었다.
+
+`printf '%s'` 는 이스케이프를 해석하지 않는다. 그게 유일한 수정이고, 그래서
+누군가 "`echo` 랑 같잖아" 하며 되돌리기 쉽다. 이 테스트가 그걸 막는다.
+
+훅을 **문자열로 grep 하지 않고 `sh` 로 실행**한다 — grep 은 `printf` 존재만 보고
+"통과"라 말하지만, 파이프라인이 다른 이유로 깨져도 똑같이 통과한다 (#910 의 rc=127
+= 실패와 구분 불가 교훈). 여기서 유일하게 믿는 신호는 **exit code** 다.
+
+세 축을 다 잠근다:
+- 위반 → exit 2 (차단이 실제로 발화)
+- 허용 파일 → exit 0 (오탐 없음 — 이게 없으면 "전부 차단"도 통과한다)
+- **개행을 품은 payload → 여전히 exit 2** (원래 버그의 카나리아)
+
+⚠️ privacy 픽스처는 ticker 를 **런타임 조립**한다. 리터럴로 적으면 이 파일을
+저장하는 순간 privacy 훅과 CI `privacy-scan` 이 자기 자신을 차단한다 (실제로 그렇게
+막혔다 — 가드가 살아있다는 증거이기도 하다).
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+
+
+def _hook_command(status_message: str) -> str:
+    """settings.json 에서 statusMessage 로 훅 명령 1개를 집어온다."""
+    data = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    for matcher in data["hooks"]["PreToolUse"]:
+        for hook in matcher["hooks"]:
+            if hook.get("statusMessage") == status_message:
+                return hook["command"]
+    raise AssertionError(
+        f"PreToolUse 훅 {status_message!r} 를 못 찾았다 — settings.json 이 바뀌었으면 이 테스트를 갱신할 것"
+    )
+
+
+def _run(command: str, payload: dict) -> int:
+    """훅을 Claude Code 와 동일하게 `sh -c` + stdin JSON 으로 실행."""
+    proc = subprocess.run(
+        ["/bin/sh", "-c", command],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    return proc.returncode
+
+
+pytestmark = pytest.mark.skipif(shutil.which("jq") is None, reason="훅이 jq 에 의존 — 미설치 환경에선 판정 불가")
+
+
+class TestSqlite3ImportGuard:
+    """`import sqlite3` 를 nuri/ 편집에서 차단 (invariants.md DB sole importer)."""
+
+    @pytest.fixture(scope="class")
+    def command(self) -> str:
+        return _hook_command("sqlite3 import guard...")
+
+    def test_blocks_import_in_nuri_module(self, command):
+        rc = _run(
+            command,
+            {"tool_input": {"file_path": f"{REPO_ROOT}/nuri/analysis/foo.py", "new_string": "import sqlite3"}},
+        )
+        assert rc == 2, "nuri/ 안의 `import sqlite3` 가 안 막혔다 — 가드가 무력하다"
+
+    def test_blocks_when_payload_contains_newlines(self, command):
+        r"""원래 버그의 카나리아 — `echo` 가 `\n` 을 펼쳐 JSON 을 깨뜨렸다.
+
+        위 단행 테스트만으로는 부족하다: 개행 없는 payload 는 `echo` 로도 살아남아
+        회귀가 조용히 통과한다. 실제 편집은 거의 항상 여러 줄이다.
+        """
+        content = 'import os\nimport sqlite3\n\ndef f():\n    return "tab\there"\n'
+        rc = _run(
+            command,
+            {"tool_input": {"file_path": f"{REPO_ROOT}/nuri/analysis/foo.py", "new_string": content}},
+        )
+        assert rc == 2, "여러 줄 payload 에서 가드가 통과했다 — `echo` 회귀 (2026-07-29 실측 형태)"
+
+    def test_allows_the_sole_importer(self, command):
+        rc = _run(
+            command,
+            {
+                "tool_input": {
+                    "file_path": f"{REPO_ROOT}/nuri/core/db/connection.py",
+                    "new_string": "import sqlite3\n",
+                }
+            },
+        )
+        assert rc == 0, "유일한 허용 모듈이 차단됐다"
+
+    def test_allows_non_nuri_file(self, command):
+        rc = _run(
+            command,
+            {"tool_input": {"file_path": f"{REPO_ROOT}/scripts/ops/x.py", "new_string": "import sqlite3\n"}},
+        )
+        assert rc == 0, "nuri/ 밖 파일까지 차단하면 오탐이다"
+
+
+class TestPrivacyGuard:
+    """ticker+PnL 인라인 작성을 차단 (STRATEGY §4.4.1, PR #202 시그니처)."""
+
+    @pytest.fixture(scope="class")
+    def command(self) -> str:
+        return _hook_command("privacy ticker+pnl check...")
+
+    @pytest.fixture(autouse=True)
+    def _needs_venv(self):
+        # 훅 자체가 .venv 부재 시 exit 0 으로 빠진다 — skip 하지 않으면 조용한 통과가 된다
+        if not (REPO_ROOT / ".venv" / "bin" / "python").exists():
+            pytest.skip(".venv 부재 — 훅이 no-op 로 빠져 판정 불가")
+
+    def test_blocks_ticker_pnl_across_newlines(self, command):
+        """개행 포함 — 이게 `echo` 회귀를 잡는 축이다."""
+        ticker = "TS" + "LA"  # 리터럴 금지 — 위 docstring ⚠️ 참조
+        content = f"## holdings\n\n- {ticker} +47.3%\n"
+        rc = _run(command, {"tool_input": {"file_path": f"{REPO_ROOT}/docs/x.md", "new_string": content}})
+        assert rc == 2, "ticker+PnL 조합이 안 막혔다 — privacy 가드가 무력하다"
+
+    def test_allows_clean_content(self, command):
+        rc = _run(
+            command,
+            {"tool_input": {"file_path": f"{REPO_ROOT}/docs/x.md", "new_string": "# 제목\n\n평범한 문장.\n"}},
+        )
+        assert rc == 0, "무해한 내용이 차단됐다 — 오탐"


### PR DESCRIPTION
Closes #953.

## 무엇이

`.claude/settings.json` 의 PreToolUse 훅 2개(sqlite3 sole-importer · privacy ticker+PnL)가 #229(2026-04-13) 이래 **3.5개월간 아무것도 차단하지 않았다**. 원인은 등가로 보이는 한 단어.

```diff
-INPUT=$(cat); FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path')
+INPUT=$(cat); FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path')
```

macOS `/bin/sh` 는 `xpg_echo` 가 켜진 bash 3.2 — `echo` 가 JSON 안의 `\n` 을 실제 개행으로 펼쳐 payload 를 깨뜨린다. jq 실패 → 변수 공백 → 조건 미스 → **exit 0 통과**. 차단 실패가 아니라 침묵이라 아무 신호가 없었다.

## 침묵의 두 번째 경로 — bashism (리뷰 중 CI 가 잡아냄)

훅이 경로 매칭에 `[[ ]]` 를 썼다. **dash 는 `[[` 를 모른다** — 조건절이 통째로 죽고 훅이 또 exit 0 한다. payload 대신 셸이 방아쇠일 뿐, 같은 침묵이다. macOS 는 `/bin/sh` 가 bash 라 로컬에선 영원히 안 터진다. 새 테스트를 CI(Linux)가 돌리면서 드러났다.

경로 매칭 3곳(sqlite3 / ruff / datetime)을 `case ... in` 으로 재작성하고, 남아 있던 `echo "$CONTENT"` 왕복 2곳도 `printf` 로 바꿨다 (스캐너가 사용자가 실제로 쓴 내용을 보도록).

## 영향 범위 (실측)

| | |
|---|---|
| `echo` 로 깨진 훅 | **2개** — sqlite3 guard, privacy guard |
| `[[ ]]` bashism | **3개** — sqlite3 guard, ruff, datetime (POSIX sh 환경에서만 발현) |
| git guard | 무관 — stdin 을 jq 로 직접 파이프, `[[:space:]]` 는 grep 문자 클래스 |
| 실제 위반 유출 | **0건** — 2차 방어선(AST 스윕 + CI `privacy-scan`)이 버텼다 |

사후 재실행: `test_sqlite3_sole_importer.py` 3 passed · `check_privacy_leak.py` clean.
PostToolUse 훅 2개는 테스트 범위 밖이라 양쪽 셸에서 수동 실행 확인 (위반 rc=1 / 정상 rc=0 / 비-py 무출력).

## 잠금 (Gotcha-Test Pair, STRATEGY §5.3.1)

`tests/test_hook_guard_execution.py` — 훅을 **문자열로 grep 하지 않고 셸로 실행**해 exit code 를 본다. grep 은 `printf` 존재만 보고 통과하는데, 파이프라인이 다른 이유로 깨져도 똑같이 통과한다 (#910 의 "rc=127 은 실패와 구분 불가" 교훈).

셸 2종 × 6 케이스 = 12. 축이 서로를 못 대신한다:

| 셸 | 잡는 것 | 이걸 안 쓰면 |
|---|---|---|
| `bash -O xpg_echo` (macOS `/bin/sh` 등가) | `echo` 회귀 | 평범한 `bash` 는 escape 를 안 펼쳐 **mutation 검출력 0** |
| `dash` (명시) | bashism | `/bin/sh` 를 쓰면 macOS 에서 bash 라 축이 **조용히 no-op**, 로컬 green 인 채 CI 에서만 터짐 |

**Mutation 실측:**

| mutant | 결과 |
|---|---|
| `printf '%s'` → `echo` | **4 FAIL** (개행 카나리아, 양쪽 셸) |
| `case ... in` → `[[ ]]` | **3 FAIL** (dash 축 2 + 제외 목록 축소를 오탐 축이 1) |
| 단행 payload 케이스 | 양쪽 mutant 에서 **PASS** ← 카나리아를 개행으로 잡아야 하는 이유 |

## 부수 발견

테스트 픽스처의 ticker+PnL 을 리터럴로 적었더니 **복구된 privacy 훅이 그 Write 를 실제로 차단했다** — 가드가 산다는 라이브 증거. 픽스처는 런타임 조립(`"TS" + "LA"`)으로 바꾸고 `tests/CLAUDE.md` 에 가이드로 남겼다.

## 문서

- `.claude/rules/enforcement.md` — gotcha + Test 인용. "blocks" 문장이 그동안 거짓이었던 사실과 POSIX sh 제약 명시
- `tests/CLAUDE.md` — privacy 가드 테스트 픽스처 규칙
- README / ARCHITECTURE / STRATEGY — test count 6,591 → 6,597

## 검증

`make verify-all` 5/5 · `make verify-doc-counts` 20/20 · ruff clean · CI 23/23 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)