### PR TITLE
fix(deploy): install plist atomically and lock the two-shell expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,696 collected across 298 files | |
+| **Backend tests** | 6,698 collected across 298 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,696 backend tests across 298 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,698 backend tests across 298 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,696 tests, 298 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,698 tests, 298 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -240,7 +240,15 @@ step 6 "scheduler + 상주 python 서비스 재기동"
 # 아무것도 안 남긴다 — 게다가 실행 중인 job 은 캐시된 정의로 계속 돌아서, unload/load
 # 가 도는 **다음 배포**까지 잠복한다 (2026-08-03 실측: scheduler 다운). 다른 설치
 # 경로(Makefile agent-launchd-install / discord-bot-install)는 원래 이 치환을 한다.
-"${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && sed \"s|/Users/USER/|\$HOME/|g\" ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} > ${PLIST_REMOTE}"
+#
+# **temp + mv 로 원자 교체**한다 (#990). `> ${PLIST_REMOTE}` 는 sed 가 돌기 전에 셸이
+# 목적지를 truncate 한다 — sed 가 실패하거나 SSH 가 끊기면 빈/부분 plist 가 남는다.
+# 하필 여기가 unload(5a) 와 load(바로 아래) **사이**라 scheduler 가 내려가 있는 창이고,
+# 깨진 파일이 그대로 load 대상이 된다. #988 로 실제 겪은 실패 모드와 같은 창이다.
+# `&&` 로 묶어 sed 실패 시 mv 가 안 돌고 **기존 plist 가 그대로 남는다** (같은 디렉터리
+# 안 rename 이라 원자적). 이 위험은 #989 가 만든 게 아니다 — 이전 `cp` 도 목적지를
+# truncate 했다.
+"${SSH}" "${REMOTE}" "mkdir -p ${REMOTE_PATH}/data/logs && sed \"s|/Users/USER/|\$HOME/|g\" ${REMOTE_PATH}/scripts/launchd/${PLIST_NAME} > ${PLIST_REMOTE}.tmp && mv ${PLIST_REMOTE}.tmp ${PLIST_REMOTE}"
 "${SSH}" "${REMOTE}" "launchctl load ${PLIST_REMOTE}"
 
 if NEW_PID=$(wait_scheduler alive) && verify_stable_pid "${NEW_PID}"; then

--- a/tests/scripts/test_deploy_plist_placeholder.py
+++ b/tests/scripts/test_deploy_plist_placeholder.py
@@ -19,7 +19,9 @@ launchd 가 캐시한 정의로 계속 살아 있어서**, 배포가 unload/load
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
 
 LAUNCHD_DIR = Path("scripts/launchd")
@@ -57,3 +59,120 @@ def test_deploy_substitutes_placeholder_when_installing_plist():
     for line in install_lines:
         assert PLACEHOLDER in line and "sed" in line, f"plist 를 치환 없이 설치한다 (cp 회귀?): {line.strip()}"
         assert "$HOME/" in line, f"치환 대상이 $HOME 이 아니다: {line.strip()}"
+
+
+# ── 두 셸 경계를 실제로 태우는 테스트 (#990) ────────────────────────────────
+#
+# 위 두 테스트는 스크립트 **본문 텍스트**를 본다. `sed`→`cp` 회귀는 확실히 잡지만
+# (mutation 실측), `$HOME` 이 **어느 셸에서** 확장되는지는 검사하지 못한다 — 로컬에서
+# 확장되게 잘못 이스케이프해도 통과한다. `/codex review` (gpt-5.4, 2026-08-03) 가
+# 지적한 갭이다.
+#
+# 그래서 아래는 grep 이 아니라 **셸을 두 번 실행**한다: 로컬 셸이 원격 명령 문자열을
+# 조립하게 하고(SSH 를 stub 으로 갈아끼워 실행 대신 문자열을 뱉게 한다), 그 문자열을
+# 원격 홈을 흉내낸 두 번째 셸이 실행한다. `tests/test_hook_guard_execution.py` 가
+# 훅을 grep 하지 않고 셸로 실행해 exit code 를 보는 것과 같은 방식이다.
+
+
+def _script_var(name: str) -> str:
+    """스크립트에서 변수 정의 한 줄을 그대로 뽑는다 (테스트가 값을 재선언하지 않도록)."""
+    for line in DEPLOY_SCRIPT.read_text().splitlines():
+        if line.startswith(f"{name}="):
+            return line
+    raise AssertionError(f"{name} 정의를 못 찾음 — 스크립트 구조가 바뀌었다")
+
+
+def _install_line() -> str:
+    for line in DEPLOY_SCRIPT.read_text().splitlines():
+        if "PLIST_REMOTE" in line and "scripts/launchd" in line:
+            return line
+    raise AssertionError("plist 설치 라인을 못 찾음 — 스크립트 구조가 바뀌었다")
+
+
+PLIST_NAME = "com.nuri-quant.scheduler.plist"
+
+
+def _emit_remote_command(tmp_path: Path, repo: Path) -> str:
+    """**로컬** 셸에 설치 라인을 실행시켜, 원격으로 보낼 명령 문자열을 얻는다."""
+    # SSH stub: 원격 명령($2)을 실행하지 않고 stdout 으로 뱉는다.
+    ssh_stub = tmp_path / "ssh_stub.sh"
+    ssh_stub.write_text('#!/bin/sh\nprintf "%s" "$2"\n')
+    ssh_stub.chmod(0o755)
+
+    script = "\n".join(
+        [
+            f'SSH="{ssh_stub}"',
+            "REMOTE=dummy-host",
+            f'REMOTE_PATH="{repo}"',
+            f'PLIST_NAME="{PLIST_NAME}"',
+            _script_var("PLIST_REMOTE"),
+            _install_line(),
+        ]
+    )
+    done = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True)
+    return done.stdout
+
+
+def test_home_expands_on_the_remote_shell_not_the_local_one(tmp_path):
+    """`$HOME` 은 로컬이 아니라 **원격** 셸에서 확장돼야 한다.
+
+    회귀 시나리오: `\\$HOME` 의 이스케이프를 빠뜨리면 로컬 홈이 박힌 plist 가 설치된다.
+    개발 머신과 mini 의 홈이 우연히 같으면 한동안 안 터지고, 달라지는 순간 exit 78.
+    """
+    repo = tmp_path / "repo"
+    (repo / "scripts" / "launchd").mkdir(parents=True)
+    (repo / "scripts" / "launchd" / PLIST_NAME).write_text(
+        f"<string>{PLACEHOLDER}workspace/nuri-quant/.venv/bin/python</string>\n"
+    )
+
+    emitted = _emit_remote_command(tmp_path, repo)
+
+    # 조립 단계에서 확장되면 안 된다 — 원격 셸이 볼 문자열에 리터럴로 남아야 한다.
+    assert "$HOME/Library/LaunchAgents/" in emitted, f"로컬 셸이 $HOME 을 미리 확장했다 (이스케이프 누락?): {emitted}"
+
+    # 2단계: 원격 셸이 실행한다. HOME 을 갈아끼워 로컬과 구분한다.
+    remote_home = tmp_path / "remote_home"
+    (remote_home / "Library" / "LaunchAgents").mkdir(parents=True)
+    subprocess.run(
+        ["bash", "-c", emitted],
+        env={**os.environ, "HOME": str(remote_home)},
+        check=True,
+    )
+
+    installed = remote_home / "Library" / "LaunchAgents" / PLIST_NAME
+    assert installed.exists(), f"원격 홈에 설치되지 않았다: {sorted(tmp_path.rglob('*.plist'))}"
+    body = installed.read_text()
+    assert PLACEHOLDER not in body, f"플레이스홀더가 그대로 남았다: {body}"
+    assert str(remote_home) in body, f"원격 홈으로 치환되지 않았다: {body}"
+
+
+def test_install_leaves_existing_plist_intact_when_source_is_missing(tmp_path):
+    """sed 가 실패하면 **기존 plist 가 그대로** 남아야 한다 (#990).
+
+    회귀 시나리오: temp+mv 를 `> ${PLIST_REMOTE}` 직접 쓰기로 되돌리면, 셸이 sed 실행
+    전에 목적지를 truncate 해 빈 파일이 남는다. 하필 unload 와 load **사이**라
+    launchd 가 그 빈 파일을 읽는다.
+    """
+    repo = tmp_path / "repo"
+    (repo / "scripts" / "launchd").mkdir(parents=True)
+    # 소스 plist 를 **일부러 만들지 않는다** → sed 가 실패한다.
+
+    emitted = _emit_remote_command(tmp_path, repo)
+
+    remote_home = tmp_path / "remote_home"
+    (remote_home / "Library" / "LaunchAgents").mkdir(parents=True)
+    installed = remote_home / "Library" / "LaunchAgents" / PLIST_NAME
+    sentinel = "<string>기존에 잘 돌던 정의</string>\n"
+    installed.write_text(sentinel)
+
+    done = subprocess.run(
+        ["bash", "-c", emitted],
+        env={**os.environ, "HOME": str(remote_home)},
+        capture_output=True,
+        text=True,
+    )
+
+    assert done.returncode != 0, "소스가 없는데 설치가 성공했다고 보고했다"
+    assert installed.read_text() == sentinel, (
+        "설치 실패가 기존 plist 를 파괴했다 — unload/load 창에서 launchd 가 이걸 읽는다"
+    )


### PR DESCRIPTION
Closes #990

`/codex review` (gpt-5.4) 가 #989 에 대해 낸 advisory 2건. P1 은 하나 나왔으나 반증됐다
(#990 본문에 기록 — bash 큰따옴표 안 `\$` 는 이스케이프라 값에 백슬래시가 남지 않고,
mini 에 리터럴 `$HOME` 디렉터리도 없다).

## 1. 목적지를 직접 truncate → temp + `mv` 원자 교체

```diff
-... > ${PLIST_REMOTE}
+... > ${PLIST_REMOTE}.tmp && mv ${PLIST_REMOTE}.tmp ${PLIST_REMOTE}
```

셸이 `sed` 실행 **전에** 목적지를 열고 비운다. sed 가 실패하거나 SSH 가 끊기면 빈/부분
plist 가 남는데, 하필 이 지점이 scheduler unload 와 load **사이**다 — launchd 가 바로
그 파일을 읽는 창이다. #988 로 실제 겪은 실패 모드와 같다.

`&&` 로 묶어 sed 실패 시 mv 가 안 돌고 **기존 plist 가 그대로 남는다**. 같은 디렉터리 안
rename 이라 원자적이다.

이 위험은 #989 가 만든 게 아니다 — 이전 `cp` 도 목적지를 truncate 했다. #988 을 겪은
지금 값어치가 올라간 기존 구멍이다.

## 2. 회귀 테스트가 원격 확장 의미를 잠그지 못함

기존 테스트는 스크립트 **본문 텍스트**를 본다. `sed`→`cp` 회귀는 확실히 잡지만,
`$HOME` 이 **어느 셸에서** 확장되는지는 검사하지 않는다 — 로컬에서 확장되게 잘못
이스케이프해도 통과한다. 개발 머신과 mini 의 홈이 같으면 한동안 안 터지고, 달라지는
순간 exit 78 이다.

새 테스트는 grep 이 아니라 **셸을 두 번 실행**한다:

1. SSH 를 stub 으로 갈아끼워, **로컬** 셸이 조립한 원격 명령 문자열을 그대로 받는다
2. 그 문자열에 `$HOME/Library/LaunchAgents/` 가 **리터럴로** 남아 있는지 확인
3. `HOME` 을 갈아끼운 두 번째 셸이 그 문자열을 실행 → 원격 홈에 치환된 plist 가 놓이는지 확인

`tests/test_hook_guard_execution.py` 가 훅을 grep 하지 않고 셸로 실행해 exit code 를 보는
것과 같은 방식이다 (STRATEGY §5.3.1).

변수 정의(`PLIST_REMOTE=`)와 설치 라인은 테스트가 재선언하지 않고 **스크립트에서 뽑아
쓴다** — 둘이 같이 움직여야 의미가 있어서다.

## Mutation 실측

각 mutation 을 **정확히 한 테스트**가 잡는다:

| Mutation | FAIL 하는 테스트 |
|---|---|
| `\$HOME` → `$HOME` (로컬 확장) | `test_home_expands_on_the_remote_shell_not_the_local_one` |
| temp+mv → 직접 truncate | `test_install_leaves_existing_plist_intact_when_source_is_missing` |

되돌리기 전에는 4 PASS.

## 검증

- `make verify-quick` 6683 passed / 6 skipped
- `make lint` clean, `make lint-sh` clean, `shellcheck` (deploy 스크립트 직접) clean
- `check_privacy_leak.py` (인자 없이, CI 동등) clean
- `make verify-doc-counts` 21/21 — 테스트 수 클레임 6,698 = 실측 6,698 collected

## 배포

이 변경은 배포 경로 자체를 건드리므로, 머지 후 `make deploy-mini` 를 돌려 새 install 라인이
실제로 도는지 확인해야 한다 (#989 와 같은 이유).