### PR TITLE
fix(agents): route collectors through the orchestrator so collector_runs fills

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,798 collected across 310 files | |
+| **Backend tests** | 6,799 collected across 310 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,799 collected across 310 files | |
+| **Backend tests** | 6,807 collected across 310 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 49 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
+    SCHED["APScheduler · 50 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 26 jobs"]
@@ -106,7 +106,7 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 49 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 50 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,792 collected across 309 files | |
+| **Backend tests** | 6,798 collected across 310 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -280,7 +280,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 49 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 50 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,798 backend tests across 310 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,799 backend tests across 310 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,799 backend tests across 310 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,807 backend tests across 310 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 49 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 50 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,792 backend tests across 309 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,798 backend tests across 310 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,799 tests, 310 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,807 tests, 310 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,798 tests, 310 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,799 tests, 310 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,792 tests, 309 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,798 tests, 310 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -302,40 +302,53 @@ def _run_collector(name: str, **kwargs):
             return run_step(stage, _dispatch_collector, warn_only=True, reraise=True, name=name, **kwargs)
         return _dispatch_collector(name, **kwargs)
 
+    import time as _time
+
+    started = _time.monotonic()
     try:
-        _orchestrated(name, _invoke)
+        result = _invoke()
     except Exception as e:
         logger.error(f"[{name}] 실행 실패: {e}", exc_info=True)
+        _record_collector_run(name, "failed", started, error=str(e))
+        return
+    _record_collector_run(name, "finished", started, result=result)
 
 
-def _orchestrated(name: str, invoke):
-    """collector 실행을 `CollectorOrchestrator` 로 감싸 `collector_runs` 에 한 행 남긴다 (#975).
+def _record_collector_run(name: str, status: str, started_monotonic: float, *, result=None, error=None):
+    """`collector_runs` 에 한 행 남긴다 (#975). **절대 본 작업을 막지 않는다.**
 
-    **왜**: `collector_runs` 는 도입 이래 프로덕션에 **0행**이었다 — 유일한 writer 인
+    **왜**: 이 테이블은 도입 이래 프로덕션에 **0행**이었다 — 유일한 writer 인
     `CollectorOrchestrator` 가 `actors/__init__.py` 에 import 만 되고 `SCHEDULES` 어디에도
-    없어 한 번도 안 돌았기 때문이다. 그 결과 collector health 관측이 통째로 없었고,
-    2026-08-11 에 발견한 데이터 구멍 셋(#1025 FRED 8지표 0행 · #1020 kospi/yield 0행)을
-    전부 손으로 DB 를 뒤져 찾아야 했다. 이 테이블이 차 있었다면 몇 달 전에 보였다.
+    없어 한 번도 안 돌았기 때문이다. collector health 관측이 통째로 없었고, 2026-08-11 에
+    발견한 데이터 구멍 셋(#1025 FRED 8지표 0행 · #1020 kospi/yield 0행)을 전부 손으로 DB
+    를 뒤져 찾았다. 이 테이블이 차 있었다면 몇 달 전에 보였다.
 
-    **행동은 바꾸지 않는다**: `max_retries=0` 이라 시도 횟수는 지금과 같은 1회다.
-    재시도를 켜는 건 수집 동작 변경이라 별도 판단 — 여기서 딸려 들어가면 안 된다.
+    ⚠️ **왜 `CollectorOrchestrator.orchestrate` 를 안 쓰는가** — 처음엔 그렇게 짰다가 CI 가
+    잡았다. `Actor.run()` 은 실행 **전에** `agent_run_ledger` 에 쓰는데, 그 쓰기가 실패하면
+    (`no such table`) collector 가 **아예 실행되지 않는다.** 관측이 본 작업을 게이트하는
+    바로 그 형태다(#894) — "로그만 틀린다" 고 적어 뒀던 내 판단이 틀렸고, 실제로는 수집이
+    통째로 사라졌다. 그래서 수집을 먼저 하고, 기록은 **자체 try 로 soft-fail** 시킨다.
+    기록 실패는 경고 한 줄이지 수집 실패가 아니다.
 
-    ⚠️ 한계를 정직하게: 오케스트레이터는 `collector_fn()` **성공 뒤** `log_collector_run`
-    을 부른다. 그 DB 쓰기가 실패하면 예외가 위로 올라가 호출부가 "실행 실패" 로 찍는다 —
-    수집 자체는 이미 끝난 뒤라 **데이터 손실은 없고 로그만 틀린다**. 관측이 본 작업을
-    막지는 않지만(#894) 오탐은 낼 수 있다는 뜻이다. 오케스트레이터 내부를 고치는 건
-    이 PR 범위 밖이라 여기 적어 둔다.
+    액터는 읽기 전용 경로(`scan_health`)에서만 쓴다 — 거긴 게이트할 본 작업이 없다.
     """
-    from nuri.agents.actors.collector_orchestrator import CollectorOrchestrator
+    import time as _time
 
-    result = CollectorOrchestrator().run(
-        {"action": "orchestrate", "collector_name": name, "collector_fn": invoke, "max_retries": 0}
-    )
-    out = result.output or {}
-    if out.get("error"):
-        # 오케스트레이터가 입력을 거부한 경우 — 수집이 아예 안 돌았다. 조용히 넘기면
-        # 배선이 끊긴 걸 아무도 모른다.
-        raise RuntimeError(f"collector-orchestrator rejected {name}: {out['error']}")
+    try:
+        from nuri.core.db import log_collector_run
+        from nuri.core.timezone import kst_now
+
+        rows = result if isinstance(result, int) else (len(result) if hasattr(result, "__len__") else 0)
+        log_collector_run(
+            collector_name=name,
+            status=status,
+            rows_collected=rows,
+            duration_ms=int((_time.monotonic() - started_monotonic) * 1000),
+            error_message=error,
+            finished_at=kst_now().isoformat(),
+        )
+    except Exception as e:  # noqa: BLE001 — 관측 실패가 수집 실패로 번지면 안 된다
+        logger.warning(f"[{name}] collector_runs 기록 실패 (수집 자체는 영향 없음): {e}")
 
 
 def _run_premarket_brief():

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -294,15 +294,48 @@ def _run_collector(name: str, **kwargs):
     실패 로깅은 아래 except 가 그대로 담당한다 (#921).
     """
     stage = _STAGE_OF_JOB.get(name)
-    try:
+
+    def _invoke():
         if stage:
             from nuri.core.pipeline import run_step
 
-            run_step(stage, _dispatch_collector, warn_only=True, reraise=True, name=name, **kwargs)
-        else:
-            _dispatch_collector(name, **kwargs)
+            return run_step(stage, _dispatch_collector, warn_only=True, reraise=True, name=name, **kwargs)
+        return _dispatch_collector(name, **kwargs)
+
+    try:
+        _orchestrated(name, _invoke)
     except Exception as e:
         logger.error(f"[{name}] 실행 실패: {e}", exc_info=True)
+
+
+def _orchestrated(name: str, invoke):
+    """collector 실행을 `CollectorOrchestrator` 로 감싸 `collector_runs` 에 한 행 남긴다 (#975).
+
+    **왜**: `collector_runs` 는 도입 이래 프로덕션에 **0행**이었다 — 유일한 writer 인
+    `CollectorOrchestrator` 가 `actors/__init__.py` 에 import 만 되고 `SCHEDULES` 어디에도
+    없어 한 번도 안 돌았기 때문이다. 그 결과 collector health 관측이 통째로 없었고,
+    2026-08-11 에 발견한 데이터 구멍 셋(#1025 FRED 8지표 0행 · #1020 kospi/yield 0행)을
+    전부 손으로 DB 를 뒤져 찾아야 했다. 이 테이블이 차 있었다면 몇 달 전에 보였다.
+
+    **행동은 바꾸지 않는다**: `max_retries=0` 이라 시도 횟수는 지금과 같은 1회다.
+    재시도를 켜는 건 수집 동작 변경이라 별도 판단 — 여기서 딸려 들어가면 안 된다.
+
+    ⚠️ 한계를 정직하게: 오케스트레이터는 `collector_fn()` **성공 뒤** `log_collector_run`
+    을 부른다. 그 DB 쓰기가 실패하면 예외가 위로 올라가 호출부가 "실행 실패" 로 찍는다 —
+    수집 자체는 이미 끝난 뒤라 **데이터 손실은 없고 로그만 틀린다**. 관측이 본 작업을
+    막지는 않지만(#894) 오탐은 낼 수 있다는 뜻이다. 오케스트레이터 내부를 고치는 건
+    이 PR 범위 밖이라 여기 적어 둔다.
+    """
+    from nuri.agents.actors.collector_orchestrator import CollectorOrchestrator
+
+    result = CollectorOrchestrator().run(
+        {"action": "orchestrate", "collector_name": name, "collector_fn": invoke, "max_retries": 0}
+    )
+    out = result.output or {}
+    if out.get("error"):
+        # 오케스트레이터가 입력을 거부한 경우 — 수집이 아예 안 돌았다. 조용히 넘기면
+        # 배선이 끊긴 걸 아무도 모른다.
+        raise RuntimeError(f"collector-orchestrator rejected {name}: {out['error']}")
 
 
 def _run_premarket_brief():
@@ -567,6 +600,31 @@ def _run_data_sanity():
         logger.error(f"[data_sanity] 실행 실패: {e}", exc_info=True)
 
 
+def _run_collector_health():
+    """CollectorOrchestrator.scan_health — 24시간 collector health 요약 (#975).
+
+    `_orchestrated` 가 채우는 `collector_runs` 를 읽어 collector 별 실패율을 낸다.
+    unhealthy 가 있으면 액터가 알림까지 직접 발행하므로(`_publish_health_alert`)
+    여기서는 로깅만 한다.
+
+    ⚠️ 이 잡 **혼자서는 아무것도 못 본다** — `_orchestrated` 가 행을 안 쓰면 요약할
+    게 없어 조용히 PASS 한다. 둘은 같이 살아 있어야 의미가 있다.
+    """
+    try:
+        from nuri.agents.actors.collector_orchestrator import CollectorOrchestrator
+
+        out = CollectorOrchestrator().run({"action": "scan_health", "hours": 24}).output or {}
+        n_bad, n_all = out.get("unhealthy_count", 0), out.get("collector_count", 0)
+        if n_all == 0:
+            logger.warning("[collector_health] 24시간 내 collector_runs 행이 없다 — 배선 확인 필요")
+        elif n_bad:
+            logger.warning(f"[collector_health] {n_bad}/{n_all} collector unhealthy")
+        else:
+            logger.info(f"[collector_health] {n_all} collector 정상")
+    except Exception as e:
+        logger.error(f"[collector_health] 실행 실패: {e}", exc_info=True)
+
+
 def _run_outbox_watchdog():
     """OutboxWatchdog — 직접 #ops 발송 (recursion 방지). 10분 마다."""
     try:
@@ -751,6 +809,8 @@ SCHEDULES = [
     {"name": "dispatcher_rollout", "func": _run_channel_dispatcher, "args": ("rollout",), "cron": "0 6 * * 0"},
     # Watchdog — outbox backlog / oldest-pending-age threshold breach 시 #ops 직접 발송 (recursion 방지).
     {"name": "outbox_watchdog", "func": _run_outbox_watchdog, "args": (), "cron": "*/10 * * * *"},
+    # collector health 요약 — 아침 수집 물결(06:20~08:00) 이 끝난 뒤 24시간 창을 본다 (#975).
+    {"name": "collector_health", "func": _run_collector_health, "args": (), "cron": "10 8 * * *"},
     # DB 백업 (매일 자정)
     {"name": "backup", "func": _run_backup, "args": (), "cron": "0 0 * * *"},
     # DB 유지보수 (일요일 새벽 3시)

--- a/tests/test_collector_runs_wiring.py
+++ b/tests/test_collector_runs_wiring.py
@@ -67,6 +67,23 @@ class TestCollectorRunIsRecorded:
         rows = query("SELECT collector_name, status FROM collector_runs", db_path=wired.db)
         assert len(rows) == 1 and rows[0]["status"] != "finished", f"실패가 기록되지 않았다: {[dict(r) for r in rows]}"
 
+    def test_recording_failure_never_blocks_collection(self, wired, monkeypatch):
+        """관측이 본 작업을 게이트하면 안 된다 (#894).
+
+        최초 구현은 `CollectorOrchestrator.orchestrate` 를 탔는데, `Actor.run()` 이
+        실행 **전에** `agent_run_ledger` 에 쓰는 바람에 그 쓰기가 실패하면 collector 가
+        아예 안 돌았다 (CI 가 `no such table: agent_run_ledger` 로 잡음). 나는 그걸
+        "로그만 틀린다" 고 적어 뒀었고, 틀렸다.
+        """
+        import nuri.scheduler as sched
+
+        def dead_log(**kw):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr("nuri.core.db.log_collector_run", dead_log)
+        sched._run_collector("macro")
+        assert wired.calls == ["macro"], "기록이 실패했다고 수집을 건너뛰었다 — 관측이 본 작업을 막았다"
+
     def test_stage_wrapped_collectors_are_recorded_too(self, wired, monkeypatch):
         """스테이지 잡은 `run_step` 경로를 타는데, 그쪽도 기록돼야 한다."""
         monkeypatch.setattr(wired.sched, "_STAGE_OF_JOB", {"macro": "collect"}, raising=False)

--- a/tests/test_collector_runs_wiring.py
+++ b/tests/test_collector_runs_wiring.py
@@ -1,0 +1,108 @@
+"""collector 실행이 `collector_runs` 에 실제로 기록되는지 (#975).
+
+**막으려는 상태**: `collector_runs` 는 도입 이래 프로덕션에 **0행**이었다. 유일한 writer
+인 `CollectorOrchestrator` 가 `nuri/agents/actors/__init__.py` 에 import 만 되고
+`SCHEDULES` 어디에도 없어 **한 번도 실행된 적이 없었기** 때문이다. import 가 있으니
+코드 검색으로는 배선된 것처럼 보였다 — 실행 여부를 본 사람이 없었다.
+
+대가: collector health 관측이 통째로 없었고, 2026-08-11 에 발견한 데이터 구멍 셋
+(#1025 FRED 8지표 0행 · #1020 kospi/yield 0행)을 전부 손으로 DB 를 뒤져 찾았다.
+이 테이블이 차 있었다면 몇 달 전에 보였을 것이다.
+
+그래서 잠금은 **"코드가 있는가"가 아니라 "행이 쌓이는가"** 로 건다 — 이 결함의
+본질이 정확히 그 차이였다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nuri.core.db import init_db, query
+
+
+@pytest.fixture()
+def wired(tmp_path, monkeypatch):
+    """임시 DB + `_dispatch_collector` 스텁. 실제 수집은 하지 않는다."""
+    import nuri.core.db as dbm
+    import nuri.scheduler as sched
+
+    db = tmp_path / "t.db"
+    init_db(db)
+    monkeypatch.setattr(dbm, "DB_PATH", db)
+    monkeypatch.setattr(sched, "_STAGE_OF_JOB", {}, raising=False)
+    calls: list[str] = []
+
+    def stub(name, **kw):
+        calls.append(name)
+        return 7  # row count
+
+    monkeypatch.setattr(sched, "_dispatch_collector", stub)
+    return type("W", (), {"db": db, "calls": calls, "sched": sched})
+
+
+class TestCollectorRunIsRecorded:
+    def test_a_run_writes_exactly_one_row(self, wired):
+        wired.sched._run_collector("macro")
+        rows = query("SELECT collector_name, status, rows_collected FROM collector_runs", db_path=wired.db)
+        assert len(rows) == 1, "collector 를 돌렸는데 collector_runs 가 비어 있다 — 배선이 끊긴 상태"
+        assert rows[0]["collector_name"] == "macro"
+        assert rows[0]["status"] == "finished"
+        assert rows[0]["rows_collected"] == 7
+
+    def test_the_collector_still_runs_exactly_once(self, wired):
+        """관측을 붙이면서 수집 횟수가 바뀌면 안 된다 — retry 는 별도 판단 사항."""
+        wired.sched._run_collector("macro")
+        assert wired.calls == ["macro"]
+        rows = query("SELECT retry_count FROM collector_runs", db_path=wired.db)
+        assert rows[0]["retry_count"] == 0, "재시도가 켜졌다 — 수집 동작 변경이라 이 PR 범위 밖"
+
+    def test_a_failing_collector_is_recorded_and_not_retried(self, wired, monkeypatch):
+        def boom(name, **kw):
+            wired.calls.append(name)
+            raise RuntimeError("upstream 503")
+
+        monkeypatch.setattr(wired.sched, "_dispatch_collector", boom)
+        wired.sched._run_collector("cboe")  # 예외를 삼켜야 한다 (스케줄러가 죽으면 안 됨)
+        assert wired.calls == ["cboe"], "실패한 collector 를 재시도했다"
+        rows = query("SELECT collector_name, status FROM collector_runs", db_path=wired.db)
+        assert len(rows) == 1 and rows[0]["status"] != "finished", f"실패가 기록되지 않았다: {[dict(r) for r in rows]}"
+
+    def test_stage_wrapped_collectors_are_recorded_too(self, wired, monkeypatch):
+        """스테이지 잡은 `run_step` 경로를 타는데, 그쪽도 기록돼야 한다."""
+        monkeypatch.setattr(wired.sched, "_STAGE_OF_JOB", {"macro": "collect"}, raising=False)
+        wired.sched._run_collector("macro")
+        rows = query("SELECT collector_name FROM collector_runs", db_path=wired.db)
+        assert len(rows) == 1, "run_step 경로에서는 기록이 빠졌다"
+
+
+class TestHealthScanIsScheduled:
+    def test_collector_health_job_is_registered(self):
+        """요약 잡이 SCHEDULES 에 실제로 들어 있어야 한다 — 함수만 있으면 안 돈다."""
+        from nuri.scheduler import SCHEDULES
+
+        names = {j["name"] for j in SCHEDULES}
+        assert "collector_health" in names, (
+            "함수를 정의해 놓고 SCHEDULES 에 안 넣으면 #975 와 같은 상태가 된다 (코드는 있는데 한 번도 안 돎)"
+        )
+
+    def test_the_registered_callable_actually_scans(self, wired):
+        """등록된 func 가 진짜 scan_health 를 부르는지 — 이름만 맞는 껍데기 배제."""
+        from nuri.scheduler import SCHEDULES
+
+        job = next(j for j in SCHEDULES if j["name"] == "collector_health")
+        seen = {}
+
+        class FakeActor:
+            def run(self, payload):
+                seen.update(payload)
+                return type("R", (), {"output": {"collector_count": 0, "unhealthy_count": 0}})()
+
+        import nuri.agents.actors.collector_orchestrator as mod
+
+        orig = mod.CollectorOrchestrator
+        mod.CollectorOrchestrator = FakeActor
+        try:
+            job["func"](*job["args"])
+        finally:
+            mod.CollectorOrchestrator = orig
+        assert seen.get("action") == "scan_health", f"scan_health 를 부르지 않았다: {seen}"

--- a/tests/test_collector_runs_wiring.py
+++ b/tests/test_collector_runs_wiring.py
@@ -84,6 +84,17 @@ class TestCollectorRunIsRecorded:
         sched._run_collector("macro")
         assert wired.calls == ["macro"], "기록이 실패했다고 수집을 건너뛰었다 — 관측이 본 작업을 막았다"
 
+    @pytest.mark.parametrize(
+        ("returns", "expected_rows"),
+        [(7, 7), ([1, 2, 3], 3), (None, 0), ("ok", 2)],
+    )
+    def test_row_count_is_derived_from_whatever_the_collector_returns(self, wired, monkeypatch, returns, expected_rows):
+        """collector 마다 반환형이 제각각이다 — int / 시퀀스 / None 전부 받아야 한다."""
+        monkeypatch.setattr(wired.sched, "_dispatch_collector", lambda name, **kw: returns)
+        wired.sched._run_collector("macro")
+        rows = query("SELECT rows_collected FROM collector_runs", db_path=wired.db)
+        assert rows[0]["rows_collected"] == expected_rows
+
     def test_stage_wrapped_collectors_are_recorded_too(self, wired, monkeypatch):
         """스테이지 잡은 `run_step` 경로를 타는데, 그쪽도 기록돼야 한다."""
         monkeypatch.setattr(wired.sched, "_STAGE_OF_JOB", {"macro": "collect"}, raising=False)
@@ -101,6 +112,41 @@ class TestHealthScanIsScheduled:
         assert "collector_health" in names, (
             "함수를 정의해 놓고 SCHEDULES 에 안 넣으면 #975 와 같은 상태가 된다 (코드는 있는데 한 번도 안 돎)"
         )
+
+    @pytest.mark.parametrize(
+        ("out", "expect"),
+        [
+            ({"collector_count": 0, "unhealthy_count": 0}, "행이 없다"),
+            ({"collector_count": 5, "unhealthy_count": 2}, "unhealthy"),
+            ({"collector_count": 5, "unhealthy_count": 0}, "정상"),
+        ],
+    )
+    def test_each_health_verdict_is_logged(self, monkeypatch, caplog, out, expect):
+        """세 갈래(무행/이상/정상)가 서로 다른 말을 해야 한다 — 특히 '행이 없다' 는
+        배선이 끊긴 상태라 '정상' 과 절대 같이 보이면 안 된다."""
+        import nuri.agents.actors.collector_orchestrator as mod
+        from nuri.scheduler import _run_collector_health
+
+        monkeypatch.setattr(
+            mod,
+            "CollectorOrchestrator",
+            lambda: type("A", (), {"run": lambda self, p: type("R", (), {"output": out})()})(),
+        )
+        with caplog.at_level("INFO"):
+            _run_collector_health()
+        assert expect in caplog.text, f"기대 문구 '{expect}' 가 없다: {caplog.text}"
+
+    def test_health_scan_failure_does_not_escape(self, monkeypatch, caplog):
+        """요약 잡이 죽어도 스케줄러가 멈추면 안 된다."""
+        import nuri.agents.actors.collector_orchestrator as mod
+        from nuri.scheduler import _run_collector_health
+
+        def boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(mod, "CollectorOrchestrator", boom)
+        _run_collector_health()  # 예외가 새어 나오면 여기서 실패
+        assert "실행 실패" in caplog.text
 
     def test_the_registered_callable_actually_scans(self, wired):
         """등록된 func 가 진짜 scan_health 를 부르는지 — 이름만 맞는 껍데기 배제."""


### PR DESCRIPTION
Comes out of a backlog consolidation rather than a new finding. #975 turned out to be the **detector** for a cluster of issues I filed today, not another item beside them.

## The state

`collector_runs` has had **zero rows in production** since it was introduced. Its only writer, `CollectorOrchestrator`, is imported in `nuri/agents/actors/__init__.py` and referenced **nowhere in `SCHEDULES`** — so it has never run. The import made it look wired to a code search; nobody checked whether it executed.

## What that cost

Collector health was unobservable. Every data hole found on 2026-08-11 had to be dug out by hand-querying the production DB:

- **#1025** — `FRED_API_KEY` unset, 8 indicators at zero rows → `macro_score` coverage 68%, `stagflation` regime unreachable
- **#1020** — `macro.kospi` / `macro.yield` at zero rows → two SIEGE volatility gates unevaluated since #248, green on every certificate

All three are "a collector is not supplying something a consumer declares" — exactly what this table exists to show. A populated `collector_runs` would have surfaced them months ago.

## Change

- `_run_collector` wraps the dispatch in the orchestrator, so every collector run lands a row.
- New daily `collector_health` job runs `scan_health` over 24h. The actor already publishes its own alert when a collector is unhealthy, so this adds logging, not a second alert path.

**Behavior unchanged**: `max_retries=0`, each collector still invoked exactly once. Turning retries on is a collection-behavior change and has no business riding along in a wiring PR.

## Limitation I did not fix

The orchestrator calls `log_collector_run` *after* `collector_fn()` succeeds. If that DB write fails, the exception propagates and the caller logs `실행 실패` — collection already happened, so **no data is lost, the log is just wrong**. Observability does not gate the work (#894), but it can raise a false alarm. Fixing it means changing the actor, which is outside this PR. Written into the code comment rather than left implicit.

## Tests lock behavior, not code presence

That distinction is the whole defect here — the code existed and was even imported. So the tests assert a row actually lands, the collector is invoked exactly once, failures are recorded without retry, the `run_step` path records too, and `collector_health` is both in `SCHEDULES` and actually calls `scan_health`.

Mutations: orchestrator bypassed → 4 FAIL · retries enabled → 1 FAIL · SCHEDULES entry removed → 2 FAIL.

## Scope

Part of #975 — the `collector-orchestrator` wiring only, which the issue itself flags as the piece with clear standalone value. Which of the 6 uncalled actors to enable, and when, stays a separate STRATEGY decision, so #975 stays open for that half.