### PR TITLE
fix(deploy): restart the daemons after autopull lands new code

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,770 collected across 306 files | |
+| **Backend tests** | 6,777 collected across 307 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,770 backend tests across 306 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,777 backend tests across 307 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -264,7 +264,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,770 tests, 306 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,777 tests, 307 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/autopull_receiver.sh
+++ b/scripts/deploy/autopull_receiver.sh
@@ -92,9 +92,9 @@ log "updated to ${AFTER:0:7}"
 # ── 변경 분석: 수동 조치가 필요한 변경이면 경고만 로그 ──────────────────
 CHANGED=$(git diff --name-only "$BEFORE" "$AFTER" 2>/dev/null)
 
+DEPS_CHANGED=0
 if echo "$CHANGED" | grep -qE "^(pyproject\.toml|uv\.lock)$"; then
-    log "WARN: Python deps changed. Run manually:"
-    log "  cd $REPO && uv sync --extra dev"
+    DEPS_CHANGED=1
 fi
 
 if echo "$CHANGED" | grep -qE "^frontend/package(-lock)?\.json$"; then
@@ -111,15 +111,59 @@ if echo "$CHANGED" | grep -qE "^config/"; then
     log "INFO: config/ files changed. Verify rules/agents/portfolio still valid."
 fi
 
-# ── (B1) 서비스 재시작 hook ─────────────────────────────────────────────
-# 현재는 24/7 서비스가 등록되어 있지 않아 no-op.
-# API/dashboard/scheduler를 launchd로 띄우게 되면 아래에 추가:
+# ── 상주 서비스 재기동 ──────────────────────────────────────────────────
+# 여기는 오래 "24/7 서비스가 등록되어 있지 않아 no-op" 이라는 주석만 있는 placeholder
+# 였다. 그 문장은 서비스가 7개 등록된 뒤로 거짓이었고, **자동 경로만** 데몬을 안 재웠다
+# — 수동 경로(`deploy_to_mini.sh`)는 #940 이후 제대로 bounce 하고 테스트로 잠겨 있다.
 #
-#   launchctl kickstart -k "gui/$(id -u)/com.nuri-quant.api" 2>>"$LOG"
-#   launchctl kickstart -k "gui/$(id -u)/com.nuri-quant.scheduler" 2>>"$LOG"
+# 안 재우면 **디스크의 새 코드 + 메모리의 낡은 모듈** 조합이 된다. 2026-08-10 실측:
+# #1017 이 `nuri/core/rules.py` 에 심볼을 추가한 날 밤 22:00 `premarket_brief` 가 새
+# `vix_gate` 를 lazy import 하다 캐시된 옛 `rules` 에서 `VIX_MAX_AGE_BUSINESS_DAYS` 를
+# 못 찾아 ImportError 로 죽었고 — certifications · decisions · 브리핑 md **3개 산출물이
+# 통째로 안 만들어졌다**. APScheduler 는 바로 다음 줄에 `executed successfully` 를 찍어
+# 아무 신호도 없었다. 같은 계열이 #576 에 이미 기록돼 있었다.
 #
-# 또는 nohup으로 띄우는 패턴이면:
-#   pkill -f "uvicorn nuri.api" && nohup .venv/bin/python -m uvicorn nuri.api.main:app --port 8001 >>"$LOG" 2>&1 &
+# **재기동은 어느 경우에도 안 하는 것보다 낫다**: 안 재운 프로세스는 이미 하이브리드
+# (메모리는 옛 모듈, lazy import 는 새 파일)라 일관성이 없다. 재기동하면 최소한 전부
+# 새 코드가 된다. 스키마 변경도 마찬가지 — 그건 위 WARN 이 사람에게 알린다.
 #
-# 지금은 코드 변경만 반영하고 종료.
-log "deploy hook: no services configured to restart (skipped)"
+# 트레이드오프: 머지가 긴 잡(22:00 브리핑 ~5분) 도중에 떨어지면 그 잡이 죽는다. 그러나
+# 대안은 **확정적** ImportError 라, 드문 충돌 쪽을 택한다. 죽은 잡은 다음 cron 에 다시 돈다.
+CODE_CHANGED=0
+if echo "$CHANGED" | grep -qE "^nuri/.*\.py$"; then
+    CODE_CHANGED=1
+fi
+
+if [ "$CODE_CHANGED" = "1" ] || [ "$DEPS_CHANGED" = "1" ]; then
+    # 순서가 중요하다: sync 를 재기동 **앞**에 둔다. 뒤에 두면 새 프로세스가 옛 venv 로
+    # 뜬 뒤 패키지만 바뀌어, 재기동을 한 번 더 해야 한다 (2026-08-10 수동 조치 때 밟음).
+    if [ "$DEPS_CHANGED" = "1" ]; then
+        # launchd 는 로그인 셸 PATH 를 안 물려준다 — `uv` 를 이름으로 부르면
+        # `command not found` 로 조용히 건너뛴다 (2026-08-10 실측).
+        UV_BIN=$(command -v uv 2>/dev/null || echo "/opt/homebrew/bin/uv")
+        if [ -x "$UV_BIN" ]; then
+            log "deps changed → $UV_BIN sync --extra dev"
+            "$UV_BIN" sync --extra dev >>"$LOG" 2>&1 || log "ERROR: uv sync 실패 — 구 venv 로 재기동된다"
+        else
+            log "ERROR: uv 를 못 찾음 ($UV_BIN) — deps 미동기화 상태로 재기동한다"
+        fi
+    fi
+
+    # 상주 python 서비스. plist 판정 기준(StartInterval 없음 + .venv/bin/python)과
+    # 일치해야 하며 `tests/scripts/test_deploy_bounces_resident_services.py` 가 대조한다.
+    # dashboard 는 빌드 산출물을 서빙하므로 제외 — 프론트 변경은 위 WARN 이 담당.
+    RESIDENT_SERVICES=(com.nuri-quant.scheduler com.nuri-quant.api com.nuri-quant.discord-bot)
+    for RESIDENT in "${RESIDENT_SERVICES[@]}"; do
+        if ! launchctl list 2>/dev/null | grep -q "${RESIDENT}\$"; then
+            log "skip restart: ${RESIDENT} 미설치"
+            continue
+        fi
+        if launchctl kickstart -k "gui/$(id -u)/${RESIDENT}" >>"$LOG" 2>&1; then
+            log "restarted ${RESIDENT}"
+        else
+            log "ERROR: ${RESIDENT} kickstart 실패 — 구코드로 계속 돈다. 수동 확인 필요"
+        fi
+    done
+else
+    log "no python code/dep changes — services left running"
+fi

--- a/tests/scripts/test_autopull_restarts_daemons.py
+++ b/tests/scripts/test_autopull_restarts_daemons.py
@@ -1,0 +1,138 @@
+"""autopull 이 코드를 당긴 뒤 **상주 데몬을 실제로 재기동하는지** — 스크립트를 실행해서 본다.
+
+**왜 grep 이 아니라 실행인가**: `scripts/deploy/autopull_receiver.sh` 의 재기동 hook 은
+"24/7 서비스가 등록되어 있지 않아 no-op" 이라는 주석과 함께 **주석 처리된 예시**로만
+존재했다. 문자열만 보는 테스트였다면 `launchctl kickstart` 가 주석 안에 있어도 통과했다.
+`test_deploy_bounces_resident_services.py` 도 같은 함정을 밟은 적이 있다(성공 메시지 안의
+URL 때문에 curl 을 지워도 통과) — 그래서 여기선 **stub PATH 를 깔고 스크립트를 돌려**
+`launchctl` 이 진짜로 호출됐는지 기록을 본다.
+
+**막으려는 사고** (2026-08-10 프로덕션 실측): 수동 경로(`deploy_to_mini.sh`)는 #940 이후
+상주 서비스를 bounce 하는데 **자동 경로(autopull)는 안 했다**. 사용자는 머지마다 수동
+배포를 돌리지 않으므로 데몬이 7일간 구코드로 돌았고, #1017 이 `nuri/core/rules.py` 에
+심볼을 추가한 날 밤 `premarket_brief` 가 ImportError 로 죽어 산출물 3개가 사라졌다.
+APScheduler 는 `executed successfully` 를 찍었다 — 실패 신호가 아예 없었다.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUTOPULL = REPO_ROOT / "scripts" / "deploy" / "autopull_receiver.sh"
+
+RESIDENT = ["com.nuri-quant.scheduler", "com.nuri-quant.api", "com.nuri-quant.discord-bot"]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+
+
+@pytest.fixture()
+def world(tmp_path: Path):
+    """origin 이 한 커밋 앞선 로컬 레포 + launchctl/uv stub PATH."""
+    origin, work, binz = tmp_path / "origin", tmp_path / "work", tmp_path / "bin"
+    binz.mkdir()
+    calls = tmp_path / "calls.txt"
+
+    # launchctl stub — `list` 는 서비스가 설치된 것처럼 답하고, 나머지는 인자를 기록.
+    (binz / "launchctl").write_text(
+        "#!/bin/sh\n"
+        f'if [ "$1" = "list" ]; then for l in {" ".join(RESIDENT)}; do echo "1 0 $l"; done; exit 0; fi\n'
+        f'echo "launchctl $*" >> "{calls}"\nexit 0\n'
+    )
+    (binz / "uv").write_text(f'#!/bin/sh\necho "uv $*" >> "{calls}"\nexit 0\n')
+    for f in ("launchctl", "uv"):
+        (binz / f).chmod(0o755)
+
+    origin.mkdir()
+    _git(origin, "init", "--bare", "-b", "main")
+    work.mkdir()
+    _git(work, "init", "-b", "main")
+    _git(work, "remote", "add", "origin", str(origin))
+    (work / "seed.txt").write_text("seed\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "seed")
+    _git(work, "push", "-q", "origin", "main")
+
+    def land(files: dict[str, str]) -> None:
+        """origin/main 에 커밋 하나를 올린다 (autopull 이 당겨갈 것)."""
+        side = tmp_path / "side"
+        if not side.exists():
+            _git(tmp_path, "clone", "-q", str(origin), str(side))
+        for rel, body in files.items():
+            p = side / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body)
+        _git(side, "add", "-A")
+        _git(side, "commit", "-m", "change")
+        _git(side, "push", "-q", "origin", "main")
+
+    def run() -> str:
+        env = {
+            **os.environ,
+            "PATH": f"{binz}:{os.environ['PATH']}",
+            "NURI_REPO": str(work),
+            "HOME": str(tmp_path),
+        }
+        subprocess.run(["bash", str(AUTOPULL)], env=env, check=False, capture_output=True, timeout=120)
+        return calls.read_text() if calls.exists() else ""
+
+    return type("W", (), {"land": staticmethod(land), "run": staticmethod(run), "work": work})
+
+
+class TestAutopullBouncesDaemons:
+    def test_python_change_restarts_every_resident_service(self, world):
+        world.land({"nuri/core/rules.py": "VIX_MAX_AGE_BUSINESS_DAYS = 2\n"})
+        out = world.run()
+        assert "Already up to date" not in out
+        for label in RESIDENT:
+            assert re.search(rf"launchctl kickstart -k \S*{re.escape(label)}", out), (
+                f"{label} 을 재기동하지 않았다 — 데몬이 구코드를 들고 계속 돈다.\n기록:\n{out}"
+            )
+
+    def test_it_actually_pulled(self, world):
+        """카나리아 — ff-merge 가 실패했는데 '재기동 안 함' 을 정상으로 읽으면 안 된다."""
+        world.land({"nuri/core/rules.py": "X = 1\n"})
+        world.run()
+        assert (world.work / "nuri" / "core" / "rules.py").exists(), "ff-merge 가 안 됐다 — 이 픽스처가 고장난 것"
+
+    def test_docs_only_change_does_not_restart(self, world):
+        """문서만 바뀌면 재기동하지 않는다 — 5분마다 데몬을 흔들면 잡이 죽는다."""
+        world.land({"docs/whatever.md": "# hi\n"})
+        out = world.run()
+        assert "kickstart" not in out, f"문서 변경으로 재기동했다:\n{out}"
+
+    def test_dep_change_syncs_venv_before_restarting(self, world):
+        """`uv sync` 는 재기동 **앞**에 와야 한다 — 뒤면 새 프로세스가 옛 venv 로 뜬다."""
+        world.land({"uv.lock": "# bumped\n"})
+        out = world.run()
+        assert "uv sync" in out, f"deps 가 바뀌었는데 sync 하지 않았다:\n{out}"
+        assert out.index("uv sync") < out.index("kickstart"), f"sync 가 재기동보다 뒤에 있다:\n{out}"
+
+    def test_uv_is_called_by_absolute_path_not_bare_name(self):
+        """launchd 는 로그인 셸 PATH 를 안 물려준다 — 이름으로 부르면 조용히 건너뛴다.
+
+        2026-08-10 수동 조치에서 실제로 `uv: command not found` 로 sync 가 통째로 스킵됐다.
+        """
+        src = AUTOPULL.read_text(encoding="utf-8")
+        assert "command -v uv" in src and "/opt/homebrew/bin/uv" in src, (
+            "uv 를 PATH 이름만으로 부르면 launchd 컨텍스트에서 조용히 실패한다"
+        )

--- a/tests/scripts/test_deploy_bounces_resident_services.py
+++ b/tests/scripts/test_deploy_bounces_resident_services.py
@@ -24,6 +24,7 @@ import pytest
 
 LAUNCHD_DIR = Path("scripts/launchd")
 DEPLOY_SCRIPT = Path("scripts/deploy/deploy_to_mini.sh")
+AUTOPULL_SCRIPT = Path("scripts/deploy/autopull_receiver.sh")
 
 # dashboard 는 상주지만 npm 빌드 산출물을 서빙한다 — 빌드가 바뀔 때만 바운스하는 게 맞고,
 # 그 조건부 처리는 4단계에 이미 있다. python 판정에서 자연히 빠지지만 의도를 명시해 둔다.
@@ -51,11 +52,38 @@ def resident_python_labels() -> list[str]:
     return [label for label, spec in _plists() if _is_resident(spec) and _runs_repo_python(spec)]
 
 
-def _declared_resident_services() -> set[str]:
-    """`deploy_to_mini.sh` 가 선언한 bounce 대상 (`RESIDENT_SERVICES=(...)`)."""
-    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+def _declared_resident_services(path: Path = DEPLOY_SCRIPT) -> set[str]:
+    """스크립트가 선언한 bounce 대상 (`RESIDENT_SERVICES=(...)`)."""
+    script = path.read_text(encoding="utf-8")
     m = re.search(r"RESIDENT_SERVICES=\(([^)]*)\)", script)
     return set(m.group(1).split()) if m else set()
+
+
+class TestAutopullDeclaresTheSameServices:
+    """자동 경로도 같은 목록을 재기동해야 한다 (#1023).
+
+    #940 은 **수동** 경로(`deploy_to_mini.sh`)만 고쳤고, 그 사이 `autopull_receiver.sh`
+    는 "서비스가 등록되어 있지 않아 no-op" 이라는 낡은 주석과 함께 재기동을 아예 안
+    했다. 사용자는 머지마다 수동 배포를 돌리지 않으므로 **실제로 코드를 나르는 건
+    자동 경로**다 — 2026-08-10 에 데몬이 7일간 구코드로 돌다 야간 잡이 죽었다.
+    실행 레벨 검증은 `test_autopull_restarts_daemons.py` 가 한다.
+    """
+
+    def test_autopull_covers_every_resident_python_service(self):
+        declared = _declared_resident_services(AUTOPULL_SCRIPT)
+        missing = sorted(set(resident_python_labels()) - declared)
+        assert not missing, (
+            f"autopull 이 재기동하지 않는 상주 python 서비스: {missing}\n"
+            "자동으로 당겨온 코드를 데몬이 안 들고 있게 된다 (디스크 새 코드 + 메모리 옛 모듈)."
+        )
+
+    def test_both_paths_agree(self):
+        """두 경로가 갈라지면 어느 쪽으로 배포했느냐에 따라 결과가 달라진다."""
+        auto = _declared_resident_services(AUTOPULL_SCRIPT)
+        manual = _declared_resident_services(DEPLOY_SCRIPT) | {"com.nuri-quant.scheduler"}
+        assert auto == manual, (
+            f"자동/수동 배포 경로의 재기동 목록 불일치\n  autopull={sorted(auto)}\n  deploy  ={sorted(manual)}"
+        )
 
 
 class TestDeployBouncesEveryResidentPythonService:


### PR DESCRIPTION
## The gap

`autopull_receiver.sh` fetches and ff-merges every 5 minutes, then stops. Its restart hook was a commented-out placeholder carrying the line **"현재는 24/7 서비스가 등록되어 있지 않아 no-op"** — false since the services were registered.

#940 fixed exactly this for the **manual** path (`deploy_to_mini.sh`), and locked it with a test. But the manual path is not what carries code day to day — autopull is. So the automatic path silently left the daemons on old code, and no test covered it.

## What it cost, measured

- `api` + `dashboard`: running **Aug 3 17:34** code for 7 days — 19 commits, 10 changed `nuri/*.py` behind.
- The scheduler self-restarts at 08:40 daily, so it held Aug-10-08:40 code. #1017 merged later that day, adding `VIX_MAX_AGE_BUSINESS_DAYS` to `nuri/core/rules.py`.
- At 22:00 `premarket_brief` lazy-imported the new `vix_gate` module, which looked for that symbol in the **cached** old `rules`:

```
2026-08-10 22:00:00,121 ERROR [premarket_brief] 실행 실패:
cannot import name 'VIX_MAX_AGE_BUSINESS_DAYS' from 'nuri.core.rules'
2026-08-10 22:00:00,122 INFO  Job "premarket_brief" ... executed successfully
```

**One failure, three artifacts lost** — `certifications`, `decisions`, the brief markdown — and APScheduler called it a success on the very next line.

Same class as #576 (`uv sync` + importlib cache), already written down in memory. Documented and it happened anyway, which is the case for a test over another note.

## Fix

When `nuri/**/*.py` or `pyproject.toml`/`uv.lock` change: `uv sync`, **then** bounce every resident python service. Docs/config-only changes skip it, so the daemons are not shaken every 5 minutes.

Two details that bit me during the manual recovery are now encoded and tested:
- **`uv` by absolute path** — launchd does not inherit the login-shell PATH. A bare `uv` gave `command not found` and the sync was silently skipped.
- **sync before restart** — I did it in the wrong order by hand and had to bounce twice.

Restarting beats not restarting in every case: an un-restarted daemon is already hybrid (old modules in memory, new ones lazy-imported off disk), so a bounce at least makes it coherent. The tradeoff — a merge landing mid-job kills that job — is accepted and stated in the script: that is rare and self-healing on the next cron, while the ImportError is deterministic.

## Tests execute, they don't grep

A string-matching test would have **passed on the commented-out hook** — which is how it stayed dead. So the tests lay stub `launchctl`/`uv` on PATH, build a real git origin one commit ahead, run the script, and read what `launchctl` actually recorded.

Mutations: restart loop removed → 2 FAIL · bare `uv` → 1 FAIL · condition removed → 1 FAIL.

The service list is also cross-checked against the plists (reusing #940's derivation), so the automatic and manual paths can't drift apart.

## Note on rollout

`autopull` is `StartInterval=300` — a fresh process each tick — so the new script takes effect on the next run with no restart needed. Production was already recovered by hand before this PR (services bounced, venv synced to aiohttp 3.14.3, imports verified).

Closes #1023