### PR TITLE
fix(tests): anchor rich_db price window to today so 90d tracking stops expiring

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -50,6 +50,18 @@ conftest 전역 mock 은 **yfinance 만** 커버. `MacroCollector.collect()` 는
 코드가 `date('now', '-N days')` 윈도우 + 최소 행 수 임계값으로 필터하면(예: `buy_candidate_emitter._get_price_signals`, 45일 윈도우 + `len(grp) < 6` skip), **고정 절대일로 seed한 fixture 는 wall-clock 이 지나며 윈도우 밖으로 밀려 silent 하게 누락**된다. 합성 가격/날짜 fixture 의 `end` 는 항상 `today_kst()` 로 앵커링 — 리터럴 날짜 금지. (#721: `end="2026-04-30"` → 39일 후 scored=0 회귀)
 **Test:** `tests/trading/recommend/test_buy_candidate_emitter.py::test_vix_caution_halves_allocation` (+`test_emit_above_threshold`, `test_allocation_split_by_score`) — 고정일로 되돌리면 즉시 FAIL.
 
+**2차 발생 (2026-08-10)** — 규칙이 여기 적혀 있었는데도 `tests/trading/recommend/conftest.py` 의
+`rich_db` 가 `bdate_range("2024-06-01", periods=500)` 로 리터럴 시작일을 썼다. 윈도우 끝
+2026-05-01, 소비 테스트는 `now - 95일` 조회 → **2026-08-05 부터 `test_90d_tracking` 이
+결정론적으로 FAIL**. 위 잠금 테스트가 안 잡은 이유는 그게 **emitter 경로만** 덮고 tracker
+경로(`track_outcomes`)는 안 덮기 때문 — 규칙 하나에 잠금이 한 경로만 걸려 있으면 나머지
+경로는 무방비다. 새 fixture 를 쓰는 소비 경로가 생기면 잠금도 같이 늘릴 것.
+- 5일간 아무도 몰랐던 이유는 별개 결함이다: `.github/workflows/main-ci-cd.yml` 의
+  `run_backend` 경로 필터가 **문서-only PR 에서 백엔드 shard 를 테스트 0건 실행하고
+  pass 로 보고**한다. 초록불이 "통과"가 아니라 "미실행"이었다.
+**Test:** `tests/trading/recommend/test_tracker.py::TestTrackerTrackOutcomes::test_90d_tracking`
+— `rich_db` 를 리터럴 시작일로 되돌리면 FAIL (2026-08-05~08-10 실제로 FAIL 상태였다).
+
 ### Privacy 가드를 테스트하는 픽스처는 런타임 조립
 가드가 차단하는 패턴 자체를 **리터럴로** 적으면 파일을 저장하는 순간 PreToolUse 훅과 CI `privacy-scan` 이 그 테스트 파일을 차단한다 (2026-07-29 실측: `TS`+`LA` 를 리터럴로 쓴 Write 가 막혔다). `ticker = "TS" + "LA"` 처럼 조립해 리터럴이 파일에 남지 않게 할 것 — 스캐너는 정규식이라 이걸로 충분하다.
 **Test:** `tests/test_hook_guard_execution.py::TestPrivacyGuard::test_blocks_ticker_pnl_across_newlines` — 리터럴로 되돌리면 커밋 자체가 CI 에서 막힌다.

--- a/tests/trading/recommend/conftest.py
+++ b/tests/trading/recommend/conftest.py
@@ -2,6 +2,7 @@
 
 Auto-loaded by pytest. Helpers live in _helpers.py to be importable.
 """
+
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -37,6 +38,7 @@ def db_path(tmp_path):
 def db_path_with_dbmod(tmp_path, monkeypatch):
     """db_path + monkeypatch DB_PATH for modules that use default path."""
     import nuri.core.db as db_mod
+
     path = tmp_path / "test.db"
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
@@ -48,8 +50,7 @@ def market_data(db_path):
     """포트폴리오 + 가격 데이터 (from test_recommend)."""
     with get_db(db_path) as conn:
         conn.executemany(
-            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?, ?, ?, ?, ?, ?)",
             [
                 ("test", "TEST1", 100, 50.0, "USD", "Technology"),
                 ("test", "TEST2", 50, 80.0, "USD", "Health Care"),
@@ -63,16 +64,18 @@ def market_data(db_path):
     close2 = np.concatenate([np.linspace(80, 60, 30), np.linspace(60, 90, 30)])
 
     for ticker, close in [("TEST1", close1), ("TEST2", close2)]:
-        df = pd.DataFrame({
-            "ticker": ticker,
-            "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": close * 0.99,
-            "high": close * 1.02,
-            "low": close * 0.98,
-            "close": close,
-            "volume": [1000000] * 60,
-            "adj_close": close,
-        })
+        df = pd.DataFrame(
+            {
+                "ticker": ticker,
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": close * 0.99,
+                "high": close * 1.02,
+                "low": close * 0.98,
+                "close": close,
+                "volume": [1000000] * 60,
+                "adj_close": close,
+            }
+        )
         upsert_prices(df, db_path)
 
     return db_path
@@ -87,22 +90,51 @@ def rich_db(tmp_path, monkeypatch):
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10, "avg_price": 190, "currency": "USD", "sector": "Tech"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5, "avg_price": 130, "currency": "USD", "sector": "Semiconductor"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 190,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 130,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+        ],
+        path,
+    )
 
-    dates = pd.bdate_range("2024-06-01", periods=500, freq="B")
+    # 윈도우 끝을 오늘에 고정한다. 소비 테스트가 `now - N일` 로 행을 찾으므로
+    # 시작일을 못박으면 캘린더가 지나가는 순간 조용히 조회 범위 밖이 된다 —
+    # `test_90d_tracking` 이 2026-08-05 부터 그렇게 깨졌다(구간 끝 2026-05-01
+    # vs now-95d = 2026-05-07). 문서-only PR 은 `run_backend` 경로 필터에
+    # 걸려 백엔드 수트를 안 돌리므로 CI 가 5일간 초록인 채였다.
+    dates = pd.bdate_range(end=today_kst(), periods=500, freq="B")
     rows = []
     for t in ["SPY", "AAPL", "NVDA"]:
         base = {"SPY": 450, "AAPL": 170, "NVDA": 120}[t]
         for i, d in enumerate(dates):
             p = base + i * 0.2 + np.sin(i / 20) * 5
-            rows.append({
-                "ticker": t, "date": d.strftime("%Y-%m-%d"),
-                "open": p, "high": p + 3, "low": p - 2,
-                "close": p + 1, "volume": 50_000_000, "adj_close": p + 1,
-            })
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 3,
+                    "low": p - 2,
+                    "close": p + 1,
+                    "volume": 50_000_000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
 
     macro = []
@@ -123,14 +155,35 @@ def rich_db_full(tmp_path, monkeypatch):
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10,
-         "avg_price": 150.0, "currency": "USD", "sector": "Technology"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5,
-         "avg_price": 120.0, "currency": "USD", "sector": "Semiconductor"},
-        {"account": "test", "ticker": "005930.KS", "quantity": 100,
-         "avg_price": 70000.0, "currency": "KRW", "sector": "반도체"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 150.0,
+                "currency": "USD",
+                "sector": "Technology",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 120.0,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+            {
+                "account": "test",
+                "ticker": "005930.KS",
+                "quantity": 100,
+                "avg_price": 70000.0,
+                "currency": "KRW",
+                "sector": "반도체",
+            },
+        ],
+        path,
+    )
 
     dates = pd.date_range("2024-01-01", periods=500, freq="B")
     rows = []
@@ -138,22 +191,28 @@ def rich_db_full(tmp_path, monkeypatch):
         base = {"SPY": 450, "AAPL": 150, "NVDA": 120, "005930.KS": 70000}[t]
         for i, d in enumerate(dates):
             p = base + i * 0.3 + np.sin(i / 20) * 5
-            rows.append({
-                "ticker": t, "date": d.strftime("%Y-%m-%d"),
-                "open": p, "high": p + 4, "low": p - 3,
-                "close": p + 1, "volume": 50_000_000, "adj_close": p + 1,
-            })
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 4,
+                    "low": p - 3,
+                    "close": p + 1,
+                    "volume": 50_000_000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
 
     macro_records = []
     for i, d in enumerate(dates):
         ds = d.strftime("%Y-%m-%d")
-        macro_records.append({"indicator": "vix", "date": ds,
-                              "value": 15 + np.sin(i / 30) * 8, "source": "test"})
-        macro_records.append({"indicator": "fear_greed", "date": ds,
-                              "value": 50 + np.sin(i / 25) * 30, "source": "test"})
-        macro_records.append({"indicator": "usd_krw", "date": ds,
-                              "value": 1350.0, "source": "test"})
+        macro_records.append({"indicator": "vix", "date": ds, "value": 15 + np.sin(i / 30) * 8, "source": "test"})
+        macro_records.append(
+            {"indicator": "fear_greed", "date": ds, "value": 50 + np.sin(i / 25) * 30, "source": "test"}
+        )
+        macro_records.append({"indicator": "usd_krw", "date": ds, "value": 1350.0, "source": "test"})
     upsert_macro(macro_records, path)
 
     with get_db(path) as conn:
@@ -192,11 +251,12 @@ def full_db(tmp_path, monkeypatch):
     today = today_kst()
 
     with get_db(path) as conn:
-        for t, q, p, s in [("AAPL", 10, 150, "Technology"), ("MSFT", 5, 300, "Software"),
-                            ("TSLA", 8, 340, "SectorA")]:
+        for t, q, p, s in [("AAPL", 10, 150, "Technology"), ("MSFT", 5, 300, "Software"), ("TSLA", 8, 340, "SectorA")]:
             conn.execute(
                 "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
-                "VALUES (?, ?, ?, ?, ?, ?)", ("test", t, q, p, "USD", s))
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("test", t, q, p, "USD", s),
+            )
 
     dates = pd.date_range(end=today, periods=400)
     for ticker, base in [("SPY", 400), ("AAPL", 140), ("MSFT", 280), ("TSLA", 300)]:
@@ -208,11 +268,18 @@ def full_db(tmp_path, monkeypatch):
         low = close * 0.99
         volume = np.random.randint(500000, 2000000, 400)
 
-        df = pd.DataFrame({
-            "ticker": ticker, "date": [d.strftime("%Y-%m-%d") for d in dates],
-            "open": close * 0.998, "high": high, "low": low,
-            "close": close, "volume": volume, "adj_close": close,
-        })
+        df = pd.DataFrame(
+            {
+                "ticker": ticker,
+                "date": [d.strftime("%Y-%m-%d") for d in dates],
+                "open": close * 0.998,
+                "high": high,
+                "low": low,
+                "close": close,
+                "volume": volume,
+                "adj_close": close,
+            }
+        )
         upsert_prices(df, path)
 
     with get_db(path) as conn:
@@ -233,15 +300,17 @@ def full_db(tmp_path, monkeypatch):
                     "(ticker, date, rsi_14, sma_20, sma_50, sma_200, "
                     "bb_upper, bb_lower, bb_middle, macd, macd_signal) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (ticker, ds, rsi, sma20, sma50, sma200,
-                     bb_upper, bb_lower, sma20, macd, macd_signal),
+                    (ticker, ds, rsi, sma20, sma50, sma200, bb_upper, bb_lower, sma20, macd, macd_signal),
                 )
 
-    upsert_macro([
-        {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
-        {"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"},
-        {"indicator": "sp500_yoy", "date": today, "value": 15.0, "source": "test"},
-        {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
-    ], path)
+    upsert_macro(
+        [
+            {"indicator": "vix", "date": today, "value": 18.0, "source": "test"},
+            {"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"},
+            {"indicator": "sp500_yoy", "date": today, "value": 15.0, "source": "test"},
+            {"indicator": "usd_krw", "date": today, "value": 1380.0, "source": "test"},
+        ],
+        path,
+    )
 
     return path


### PR DESCRIPTION
## main has been red for five days

`tests/trading/recommend/test_tracker.py::TestTrackerTrackOutcomes::test_90d_tracking` fails on `main` right now:

```
assert updated >= 1
E   assert 0 >= 1
```

Not flaky, not environmental. Deterministic since **2026-08-05**.

## Root cause

`tests/trading/recommend/conftest.py` seeded prices from a literal start date:

```python
dates = pd.bdate_range("2024-06-01", periods=500, freq="B")   # last date: 2026-05-01
```

Consumers query relative to now. `now - 95d` = 2026-05-07, past the window's end, so `track_outcomes` matched no prices and returned 0. Arithmetic:

```
fixture last price date : 2026-05-01
now-95d                 : 2026-05-07   -> outside window
armed on                : 2026-08-05
```

Fix: `pd.bdate_range(end=today_kst(), periods=500, freq="B")`.

## Why nobody saw it for five days

`.github/workflows/main-ci-cd.yml:67` gates the backend shards on a `run_backend` path filter. Docs-only PRs skip the test steps but the jobs still report **pass** — so PR #1002 and #1003 both showed four green backend shards having executed zero tests. PR #1009 was the first to touch `tests/`, which turned the suite on and exposed this.

Green meant not-run. That is the inverse of the `dead gate vs failing gate` pattern this repo already documents, and it is **not fixed here** — separate concern, flagged below.

## This rule already existed

`tests/CLAUDE.md` has said since #721:

> 합성 가격/날짜 fixture 의 `end` 는 항상 `today_kst()` 로 앵커링 — 리터럴 날짜 금지

The existing Gotcha-Test Pair locks only the `buy_candidate_emitter` path, so the `track_outcomes` path was unguarded and the same bug recurred in a different fixture. This PR records the second occurrence in `tests/CLAUDE.md` and cites `test_90d_tracking` as the tracker-path lock — it fails if the literal start date is restored, which is empirically true since it was failing for five days.

## Checked and NOT changed

- `rich_db_full` (same file, literal `date_range("2024-01-01", …)`, window ends 2025-11-28): its only consumer is `test_price_targets.py`, and `nuri/trading/recommend/price_targets.py` contains no relative-date query. Fixed on both sides, so self-consistent, not a bomb.
- `full_db` (same file): already anchored with `today_kst()`.

## Verification

- `tests/trading/recommend/` + `tests/trading/engine/`: **792 passed**
- `make verify-doc-counts`: 21/21
- `check_privacy_leak.py` (no args, CI parity): clean

## Follow-ups, not in this PR

1. `run_backend` path filter reports green backend shards that ran zero tests.
2. `tests/verify/test_doc_claim_parity.py:47` runs the mutator `sync_doc_counts.sh` with `cwd=REPO_ROOT`, rewriting doc counts in the developer's working tree on every run.
3. Other fixtures pairing a literal window with relative-date consumers (`tests/trading/engine/conftest.py`, `tests/trading/agents/conftest.py`, `tests/api/conftest.py`, two swing test files) — audit in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)