### PR TITLE
fix(privacy): remove a live credential fragment, a broker name, and real home paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ flowchart TB
     SCHED["APScheduler · 49 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
-    subgraph Collect["Collect — 25 jobs"]
+    subgraph Collect["Collect — 26 jobs"]
         COL(["27 data collectors"]):::pipe
     end
     subgraph Decide["Decide — 1 job, 07:05 KST"]
@@ -106,11 +106,11 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 48 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 49 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
-| **Collect** | 25 jobs, `*/5` during market hours down to weekly | external APIs | `prices` · `fundamentals` · `macro` · `news` |
+| **Collect** | 26 jobs, `*/5` during market hours down to weekly | external APIs | `prices` · `fundamentals` · `macro` · `news` |
 | **Analyze** | **no job** — 22 per-ticker signals · 10 regimes (6 base + 4 special) · 4-factor composite are computed when a report or an endpoint asks | `prices` · `macro` | nothing (`news.sentiment` aside) |
 | **Consensus** | `consensus`, `5 7 * * *` | `recommendations.outcome_30d` (for weights) · collector tables | `recommendations` with `agent_verdicts` JSON |
 | **Certify** | **no job of its own** — `record_decisions` runs inside the consensus job; the `certifications` table is written by `premarket_brief` (`0 9 * * 1-5`) | consensus result **in memory** | `decisions` · `agent_decisions` · `certifications` |
@@ -280,7 +280,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 48 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 49 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 48 cron jobs · in-process<br/>Mac mini is the sole writer"]:::driver
+    SCHED["APScheduler · 49 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 25 jobs"]
@@ -171,7 +171,7 @@ make certify        # Certification (3-D gates)
 make scan           # Daily swing scan (us_core, 85 tickers)
 make scan-extended  # Weekly swing scan (us_core + S&P 500 extension, 543 tickers)
 
-make test-fast      # backend, slow tests excluded — 111s on an 18-core M5 Max
+make test-fast      # backend, slow tests excluded
 make test           # full backend suite (adds 24 slow-marked tests)
 make ci-cov         # combine CI shard artifacts — ground-truth coverage
 
@@ -227,7 +227,7 @@ LLM integrations are **wired but inactive** unless you set the corresponding env
 
 ## Deployment
 
-The reference operator setup is two Apple Silicon Macs — a MacBook Pro for development, a Mac mini as a 24/7 receiver — synced by `make deploy-mini` in one command. The receiver is the sole writer; the development machine treats its database as a read replica, so adjudication records have exactly one ledger of record.
+The reference setup is two machines by role: a development host, and an always-on receiver that runs the scheduler. `make deploy-mini` syncs them in one command. The receiver is the sole writer; the development host treats its database as a read replica, so adjudication records have exactly one ledger of record.
 
 Production binds the API to `127.0.0.1`. The dashboard proxy is the only public surface and sits behind a password gate.
 

--- a/docs/KIS_INTEGRATION.md
+++ b/docs/KIS_INTEGRATION.md
@@ -24,7 +24,7 @@ nuri/collectors/
 
 ```bash
 # 실전 (Production)
-KIS_PROD_APP_KEY=PSO510...
+KIS_PROD_APP_KEY=PSxxxxxx...
 KIS_PROD_APP_SECRET=...
 KIS_PROD_ACCOUNT=1000000  # 8자리 종합계좌 (시세만 조회 시 비워둬도 OK)
 
@@ -74,7 +74,7 @@ ln -sf "$(pwd)/config/kis/cache" ~/KIS/cache
 
 ```bash
 make collect-kis-check
-# → KIS 자격 증명 OK [prod] app_key=PSO510ne... account=(미설정)
+# → KIS 자격 증명 OK [prod] app_key=PSxxxxxx... account=(미설정)
 ```
 
 ### 2. 실시간 시세 수집

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -448,7 +448,7 @@ Phase 1 ship + brief 재실행 검증 중 발견된 4건 — 별도 PR로 fix:
 | **#513** | `premarket_brief.py`가 `FRESHNESS_POLICIES["portfolio"]` 결과를 brief 본문에 surface 안 함 (backend 작동, 사용자 가시성 0) | P1 |
 | **#514** | `recommendations.action='HOLD'` 행이 portfolio JOIN filter 미적용 → 0주 ticker (TSM 등) HOLD noise surface | P2 |
 | **#515** | 신규 매수 후 `make consensus` 수동 호출 운영 burden — `scripts/ops/import_portfolio.py` 에 newly-added ticker detection + auto-trigger 필요 | P1 |
-| **#516** | Pension 4-18 매도 종목 3개 (테크TOP10/나스닥100/KRX300) 4-30 재진입 — 한화증권 자동매수 설정 의도 검증 필요 | P3 |
+| **#516** | Pension 계좌 4월 매도 3종목 재진입 — 증권사 자동매수 설정 의도 검증 필요 | P3 |
 ### 5.13 BUY candidate backtracking ledger (Session 8 신설)
 **Goal**: Phase 1 emitter score 신뢰도 검증 + Phase 2c threshold backtest 표본 자동 적립.
 **Mechanism**:

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -215,7 +215,7 @@ def _get_account_labels() -> dict[str, str]:
     """계좌명 → 표시 라벨 매핑.
 
     Resolution order (#214 polish):
-      1. `label` field in portfolio.yaml (user custom, e.g. "Toss" or "hojin kakao")
+      1. `label` field in portfolio.yaml (user custom, e.g. "Brokerage Alpha" or "Brokerage Beta")
       2. strategy-based default ("core" → "Main", "swing" → "Sub", ...)
       3. strategy name title-cased if unknown
 

--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -151,9 +151,11 @@ update_claim live_migrations     README.md                     '[0-9]+ forward-o
 # ARCHITECTURE 도 같은 수치를 적는데 등록이 안 돼 있었다 — 2026-07-30 실측 46 vs 실제 49.
 update_claim live_migrations     docs/ARCHITECTURE.md          '\([0-9]+ migrations as of'
 update_claim live_scheduler_jobs docs/ARCHITECTURE.md          '[0-9]+ cron jobs in'
-# README 아키텍처 다이어그램도 같은 수치를 적는데 등록이 안 돼 있었다 — 2026-08-03 실측
-# 48 vs 실제 49 (data_sanity 추가분). ARCHITECTURE 만 보던 것과 같은 누락 패턴.
+# README 는 같은 수치를 세 군데 적는데 (다이어그램 · 산문 · Project Stats) 전부 미등록이라
+# 셋 다 48 로 굳어 있었다 — 2026-08-03 실측, 실제 49. verify 쪽과 패턴을 맞춰 둘 것.
 update_claim live_scheduler_jobs README.md                     '[0-9]+ cron jobs · in-process'
+update_claim live_scheduler_jobs README.md                     '[0-9]+ independent APScheduler jobs'
+update_claim live_scheduler_jobs README.md                     '[0-9]+ cron entries'
 update_claim live_rules_lines    config/CLAUDE.md              '\| [0-9]+ \| Investment rules'
 
 # Pytest collect count — runs pytest which is slow; do last so failures above

--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -151,6 +151,9 @@ update_claim live_migrations     README.md                     '[0-9]+ forward-o
 # ARCHITECTURE 도 같은 수치를 적는데 등록이 안 돼 있었다 — 2026-07-30 실측 46 vs 실제 49.
 update_claim live_migrations     docs/ARCHITECTURE.md          '\([0-9]+ migrations as of'
 update_claim live_scheduler_jobs docs/ARCHITECTURE.md          '[0-9]+ cron jobs in'
+# README 아키텍처 다이어그램도 같은 수치를 적는데 등록이 안 돼 있었다 — 2026-08-03 실측
+# 48 vs 실제 49 (data_sanity 추가분). ARCHITECTURE 만 보던 것과 같은 누락 패턴.
+update_claim live_scheduler_jobs README.md                     '[0-9]+ cron jobs · in-process'
 update_claim live_rules_lines    config/CLAUDE.md              '\| [0-9]+ \| Investment rules'
 
 # Pytest collect count — runs pytest which is slow; do last so failures above

--- a/scripts/launchd/com.nuri-quant.autopull.plist
+++ b/scripts/launchd/com.nuri-quant.autopull.plist
@@ -35,11 +35,11 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/ehbebe/workspace/nuri-quant/scripts/deploy/autopull_receiver.sh</string>
+        <string>/Users/USER/workspace/nuri-quant/scripts/deploy/autopull_receiver.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/ehbebe/workspace/nuri-quant</string>
+    <string>/Users/USER/workspace/nuri-quant</string>
 
     <key>StartInterval</key>
     <integer>300</integer>
@@ -48,17 +48,17 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/Users/ehbebe/Library/Logs/nuri-quant-autopull.log</string>
+    <string>/Users/USER/Library/Logs/nuri-quant-autopull.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/ehbebe/Library/Logs/nuri-quant-autopull.log</string>
+    <string>/Users/USER/Library/Logs/nuri-quant-autopull.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
         <key>HOME</key>
-        <string>/Users/ehbebe</string>
+        <string>/Users/USER</string>
         <key>GIT_TERMINAL_PROMPT</key>
         <string>0</string>
     </dict>

--- a/scripts/launchd/com.nuri-quant.scheduler.plist
+++ b/scripts/launchd/com.nuri-quant.scheduler.plist
@@ -16,12 +16,12 @@
     <string>com.nuri-quant.scheduler</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/ehbebe/workspace/nuri-quant/.venv/bin/python</string>
+        <string>/Users/USER/workspace/nuri-quant/.venv/bin/python</string>
         <string>-m</string>
         <string>nuri.scheduler</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>/Users/ehbebe/workspace/nuri-quant</string>
+    <string>/Users/USER/workspace/nuri-quant</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -47,8 +47,8 @@
         <string>production</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>/Users/ehbebe/workspace/nuri-quant/data/logs/scheduler.log</string>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/scheduler.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/ehbebe/workspace/nuri-quant/data/logs/scheduler.err</string>
+    <string>/Users/USER/workspace/nuri-quant/data/logs/scheduler.err</string>
 </dict>
 </plist>

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -147,6 +147,9 @@ check_claim "migrations"       "$MIG"   "README.md"            '[0-9]+ forward-o
 # ARCHITECTURE 도 같은 수치를 적는데 게이트가 없어 조용히 갈렸다 (2026-07-30 실측 46 vs 49).
 check_claim "migrations"       "$MIG"   "docs/ARCHITECTURE.md" '\([0-9]+ migrations as of' || true
 check_claim "scheduler_jobs"   "$JOBS"  "docs/ARCHITECTURE.md" '[0-9]+ cron jobs in' || true
+# README 아키텍처 다이어그램도 같은 수치를 적는데 등록이 안 돼 있어 48 로 굳어 있었다
+# (2026-08-03 실측, 실제 49). ARCHITECTURE 만 보던 migrations 누락과 같은 패턴.
+check_claim "scheduler_jobs"   "$JOBS"  "README.md"            '[0-9]+ cron jobs · in-process' || true
 check_claim "rules_yaml_lines" "$RULES" "config/CLAUDE.md"     '\| [0-9]+ \| Investment rules' || true
 
 # Note: agent count + pytest collect count intentionally excluded from hard

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -147,9 +147,11 @@ check_claim "migrations"       "$MIG"   "README.md"            '[0-9]+ forward-o
 # ARCHITECTURE 도 같은 수치를 적는데 게이트가 없어 조용히 갈렸다 (2026-07-30 실측 46 vs 49).
 check_claim "migrations"       "$MIG"   "docs/ARCHITECTURE.md" '\([0-9]+ migrations as of' || true
 check_claim "scheduler_jobs"   "$JOBS"  "docs/ARCHITECTURE.md" '[0-9]+ cron jobs in' || true
-# README 아키텍처 다이어그램도 같은 수치를 적는데 등록이 안 돼 있어 48 로 굳어 있었다
-# (2026-08-03 실측, 실제 49). ARCHITECTURE 만 보던 migrations 누락과 같은 패턴.
-check_claim "scheduler_jobs"   "$JOBS"  "README.md"            '[0-9]+ cron jobs · in-process' || true
+# README 는 같은 수치를 **세 군데** 적는데 (다이어그램 노드 · 산문 · Project Stats 표)
+# 전부 미등록이라 셋 다 48 로 굳어 있었다 (2026-08-03 실측, 실제 49). ARCHITECTURE 만
+# 보던 migrations 누락(#864)과 같은 패턴 — 한 사이트만 등록하면 나머지가 조용히 드리프트한다.
+check_claim "scheduler_jobs"   "$JOBS"  "README.md" \
+    '[0-9]+ (cron jobs · in-process|independent APScheduler jobs|cron entries)' || true
 check_claim "rules_yaml_lines" "$RULES" "config/CLAUDE.md"     '\| [0-9]+ \| Investment rules' || true
 
 # Note: agent count + pytest collect count intentionally excluded from hard

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -10,7 +10,7 @@ Lock-in:
 spec: docs/plans/507_buy_candidate_emitter_phase2_spec.md §4.6.
 """
 
-# cspell:ignore kakaopay
+# cspell:ignore acct_alpha
 
 from __future__ import annotations
 
@@ -714,7 +714,7 @@ class TestDBProviders:
         conn.executemany(
             "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?, ?, ?, ?, ?)",
             [
-                ("kakaopay", "AAPL", 10.0, 100.0, "USD"),
+                ("acct_alpha", "AAPL", 10.0, 100.0, "USD"),
                 ("test", "BBB", 5.0, 50.0, "USD"),
                 ("sample", "CCC", 3.0, 30.0, "USD"),
             ],
@@ -731,14 +731,14 @@ class TestDBProviders:
 
         monkeypatch.setattr(core_db, "DB_PATH", path)
 
-        # _get_real_accounts stub: kakaopay 만 substantive
+        # _get_real_accounts stub: acct_alpha 만 substantive
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_real_accounts",
-            lambda: {"kakaopay"},
+            lambda: {"acct_alpha"},
         )
         positions = ha._get_held_positions()
         accounts_seen = {p["account"] for p in positions}
-        assert accounts_seen == {"kakaopay"}
+        assert accounts_seen == {"acct_alpha"}
         assert "test" not in accounts_seen
         assert "sample" not in accounts_seen
 
@@ -750,9 +750,9 @@ class TestDBProviders:
         conn.executemany(
             "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?, ?, ?, ?, ?)",
             [
-                ("kakaopay", "AAA", 10.0, 100.0, "USD"),
-                ("kakaopay", "BBB", 0.0, 100.0, "USD"),  # zero qty
-                ("kakaopay", "CCC", 5.0, 0.0, "USD"),  # zero avg
+                ("acct_alpha", "AAA", 10.0, 100.0, "USD"),
+                ("acct_alpha", "BBB", 0.0, 100.0, "USD"),  # zero qty
+                ("acct_alpha", "CCC", 5.0, 0.0, "USD"),  # zero avg
             ],
         )
         conn.commit()
@@ -763,7 +763,7 @@ class TestDBProviders:
         monkeypatch.setattr(core_db, "DB_PATH", path)
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_real_accounts",
-            lambda: {"kakaopay"},
+            lambda: {"acct_alpha"},
         )
         positions = ha._get_held_positions()
         tickers = [p["ticker"] for p in positions]


### PR DESCRIPTION
4-lens 적대적 스윕 결과입니다. **raised 45 → 검증 통과 5, 반증 27.** 확정 5건 전부 수정했습니다.

## 🔴 가장 중요한 것 — 실제 프로덕션 앱키 앞 8자가 공개돼 있었습니다

`docs/KIS_INTEGRATION.md` 27·77행이 실제 `make collect-kis-check` 출력을 그대로 옮겨 적어, **live KIS 프로덕션 앱키의 앞 8자**가 들어 있었습니다.

검증 에이전트가 gitignored `.env` 와 직접 대조해 확인했습니다 — 36자 키의 첫 8자가 정확히 일치합니다. **#108 (2026-04-09) 이래 공개 상태**였습니다.

같은 블록의 다른 줄들은 `...` / `your_hts_id` 로 제대로 가려져 있어, 이건 규약이 아니라 **드리프트**입니다.

> ⚠️ **HEAD 에서 지워도 git 이력에는 남습니다.** `KIS_PROD_APP_SECRET` 은 레포에 한 번도 없었으므로 이 조각만으로는 사용 불가 — 즉 활성 침해가 아니라 위생 문제입니다. 다만 그 8바이트를 실제로 무효화하는 유일한 방법은 **프로덕션 앱키 재발급**입니다. 이건 사장님 판단 영역이라 제가 임의로 하지 않았습니다.

## 나머지 4건

| 파일 | 문제 | 스캐너가 못 잡은 이유 |
|---|---|---|
| `docs/STRATEGY.md:451` | 증권사명 + 연금계좌 ETF 3종 + 매도/재진입 **정확한 날짜** | 해당 증권사가 `BROKER_NAMES_KO` 에 없음 **+** 이 파일이 `ALLOWLIST_PATHS` 라 파일 전체가 스캔 면제 |
| `scripts/launchd/*.plist` 2개 | 실제 홈 경로 9곳 | 스캐너 대상 아님 |
| `nuri/api/routes/dashboard.py:218` | docstring 예시에 **실명 + 브로커 약칭** | 브로커 약칭이 목록에 없음 |
| `tests/trading/recommend/test_held_add_mode.py` | 픽스처 9곳에 실제 증권사명 | 〃 |

**plist 는 개인정보 문제만이 아니었습니다.** 나머지 7개는 `/Users/USER` 플레이스홀더를 쓰고 `install_crons.sh:98` 의 `sed` 가 `$HOME` 으로 치환하는데, 이 둘만 실제 경로가 박혀 있어 **sed 가 매칭되지 않았습니다** → 신규 클론이 남의 홈 디렉터리를 가리키는 unit 을 설치합니다. 이제 9개 전부 일치합니다.

`dashboard.py` 예시는 아이러니하게도 **6줄 아래에서 "personal names never enter the code" 라고 주장하는 docstring** 안에 있었습니다.

## README

요청하신 대로:

- **`18-core M5 Max` 벤치마크 삭제** — 하드웨어 없는 시간은 무의미하고, 그 하드웨어는 메인테이너 개인 머신입니다
- **배포 문단을 제품명이 아닌 역할로 재작성** — "두 대의 Apple Silicon Mac(MacBook Pro / Mac mini)" → 개발 호스트 + 상시 리시버. **아키텍처 속성**(2 호스트, 리시버가 유일 writer)은 실제 설계라 남겼습니다

## 부수 발견 — README cron 수가 48 로 굳어 있었습니다 (실제 49)

drift 게이트가 `docs/ARCHITECTURE.md` 만 보고 있었고 README 는 **같은 수치를 적는데 등록이 안 돼 있었습니다.** `#864` 에서 migrations 가 드리프트한 것과 **똑같은 누락 패턴**입니다.

sync·verify 양쪽에 등록해 게이트를 20 → **21 검사**로 늘렸습니다. 실제로 무는지 확인했습니다:

```
README 를 48 로 되돌림 → ✗ scheduler_jobs (README.md): doc=48, live=49 — DRIFT
원복                    → 21 passed
```

## 검증

- privacy scan · lint · shellcheck · doc counts(21) 통과
- `tests/trading/recommend/` + `tests/api/test_dashboard.py` **541 passed**
- 추적 파일 전체에 실제 홈 경로 **0건**, `PSO510` **0건**
- plist 9개 규약 일치 확인

## 반증된 27건에 대해

`researcherhojin` 배지/CODEOWNERS, `Brokerage Alpha` 같은 기존 플레이스홀더, `toss`(스캐너에 명시된 carve-out), gitignored 파일 등은 전부 정상으로 판정돼 걸러졌습니다.

## ⚠️ 이 PR 이 다루지 않은 것

README 정확성 감사(수치·링크·과장 주장)는 **검증 에이전트 13개가 세션 한도로 죽어** 미완입니다. 위 cron 건은 제가 직접 잡은 것이고, 나머지 README 클레임은 미검증 상태입니다. 별도로 진행해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)