### PR TITLE
docs: stop claiming config knobs work when nothing reads them

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Rules live in [`config/rules.yaml`](config/rules.yaml) (loaded via `nuri/core/ru
 | Strategy | Stop-loss | Profile |
 |----------|-----------|---------|
 | `core` | -7% | Default — strict O'Neil discipline |
-| `active` | -10% | Cut losses early, trailing stop arms at +15% |
+| `active` | -10% | Cut losses early |
 | `swing` | -15% | Short-term rotations (≤ 7 trading days) |
 | `long_term` | -20% | Buy-and-hold ETFs |
 | `pension` | -30% | Long-horizon retirement allocations |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 508 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 527 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -30,6 +30,12 @@ stop_loss:
 
 # ─── 계좌별 전략 프로파일 ──────────────────────────────
 # portfolio.yaml의 strategy 필드와 매칭. 기본값 = core.
+# ⚠️ 미배선 항목 (2026-08-02 감사): 아래에서 실제로 강제되는 건 `stop_loss` 와
+# `max_single_position` 뿐이다.
+#   · `max_sector_exposure` (계좌별) — 읽는 코드 없음. 섹터 검사는 certification ·
+#     rebalance_advisor · execution_firewall 전부 전역 position_limits 값(35%)을 쓴다.
+#   · `trailing_stop_arm` — 읽는 코드 없음. 트레일링은 계좌 무관하게 진입 후 고점(HWM)
+#     대비 하락으로 동작하며 무장 임계가 없다 (price_targets.check_trailing_stop_signals).
 account_strategies:
   core:
     stop_loss: -7
@@ -105,7 +111,11 @@ trailing_stop:
 # ─── 매수 진입 조건 ─────────────────────────────────────
 # 레짐 기반 포지션 사이징
 entry_rules:
-  # VIX + Fear&Greed 기반 현금 비중
+  # ⚠️ 미배선 (2026-08-02 감사) — 아래 값을 고쳐도 동작이 바뀌지 않는다.
+  # 살아있는 건 vix_gate.block_above / caution_above 둘뿐이다. regime_cash ·
+  # scaling_in · vix_gate.normal_below 는 읽는 코드가 없다(상수는 로드되지만
+  # 어디서도 import 하지 않음). 배선은 사이징 변경이라 STRATEGY PR 대상.
+  # VIX + Fear&Greed 기반 현금 비중 — # ⚠️ 미배선 (2026-08-02 감사) — 아래 값을 고쳐도 동작이 바뀌지 않는다.
   regime_cash:
     extreme_fear: 0.60          # F&G < 20: 현금 60% (방어적)
     fear: 0.40                  # F&G 20-40: 현금 40%
@@ -116,8 +126,8 @@ entry_rules:
   vix_gate:
     block_above: 30             # VIX > 30: 신규 매수 금지
     caution_above: 25           # VIX 25-30: 절반 포지션만
-    normal_below: 20            # VIX < 20: 정상 포지션
-  # 분할 매수 규칙
+    normal_below: 20            # VIX < 20: 정상 포지션 — ⚠️ 미배선 (로드조차 안 됨)
+  # 분할 매수 규칙 — ⚠️ 미배선
   scaling_in:
     max_tranches: 3             # 최대 3회 분할 매수
     tranche_interval_days: 5    # 분할 간격 최소 5일
@@ -139,6 +149,7 @@ leverage:
     - SQQQ
     - UPRO
     - SPXU
+  # ⚠️ 미배선 — LEVERAGE_MAX_DAYS 를 import 하는 코드 없음 (보유일 제한 미집행)
   max_holding_days: 5           # 레버리지 ETF 최대 보유일 (스윙만 허용)
   max_leverage: 1.5             # long_exposure / cash 최대 배수 (ExecutionFirewall leverage_cap)
 
@@ -146,6 +157,10 @@ leverage:
 # 근거: 하락 모멘텀 종목의 1시간 지연 = 추가 손실 확정.
 #       상승 모멘텀 종목의 1시간 지연 = 추가 수익 가능.
 #       "출혈 차단이 수익 확정보다 선행" — 감정이 아닌 재무 논리.
+# ⚠️ 미배선 (2026-08-02 감사) — 아래 값을 고쳐도 동작이 바뀌지 않는다.
+# 이 순서를 읽는 모듈이 없다 (order / stop_loss_sort / take_profit_sort 소비처 0).
+# `nuri/trading/engine/CLAUDE.md` 가 "Codified in config" 라 적어 배선된 것처럼
+# 읽혀 왔으나 사실이 아니다. 설계 의도로만 남긴다.
 execution_priority:
   order:
     - stop_loss            # 1순위: 손절 (손실률 절대값 큰 것부터)
@@ -157,6 +172,10 @@ execution_priority:
 
 # ─── 매수 체크리스트 ────────────────────────────────────
 # 매수 전 최소 확인 항목 (자동화 대상)
+# ⚠️ 미배선 (2026-08-02 감사) — 아래 값을 고쳐도 동작이 바뀌지 않는다.
+# 다섯 항목 전부 `nuri/core/rules.py` 가 상수로 만들지만 **아무도 import 하지 않는다**.
+# 실제 BUY 후보는 `config/buy_signals.yaml` 의 팩터 점수 + VIX/레짐 게이트로만 걸러진다.
+# 즉 "TipRanks ≥ Moderate Buy · 슈퍼투자자 ≥ 3 · PE < 100" 은 현재 강제되지 않는다.
 buy_checklist:
   min_tipranks_consensus: "moderate_buy"   # TipRanks 최소 Moderate Buy
   min_superinvestors: 3                     # 슈퍼투자자 최소 3명 보유

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -112,8 +112,8 @@ base = regime_win_rate × 60% + profit_factor × 40%
 | VIX > 30 매수 차단 | 공포 구간 승률 붕괴 검증 | 자체 시그널 백테스트 |
 | 슈퍼투자자 ≥ 3명 | 13F 보유 종목 초과수익 | SEC EDGAR 분석 |
 | 처분효과 경고 | 수익 조기 매도 편향 | Shefrin & Statman, 1985 |
-| **execution_priority** | 하락 모멘텀 1h 지연 = 추가 손실 확정 | 자체 재무 논리 (PR #200) |
-| **trailing_stop_arm +15%** | 수익 give-back 방지 | PR #202 |
+| **execution_priority** | 하락 모멘텀 1h 지연 = 추가 손실 확정 | 자체 재무 논리 (PR #200) — ⚠️ **미배선**: config 를 읽는 코드 없음 (§3.5 주석) |
+| **trailing_stop_arm +15%** | 수익 give-back 방지 | PR #202 — ⚠️ **미배선**: 트레일링은 무장 조건 없이 HWM 기준 동작 (§3.5 주석) |
 | **decisions 결과 추적** | 에이전트별 적중률로 가중치 동적 조정 | PR #181, #183 |
 | **Kelly f\* = (bp−q)/b** | edge·승률·payoff 반영 position size. Fractional Kelly (full 은 estimation error·DD 로 부적합). E3 실배선. | Kelly (1956); MacLean/Thorp/Ziemba (2011) |
 | **Mean-variance frontier** | sector cap 의도. `max_sector_exposure: 35%` 는 frontier 도출 아닌 prudential default. regime 재평가 E3 후보. | Markowitz (1952) |
@@ -128,6 +128,12 @@ base = regime_win_rate × 60% + profit_factor × 40%
 | **long_term** | -20% | 25% | 50% | — | 장기 보유 |
 | **pension** | -30% | 40% | 60% | — | 연금 ETF 초장기 |
 **선택**: Core 보수, Active 적극 컷+위너보호, Swing 진짜 단기, Long_term/Pension 장기 ETF. 규칙 변경은 YAML + 백테스트 + PR.
+
+> ⚠️ **위 표 중 실제로 강제되는 건 손절과 단일종목 한도뿐이다 (2026-08-02 감사).**
+> - **섹터 열은 장식이다.** `account_strategies.*.max_sector_exposure` 를 읽는 코드가 없고, 섹터 검사(certification · rebalance_advisor · execution_firewall)는 전부 전역 `position_limits.max_sector_exposure`(35%)를 쓴다. 즉 pension 계좌를 60%로 적어둬도 35%에서 걸린다.
+> - **`trailing_stop_arm: 15` 도 읽는 코드가 없다.** 트레일링은 존재하되 계좌별도 아니고 무장 조건도 없다 — `check_trailing_stop_signals()` 가 보유 전 종목에 대해 진입 후 고점(HWM) 대비 하락으로 판정한다(-15% growth/value, -20% volatile/swing). "+15%에 도달해야 켜진다"는 서술은 사실이 아니었다.
+>
+> 배선하는 건 매매 동작 변경이라 별도 STRATEGY PR 대상이다. 지금 이 문단은 **문서를 코드에 맞춘 것**이지 규칙을 약화시킨 게 아니다.
 ### 3.6 Regime-adaptive framework (E3)
 **상태 (2026-04-29)**: Phase 1 shadow shipped (#479). **Phase 2 paired counterfactual: FAIL by binary rule** — 30d horizon CI_lower=-1.06% ≤ 0. 60d/90d horizons는 robust PASS (CI_lower=+1.95% / +2.60%). 자세히 아래 "Phase 2 verdict" 참조. **Phase 3 영구 보류 (2026-04-29 3-LLM consensus)** — Codex(gpt-5.4) Round 1 B → Round 2 A, Qwen3.5-122B Round 1 D → Round 2 A, Claude A 일관. Phase 1 shadow telemetry 영구 유지 (`enabled: false`, 무기한). Reopen trigger: §7.1 auto-trade reversal only. 자세한 Round 1/2 verdicts: `data/llm_consults/2026-04-29_e3-phase2-shelve-decision.md` + `..._round2-three-way.md` (gitignored, 사용자 머신 local).
 **Phase 2 verdict (2026-04-29, branch `feat/e3-phase2-paired-counterfactual`)**:

--- a/nuri/trading/engine/CLAUDE.md
+++ b/nuri/trading/engine/CLAUDE.md
@@ -25,4 +25,5 @@ These are operational details unique to this directory; the canonical sources ab
 Mechanical ordering when emitting actions: `stop_loss → take_profit → trailing_stop_set → new_buy`.
 - Within `stop_loss`: sort by `loss%` descending (biggest loss first — bleeding stops first).
 - Within `take_profit`: sort by `excess%` descending (biggest winner first — lock in gains).
-- Rationale: declining momentum loses more per hour delayed; rising momentum is more forgiving. Codified in `config/rules.yaml execution_priority` (order + sort keys).
+- Rationale: declining momentum loses more per hour delayed; rising momentum is more forgiving.
+- ⚠️ **이 순서는 코드에 없다 (2026-08-02 감사).** `config/rules.yaml execution_priority` 는 어느 모듈도 읽지 않고(`order` / `stop_loss_sort` / `take_profit_sort` 전부 소비처 0), 이 문서가 "Codified in config" 라고 적어둔 탓에 배선된 것으로 읽혀 왔다. 위 서술은 **설계 의도**이지 현재 동작이 아니다. 실제로 순서를 강제하려면 소비자를 만들어야 하고 그건 매매 동작 변경이라 STRATEGY PR 대상.


### PR DESCRIPTION
Documentation-only. **No key removed, no value changed, no runtime behavior touched** — every edit is prose or a YAML comment. Full suite 6,602 passed.

## Method

Three independent passes, then an adversarial one:
1. Codex (gpt-5.4) audit of `config/rules.yaml` against its consumers
2. A second model's independent audit
3. My own greps
4. A refutation agent per finding, told to *find the consumer the others missed* — dynamic `RULES.get(a, {}).get(b)`, wildcard imports, string-built `getattr`, TypeScript in `frontend/`, scheduler-only paths

Verdicts that survived refutation are below. One that did **not** survive is excluded (see bottom).

## Corrected claims

| Key | Doc said | Reality |
|---|---|---|
| `trailing_stop_arm: 15` | README:206, STRATEGY:116/126 — "trailing stop arms at +15%" | No reader. `git log --all -S` finds no commit on **any branch** that ever wired it. `check_trailing_stop_signals()` runs on every holding, measures drawdown from the post-entry high water mark, and has **no arming threshold and no per-account variation** — the doc was wrong twice over |
| per-account `max_sector_exposure` | STRATEGY §3.5 tabulates 35/45/50/60% by strategy | No reader. certification · rebalance_advisor · execution_firewall all use the global 35%. A pension account written as 60% still trips at 35% |
| `execution_priority` | engine/CLAUDE.md:28 — "Codified in `config/rules.yaml execution_priority`" | No reader. That sentence is what made it read as wired |
| `buy_checklist` (5 keys) | STRATEGY §3.4 buy discipline | All five load, none is imported. BUY candidates are screened by `buy_signals.yaml` factor scores + VIX/regime gate only |
| `entry_rules.regime_cash`, `scaling_in`, `vix_gate.normal_below`, `leverage.max_holding_days` | active levers | No readers. Only `vix_gate.block_above` / `caution_above` are live |

The yaml now carries a NOT-WIRED banner at each site, so editing a value cannot be mistaken for pulling a lever.

## Deliberately excluded

One reviewer called the 20% cash floor (`min_cash_reserve`) versus the 5-10% SAA `cash_min` a contradiction. The verification pass returned **NOT_A_CONFLICT**, so it is not written down as one. Recording a false correction would be worse than the drift it replaces.

## Not in scope

Wiring any of these changes trading behavior and belongs in its own STRATEGY PR. This PR only makes the documentation true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)