### PR TITLE
feat(brief): deliver take-profit hits, the other half of the same gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,651 collected across 296 files | |
+| **Backend tests** | 6,657 collected across 296 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,651 backend tests across 296 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,657 backend tests across 296 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,651 tests, 296 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,657 tests, 296 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -669,6 +669,16 @@ def write_brief(
     except Exception:
         logger.warning("trailing give-back brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
 
+    # Tier 1e — 익절 도달(TP1/TP2). 트레일링과 같은 배달 공백이었다: 계산은
+    # `check_take_profit_signals()` 가 하고 있었지만 소비자가 `/targets` 하나뿐이라
+    # 대시보드를 열어야만 보였다. 트레일링과 별도 try — 한쪽 실패가 다른 쪽을 막지 않게.
+    try:
+        from nuri.alerts.profit_signals import stage_take_profit_briefs
+
+        stage_take_profit_briefs(session, d, db_path=db_path)
+    except Exception:
+        logger.warning("take-profit brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+
     # Tier 1b/1c/1d — 포트폴리오 드리프트(집중도·섹터·슬리브)를 digest 에 REBALANCE 로 표면화
     # (portfolio 축, #429). 둘 다 portfolio-wide → US 세션에서만 stage (US-heavy
     # 포트폴리오 · US 종장 직후 타이밍). kr/us 양 세션 호출 시 dispatcher 가 US 행을

--- a/nuri/alerts/profit_signals.py
+++ b/nuri/alerts/profit_signals.py
@@ -86,6 +86,102 @@ def scan_trailing_giveback(
     return out
 
 
+def scan_take_profit(
+    session: Optional[Session] = None,
+    db_path: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    """익절 목표(TP1/TP2)에 닿은 보유 — 트레일링과 같은 배달 공백이었다.
+
+    계산은 canonical `check_take_profit_signals()` 를 그대로 쓴다(리더는 그쪽에서
+    이미 제외 — 고정 익절 폐기, 추세 트레일로 관리). 여기서는 session 과 pension
+    만 거른다.
+    """
+    from nuri.trading.recommend.price_targets import check_take_profit_signals
+
+    out: list[dict[str, Any]] = []
+    for sig in check_take_profit_signals(db_path=db_path):
+        ticker = str(sig["ticker"])
+        if session == "kr" and not is_kr_ticker(ticker):
+            continue
+        if session == "us" and is_kr_ticker(ticker):
+            continue
+        if get_account_strategy_name(sig.get("account")) == "pension":
+            continue
+        out.append(sig)
+    out.sort(key=lambda s: s["return_pct"], reverse=True)  # 많이 오른 순
+    return out
+
+
+def _build_tp_payload(sig: dict[str, Any], date: str) -> dict[str, Any]:
+    """익절 도달 1건 → #brief payload.
+
+    손절(🔴)·트레일링(🟡)과 시각적으로 가른다(🟢) — 셋 다 오늘 볼 것이지만
+    이건 유일하게 **좋은 소식**이고, 요구하는 행동도 다르다(부분 매도).
+    카드는 룰이 뭐라 하는지 말할 뿐 매도를 지시하지 않는다(§7.1).
+    """
+    from nuri.agents.discord.outbox import format_money
+
+    ticker = str(sig["ticker"])
+    name = get_ticker_name(ticker)
+    label = f"{ticker} {name}" if name else ticker
+    tier = "1차" if sig["level"] == "target_1" else "2차"
+
+    head = f"🟢 {label} · {tier} 익절 도달 · {sig.get('account', '')}".rstrip(" ·")
+    now_line = (
+        f"　현재 {format_money(sig['current_price'], ticker)}"
+        f" / 진입 {format_money(sig['entry_price'], ticker)} ({sig['return_pct']:+.1f}%)"
+        f" · 목표 {format_money(sig['target_price'], ticker)}"
+    )
+    rule = f"　룰 {sig['stock_type']} {tier} 익절 → {sig['sell_pct']:.0f}% 매도 구간"
+
+    return {
+        "kind": "SELL",
+        "ticker": ticker,
+        "summary": "\n".join([head, now_line, rule]),
+        "note": sig.get("account"),
+        "reason": f"{tier} 익절 도달 ({sig['return_pct']:+.1f}%)",
+        "date": date,
+        "current": sig["current_price"],
+        "return_pct": sig["return_pct"],
+        "level": sig["level"],
+    }
+
+
+def stage_take_profit_briefs(
+    session: Optional[Session] = None,
+    date: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """익절 도달을 #brief outbox 에 stage. staged 건수 반환.
+
+    트레일링으로 이미 표면화된 (ticker, account) 는 건너뛴다 — 고점에서 되돌리는
+    중인 포지션에 "익절 도달" 카드를 함께 보내면 서로 다른 방향을 가리킨다.
+    되돌림이 더 급한 신호이므로 그쪽을 남긴다.
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    d = date or today_kst()
+    trailing = {(s["ticker"], s.get("account")) for s in scan_trailing_giveback(session, db_path=db_path)}
+
+    staged = 0
+    for sig in scan_take_profit(session, db_path=db_path):
+        if (sig["ticker"], sig.get("account")) in trailing:
+            logger.debug("take-profit skip %s — 트레일링으로 이미 표면화", sig["ticker"])
+            continue
+        outbox_id = stage_brief(
+            payload=_build_tp_payload(sig, d),
+            dedupe_key=f"take-profit:{sig['ticker']}:{sig.get('account', '')}:{sig['level']}:{d}",
+            priority="normal",
+            actor_name="profit-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("take-profit briefs staged: %d (session=%s)", staged, session or "all")
+    return staged
+
+
 def _build_giveback_payload(sig: dict[str, Any], date: str) -> dict[str, Any]:
     """트레일링 도달 1건 → #brief SELL payload.
 

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -409,7 +409,8 @@ def check_take_profit_signals(db_path: Optional[Path] = None) -> list[dict]:
             - sell_pct (매도 비율: 50% or 25%)
     """
     df = query_df(
-        "SELECT ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
+        # account 포함 — 계좌별 평단이 달라 신호도 다르다 (트레일링과 동일 수정).
+        "SELECT account, ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
         db_path=db_path,
     )
     if df.empty:
@@ -450,6 +451,7 @@ def check_take_profit_signals(db_path: Optional[Path] = None) -> list[dict]:
             signals.append(
                 {
                     "ticker": ticker,
+                    "account": row["account"],
                     "stock_type": stock_type,
                     "entry_price": entry_price,
                     "current_price": current_price,
@@ -472,6 +474,7 @@ def check_take_profit_signals(db_path: Optional[Path] = None) -> list[dict]:
             signals.append(
                 {
                     "ticker": ticker,
+                    "account": row["account"],
                     "stock_type": stock_type,
                     "entry_price": entry_price,
                     "current_price": current_price,

--- a/tests/alerts/test_profit_signals.py
+++ b/tests/alerts/test_profit_signals.py
@@ -266,3 +266,121 @@ def test_signal_without_prices_is_skipped(monkeypatch):
         lambda **k: [{"ticker": "TST_X", "account": "A", "entry_price": None, "high_water_mark": 10.0}],
     )
     assert ps.scan_trailing_giveback() == []
+
+
+# ─── 익절(TP1/TP2) 배달 — 트레일링과 같은 공백이었다 ─────────────────────────
+
+
+def _seed_winner(path, *, ticker, account, avg, current, qty=10):
+    """진입 avg → 현재 current (상승). 고점은 현재가 = 트레일링 미발동."""
+    upsert_portfolio(
+        [
+            {
+                "account": account,
+                "ticker": ticker,
+                "quantity": qty,
+                "avg_price": avg,
+                "currency": "USD",
+                "sector": "Tech",
+                "first_buy_date": "2026-01-02",
+            }
+        ],
+        path,
+    )
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": ticker,
+                    "date": "2026-07-31",
+                    "open": current,
+                    "high": current,
+                    "low": current,
+                    "close": current,
+                    "volume": 1_000_000,
+                    "adj_close": current,
+                }
+            ]
+        ),
+        path,
+    )
+
+
+def test_take_profit_reached_is_surfaced(db_path, monkeypatch):
+    """익절 도달이 디스코드로 나간다 — 이제껏 대시보드 전용이었다."""
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "core")
+    _seed_winner(db_path, ticker="TST_TP", account="Brokerage Alpha", avg=100.0, current=125.0)
+
+    sigs = ps.scan_take_profit(db_path=db_path)
+
+    assert [s["ticker"] for s in sigs] == ["TST_TP"]
+    assert sigs[0]["level"] in ("target_1", "target_2")
+    card = ps._build_tp_payload(sigs[0], "2026-08-02")["summary"]
+    assert card.startswith("🟢"), "익절은 손절(🔴)·트레일링(🟡)과 시각적으로 갈라야 한다"
+    assert "익절 도달" in card and "매도 구간" in card
+
+
+def test_take_profit_pension_excluded(db_path, monkeypatch):
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "pension")
+    _seed_winner(db_path, ticker="TST_TP", account="Pension Gamma", avg=100.0, current=125.0)
+
+    assert ps.scan_take_profit(db_path=db_path) == []
+
+
+def test_trailing_wins_over_take_profit_no_conflicting_cards(db_path, monkeypatch):
+    """되돌리는 중인 포지션에 '익절 도달' 을 함께 보내면 서로 다른 방향을 가리킨다."""
+    _core(monkeypatch)
+    # 진입 100 → 고점 200 → 현재 130: TP 도달 상태이면서 고점 대비 -35% (트레일링)
+    _seed(db_path, ticker="TST_BOTH2", account="Brokerage Alpha", avg=100.0, peak=200.0, current=130.0)
+
+    assert ps.scan_trailing_giveback(db_path=db_path), "트레일링 발동(전제)"
+    assert ps.scan_take_profit(db_path=db_path), "익절도 도달(전제)"
+
+    staged = ps.stage_take_profit_briefs(date="2026-08-02", db_path=db_path)
+
+    assert staged == 0, "트레일링이 이미 알린 포지션은 익절로 또 올리지 않는다"
+
+
+def test_write_brief_stages_take_profit(db_path):
+    """배선 잠금 — write_brief 가 익절 stage 를 실제로 호출한다."""
+    from unittest.mock import MagicMock, patch
+
+    spy = MagicMock(return_value=1)
+    with patch("nuri.alerts.profit_signals.stage_take_profit_briefs", spy):
+        from nuri.alerts import postmarket_brief as pmb
+
+        with (
+            patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+            patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+            patch("nuri.alerts.risk_signals.stage_stop_breach_briefs", MagicMock()),
+            patch("nuri.alerts.profit_signals.stage_trailing_briefs", MagicMock()),
+        ):
+            pmb.write_brief("us", date="2026-08-02", db_path=db_path)
+
+    spy.assert_called_once()
+    assert spy.call_args[0][0] == "us"
+
+
+def test_take_profit_session_filter(db_path, monkeypatch):
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "core")
+    _seed_winner(db_path, ticker="TST_TPUS", account="Brokerage Alpha", avg=100.0, current=125.0)
+    _seed_winner(db_path, ticker="900003.KQ", account="Brokerage Alpha", avg=100.0, current=125.0)
+
+    kr = [s["ticker"] for s in ps.scan_take_profit("kr", db_path=db_path)]
+    us = [s["ticker"] for s in ps.scan_take_profit("us", db_path=db_path)]
+
+    assert kr == ["900003.KQ"] and us == ["TST_TPUS"]
+
+
+def test_take_profit_staging_writes_and_dedupes(db_path, monkeypatch):
+    monkeypatch.setattr(ps, "get_account_strategy_name", lambda a: "core")
+    _seed_winner(db_path, ticker="TST_TP", account="Brokerage Alpha", avg=100.0, current=125.0)
+
+    first = ps.stage_take_profit_briefs(date="2026-08-02", db_path=db_path)
+    second = ps.stage_take_profit_briefs(date="2026-08-02", db_path=db_path)
+
+    from nuri.core.db import claim_pending_outbox
+
+    _, rows = claim_pending_outbox("brief", db_path=db_path)
+    assert (first, second) == (1, 0), "같은 날 두 번째는 dedupe"
+    assert "익절 도달" in rows[0]["payload"]["summary"]


### PR DESCRIPTION
Completes what #968 started. `check_take_profit_signals()` had the identical delivery gap — one caller, `api/routes/targets.py` — so a position reaching its target was visible only while the dashboard was open.

## On the live portfolio right now

Two positions, neither ever announced:

```
🟢 <TICKER> · 2차 익절 도달 · <account>
　현재 $196.93 / 진입 $125.37 (+57.1%) · 목표 $175.52
　룰 growth 2차 익절 → 25% 매도 구간

🟢 <TICKER> · 1차 익절 도달 · <account>
　현재 $402.90 / 진입 $320.69 (+25.6%) · 목표 $384.83
　룰 growth 1차 익절 → 50% 매도 구간
```

## Three colors, three meanings

🔴 stop-loss · 🟡 trailing give-back · 🟢 take-profit. Not decoration — take-profit is the only one that is good news and the only one asking for a partial sell. The card names the rule's sell fraction and stops; the user executes (§7.1).

## Ordering, because the two profit signals can contradict

A position can be **above its target and simultaneously falling from a higher peak**. Those cards point opposite ways. Trailing wins: losing what you gained is the more urgent fact. Locked by test.

Leaders are already excluded upstream (fixed take-profit was withdrawn for them in favour of the trend trail), so this does not reintroduce it.

## Also

`check_take_profit_signals()` gains `account` — the same blindness fixed for trailing in #968.

## Verification

Full suite **6,627 passed**. `nuri/alerts/profit_signals.py` **100%** statement coverage (21 tests). Mutation-tested: removing the trailing-priority skip, the pension exclusion, or the `write_brief` wiring each fails a specific test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)