### PR TITLE
test(brief): cover the market-comparison paths #966 shipped untested

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,647 collected across 296 files | |
+| **Backend tests** | 6,651 collected across 296 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,647 backend tests across 296 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,651 backend tests across 296 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,647 tests, 296 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,651 tests, 296 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/alerts/test_risk_signals.py
+++ b/tests/alerts/test_risk_signals.py
@@ -666,3 +666,73 @@ def test_market_context_skips_stale_benchmark(db_path):
     ctx = risk_signals._market_context("TST_A", ret_20d=-25.0, date="2026-08-02", db_path=db_path)
 
     assert "benchmark" not in ctx, "stale 벤치마크로 비교하면 안 된다"
+
+
+# ─── #966 시장 대비 · 실적 D-day 성공 경로 ────────────────────────────────────
+
+
+def test_market_context_computes_excess_vs_benchmark(db_path):
+    """시장 대비가 실제로 계산되는 경로 — #966 이 이 성공 경로 없이 머지됐다.
+
+    거부 경로(성긴 데이터·stale 벤치마크)만 잠겨 있었고, 정작 숫자를 만드는 쪽은
+    한 번도 실행되지 않았다. 형제 기능에서 같은 자리에 공식 오류가 있었다.
+    """
+    _seed_series(db_path, "SPY", n=25, day_step=1, base=100.0, step=1.0)  # 20봉 전 104 → 124
+
+    ctx = risk_signals._market_context("TST_A", ret_20d=-30.0, date="2026-01-29", db_path=db_path)
+
+    expected_bench = (124 - 104) / 104 * 100
+    assert ctx["benchmark"] == "SPY"
+    assert ctx["benchmark_ret_20d"] == pytest.approx(expected_bench)
+    assert ctx["excess_20d"] == pytest.approx(-30.0 - expected_bench)
+
+
+def test_market_context_attaches_earnings_inside_window(db_path):
+    from nuri.core.db import get_db
+
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO events (date, event_type, ticker, description, importance) VALUES (?,?,?,?,?)",
+            ("2026-08-05", "earnings", "TST_E", "실적발표", 2),
+        )
+
+    ctx = risk_signals._market_context("TST_E", ret_20d=None, date="2026-08-02", db_path=db_path)
+
+    assert ctx["earnings_in_days"] == 3
+
+
+def test_market_context_ignores_earnings_outside_window(db_path):
+    """창 밖의 실적은 지금 결정과 무관하므로 붙이지 않는다."""
+    from nuri.core.db import get_db
+
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO events (date, event_type, ticker, description, importance) VALUES (?,?,?,?,?)",
+            ("2026-09-30", "earnings", "TST_E", "실적발표", 2),
+        )
+
+    ctx = risk_signals._market_context("TST_E", ret_20d=None, date="2026-08-02", db_path=db_path)
+
+    assert "earnings_in_days" not in ctx
+
+
+def test_card_renders_market_line_and_earnings():
+    """카드에 시장 대비 줄과 실적 D-day 가 실제로 찍히는지."""
+    from nuri.agents.discord.outbox import _format_event_line
+
+    payload = risk_signals._build_breach_payload(
+        _breach(
+            pnl_pct=-30.0,
+            ret_20d=-30.0,
+            benchmark="SPY",
+            benchmark_ret_20d=-1.8,
+            excess_20d=-28.2,
+            earnings_in_days=3,
+        ),
+        "2026-08-02",
+    )
+    card = _format_event_line(payload)
+
+    assert "시장(SPY) -1.8%" in card
+    assert "종목 요인 -28.2%p" in card
+    assert "실적 D-3" in card


### PR DESCRIPTION
Codecov reported #966's patch at **76.19%**.

The six uncovered lines were the feature's **entire success path**:

| line | what it does |
|---|---|
| 255 | benchmark comparison actually computes `excess_20d` |
| 263-265 | earnings D-day actually resolves |
| 332 | market line renders onto the card |
| 337 | earnings D-day renders onto the card |

Only the *refusal* paths — sparse bars, stale benchmark — had tests. That is the wrong half to cover: the sibling feature (#968) shipped **two arithmetic errors in exactly this position**, and they were caught by rendering against real holdings, not by any test.

Now covered:
- excess return checked against hand-computed expectations from a seeded 25-bar series
- earnings window checked on **both sides** of its boundary (inside → attached, outside → omitted)
- rendered card asserted to carry the market line and the D-day

`nuri/alerts/risk_signals.py`: **96% → 100%**. `nuri/alerts/profit_signals.py` also verified at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)