### PR TITLE
fix(ci): widen Shell Lint from 1 script to all 27

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -289,7 +289,7 @@ jobs:
         run: python3 scripts/verify/check_privacy_leak.py
 
   # ── Shell script lint ──
-  # shellcheck로 scripts/*.sh 린트. Graduated from warning-only 2026-04-15 —
+  # shellcheck로 scripts/ 하위 **전체** .sh 린트. Graduated from warning-only 2026-04-15 —
   # passed cleanly across multiple consecutive runs (docs/TODO.md Tier 1 #7
   # shipped 16 files clean). Failures now block the job, but the check
   # is still not in required_status_checks (branch protection update is a
@@ -302,7 +302,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Run shellcheck
-        run: shellcheck --source-path=SCRIPTDIR --external-sources scripts/*.sh
+        # `scripts/*.sh` 는 7개 하위 디렉터리로 옮긴 뒤 27개 중 1개(_common.sh)만
+        # 잡았다 — required check 가 사실상 비어 있었다. find 로 재귀 수집한다.
+        run: find scripts -name '*.sh' -exec shellcheck --source-path=SCRIPTDIR --external-sources {} +
 
   # ── Doc count drift gate ──
   # verify_doc_counts.sh checks that numeric claims in CLAUDE.md / README.md /

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ lint-fix:
 
 lint-sh: ## Shell script lint via shellcheck (brew install shellcheck)
 	@command -v shellcheck >/dev/null 2>&1 || { echo "shellcheck not installed: brew install shellcheck"; exit 1; }
-	shellcheck --source-path=SCRIPTDIR --external-sources scripts/*.sh
+	find scripts -name '*.sh' -exec shellcheck --source-path=SCRIPTDIR --external-sources {} +
 
 typecheck: ## Pyright static type-check across nuri/, tests/, scripts/ (advisory; severity 8 only)
 	@command -v npx >/dev/null 2>&1 || { echo "npx not installed: install Node.js"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,734 collected across 303 files | |
+| **Backend tests** | 6,739 collected across 304 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,734 backend tests across 303 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,739 backend tests across 304 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -254,7 +254,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,734 tests, 303 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,739 tests, 304 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/verify/pre_push_check.sh
+++ b/scripts/verify/pre_push_check.sh
@@ -52,7 +52,7 @@ fi
 # feedback_ci_check_reading.md).
 if command -v shellcheck > /dev/null 2>&1; then
     echo -e "${YELLOW}━━━ 2b. Shell Lint (shellcheck) ━━━${NC}"
-    if shellcheck --source-path=SCRIPTDIR --external-sources scripts/*.sh; then
+    if find scripts -name '*.sh' -exec shellcheck --source-path=SCRIPTDIR --external-sources {} +; then
         echo -e "${GREEN}✓ Shell lint clean${NC}\n"
     else
         echo -e "${RED}✗ Shellcheck failed — mirrors CI job 'Shell Lint'${NC}\n"

--- a/tests/scripts/test_shellcheck_scope.py
+++ b/tests/scripts/test_shellcheck_scope.py
@@ -1,0 +1,58 @@
+"""shellcheck 가 `scripts/` 하위 전체를 보는지 잠근다.
+
+`Shell Lint` 는 required status check 인데, 세 호출부가 모두 `scripts/*.sh` 라는
+비재귀 글롭을 썼다. 스크립트가 7개 하위 디렉터리로 이사한 뒤 그 글롭은 **27개 중
+1개**(`scripts/_common.sh`)만 잡았다 — 필수 게이트가 사실상 비어 있었고, 그래서
+`verify_all.sh` 의 파이프-종료코드 버그도 shellcheck 에 걸릴 기회가 없었다.
+
+Gotcha-Test Pair (STRATEGY §5.3.1): 어느 호출부든 비재귀 글롭으로 되돌리면 FAIL.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CALL_SITES = (
+    Path(".github/workflows/main-ci-cd.yml"),
+    Path("Makefile"),
+    Path("scripts/verify/pre_push_check.sh"),
+)
+
+# 비재귀 글롭이 shellcheck 인자로 쓰인 자리. 산문/주석의 언급은 잡지 않는다.
+_NON_RECURSIVE = re.compile(r"(?<!')\bshellcheck\b[^\n]*\bscripts/\*\.sh")
+
+
+class TestShellcheckScope:
+    def test_no_call_site_uses_the_non_recursive_glob(self):
+        offenders = []
+        for rel in CALL_SITES:
+            text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+            for i, line in enumerate(text.splitlines(), 1):
+                if _NON_RECURSIVE.search(line):
+                    offenders.append(f"{rel}:{i}  {line.strip()[:90]}")
+        assert not offenders, (
+            "`scripts/*.sh` 는 하위 디렉터리를 놓친다 (27개 중 1개). "
+            "`find scripts -name '*.sh' -exec shellcheck ... {} +` 를 쓸 것:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_every_call_site_collects_recursively(self):
+        """세 곳 모두 재귀 수집 형태를 실제로 갖고 있는가 (위 테스트의 공백 통과 방지)."""
+        missing = [
+            str(rel)
+            for rel in CALL_SITES
+            if "-name '*.sh'" not in (REPO_ROOT / rel).read_text(encoding="utf-8")
+        ]
+        assert not missing, f"재귀 수집 형태가 없는 호출부: {missing}"
+
+    def test_recursive_form_actually_matches_more_than_the_old_glob(self):
+        """카나리아: 트리가 다시 평평해지면 이 테스트가 무의미해지므로 그때 알린다."""
+        all_sh = sorted(REPO_ROOT.glob("scripts/**/*.sh"))
+        top_only = sorted(REPO_ROOT.glob("scripts/*.sh"))
+        assert len(all_sh) > len(top_only), (
+            f"scripts/ 하위 .sh 가 최상위에만 있다 (전체 {len(all_sh)} / 최상위 {len(top_only)}). "
+            "트리 구조가 바뀌었다면 이 테스트의 전제를 다시 확인할 것."
+        )


### PR DESCRIPTION
## A required check that lints one file

`Shell Lint` is in branch protection's required checks. All three call sites globbed `scripts/*.sh`, which stopped matching once the scripts moved into seven subdirectories.

```
$ ls scripts/*.sh
scripts/_common.sh          # 1

$ find scripts -name '*.sh' | wc -l
27
```

This is why `scripts/verify/verify_all.sh` could carry a pipe-swallows-exit-code bug for months without shellcheck ever seeing the file (companion PR #1011).

## Change

All three sites move to `find scripts -name '*.sh' -exec shellcheck … {} +`:

- `.github/workflows/main-ci-cd.yml` — the required check
- `Makefile` `lint-sh`
- `scripts/verify/pre_push_check.sh` — the local mirror of that check

**Why `-exec … +` and not `$(find …)`:** I wrote the command-substitution form first. The widened check immediately flagged it — unquoted command substitution is SC2046 word splitting, in `pre_push_check.sh` itself. The tool caught a real defect on its first widened run, which is a decent sign the widening is worth having.

Exit propagation measured, since the `if` in `pre_push_check.sh` depends on it:

```
broken script present  -> exit 1
real tree (27 files)   -> exit 0
```

## Zero-diff promotion

All 27 scripts already lint clean, so this adds coverage without changing a single line of script logic.

## Gotcha-Test Pair (STRATEGY §5.3.1)

`tests/scripts/test_shellcheck_scope.py`:

1. no call site uses the non-recursive glob as a shellcheck argument
2. each call site actually collects recursively (so test 1 can't pass vacuously)
3. **canary**: `scripts/**/*.sh` still outnumbers `scripts/*.sh` — if the tree is ever flattened back, that surfaces instead of quietly making this test meaningless

Mutation-verified: reverting any single call site to the old glob fails tests 1 and 2.

## Verification

- `make lint-sh` on all 27: clean
- workflow YAML parses, 15 jobs
- new test: 3 passed; mutation: 2 failed as expected
- `check_privacy_leak.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)