### PR TITLE
fix(macro): drop unmeasured components and renormalize, don't score them 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,777 collected across 307 files | |
+| **Backend tests** | 6,784 collected across 308 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 548 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 554 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -143,6 +143,12 @@ entry_rules:
 # 랭킹은 안 바뀌고 절대 점수 수준만 움직이므로 `quality_bar` 통과 **개수**에 작용한다.
 # 값이 없거나 노후하면 0.5 로 메우지 않고 **성분을 빼고 나머지 3팩터를 재정규화**한다
 # (STRATEGY §2.6 — 없는 관측을 지어내지 않는다). 비중 자체는 `composite.py WEIGHTS`.
+# 매크로 종합 점수 (nuri/quant/regime/macro_score.py)
+macro:
+  # 측정된 성분의 가중치 합이 이 아래면 interpretation 을 'Insufficient' 로 낮춘다.
+  # 얇은 표본이 'Favorable' 같은 확신 라벨로 읽히는 걸 막는다 (#1026).
+  min_coverage: 0.6
+
 factors:
   # Fear & Greed 는 시장 지수라 주말·휴장에 갱신 안 됨 → 영업일 기준
   sentiment_max_age_business_days: 2

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,777 backend tests across 307 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,784 backend tests across 308 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -77,6 +77,8 @@ Maintainer note: 이 파일은 `CLAUDE.md` 에서 `@docs/STRATEGY.md` 로 import
 
 **점수 성분에는 다른 규칙이 적용된다 (2026-08-10)** — 위 조항은 *게이트*(통과/차단) 이야기다. `factors/composite` 의 센티먼트처럼 **점수 성분**이 없을 때는 "가장 보수적 관측치" 라는 게 정의되지 않는다. 그때는 값을 지어내지 말고 **성분을 빼고 나머지 비중을 비례 재정규화**한다(합계 1.0 유지). 과거엔 Fear & Greed 부재 시 `0.5` 를 채웠는데, 0.5 는 중립이라 무해해 보여도 실측 0.637 대비 0-100 스케일에서 2.74점이고 `quality_bar.base_threshold: 70` 앞에서 통과 **개수**를 움직였다. 재정규화는 "모른다" 가 점수를 위로도 아래로도 밀지 않게 한다. 랭킹은 어차피 불변이다 — 시장 전체 값이라 모든 티커에 같은 양이 들어간다.
 
+**2차 적용: `regime/macro_score` (2026-08-11, #1026)** — 같은 조항을 9성분 매크로 점수에 적용했다. 결측 성분에 `50.0` 을 채워 가중합하던 것을 **성분 제외 + 비례 재정규화**로 바꾸고 `coverage`(측정된 가중치 합)를 함께 내보낸다. 실측 여파가 크다: `FRED_API_KEY` 미설정으로 FRED 전용 지표 **8개 전부 0행**이라 3성분(3M-10Y · 실업 · CPI)이 결측이고, 총점 **64.4 "Neutral" → 71.3 "Favorable"** 로 **해석 경계를 넘는다**. 지어낸 중립이 우호적 판독을 눌러 온 것이다. 코드는 이미 결측을 감지해 `warnings` 에 담고 있었으나 **읽는 소비처가 0개**였다 — 감지는 어디에도 닿지 않으면 없는 것과 같다. 얇은 표본이 확신 라벨을 달지 않도록 `macro.min_coverage`(기본 0.6) 미만이면 `interpretation="Insufficient"`.
+
 **SIEGE 게이트에도 같은 원칙이 적용된다 (2026-08-10, #1022)** — §6 gate 7 `volatility_gate` 는 지표가 없으면 `passed=True, "데이터 없음 — 스킵"` 을 냈다. 이 게이트의 가장 보수적 관측치는 **자기 자신의 실패 상태**(warning)이므로, 입력 부재는 `passed=False, severity=warning` 으로 낸다. 적용 범위는 게이트의 **판정 입력**(primary)이다 — 보조 spillover 지표(secondary)는 값이 없으면 condition 을 아예 만들지 않아 "정상" 이라 주장하지도 score 를 부풀리지도 않으므로 그대로 둔다. 없는 참고 지표마다 경고를 띄우는 건 §2.6 이 경계하는 performative 경고 쪽이다. 영구 미수집 secondary 는 런타임이 아니라 PR 시점 계약 테스트가 잡는다. 30줄 위 `data_fresh` 는 처음부터 그렇게 동작했다 — 같은 파일 두 게이트가 같은 상황에 반대로 답하고 있었다. warning 이라 `certified` 는 안 막는다 — **매매 행동은 안 바뀐다**(Surface rung). 다만 "무변화" 는 아니다: `score = passed/total` 이라 인증서 점수가 내려가고, 그 값은 `certifications` 테이블에 적재돼 `/api/engine` 이 rolling 평균을 낸다. 즉 **이 커밋 앞뒤의 score 시계열은 정의가 달라 직접 비교하면 안 된다** (실측 63 → 56). 이전 구간이 높았던 건 개선이 아니라 평가되지 않은 게이트를 통과로 세었기 때문이다. E4-0b predictivity 감사가 이 경계를 넘는 구간을 쓸 때 반드시 분리할 것. 실측 여파: `kr_index` · `bond` 의 primary 지표(`kospi` / `yield`)는 프로덕션 `macro` 에 n=0 이라, 두 게이트는 도입(#248) 이래 한 번도 평가되지 않은 채 매 인증서에 초록으로 찍혀 있었다. **미수집이 아니라 배관 문제다** — `prices.KOSPI` 는 419행 있고 같은 인증서의 freshness 게이트가 이미 그걸 읽는다. 변동성 게이트만 `macro` 전용 경로라 못 볼 뿐이다. 그래서 이 PR 은 semantics 만 고치고(거짓말 제거), 입력 경로 연결과 bond threshold 재도출은 분리한다 — 후자는 `_compute_3d_change` 가 pct 를 돌려주는데 threshold 0.3 은 bp 의미로 쓰여 있어 포인터만 바꾸면 죽은 게이트가 상시 발화 게이트로 바뀐다.
 
 이 조항에 백테스트를 붙이지 않는다. 발동 조건이 시장 시그널이 아니라 **데이터 장애**라, "VIX 가 없었다면" 을 과거 시장에 되돌려 세우는 것은 의미 있는 증거가 아니다. 등급을 올리거나 내리려면 실제 장애 발생 빈도와 그때의 시장 분포를 먼저 측정할 것.
@@ -264,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,777 tests, 307 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,784 tests, 308 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -145,10 +145,14 @@ def _get_macro() -> dict:
         from nuri.quant.regime.macro_score import compute_macro_score
 
         m = compute_macro_score()
-        return {"score": round(m.total_score), "interpretation": m.interpretation}
+        # coverage 를 같이 내보낸다 — 68% 짜리 점수가 100% 인 척 보이면 안 된다 (#1026).
+        return {"score": round(m.total_score), "interpretation": m.interpretation, "coverage": m.coverage}
     except Exception as e:
-        logger.debug(f"Macro: {e}")
-    return {"score": 50, "interpretation": "Neutral"}
+        logger.warning(f"Macro score 계산 실패 — 미측정으로 표기: {e}")
+    # ⚠️ 여기 `score: 50` 은 **측정값이 아니라 스키마 자리표시자**다. 프론트가 숫자 필드를
+    # 요구해서 남겨 둘 뿐이고, 판별은 `coverage == 0` / `interpretation` 으로 한다.
+    # 예전엔 "Neutral" 이라 적어 실패가 정상 판독으로 둔갑했다.
+    return {"score": 50, "interpretation": "Unavailable", "coverage": 0.0}
 
 
 def _get_allocation(regime: str) -> dict:

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -81,6 +81,9 @@ REGIME_CASH = _entry.get(
 MAX_TRANCHES = _entry.get("scaling_in", {}).get("max_tranches", 3)
 TRANCHE_INTERVAL_DAYS = _entry.get("scaling_in", {}).get("tranche_interval_days", 5)
 
+# ─── 매크로 종합 점수 ───
+MACRO_MIN_COVERAGE = RULES.get("macro", {}).get("min_coverage", 0.6)
+
 # ─── 멀티팩터 합성 ───
 FACTOR_RULES = RULES.get("factors", {})
 

--- a/nuri/quant/regime/macro_score.py
+++ b/nuri/quant/regime/macro_score.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from nuri.core.db import query
+from nuri.core.rules import MACRO_MIN_COVERAGE
 from nuri.core.timezone import today_kst
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,9 @@ class MacroScore:
     interpretation: str  # "Favorable", "Neutral", "Cautious", "Adverse"
     details: dict  # 원본 지표 값
     warnings: list[str] | None = None  # 누락된 지표 경고 목록
+    # 실제로 측정된 성분의 가중치 합 (1.0 = 전부 측정). 결측 성분은 50 을 채우는 대신
+    # 빼고 재정규화하므로, 소비처는 total_score 를 이 값과 **함께** 읽어야 한다 (#1026).
+    coverage: float = 1.0
 
 
 def _get_latest_macro(indicator: str, date: str | None = None, db_path=None) -> float | None:
@@ -336,26 +340,50 @@ def compute_macro_score(date: str | None = None, db_path=None) -> MacroScore:
         ("inflation", inf_score, inf_detail, ["cpi_yoy"]),
         ("monetary", mon_score, mon_detail, ["fed_funds"]),
     ]
+    unavailable: set[str] = set()
     for name, score, detail, keys in _MISSING_CHECKS:
         if score == 50.0 and any(detail.get(k) is None for k in keys):
             missing_keys = [k for k in keys if detail.get(k) is None]
-            msg = f"{name}: 데이터 누락 ({', '.join(missing_keys)}) → 중립 50점 사용"
+            unavailable.add(name)
+            msg = f"{name}: 데이터 누락 ({', '.join(missing_keys)}) → 가중치에서 제외"
             warnings.append(msg)
-            logger.debug("매크로 지표 누락 — %s", msg)
+            logger.warning("매크로 지표 누락 — %s", msg)
 
-    total = (
-        yc_score * WEIGHTS["yield_curve"]
-        + ys3m10y_score * WEIGHTS["yield_spread_3m10y"]
-        + vix_score * WEIGHTS["vix"]
-        + pcr_score * WEIGHTS["put_call_ratio"]
-        + sent_score * WEIGHTS["sentiment"]
-        + emp_score * WEIGHTS["employment"]
-        + inf_score * WEIGHTS["inflation"]
-        + mon_score * WEIGHTS["monetary"]
-        + evt_score_normalized * WEIGHTS["event"]
-    )
+    # ── 결측 성분은 **빼고 나머지를 비례 재정규화**한다 (STRATEGY §2.6, #1019 선례) ──
+    # 예전엔 결측 성분에 50.0 을 채워 그대로 가중합했다. 50 은 중립이라 무해해 보이지만
+    # **총점을 가운데로 끌어당기는 방향성 있는 힘**이다. 2026-08-11 프로덕션 실측:
+    # 9개 중 3개(3M-10Y · 실업 · CPI, FRED_API_KEY 미설정으로 0행)가 결측이라 가중치
+    # 0.324 만큼 50 이 들어갔고, 총점 64.4 "Neutral" 이 나왔다. 재정규화하면 71.3
+    # "Favorable" — **해석 경계를 넘는다.** 지어낸 중립이 우호적 판독을 눌러 온 것이다.
+    #
+    # 코드는 이미 결측을 감지해 `warnings` 에 담고 있었는데, 읽는 소비처가 0개였고
+    # 로그도 debug 레벨이라 아무도 몰랐다. 그래서 여기서 **점수 자체를 고치고**
+    # coverage 를 함께 내보낸다 — 68% 짜리 점수를 100% 인 척 보이게 두지 않는다.
+    parts = [
+        ("yield_curve", yc_score),
+        ("yield_spread_3m10y", ys3m10y_score),
+        ("vix", vix_score),
+        ("put_call_ratio", pcr_score),
+        ("sentiment", sent_score),
+        ("employment", emp_score),
+        ("inflation", inf_score),
+        ("monetary", mon_score),
+        ("event", evt_score_normalized),  # event 는 항상 계산된다 (결측 개념 없음)
+    ]
+    live = [(n, s) for n, s in parts if n not in unavailable]
+    coverage = sum(WEIGHTS[n] for n, _ in live)
 
-    if total >= 70:
+    if coverage <= 0:
+        # 전 성분 결측 — 점수를 지어내지 않는다. 소비처가 interpretation 으로 판별한다.
+        logger.error("매크로 성분이 전부 결측 — 점수 산출 불가")
+        total = 0.0
+    else:
+        total = sum(s * WEIGHTS[n] for n, s in live) / coverage
+
+    if coverage < MACRO_MIN_COVERAGE:
+        # 얇은 표본이 확신에 찬 라벨로 읽히면 안 된다. 숫자는 그대로 두되 라벨로 막는다.
+        interpretation = "Insufficient"
+    elif total >= 70:
         interpretation = "Favorable"
     elif total >= 50:
         interpretation = "Neutral"
@@ -377,6 +405,7 @@ def compute_macro_score(date: str | None = None, db_path=None) -> MacroScore:
         monetary_score=round(mon_score, 1),
         event_score=round(evt_score_normalized, 1),
         interpretation=interpretation,
+        coverage=round(coverage, 3),
         details={
             **yc_detail,
             **ys3m10y_detail,
@@ -389,6 +418,7 @@ def compute_macro_score(date: str | None = None, db_path=None) -> MacroScore:
             "event_raw": es.score,
             "event_count": es.event_count,
             "event_dominant": es.dominant_category,
+            "coverage": round(coverage, 3),
         },
         warnings=warnings if warnings else None,
     )
@@ -397,7 +427,8 @@ def compute_macro_score(date: str | None = None, db_path=None) -> MacroScore:
 def print_macro_score(score: MacroScore) -> None:
     """매크로 스코어 CLI 출력."""
     print(f"\n{'=' * 55}")
-    print(f"  Macro Score: {score.total_score:.0f}/100 — {score.interpretation}")
+    cov = f"  [측정 {score.coverage:.0%}]" if score.coverage < 1.0 else ""
+    print(f"  Macro Score: {score.total_score:.0f}/100 — {score.interpretation}{cov}")
     print(f"{'=' * 55}")
     print(f"  Date:             {score.date}")
     print(f"  Yield Curve:      {score.yield_curve_score:5.1f}  (2Y-10Y: {score.details.get('spread', '—')})")

--- a/tests/quant/test_macro_score_coverage.py
+++ b/tests/quant/test_macro_score_coverage.py
@@ -1,0 +1,115 @@
+"""매크로 종합 점수 — 결측 성분을 지어내지 않는다 (#1026).
+
+`compute_macro_score` 는 입력이 없는 성분에 **50.0(중립)을 채워 그대로 가중합**했다.
+50 은 중립이라 무해해 보이지만 총점을 가운데로 끌어당기는 방향성 있는 힘이다.
+
+2026-08-11 프로덕션 실측: `FRED_API_KEY` 미설정으로 FRED 전용 지표 **8개 전부 0행** (#1025)
+(`cpi_yoy` · `unemployment` · `us_3m_yield` 등). 9개 성분 중 3개가 결측이라 가중치
+0.324 만큼 50 이 들어갔고 총점은 **64.4 "Neutral"** — 재정규화하면 **71.3 "Favorable"**
+로 해석 경계를 넘는다. 지어낸 중립이 우호적 판독을 눌러 온 것이다.
+
+코드는 이미 결측을 감지해 `warnings` 에 담고 있었는데 **읽는 소비처가 0개**였고 로그도
+debug 레벨이었다. 감지가 있어도 아무 데도 안 닿으면 없는 것과 같다.
+
+정책은 STRATEGY §2.6 의 **점수 성분** 조항(#1019 선례): 값을 지어내지 말고 성분을 빼고
+나머지를 비례 재정규화. 여기에 coverage 를 함께 내보내 얇은 표본이 확신 라벨로 읽히지
+않게 한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nuri.core.db import upsert_macro
+from nuri.core.timezone import today_kst
+from nuri.quant.regime.macro_score import WEIGHTS, compute_macro_score
+
+
+def _seed(db_path, **indicators):
+    today = today_kst()
+    upsert_macro(
+        [{"indicator": k, "date": today, "value": v, "source": "test"} for k, v in indicators.items()],
+        db_path,
+    )
+
+
+class TestMissingComponentsAreDroppedNotInvented:
+    def test_absent_component_is_excluded_from_the_weighting(self, db_path):
+        """결측 성분이 50.0 으로 가중되면 안 된다 — coverage 가 그 사실을 드러낸다."""
+        _seed(db_path, vix=15.0)
+        score = compute_macro_score(db_path=db_path)
+        assert score.coverage < 1.0, "결측이 있는데 coverage 가 1.0 이면 지어낸 값을 세고 있는 것"
+        # 측정된 건 vix 와 event 뿐 — 나머지는 빠져야 한다.
+        assert score.coverage == pytest.approx(WEIGHTS["vix"] + WEIGHTS["event"], abs=1e-6)
+
+    def test_coverage_is_one_when_everything_is_present(self, db_path):
+        _seed(
+            db_path,
+            us_10y_yield=4.5,
+            us_2y_yield=3.7,
+            us_3m_yield=4.0,
+            vix=15.0,
+            put_call_ratio=1.0,
+            fear_greed=60.0,
+            unemployment=4.0,
+            cpi_yoy=2.1,
+            fed_funds_rate=3.5,
+        )
+        score = compute_macro_score(db_path=db_path)
+        assert score.coverage == pytest.approx(1.0, abs=1e-6)
+        assert score.interpretation != "Insufficient"
+
+    def test_thin_coverage_is_labelled_insufficient(self, db_path):
+        """얇은 표본은 'Favorable' 같은 확신 라벨을 달지 못한다."""
+        _seed(db_path, vix=10.0)  # VIX 10 → 성분 점수 100, 재정규화하면 총점이 매우 높다
+        score = compute_macro_score(db_path=db_path)
+        assert score.coverage < 0.6
+        assert score.interpretation == "Insufficient", (
+            f"커버리지 {score.coverage:.0%} 인데 '{score.interpretation}' 로 표기했다 — "
+            "두 성분짜리 점수가 확신 라벨을 달면 안 된다"
+        )
+
+    def test_renormalized_total_is_not_dragged_toward_fifty(self, db_path):
+        """결측 성분에 50 을 채우던 시절의 실제 사고를 재현한다.
+
+        측정된 성분이 전부 100 점이면 총점도 100 이어야 한다. 예전엔 결측분에 50 이
+        들어가 총점이 그만큼 끌려 내려갔다.
+        """
+        _seed(db_path, vix=10.0, fear_greed=50.0)  # 둘 다 최고점 구간
+        score = compute_macro_score(db_path=db_path)
+        measured = [score.vix_score, score.sentiment_score]
+        assert all(m > 95 for m in measured), f"픽스처가 최고점 구간이 아니다: {measured}"
+        # event 성분이 섞여 정확히 100 은 아니지만, 50 폴백이 살아있다면 60 대로 눌린다.
+        assert score.total_score > 80, (
+            f"총점 {score.total_score} — 결측 성분이 여전히 50 으로 가중되고 있다 (coverage={score.coverage})"
+        )
+
+    def test_missing_inputs_are_reported(self, db_path):
+        """감지가 로그에만 남고 아무 데도 안 닿던 상태를 배제."""
+        _seed(db_path, vix=15.0)
+        score = compute_macro_score(db_path=db_path)
+        assert score.warnings, "결측이 있는데 warnings 가 비어 있다"
+        assert any("cpi_yoy" in w or "inflation" in w for w in score.warnings)
+
+
+class TestDashboardSurfacesCoverage:
+    def test_macro_payload_carries_coverage(self, db_path, monkeypatch):
+        """대시보드가 점수만 보내고 커버리지를 숨기면 68% 가 100% 처럼 읽힌다."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "compute_macro_score", None, raising=False)
+        _seed(db_path, vix=15.0)
+        payload = dash._get_macro()
+        assert "coverage" in payload, "macro payload 에 coverage 가 없다"
+
+    def test_failure_is_not_labelled_neutral(self, monkeypatch):
+        """계산 실패를 'Neutral' 로 적으면 장애가 정상 판독으로 둔갑한다."""
+        import nuri.api.routes.dashboard as dash
+
+        def boom(*a, **k):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr("nuri.quant.regime.macro_score.compute_macro_score", boom)
+        payload = dash._get_macro()
+        assert payload["interpretation"] == "Unavailable"
+        assert payload["coverage"] == 0.0


### PR DESCRIPTION
Continues the ②F sweep into `regime/`. Same shape as #1017 (VIX 20.0), #1019 (sentiment 0.5) and #1022 (volatility gate PASS): **an absent input wearing the costume of a measurement.**

## What was wrong

`compute_macro_score` filled each missing component with `50.0` and weighted it into the total.

Measured on production, 2026-08-11 — `FRED_API_KEY` is unset, so **all 8 FRED-only indicators have zero rows** (filed as #1025). Three of nine components were invented:

| | weight | production |
|---|---|---|
| `yield_spread_3m10y` | 0.090 | `us_3m_yield` — 0 rows |
| `employment` | 0.117 | `unemployment` — 0 rows |
| `inflation` | 0.117 | `cpi_yoy` — 0 rows |

Weight 0.324 of fabricated 50s → **16.2 points** of the total.

```
현재     : 64.4  Neutral
재정규화 : 71.3  Favorable   (커버리지 68%)
```

It crosses an interpretation boundary. Neutral filler is not neutral in effect — it pulls toward the middle, and it had been suppressing a favorable read on the number the dashboard and the brief show every day.

## The part that stings

The code **already knew**. `_MISSING_CHECKS` detected every one of these and appended to `MacroScore.warnings`. But no consumer reads that field — the dashboard takes `{score, interpretation}` and drops the rest — and the log line was `logger.debug`. Detection that reaches nobody is the same as no detection.

## Fix

Per the score-component clause of STRATEGY §2.6 (adopted in #1019): drop the term, renormalize the remainder, publish `coverage`.

- Missing components leave the weighting instead of being invented; the rest is renormalized so the total stays comparable across days.
- `coverage` (weight actually measured) rides along on `MacroScore`, `details`, the CLI line, and the dashboard payload — a 68% number should not read as a complete one.
- Below `macro.min_coverage` (0.6, config) the interpretation is `"Insufficient"`, so a two-component score cannot wear a confident label.
- The warning moved from `debug` to `warning`.

Also: the dashboard's exception path returned `{"score": 50, "interpretation": "Neutral"}` — a failure rendered as a normal reading. It now returns `"Unavailable"` with `coverage: 0.0`. The numeric 50 stays purely as a schema placeholder because the frontend keys off score thresholds; that is stated in the code, and a follow-up can teach the UI to render coverage.

## Verification

- Mutations: components re-included → 3 FAIL · renormalization removed → 1 FAIL · Insufficient gate removed → 1 FAIL
- `make test-fast` 6751 passed · lint clean · doc counts 19/19 · privacy scan clean (no args)
- Measured against the production DB before and after, numbers above

## Scope note

This PR does not fix the missing data — that is #1025 (set `FRED_API_KEY`; the collector already has the code path). It stops the absence from being laundered into a confident number. Worth knowing from the same sweep: `_detect_stagflation` reads `cpi_yoy` and `gdp_growth`, both zero-row, so the `stagflation` regime — one of the documented 10, and the only one mapping to `"minimal"` sizing — has never been able to fire. Detailed in #1025 rather than widened into this PR.