### PR TITLE
fix(api): keep sold and never-held tickers out of the action buckets

### DIFF
--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -92,6 +92,14 @@ def _build_actions() -> dict:
         # 중복 ticker skip (복수 계좌 동일 종목)
         if ticker in seen_tickers:
             continue
+        # 미보유 종목 skip (#998). `recommendations` 는 보유 테이블이 아니라 스캔
+        # 유니버스(AMD·AMZN·INTC…)를 함께 담는다. 걸러내지 않으면 미보유 종목이
+        # `pnl=0 / 비중=0 / 계좌=''` 인 채 "✅ 유지" 로 들어가, **매도한 종목이 아직
+        # 보유 중인 것처럼** 읽힌다 (2026-08-03 실측: hold 6건 중 4건이 미보유,
+        # 그중 하나는 당일 매도한 KB금융). 이 모듈 docstring 이 이미 정한 계약대로
+        # 비보유 종목의 자리는 "🔍 기회 탐색"(`/api/opportunities`) 이다.
+        if ticker not in portfolio_holdings:
+            continue
         seen_tickers.add(ticker)
 
         action = rec["action"]

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -870,6 +870,35 @@ class TestBuildActionsLogic:
             "account": "Main",
         }
 
+    def test_non_held_ticker_never_enters_any_bucket(self):
+        """미보유 종목은 어느 버킷에도 안 들어간다 (#998).
+
+        `recommendations` 는 보유 테이블이 아니라 스캔 유니버스를 함께 담는다. 걸러내지
+        않으면 미보유 종목이 `pnl=0 / 비중=0 / 계좌=''` 인 채 "✅ 유지" 로 들어가,
+        **매도한 종목이 아직 보유 중인 것처럼** 읽힌다. 2026-08-03 실측: hold 6건 중
+        4건이 미보유였고 그중 하나는 당일 매도한 종목이었다.
+
+        회귀 시나리오: 보유 필터를 지우면 SOLD 가 hold 에 나타난다.
+        """
+        result = self._run(
+            [
+                {"ticker": "HELD", "action": "HOLD", "confidence": 60, "agreement": 50},
+                {"ticker": "SOLD", "action": "BUY", "confidence": 44, "agreement": 40},
+            ],
+            portfolio={"HELD": self._pf()},  # SOLD 는 보유 맵에 없다
+        )
+        every = [i["ticker"] for b in ("urgent", "check", "hold", "portfolio") for i in result[b]]
+        assert "SOLD" not in every, f"미보유 종목이 버킷에 들어갔다: {every}"
+        assert "HELD" in every, "보유 종목까지 걸러내면 안 된다"
+
+    def test_empty_portfolio_yields_no_actions(self):
+        """보유가 하나도 없으면 액션도 없어야 한다 — 필터의 경계 조건."""
+        result = self._run(
+            [{"ticker": "ANY", "action": "SELL", "confidence": 90, "agreement": 80}],
+            portfolio={},
+        )
+        assert all(not result[b] for b in ("urgent", "check", "hold")), result
+
     def test_siege_violation_goes_to_portfolio_bucket(self):
         """PR A (2026-04-21): SIEGE position_limit 위반은 "매도 강제" urgent 가
         아닌 "리밸런스 권고" portfolio bucket. 이전 동작 (urgent) → 사용자 -₩7M


### PR DESCRIPTION
Closes #998

## 증상

"오늘의 액션 → ✅ 유지 종목" 6건 중 **4건이 미보유**였다.

```
[hold] PATH    pnl=0%  비중=0%  계좌=''
[hold] AAPL    pnl=0%  비중=0%  계좌=''
[hold] VOO     pnl=0%  비중=0%  계좌=''
[hold] KB금융   pnl=0%  비중=0%  계좌=''     ← 당일 매도한 종목
```

**방금 정리한 포지션이 아직 들고 있는 것처럼 읽힌다.** 처분 여부를 화면으로 확인하는
사용자에게 직접적인 오독이다.

## 원인

`_build_actions()` 가 `recommendations` 를 순회하며 `portfolio_holdings.get(ticker, {})` 로
보유 정보를 붙인다. 미보유면 빈 dict 라 `pnl=0 / 비중=0 / 계좌=''` 로 채워진 채 그대로
버킷에 들어간다. **어디에도 "보유 중인가" 를 묻지 않았다.**

`recommendations` 는 보유 테이블이 아니라 스캔 유니버스(AMD·AMZN·INTC…)를 함께 담는다.
그게 정상이므로 액션 쪽에서 걸러야 한다.

## 계약은 이미 문서에 있었다

모듈 docstring:

```
✅ 유지: 정상 보유 종목
🔍 기회 탐색: 비보유 이슈 종목 + 매수 판정
```

비보유 종목의 자리는 이미 "기회 탐색"(`/api/opportunities`)으로 정해져 있었다. 설계 변경이
아니라 **적어둔 계약을 구현**하는 수정이다.

## 왜 이제야 드러났나

`portfolio` 테이블에 픽스처 계좌(main/sample/test)가 남아 AAPL·VOO 가 "보유"로 잡혔고,
그래서 미보유 유입이 가려져 있었다. 픽스처를 걷어내자 그대로 노출됐다.

## 실측 (라이브 API, 전 → 후)

```
hold (6): MSFT, PATH, AAPL, SPACEX, VOO, KB금융
      ↓
hold (2): MSFT, SPACEX          ← 둘 다 실보유
```

`urgent` 6건 · `check` 3건은 전부 보유 종목이라 변화 없음.

## Gotcha-Test Pair

- `test_non_held_ticker_never_enters_any_bucket` — 보유/미보유를 섞어 넣고, 미보유가
  **4개 버킷 어디에도** 없고 보유는 남는지 확인
- `test_empty_portfolio_yields_no_actions` — 필터의 경계 조건

**Mutation 실측**: 보유 필터를 제거하면 **2 FAIL**. 복원 시 100 PASS.

## 검증

- `tests/api/test_actions.py` 100 passed (기존 98건 무손상)
- `make lint` clean · `check_privacy_leak.py` clean · `verify-doc-counts` 21/21