### PR TITLE
test(brief): cover the two paths #964 shipped without tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,626 collected across 295 files | |
+| **Backend tests** | 6,628 collected across 295 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,626 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,628 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -248,7 +248,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,626 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,628 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/alerts/test_risk_signals.py
+++ b/tests/alerts/test_risk_signals.py
@@ -579,3 +579,38 @@ def test_weight_computed_for_single_currency_account(db_path, monkeypatch):
 
     assert len(b) == 1 and b[0]["ticker"] == "TST_A"
     assert b[0]["weight_pct"] == pytest.approx(40.0)
+
+
+def test_price_context_returns_empty_without_history(db_path):
+    """가격 이력이 없으면 추세도 이탈 경과도 만들 수 없다 — 빈 dict 로 빠져야 한다.
+
+    (이 쿼리는 `date('now')` 윈도우가 없어 고정 날짜 시드가 안전하다.)
+    """
+    assert risk_signals._price_context("NO_SUCH", avg=100.0, threshold=-7, db_path=db_path) == {}
+
+
+def test_price_context_computes_5d_and_20d_returns(db_path):
+    """추세 줄의 근거 — 5일/20일 수익률과 52주고 낙폭.
+
+    25봉을 100,101,…,124 로 심으면 최신 124, 5봉 전 119, 20봉 전 104 다.
+    """
+    rows = [
+        {
+            "ticker": "TST_T",
+            "date": f"2026-06-{i + 1:02d}",
+            "open": 100.0 + i,
+            "high": 100.0 + i,
+            "low": 100.0 + i,
+            "close": 100.0 + i,
+            "volume": 1_000_000,
+            "adj_close": 100.0 + i,
+        }
+        for i in range(25)
+    ]
+    upsert_prices(pd.DataFrame(rows), db_path)
+
+    ctx = risk_signals._price_context("TST_T", avg=200.0, threshold=-7, db_path=db_path)
+
+    assert ctx["ret_5d"] == pytest.approx((124 - 119) / 119 * 100)
+    assert ctx["ret_20d"] == pytest.approx((124 - 104) / 104 * 100)
+    assert ctx["drawdown_52w"] == pytest.approx(0.0)  # 최신가가 곧 고점


### PR DESCRIPTION
#964 merged with `codecov/patch` red — it is not a required check, so auto-merge took it through.

Two lines of `_price_context` had never executed:

- the early return when a ticker has no price history at all
- the 5-day / 20-day return computation, which needs more than 20 bars while every existing fixture seeds at most five

The second is the one that matters. The trend line is the part of the card that tells the user which way the position is moving, and no test had ever evaluated its arithmetic. It is now checked against a 25-bar series with hand-computed expectations (latest 124, five bars back 119, twenty bars back 104).

`nuri/alerts/risk_signals.py`: 98% → **100%** statement coverage, 27 tests in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)