### PR TITLE
fix(api): key /api/targets signals by (ticker, account), not ticker alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,692 collected across 297 files | |
+| **Backend tests** | 6,693 collected across 297 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,692 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,693 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,692 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,693 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/targets.py
+++ b/nuri/api/routes/targets.py
@@ -17,23 +17,30 @@ def get_portfolio_targets():
 
     targets = calculate_portfolio_targets()
 
-    # 익절/트레일링/리더-트레일 도달 종목 태깅
+    # 익절/트레일링/리더-트레일 도달 종목 태깅.
+    # 키는 **(ticker, account)** 다 — 티커만으로 잡으면 같은 종목을 두 계좌에
+    # 보유할 때 dict 조립에서 마지막 계좌 것만 남고(앞 계좌 신호 소실), 남은 하나가
+    # 두 행 모두에 붙는다. 계좌마다 평단이 다르면 손절/익절선도 다르므로 한쪽은
+    # 반드시 틀린 신호를 받는다 (#974).
+    def _key(row: dict) -> tuple:
+        return (row.get("ticker"), row.get("account"))
+
     try:
-        tp_signals = {s["ticker"]: s for s in check_take_profit_signals()}
+        tp_signals = {_key(s): s for s in check_take_profit_signals()}
     except Exception:
         tp_signals = {}
     try:
-        ts_signals = {s["ticker"]: s for s in check_trailing_stop_signals()}
+        ts_signals = {_key(s): s for s in check_trailing_stop_signals()}
     except Exception:
         ts_signals = {}
     try:
-        lt_signals = {s["ticker"]: s for s in check_leader_trail_signals()}
+        lt_signals = {_key(s): s for s in check_leader_trail_signals()}
     except Exception:
         lt_signals = {}
     for t in targets:
-        tp = tp_signals.get(t["ticker"])
-        ts = ts_signals.get(t["ticker"])
-        lt = lt_signals.get(t["ticker"])
+        tp = tp_signals.get(_key(t))
+        ts = ts_signals.get(_key(t))
+        lt = lt_signals.get(_key(t))
         t["take_profit_triggered"] = tp["level"] if tp else None
         t["take_profit_sell_pct"] = tp["sell_pct"] if tp else None
         t["trailing_stop_triggered"] = ts is not None

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -265,11 +265,15 @@ def calculate_portfolio_targets(
 ) -> list[dict]:
     """포트폴리오 전체 보유 종목의 가격 목표 계산.
 
+    같은 티커를 여러 계좌에 보유하면 **행이 계좌마다 하나씩** 나온다 — 평단이
+    다르면 손절/익절/트레일링 가격도 달라지므로 합칠 수 없다. 소비자는 티커가
+    아니라 `(ticker, account)` 로 식별해야 한다 (#974).
+
     Returns:
-        list[dict]: 종목별 가격 목표 리스트
+        list[dict]: (종목, 계좌)별 가격 목표 리스트
     """
     df = query_df(
-        "SELECT ticker, quantity, avg_price, sector FROM portfolio",
+        "SELECT account, ticker, quantity, avg_price, sector FROM portfolio",
         db_path=db_path,
     )
     if df.empty:
@@ -291,12 +295,13 @@ def calculate_portfolio_targets(
             continue
 
         # 포트폴리오 추가 정보
+        result["account"] = row["account"]
         result["quantity"] = row["quantity"]
         result["avg_price"] = avg_price
         targets.append(result)
 
-    # 종목명 기준 정렬
-    targets.sort(key=lambda t: t["ticker"])
+    # (종목, 계좌) 기준 정렬 — 같은 티커의 계좌별 행이 인접하게
+    targets.sort(key=lambda t: (t["ticker"], t.get("account") or ""))
     return targets
 
 
@@ -504,7 +509,7 @@ def check_leader_trail_signals(db_path: Optional[Path] = None) -> list[dict]:
         return []
 
     df = query_df(
-        "SELECT ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
+        "SELECT account, ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
         db_path=db_path,
     )
     if df.empty:
@@ -530,6 +535,7 @@ def check_leader_trail_signals(db_path: Optional[Path] = None) -> list[dict]:
             signals.append(
                 {
                     "ticker": ticker,
+                    "account": row["account"],
                     "entry_price": entry_price,
                     "current_price": current_price,
                     "ma": round(ma, 2),

--- a/tests/api/test_targets.py
+++ b/tests/api/test_targets.py
@@ -53,6 +53,35 @@ class TestTargetsCoverageGaps:
         assert m["AAPL"]["take_profit_sell_pct"] == 0.5
         assert m["MSFT"]["trailing_stop_triggered"] is True
 
+    def test_same_ticker_two_accounts_keeps_signals_apart(self, client, monkeypatch):
+        """같은 티커를 두 계좌에 보유해도 신호가 섞이지 않는다 (#974).
+
+        회귀 잠금: 티커로만 키를 잡으면 dict 조립에서 **마지막 계좌 것만 남고**(앞
+        계좌 신호 소실), 남은 하나가 두 행 모두에 붙는다. 계좌마다 평단이 달라
+        손절/익절선이 다르므로 한쪽은 반드시 틀린 신호를 받는다.
+
+        한쪽 계좌만 익절에 닿은 케이스를 쓴다 — 양쪽 다 발화하면 충돌이 안 드러난다.
+        """
+        monkeypatch.setattr(
+            "nuri.trading.recommend.price_targets.calculate_portfolio_targets",
+            lambda: [
+                {"ticker": "AAPL", "account": "Brokerage Alpha"},
+                {"ticker": "AAPL", "account": "Brokerage Beta"},
+            ],
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.price_targets.check_take_profit_signals",
+            lambda: [{"ticker": "AAPL", "account": "Brokerage Beta", "level": "TP1", "sell_pct": 0.5}],
+        )
+        monkeypatch.setattr("nuri.trading.recommend.price_targets.check_trailing_stop_signals", lambda: [])
+        monkeypatch.setattr("nuri.trading.recommend.price_targets.check_leader_trail_signals", lambda: [])
+
+        data = client.get("/api/targets").json()
+        by_account = {t["account"]: t for t in data["targets"]}
+
+        assert by_account["Brokerage Beta"]["take_profit_triggered"] == "TP1", "닿은 계좌에는 붙어야 한다"
+        assert by_account["Brokerage Alpha"]["take_profit_triggered"] is None, "안 닿은 계좌에 새면 안 된다"
+
     def test_targets_signal_failures_swallowed(self, client, monkeypatch):
         """tp/ts signal exceptions don't block response (lines 22-23, 26-27)."""
         monkeypatch.setattr(


### PR DESCRIPTION
Closes #974.

## 버그 — 두 번 무너진다

`nuri/api/routes/targets.py` 가 신호를 **티커로만** 키잉하고 있었습니다.

```python
tp_signals = {s["ticker"]: s for s in check_take_profit_signals()}   # ① 앞 계좌 소실
...
tp = tp_signals.get(t["ticker"])                                     # ② 남은 하나가 두 행 모두에
```

1. dict 조립에서 **마지막 계좌 것만 남고** 앞 계좌 신호는 사라집니다
2. `calculate_portfolio_targets()` 가 계좌별로 행을 만드는데 조회는 티커로 하므로, **살아남은 신호가 두 행 모두에** 붙습니다

계좌마다 평단이 다르면 손절·익절·트레일링 가격이 전부 다릅니다. 즉 **둘 중 한 행은 다른 계좌의 원가로 계산된 신호**를 받습니다.

## 왜 지금까지 안 보였나

`check_take_profit_signals` · `check_trailing_stop_signals` 는 `#968`/`#970` 에서 이미 `account` 를 반환하도록 고쳤는데, **소비자가 그걸 안 쓰고 있었습니다.** 그리고 나머지 둘은 `account` 를 SELECT 조차 안 해서 키로 쓸 값 자체가 없었습니다.

| 함수 | 수정 전 | 수정 후 |
|---|---|---|
| `check_take_profit_signals` | ✅ account 반환 | 그대로 |
| `check_trailing_stop_signals` | ✅ account 반환 | 그대로 |
| `calculate_portfolio_targets` | ❌ SELECT 안 함 | ✅ + `(ticker, account)` 정렬 |
| `check_leader_trail_signals` | ❌ SELECT 안 함 | ✅ |

## 현재 영향 — 0

프로덕션 실측(2026-08-02): 19행 / distinct ticker 19 → **여러 계좌에 걸친 티커 0개**.

다만 계좌별 전략 프로파일이 설계상 다르므로(main=정석 · sub=스윙 · toss=장기) 같은 종목을 두 계좌에 담는 건 **이상한 경우가 아니라 정상 시나리오**입니다.

## 테스트가 한쪽만 발화시키는 이유

```python
check_take_profit_signals → [{"ticker": "AAPL", "account": "Brokerage Beta", ...}]   # Beta 만
assert by_account["Brokerage Beta"]["take_profit_triggered"] == "TP1"
assert by_account["Brokerage Alpha"]["take_profit_triggered"] is None
```

양쪽 다 발화시키면 **충돌이 안 드러납니다** — 어느 쪽으로 잘못 붙어도 두 행 다 맞아 보입니다.

## 검증

- mutation: 키를 `row.get("ticker")` 로 되돌리면 새 테스트 **FAIL**, 원복 후 10 passed
- `tests/api/` + `tests/trading/recommend/` **1029 passed**
- lint · privacy scan · doc counts 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)