### PR TITLE
fix(collectors): route KOSDAQ to the KR collector instead of the US one

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,691 collected across 297 files | |
+| **Backend tests** | 6,692 collected across 297 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,691 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,692 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,691 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,692 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -21,7 +21,8 @@ KIS Open API is NOT needed for KR fundamentals (was previously believed required
 ## Ticker Filtering + Source
 
 `_get_tickers(market=, source=)` (#272 Phase 2b):
-- `market`: `"us"` (excludes `.KS`) | `"kr"` (only `.KS`) | `None` (전체)
+- `market`: `"us"` (excludes KR) | `"kr"` (KR only) | `None` (전체). KR 판정은 canonical `is_kr_ticker()` — `.KS` **및** `.KQ` (#764). `.KS` 로만 필터하면 KOSDAQ 이 kr 에서 누락되고 동시에 `not .KS` 인 us 로 새어 미국장 시간대(KOSDAQ 휴장)에 수집된다.
+  **Test:** `tests/collectors/test_base.py::TestGetTickers::test_kosdaq_routes_to_kr_not_us` — 양방향 잠금(한쪽만 보면 반대 회귀가 통과한다).
 - `source`: `"portfolio"` (default, 보유종목 — `SELECT FROM portfolio`) | `"universe"` (`config/universe.yaml` 전체 ~746) | `"all"` (union)
 
 CLI: `--source` flag is the standard way to switch (stock, stock_kr, fundamental, wallstreet, estimates, technical, events, news).

--- a/nuri/collectors/base.py
+++ b/nuri/collectors/base.py
@@ -158,7 +158,7 @@ class BaseCollector(ABC):
         """티커 목록 조회. source로 범위 선택, market으로 한국/미국 필터링.
 
         Args:
-            market: 'us' | 'kr' | None (전체)
+            market: 'us' | 'kr' | None (전체). KR 판정은 `is_kr_ticker()` 경유 — `.KS`+`.KQ` (#764)
             source: 'portfolio' (default, 보유 종목만)
                   | 'universe'  (config/universe.yaml 전체, us_core + us_sp500_extended + kr_kospi200)
                   | 'all'       (portfolio ∪ universe)
@@ -168,6 +168,7 @@ class BaseCollector(ABC):
         Default는 'portfolio' 유지 — backwards compat.
         """
         from nuri.core.db import get_tickers
+        from nuri.core.ticker_names import is_kr_ticker
 
         portfolio_tickers = get_tickers()
 
@@ -180,10 +181,13 @@ class BaseCollector(ABC):
         else:
             raise ValueError(f"Unknown source: {source!r}. Must be 'portfolio' | 'universe' | 'all'")
 
+        # canonical KR 게이트 (#764) — `.KS` 만 보면 KOSDAQ(`.KQ`) 이 **양쪽에서 틀린다**:
+        # kr 에서 누락돼 pykrx 순차 경로가 영영 못 보고, 여집합인 us 에는 포함돼
+        # 미국장 시간대(KST 23:30~06:00, KOSDAQ 휴장)에 수집된다.
         if market == "kr":
-            return [t for t in tickers if t.endswith(".KS")]
+            return [t for t in tickers if is_kr_ticker(t)]
         elif market == "us":
-            return [t for t in tickers if not t.endswith(".KS")]
+            return [t for t in tickers if not is_kr_ticker(t)]
         return tickers
 
 

--- a/tests/collectors/test_base.py
+++ b/tests/collectors/test_base.py
@@ -191,6 +191,27 @@ class TestGetTickers:
         assert "005930.KS" in kr
         assert "AAPL" not in kr
 
+    def test_kosdaq_routes_to_kr_not_us(self, db_path):
+        """`.KQ` 는 KR 이다 — 양방향으로 잠근다 (#764 · #973).
+
+        `.KS` 로만 필터하면 KOSDAQ 이 **두 번 틀린다**: kr 에서 빠져 pykrx 순차 경로가
+        영영 못 보고, `not .KS` 인 us 에 포함돼 미국장 시간대(KOSDAQ 휴장)에 수집된다.
+        한쪽만 assert 하면 반대 방향 회귀가 조용히 통과하므로 둘 다 본다.
+        """
+        with get_db(db_path) as conn:
+            for t, cur in (("AAPL", "USD"), ("005930.KS", "KRW"), ("900002.KQ", "KRW")):
+                conn.execute(
+                    "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?, ?, ?, ?, ?)",
+                    ("t", t, 1, 100, cur),
+                )
+
+        c = GoodCollector()
+        kr, us = c._get_tickers(market="kr"), c._get_tickers(market="us")
+
+        assert "900002.KQ" in kr, "KOSDAQ 이 KR 수집 경로에 있어야 한다"
+        assert "900002.KQ" not in us, "KOSDAQ 이 US 수집 경로로 새면 안 된다"
+        assert "005930.KS" in kr and "AAPL" in us, "기존 동작 유지(전제)"
+
     def test_filter_all(self, db_path):
         with get_db(db_path) as conn:
             conn.execute(


### PR DESCRIPTION
Closes #973.

## 버그

`nuri/collectors/base.py` `_get_tickers()` 가 `.KS` 로만 필터해서 `.KQ`(KOSDAQ)가 **양방향으로 동시에 틀렸습니다.**

```python
if market == "kr":
    return [t for t in tickers if t.endswith(".KS")]      # .KQ 누락
elif market == "us":
    return [t for t in tickers if not t.endswith(".KS")]  # .KQ 포함 ← 여집합
```

`us` 분기가 `not .KS` 인 **여집합**이라, KOSDAQ 종목은 KR 경로에서 빠지는 동시에 US 경로로 샙니다. 결과적으로 **KOSDAQ 휴장 시간대(KST 23:30~06:00)에 미국장 수집기가 가져가고**, 하루 묵은 가격이 손절·트레일링 계산에 그대로 들어갑니다.

`#764` 가 이미 `.KS`+`.KQ` 를 모두 커버하는 canonical `is_kr_ticker()` 를 만들었고 `risk_signals.py` 의 같은 split-brain 도 그때 고쳤습니다. **이 호출처만 남아 있었습니다.**

## 현재 영향 — 0

프로덕션 실측(2026-08-02): `portfolio` 19행, **`.KQ` 0종**. 지금 손해는 없습니다.

**첫 KOSDAQ 매수 전에 고치는 것**이지 사고 후 수습이 아닙니다. 발현했다면 조용했을 종류입니다 — 가격이 들어오긴 하므로 freshness 도 통과합니다.

## 테스트가 양방향을 잠그는 이유

```python
assert "900002.KQ" in kr,     "KOSDAQ 이 KR 수집 경로에 있어야 한다"
assert "900002.KQ" not in us, "KOSDAQ 이 US 수집 경로로 새면 안 된다"
```

`in kr` 만 assert 하면 "us 로 샌다" 쪽 회귀가 **조용히 통과**합니다. #764 스윕이 이 호출처를 놓친 것도 같은 이유로 보입니다.

## 검증

- mutation: `is_kr_ticker` → `.endswith(".KS")` 되돌리면 새 테스트 **FAIL**, 원복 후 20 passed
- `tests/collectors/` 810 passed, 2 skipped
- lint · privacy scan · doc counts 통과
- `nuri/collectors/CLAUDE.md` 의 `"kr" (only .KS)` 서술도 정정 + Gotcha-Test Pair 인용 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)