### PR TITLE
fix(ci): stop Universe Coverage Validation from failing open when changes fails

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -341,9 +341,23 @@ jobs:
     # this check as "skipping", which blocks merge under the new required-check
     # policy. The job is fast (~15s, no network), so always-on cost is trivial
     # vs the merge-block cost.
+    #
+    # `!cancelled()` + the guard step below are what make "always run" true.
+    # Without them `needs: changes` means a FAILED `changes` job skips this one,
+    # and GitHub counts a skipped required check as satisfied — the gate would
+    # fail open exactly when the thing that decides what to test is broken.
+    # Every other `needs: changes` job here already carries both; this was the
+    # only one that did not.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Guard — require changes to succeed
+        if: needs.changes.result != 'success'
+        working-directory: .
+        run: |
+          echo "::error::changes job did not succeed (result=${{ needs.changes.result }}) — cannot verify gates"
+          exit 1
       - uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,734 collected across 302 files | |
+| **Backend tests** | 6,734 collected across 303 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,734 backend tests across 302 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,734 backend tests across 303 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,734 tests, 302 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,734 tests, 303 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/scripts/test_ci_required_checks_fail_closed.py
+++ b/tests/scripts/test_ci_required_checks_fail_closed.py
@@ -1,0 +1,92 @@
+"""필수 CI 체크가 fail-open 하지 않는지 잠근다.
+
+GitHub 은 **skipped 된 required check 를 만족으로 센다.** 그래서 `needs: <job>` 만
+걸고 `if: ${{ !cancelled() }}` 를 빼면, 의존 잡이 실패했을 때 required check 가
+조용히 건너뛰어지고 머지가 열린다 — 무엇을 테스트할지 결정하는 잡이 깨진 바로 그
+순간에 게이트가 열리는 최악의 조합이다.
+
+2026-08-10 감사에서 `Universe Coverage Validation` 이 유일하게 둘 다 빠져 있었다.
+주석에는 "Always run — required gate" 라고 적혀 있었지만 실제로는 아니었다.
+
+Gotcha-Test Pair (STRATEGY §5.3.1): 어느 required 잡에서든 `if: !cancelled()` 나
+`changes.result` 검사를 빼면 이 테스트가 FAIL 한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "main-ci-cd.yml"
+
+# branch protection 의 required_status_checks 사본.
+#   gh api repos/researcherhojin/nuri-quant/branches/main/protection \
+#     --jq '.required_status_checks.contexts'
+# 로 실측 갱신할 것. 여기 목록이 낡으면 이 테스트는 조용히 범위가 줄어든다.
+REQUIRED_CHECKS = {
+    "Backend Tests",
+    "Backend Lint",
+    "Frontend Tests",
+    "Frontend Build",
+    "Security Scan",
+    "Universe Coverage Validation",
+    "Shell Lint",
+    "Doc Count Drift Check",
+    "Privacy Leak Scan",
+    "Frontend Lint",
+}
+
+
+def _jobs() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def _needs(job: dict) -> list[str]:
+    n = job.get("needs")
+    if n is None:
+        return []
+    return [n] if isinstance(n, str) else list(n)
+
+
+def _validates_dep_result(job: dict, dep: str) -> bool:
+    """잡이 의존 잡의 result 를 스스로 검사하는가.
+
+    스텝 *이름* 으로 찾지 않는다 — `Backend Tests` 애그리게이터는 "Guard" 가 아니라
+    "Aggregate shard + slow results" 안에서 같은 검사를 한다. 이름으로 찾으면 오탐.
+    """
+    blob = " ".join(str(s.get("run", "")) + str(s.get("if", "")) for s in job.get("steps", []))
+    return f"needs.{dep}.result" in blob
+
+
+class TestRequiredChecksFailClosed:
+    def test_workflow_parses_and_required_names_exist(self):
+        """정규식/목록이 조용히 눈멀면 아래 테스트가 공허하게 통과한다."""
+        names = {j.get("name", jid) for jid, j in _jobs().items()}
+        # matrix 잡은 이름에 ${{ }} 가 남으므로 prefix 매칭 허용
+        missing = [c for c in REQUIRED_CHECKS if not any(n.startswith(c) for n in names)]
+        assert not missing, f"required check 인데 워크플로에 해당 잡이 없음: {missing}"
+
+    def test_every_required_job_with_needs_runs_when_its_dep_fails(self):
+        """required + `needs:` 면 `!cancelled()` 와 dep result 검사가 **둘 다** 있어야 한다."""
+        offenders = []
+        for jid, job in _jobs().items():
+            name = job.get("name", jid)
+            if name not in REQUIRED_CHECKS:
+                continue
+            deps = _needs(job)
+            if not deps:
+                continue
+            cond = str(job.get("if", ""))
+            if "cancelled()" not in cond:
+                offenders.append(f"{name}: `if: !cancelled()` 없음 (if={cond!r})")
+                continue
+            if not any(_validates_dep_result(job, d) for d in deps):
+                offenders.append(f"{name}: 의존 잡 {deps} 의 result 를 검사하지 않음")
+        assert not offenders, (
+            "skipped required check 는 GitHub 에서 '성공' 으로 계산된다 — "
+            "아래 잡은 의존 잡이 실패하면 fail-open 한다:\n  " + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
## A required check that opens the gate exactly when things break

GitHub counts a **skipped** required status check as satisfied.

`universe-check` declared `needs: changes` with neither `if: ${{ !cancelled() }}` nor any step inspecting `needs.changes.result`. So a failed `changes` job skipped it, and the required gate reported green — the gate opening at the moment the job that decides *what to test* is broken.

Its own comment already claimed the opposite:

```
# Always run — required gate (PR #343 promoted this to required_status_checks).
```

It was the only one of the seven required `needs: changes` jobs where that was not true. The other six already carry both halves.

| Required job | `!cancelled()` | validates `changes.result` |
|---|---|---|
| Frontend Tests / Build / Lint | yes | yes |
| Backend Lint | yes | yes |
| Backend Tests | yes | yes (inside "Aggregate shard + slow results") |
| Security Scan | yes | yes |
| **Universe Coverage Validation** | **no** | **no** |

Fix adds both, copying the existing guard step verbatim.

## Honest scope note

The audit that found this also flagged three shard jobs as unguarded. They are **not** required checks, and the required `Backend Tests` aggregator catches a failed `changes` on their behalf, so they are fine as-is. My first sweep reported them as problems because it looked for a step *named* "Guard" — the aggregator does the same check inside a differently-named step. Detecting by name was a false-positive generator; the test below detects by behaviour instead.

## Gotcha-Test Pair (STRATEGY §5.3.1)

`tests/scripts/test_ci_required_checks_fail_closed.py` parses the workflow and asserts every required job with `needs:` has `!cancelled()` **and** validates its dependency's result.

Mutation-verified: removing either half fails the test, naming the offending job.

The required-check list is a hand-copied mirror of branch protection. The test carries the refresh command in a comment —

```
gh api repos/researcherhojin/nuri-quant/branches/main/protection \
  --jq '.required_status_checks.contexts'
```

— because a stale list would silently narrow the sweep, which is the same class of failure this PR is fixing.

## Verification

- workflow YAML parses, 15 jobs
- new test: 2 passed; mutation: 1 failed as expected
- `check_privacy_leak.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)