### PR TITLE
docs(rules): drop derivable inventory from always-loaded architecture rules

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -6,7 +6,7 @@
 
 ⚠️ **화살표는 읽는 순서지 실행 순서가 아니다.** 스테이지를 이어 붙이는 주체가 없다 — `scheduler.py` 는 독립 cron job 을 등록할 뿐이고, 스테이지 job 은 `run_step(..., warn_only=True)` 로 감싸이지만 그건 lifecycle 이벤트 기록용이라 의존성이 안 맞아도 **경고만 남기고 그대로 실행**한다(관측이 본 작업을 게이트하면 안 된다 — #894). `analyze` 와 `certify` 는 **자기 cron job 이 아예 없고**(certify=consensus job 안에서 in-memory, `certifications` 는 `premarket_brief` 가 씀), cron 시각도 읽는 순서와 다르다 — outcome tracking 07:02 가 그걸 소비하는 consensus 07:05 **앞**에 있다(전날 것을 읽는다). 공개 서술은 `README.md` 스테이지 표.
 
-`nuri/core` (sole sqlite3 importer) / `nuri/collectors` (27 collector modules) / `analysis` / `quant` / `trading` (agents · engine · strategy · recommend · swing · execution) / `api` (72 endpoints, routes/) / `alerts` / `llm` / `agents` (top-level actor fleet: 18 `actors/` — SRE incident · drift sentinel · forward outcome tracker · walkforward validator · execution firewall · … — plus `discord/` bot layer, wired by `nuri/scheduler.py`). Plus `tests/` mirror + `scripts/` automation + `frontend/` (Next.js). Detailed map (DB schema, migrations, env vars, CI/CD): `docs/ARCHITECTURE.md`.
+디렉터리 구성과 모듈 개수는 `ls` 로 확인한다 — 여기 적지 않는다(드리프트만 만든다). 상세 지도(DB schema, migrations, env vars, CI/CD)는 `docs/ARCHITECTURE.md`, 스테이지별 규약은 `load-triggers.md` 가 가리키는 scoped CLAUDE.md.
 
 ## Commands
 

--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -119,13 +119,13 @@ update_claim() {
 
 banner "Doc Count Sync"
 
-# Collectors (3 sites) — CLAUDE.md 가 .claude/rules/ 로 분할되며 이사함 (#916)
-update_claim live_collectors     .claude/rules/architecture.md '[0-9]+ collector modules'
+# Collectors (2 sites) — CLAUDE.md 가 .claude/rules/ 로 분할되며 이사함 (#916).
+# .claude/rules/architecture.md 는 사이트에서 제외됨 — always-loaded 파일에서
+# 인벤토리/카운트를 걷어냈다. verify_doc_counts.sh 의 같은 주석 참조.
 update_claim live_collectors     nuri/collectors/CLAUDE.md     '[0-9]+ Data Collectors'
 update_claim live_collectors     README.md                     '[0-9]+ collectors \(BaseCollector'
 
-# Endpoints (4 sites)
-update_claim live_endpoints      .claude/rules/architecture.md '\([0-9]+ endpoints, routes/'
+# Endpoints (3 sites)
 update_claim live_endpoints      docs/ARCHITECTURE.md          '## API \([0-9]+ endpoints\)'
 update_claim live_endpoints      docs/ARCHITECTURE.md          '— [0-9]+ REST endpoints'
 update_claim live_endpoints      nuri/api/CLAUDE.md            'read surface \([0-9]+ endpoints\)'

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -118,10 +118,14 @@ RULES=$(live_rules_lines)
 
 # Claim checks: pattern must uniquely identify the phrase containing the target
 # number. Target is always the LAST [0-9]+ in the matched substring.
-check_claim "collectors"     "$COLL" ".claude/rules/architecture.md" '[0-9]+ collector modules' || true
+# .claude/rules/architecture.md 는 의도적으로 사이트가 아니다 — always-loaded 파일에서
+# 인벤토리/카운트를 걷어냈다. 사이트를 되살리는 건 그 파일에 카운트를 다시 넣는다는
+# 뜻이니, 되살리기 전에 그 결정부터 뒤집을 것.
+# ⚠️ 사이트 목록과 문서는 같이 고친다: 문서에서 카운트만 지우고 여기를 안 고치면
+# check_claim 이 fail 이 아니라 warn 을 부르고 스크립트는 exit 0 으로 통과한다
+# (실측: 뮤테이션 시 "19 passed, 1 warnings", EXIT 0). 감시가 초록불인 채 죽는다.
 check_claim "collectors"     "$COLL" "nuri/collectors/CLAUDE.md"  '[0-9]+ Data Collectors' || true
 check_claim "collectors"     "$COLL" "README.md"                  '[0-9]+ collectors \(BaseCollector' || true
-check_claim "endpoints"      "$EP"   ".claude/rules/architecture.md" '\([0-9]+ endpoints, routes/' || true
 check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '## API \([0-9]+ endpoints\)' || true
 check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '— [0-9]+ REST endpoints' || true
 check_claim "endpoints"      "$EP"   "nuri/api/CLAUDE.md"         'read surface \([0-9]+ endpoints\)' || true

--- a/tests/verify/test_doc_claim_parity.py
+++ b/tests/verify/test_doc_claim_parity.py
@@ -69,8 +69,12 @@ class TestStaleTargetIsSurvivable:
         Gotcha-Test Pair: `grep ... | head -1 || true` 의 `|| true` 를 지우면
         set -e 가 첫 클레임에서 스크립트를 죽여 processed 가 0 이 되고 FAIL.
         """
-        target = repo_copy / ".claude" / "rules" / "architecture.md"
-        target.write_text(target.read_text().replace("collector modules", "collector thingies"))
+        # 카나리아는 sync 목록의 **첫** 클레임 대상이어야 한다 — 첫 항목에서 죽는지가
+        # 이 테스트가 잠그는 것이기 때문. `.claude/rules/architecture.md` 를 쓰다가
+        # 그 파일이 사이트에서 빠지면서(always-loaded 파일의 카운트 제거) 카나리아가
+        # 아무 것도 안 겨냥하게 돼 조용히 통과했다 — 사이트를 옮길 땐 여기도 옮긴다.
+        target = repo_copy / "nuri" / "collectors" / "CLAUDE.md"
+        target.write_text(target.read_text().replace("Data Collectors", "Data Thingies"))
 
         r = _run(SYNC, repo_copy)
 


### PR DESCRIPTION
## Why

`.claude/rules/architecture.md` loads in every session. Its Code layout paragraph listed directories plus three counts (27 collectors, 72 endpoints, 18 actors) — all of it either derivable from `ls` or duplicated in a doc that loads on demand.

Anthropic's [context engineering guidance for Claude 5 models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) says to "spend most of the tokens on gotchas" and "avoid stating 'the obvious' things Claude should know by looking at your file system or your repo." That is the framing, not the reason. The reason is local: always-loaded context should carry traps, not repo sightseeing.

Codex reviewed the options independently and rejected the two alternatives I had drafted — including moving the whole paragraph to `docs/ARCHITECTURE.md`, which would have relocated the one non-derivable part out of always-loaded context. It was right.

## What stays

The scheduler warning directly above the deleted paragraph, verbatim: arrows are reading order not execution order, no orchestrator chains the stages, `analyze`/`certify` have no cron job, and outcome tracking at 07:02 runs **before** the consensus job at 07:05 that consumes it. Not derivable, easy to get wrong.

## No count is lost

| Count | Still documented in | CI-checked |
|---|---|---|
| collectors 27 | `README.md`, `nuri/collectors/CLAUDE.md` | yes, both |
| endpoints 72 | `docs/ARCHITECTURE.md` (2 sites), `nuri/api/CLAUDE.md` | yes, all 3 |
| actors 18 | `nuri/agents/CLAUDE.md` — more precisely: "15 registered + 3 unregistered infra helpers" | no, and was not before either |

## The load-bearing part: de-registering the site

Removing the count from the markdown alone would have left a **green dead gate**. `check_claim()` calls `warn()` (not `fail()`) when a pattern is missing, and the caller has `|| true`:

```bash
if [ -z "$nums" ]; then warn "$label: pattern not found in $file"; return 1; fi
warn() { ...; WARN=$((WARN + 1)); }
summary; if [ "$FAIL" -gt 0 ]; then exit 1; fi; exit 0
```

Measured on a mutant that restores the site pointer against the now-countless file:

```
⚠ collectors: pattern not found in .claude/rules/architecture.md
Summary: 19 passed, 1 warnings (20 checks)
EXIT CODE = 0
```

So this PR de-registers the file from `verify_doc_counts.sh` and `sync_doc_counts.sh`, with a comment in both explaining why the site is intentionally absent and what happens if someone splits the two changes.

It also repoints the canary in `tests/verify/test_doc_claim_parity.py::TestStaleTargetIsSurvivable`. That test locks the `|| true` defence from #916 by deleting a target phrase and asserting the script warns and continues; its target was `architecture.md`, which no longer has one. Left as-is it would have passed while testing nothing — the same silent-canary failure the test itself exists to prevent. It now targets `nuri/collectors/CLAUDE.md`, the first claim in the sync list.

## Verification

- `make verify-doc-counts`: **19 passed, 0 warnings** (was 21 passed — the 2 removed sites)
- `tests/verify/test_doc_claim_parity.py`: 7 passed, including the repointed canary
- `make lint-sh` (shellcheck): clean
- `check_privacy_leak.py` (no args, CI parity): clean
- Test-merged against `docs/rules-drop-duplicated-api-pattern` (PR #1003, same file): auto-merges clean, no conflict

## Separate finding, not fixed here

`tests/verify/test_doc_claim_parity.py:47` (`test_sync_does_more_than_print_its_banner`) runs the **mutator** `sync_doc_counts.sh` with `cwd=REPO_ROOT` instead of the `repo_copy` fixture its six sibling tests use. Every run rewrites doc counts in the developer's working tree — it is why `README.md`, `docs/ARCHITECTURE.md`, and `docs/STRATEGY.md` show up modified after `make verify-all`. Pre-existing, one-line fix, out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)