### PR TITLE
docs(env): document AUTH_SECRET and say which file each dashboard key belongs in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,7 +183,22 @@ CORS_ORIGINS=http://localhost:3000       # 쉼표 구분 — production allowlis
 # ───────────────────────────────────────────────────────────────
 # 7. Dashboard (Next.js middleware auth)
 # ───────────────────────────────────────────────────────────────
+# ⚠️ 이 두 키는 **읽는 프로세스가 다르다.** 위치를 틀리면 조용히 약한 모드로 돈다.
+#
+# DASHBOARD_PASSWORD — 양쪽이 읽는다:
+#   · 프론트 미들웨어(Edge Runtime)는 `frontend/.env.local` 에서 읽는다.
+#     `npm run start` 의 cwd 가 frontend/ 라 Next 는 거기서만 env 파일을 로드한다 —
+#     이 루트 파일에만 넣으면 대시보드 게이트가 안 걸린다.
+#   · 백엔드는 이 루트 `.env` 에서 읽는다 (`nuri/api/main.py` — 미설정 시 503).
+#   → 즉 **양쪽 파일 모두**에 같은 값이 필요하다.
 # DASHBOARD_PASSWORD=                    # HMAC-SHA256 쿠키 인증 (Edge Runtime)
+#
+# AUTH_SECRET — 프론트 전용. **`frontend/.env.local` 에만** 넣는다 (이 파일 아님).
+#   쿠키 HMAC 서명 키다. 미설정 시 `frontend/src/lib/auth-token.ts` 가
+#   DASHBOARD_PASSWORD 자체를 키로 쓰는 fallback 으로 내려가고, 그러면 **비밀번호를
+#   바꾸는 순간 발급된 세션이 전부 무효화**된다. 명시적으로 설정해야 그게 안 일어난다.
+#   생성: python3 -c "import secrets; print(secrets.token_hex(32))"
+# AUTH_SECRET=                           # (frontend/.env.local 에 둘 것)
 
 
 # ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 질문에 대한 답: `.bak` 내용을 `.env.example` 에 넣을 필요는 없습니다

키 이름만 비교했습니다 (**값은 읽지도 출력하지도 않았습니다**):

```
.env.bak=44키   .env=44키   .env.example=41 활성 + 15 주석 = 52키 문서화

.bak 에만 있고 .env.example 에 없는 키 → 0개
```

`.bak` 은 07-28 에 9개 키의 **값**이 비워지기 직전 백업이라, 키 **이름** 집합은 현재 `.env` 와 동일합니다. 그래서 템플릿에 보탤 게 없습니다.

## 대신 진짜 구멍이 하나 있었습니다 — `AUTH_SECRET`

`.env` 에 있는데 `.env.example` 에 **주석으로도 없는** 유일한 키였습니다.

`frontend/src/lib/auth-token.ts:35`:
```ts
return process.env.AUTH_SECRET || process.env.DASHBOARD_PASSWORD || "nuri-dev-key";
```

미설정이면 **비밀번호 자체가 HMAC 키**가 되는 fallback 으로 조용히 내려갑니다. 동작은 하지만 **비밀번호를 바꾸는 순간 발급된 세션이 전부 무효화**됩니다. `frontend/CLAUDE.md` 는 이미 *"set it explicitly so sessions survive a password change"* 라고 적어뒀는데, 정작 **사람이 복사하는 파일**에는 언급이 없었습니다.

## 그리고 두 키는 읽는 프로세스가 다릅니다

템플릿이 이걸 말하지 않아 위치를 틀리기 쉽습니다.

| 키 | 읽는 곳 | 필요한 파일 |
|---|---|---|
| `DASHBOARD_PASSWORD` | 프론트 미들웨어(Edge Runtime) **+** `nuri/api/main.py` | **양쪽 다** — `frontend/.env.local` 과 루트 `.env` |
| `AUTH_SECRET` | 프론트 전용 (`auth-token.ts`) | `frontend/.env.local` **만** |

`npm run start` 의 cwd 가 `frontend/` 라 Next 는 거기서만 env 를 로드합니다. 루트 `.env` 에만 넣으면 **대시보드 게이트가 안 걸리고**, 반대로 루트에 없으면 백엔드가 503 을 냅니다. 한쪽만 넣으면 둘 다 조용히 실패합니다.

프로덕션 실측으로 확인: mini 는 루트 `.env` 3키 · `frontend/.env.local` 2키로 이미 올바르게 배치돼 있습니다.

## 자기 정정 하나

처음엔 "루트 `.env.example` 이 `DASHBOARD_PASSWORD` 를 안내하는 게 틀렸다" 고 봤는데, `nuri/api/main.py:143` 이 실제로 읽으므로 **루트도 정당한 위치**입니다. 틀린 게 아니라 **불완전**했던 것이고, 그래서 삭제가 아니라 설명 추가로 고쳤습니다.

## 검증

- `#907` 인라인 주석 트랩 회피 — 전부 **전체 줄 주석**으로 추가
- `dotenv` 파싱 실측: 활성 키 여전히 **41개**, 보안 키 3개 모두 unset 으로 파싱
- `tests/core/test_env_example_parses.py` + `tests/alerts/test_alpha_report.py` **44 passed**
- privacy scan · lint · doc counts 통과
- 최종 확인: `.env` · `.bak` 양쪽 모두 **문서화 안 된 키 0개**

🤖 Generated with [Claude Code](https://claude.com/claude-code)