### PR TITLE
feat(brief): deliver the trailing stop, which never reached the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,632 collected across 295 files | |
+| **Backend tests** | 6,647 collected across 296 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 527 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 533 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -525,3 +525,9 @@ brief:
 
   # 실적 D-day 를 카드에 붙이는 창(일). 이 밖의 실적은 지금 결정과 무관해 생략.
   earnings_window_days: 14
+
+  # 트레일링을 "이익 반납" 이라 부르려면 되돌릴 이익이 실제로 있었어야 한다.
+  # `check_trailing_stop_signals()` 는 HWM 을 max(고점, 진입가) 로 바닥 처리하므로
+  # 오른 적 없는 종목도 -15% 손실이 트레일링으로 잡힌다 — 그건 손절 소관이다.
+  # 최고점이 진입가 대비 이 값 이상 올랐던 포지션만 give-back 알림 대상.
+  trailing_min_peak_gain_pct: 10

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,632 backend tests across 295 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,647 backend tests across 296 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,632 tests, 295 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,647 tests, 296 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -657,7 +657,17 @@ def write_brief(
 
         stage_stop_breach_briefs(session, d, db_path=db_path)
     except Exception:
-        logger.warning("stop-breach brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+        logger.warning("stop-breach SELL brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+
+    # Tier 1e — 트레일링 give-back (이익 보호). 손절과 **반대 방향**의 결정론 신호로,
+    # 이제껏 대시보드에만 있고 디스코드로는 한 번도 안 나갔다. 손절 staging 과 별도
+    # try 로 둔다 — 한쪽 실패가 다른 쪽을 막으면 안 된다(1b/1c/1d 와 동일 패턴).
+    try:
+        from nuri.alerts.profit_signals import stage_trailing_briefs
+
+        stage_trailing_briefs(session, d, db_path=db_path)
+    except Exception:
+        logger.warning("trailing give-back brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
 
     # Tier 1b/1c/1d — 포트폴리오 드리프트(집중도·섹터·슬리브)를 digest 에 REBALANCE 로 표면화
     # (portfolio 축, #429). 둘 다 portfolio-wide → US 세션에서만 stage (US-heavy

--- a/nuri/alerts/profit_signals.py
+++ b/nuri/alerts/profit_signals.py
@@ -1,0 +1,197 @@
+"""Mechanical profit-protection signals → #brief (Tier 1e: 트레일링 give-back).
+
+브리프는 지금까지 **손실 쪽만** 밀어줬다 — 손절 이탈(Tier 1a)·집중도/섹터/슬리브
+(1b/1c/1d). 이익을 지켜야 할 때는 한 번도 알리지 않았다. 트레일링 스톱은
+`price_targets.check_trailing_stop_signals()` 가 이미 계산하고 있었지만 유일한
+소비자가 `api/routes/targets.py` 라 **대시보드를 직접 열어야만** 보였다. 스케줄러
+job 도, 디스코드 경로도 없었다(2026-08-02 감사). 여기서 그 배달만 만든다.
+
+Escalation Ladder: **Surface 등급**이다. 새 룰도, 임계 변경도 없다 — 이미 계산되는
+결정론 신호를 사용자에게 도달시키기만 한다. 집행은 사용자다(§7.1).
+
+⚠️ **되돌릴 이익이 있었을 때만 트레일링이다.** `check_trailing_stop_signals()` 는
+HWM 을 `max(고점, 진입가)` 로 바닥 처리하므로, 진입가 위로 간 적 없는 종목도
+HWM=진입가가 되어 -15% 손실이 그대로 "트레일링 도달"로 잡힌다. 그걸 그대로
+알리면 (a) 이익 보호가 아닌 것을 이익 보호라 부르고 (b) 이미 손절 알림이 나간
+종목에 중복으로 얹힌다. 그래서 최고점이 진입가 대비 최소
+`config/rules.yaml brief.trailing_min_peak_gain_pct` 만큼 올라갔던 포지션만 남기고,
+같은 날 손절 이탈로 이미 표면화된 (ticker, account) 는 제외한다.
+
+Privacy: Discord 는 사용자 private 채널이라 ticker+PnL 노출 OK (risk_signals 선례).
+테스트는 합성 티커만.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from nuri.core.rules import BRIEF_TRAILING_MIN_PEAK_GAIN_PCT, get_account_strategy_name
+from nuri.core.ticker_names import get_ticker_name, is_kr_ticker
+from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
+
+Session = Literal["kr", "us"]
+
+
+def scan_trailing_giveback(
+    session: Optional[Session] = None,
+    db_path: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    """트레일링 임계에 닿은 보유 중 **실제로 이익을 반납한 것**만.
+
+    계산은 재구현하지 않고 canonical `check_trailing_stop_signals()` 를 그대로 쓴다.
+    여기서 하는 건 세 가지 필터뿐:
+
+    1. session (KR `.KS`/`.KQ` vs 그 외) — `is_kr_ticker()` 경유 (#764)
+    2. pension 계좌 제외 — daily action 대상이 아니다 (risk_signals 와 동일 정책)
+    3. **최고점이 진입가 대비 최소 임계만큼 올라갔던 포지션만** — 그래야 "반납"이다
+
+    반환 dict 는 원본 + `peak_gain_pct` / `given_back_pct`(고점이익 중 반납 비율).
+    """
+    from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
+    out: list[dict[str, Any]] = []
+    for sig in check_trailing_stop_signals(db_path=db_path):
+        ticker = str(sig["ticker"])
+        if session == "kr" and not is_kr_ticker(ticker):
+            continue
+        if session == "us" and is_kr_ticker(ticker):
+            continue
+        if get_account_strategy_name(sig.get("account")) == "pension":
+            continue
+
+        entry, hwm = sig.get("entry_price"), sig.get("high_water_mark")
+        if not entry or not hwm:
+            continue
+        peak_gain = (hwm - entry) / entry * 100
+        if peak_gain < BRIEF_TRAILING_MIN_PEAK_GAIN_PCT:
+            # 오른 적 없는 포지션 — 이건 반납이 아니라 그냥 손실이고, 손절 알림 소관.
+            continue
+
+        current = sig.get("current_price") or 0
+        out.append(
+            {
+                **sig,
+                "peak_gain_pct": peak_gain,
+                # 고점 이익 중 얼마를 되돌렸나 — "+30% 갔다가 +10% 남았다" 를 한 수로.
+                "given_back_pct": (hwm - current) / (hwm - entry) * 100 if hwm > entry else None,
+            }
+        )
+
+    out.sort(key=lambda s: s.get("given_back_pct") or 0, reverse=True)  # 많이 반납한 순
+    return out
+
+
+def _build_giveback_payload(sig: dict[str, Any], date: str) -> dict[str, Any]:
+    """트레일링 도달 1건 → #brief SELL payload.
+
+    손절 카드(🔴)와 시각적으로 가른다(🟡) — 둘 다 오늘 볼 것이지만 성격이 다르다.
+    손절은 손실 확대 차단, 이쪽은 **남은 이익 보호**다. 카드는 룰이 이 상태를 뭐라
+    부르는지 말할 뿐 매도를 지시하지 않는다(§7.1, footer 가 이미 manual execute only).
+    """
+    from nuri.agents.discord.outbox import format_money
+
+    ticker = str(sig["ticker"])
+    name = get_ticker_name(ticker)
+    label = f"{ticker} {name}" if name else ticker
+
+    head = f"🟡 {label} · 트레일링 도달 · {sig.get('account', '')}".rstrip(" ·")
+
+    # 진입가 대비는 **직접** 계산한다. `peak_gain - |drop|` 로 합치면 틀린다 —
+    # 퍼센트 변화는 기준이 달라 뺄셈으로 합성되지 않는다(+21.6% 뒤 -29.9% 는
+    # -8.3% 가 아니라 -14.8%). 실데이터 렌더에서 잡힌 오류다.
+    entry, current, hwm = sig["entry_price"], sig["current_price"], sig["high_water_mark"]
+    from_entry = (current - entry) / entry * 100
+    now_line = (
+        f"　현재 {format_money(current, ticker)}"
+        f" / 고점 {format_money(hwm, ticker)} ({sig['drop_pct']:+.1f}%)"
+        f" · 진입 {format_money(entry, ticker)} 대비 {from_entry:+.1f}%"
+    )
+
+    bits = [f"룰 {sig['stock_type']} 트레일링 {sig['threshold']}% · 청산가 {format_money(sig['stop_price'], ticker)}"]
+    # "고점이익의 168% 반납" 은 무의미하다. 진입가 아래로 내려갔으면 이익은 전부
+    # 반납된 것이고, 그 사실을 그렇게 말하는 게 맞다.
+    if current < entry:
+        bits.append(f"고점 +{sig['peak_gain_pct']:.0f}% 이익 전량 반납 (진입가 아래)")
+    elif sig.get("given_back_pct") is not None:
+        bits.append(f"고점 +{sig['peak_gain_pct']:.0f}% 중 {min(sig['given_back_pct'], 100):.0f}% 반납")
+    rule = "　" + " · ".join(bits)
+
+    return {
+        "kind": "SELL",
+        "ticker": ticker,
+        "summary": "\n".join([head, now_line, rule]),
+        "note": sig.get("account"),
+        "reason": f"트레일링 도달 (고점 대비 {sig['drop_pct']:+.1f}% ≤ {sig['threshold']}%)",
+        "date": date,
+        "current": sig["current_price"],
+        "high_water_mark": sig["high_water_mark"],
+        "peak_gain_pct": sig["peak_gain_pct"],
+    }
+
+
+def stage_trailing_briefs(
+    session: Optional[Session] = None,
+    date: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """트레일링 도달을 #brief outbox 에 stage. staged 건수 반환.
+
+    같은 (ticker, account) 가 **오늘 손절 이탈로 이미 표면화**됐으면 건너뛴다 —
+    한 포지션에 두 장의 카드가 가면 사용자는 둘 중 무엇이 진짜인지 판단해야 한다.
+    손절이 더 급한 신호이므로 그쪽을 남긴다.
+    """
+    from nuri.agents.discord.outbox import stage_brief
+    from nuri.alerts.risk_signals import scan_stop_breaches
+
+    d = date or today_kst()
+    breached = {(b["ticker"], b["account"]) for b in scan_stop_breaches(session, db_path=db_path)}
+
+    staged = 0
+    for sig in scan_trailing_giveback(session, db_path=db_path):
+        key = (sig["ticker"], sig.get("account"))
+        if key in breached:
+            logger.debug("trailing skip %s — 손절 이탈로 이미 표면화", sig["ticker"])
+            continue
+        outbox_id = stage_brief(
+            payload=_build_giveback_payload(sig, d),
+            dedupe_key=f"trailing:{sig['ticker']}:{sig.get('account', '')}:{d}",
+            priority="high",
+            actor_name="profit-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("trailing give-back briefs staged: %d (session=%s)", staged, session or "all")
+    return staged
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="트레일링 give-back → #brief (Tier 1e)")
+    parser.add_argument("--session", choices=("kr", "us"), default=None, help="세션 필터 (기본: 전체)")
+    parser.add_argument("--dry-run", action="store_true", help="stage 없이 목록만 출력")
+    args = parser.parse_args(argv)
+
+    sigs = scan_trailing_giveback(args.session)
+    if not sigs:
+        print("트레일링 give-back 없음 (되돌릴 이익이 있었던 포지션 기준)")
+        return 0
+    for s in sigs:
+        print(
+            f"  {s['ticker']} [{s.get('account')}] 고점 대비 {s['drop_pct']:+.1f}% "
+            f"(최고 +{s['peak_gain_pct']:.1f}% → 반납 {s.get('given_back_pct') or 0:.0f}%)"
+        )
+    if args.dry_run:
+        print(f"[dry-run] {len(sigs)}건 — stage 안 함")
+        return 0
+    print(f"staged {stage_trailing_briefs(args.session)}건 → #brief")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -38,6 +38,7 @@ _brief = RULES.get("brief", {})
 BRIEF_SEVERITY_GAP_PCT = _brief.get("severity_gap_pct", -10)
 BRIEF_BENCHMARK = _brief.get("benchmark", {"us": "SPY", "kr": "069500.KS"})
 BRIEF_EARNINGS_WINDOW_DAYS = _brief.get("earnings_window_days", 14)
+BRIEF_TRAILING_MIN_PEAK_GAIN_PCT = _brief.get("trailing_min_peak_gain_pct", 10)
 STOCK_STOP_LOSS_VALUE = RULES.get("stop_loss", {}).get("per_stock_value", -10)
 PORTFOLIO_STOP = RULES["stop_loss"]["portfolio"]
 

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -555,7 +555,10 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
         list[dict]: 트레일링 스톱 시그널 리스트
     """
     df = query_df(
-        "SELECT ticker, avg_price, quantity, DATE(first_buy_date) AS entry_anchor FROM portfolio WHERE quantity > 0",
+        # account 를 함께 싣는다 — 같은 티커를 두 계좌에 보유하면 평단이 달라 신호도
+        # 달라지는데, 이제껏 반환값에 계좌가 없어 소비자가 구분할 수 없었다.
+        "SELECT account, ticker, avg_price, quantity, DATE(first_buy_date) AS entry_anchor "
+        "FROM portfolio WHERE quantity > 0",
         db_path=db_path,
     )
     if df.empty:
@@ -621,6 +624,7 @@ def check_trailing_stop_signals(db_path: Optional[Path] = None) -> list[dict]:
                     "stock_type": stock_type,
                     "entry_price": entry_price,
                     "current_price": current_price,
+                    "account": row["account"],
                     "high_water_mark": hwm,
                     "stop_price": stop_price,
                     "drop_pct": round(drop_pct, 1),

--- a/tests/alerts/test_profit_signals.py
+++ b/tests/alerts/test_profit_signals.py
@@ -1,0 +1,268 @@
+"""Tier 1e — 트레일링 give-back → #brief (`nuri/alerts/profit_signals.py`).
+
+합성 티커 TST_* 만 사용 (privacy: 사용자 실보유/실티커 금지).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nuri.alerts import profit_signals as ps
+from nuri.core.db import init_db, upsert_portfolio, upsert_prices
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "profit.db"
+    init_db(path)
+    return path
+
+
+def _seed(path, *, ticker, account, avg, peak, current, qty=10):
+    """진입 avg → 고점 peak → 현재 current 인 포지션 하나."""
+    upsert_portfolio(
+        [
+            {
+                "account": account,
+                "ticker": ticker,
+                "quantity": qty,
+                "avg_price": avg,
+                "currency": "USD",
+                "sector": "Tech",
+                "first_buy_date": "2026-01-02",
+            }
+        ],
+        path,
+    )
+    rows = []
+    for date, px in (("2026-03-02", peak), ("2026-07-31", current)):
+        rows.append(
+            {
+                "ticker": ticker,
+                "date": date,
+                "open": px,
+                "high": px,
+                "low": px,
+                "close": px,
+                "volume": 1_000_000,
+                "adj_close": px,
+            }
+        )
+    upsert_prices(pd.DataFrame(rows), path)
+
+
+def _core(monkeypatch, stop=-30):
+    """계좌 전략을 core 로 고정하고 손절선을 넉넉히 — 트레일링만 격리해 본다."""
+    import nuri.alerts.risk_signals as rs
+
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(rs, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(rs, "get_stop_loss_for_account", lambda a: stop)
+
+
+def test_position_that_never_rose_is_not_a_giveback(db_path, monkeypatch):
+    """되돌릴 이익이 없었으면 트레일링이 아니다 — 그건 손절 소관이다.
+
+    회귀 잠금: `check_trailing_stop_signals()` 는 HWM 을 max(고점, 진입가) 로 바닥
+    처리해서, 오른 적 없는 종목도 -15% 손실이 '트레일링 도달' 로 잡힌다. 그대로
+    알리면 이익 보호가 아닌 것을 이익 보호라 부르고 손절 알림과 중복된다.
+    """
+    _core(monkeypatch)
+    # 고점이 진입가와 같다 = 오른 적 없음. 현재 -20% → 원본 신호는 뜬다.
+    _seed(db_path, ticker="TST_FLAT", account="Brokerage Alpha", avg=100.0, peak=100.0, current=80.0)
+
+    from nuri.trading.recommend.price_targets import check_trailing_stop_signals
+
+    assert check_trailing_stop_signals(db_path=db_path), "원본 신호는 뜬다(전제 확인)"
+    assert ps.scan_trailing_giveback(db_path=db_path) == [], "give-back 으로 올리면 안 된다"
+
+
+def test_real_giveback_is_surfaced(db_path, monkeypatch):
+    _core(monkeypatch)
+    # +50% 까지 갔다가 고점 대비 -20% → 진입 대비 +20% 남음
+    _seed(db_path, ticker="TST_WIN", account="Brokerage Alpha", avg=100.0, peak=150.0, current=120.0)
+
+    sigs = ps.scan_trailing_giveback(db_path=db_path)
+
+    assert [s["ticker"] for s in sigs] == ["TST_WIN"]
+    assert sigs[0]["peak_gain_pct"] == pytest.approx(50.0)
+    assert sigs[0]["given_back_pct"] == pytest.approx(60.0)  # (150-120)/(150-100)
+
+
+def test_from_entry_percent_is_computed_not_composed(db_path, monkeypatch):
+    """진입 대비 %는 직접 계산해야 한다 — 퍼센트 뺄셈으로 합성하면 틀린다.
+
+    회귀 잠금: `peak_gain - |drop|` 로 만들면 +21.6% 뒤 -29.9% 가 -8.3% 로 나오지만
+    실제는 -14.8% 다. 실데이터 렌더에서 잡힌 오류.
+    """
+    _core(monkeypatch)
+    _seed(db_path, ticker="TST_W2", account="Brokerage Alpha", avg=100.0, peak=150.0, current=90.0)
+
+    card = ps._build_giveback_payload(ps.scan_trailing_giveback(db_path=db_path)[0], "2026-08-02")["summary"]
+
+    assert "진입 $100.00 대비 -10.0%" in card, card
+    assert "-50.0%" not in card  # 50 - 40 같은 합성값이 새면 안 된다
+
+
+def test_below_entry_says_full_giveback_not_over_100_percent(db_path, monkeypatch):
+    """진입가 아래면 '이익 전량 반납' 이라 말한다 — '168% 반납' 은 무의미하다."""
+    _core(monkeypatch)
+    _seed(db_path, ticker="TST_W3", account="Brokerage Alpha", avg=100.0, peak=150.0, current=90.0)
+
+    card = ps._build_giveback_payload(ps.scan_trailing_giveback(db_path=db_path)[0], "2026-08-02")["summary"]
+
+    assert "전량 반납 (진입가 아래)" in card
+    assert "중 " not in card, "진입가 아래인데 '고점 이익 중 N% 반납' 문구가 나오면 안 된다"
+
+
+def test_pension_excluded(db_path, monkeypatch):
+    import nuri.alerts.risk_signals as rs
+
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "pension")
+    monkeypatch.setattr(rs, "get_account_strategy_name", lambda a: "pension")
+    _seed(db_path, ticker="TST_P", account="Pension Gamma", avg=100.0, peak=150.0, current=120.0)
+
+    assert ps.scan_trailing_giveback(db_path=db_path) == []
+
+
+def test_stop_loss_breach_wins_no_double_card(db_path, monkeypatch):
+    """같은 포지션에 손절 카드와 트레일링 카드가 둘 다 가면 안 된다."""
+    _core(monkeypatch, stop=-5)  # 손절선을 -5% 로 좁혀 이탈 상태로 만든다
+    _seed(db_path, ticker="TST_BOTH", account="Brokerage Alpha", avg=100.0, peak=150.0, current=90.0)
+
+    from nuri.alerts.risk_signals import scan_stop_breaches
+
+    assert [b["ticker"] for b in scan_stop_breaches(db_path=db_path)] == ["TST_BOTH"], "손절도 걸린 상태(전제)"
+    assert ps.scan_trailing_giveback(db_path=db_path), "트레일링 자체는 감지된다(전제)"
+
+    staged = ps.stage_trailing_briefs(date="2026-08-02", db_path=db_path)
+
+    assert staged == 0, "손절이 이미 알린 종목은 트레일링으로 또 올리지 않는다"
+
+
+def test_write_brief_stages_trailing(db_path, monkeypatch):
+    """배선 잠금 — write_brief 가 트레일링 stage 를 실제로 호출한다.
+
+    이 배선이 없어서 트레일링 신호가 대시보드에만 있고 디스코드로는 한 번도
+    나가지 않았다 (2026-08-02 감사).
+    """
+    from unittest.mock import MagicMock, patch
+
+    spy = MagicMock(return_value=1)
+    with patch("nuri.alerts.profit_signals.stage_trailing_briefs", spy):
+        from nuri.alerts import postmarket_brief as pmb
+
+        with (
+            patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+            patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+            patch("nuri.alerts.risk_signals.stage_stop_breach_briefs", MagicMock()),
+        ):
+            pmb.write_brief("us", date="2026-08-02", db_path=db_path)
+
+    spy.assert_called_once()
+    assert spy.call_args[0][0] == "us"
+
+
+def test_session_filter_splits_kr_and_us(db_path, monkeypatch):
+    _core(monkeypatch)
+    _seed(db_path, ticker="TST_US", account="Brokerage Alpha", avg=100.0, peak=150.0, current=120.0)
+    _seed(db_path, ticker="900002.KQ", account="Brokerage Alpha", avg=100.0, peak=150.0, current=120.0)
+
+    kr = [s["ticker"] for s in ps.scan_trailing_giveback("kr", db_path=db_path)]
+    us = [s["ticker"] for s in ps.scan_trailing_giveback("us", db_path=db_path)]
+
+    assert kr == ["900002.KQ"]  # KOSDAQ 도 KR (#764)
+    assert us == ["TST_US"]
+
+
+def test_missing_prices_skipped_without_crash(db_path, monkeypatch):
+    _core(monkeypatch)
+    upsert_portfolio(
+        [
+            {
+                "account": "Brokerage Alpha",
+                "ticker": "TST_NOPX",
+                "quantity": 10,
+                "avg_price": 100.0,
+                "currency": "USD",
+                "sector": "Tech",
+                "first_buy_date": "2026-01-02",
+            }
+        ],
+        db_path,
+    )
+    assert ps.scan_trailing_giveback(db_path=db_path) == []
+
+
+def test_staging_writes_to_brief_outbox(db_path, monkeypatch):
+    _core(monkeypatch)
+    _seed(db_path, ticker="TST_WIN", account="Brokerage Alpha", avg=100.0, peak=150.0, current=120.0)
+
+    staged = ps.stage_trailing_briefs(date="2026-08-02", db_path=db_path)
+
+    from nuri.core.db import claim_pending_outbox
+
+    _, rows = claim_pending_outbox("brief", db_path=db_path)
+    assert staged == 1
+    assert rows[0]["payload"]["kind"] == "SELL"
+    assert "트레일링 도달" in rows[0]["payload"]["summary"]
+
+
+def test_dedupe_same_day(db_path, monkeypatch):
+    _core(monkeypatch)
+    _seed(db_path, ticker="TST_WIN", account="Brokerage Alpha", avg=100.0, peak=150.0, current=120.0)
+
+    first = ps.stage_trailing_briefs(date="2026-08-02", db_path=db_path)
+    second = ps.stage_trailing_briefs(date="2026-08-02", db_path=db_path)
+
+    assert (first, second) == (1, 0), "같은 날 두 번째는 dedupe 로 skip"
+
+
+def test_cli_reports_when_nothing_to_show(db_path, monkeypatch, capsys):
+    monkeypatch.setattr(ps, "scan_trailing_giveback", lambda *a, **k: [])
+    assert ps.main([]) == 0
+    assert "없음" in capsys.readouterr().out
+
+
+def test_cli_dry_run_lists_without_staging(monkeypatch, capsys):
+    sig = {
+        "ticker": "TST_WIN",
+        "account": "Brokerage Alpha",
+        "drop_pct": -20.0,
+        "peak_gain_pct": 50.0,
+        "given_back_pct": 60.0,
+    }
+    monkeypatch.setattr(ps, "scan_trailing_giveback", lambda *a, **k: [sig])
+    staged = []
+    monkeypatch.setattr(ps, "stage_trailing_briefs", lambda *a, **k: staged.append(1))
+
+    assert ps.main(["--dry-run"]) == 0
+
+    out = capsys.readouterr().out
+    assert "TST_WIN" in out and "dry-run" in out
+    assert staged == [], "dry-run 은 stage 하지 않는다"
+
+
+def test_cli_stages_without_dry_run(monkeypatch, capsys):
+    monkeypatch.setattr(
+        ps,
+        "scan_trailing_giveback",
+        lambda *a, **k: [
+            {"ticker": "T", "account": "A", "drop_pct": -20.0, "peak_gain_pct": 50.0, "given_back_pct": 60.0}
+        ],
+    )
+    monkeypatch.setattr(ps, "stage_trailing_briefs", lambda *a, **k: 1)
+
+    assert ps.main([]) == 0
+    assert "staged 1건" in capsys.readouterr().out
+
+
+def test_signal_without_prices_is_skipped(monkeypatch):
+    """상류가 entry/HWM 없는 행을 주더라도 죽지 않고 건너뛴다 (방어 가드)."""
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "core")
+    monkeypatch.setattr(
+        "nuri.trading.recommend.price_targets.check_trailing_stop_signals",
+        lambda **k: [{"ticker": "TST_X", "account": "A", "entry_price": None, "high_water_mark": 10.0}],
+    )
+    assert ps.scan_trailing_giveback() == []


### PR DESCRIPTION
## The gap

The brief pushes only the **losing** side. Verified by grep:

| reaches Discord | does not |
|---|---|
| stop-loss SELL · concentration/sector/sleeve REBALANCE · consensus BUY/SELL · market-close summary | **trailing stop** · take-profit TP1/TP2 |

`check_trailing_stop_signals()` has exactly one production caller — `nuri/api/routes/targets.py:26`. No scheduler job mentions trailing. None of the five Discord producers emits it. The signal existed only while the dashboard page was open.

So the "수익 give-back 방지" STRATEGY described was unreachable in two ways at once: no arming gate (see #967), and no delivery.

## What this adds

Delivery only. No new rule, no threshold change — an already-computed deterministic signal routed to the user. **Surface rung** of the Escalation Ladder.

## Two filters, because the raw signal is not honest on its own

**1. There must have been a gain to give back.** `check_trailing_stop_signals()` floors HWM at entry, so a position that never traded above cost still reports a "trailing" hit at -15%. That is not a give-back, it is a loss, and stop-loss already owns it. Measured on the real portfolio: **7 raw signals → 3 never rose → 4 genuine**. Threshold in `config/rules.yaml brief.trailing_min_peak_gain_pct`.

**2. One position, one card.** If a position is already surfaced as a stop-loss breach today, the trailing card is suppressed. The more urgent signal keeps the slot.

## Two arithmetic errors caught by rendering against real holdings

- Percent changes were composed by **subtraction**. A position that ran +21.6% then fell 29.9% from its peak was reported as **-8.3% from entry**; the true figure is **-14.8%**. Now computed directly and checked against independent arithmetic in the test.
- "gave back **168%** of the peak gain" is not a sentence. Below entry the card now states the gain is fully returned.

## Result on real holdings

```
🟡 <TICKER> · 트레일링 도달 · <account>
　현재 ₩1,038,000 / 고점 ₩2,189,000 (-52.6%) · 진입 ₩1,275,000 대비 -18.6%
　룰 growth 트레일링 -15% · 청산가 ₩1,860,650 · 고점 +72% 이익 전량 반납 (진입가 아래)
```

One live position peaked **+72% above entry and is now 18.6% below it**, and nothing ever said so.

## Also

`check_trailing_stop_signals()` gains an `account` field. It already reads per-(account, ticker) rows but discarded which account they came from, so no consumer could tell two holdings of the same ticker apart.

## Verification

Full suite **6,617 passed**. `nuri/alerts/profit_signals.py` at **100%** statement coverage (15 tests). Mutation-tested: removing the peak-gain filter, restoring the subtraction arithmetic, removing the stop-loss dedupe, or cutting the `write_brief` wiring each fails a specific test.

## Not in scope

TP1/TP2 take-profit alerts have the same delivery gap and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)