### PR TITLE
chore(types): drop pyright suppressions that suppress nothing

### DIFF
--- a/nuri/collectors/base.py
+++ b/nuri/collectors/base.py
@@ -1,4 +1,3 @@
-# pyright: reportAttributeAccessIssue=false
 """
 BaseCollector — 모든 데이터 수집기의 추상 기반 클래스.
 

--- a/nuri/collectors/kis_analyst_opinion.py
+++ b/nuri/collectors/kis_analyst_opinion.py
@@ -1,4 +1,3 @@
-# pyright: reportMissingImports=false
 """KR analyst-opinion collector via KIS Open API `invest_opinion` endpoint.
 
 NOT a research-report scraper (the original Playwright skeleton was deleted in

--- a/nuri/collectors/technical.py
+++ b/nuri/collectors/technical.py
@@ -1,4 +1,3 @@
-# pyright: reportArgumentType=false
 """
 기술적 지표 수집기 — prices 테이블 데이터 기반으로 지표 계산.
 

--- a/nuri/quant/factors/composite.py
+++ b/nuri/quant/factors/composite.py
@@ -1,4 +1,3 @@
-# pyright: reportArgumentType=false, reportCallIssue=false, reportAttributeAccessIssue=false, reportOperatorIssue=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false, reportOptionalOperand=false
 """멀티팩터 합성 스코어 — 모멘텀(30%) + 가치(25%) + 퀄리티(25%) + 센티먼트(20%).
 
 사용법:

--- a/tests/quant/test_factors_quality.py
+++ b/tests/quant/test_factors_quality.py
@@ -1,5 +1,4 @@
 # cspell:ignore qmod
-# pyright: reportArgumentType=false
 """Tests for factors_quality — split from test_quant_all.py."""
 
 from datetime import timedelta

--- a/tests/quant/test_factors_value.py
+++ b/tests/quant/test_factors_value.py
@@ -1,5 +1,4 @@
 # cspell:ignore vmod
-# pyright: reportArgumentType=false
 """Tests for factors_value — split from test_quant_all.py."""
 
 from datetime import timedelta


### PR DESCRIPTION
②F 감사 중 `nuri/quant/factors/composite.py` 1행의 **파일 전체 pyright 억제 7종**을 발견했습니다. BUY 스코어링에 쓰이는 모듈인데 타입 검사가 통째로 꺼져 있었습니다.

떼어내고 재보니 **에러 0** — 가리는 게 아무것도 없었습니다.

## 스윕

같은 형태가 39개 파일에 있어 동일하게 측정했습니다: 전부 떼고 pyright 한 번 → 실제로 잡히는 파일만 복원.

| | 개수 |
|---|---|
| 파일 전체 억제 | 39 (+ composite.py = 40) |
| **낡음 (0 에러)** — 제거 | **7** |
| 여전히 필요 — 복원 | 33 |

제거된 7개 중 6개가 추적 파일이고, `scripts/analysis/exit_rule_backtest.py` 는 gitignored 로컬입니다.

pyright 에러 수는 **190 → 190**, 변화 없습니다.

## 기준선을 잘못 물려받았던 것 (기록)

`NEXT_SESSION.md` 와 #976 기록이 둘 다 **183** 이라 적고 있어, 처음에 190을 보고 "7개 회귀"로 잠깐 읽었습니다. 실제로 main 에서 재보니 기준선 자체가 이미 **190** 이었습니다 — 그 사이 드리프트한 것입니다.

기억된 숫자와 대조하면 안 되고 그 자리에서 재야 한다는, 이번 세션에 반복해서 나온 그 패턴입니다.

## 검증

- pyright: 190 (main) → 190 (이 PR)
- `ruff check nuri/ tests/ scripts/` 통과
- `tests/quant/` + `tests/collectors/`: 1566 passed, 3 skipped

## 남은 것 (이 PR 범위 아님)

`composite.py` 의 실질 결함 2건은 정책 결정이 필요해 분리했습니다:
- `fg_score` 부재 시 **0.5 를 지어냄** (오늘 실측 0.637 대비 0-100 스케일 2.74점 차, 임계 70)
- fear&greed **신선도 검사 없음** — `#1017` 에서 VIX 에 고친 것과 같은 구멍

🤖 Generated with [Claude Code](https://claude.com/claude-code)