### PR TITLE
fix(privacy): ignore portfolio.yaml derivatives, not just the exact path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,14 @@ config/toss/*
 **/.tokens/
 
 # Personal portfolio (보유 종목 정보)
-config/portfolio.yaml
+# 접두사 glob 로 **파생 파일까지** 막는다. `config/portfolio.yaml` 만 적혀 있던 탓에
+# `portfolio.yaml.bak-20260803_163959` (편집 전 백업) 가 무시되지 않아 `git status` 에
+# untracked 로 떴다 — `git add -A` 한 번이면 실보유 종목·수량·평단이 public repo 로
+# 들어간다. `*.bak` 은 이미 아래에서 막히지만 `*.bak-<timestamp>` 는 그 패턴에 안 걸린다.
+# (2026-08-03 실측. 커밋된 적은 없어 히스토리는 깨끗했다.)
+# `portfolio.example.yaml` 은 접두사가 달라 영향 없고, 혹시 몰라 아래에서 명시적으로 되살린다.
+config/portfolio*
+!config/portfolio.example.yaml
 
 # Backlog + 개인 plan 노트 (broker names + ticker+PnL + 실현 손실 노출 — STRATEGY §4.4.1)
 docs/TODO.md

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,709 collected across 300 files | |
+| **Backend tests** | 6,729 collected across 301 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,709 backend tests across 300 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,729 backend tests across 301 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,709 tests, 300 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,729 tests, 301 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/test_gitignore_covers_private_derivatives.py
+++ b/tests/test_gitignore_covers_private_derivatives.py
@@ -1,0 +1,68 @@
+"""민감 파일의 **파생 이름**까지 gitignore 가 막는지 잠근다 (#996).
+
+Gotcha-Test Pair:
+`.gitignore` 는 `config/portfolio.yaml` 을 **정확 경로**로만 막고 있었다. 그래서 편집 전
+백업으로 만든 `config/portfolio.yaml.bak-20260803_163959` 가 무시되지 않고 `git status` 에
+untracked 로 떴다 — `git add -A` 한 번이면 실보유 종목·수량·평단이 public repo 로 들어간다.
+(2026-08-03 실측. 다행히 커밋된 적은 없어 히스토리는 깨끗했다.)
+
+왜 놓쳤나: `*.bak` 과 `*.orig` 는 이미 막혀 있었다. 사람이 흔히 붙이는
+`*.bak-<timestamp>` 만 그 패턴에 안 걸린다 — "백업은 막혀 있다" 는 인상은 맞았고
+**한 칸 옆이 뚫려** 있었다. 도구(그리고 에이전트)가 타임스탬프 백업을 만드는 게 관례라
+이 틈은 반복해서 밟힌다.
+
+privacy 스캐너(`scripts/verify/check_privacy_leak.py`)는 **diff** 를 본다. untracked 파일은
+diff 에 없으므로 이 계열을 못 잡는다 — 방어선이 gitignore 하나뿐이라 여기서 잠근다.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+# 사람이/도구가 실제로 만드는 파생 이름들. 전부 무시돼야 한다.
+MUST_BE_IGNORED = [
+    # 보유 종목 — 종목·수량·평단
+    "config/portfolio.yaml",
+    "config/portfolio.yaml.bak",
+    "config/portfolio.yaml.bak-20260803_163959",  # 실제로 발생한 이름
+    "config/portfolio.yaml.orig",
+    "config/portfolio.yaml.save",
+    "config/portfolio.yaml.tmp",
+    "config/portfolio_backup.yaml",
+    # 크리덴셜
+    ".env",
+    ".env.bak-20260803_155436",
+    ".env.save",
+    # 개인 상태 / 내부 운영 문서
+    "NEXT_SESSION.md",
+    "NEXT_SESSION.md.bak",
+    "docs/OPERATIONS.md",
+    "docs/OPERATIONS.md.bak",
+]
+
+# 반대로 **추적돼야** 하는 것 — 과잉 차단 회귀 방지
+MUST_NOT_BE_IGNORED = [
+    "config/portfolio.example.yaml",
+    "config/rules.yaml",
+    "config/agents.yaml",
+    "config/signals.yaml",
+]
+
+
+def _is_ignored(path: str) -> bool:
+    """`git check-ignore` 로 판정 — 파일이 실재하지 않아도 패턴 판정은 된다."""
+    return subprocess.run(["git", "check-ignore", "-q", path], check=False).returncode == 0
+
+
+@pytest.mark.parametrize("path", MUST_BE_IGNORED)
+def test_private_file_and_its_derivatives_are_ignored(path):
+    """회귀 시나리오: 접두사 glob 을 정확 경로로 되돌리면 백업 파일이 커밋 가능해진다."""
+    assert _is_ignored(path), f"{path} 가 gitignore 에 안 걸린다 — git add -A 한 번이면 public repo 로 나간다"
+
+
+@pytest.mark.parametrize("path", MUST_NOT_BE_IGNORED)
+def test_shared_config_stays_trackable(path):
+    """차단 범위를 넓히다 공유돼야 할 파일까지 삼키면 안 된다."""
+    assert not _is_ignored(path), f"{path} 는 추적돼야 하는데 gitignore 가 삼켰다"


### PR DESCRIPTION
Closes #996

사용자가 cSpell 경고로 발견. **공개 레포에 실보유 정보가 커밋 가능한 상태로 놓여 있었다.**

## 무엇이 뚫려 있었나

```
config/portfolio.yaml          ← 정확 경로만
```

편집 전 백업 `config/portfolio.yaml.bak-20260803_163959` 가 무시되지 않아 `git status` 에
`??` 로 떴다. `git add -A` 한 번이면 **종목·수량·평단**이 public repo 로 들어간다.

```
✓ ignored   config/portfolio.yaml.bak       ← *.bak 은 막혀 있었다
✓ ignored   config/portfolio.yaml.orig
✗ EXPOSED   config/portfolio.yaml.bak-20260803    ← 사람·도구가 실제로 만드는 이름
✗ EXPOSED   config/portfolio.yaml.save
✗ EXPOSED   config/portfolio_backup.yaml
```

"백업은 막혀 있다"는 인상은 맞았고 **한 칸 옆이** 뚫려 있었다.

## 노출 범위 (실측)

- `git log --all -- 'config/portfolio.yaml*'` → **결과 없음. 커밋된 적 없어 히스토리는 깨끗하다.**
- 파일은 즉시 레포 밖(`~/.nuri-quant-private-backups/`, 0600)으로 이동
- `git status` 깨끗 확인

## 왜 기존 방어선이 못 잡았나

`scripts/verify/check_privacy_leak.py` 는 **diff** 를 본다. untracked 파일은 diff 에 없다.
이 계열의 방어선은 **gitignore 하나뿐**이라 lock-test 를 붙였다.

`.env` 는 `.env.*` 접두사 glob 이 있어 `.env.bak-<ts>` 도 걸린다 — portfolio 만 정확 경로였다.

## 변경

```diff
-config/portfolio.yaml
+config/portfolio*
+!config/portfolio.example.yaml
```

`portfolio.example.yaml` 은 접두사가 달라 원래 영향이 없지만, 과잉 차단 회귀를 막으려고
명시적 예외 + 테스트로 양방향을 잠갔다.

## Gotcha-Test Pair

`tests/test_gitignore_covers_private_derivatives.py` — `git check-ignore` 실행으로 판정한다
(패턴을 grep 하지 않는다).

- 무시돼야 할 14개: portfolio 파생 7 · `.env` 파생 3 · NEXT_SESSION / OPERATIONS 파생 4
- 추적돼야 할 4개: `portfolio.example.yaml`, `rules.yaml`, `agents.yaml`, `signals.yaml`

**Mutation 실측**: 접두사 glob 을 정확 경로로 되돌리면 **3 FAIL**
(`*.bak-<ts>`, `*.save`, `portfolio_backup.yaml`). 복원 시 18 PASS.

## 검증

- `make lint` clean · `check_privacy_leak.py` clean · `verify-doc-counts` 21/21
- `portfolio.example.yaml` 이 여전히 TRACKED 임을 `git ls-files` 로 확인