### PR TITLE
fix(api): make /api/actions read targets from the same account its holding row picked

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,693 collected across 297 files | |
+| **Backend tests** | 6,694 collected across 297 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,693 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,694 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,693 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,694 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -103,7 +103,9 @@ def _build_actions() -> dict:
         holding = portfolio_holdings.get(ticker, {})
         pnl_pct = holding.get("pnl_pct", 0)
         position_pct = holding.get("position_pct", 0)
-        target = targets_status.get(ticker, {})
+        # 보유 행이 고른 계좌(worst-PnL)와 **같은 계좌**의 타겟을 본다 — 티커로만
+        # 조회하면 둘이 갈라져 서로 다른 원가 기준이 한 줄에 섞인다 (#982).
+        target = targets_status.get((ticker, holding.get("account")), {})
 
         # A-5: 시장 시간이면 live price fetch + divergence 체크. stored price 는
         # T-1 이라 장중 >3% 차이가 날 수 있음 (NFLX 사례). 지금은 flag 만 — 실제
@@ -491,9 +493,19 @@ def _get_siege_violations() -> list[dict]:
     return violations
 
 
-def _get_targets_status() -> dict[str, dict]:
-    """포트폴리오 가격 타겟 조회."""
-    targets = {}
+def _get_targets_status() -> dict[tuple[str, str], dict]:
+    """포트폴리오 가격 타겟 조회 — **(ticker, 계좌라벨)** 로 키잉.
+
+    같은 티커를 두 계좌에 보유하면 평단이 달라 손절/익절선도 다르다. 티커로만
+    키잉하면 한 계좌 것만 남고, 그게 `_get_portfolio_map()` 이 고른 계좌와
+    일치한다는 보장이 없다 — 그러면 UI 에서 **보유 정보와 손절선이 서로 다른
+    계좌 기준**으로 나란히 붙는다. 여기서 계좌까지 키에 넣고, 소비자가
+    `_get_portfolio_map()` 이 고른 계좌로 조회해 둘을 일치시킨다 (#982).
+    """
+    from nuri.api.routes.dashboard import _get_account_labels
+
+    labels = _get_account_labels()
+    targets: dict[tuple[str, str], dict] = {}
     try:
         from nuri.trading.recommend.price_targets import (
             calculate_portfolio_targets,
@@ -501,11 +513,14 @@ def _get_targets_status() -> dict[str, dict]:
         )
 
         try:
-            _leader_trail = {x["ticker"] for x in check_leader_trail_signals()}
+            _leader_trail = {
+                (x["ticker"], labels.get(x.get("account"), x.get("account"))) for x in check_leader_trail_signals()
+            }
         except Exception:
             _leader_trail = set()
         for t in calculate_portfolio_targets():
-            targets[t["ticker"]] = {
+            key = (t["ticker"], labels.get(t.get("account"), t.get("account")))
+            targets[key] = {
                 "stop_loss": t.get("stop_loss"),
                 "target_1": t.get("target_1"),
                 "target_2": t.get("target_2"),
@@ -513,7 +528,7 @@ def _get_targets_status() -> dict[str, dict]:
                 "analyst_target": t.get("analyst_target"),
                 "is_leader": t.get("is_leader"),
                 "leader_ma": t.get("leader_ma"),
-                "leader_trail_triggered": t["ticker"] in _leader_trail,
+                "leader_trail_triggered": key in _leader_trail,
             }
     except Exception as e:
         logger.debug(f"Targets: {e}")

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -650,6 +650,7 @@ class TestGetTargetsStatus:
         mock_fn.return_value = [
             {
                 "ticker": "AAPL",
+                "account": "Brokerage Alpha",
                 "stop_loss": 140,
                 "target_1": 180,
                 "target_2": 210,
@@ -660,7 +661,26 @@ class TestGetTargetsStatus:
         from nuri.api.routes.actions import _get_targets_status
 
         result = _get_targets_status()
-        assert result["AAPL"]["stop_loss"] == 140
+        assert result[("AAPL", "Brokerage Alpha")]["stop_loss"] == 140
+
+    @patch("nuri.trading.recommend.price_targets.calculate_portfolio_targets")
+    def test_two_accounts_keep_separate_targets(self, mock_fn):
+        """같은 티커의 계좌별 타겟이 서로를 덮어쓰지 않는다 (#982).
+
+        회귀 잠금: 티커로만 키잉하면 한 계좌 것만 남고, 그게 `_get_portfolio_map()`
+        이 고른 계좌(worst-PnL)와 일치한다는 보장이 없다 → UI 에서 보유 정보와
+        손절선이 서로 다른 원가 기준으로 한 줄에 붙는다.
+        """
+        mock_fn.return_value = [
+            {"ticker": "AAPL", "account": "Brokerage Alpha", "stop_loss": 140},
+            {"ticker": "AAPL", "account": "Brokerage Beta", "stop_loss": 90},
+        ]
+        from nuri.api.routes.actions import _get_targets_status
+
+        result = _get_targets_status()
+
+        assert result[("AAPL", "Brokerage Alpha")]["stop_loss"] == 140
+        assert result[("AAPL", "Brokerage Beta")]["stop_loss"] == 90, "뒤 행이 앞 행을 덮어쓰면 안 된다"
 
     @patch("nuri.trading.recommend.price_targets.calculate_portfolio_targets", side_effect=Exception)
     def test_handles_exception(self, _):
@@ -1040,7 +1060,7 @@ class TestBuildActionsLogic:
     def test_target_1_hit_check(self):
         result = self._run(
             [{"ticker": "WIN", "action": "BUY", "confidence": 70, "agreement": 40}],
-            targets={"WIN": {"stop_loss": 90, "target_1": 120, "target_2": 140}},
+            targets={("WIN", "Main"): {"stop_loss": 90, "target_1": 120, "target_2": 140}},
             portfolio={"WIN": self._pf(125, 100, 25, 5)},
         )
         assert len(result["check"]) == 1
@@ -1049,7 +1069,7 @@ class TestBuildActionsLogic:
     def test_target_2_hit_check(self):
         result = self._run(
             [{"ticker": "BIG", "action": "BUY", "confidence": 80, "agreement": 60}],
-            targets={"BIG": {"stop_loss": 90, "target_1": 120, "target_2": 140}},
+            targets={("BIG", "Main"): {"stop_loss": 90, "target_1": 120, "target_2": 140}},
             portfolio={"BIG": self._pf(145, 100, 45, 8)},
         )
         assert "2차 익절" in result["check"][0]["reasons"][0]

--- a/tests/api/test_actions_leader_trail.py
+++ b/tests/api/test_actions_leader_trail.py
@@ -51,7 +51,7 @@ class TestLeaderTrailWiring:
                 }
             },
             targets_status={
-                "GRW": {
+                ("GRW", "Main"): {
                     "is_leader": True,
                     "leader_trail_triggered": True,
                     "target_1": None,


### PR DESCRIPTION
**#979 를 검증하다 그 수정이 불완전했음을 발견해 마무리하는 PR 입니다.**

## 무엇이 남아 있었나

`price_targets.py` 의 네 함수를 소비하는 곳은 **둘**입니다:

```
nuri/api/routes/targets.py   ← #979 에서 고침
nuri/api/routes/actions.py   ← 그대로 남아 있었음
```

`actions.py` 는 여전히 티커로만 키잉하고 있었습니다.

## 여기서의 증상은 `targets.py` 와 다릅니다

`actions.py` 는 **의도적으로 티커 집계 뷰**입니다 (#527). `_get_portfolio_map()` 이 다계좌 행을 **worst-PnL 우선**으로 접어서, 보유 줄은 "가장 손실 큰 계좌의 원가" 를 일부러 보여줍니다.

그런데 `_get_targets_status()` 는 `calculate_portfolio_targets()` 의 **마지막 행**을 남겼고, 그건 그 계좌가 아닙니다.

| 한 티커의 UI 한 줄 | 어느 계좌 기준이었나 |
|---|---|
| 보유 정보 (평단·PnL·비중) | worst-PnL 계좌 |
| 손절/익절/트레일링 | 마지막 행 계좌 |

**같은 줄에 서로 다른 원가 기준이 섞여 있었습니다.**

## 제가 #979 에서 만든 부작용도 함께 정리합니다

`calculate_portfolio_targets` 의 정렬을 `t["ticker"]` → `(t["ticker"], account)` 로 바꾸면서, 여기서 이기는 행이 **"DB 순서 마지막" → "알파벳상 마지막 계좌"** 로 조용히 바뀌었습니다.

둘 다 자의적이라 **맞던 동작이 깨진 건 아닙니다.** 다만 선택이 우연이어서는 안 되고, 이제 아닙니다.

## 고친 방법

`targets` 와 leader-trail 집합을 `(ticker, 계좌라벨)` 로 키잉하고, 소비자가 **`_get_portfolio_map()` 이 이미 고른 계좌**로 조회합니다. 두 줄이 같은 보유를 가리키는 것이 보장됩니다.

## 현재 영향 — 0

프로덕션 다계좌 중복 티커 **0종** (2026-08-02 실측). #973·#974 와 같이 발현 전 차단입니다.

## 테스트

기존 4개가 티커 키 계약을 잠그고 있었습니다. **약화하지 않고 새 계약으로 갱신**했고, "두 계좌 타겟이 서로 덮어쓰지 않는다" 테스트를 추가했습니다.

> ⚠️ 그중 **1개는 다른 파일**(`test_actions_leader_trail.py`)에 있어 `tests/api/test_actions.py` 만 돌렸을 땐 **초록이었습니다.** 브로더 스위트에서야 드러났습니다.

## 검증

- mutation: `key` 를 `t["ticker"]` 로 되돌리면 **2 FAIL**, 원복 후 98 passed
- 백엔드 전체 **6664 passed** / 프론트 **1449 passed**
- lint · privacy · doc counts(21) 통과
- `/api/actions` 응답 **형태는 불변** — 키잉은 내부 구현이라 프론트 무영향(프론트 테스트로 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)