### PR TITLE
fix(deploy): substitute /Users/USER placeholder when installing scheduler plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,694 collected across 297 files | |
+| **Backend tests** | 6,696 collected across 298 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,694 backend tests across 297 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,696 backend tests across 298 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,694 tests, 297 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,696 tests, 298 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -233,8 +233,14 @@ step 6 "scheduler + 상주 python 서비스 재기동"
 # plist 는 **매번** 재설치한다. 이전에는 미설치일 때만 cp 해서, 이미 설치된
 # mini 에는 repo 의 plist 수정이 영영 도달하지 않았다 (#856 에서 발각: 스케줄러
 # plist 에 넣은 NURI_ROLE 이 배포돼도 반영 안 됨 → 기능이 조용히 죽은 채 시작).
-# unload(5a) 와 load 사이라 cp 안전. kickstart 로는 못 고치는 문제 (#778 참조).
-"${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && cp ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} ${PLIST_REMOTE}"
+# unload(5a) 와 load 사이라 재설치 안전. kickstart 로는 못 고치는 문제 (#778 참조).
+# `cp` 가 아니라 **sed 치환**이다: #980(privacy)이 repo plist 의 실제 홈 경로를
+# `/Users/USER/` 플레이스홀더로 바꿨는데 여기만 평범한 cp 라서, 배포가 존재하지 않는
+# 경로를 가리키는 plist 를 설치했다. launchd 는 exit 78(EX_CONFIG)로 죽고 stderr 에
+# 아무것도 안 남긴다 — 게다가 실행 중인 job 은 캐시된 정의로 계속 돌아서, unload/load
+# 가 도는 **다음 배포**까지 잠복한다 (2026-08-03 실측: scheduler 다운). 다른 설치
+# 경로(Makefile agent-launchd-install / discord-bot-install)는 원래 이 치환을 한다.
+"${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && sed \"s|/Users/USER/|\$HOME/|g\" ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} > ${PLIST_REMOTE}"
 "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
 
 if NEW_PID=$(wait_scheduler alive) && verify_stable_pid "${NEW_PID}"; then

--- a/tests/scripts/test_deploy_plist_placeholder.py
+++ b/tests/scripts/test_deploy_plist_placeholder.py
@@ -1,0 +1,59 @@
+"""배포가 plist 의 `/Users/USER/` 플레이스홀더를 실제 홈으로 치환하는지 검증.
+
+Gotcha-Test Pair:
+#980(privacy)이 repo 의 launchd plist 에서 실제 홈 경로를 지우고 `/Users/USER/`
+플레이스홀더로 바꿨다. 그 자체는 옳다 — public repo 에 홈 경로가 남으면 안 된다.
+그런데 `deploy_to_mini.sh` 의 plist 재설치만 평범한 `cp` 였다. 치환 전에는 repo 에
+실제 경로가 박혀 있어서 cp 로도 우연히 동작했고, #980 이후로는 **존재하지 않는 경로를
+가리키는 plist** 를 프로덕션에 설치하게 됐다.
+
+이 고장은 조용하다. launchd 는 exit 78(EX_CONFIG)로 죽고 `scheduler.err` 에 아무것도
+남기지 않는다 — 로그만 보면 정상 종료와 구분이 안 된다. 게다가 **이미 돌고 있는 job 은
+launchd 가 캐시한 정의로 계속 살아 있어서**, 배포가 unload/load 를 도는 다음 번까지
+잠복한다. 2026-08-03 실측: 의존성 범프 배포가 scheduler 를 내렸고, 그때서야 #980 이
+심어둔 고장이 드러났다.
+
+다른 설치 경로(Makefile `agent-launchd-install` / `discord-bot-install`)는 처음부터
+같은 sed 치환을 했다. 배포 경로만 빠져 있었다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+LAUNCHD_DIR = Path("scripts/launchd")
+DEPLOY_SCRIPT = Path("scripts/deploy/deploy_to_mini.sh")
+
+PLACEHOLDER = "/Users/USER/"
+
+
+def test_repo_plists_use_placeholder_not_real_home():
+    """repo plist 는 실제 홈 경로를 담지 않는다 (#980 privacy).
+
+    이 테스트가 이 파일에 있는 이유: 아래 치환 테스트의 **전제**다. 언젠가 plist 가
+    실제 경로로 되돌아가면 치환은 무의미해지고 privacy 도 깨진다.
+    """
+    offenders = []
+    for path in sorted(LAUNCHD_DIR.glob("*.plist")):
+        text = path.read_text()
+        # `/Users/<something>/` 중 플레이스홀더가 아닌 것
+        for match in re.findall(r"/Users/[^/\s<]+/", text):
+            if match != PLACEHOLDER:
+                offenders.append(f"{path.name}: {match}")
+    assert not offenders, f"plist 에 실제 홈 경로 노출: {offenders}"
+
+
+def test_deploy_substitutes_placeholder_when_installing_plist():
+    """배포는 plist 를 그대로 cp 하지 않고 `$HOME` 으로 치환해 설치한다.
+
+    회귀 시나리오: 이 sed 를 `cp` 로 되돌리면 프로덕션 scheduler 가 exit 78 로 죽는다.
+    """
+    text = DEPLOY_SCRIPT.read_text()
+
+    install_lines = [line for line in text.splitlines() if "PLIST_REMOTE" in line and "scripts/launchd" in line]
+    assert install_lines, "plist 설치 라인을 못 찾음 — 스크립트 구조가 바뀌었다"
+
+    for line in install_lines:
+        assert PLACEHOLDER in line and "sed" in line, f"plist 를 치환 없이 설치한다 (cp 회귀?): {line.strip()}"
+        assert "$HOME/" in line, f"치환 대상이 $HOME 이 아니다: {line.strip()}"


### PR DESCRIPTION
Closes #988

## 무엇이 고장났나

2026-08-03 의존성 범프 배포 중 `deploy_to_mini.sh` 6단계에서 프로덕션 scheduler 가 내려갔다.
launchd 는 exit 78 (EX_CONFIG), `scheduler.err` 는 **빈 채**였다.

`scripts/deploy/deploy_to_mini.sh:237` 이 repo plist 를 평범한 `cp` 로 설치한다.
#980(privacy)이 plist 의 실제 홈 경로를 `/Users/USER/` 플레이스홀더로 바꾼 뒤로, 배포는
**존재하지 않는 경로**를 가리키는 plist 를 프로덕션에 설치해 왔다.

다른 설치 경로는 원래 치환을 한다 — `Makefile: agent-launchd-install`,
`discord-bot-install` 둘 다 `sed "s|/Users/USER/|$HOME/|g"`. 배포 경로만 빠져 있었다.

## 왜 #980 머지 때 안 터졌나

launchd 는 **이미 로드된 job 을 캐시된 정의로 계속 실행**한다. 디스크의 plist 가 깨져도
돌던 scheduler 는 멀쩡했다. 배포가 unload → load 를 도는 순간에만 드러난다. 그래서 고장은
#980 이 심고 **다음 배포**가 터뜨렸다.

`.err` 가 비어 있어 로그만으로는 정상 종료와 구분이 안 된다 — `Dead Gate vs Failing Gate`
계열의 조용한 실패다.

## 변경

- `cp` → `sed "s|/Users/USER/|$HOME/|g"` (다른 설치 경로와 동일 패턴)
- Gotcha-Test Pair 회귀 테스트 `tests/scripts/test_deploy_plist_placeholder.py`
  - `test_deploy_substitutes_placeholder_when_installing_plist` — cp 회귀 차단
  - `test_repo_plists_use_placeholder_not_real_home` — 위 테스트의 전제(#980 privacy) 유지
- 문서 테스트 카운트 297→298 / 6,694→6,696 (`make verify-doc-counts` 게이트)

## 검증

- **Mutation 실측**: sed 를 `cp` 로 되돌리면 `test_deploy_substitutes_placeholder_when_installing_plist` FAIL. 되돌리기 전에는 2 PASS.
- **라이브 대조**: mini 에서 이 sed 를 돌린 산출물이 현재 정상 기동 중인 plist 와 `diff` 결과 **byte-identical**.
- `make verify-quick` 6681 passed / 6 skipped
- `make lint` clean, `make lint-sh` clean
- `check_privacy_leak.py` (인자 없이, CI 동등) clean
- `make verify-doc-counts` 21/21

## 프로덕션 상태

이미 복구했다 — 설치된 plist 를 치환하고 reload, scheduler PID 정상, API 200,
프록시 경로 `:3000/api/pipeline/status` → 307 `/login` (인증 게이트, stale-build 404 아님).
오염 범위는 `com.nuri-quant.scheduler.plist` 하나 (배포가 그 plist 만 `cp` 하므로).

이 PR 은 재발 방지다. 머지 후 배포하면 치환 경로가 실제로 돌게 된다.