### PR TITLE
fix(rules): resolve account strategy by label, not just id

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,701 collected across 299 files | |
+| **Backend tests** | 6,709 collected across 300 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,701 backend tests across 299 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,709 backend tests across 300 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,701 tests, 299 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,709 tests, 300 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -169,7 +169,13 @@ def _build_actions() -> dict:
             stop_loss_threshold = get_stop_loss_for_account(holding.get("account"))
             if pnl_pct < stop_loss_threshold:
                 # stop-loss breach — 기계적 실행 (§2.2). catalyst 무관.
-                item["reasons"].append(f"손실 {pnl_pct:+.1f}% — 손절선 근접 ({stop_loss_threshold}%)")
+                # "근접" 이 아니라 **돌파**다 (#994). 이 분기 자체가 `pnl_pct <
+                # threshold` — 관찰이 아니라 기계적 청산 신호이고, 초과폭을 같이
+                # 적어야 사용자가 -7% 근처인지 35%p 초과인지 구분한다.
+                over = stop_loss_threshold - pnl_pct  # 임계 대비 초과폭 (%p)
+                item["reasons"].append(
+                    f"손실 {pnl_pct:+.1f}% — 손절선 {stop_loss_threshold}% 돌파 ({over:.1f}%p 초과)",
+                )
                 item["priority"] = "urgent"
                 urgent.append(item)
                 continue

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -114,18 +114,52 @@ _DEFAULT_STRATEGY = ACCOUNT_STRATEGIES.get(
 )
 
 
-def get_account_strategy(account: str) -> dict:
-    """계좌명 → 전략 프로파일 반환. portfolio.yaml의 strategy 필드 기준."""
+PORTFOLIO_PATH = Path(__file__).parent.parent.parent / "config" / "portfolio.yaml"
+
+
+def _resolve_account_key(accounts: dict, account: str | None) -> str | None:
+    """계좌 **id · label · name** 중 무엇이 와도 yaml 의 계좌 키로 정규화한다 (#994).
+
+    yaml 은 id 로 키잉하는데(`toss`), DB/API 는 label 을 들고 다닌다(`Toss`). 매칭
+    실패가 예외가 아니라 조용한 폴백(`core`, stop_loss -7)이라 **전 계좌가 -7 로
+    평가**됐고, `actions.py` 의 "하드코딩 -7 제거" 주석과 정반대로 동작했다.
+    2026-08-03 실측: Toss(long_term, -20) 보유가 -19.6% 에서 urgent SELL 로 떴다.
+    """
+    if not account:
+        return None
+    if account in accounts:
+        return account
+    needle = str(account).strip().casefold()
+    for key, info in accounts.items():
+        if not isinstance(info, dict):
+            continue
+        for cand in (key, info.get("label"), info.get("name")):
+            if cand and str(cand).strip().casefold() == needle:
+                return key
+    return None
+
+
+def _load_accounts() -> dict:
     import yaml
 
-    _portfolio_path = Path(__file__).parent.parent.parent / "config" / "portfolio.yaml"
     try:
-        with open(_portfolio_path, encoding="utf-8") as f:
-            portfolio = yaml.safe_load(f)
-        strategy_name = portfolio.get("accounts", {}).get(account, {}).get("strategy", "core")
-        return ACCOUNT_STRATEGIES.get(strategy_name, _DEFAULT_STRATEGY)
+        with open(PORTFOLIO_PATH, encoding="utf-8") as f:
+            return (yaml.safe_load(f) or {}).get("accounts", {}) or {}
     except Exception:
+        return {}
+
+
+def get_account_strategy(account: str) -> dict:
+    """계좌명 → 전략 프로파일 반환. portfolio.yaml의 strategy 필드 기준.
+
+    id 뿐 아니라 label / name 으로도 조회된다 (#994).
+    """
+    accounts = _load_accounts()
+    key = _resolve_account_key(accounts, account)
+    if key is None:
         return _DEFAULT_STRATEGY
+    strategy_name = (accounts.get(key) or {}).get("strategy") or "core"
+    return ACCOUNT_STRATEGIES.get(strategy_name, _DEFAULT_STRATEGY)
 
 
 def get_account_strategy_name(account: str | None) -> str:
@@ -134,18 +168,17 @@ def get_account_strategy_name(account: str | None) -> str:
     `get_account_strategy()` 는 rules dict(stop_loss/max_position/...)만 반환해
     이름이 소실된다 — pension 판별(daily action 제외)엔 이름이 authoritative 하므로
     yaml 의 strategy 필드를 직접 노출.
+
+    `get_account_strategy()` 와 동일하게 id / label / name 을 모두 받는다 (#994).
+    label 로 조회하면 'core' 가 나오던 탓에, 연금 제외가 label 경로에서 무력했다.
     """
     if not account:
         return "core"
-    import yaml
-
-    _portfolio_path = Path(__file__).parent.parent.parent / "config" / "portfolio.yaml"
-    try:
-        with open(_portfolio_path, encoding="utf-8") as f:
-            portfolio = yaml.safe_load(f) or {}
-        return portfolio.get("accounts", {}).get(account, {}).get("strategy", "core")
-    except Exception:
+    accounts = _load_accounts()
+    key = _resolve_account_key(accounts, account)
+    if key is None:
         return "core"
+    return (accounts.get(key) or {}).get("strategy") or "core"
 
 
 _REAL_ACCOUNT_KEYS = ("broker", "name", "label", "strategy", "balance")

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -900,7 +900,11 @@ class TestBuildActionsLogic:
             portfolio={"BAD": self._pf(90, 100, -10, 5)},
         )
         assert len(result["urgent"]) == 1
-        assert "손절선 근접" in result["urgent"][0]["reasons"][1]
+        assert "손절선" in result["urgent"][0]["reasons"][1]
+        # "근접" 이 아니라 "돌파" 여야 한다 (#994) — 이 분기는 관찰이 아니라
+        # 기계적 청산이고, 문구가 행동을 바꾼다 (처분효과).
+        assert "돌파" in result["urgent"][0]["reasons"][1]
+        assert "근접" not in result["urgent"][0]["reasons"][1]
 
     def test_a3_long_term_account_minus_10_not_urgent(self):
         """A-3: long_term 계좌(-20) 의 -10% 손실은 urgent 아님.
@@ -925,7 +929,11 @@ class TestBuildActionsLogic:
                 portfolio={"LTMX": self._pf(78, 100, -22, 5)},
             )
         assert len(result["urgent"]) == 1
-        assert "손절선 근접" in result["urgent"][0]["reasons"][1]
+        assert "손절선" in result["urgent"][0]["reasons"][1]
+        # "근접" 이 아니라 "돌파" 여야 한다 (#994) — 이 분기는 관찰이 아니라
+        # 기계적 청산이고, 문구가 행동을 바꾼다 (처분효과).
+        assert "돌파" in result["urgent"][0]["reasons"][1]
+        assert "근접" not in result["urgent"][0]["reasons"][1]
         assert "-20%" in result["urgent"][0]["reasons"][1]
 
     def test_a3_core_account_minus_10_still_urgent(self):
@@ -936,7 +944,11 @@ class TestBuildActionsLogic:
                 portfolio={"BAD": self._pf(90, 100, -10, 5)},
             )
         assert len(result["urgent"]) == 1
-        assert "손절선 근접" in result["urgent"][0]["reasons"][1]
+        assert "손절선" in result["urgent"][0]["reasons"][1]
+        # "근접" 이 아니라 "돌파" 여야 한다 (#994) — 이 분기는 관찰이 아니라
+        # 기계적 청산이고, 문구가 행동을 바꾼다 (처분효과).
+        assert "돌파" in result["urgent"][0]["reasons"][1]
+        assert "근접" not in result["urgent"][0]["reasons"][1]
 
     def test_a3_boundary_equality_not_urgent(self):
         """A-3 operator consistency: pnl == threshold 는 urgent 아님 (< 통일,
@@ -1045,7 +1057,11 @@ class TestBuildActionsLogic:
 
             result = _build_actions()
         assert len(result["urgent"]) == 1
-        assert "손절선 근접" in result["urgent"][0]["reasons"][1]
+        assert "손절선" in result["urgent"][0]["reasons"][1]
+        # "근접" 이 아니라 "돌파" 여야 한다 (#994) — 이 분기는 관찰이 아니라
+        # 기계적 청산이고, 문구가 행동을 바꾼다 (처분효과).
+        assert "돌파" in result["urgent"][0]["reasons"][1]
+        assert "근접" not in result["urgent"][0]["reasons"][1]
         # catalyst 함수 호출 자체가 없어야 함 (breach path 가 먼저 continue)
         mock_cat.assert_not_called()
 

--- a/tests/core/test_account_strategy_lookup.py
+++ b/tests/core/test_account_strategy_lookup.py
@@ -92,6 +92,36 @@ def test_pension_is_identifiable_by_label(portfolio_yaml):
     assert rules.get_account_strategy_name("retirement") == "pension"
 
 
+def test_empty_account_falls_back_without_touching_yaml(portfolio_yaml):
+    """계좌명이 비면 조회 자체를 하지 않는다 — `_resolve_account_key` 의 early return."""
+    assert rules.get_account_strategy("") == rules._DEFAULT_STRATEGY
+    assert rules.get_account_strategy(None) == rules._DEFAULT_STRATEGY
+
+
+def test_malformed_account_entry_is_skipped_not_crashed(tmp_path, monkeypatch):
+    """yaml 의 계좌 엔트리가 dict 가 아니어도 죽지 않고 건너뛴다.
+
+    portfolio.yaml 은 손으로 편집하는 파일이라 `account:` 뒤가 비어 null 이 되는 실수가
+    난다. 그 한 줄이 손절 조회 전체를 죽이면 안 된다.
+    """
+    path = tmp_path / "portfolio.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            accounts:
+              broken:
+              brokerage_beta:
+                label: Beta Long
+                strategy: long_term
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(rules, "PORTFOLIO_PATH", path)
+    assert rules.get_account_strategy_name("Beta Long") == "long_term"
+    assert rules.get_account_strategy_name("broken") == "core"
+
+
 def test_unknown_account_falls_back_to_core(portfolio_yaml):
     assert rules.get_account_strategy_name("Nonexistent") == "core"
     assert rules.get_stop_loss_for_account("Nonexistent") == rules.ACCOUNT_STRATEGIES["core"]["stop_loss"]

--- a/tests/core/test_account_strategy_lookup.py
+++ b/tests/core/test_account_strategy_lookup.py
@@ -1,0 +1,98 @@
+"""계좌 전략 조회가 id·label·name 을 모두 받는지 잠근다 (#994).
+
+Gotcha-Test Pair:
+`portfolio.yaml` 은 계좌를 **id** 로 키잉하고(`toss`), DB/API 는 **label** 을 들고
+다닌다(`Toss`). 조회가 id 만 보던 탓에 label 로 물으면 매칭에 실패했고, 실패가 예외가
+아니라 조용한 폴백(`core`, stop_loss -7)이라 **전 계좌가 -7 로 평가**됐다.
+
+2026-08-03 실측: Toss(long_term, 손절 -20%) 보유가 **-19.6% 에서 urgent SELL** 로 떴다.
+돌파가 아닌데 기계적 청산 신호가 나간 것이다. `actions.py` 의 "A-3: 하드코딩 -7 제거"
+주석은 그 시점에 이미 거짓이었다 — 코드는 계좌를 물어보는 모양만 갖췄고 값은 늘 -7 이었다.
+
+영향 3 call site: `api/routes/actions.py`(대시보드) · `alerts/risk_signals.py`(Discord
+Tier-1 손절) · `trading/agents/risk_agent.py`(consensus).
+
+같은 폴백이 `get_account_strategy_name()` 에도 있었다. 이건 **연금 제외 판정**에 쓰이므로,
+label 로 조회되는 경로에서는 연금이 일일 액션에서 안 빠졌다.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from nuri.core import rules
+
+
+@pytest.fixture
+def portfolio_yaml(tmp_path, monkeypatch):
+    """실제 사용자 portfolio.yaml 대신 픽스처를 쓴다 (public repo — privacy)."""
+    path = tmp_path / "portfolio.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            accounts:
+              brokerage_alpha:
+                name: Brokerage Alpha 기본계좌
+                label: Alpha Main
+                strategy: core
+              brokerage_beta:
+                name: Brokerage Beta 장기계좌
+                label: Beta Long
+                strategy: long_term
+              retirement:
+                name: 퇴직연금
+                label: 연금
+                strategy: pension
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(rules, "PORTFOLIO_PATH", path)
+    return path
+
+
+@pytest.mark.parametrize(
+    ("lookup", "expected_strategy"),
+    [
+        ("brokerage_beta", "long_term"),  # id
+        ("Beta Long", "long_term"),  # label — 회귀 축
+        ("Brokerage Beta 장기계좌", "long_term"),  # name
+        ("beta long", "long_term"),  # 대소문자 무시
+        ("  Beta Long  ", "long_term"),  # 공백 무시
+    ],
+)
+def test_strategy_name_resolves_by_id_label_and_name(portfolio_yaml, lookup, expected_strategy):
+    assert rules.get_account_strategy_name(lookup) == expected_strategy
+
+
+def test_stop_loss_follows_the_account_profile_not_the_global_default(portfolio_yaml):
+    """label 로 물어도 config 의 계좌 프로파일 값이 나와야 한다.
+
+    회귀 시나리오: id-only 조회로 되돌리면 전부 global -7 이 되고, -19.6% 보유가
+    -20% 프로파일에서 '돌파' 로 오판돼 urgent SELL 로 나간다.
+    """
+    long_term = rules.ACCOUNT_STRATEGIES["long_term"]["stop_loss"]
+    core = rules.ACCOUNT_STRATEGIES["core"]["stop_loss"]
+    assert long_term != core, "픽스처 전제 붕괴 — 두 프로파일이 같으면 이 테스트는 무의미"
+
+    assert rules.get_stop_loss_for_account("Beta Long") == long_term
+    assert rules.get_stop_loss_for_account("Alpha Main") == core
+
+    # 그리고 그 차이가 판정을 바꾼다 (이게 사고의 본질)
+    pnl = -19.6
+    assert pnl > long_term, "long_term 프로파일에선 돌파가 아니다"
+    assert pnl < core, "core 프로파일에선 돌파다 — 잘못 조회하면 여기로 떨어진다"
+
+
+def test_pension_is_identifiable_by_label(portfolio_yaml):
+    """연금 제외 판정이 label 경로에서도 서야 한다."""
+    assert rules.get_account_strategy_name("연금") == "pension"
+    assert rules.get_account_strategy_name("retirement") == "pension"
+
+
+def test_unknown_account_falls_back_to_core(portfolio_yaml):
+    assert rules.get_account_strategy_name("Nonexistent") == "core"
+    assert rules.get_stop_loss_for_account("Nonexistent") == rules.ACCOUNT_STRATEGIES["core"]["stop_loss"]
+    assert rules.get_stop_loss_for_account(None) == int(rules.STOCK_STOP_LOSS)


### PR DESCRIPTION
Closes #994

대시보드 "오늘의 액션"을 실측하다 발견. **화면에 틀린 매도 지시가 떠 있었다.**

## 근본 원인

`nuri/core/rules.py` 의 두 함수가 `portfolio.yaml` 을 **계좌 id** 로 키잉하는데, DB/API 는
**label** 을 들고 다닌다. 매칭 실패가 예외가 아니라 조용한 폴백이라 **전 계좌가 core
프로파일(-7%)** 로 평가됐다.

```
yaml:  toss -> label 'Toss' / long_term       kakaopay -> label 'Kakao Main' / core
실측 (label 로 조회, 수정 전):
  Toss / Kakao Main / Kakao Sub / Pension  ->  전부 strategy='core', stop_loss=-7
```

`actions.py:167` 주석은 `A-3: 하드코딩 -7 제거` 라고 적혀 있었다. 정확히 그 -7 이 한 층
아래에서 되살아나 있었다 — §5 phantom fix.

## 실측 효과 (로컬 API, 수정 전 → 후)

`urgent 7건 → 6건`.

| 종목 | 계좌 | PnL | before | after |
|---|---|---|---|---|
| SK스퀘어 | Toss (long_term −20) | −19.6% | 🔴 urgent `손절선 근접 (-7%)` | 🟡 check — **돌파 아님** |
| 현대차 | Toss | −41.9% | `손절선 근접 (-7%)` | `손절선 -20% 돌파 (21.9%p 초과)` |
| DRAM | Kakao Main (core −7) | −19.5% | `근접 (-7%)` | `손절선 -7% 돌파 (12.5%p 초과)` |

## 왜 기존 테스트가 못 잡았나

`tests/api/test_actions.py` 의 A-3 테스트들이 **깨진 함수 자체를 patch** 한다:

```python
with patch("nuri.api.routes.actions.get_stop_loss_for_account", return_value=-20):
```

그래서 "`actions.py` 가 resolver 반환값을 그대로 쓴다"만 증명했고, resolver 가 실계좌
label 에 대해 옳은 값을 주는지는 한 번도 확인하지 않았다. docstring 은
`Regression lock: threshold 가 하드코딩으로 돌아가면 fail` 이라 적혀 있었지만, 하드코딩은
한 층 아래에 있었다.

새 테스트 `tests/core/test_account_strategy_lookup.py` 는 patch 없이 **yaml 픽스처**로
resolver 를 직접 태운다.

## 영향 범위 (3 call site)

- `api/routes/actions.py` — 대시보드
- `alerts/risk_signals.py` — Discord #brief Tier-1 손절 신호
- `trading/agents/risk_agent.py` — consensus risk agent

`get_account_strategy_name()` 에도 같은 폴백이 있었다. 이건 **연금 제외 판정**에 쓰이므로
label 로 조회되는 경로에서 연금이 일일 액션에서 안 빠졌다.

## 부수 수정 — `근접` → `돌파`

이 분기는 `if pnl_pct < threshold` 로만 진입한다. 같은 함수 주석도
`stop-loss breach — 기계적 실행` 이라 적혀 있다. −41.9% 는 −7% 에 "근접"이 아니라 35%p
초과다. 관찰과 기계적 청산은 행동이 다르고, 처분효과를 유발하는 문구다. 초과폭(%p)을
같이 적어 −7% 근처인지 한참 지났는지 구분되게 했다.

## 검증

- Mutation: label/name 매칭 제거 → 새 테스트 **6 FAIL** (복원 시 8 PASS)
- 전체 스위트 `6679 passed / 6 skipped` (`-m "not slow"`)
- `tests/api/test_actions.py` 98 passed — 문구 assertion 4곳 갱신 (`근접` 부재까지 assert)
- `make lint` clean · `check_privacy_leak.py` clean · `verify-doc-counts` 21/21
- 라이브 API 재기동 후 버킷 이동 실측 (위 표)