### PR TITLE
fix(launchd): harden every install path and drop the bare-cp instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,7 @@ deploy:
 	bash scripts/deploy/pre_deploy_check.sh
 	bash scripts/deploy/deploy_remote.sh
 
-deploy-mini: ## MBP → Mac mini 전체 동기화 (git pull + config + scheduler reload)
+deploy-mini: ## MBP → Mac mini 7단계 동기화 (git pull + config + frontend 재빌드 + scheduler plist 재설치/reload + 상주 서비스 bounce + 검증)
 	bash scripts/deploy/deploy_to_mini.sh
 
 backup:
@@ -602,9 +602,10 @@ agent-launchd-install: ## Install launchd plists (state-replicator + health-chec
 	@USER_NAME=$$(whoami); \
 	  for plist in scripts/launchd/com.nuri-quant.state-replicator.plist scripts/launchd/com.nuri-quant.health-check.plist; do \
 	    NAME=$$(basename "$$plist"); \
-	    sed "s|/Users/USER/|$$HOME/|g" "$$plist" > "$$HOME/Library/LaunchAgents/$$NAME"; \
-	    launchctl unload "$$HOME/Library/LaunchAgents/$$NAME" 2>/dev/null || true; \
-	    launchctl load "$$HOME/Library/LaunchAgents/$$NAME"; \
+	    DST="$$HOME/Library/LaunchAgents/$$NAME"; \
+	    sed "s|/Users/USER/|$$HOME/|g" "$$plist" > "$$DST.tmp" && mv "$$DST.tmp" "$$DST" || { echo "  ❌ install failed: $$NAME (기존 plist 유지)"; exit 1; }; \
+	    launchctl unload "$$DST" 2>/dev/null || true; \
+	    launchctl load "$$DST"; \
 	    echo "  ✅ installed: $$NAME"; \
 	  done
 
@@ -635,9 +636,10 @@ discord-sync-commands: ## Register slash commands to guild (no long-running). Re
 
 discord-bot-install: ## (Mac mini) Install discord-bot launchd plist (long-running gateway).
 	@NAME=com.nuri-quant.discord-bot.plist; \
-	  sed "s|/Users/USER/|$$HOME/|g" "scripts/launchd/$$NAME" > "$$HOME/Library/LaunchAgents/$$NAME"; \
-	  launchctl unload "$$HOME/Library/LaunchAgents/$$NAME" 2>/dev/null || true; \
-	  launchctl load "$$HOME/Library/LaunchAgents/$$NAME"; \
+	  DST="$$HOME/Library/LaunchAgents/$$NAME"; \
+	  sed "s|/Users/USER/|$$HOME/|g" "scripts/launchd/$$NAME" > "$$DST.tmp" && mv "$$DST.tmp" "$$DST" || { echo "  ❌ install failed: $$NAME (기존 plist 유지)"; exit 1; }; \
+	  launchctl unload "$$DST" 2>/dev/null || true; \
+	  launchctl load "$$DST"; \
 	  echo "  ✅ installed: $$NAME — tail data/logs/discord_bot.log"
 
 discord-bot-uninstall: ## (Mac mini) Uninstall discord-bot launchd plist.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,698 collected across 298 files | |
+| **Backend tests** | 6,701 collected across 299 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,698 backend tests across 298 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,701 backend tests across 299 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,698 tests, 298 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,701 tests, 299 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/autopull_receiver.sh
+++ b/scripts/deploy/autopull_receiver.sh
@@ -15,9 +15,16 @@
 # 수동 테스트:
 #   bash scripts/autopull_receiver.sh
 #
-# 설치:
-#   cp scripts/launchd/com.nuri-quant.autopull.plist ~/Library/LaunchAgents/
-#   launchctl load ~/Library/LaunchAgents/com.nuri-quant.autopull.plist
+# 설치 (권장): make crons-install   — 치환 + 원자 교체를 대신 해준다
+#
+# 손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+# 담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988).
+#   N=com.nuri-quant.autopull.plist
+#   sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+#     && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+#     && launchctl load ~/Library/LaunchAgents/$N
+#
+# ⚠️ make deploy-mini 는 이 plist 를 설치하지 않는다 — 상태를 읽기만 한다 (7단계).
 #
 # 상태 확인:
 #   launchctl list | grep autopull

--- a/scripts/launchd/com.nuri-quant.autopull.plist
+++ b/scripts/launchd/com.nuri-quant.autopull.plist
@@ -9,8 +9,16 @@
     변경 감지, 서비스 재시작 hook 등을 처리.
 
   설치 (Mac mini에서 1회):
-    cp scripts/com.nuri-quant.autopull.plist ~/Library/LaunchAgents/
-    launchctl load ~/Library/LaunchAgents/com.nuri-quant.autopull.plist
+    설치 (권장): make crons-install   # 치환 + 원자 교체를 대신 해준다
+
+    손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+    담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988). 게다가
+    stderr 에 아무것도 안 남고, 돌던 job 은 캐시된 정의로 살아남아 다음 재시작까지
+    잠복한다. `&&` 로 묶어 치환 실패가 load 로 이어지지 않게 한다.
+      N=com.nuri-quant.autopull.plist
+      sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+        && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+        && launchctl load ~/Library/LaunchAgents/$N
     # 즉시 검증 (RunAtLoad=true이므로 load 직후 한 번 실행됨)
     sleep 5 && tail -20 ~/Library/Logs/nuri-quant-autopull.log
 

--- a/scripts/launchd/com.nuri-quant.discord-bot.plist
+++ b/scripts/launchd/com.nuri-quant.discord-bot.plist
@@ -12,8 +12,16 @@
     DISCORD_GUILD_ID=...
 
   설치:
-    cp scripts/launchd/com.nuri-quant.discord-bot.plist ~/Library/LaunchAgents/
-    launchctl load ~/Library/LaunchAgents/com.nuri-quant.discord-bot.plist
+    설치 (권장): make crons-install   # 치환 + 원자 교체를 대신 해준다
+
+    손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+    담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988). 게다가
+    stderr 에 아무것도 안 남고, 돌던 job 은 캐시된 정의로 살아남아 다음 재시작까지
+    잠복한다. `&&` 로 묶어 치환 실패가 load 로 이어지지 않게 한다.
+      N=com.nuri-quant.discord-bot.plist
+      sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+        && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+        && launchctl load ~/Library/LaunchAgents/$N
 
   로그:
     tail -f data/logs/discord_bot.log

--- a/scripts/launchd/com.nuri-quant.health-check.plist
+++ b/scripts/launchd/com.nuri-quant.health-check.plist
@@ -13,8 +13,16 @@
   슬래시 명령의 on-demand 실행 경로로 남는다.
 
   설치:
-    cp scripts/launchd/com.nuri-quant.health-check.plist ~/Library/LaunchAgents/
-    launchctl load ~/Library/LaunchAgents/com.nuri-quant.health-check.plist
+    설치 (권장): make crons-install   # 치환 + 원자 교체를 대신 해준다
+
+    손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+    담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988). 게다가
+    stderr 에 아무것도 안 남고, 돌던 job 은 캐시된 정의로 살아남아 다음 재시작까지
+    잠복한다. `&&` 로 묶어 치환 실패가 load 로 이어지지 않게 한다.
+      N=com.nuri-quant.health-check.plist
+      sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+        && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+        && launchctl load ~/Library/LaunchAgents/$N
 
   주의: PROGRAM_PATH 는 사용자 환경에 맞게 수정 필요 (USER 자리).
 -->

--- a/scripts/launchd/com.nuri-quant.scheduler.plist
+++ b/scripts/launchd/com.nuri-quant.scheduler.plist
@@ -4,8 +4,16 @@
   Nuri-Quant 스케줄러 launchd 설정.
 
   설치:
-    cp scripts/com.nuri-quant.scheduler.plist ~/Library/LaunchAgents/
-    launchctl load ~/Library/LaunchAgents/com.nuri-quant.scheduler.plist
+    설치 (권장): make crons-install   # 치환 + 원자 교체를 대신 해준다
+
+    손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+    담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988). 게다가
+    stderr 에 아무것도 안 남고, 돌던 job 은 캐시된 정의로 살아남아 다음 재시작까지
+    잠복한다. `&&` 로 묶어 치환 실패가 load 로 이어지지 않게 한다.
+      N=com.nuri-quant.scheduler.plist
+      sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+        && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+        && launchctl load ~/Library/LaunchAgents/$N
 
   제거:
     launchctl unload ~/Library/LaunchAgents/com.nuri-quant.scheduler.plist

--- a/scripts/launchd/com.nuri-quant.sre-scan.plist
+++ b/scripts/launchd/com.nuri-quant.sre-scan.plist
@@ -12,7 +12,16 @@
   sre-scan 은 runtime incident 추적 (operation-time).
 
   설치:
-    cp scripts/launchd/com.nuri-quant.sre-scan.plist ~/Library/LaunchAgents/
+    설치 (권장): make crons-install   # 치환 + 원자 교체를 대신 해준다
+
+    손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+    담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988). 게다가
+    stderr 에 아무것도 안 남고, 돌던 job 은 캐시된 정의로 살아남아 다음 재시작까지
+    잠복한다. `&&` 로 묶어 치환 실패가 load 로 이어지지 않게 한다.
+      N=com.nuri-quant.sre-scan.plist
+      sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+        && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+        && launchctl load ~/Library/LaunchAgents/$N
     sed -i '' "s|/Users/USER|$HOME|g" ~/Library/LaunchAgents/com.nuri-quant.sre-scan.plist
     launchctl load ~/Library/LaunchAgents/com.nuri-quant.sre-scan.plist
 -->

--- a/scripts/launchd/com.nuri-quant.state-replicator.plist
+++ b/scripts/launchd/com.nuri-quant.state-replicator.plist
@@ -8,8 +8,16 @@
   MBP (REPLICA): replica mode - 받은 snapshot verify (수동 호출 권장)
 
   설치:
-    cp scripts/launchd/com.nuri-quant.state-replicator.plist ~/Library/LaunchAgents/
-    launchctl load ~/Library/LaunchAgents/com.nuri-quant.state-replicator.plist
+    설치 (권장): make crons-install   # 치환 + 원자 교체를 대신 해준다
+
+    손수 할 때. bare cp 금지 — #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를
+    담아서, 그대로 복사하면 launchd 가 exit 78 (EX_CONFIG) 로 죽는다 (#988). 게다가
+    stderr 에 아무것도 안 남고, 돌던 job 은 캐시된 정의로 살아남아 다음 재시작까지
+    잠복한다. `&&` 로 묶어 치환 실패가 load 로 이어지지 않게 한다.
+      N=com.nuri-quant.state-replicator.plist
+      sed "s|/Users/USER/|$HOME/|g" scripts/launchd/$N > ~/Library/LaunchAgents/$N.tmp \
+        && mv ~/Library/LaunchAgents/$N.tmp ~/Library/LaunchAgents/$N \
+        && launchctl load ~/Library/LaunchAgents/$N
 
   제거:
     launchctl unload ~/Library/LaunchAgents/com.nuri-quant.state-replicator.plist

--- a/scripts/launchd/install_crons.sh
+++ b/scripts/launchd/install_crons.sh
@@ -94,8 +94,15 @@ for plist in "${SELECTED[@]}"; do
         launchctl unload "$dst" 2>/dev/null || true
     fi
 
-    cp "$src" "$dst"
-    sed -i '' "s|/Users/USER|$HOME|g" "$dst"
+    # 치환한 결과를 temp 에 쓰고 mv 로 원자 교체한다 (#992). 이전에는 `cp` 로 목적지에
+    # 플레이스홀더를 먼저 깐 뒤 in-place sed 로 고쳤는데, 그 사이(그리고 sed 가 실패하면
+    # 영구히) 목적지가 `/Users/USER` 를 담는다. 바로 위에서 unload 를 이미 했으므로 그
+    # 상태로 load 하면 launchd 가 exit 78 로 죽는다 — #988 로 실제 겪은 고장이다.
+    if ! sed "s|/Users/USER|$HOME|g" "$src" > "$dst.tmp" || ! mv "$dst.tmp" "$dst"; then
+        rm -f "$dst.tmp"
+        echo " ❌ 치환 실패: $plist (기존 plist 유지, load 하지 않음)"
+        continue
+    fi
     launchctl load "$dst"
     echo " ✅ installed: $plist"
 done

--- a/tests/scripts/test_launchd_install_paths.py
+++ b/tests/scripts/test_launchd_install_paths.py
@@ -1,0 +1,109 @@
+"""모든 launchd 설치 경로가 치환·원자 교체를 하는지, 그리고 레포가 bare-cp 설치를
+지시하지 않는지 잠근다 (#992).
+
+Gotcha-Test Pair:
+#989/#990 이 배포 경로 하나를 고쳤다. 그런데 `/codex review` (gpt-5.4, 2026-08-03) 가
+같은 클래스가 레포에 그대로 남아 있는 걸 찾았다 — 설치 경로 3곳이 최종 경로에 직접 쓰고
+있었고(`Makefile` 2곳 + `install_crons.sh`), 추적 파일 8곳이 아직 bare `cp` 로 설치하라고
+**지시**하고 있었다. 그중 2곳은 경로까지 틀렸다.
+
+지시가 위험한 이유: #980 이후 repo plist 는 `/Users/USER/` 플레이스홀더를 담는다. 그대로
+복사하면 launchd 가 exit 78(EX_CONFIG)로 죽고 stderr 에 **아무것도 안 남긴다**. 게다가
+돌고 있던 job 은 launchd 가 캐시한 정의로 살아남아 다음 재시작까지 잠복한다. 사람이든
+에이전트든 파일 안에 적힌 설치 명령을 그대로 따르므로, 문서가 곧 사고 경로다.
+
+`tests/scripts/test_deploy_plist_placeholder.py` 는 **배포 경로만** 본다. 이 파일은
+나머지 전부를 본다 — 인스턴스가 아니라 클래스를 잠그는 게 목적이다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+LAUNCHD_DIR = Path("scripts/launchd")
+MAKEFILE = Path("Makefile")
+INSTALL_CRONS = LAUNCHD_DIR / "install_crons.sh"
+
+PLACEHOLDER_SED = "/Users/USER"
+
+# 레포에서 설치 지시가 실릴 수 있는 파일들 (주석·문서 포함)
+_INSTRUCTION_FILES = [
+    *sorted(LAUNCHD_DIR.glob("*.plist")),
+    *sorted(Path("scripts").rglob("*.sh")),
+    MAKEFILE,
+]
+
+# `cp <무언가> ~/Library/LaunchAgents/...` — 치환 없이 복사하라는 지시
+_BARE_CP = re.compile(r"cp\s+\S*\.plist\s+.*Library/LaunchAgents")
+
+
+def test_no_tracked_file_instructs_a_bare_cp_install():
+    """레포 어디에도 bare `cp` 로 plist 를 설치하라는 지시가 없어야 한다.
+
+    회귀 시나리오: 누가 편의로 `cp ... ~/Library/LaunchAgents/` 를 주석에 되살리면,
+    그걸 따른 사람이 프로덕션 scheduler 를 exit 78 로 죽인다 (#988).
+    """
+    offenders = []
+    for path in _INSTRUCTION_FILES:
+        if not path.exists():
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if _BARE_CP.search(line):
+                offenders.append(f"{path}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "bare cp 설치 지시가 남아 있다 — 그대로 따르면 /Users/USER 플레이스홀더가 설치돼 "
+        "launchd exit 78:\n" + "\n".join(offenders)
+    )
+
+
+def test_plist_install_instructions_reference_the_launchd_dir():
+    """plist 헤더의 설치 예시가 실제 경로(`scripts/launchd/`)를 가리켜야 한다.
+
+    `scheduler` / `autopull` 두 헤더는 `scripts/<name>.plist` 라는 **없는 경로**를 적고
+    있었다. 따라 하면 sed/cp 가 실패하고, 실패를 무시하면 다음 단계가 더 나쁘게 굴러간다.
+    """
+    offenders = []
+    for path in sorted(LAUNCHD_DIR.glob("*.plist")):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            for ref in re.findall(r"scripts/\S*\.plist", line):
+                if not ref.startswith("scripts/launchd/"):
+                    offenders.append(f"{path}:{lineno}: {ref}")
+    assert not offenders, f"plist 설치 예시가 없는 경로를 가리킨다: {offenders}"
+
+
+# 플레이스홀더를 치환하면서 **어딘가로 쓰는** 라인 (`sed "s|/Users/USER..." ... > dest`)
+_SUBSTITUTING_WRITE = re.compile(r"s\|/Users/USER.*?>\s*(?P<dest>\S+)")
+
+
+def _substituting_writes(path: Path) -> list[tuple[str, str]]:
+    out = []
+    for line in path.read_text().splitlines():
+        m = _SUBSTITUTING_WRITE.search(line)
+        if m:
+            out.append((m.group("dest"), line))
+    return out
+
+
+def test_every_install_path_substitutes_and_swaps_atomically():
+    """설치 경로는 전부 치환 결과를 temp 에 쓰고 `mv` 로 교체해야 한다.
+
+    회귀 시나리오: 최종 경로에 직접 쓰면 셸이 sed 전에 목적지를 truncate 한다. 세 경로 다
+    `launchctl unload` 뒤에 실행되므로, 실패하면 깨진(또는 빈) plist 를 load 하게 된다.
+
+    배포 경로(`deploy_to_mini.sh`)는 `test_deploy_plist_placeholder.py` 가 셸을 실제로
+    태워서 잠근다. 여기서는 나머지 경로를 텍스트로 잠근다 — 셸 실행이 launchctl 을
+    건드리게 되어 테스트에서 돌릴 수 없기 때문이다.
+    """
+    checked = 0
+    for path in (MAKEFILE, INSTALL_CRONS):
+        assert path.exists(), f"{path} 가 없다 — 구조가 바뀌었다"
+        for dest, line in _substituting_writes(path):
+            checked += 1
+            assert ".tmp" in dest, f"치환 결과를 최종 경로에 직접 쓴다 (truncate 위험): {path}: {line.strip()}"
+            # 같은 라인이나 바로 뒤에서 mv 로 되돌려놔야 한다
+            assert "mv " in line or "mv " in path.read_text(), f"{path} 에 temp → 최종 경로 원자 교체(mv)가 없다"
+    assert checked >= 3, (
+        f"치환 쓰기 라인이 {checked}개뿐 — Makefile 2곳 + install_crons.sh 를 못 찾았다. "
+        "설치 경로가 사라졌거나 이 테스트의 패턴이 낡았다"
+    )


### PR DESCRIPTION
Closes #992

`/codex review` (gpt-5.4) 가 #989/#991 세션을 검증하다 찾은 P2 2건. #990 은 **배포 경로
하나만** 고쳤고, 같은 클래스가 레포에 그대로 살아 있었다 — 인스턴스를 고치고 클래스를
안 고친 전형이다.

## 1. 설치 경로 3곳이 최종 경로에 직접 썼다

| 위치 | 문제 |
|---|---|
| `Makefile` `agent-launchd-install` | `sed ... > $DST` — sed 전에 목적지 truncate |
| `Makefile` `discord-bot-install` | 동일 |
| `scripts/launchd/install_crons.sh` | **더 나빴다** — `cp` 로 목적지에 플레이스홀더를 먼저 깔고 in-place `sed`. 실패하면 `/Users/USER` 가 그대로 설치돼 남는다 |

셋 다 `launchctl unload` **뒤에** 돈다. 실패하면 깨진/빈 plist 를 load 하게 된다 — #988 의 창.

전부 치환 결과를 temp 에 쓰고 `mv` 로 교체하도록 바꿨고, 실패 시 **load 하지 않고 기존
plist 를 유지**하며 실패를 보고한다.

격리 실행으로 동작 확인:
- 성공: 플레이스홀더 잔존 0, 치환 6곳, `.tmp` 잔여물 없음
- 실패(소스 없음): 기존 파일 `<PRESERVE-ME/>` 보존, `.tmp` 정리됨, rc≠0

## 2. 추적 파일 8곳이 bare-`cp` 설치를 지시했다

plist 헤더 6개 + `autopull_receiver.sh`. #980 이후 그 지시를 따르면 `/Users/USER`
플레이스홀더가 설치돼 **launchd exit 78** 이다 — 이번 세션에 실제로 터진 그 고장.
문서가 곧 사고 경로다.

그중 `scheduler` / `autopull` 2개는 **경로까지 틀렸다** (`scripts/` ← `scripts/launchd/`).

이제 `make crons-install` 을 먼저 안내하고, 손수 할 때의 치환 명령을 `&&` 체인으로 보여준다.
XML 주석이라 `--` 를 못 쓰는 점을 지켜 `plutil -lint` 9개 전부 OK.

## 3. `make help` 의 deploy-mini 설명 갱신

"git pull + config + scheduler reload" → 실제 7단계(frontend 재빌드 + 상주 서비스 bounce 포함).

## Gotcha-Test Pair — 인스턴스가 아니라 클래스를 잠근다

`tests/scripts/test_launchd_install_paths.py` 신규. 기존
`test_deploy_plist_placeholder.py` 는 배포 경로만 봐서 이걸 놓쳤다.

Mutation 실측 — 각 mutation 을 **정확히 한 테스트**가 잡는다:

| Mutation | FAIL 하는 테스트 |
|---|---|
| plist 주석에 bare cp 부활 | `test_no_tracked_file_instructs_a_bare_cp_install` |
| 설치 예시를 `scripts/` 로 되돌림 | `test_plist_install_instructions_reference_the_launchd_dir` |
| Makefile 을 직접 쓰기로 되돌림 | `test_every_install_path_substitutes_and_swaps_atomically` |

되돌리기 전에는 3 PASS.

## 검증

- `make verify-quick` 6686 passed / 6 skipped · `tests/scripts/` 303 passed
- `make lint` clean · `make lint-sh` clean · `shellcheck` (변경 스크립트 직접) clean
- `bash -n` + `make -n` 파싱 OK · `install_crons.sh --dry` 9 plist 정상
- `plutil -lint` 9/9 OK
- `check_privacy_leak.py` (인자 없이, CI 동등) clean
- `make verify-doc-counts` 21/21

## 배포

이 PR 은 배포 경로(`deploy_to_mini.sh`)를 건드리지 않는다 — 이미 #991 에서 고쳤고 라이브
검증까지 끝났다. 여기서 바뀐 건 **다른** 설치 경로와 지시문이라, 배포 후 `make crons-install`
을 쓸 때 효과가 난다.