### PR TITLE
fix(tests): stop the doc-count fixer from rewriting the real repo

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -62,6 +62,28 @@ conftest 전역 mock 은 **yfinance 만** 커버. `MacroCollector.collect()` 는
 **Test:** `tests/trading/recommend/test_tracker.py::TestTrackerTrackOutcomes::test_90d_tracking`
 — `rich_db` 를 리터럴 시작일로 되돌리면 FAIL (2026-08-05~08-10 실제로 FAIL 상태였다).
 
+### 문서 fixer 를 실제 레포에서 돌리는 테스트
+`scripts/doc/sync_doc_counts.sh` 는 검사기가 아니라 **in-place fixer** 다. `tests/verify/` 의
+테스트가 이걸 `REPO_ROOT` env override 없이 실행하면 **백엔드 테스트를 돌릴 때마다 실제
+README / ARCHITECTURE / STRATEGY 가 조용히 재작성**된다. `cwd=` 로는 막을 수 없다 —
+`scripts/_common.sh` 가 **스크립트 자신의 레포 루트로 cd** 하므로 override 가 유일한 수단이다.
+테스트는 통과하고 pytest 출력에 흔적이 없어 `git status` 를 볼 때까지 모른다 (2026-08-10 하루에
+두 번 밟음: 편집 중이던 문서가 되돌려졌다).
+`tests/verify/conftest.py` 가 `subprocess.Popen.__init__` 을 감싸 **실행 자체를 막는다.**
+쓰기가 일어난 **뒤**가 아니라 **겨눈 순간** 터지므로 문서가 sync 상태여도 발화한다.
+설계 3가지가 각각 우회로를 막는다 — 모듈 속성이 아니라 **클래스**를 잡아서 사전 바인딩
+별칭(`from subprocess import Popen as X`)까지 덮고, argv 리스트가 아니라 **합친 커맨드
+문자열**을 봐서 `shell=True` / `bash -lc "…"` 도 걸리고, fixer 집합을 폴더가 아니라
+**동작**(`scripts/**/*.sh` 중 `sed -i` 하는 것 — 실측 27개 중 1개)으로 유도해 이사·신규 추가에
+따라간다. 처음엔 소스를 스캔하는 AST 스윕으로 짰다가 argv 변수·`check_call`·헬퍼 래핑·
+별칭·shell 문자열에 전부 뚫려 폐기했다 (Codex 리뷰 2라운드, 2026-08-10).
+**우회 시도 10종 전부 차단 실측** — 되돌림·argv 변수·`check_call`·`check_output`·헬퍼·
+`Popen` 직접·별칭 override·`shell=True`·`bash -lc`·사전 바인딩 별칭.
+**Test:** `tests/verify/test_doc_claim_parity.py::TestFixerGuard::test_launching_the_fixer_at_the_real_repo_is_blocked`
+— 가드를 걷어내면 FAIL. `_run(SYNC, repo_copy)` 를 직접 실행으로 되돌리면 그 테스트가 여기서 막힌다.
+같은 파일의 내용 해시 가드는 **보조** — subprocess 를 안 거치는 직접 쓰기용이고, 문서가 sync 면
+발화하지 않으므로 회귀 잠금이 아니다.
+
 ### Privacy 가드를 테스트하는 픽스처는 런타임 조립
 가드가 차단하는 패턴 자체를 **리터럴로** 적으면 파일을 저장하는 순간 PreToolUse 훅과 CI `privacy-scan` 이 그 테스트 파일을 차단한다 (2026-07-29 실측: `TS`+`LA` 를 리터럴로 쓴 Write 가 막혔다). `ticker = "TS" + "LA"` 처럼 조립해 리터럴이 파일에 남지 않게 할 것 — 스캐너는 정규식이라 이걸로 충분하다.
 **Test:** `tests/test_hook_guard_execution.py::TestPrivacyGuard::test_blocks_ticker_pnl_across_newlines` — 리터럴로 되돌리면 커밋 자체가 CI 에서 막힌다.

--- a/tests/verify/conftest.py
+++ b/tests/verify/conftest.py
@@ -1,0 +1,117 @@
+"""이 디렉터리는 문서 게이트를 테스트한다 — 그중 `scripts/doc/sync_doc_counts.sh` 는
+검사기가 아니라 **in-place fixer** 다. 사본이 아니라 레포에 겨누면 실제 문서를 고쳐 쓴다.
+
+`test_sync_does_more_than_print_its_banner` 하나가 override 없이 그걸 돌려서 **백엔드
+테스트를 돌릴 때마다 실제 README/ARCHITECTURE/STRATEGY 가 조용히 재작성**됐다. 테스트는
+통과하고 pytest 출력에 흔적이 없어 `git status` 를 볼 때까지 몰랐다.
+
+여기 두 겹을 건다:
+
+1. `_fixer_never_targets_the_real_repo` — `subprocess.Popen` 을 감싸 **실행 자체를 막는다.**
+   `Popen` 이 `run`/`call`/`check_call`/`check_output` 의 공통 관문이라 한 곳만 잡으면
+   argv 를 변수에 담든 헬퍼로 감싸든 전부 걸린다. 쓰기가 일어난 뒤가 아니라 **겨눈 순간**
+   터지므로 문서가 sync 상태여도 발화한다 — 이게 결정론적 회귀 잠금이다.
+   카나리아: `test_doc_claim_parity.py::TestFixerGuard` 가 실제로 위반을 시도해 본다.
+2. `_repo_docs_stay_untouched` — fixer 대상 문서의 해시 대조. subprocess 를 안 거치는
+   직접 쓰기(테스트가 `README.md` 를 파이썬으로 여는 경우)를 덮는 **보조** 트립와이어다.
+   문서가 sync 면 안 울리므로 이쪽은 회귀 잠금이 아니다.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SYNC = REPO_ROOT / "scripts" / "doc" / "sync_doc_counts.sh"
+
+# in-place fixer 집합은 **디렉터리가 아니라 동작**으로 유도한다 — `scripts/` 전체를 훑어
+# `sed -i` 로 파일을 고쳐 쓰는 셸 스크립트만 고른다. 폴더 위치로 정의하면 읽기 전용 헬퍼가
+# 그 폴더에 들어올 때 과잉 차단하고, fixer 가 이사가면 못 잡는다 (Codex 리뷰 2026-08-10).
+# 실측 2026-08-10: `scripts/**/*.sh` 27개 중 해당 1개 (`sync_doc_counts.sh`).
+# ⚠️ 유지보수 한계: `sed -i` 만 본다. 새 fixer 가 `perl -i` / `tee` / 리다이렉션 / `python -c`
+# 로 고쳐 쓰면 **자동 등록되지 않는다** — 그런 fixer 를 추가할 땐 여기 패턴도 같이 넓힐 것.
+# (리다이렉션을 지금 넣지 않는 이유: 로그·임시파일 쓰는 정상 스크립트가 통째로 걸린다.)
+_FIXERS = sorted({p.name for p in (REPO_ROOT / "scripts").rglob("*.sh") if re.search(r"\bsed -i\b", p.read_text())})
+
+# 카나리아 — 탐지가 눈이 멀면 가드가 빈 집합을 지키는 green dead gate 가 된다.
+if not _FIXERS:
+    raise RuntimeError("in-place fixer 를 하나도 못 찾았다 — `sed -i` 탐지가 scripts/ 와 어긋남")
+
+# fixer 가 쓰는 파일 목록은 스크립트에서 직접 읽는다 — 손으로 적으면 드리프트한다.
+# `update_claim <live_fn> <file> '<pattern>'`
+_FIXER_TARGETS = sorted({m.group(1) for m in re.finditer(r"^update_claim\s+\S+\s+(\S+)", _SYNC.read_text(), re.M)})
+
+# 카나리아 — 정규식이 눈이 멀면 해시 가드가 빈 목록을 지킨다. collection 단계에서 크게 터뜨린다.
+if len(_FIXER_TARGETS) < 6:
+    raise RuntimeError(f"update_claim 대상을 {len(_FIXER_TARGETS)}건만 파싱했다 — 정규식이 어긋남: {_SYNC}")
+
+
+def fixer_aimed_at_real_repo(args, env) -> str | None:
+    """이 실행이 in-place fixer 를 **실제 레포**에 겨눴으면 그 스크립트 이름을 돌려준다.
+
+    argv 리스트가 아니라 **합친 커맨드 문자열**을 본다 — `shell=True` 로 넘긴 문자열도,
+    `["bash", "-lc", "... sync_doc_counts.sh"]` 같은 중첩 셸도 같은 검사를 통과해야 한다
+    (Codex 리뷰 2026-08-10 에서 이 두 형태가 뚫렸다).
+
+    `scripts/_common.sh` 는 스크립트 자신의 레포 루트로 cd 하므로 `cwd=` 로는 사본을
+    가리킬 수 없다 — `REPO_ROOT` env override 가 유일한 수단이고, 없으면 실제 레포다.
+    """
+    text = " ".join(str(a) for a in args) if isinstance(args, (list, tuple)) else str(args)
+    hit = next((name for name in _FIXERS if name in text), None)
+    if hit is None:
+        return None
+    effective = Path((env if env is not None else os.environ).get("REPO_ROOT", str(REPO_ROOT)))
+    return hit if effective.resolve() == REPO_ROOT else None
+
+
+@pytest.fixture
+def fixer_guard():
+    """가드의 판정 함수 — 카나리아 테스트가 실행 없이 경계를 확인할 때 쓴다."""
+    return fixer_aimed_at_real_repo
+
+
+@pytest.fixture(autouse=True)
+def _fixer_never_targets_the_real_repo(monkeypatch):
+    """`Popen.__init__` 을 감싼다 — 모듈 속성이 아니라 **클래스**를 잡는 이유는
+    `from subprocess import Popen as X` 로 미리 묶어둔 별칭이 같은 클래스 객체라
+    이쪽만 갈아끼우면 그 경로까지 덮이기 때문이다.
+    """
+    real_init = subprocess.Popen.__init__
+
+    def guarded_init(self, args, *a, **kw):
+        offender = fixer_aimed_at_real_repo(args, kw.get("env"))
+        if offender:
+            raise AssertionError(
+                f"in-place fixer 를 실제 리포에 겨눴다: {offender}\n"
+                "실행되면 README/ARCHITECTURE/STRATEGY 가 조용히 재작성된다. "
+                "사본에서 돌릴 것 — `_run(SYNC, repo_copy)` (env 에 REPO_ROOT override)."
+            )
+        return real_init(self, args, *a, **kw)
+
+    monkeypatch.setattr(subprocess.Popen, "__init__", guarded_init)
+
+
+def _digest() -> dict[str, str]:
+    return {
+        rel: hashlib.sha256((REPO_ROOT / rel).read_bytes()).hexdigest()
+        for rel in _FIXER_TARGETS
+        if (REPO_ROOT / rel).exists()
+    }
+
+
+@pytest.fixture(autouse=True)
+def _repo_docs_stay_untouched():
+    before = _digest()
+    yield
+    changed = sorted(rel for rel, h in _digest().items() if before.get(rel) != h)
+    assert not changed, (
+        "테스트가 실제 리포의 문서를 수정했다: "
+        + ", ".join(changed)
+        + "\ndoc fixer 는 사본에서만 돌릴 것 — `_run(SYNC, repo_copy)` (REPO_ROOT env override)."
+    )

--- a/tests/verify/test_doc_claim_parity.py
+++ b/tests/verify/test_doc_claim_parity.py
@@ -40,18 +40,23 @@ def _verify_targets() -> set[tuple[str, str]]:
 
 
 class TestSyncRuns:
-    def test_sync_does_more_than_print_its_banner(self):
+    def test_sync_does_more_than_print_its_banner(self, repo_copy):
         """#916 의 고장 모드 그대로 — 배너만 찍고 종료하면 FAIL.
 
         Gotcha-Test Pair: `current=$(grep ... || true)` 의 `|| true` 를 지우면
         set -e 가 첫 클레임에서 스크립트를 죽여 이 테스트가 FAIL.
+
+        `repo_copy` 필수 — sync 는 in-place fixer 다. 이 테스트만 `cwd=REPO_ROOT`
+        로 돌아서 **백엔드 테스트를 돌릴 때마다 실제 README/ARCHITECTURE/STRATEGY 가
+        조용히 재작성**됐다. 통과하면서 쓰기 때문에 아무 신호가 없었다.
+        `conftest.py` 의 `_repo_docs_stay_untouched` 가 되돌림을 잡는다.
         """
-        r = subprocess.run(["bash", str(SYNC)], cwd=REPO_ROOT, capture_output=True, text=True, timeout=300, check=False)
+        r = _run(SYNC, repo_copy)
         processed = [ln for ln in r.stdout.splitlines() if "already in sync" in ln or "→" in ln]
         assert len(processed) >= 15, (
             f"클레임을 {len(processed)}건만 처리했다 — 중간에 죽었을 가능성:\n{r.stdout}{r.stderr}"
         )
-        assert r.returncode == 0, f"clean tree 인데 exit {r.returncode}:\n{r.stdout}{r.stderr}"
+        assert r.returncode == 0, f"manifest 가 온전한 사본인데 exit {r.returncode}:\n{r.stdout}{r.stderr}"
 
 
 class TestStaleTargetIsSurvivable:
@@ -82,6 +87,29 @@ class TestStaleTargetIsSurvivable:
         assert len(processed) >= 10, f"stale 대상 하나에 스크립트가 멈췄다 ({len(processed)}건 처리):\n{r.stdout}"
         assert "pattern not found" in r.stdout, f"누락을 알리지 않음:\n{r.stdout}"
         assert r.returncode != 0, "manifest 가 깨졌는데 exit 0 — 조용히 넘어감"
+
+
+class TestFixerGuard:
+    """`conftest.py` 의 fixer 가드가 **무장돼 있는지** 실제로 위반을 시도해 확인한다.
+
+    가드는 `subprocess.Popen` 을 감싸므로 argv 를 변수에 담든 `check_call` 을 쓰든
+    헬퍼로 감싸든 전부 같은 관문을 지난다 — 소스 문자열이 아니라 **실행 시도**를 본다.
+    """
+
+    def test_launching_the_fixer_at_the_real_repo_is_blocked(self):
+        """Gotcha-Test Pair: `_run(SYNC, repo_copy)` 를 `cwd=REPO_ROOT` 직접 실행으로
+        되돌리면 그 테스트가 여기서 막혀 FAIL. 문서의 sync 상태와 무관하게 결정론적이다.
+        """
+        with pytest.raises(AssertionError, match="실제 리포에 겨눴다"):
+            subprocess.run(["bash", str(SYNC)], cwd=REPO_ROOT, capture_output=True, check=False)
+
+    def test_a_copy_override_is_accepted(self, fixer_guard, repo_copy):
+        """정상 경로까지 막으면 사본 실행이 불가능해진다 — 과잉 차단 방지."""
+        assert fixer_guard(["bash", str(SYNC)], {"REPO_ROOT": str(repo_copy)}) is None
+
+    def test_read_only_checkers_are_not_blocked(self, fixer_guard):
+        """`scripts/verify/` 의 검사기는 레포에서 돌아도 무해하다 — 대상 아님."""
+        assert fixer_guard(["bash", str(VERIFY)], None) is None
 
 
 class TestClaimListParity:


### PR DESCRIPTION
## 무엇이 문제였나

`tests/verify/test_doc_claim_parity.py::TestSyncRuns::test_sync_does_more_than_print_its_banner`
가 `scripts/doc/sync_doc_counts.sh` — **in-place 문서 fixer** — 를 `cwd=REPO_ROOT` 로 실행했다.
같은 파일의 형제 테스트는 전부 `repo_copy` 픽스처를 쓴다.

**백엔드 테스트를 돌릴 때마다 실제 README / ARCHITECTURE / STRATEGY 가 조용히 재작성됐다.**
테스트는 통과하면서 그렇게 했고 pytest 출력에 흔적이 없어 `git status` 를 볼 때까지 몰랐다.

격리된 worktree 에서 재현: `README.md` 의 `51 tables` → `88 tables` 로 손상 → 그 테스트 **하나**만
실행 → PASS 하면서 손상이 복구됨(= 리포에 썼다).

`cwd=` 로는 못 막는다. `scripts/_common.sh` 가 **스크립트 자신의 레포 루트로 cd** 하므로
`REPO_ROOT` env override 가 유일한 리다이렉트고, 그게 빠진 것이 결함이었다.

## 고친 것

1. 그 테스트를 형제들처럼 `_run(SYNC, repo_copy)` 로 옮겼다.
2. `tests/verify/conftest.py` 에 **런타임 인터셉터** — `subprocess.Popen.__init__` 을 감싸,
   in-place fixer 가 실제 레포를 겨누면 **실행 전에** 터진다.
3. 보조로 내용 해시 트립와이어 (subprocess 를 안 거치는 직접 쓰기용).

## 왜 이 설계인가 (Codex 리뷰 3라운드)

처음엔 소스를 스캔하는 **AST 스윕**으로 짰다. Codex 가 뚫었다 — argv 를 변수에 담기,
`check_call`, 헬퍼 래핑, 서브디렉터리, 별칭 env override. 폐기했다.

2라운드에서 `Popen` 모듈 속성 패치도 뚫렸다 — `shell=True` 문자열, `bash -lc` 중첩 셸,
사전 바인딩 별칭. 그래서 세 가지를 바꿨다:

| 우회로 | 대응 |
|---|---|
| 사전 바인딩 `from subprocess import Popen as X` | 모듈 속성이 아니라 **클래스 메서드**(`Popen.__init__`) 패치 — 별칭은 같은 클래스 객체 |
| `shell=True` / `bash -lc "…"` | argv 원소가 아니라 **합친 커맨드 문자열** 매칭 |
| fixer 가 이사가거나 새로 생김 | 폴더가 아니라 **동작**으로 유도 (`scripts/**/*.sh` 중 `sed -i` 하는 것 — 실측 27개 중 1개) |

3라운드 판정 **PASS**, findings 없음.

## 검증

우회 시도 10종을 격리 worktree 에서 각각 적용해 실행 — **전부 실행 전에 차단**:

| # | 뮤테이션 | 결과 |
|---|---|---|
| 1 | `cwd=REPO_ROOT` 직접 (원래 결함) | BLOCKED |
| 2 | `argv = [...]` 변수 경유 | BLOCKED |
| 3 | `subprocess.check_call` | BLOCKED |
| 4 | 로컬 헬퍼로 감싸기 | BLOCKED |
| 5 | 별칭 통한 실제 루트 env override | BLOCKED |
| 6 | `subprocess.Popen` 직접 | BLOCKED |
| 7 | `shell=True` 문자열 | BLOCKED |
| 8 | `bash -lc` 중첩 셸 | BLOCKED |
| 9 | `from subprocess import Popen as X` | BLOCKED |
| 10 | `subprocess.check_output` | BLOCKED |

카나리아 2개도 뮤테이션 검증: fixer 탐지가 눈이 멀면 collection 단계에서 `RuntimeError`,
가드가 걷히면 `TestFixerGuard` 가 FAIL.

- 전체 백엔드 스위트: **6727 passed, 6 skipped** — 실행 후 `git status` 클린 (이 PR 의 목적)
- `ruff check` + `ruff format --check` 통과
- `check_privacy_leak.py` (인자 없이 = CI 패리티) 통과

## 알려진 한계 (코드에 명시)

fixer 탐지는 `sed -i` 만 본다. 향후 fixer 가 `perl -i` / `tee` / 리다이렉션 / `python -c` 로
고쳐 쓰면 자동 등록되지 않는다 — 그때 패턴을 같이 넓혀야 한다. 리다이렉션을 지금 넣지 않는
이유는 로그·임시파일을 쓰는 정상 스크립트가 통째로 걸리기 때문.

내용 해시 가드는 **회귀 잠금이 아니다** — 문서가 sync 상태면 fixer 가 아무것도 안 써서
발화하지 않고, CI 는 항상 그 상태다. 로컬 편집 중 오염을 잡는 트립와이어로만 문서화했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)