### PR TITLE
fix(verify): make verify-all report failures instead of always passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,729 collected across 301 files | |
+| **Backend tests** | 6,734 collected across 302 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,729 backend tests across 301 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,734 backend tests across 302 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,729 tests, 301 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,734 tests, 302 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -1,38 +1,56 @@
 #!/usr/bin/env bash
 # Nuri-Quant System Verification — 커밋 전 필수
-# 주: pipefail 미사용 — 1~4단계가 `| tail -1` 로 요약을 뽑는데, 앞 단계가 조기
-# 종료하면 pipefail 하에서 subshell 전체가 실패한다. tolerance 위해 생략.
-# (5/5 의 grep 체인은 #902 에서 python 검사로 대체됐다.)
-set -eu
+#
+# 실행과 표시를 분리한다. 실패 판정이 필요한 단계는 로그 파일로 돌리고 요약은
+# 후처리한다. 옛 구조는 `pytest ... | tail -1` 다음 줄에서 check() 가 ambient `$?`
+# 를 읽었는데, 그 `$?` 는 pytest 가 아니라 **`tail` 의 것**이라 1·3단계가 항상
+# PASS 였다 — 2026-08-10 에 test_90d_tracking 이 깨진 채로 "ALL 5/5 PASSED" 가
+# 찍혔다. 헤더에 적혀 있던 "pipefail 을 켜면 tail 요약이 깨진다"는 절반만 맞다:
+# 깨지는 건 요약이 아니라 `set -e` 아래에서 잡히지 않은 non-zero 다. 파이프에서
+# 실행을 빼내면 pipefail 이 논쟁거리가 아니게 된다.
+#
+# PIPESTATUS 로 때우지 않는 이유: 파이프와 캡처 사이에 `cd`/`echo`/대입이 하나만
+# 끼어도 조용히 죽는다(옛 3단계의 `cd ..` 가 정확히 그 자리였다).
+set -euo pipefail
 
 # Source shared helpers (colors, PYTHON, REPO_ROOT cd, counters).
 # shellcheck source=scripts/_common.sh
 # (sourced via $(dirname "$0")/../_common.sh — moved to subdir)
 source "$(dirname "$0")/../_common.sh"
 
-# Local check() that inspects $? from the previous command — distinct from
-# _common.sh's check_cmd which takes the command as args. Updates _common.sh's
-# PASS/FAIL counters.
+# Local check() — **명시적 status 인자**를 받는다 (ambient `$?` 금지). distinct
+# from _common.sh's check_cmd which takes the command as args. Updates
+# _common.sh's PASS/FAIL counters.
 check() {
-    if [ $? -eq 0 ]; then
-        echo -e "  ${GREEN}✓ $1${NC}"
+    local status="$1" label="$2"
+    if [ "$status" -eq 0 ]; then
+        echo -e "  ${GREEN}✓ ${label}${NC}"
         PASS=$((PASS + 1))
     else
-        echo -e "  ${RED}✗ $1${NC}"
+        echo -e "  ${RED}✗ ${label}${NC}"
         FAIL=$((FAIL + 1))
     fi
 }
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/verify_all.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
 
 banner "Nuri-Quant System Verification"
 
 # 1. Tests (yfinance mocked via conftest.py → ~5s)
 echo ""; echo "━━━ 1/5. Unit Tests ━━━"
-$PYTHON -m pytest tests/ -q --tb=line 2>&1 | tail -1
-check "Unit Tests"
+tests_log="$tmpdir/unit_tests.log"
+if $PYTHON -m pytest tests/ -q --tb=line >"$tests_log" 2>&1; then
+    tests_status=0
+else
+    tests_status=$?
+fi
+tail -1 "$tests_log"
+check "$tests_status" "Unit Tests"
 
 # 2. All-in-one Python check (DB + imports + API + logic + backtest 한 프로세스)
 echo ""; echo "━━━ 2/5. Backend (API + Logic + Backtest) ━━━"
-$PYTHON -c "
+if $PYTHON -c "
 import time
 start = time.time()
 
@@ -86,18 +104,31 @@ print(f'  ({elapsed:.1f}s)')
 assert r is not None
 assert ok == len(fast_eps)
 assert bt.sharpe > 0.5
-" 2>&1
-check "Backend"
+" 2>&1; then
+    backend_status=0
+else
+    backend_status=$?
+fi
+check "$backend_status" "Backend"
 
 # 3. Frontend
+# `cd frontend && ... ; cd ..` 를 쓰지 않는다 — 서브셸로 감싸면 실패해도 cwd 가
+# 돌아오고, cd 가 상태 캡처와 표시 사이에 끼어들 자리 자체가 없어진다.
 echo ""; echo "━━━ 3/5. Frontend Build ━━━"
-cd frontend && npm run build 2>&1 | grep -c "ƒ\|○" | xargs -I{} echo "  {} pages"
-cd ..
-check "Frontend"
+frontend_log="$tmpdir/frontend_build.log"
+if (cd frontend && npm run build) >"$frontend_log" 2>&1; then
+    frontend_status=0
+else
+    frontend_status=$?
+fi
+# grep -c 는 매치 0 건일 때 rc=1 — pipefail 아래에서 스크립트를 죽이므로 || true.
+page_count="$(grep -cE 'ƒ|○' "$frontend_log" || true)"
+echo "  ${page_count} pages"
+check "$frontend_status" "Frontend"
 
 # 4. Heavy API (consensus + scan — 캐시 워밍 포함)
 echo ""; echo "━━━ 4/5. Heavy Endpoints (cached) ━━━"
-$PYTHON -c "
+if $PYTHON -c "
 from fastapi.testclient import TestClient
 from nuri.api.main import app
 c = TestClient(app)
@@ -105,8 +136,12 @@ heavy = ['/api/consensus/TSLA','/api/backtest','/api/ticker/TSLA','/api/report/c
 ok = sum(1 for ep in heavy if c.get(ep).status_code == 200)
 print(f'  {ok}/{len(heavy)} heavy endpoints OK')
 assert ok == len(heavy)
-" 2>&1
-check "Heavy Endpoints"
+" 2>&1; then
+    heavy_status=0
+else
+    heavy_status=$?
+fi
+check "$heavy_status" "Heavy Endpoints"
 
 # 5. Integrity
 echo ""; echo "━━━ 5/5. File Integrity ━━━"
@@ -117,8 +152,12 @@ echo ""; echo "━━━ 5/5. File Integrity ━━━"
 # 이제 "옛 경로인가" 대신 **"그 모듈이 존재하는가"** 를 묻는다. 목록이 없으니 드리프트도 없다.
 old=$($PYTHON "$(dirname "$0")/check_orphan_imports.py" -v)
 echo "  Orphan imports: $old"
-test "$old" -eq "0"
-check "File Integrity"
+if [ "$old" -eq 0 ]; then
+    integrity_status=0
+else
+    integrity_status=1   # test 의 실패는 항상 1 — `$?` 를 쓰면 SC2319 (조건 참조)
+fi
+check "$integrity_status" "File Integrity"
 
 # Summary
 echo ""

--- a/tests/scripts/test_verify_all_exit_propagation.py
+++ b/tests/scripts/test_verify_all_exit_propagation.py
@@ -1,0 +1,109 @@
+"""`verify_all.sh` 가 실제 실패를 종료코드로 전파하는지 잠근다.
+
+2026-08-10: 1단계가 `pytest ... | tail -1` 이고 바로 다음 줄의 `check()` 가 ambient
+`$?` 를 읽었다. 그 `$?` 는 pytest 가 아니라 **`tail` 의 것**이라 항상 0 이었다. 3단계
+(`npm run build | grep -c | xargs`)도 같은 구조로 `xargs` 의 종료코드를 봤다. 그 결과
+`test_90d_tracking` 이 5일간 깨진 채로 `make verify-all` 이 "ALL 5/5 PASSED" 를 찍었다.
+
+Gotcha-Test Pair (STRATEGY §5.3.1): 아래 두 테스트는 파이프-기반 구조로 되돌리면
+FAIL 한다. 검증 방식이 중요하다 —
+  * 파이썬 mock 은 쓸모없다. 버그가 bash 에 있다.
+  * 실제 pytest/npm 을 돌리면 느리고 불안정하다.
+  * 그래서 PATH 앞에 **실행 가능한 shim** 을 놓아 결정론적으로 실패시킨다.
+  * 전체 종료코드만 보면 안 된다 — 다른 단계가 실패해도 통과해버려 정확히 이 버그를
+    놓친다. 그래서 해당 단계의 `✗ <label>` 문자열까지 함께 assert 한다.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "verify" / "verify_all.sh"
+
+# 4·5 단계까지 가지 않고 1·3 단계 판정만 보면 되므로, shim 은 나머지를 값싸게 통과시킨다.
+_PY_SHIM = """#!/usr/bin/env bash
+# pytest 만 실패시키고 나머지 python 호출은 통과시킨다.
+for a in "$@"; do
+    if [ "$a" = "pytest" ]; then
+        echo "1 failed, 2 passed"
+        exit 1
+    fi
+done
+# check_orphan_imports.py -v 는 정수 하나를 뱉어야 한다 ('$old' -eq 0 비교).
+case "$*" in
+    *check_orphan_imports.py*) echo 0; exit 0 ;;
+esac
+exit 0
+"""
+
+_NPM_OK = """#!/usr/bin/env bash
+echo "ƒ /  ○ /about"
+exit 0
+"""
+
+_NPM_FAIL = """#!/usr/bin/env bash
+echo "Failed to compile."
+exit 1
+"""
+
+
+def _shim(dirpath: Path, name: str, body: str) -> None:
+    p = dirpath / name
+    p.write_text(body, encoding="utf-8")
+    p.chmod(0o755)
+
+
+def _run(tmp_path: Path, npm_body: str) -> subprocess.CompletedProcess:
+    binp = tmp_path / "bin"
+    binp.mkdir()
+    _shim(binp, "npm", npm_body)
+    py = binp / "pyshim"
+    py.write_text(_PY_SHIM, encoding="utf-8")
+    py.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{binp}:{os.environ['PATH']}",
+        # _common.sh 가 PYTHON 을 이미 설정했다면 존중하도록 되어 있어야 한다.
+        "PYTHON": str(py),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+@pytest.mark.slow
+class TestVerifyAllExitPropagation:
+    def test_pytest_failure_marks_unit_tests_failed(self, tmp_path):
+        """pytest 가 실패하면 1단계가 ✗ 로 찍히고 스크립트가 non-zero 로 끝난다."""
+        r = _run(tmp_path, _NPM_OK)
+        out = r.stdout + r.stderr
+        assert "✗ Unit Tests" in out, f"pytest 실패가 1단계에 반영되지 않음:\n{out}"
+        assert "✓ Unit Tests" not in out, f"실패했는데 초록으로도 찍힘:\n{out}"
+        assert r.returncode != 0, f"단계가 실패했는데 exit 0:\n{out}"
+
+    def test_npm_build_failure_marks_frontend_failed(self, tmp_path):
+        """npm run build 가 실패하면 3단계가 ✗ 로 찍힌다."""
+        r = _run(tmp_path, _NPM_FAIL)
+        out = r.stdout + r.stderr
+        assert "✗ Frontend" in out, f"빌드 실패가 3단계에 반영되지 않음:\n{out}"
+        assert "✓ Frontend" not in out, f"실패했는데 초록으로도 찍힘:\n{out}"
+        assert r.returncode != 0, f"단계가 실패했는데 exit 0:\n{out}"
+
+    def test_summary_never_claims_all_passed_when_a_step_failed(self, tmp_path):
+        """'ALL n/n PASSED' 배너가 실패와 공존하면 안 된다 — 실제로 목격된 증상."""
+        r = _run(tmp_path, _NPM_FAIL)
+        out = r.stdout + r.stderr
+        assert "ALL" not in out or "PASSED" not in out, f"실패 상태에서 ALL PASSED 배너:\n{out}"
+        assert "FAILED" in out, f"실패 요약이 없음:\n{out}"


### PR DESCRIPTION
## `make verify-all` could not fail on tests or the frontend build

It printed **"ALL 5/5 PASSED"** while the unit suite and the production build were structurally incapable of reporting failure.

`check()` read the ambient `$?` of the previous command. Step 1 was `pytest … | tail -1`, so `$?` was **tail's**. Step 3 was `npm run build | grep -c | xargs`, so `$?` was **xargs's**. Both always 0.

**Live receipt:** on 2026-08-10 `test_90d_tracking` had been failing on `main` for five days (fixed in #1010). `make verify-all` reported no test failure that morning — it failed only on the Backend step, the one step with no pipe.

## The header comment was half folklore

```
# 주: pipefail 미사용 — 1~4단계가 `| tail -1` 로 요약을 뽑는데, 앞 단계가 조기
# 종료하면 pipefail 하에서 subshell 전체가 실패한다. tolerance 위해 생략.
```

What breaks under `pipefail` is not the summary — it is an **uncaught non-zero under `set -e`**. The real defect is that status and presentation were coupled through a pipeline.

## Design came from an independent Codex review, which rejected my first patch

I had drafted a `PIPESTATUS`-capture fix. Codex rejected it:

> Reject per-step `PIPESTATUS` as the final design because it is fragile. One stray `echo`, `cd`, assignment, or helper call between the pipeline and the capture, and the fix is dead again. You already noticed the `cd frontend … ; cd ..` trap. Future you will re-break it.

It was right — I had found that exact trap and was about to build on top of it anyway.

What landed instead:

- `check()` takes an **explicit status argument**; ambient `$?` is never read
- each step runs as `if cmd; then rc=0; else rc=$?; fi`, output to a log, summary parsed afterwards
- **all five steps** converted, not just the two broken ones, so the script has one status-handling style rather than two and one latent footgun
- `cd frontend && … ; cd ..` becomes a subshell
- `set -euo pipefail`; `grep -c` gets `|| true` (rc=1 on zero matches)
- integrity step asserts `1` explicitly instead of `$?` of a `test` builtin (shellcheck SC2319)

`ruff` is deliberately **not** added here despite the docs claiming lint coverage — Codex called that scope creep and I agree. Separate concern.

## Gotcha-Test Pair (STRATEGY §5.3.1)

`tests/scripts/test_verify_all_exit_propagation.py` puts **executable shims** for `python` and `npm` ahead of `PATH`. Mocks would be useless — the bug is in bash — and running the real tools would be slow and flaky.

It asserts the per-step `✗ <label>` line, not just the exit code. Checking only the exit code would pass on an unrelated step's failure and miss this exact bug.

| Variant | Result |
|---|---|
| This patch | 3 passed |
| Partial revert (step 1 back to a pipe) | **3 failed** |
| Unmodified pre-fix script from `main` | **3 failed** |

## Verification

- `shellcheck` clean (note: this file is **not** covered by the Shell Lint job today — see the companion PR widening that glob, which is why this bug never surfaced there)
- `bash -n` clean, `ruff` clean, `check_privacy_leak.py` clean
- A full end-to-end `verify_all.sh` run is in progress; the suite runs ~6,700 tests single-process so it is slow. Result will be reported on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)