### PR TITLE
fix(scheduler): register the US post-market cron that DST actually needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,603 collected across 295 files | |
+| **Backend tests** | 6,604 collected across 295 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,603 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,604 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,603 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,604 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -681,10 +681,15 @@ def _is_now_within_us_postclose_window(*, _now_kst=None) -> bool:
 
     NYSE close: 16:00 America/New_York. close + 30min = 16:30 ET.
     EST (Nov 첫 일요일 ~ Mar 둘째 일요일): KST 06:30
-    EDT (Mar 둘째 일요일 ~ Nov 첫 일요일): KST 05:30 — but cron 06:30 / 07:30
-    KST 양쪽 등록이라 EDT 기간엔 06:30 (=NYSE 17:30 ET, late-fire) skip.
+    EDT (Mar 둘째 일요일 ~ Nov 첫 일요일): KST 05:30
 
-    실제 trigger 는 dual-cron 중 NYSE 16:30 ET 와 매칭되는 한쪽만 진행.
+    scheduler 는 이 두 시각을 dual-cron 으로 등록하고, 여기서 맞는 쪽만 통과시킨다.
+    ⚠️ 등록 시각과 이 window 는 **같이** 바뀌어야 한다 — 예전에 cron 이 06:30·07:30
+    으로 잡혀 있어 EDT 기간엔 어느 쪽도 window 에 못 들어갔고, US 브리프가 8개월간
+    한 번도 안 돌았다(그동안 `*-us.md` 0개). 이 함수만 보면 05:30 을 옳게 True 로
+    답하므로 함수 단위 테스트로는 안 잡힌다.
+    **Test:** `tests/alerts/test_postmarket_brief.py::test_registered_us_crons_actually_hit_the_window_in_both_dst_regimes`
+    — SCHEDULES 의 실제 등록 시각을 읽어 두 DST 시기 각각에 적중 cron 이 있는지 본다.
     """
     now_kst = _now_kst or kst_now()
     nyse_now = now_kst.astimezone(ZoneInfo("America/New_York"))

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -687,8 +687,15 @@ SCHEDULES = [
     # Dual-cron 06:30/07:30 KST 등록, 함수 내부에서 NYSE 16:30 ET window 일치
     # 시점만 진행. EDT 기간 → 05:30 KST (둘 다 skip → 다음날 fire),
     # EST 기간 → 06:30 KST 매칭. 함수 idempotent UPSERT 라 2회 fire 도 안전.
-    {"name": "postmarket_brief_us_a", "func": _run_postmarket_brief_us, "args": (), "cron": "30 6 * * 2-6"},
-    {"name": "postmarket_brief_us_b", "func": _run_postmarket_brief_us, "args": (), "cron": "30 7 * * 2-6"},
+    # NYSE 16:30 ET(종가+30분)에 해당하는 KST 시각은 DST 에 따라 갈린다:
+    #   EDT(3월중~11월초) = 05:30 KST · EST(11월초~3월중) = 06:30 KST
+    # `run_postmarket_us_dst_aware` 가 ±15분 window 로 맞는 쪽만 통과시키므로 두 시각을
+    # 모두 등록해야 한다. 이전 등록은 06:30·07:30 이었고 **07:30 은 두 시기 모두 window
+    # 밖**(EST 17:30 ET / EDT 18:30 ET)이라 발화 불가였다. 그 결과 EDT 8개월 동안
+    # US 브리프가 통째로 안 돌았다 — 손절 SELL·장마감 요약뿐 아니라 `session == "us"`
+    # 안에 있는 집중도·섹터·슬리브 REBALANCE(Tier 1b/1c/1d)까지 함께 침묵했다.
+    {"name": "postmarket_brief_us_a", "func": _run_postmarket_brief_us, "args": (), "cron": "30 5 * * 2-6"},
+    {"name": "postmarket_brief_us_b", "func": _run_postmarket_brief_us, "args": (), "cron": "30 6 * * 2-6"},
     # Brief auditor (Discord-as-dev-loop) — 매 6시간 #brief 품질 self-audit.
     # decision_compiler emit 의 conflict / noise / identical-conviction 검출 →
     # #incidents 로 ticket 자동 emit. dedupe 24h. recommend-only, ZERO LLM.

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -308,11 +308,11 @@ def test_write_brief_survives_sleeve_staging_error(seeded_db, portfolio_yaml):
 
 
 def test_us_session_dst_aware_cron_dispatch():
-    """NYSE 16:30 ET window — EDT (KST 05:30) / EST (KST 06:30) 양쪽 검증.
+    """NYSE 16:30 ET window 함수 자체 — EDT (KST 05:30) / EST (KST 06:30).
 
-    cron 06:30 + 07:30 KST 등록이라 EDT 기간엔 cron 06:30 fire 시 NYSE 17:30
-    ET (60분 늦음) → window 미달 → skip. EST 기간엔 cron 06:30 fire = NYSE
-    16:30 ET (정확) → window 진입 → run.
+    ⚠️ 이 테스트는 window **함수만** 본다. 실제 cron 이 그 시각에 등록돼 있는지는
+    `test_registered_us_crons_actually_hit_the_window_in_both_dst_regimes` 가 본다 —
+    둘을 나눠두지 않아 EDT 8개월 공백을 이 파일이 통과시켰다.
     """
     from nuri.alerts.postmarket_brief import _is_now_within_us_postclose_window
 
@@ -430,6 +430,36 @@ def test_postmarket_jobs_registered_in_scheduler():
 
     kr = next(j for j in SCHEDULES if j["name"] == "postmarket_brief_kr")
     assert kr["cron"] == "0 16 * * 1-5", "KR session must fire at KST 16:00 weekdays"
+
+
+def test_registered_us_crons_actually_hit_the_window_in_both_dst_regimes():
+    """등록된 cron 중 최소 하나가 각 DST 시기의 window 에 들어가야 한다.
+
+    회귀 잠금 — 이전 등록(06:30·07:30 KST)은 **EDT 8개월간 어느 것도 window 에
+    못 들어갔다**(06:30→NYSE 17:30 ET, 07:30→18:30 ET). 그래서 US 브리프가 한 번도
+    생성되지 않았고, 프로덕션 `data/reports/postmarket/` 에 `*-us.md` 는 0개인 채
+    `*-kr.md` 만 50개 쌓였다. 손절 SELL 과 Tier 1b/1c/1d REBALANCE 가 동시에 침묵했다.
+
+    기존 `test_us_session_dst_aware_cron_dispatch` 는 window **함수만** 검증해
+    이 결함을 못 봤다 — 함수는 05:30 을 옳게 True 로 답했고, 아무도 05:30 에
+    cron 이 없다는 걸 묻지 않았다. 여기서는 SCHEDULES 의 실제 등록 시각을 읽는다.
+    """
+    from nuri.alerts.postmarket_brief import _is_now_within_us_postclose_window
+    from nuri.scheduler import SCHEDULES
+
+    us_crons = [j["cron"] for j in SCHEDULES if j["name"].startswith("postmarket_brief_us")]
+    assert us_crons, "US postmarket job 이 등록돼 있어야 한다"
+
+    for label, day in (("EDT", "2026-07-15"), ("EST", "2026-01-15")):
+        hits = []
+        for cron in us_crons:
+            minute, hour = cron.split()[0], cron.split()[1]
+            now = datetime.fromisoformat(f"{day}T{int(hour):02d}:{int(minute):02d}:00").replace(
+                tzinfo=ZoneInfo("Asia/Seoul")
+            )
+            if _is_now_within_us_postclose_window(_now_kst=now):
+                hits.append(cron)
+        assert hits, f"{label} 기간에 window 에 드는 cron 이 없다 — US 브리프가 그 기간 내내 안 돈다 (등록: {us_crons})"
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What is broken

NYSE 16:30 ET (close + 30 min) lands at **05:30 KST under EDT** and **06:30 KST under EST**. The dual cron was registered at **06:30 and 07:30**:

| Regime | 05:30 KST | 06:30 KST | 07:30 KST |
|---|---|---|---|
| **EDT** (mid-Mar → early Nov) | 16:30 ET ✅ **no cron** | 17:30 ET ❌ | 18:30 ET ❌ |
| **EST** (early Nov → mid-Mar) | 15:30 ET ❌ | 16:30 ET ✅ | 17:30 ET ❌ |

So for roughly eight months a year nothing qualifies, the guard logs `postmarket_us skip — not within NYSE 16:30 ET window`, and the job exits successfully. `07:30` never qualified under either regime.

## Measured on production

```
data/reports/postmarket/  →  50 × *-kr.md,  0 × *-us.md   (none, ever)
```

## What went silent with it

`write_brief("us")` is not only the US market-close summary. It is also where:

- **stop-loss SELL staging** runs for non-KR holdings, and
- **Tier 1b/1c/1d REBALANCE** (concentration, sector, sleeve) is staged — all three sit behind `if session == "us"`.

Every `stop-breach:` row in the production outbox since 2026-07-09 is a KR ticker from the 16:00 KST session. Four US positions are in breach right now, the deepest for 43 consecutive trading days, and not one has ever been surfaced.

## Why the tests passed

`test_us_session_dst_aware_cron_dispatch` asserted the window function in isolation, and the function is correct — it answers `True` for 05:30 KST under EDT. It even documents 06:30 EDT skipping as expected. What no test asked was whether a cron existed at 05:30.

The new test reads the registered times out of `SCHEDULES` and requires that at least one lands inside the window **in both DST regimes**. Reverting to the old pair fails it with `EDT 기간에 window 에 드는 cron 이 없다`.

This is the same shape as `tests/test_scheduler_weekday.py`, which asks the registered triggers which weekdays they actually fire on rather than trusting the cron string.

## Change

`postmarket_brief_us_a` 06:30 → **05:30**, `postmarket_brief_us_b` 07:30 → **06:30**. Job count and names unchanged.

## After merge

This needs deployment to the Mac mini and a scheduler restart to take effect — a config-only pull will not rearm the cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
