### PR TITLE
fix(collectors): collect the KR benchmark that four consumers already read

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,689 collected across 297 files | |
+| **Backend tests** | 6,691 collected across 297 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,689 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,691 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,689 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,691 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -26,6 +26,9 @@ KIS Open API is NOT needed for KR fundamentals (was previously believed required
 
 CLI: `--source` flag is the standard way to switch (stock, stock_kr, fundamental, wallstreet, estimates, technical, events, news).
 
+**KR reference tickers bypass `source` entirely.** `stock_kr.collect()` unions `_reference_tickers()` (derived from `rules.yaml brief.benchmark.kr`) into every run. The KR benchmark is not a holding, so `portfolio` misses it, and `universe.yaml` is auto-synced from KRX constituents so a hand-added ETF is wiped by the next `make universe-sync` — it was collected by neither path and sat at **0 rows in production** while four consumers read it (brief benchmark, sector-mover fallback, events, risk_signals). Derived from config, not a second hardcoded list, so changing the benchmark moves collection with it.
+**Test:** `tests/collectors/test_stock_kr.py::TestStockKRCollectorScenarios::test_collect_without_kr_holdings_still_gets_reference` — dropping the union returns an empty frame again.
+
 ## Parallelism Pattern (yfinance vs KRX) ⚠️
 
 **yfinance**: 10 concurrent threads OK. Use `ThreadPoolExecutor(max_workers=10)`.

--- a/nuri/collectors/stock_kr.py
+++ b/nuri/collectors/stock_kr.py
@@ -44,6 +44,25 @@ def _call_with_timeout(func, timeout_sec: int, *args, **kwargs):
             raise
 
 
+def _reference_tickers() -> list[str]:
+    """시스템이 **이미 의존한다고 선언한** KR 기준 티커.
+
+    브리프의 KR 벤치마크(`069500.KS`)는 보유 종목이 아니라 `source=portfolio` 에
+    안 잡히고, `universe.yaml` 은 KRX 구성종목 자동 동기화(`make universe-sync`)라
+    ETF 를 손으로 넣어도 다음 sync 에 지워진다. 그래서 어느 경로로도 수집되지
+    않았고 — 프로덕션 `prices` 에 **0행**이다(2026-08-02 실측). 소비자는 넷인데
+    (브리프 벤치마크 · 섹터 무버 fallback · 이벤트 수집 · risk_signals) 공급자가
+    없었다.
+
+    목록을 새로 하드코딩하지 않고 config 선언에서 뽑는다 — 벤치마크를 바꾸면
+    수집 대상이 따라 움직여야지, 두 곳을 손으로 맞추면 또 갈라진다.
+    """
+    from nuri.core.rules import BRIEF_BENCHMARK
+    from nuri.core.ticker_names import is_kr_ticker
+
+    return sorted({str(t) for t in BRIEF_BENCHMARK.values() if t and is_kr_ticker(str(t))})
+
+
 class StockKRCollector(BaseCollector):
     """pykrx로 한국 주가 수집 (KOSPI/KOSDAQ) + 지수 수집 (yfinance)."""
 
@@ -60,12 +79,15 @@ class StockKRCollector(BaseCollector):
             source: 'portfolio' (default, 보유) | 'universe' (KOSPI 200 전체) | 'all'
                     #272 Phase 2c bug fix — collect-universe에서 KR 사일로 잔존 해결.
         """
-        tickers = self._get_tickers(market="kr", source=source)
+        # 기준 티커는 source 와 무관하게 항상 붙인다 — 보유도 universe 도 아니지만
+        # 브리프·타당성 검사가 매일 읽는다.
+        reference = _reference_tickers()
+        tickers = sorted(set(self._get_tickers(market="kr", source=source)) | set(reference))
         if not tickers:
             self.logger.warning("수집할 한국 종목이 없습니다")
             return pd.DataFrame()
 
-        self.logger.info(f"수집 대상: {len(tickers)} 한국 종목 ({days}일, source={source})")
+        self.logger.info(f"수집 대상: {len(tickers)} 한국 종목 ({days}일, source={source}, 기준 {len(reference)}종)")
 
         # KST 기준 날짜 (KRX는 한국 영업일 기준)
         from nuri.core.timezone import kst_now

--- a/tests/collectors/test_stock_kr.py
+++ b/tests/collectors/test_stock_kr.py
@@ -52,9 +52,18 @@ class TestStockKRCollectorScenarios:
         )
         assert StockKRCollector().collect(days=5).empty
 
-    def test_collect_no_kr_tickers(self, monkeypatch, tmp_path):
+    def test_collect_without_kr_holdings_still_gets_reference(self, monkeypatch, tmp_path):
+        """KR 보유가 0이어도 기준 티커는 수집한다.
+
+        브리프의 KR 벤치마크는 보유 종목이 아니라 `source=portfolio` 에 안 잡히고,
+        `universe.yaml` 은 KRX 구성종목 자동 동기화라 ETF 를 넣어도 지워진다. 그래서
+        어느 경로로도 안 잡혀 프로덕션 `prices` 에 0행이었다 (2026-08-02 실측).
+
+        회귀 잠금: 기준 티커 union 을 지우면 다시 빈 DataFrame 이 되고, KR 벤치마크·
+        섹터 무버 fallback 이 조용히 죽는다.
+        """
         import nuri.core.db as db_mod
-        from nuri.collectors.stock_kr import StockKRCollector
+        from nuri.collectors.stock_kr import StockKRCollector, _reference_tickers
 
         path = tmp_path / "empty.db"
         init_db(path)
@@ -72,7 +81,23 @@ class TestStockKRCollectorScenarios:
             ],
             path,
         )
-        assert StockKRCollector().collect(days=5).empty
+        mock_ohlcv = pd.DataFrame(
+            {"시가": [40000], "고가": [41000], "저가": [39000], "종가": [40500], "거래량": [1000000]},
+            index=pd.to_datetime(["2026-07-31"]),
+        )
+        monkeypatch.setattr("nuri.collectors.stock_kr.krx.get_market_ohlcv", MagicMock(return_value=mock_ohlcv))
+
+        df = StockKRCollector().collect(days=5)
+
+        assert set(df["ticker"]) == set(_reference_tickers()), "기준 티커만 — 보유 KR 은 없다"
+
+    def test_reference_tickers_come_from_config_not_a_second_list(self):
+        """기준 티커는 config 선언에서 뽑는다 — 목록을 또 하드코딩하면 갈라진다."""
+        from nuri.collectors.stock_kr import _reference_tickers
+        from nuri.core.rules import BRIEF_BENCHMARK
+
+        assert _reference_tickers() == [BRIEF_BENCHMARK["kr"]]
+        assert BRIEF_BENCHMARK["us"] not in _reference_tickers(), "US 벤치마크는 KR 수집기 소관이 아니다"
 
     def test_collect_includes_indices(self, monkeypatch, db_with_portfolio):
         """KOSPI/KOSDAQ 지수가 같이 수집되는지 확인 (#247)."""

--- a/tests/collectors/test_stock_kr.py
+++ b/tests/collectors/test_stock_kr.py
@@ -91,6 +91,23 @@ class TestStockKRCollectorScenarios:
 
         assert set(df["ticker"]) == set(_reference_tickers()), "기준 티커만 — 보유 KR 은 없다"
 
+    def test_config_without_kr_benchmark_falls_back_to_empty(self, monkeypatch, tmp_path):
+        """`brief.benchmark.kr` 이 사라지면 기준 티커도 없다 — 그때만 빈 결과다.
+
+        기준 티커 union 이후 "수집할 한국 종목이 없습니다" 경로는 config 에서 KR
+        벤치마크가 빠졌을 때만 도달한다. 그 상태는 옛 버그(0행)로의 조용한 복귀라
+        동작을 명시적으로 잠가둔다.
+        """
+        import nuri.core.db as db_mod
+        from nuri.collectors.stock_kr import StockKRCollector
+
+        path = tmp_path / "empty.db"
+        init_db(path)
+        monkeypatch.setattr(db_mod, "DB_PATH", path)
+        monkeypatch.setattr("nuri.core.rules.BRIEF_BENCHMARK", {"us": "SPY"})
+
+        assert StockKRCollector().collect(days=5).empty
+
     def test_reference_tickers_come_from_config_not_a_second_list(self):
         """기준 티커는 config 선언에서 뽑는다 — 목록을 또 하드코딩하면 갈라진다."""
         from nuri.collectors.stock_kr import _reference_tickers


### PR DESCRIPTION
## 무엇이 없었나

`069500.KS` (KODEX 200) 는 **프로덕션 `prices` 에 0행**이다. 그런데 읽는 곳은 넷이다:

| 소비자 | 무엇을 위해 |
|---|---|
| `_brief_common.py:48` | 브리프 KR 벤치마크 (포지션 vs 시장 비교) |
| `postmarket_brief.py:193` | 섹터 ETF 부재 시 KR 시장 proxy fallback |
| `events.py:102` | 이벤트 수집 대상 |
| `risk_signals.py:252` | KR 카드 시장 비교 |

수요는 config 에 선언돼 있는데 공급이 없었다.

## 왜 어느 경로로도 안 잡혔나

- **보유가 아니다** → `source=portfolio` 미포함
- **`universe.yaml` 은 KRX 구성종목 자동 동기화** (`make universe-sync`) → ETF 를 손으로 넣어도 다음 sync 에 지워진다

두 소스가 전부라 어느 쪽으로도 들어올 수 없었다.

## 고친 방법

`stock_kr.collect()` 가 `source` 와 무관하게 기준 티커를 union 한다. 목록을 새로 하드코딩하지 않고 `rules.yaml brief.benchmark.kr` 에서 뽑는다 — 벤치마크를 바꾸면 수집이 따라 움직여야지, 두 곳을 손으로 맞추면 지금과 같은 갈라짐이 다시 생긴다.

## pykrx 가 이 ETF 를 주는지 먼저 확인했다

가정하지 않고 실측:

```
get_market_ohlcv_by_date("069500")  → 10행  ✅
get_etf_ohlcv_by_date("069500")     → 0행
get_market_ticker_name("069500")    → 빈 값 (ETF 는 종목명 테이블에 없음)
```

뒤의 둘은 **수집 경로에 없다** — `_collect_ticker` 는 `get_market_ohlcv` 만 쓴다. 그리고 pykrx 값이 yfinance `069500.KS` 와 **모든 봉에서 정확히 일치**한다 (7/30 89325/87635, 7/31 97905/108820). 실제 collector 경로도 10행을 올바른 스키마로 반환.

## 기존 테스트 하나를 고쳤다

`test_collect_no_kr_tickers` 는 "KR 보유가 없으면 빈 DataFrame" 이라는 **옛 동작을 잠그고 있었다.** 게다가 pykrx 를 mock 하지 않아 **실제 네트워크를 타고 있었다** — 아무것도 수집되지 않아서 통과했을 뿐이다 (레포 규약은 network-free).

약화시키지 않고 새 의도를 잠그도록 다시 썼다: 기준 티커는 수집되고 보유 KR 은 안 섞인다, pykrx mock 적용.

## 검증

- mutation 2개 — union 제거 / config 도출 제거, 각각 자기 테스트 FAIL 후 원복 20 PASS
- `tests/collectors/` 808 passed, 2 skipped
- lint · privacy scan · doc count 통과
- 프로덕션 실측: `069500.KS` 0행 · KOSPI 438행 · SPY 1,335행

## 남는 것 (이 PR 범위 밖)

`_get_tickers(market="kr")` 는 `.KS` 로만 필터해서 `.KQ` 가 US 수집기로 샌다 (#764 와 같은 split-brain). **프로덕션 KOSDAQ 보유는 현재 0종이라 실제 손해는 없다** — 잠재 버그로 남기고 별도 이슈로 뺀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)