### PR TITLE
ux(dashboard): grid the action buckets and lift the labels people read

### DIFF
--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -55,7 +55,7 @@ function ActionCard({ item }: { item: ActionItem }) {
             <Link href={`/ticker/${item.ticker}`} className="text-sm font-semibold text-zinc-100 hover:text-white transition-colors">
               {item.name || item.ticker}
             </Link>
-            {item.name && <span className="text-[10px] text-zinc-600">{item.ticker}</span>}
+            {item.name && <span className="text-[11px] text-zinc-400">{item.ticker}</span>}
             <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
               item.action === "SELL" ? "bg-red-500/20 text-red-400" :
               item.action === "BUY" ? "bg-emerald-500/20 text-emerald-400" :
@@ -63,7 +63,7 @@ function ActionCard({ item }: { item: ActionItem }) {
             }`}>
               {item.action}
             </span>
-            {item.account && <span className="text-[10px] text-zinc-600">{item.account}</span>}
+            {item.account && <span className="text-[11px] text-zinc-400">{item.account}</span>}
           </div>
           <div className="mt-1 space-y-0.5">
             {item.reasons.map((r, i) => (
@@ -75,14 +75,14 @@ function ActionCard({ item }: { item: ActionItem }) {
           <p className={`text-sm font-semibold tabular-nums ${item.pnl_pct >= 0 ? "text-emerald-400" : "text-red-400"}`}>
             {item.pnl_pct >= 0 ? "+" : ""}{item.pnl_pct.toFixed(1)}%
           </p>
-          <p className="text-[10px] text-zinc-500 tabular-nums">{ACTION.WEIGHT} {item.position_pct.toFixed(1)}%</p>
-          <p className="text-[10px] text-zinc-600 tabular-nums">{ACTION.CONF} {item.confidence}</p>
+          <p className="text-[11px] text-zinc-400 tabular-nums">{ACTION.WEIGHT} {item.position_pct.toFixed(1)}%</p>
+          <p className="text-[11px] text-zinc-400 tabular-nums">{ACTION.CONF} {item.confidence}</p>
         </div>
       </div>
 
       {/* 확장 상세 */}
       {expanded && (
-        <div className="mt-2 pt-2 border-t border-zinc-800/50 grid grid-cols-3 gap-2 text-[10px]">
+        <div className="mt-2 pt-2 border-t border-zinc-800/50 grid grid-cols-3 gap-2 text-[11px]">
           <div><span className="text-zinc-600">현재가</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></div>
           <div><span className="text-zinc-600">손절</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></div>
           <div><span className="text-zinc-600">1차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></div>
@@ -121,7 +121,7 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
             <span className="w-2 h-2 rounded-full bg-red-500" />
             {ACTION.URGENT} ({urgent.length})
           </h3>
-          <div className="space-y-2">
+          <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2 items-start">
             {urgent.map((item) => <ActionCard key={`${item.ticker}-${item.account}`} item={item} />)}
           </div>
         </div>
@@ -134,7 +134,7 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
             <span className="w-2 h-2 rounded-full bg-sky-500" />
             {ACTION.PORTFOLIO} ({portfolio.length})
           </h3>
-          <div className="space-y-2">
+          <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2 items-start">
             {portfolio.map((item) => <ActionCard key={`${item.ticker}-${item.account}`} item={item} />)}
           </div>
         </div>
@@ -147,7 +147,7 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
             <span className="w-2 h-2 rounded-full bg-amber-500" />
             {ACTION.CHECK} ({check.length})
           </h3>
-          <div className="space-y-2">
+          <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2 items-start">
             {check.map((item) => <ActionCard key={`${item.ticker}-${item.account}`} item={item} />)}
           </div>
         </div>

--- a/frontend/src/components/ui/hero-stats.tsx
+++ b/frontend/src/components/ui/hero-stats.tsx
@@ -62,7 +62,7 @@ export function HeroStats({
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         {/* 1. 총 자산 */}
         <div className="flex flex-col" data-testid="hero-total">
-          <p className="text-[10px] text-zinc-500 uppercase tracking-wide">{HERO.TOTAL_ASSET}</p>
+          <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.TOTAL_ASSET}</p>
           <div className="flex items-baseline gap-2 mt-0.5">
             <span className="text-3xl font-semibold tabular-nums tracking-tight text-zinc-100">
               {formatBigUsd(totalUsd)}
@@ -70,7 +70,7 @@ export function HeroStats({
             <StatusBadge status={verdictLabel} />
           </div>
           {(holdingsValueUsd > 0 || cashTotalUsd > 0) && (
-            <p className="text-[10px] text-zinc-500 mt-1 tabular-nums">
+            <p className="text-xs text-zinc-400 mt-1 tabular-nums">
               {HERO.HOLDINGS_PREFIX} ${holdingsValueUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}
               {" · "}
               {HERO.CASH_PREFIX} ${cashTotalUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}
@@ -80,7 +80,7 @@ export function HeroStats({
 
         {/* 2. 오늘 P&L */}
         <div className="flex flex-col" data-testid="hero-today">
-          <p className="text-[10px] text-zinc-500 uppercase tracking-wide">{HERO.TODAY_PNL}</p>
+          <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.TODAY_PNL}</p>
           <div className={`flex items-baseline gap-2 mt-0.5 ${todayColor}`}>
             <span className="text-3xl font-semibold tabular-nums tracking-tight">
               {todayArrow} {formatDeltaUsd(t.totalUsd)}
@@ -90,7 +90,7 @@ export function HeroStats({
               {t.totalPct.toFixed(2)}%
             </span>
           </div>
-          <p className="text-[10px] text-zinc-500 mt-1 tabular-nums">
+          <p className="text-xs text-zinc-400 mt-1 tabular-nums">
             <span className="text-emerald-500">&uarr; {t.upCount}</span>
             {" · "}
             <span className="text-red-500">&darr; {t.downCount}</span>
@@ -99,7 +99,7 @@ export function HeroStats({
 
         {/* 3. 누적 수익률 */}
         <div className="flex flex-col" data-testid="hero-cumulative">
-          <p className="text-[10px] text-zinc-500 uppercase tracking-wide">{HERO.CUMULATIVE_RETURN}</p>
+          <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.CUMULATIVE_RETURN}</p>
           <div className={`flex items-baseline gap-2 mt-0.5 ${cumColor}`}>
             <span className="text-3xl font-semibold tabular-nums tracking-tight">
               {cumArrow} {formatDeltaUsd(c.totalUsd)}
@@ -109,7 +109,7 @@ export function HeroStats({
               {c.totalPct.toFixed(1)}%
             </span>
           </div>
-          <p className="text-[10px] text-zinc-500 mt-1">{HERO.CUMULATIVE_SUB}</p>
+          <p className="text-xs text-zinc-400 mt-1">{HERO.CUMULATIVE_SUB}</p>
         </div>
 
         {/* 4. 승률 (winners / (winners+losers) × 100) — replaces 연 배당.
@@ -127,7 +127,7 @@ export function HeroStats({
               : "text-red-400";
           return (
             <div className="flex flex-col" data-testid="hero-winrate">
-              <p className="text-[10px] text-zinc-500 uppercase tracking-wide">{HERO.WIN_RATE}</p>
+              <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.WIN_RATE}</p>
               <div className={`flex items-baseline gap-2 mt-0.5 ${wrColor}`}>
                 <span className="text-3xl font-semibold tabular-nums tracking-tight">
                   {movers > 0 ? `${wr.winRatePct.toFixed(0)}%` : "—"}
@@ -136,7 +136,7 @@ export function HeroStats({
                   {movers > 0 ? `${wr.winners}W / ${wr.losers}L` : ""}
                 </span>
               </div>
-              <p className="text-[10px] text-zinc-500 mt-1">
+              <p className="text-xs text-zinc-400 mt-1">
                 {wr.flat > 0 ? `${HERO.FLAT} ${wr.flat}` : HERO.HOLDINGS_BASIS}
               </p>
             </div>

--- a/frontend/src/components/ui/market-context.tsx
+++ b/frontend/src/components/ui/market-context.tsx
@@ -105,9 +105,9 @@ export function sparklinePath(events: MacroEvent[], width: number, height: numbe
 function HealthCard({ label, value, sub, href, color }: { label: string; value: string; sub: string; href: string; color: string }) {
   return (
     <Link href={href} className="flex-1 min-w-20 rounded-lg bg-zinc-900/60 border border-zinc-800/50 p-2.5 hover:bg-zinc-800/60 transition-colors">
-      <p className="text-[10px] text-zinc-600 mb-0.5">{label}</p>
+      <p className="text-[11px] text-zinc-400 mb-0.5">{label}</p>
       <p className={`text-lg font-bold tabular-nums leading-tight ${color}`}>{value}</p>
-      <p className="text-[10px] text-zinc-500 mt-0.5 truncate">{sub}</p>
+      <p className="text-[11px] text-zinc-400 mt-0.5 truncate">{sub}</p>
     </Link>
   );
 }
@@ -196,7 +196,7 @@ export function MarketContext({ events, health }: MarketContextProps) {
               const isHighConf = (ev.confidence ?? 0) >= 0.8;
               const headlineCls = isHighConf ? "text-zinc-300 font-medium" : "text-zinc-500";
               return (
-                <div key={i} className="flex items-start gap-1.5 text-[10px]">
+                <div key={i} className="flex items-start gap-1.5 text-[11px]">
                   <span className="shrink-0">{style.emoji}</span>
                   <span className={`shrink-0 ${style.color} ${isHighConf ? "font-bold" : "font-medium"}`}>{date}</span>
                   <span className={`shrink-0 ${style.color} ${isHighConf ? "font-bold" : "font-semibold"}`}>{ev.category_ko ?? ev.category}</span>


### PR DESCRIPTION
Closes #1000

## 1. 액션 버킷 → 반응형 그리드

즉시 실행 · 포트폴리오 리밸런스 · 오늘 확인 세 버킷이 전부 `space-y-2` 세로 스택이라
1920px 화면에서도 카드 하나가 한 행을 통째로 썼다. 셋 다 같은 그리드로 바꿨다 —
1열 → `lg` 2열 → `2xl` 3열.

**Playwright 실측** (뷰포트 높이 1200px):

| 폭 | 버킷 열 수 | 페이지 높이 |
|---|---|---|
| 900 | 1 | 3773px |
| 1280 | 2 | 2877px |
| 1440 | 2 | 2877px |
| 1920 | 3 | **2649px** |
| 2560 | 3 | 2649px |

"오늘의 액션" 섹션 자체는 **469px** 로 내려왔다.

## 2. 읽어야 하는 라벨 상향

`text-[10px]` 은 레포에 164곳 있고 `frontend/CLAUDE.md` 에 컨벤션으로 적혀 있다.
**일괄 변경은 하지 않았다** — 측정하지 않은 페이지의 레이아웃이 깨질 위험이 크다.
대신 매일 읽는 값만 선별했다:

- 히어로 서브라인 (`보유 $x · 현금 $y`, `↑14 · ↓7`, `실현 미실현 합계`, `보유 종목 기준`) → 12px
- 히어로 캡션 (`총 자산` `오늘 P&L` `누적 수익률` `승률`) → 11px
- 헬스 카드 라벨/값 (`Certification` `레짐` `매크로` `데이터` / `미인증` `bull 100%` `2 fail`) → 11px
- 액션 카드 티커 · 계좌명 · 비중 · 확신도 → 11px
- 시장 컨텍스트 뉴스 줄 → 11px

대비도 같이 올렸다: 헬스 카드 라벨이 `zinc-600` (zinc-950 배경에서 거의 안 읽힘) → `zinc-400`.

배지·버튼 등 chrome 은 그대로 뒀다.

## 검증

- `npm run lint` clean
- `vitest` dashboard + action-items 59 passed
- `next build` 성공 후 프로덕션 빌드로 Playwright 실측 (위 표)

## 남은 것 — 별도 판단 필요

액션을 압축해도 1920×1200 기준 페이지가 **2.21화면**이다. 남은 높이:

| 섹션 | 높이 |
|---|---|
| 자산 (도넛) | 447px |
| 🔍 기회 탐색 | 402px |
| 보유 종목 | 351px |
| 시장 컨텍스트 | 297px |
| DATA COVERAGE | 246px |

"스크롤 거의 없음" 까지 가려면 이 섹션들을 접을지/우선순위를 낮출지 결정이 필요하다.
이번 PR 범위 밖으로 둔다.