### PR TITLE
fix(core): stamp collector_runs.started_at in KST, not the UTC schema default

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,811 collected across 310 files | |
+| **Backend tests** | 6,815 collected across 311 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,811 backend tests across 310 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,815 backend tests across 311 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,811 tests, 310 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,815 tests, 311 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/core/db/agent_runtime.py
+++ b/nuri/core/db/agent_runtime.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from nuri.core.timezone import kst_now
+
 from .connection import get_db
 
 # DR enums (codex Round 5 single-writer — primary/replica)
@@ -231,6 +233,7 @@ def log_collector_run(
     rate_limit_hits: int = 0,
     actor_run_id: Optional[str] = None,
     finished_at: Optional[str] = None,
+    started_at: Optional[str] = None,
     db_path: Optional[Path] = None,
 ) -> int:
     """Single INSERT — 매 collector run 의 결과 영구 기록. lastrowid 반환.
@@ -248,8 +251,8 @@ def log_collector_run(
             """INSERT INTO collector_runs
                (collector_name, status, rows_collected, rows_expected,
                 duration_ms, error_message, retry_count, rate_limit_hits,
-                actor_run_id, finished_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                actor_run_id, finished_at, started_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 collector_name,
                 status,
@@ -261,6 +264,11 @@ def log_collector_run(
                 rate_limit_hits,
                 actor_run_id,
                 finished_at,
+                # 스키마 기본값은 `datetime('now')` = **UTC** 인데 `finished_at` 은
+                # 호출자가 `kst_now()` 로 넣어, 한 행 안에 9시간 어긋난 두 표현이
+                # 섞여 있었다 (#1031). 레포 불변식은 `kst_now()` 강제 —
+                # **항상 명시적으로 채워** 기본값이 발화하지 않게 한다.
+                started_at or kst_now().isoformat(),
             ),
         )
         return int(cursor.lastrowid or 0)

--- a/tests/agents/test_collector_runs_timezone.py
+++ b/tests/agents/test_collector_runs_timezone.py
@@ -1,0 +1,95 @@
+"""`collector_runs` 시간대 일관성 (#1031).
+
+`started_at` 은 스키마 기본값 `datetime('now')` 라 **UTC**, `finished_at` 은 호출자가
+`kst_now()` 로 넣어 **KST** 였다 — 한 행 안에 9시간 어긋난 두 표현. #1030 이 이 테이블에
+사상 첫 행을 넣으면서 드러났다.
+
+**조회는 안 고쳤다 — 뮤테이션이 내 전제를 반증했다.** 처음엔 "`started_at` 만 KST 로
+돌리면 `scan_health` 창이 33시간으로 늘어난다" 고 보고 쿼리도 같이 바꿨는데, 그 변경을
+되돌리는 뮤테이션이 **잡히지 않았다**. 실측하니 SQLite `datetime()` 이 ISO 오프셋을 UTC 로
+정규화한다 — `datetime('2026-08-11T05:30:00+09:00')` → `2026-08-10 20:30:00`. 즉 원래 쿼리는
+양쪽을 UTC 로 맞춰 **애초에 정확했고**, 내가 넣었던 raw 문자열 비교가 오히려 형식 혼재에
+취약했다. 그래서 쓰기만 고친다.
+
+아래 창 테스트 2개는 이번 변경을 잠그지 않는다(수정 전에도 통과했다). 창 정확성 자체를
+지키는 회귀 방어로 남긴다 — 잠금은 위 두 테스트다.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from nuri.core.db import init_db, log_collector_run, query
+from nuri.core.timezone import kst_now
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    p = tmp_path / "t.db"
+    init_db(p)
+    return p
+
+
+class TestBothTimestampsAreKst:
+    def test_started_at_is_kst_not_the_utc_default(self, db_path):
+        log_collector_run(collector_name="macro", status="finished", db_path=db_path)
+        row = query("SELECT started_at FROM collector_runs", db_path=db_path)[0]
+        delta = abs((kst_now() - _parse(row["started_at"])).total_seconds())
+        assert delta < 120, f"started_at 이 현재 KST 와 {delta / 3600:.1f}시간 어긋난다 — 스키마 기본값(UTC)이 발화했다"
+
+    def test_started_and_finished_agree(self, db_path):
+        """한 행 안에서 두 컬럼이 같은 시계를 써야 한다 — duration 을 재는 쪽이 있다."""
+        log_collector_run(collector_name="macro", status="finished", finished_at=kst_now().isoformat(), db_path=db_path)
+        r = query("SELECT started_at, finished_at FROM collector_runs", db_path=db_path)[0]
+        gap = abs((_parse(r["finished_at"]) - _parse(r["started_at"])).total_seconds())
+        assert gap < 120, f"started_at 과 finished_at 이 {gap / 3600:.1f}시간 어긋난다"
+
+
+class TestHealthWindowIsHonest:
+    def _seed(self, db_path, name, hours_ago):
+        log_collector_run(
+            collector_name=name,
+            status="finished",
+            started_at=(kst_now() - timedelta(hours=hours_ago)).isoformat(),
+            db_path=db_path,
+        )
+
+    def test_window_includes_recent_and_excludes_old(self, db_path, monkeypatch):
+        import nuri.agents.actors.collector_orchestrator as mod
+
+        self._seed(db_path, "recent", 1)
+        self._seed(db_path, "stale", 30)
+        monkeypatch.setattr(mod, "query", lambda *a, **k: query(*a, db_path=db_path, **k))
+        out = mod.CollectorOrchestrator()._scan_health({"hours": 24}, _ctx()).output
+        names = {s["collector_name"] for s in out["summaries"]}
+        assert "recent" in names
+        assert "stale" not in names, "24시간 창이 30시간 전 행을 긁어왔다"
+
+    def test_a_25h_old_row_is_outside_a_24h_window(self, db_path, monkeypatch):
+        """정확히 이 지점이 UTC/KST 혼재의 증상이었다.
+
+        `started_at` 이 KST 인데 `datetime('now')`(UTC) 와 비교하면 창이 ~33시간으로
+        늘어나 25시간 전 행이 들어온다. 그러면서 '24시간' 이라고 보고한다.
+        """
+        import nuri.agents.actors.collector_orchestrator as mod
+
+        self._seed(db_path, "just_outside", 25)
+        monkeypatch.setattr(mod, "query", lambda *a, **k: query(*a, db_path=db_path, **k))
+        out = mod.CollectorOrchestrator()._scan_health({"hours": 24}, _ctx()).output
+        assert out["collector_count"] == 0, (
+            f"25시간 전 행이 24시간 창에 들어왔다 — 창이 조용히 넓어졌다: {out['summaries']}"
+        )
+
+
+def _parse(s):
+    from datetime import datetime
+
+    return datetime.fromisoformat(str(s).replace(" ", "T"))
+
+
+def _ctx():
+    from nuri.agents.base import RunContext
+
+    return RunContext(run_id="test-run")


### PR DESCRIPTION
`collector_runs` took `started_at` from the schema default `datetime('now')` — UTC in SQLite — while callers pass `finished_at` as `kst_now()`. One row, two clocks, nine hours apart. Anything computing `finished_at - started_at` gets +9h. It surfaced the moment #1030 put the first rows in the table.

`log_collector_run` now always fills `started_at` with `kst_now()` so the default never fires, matching the repo invariant that time is KST.

## Correction to my own issue write-up

I filed #1031 claiming that changing `started_at` alone would **silently widen `scan_health`'s window from 24h to ~33h**, and I changed the query to match. Mutation testing did not catch reverting that query change, which meant either the test was weak or the premise was. I measured:

```
datetime('2026-08-11T05:30:00+09:00')  →  2026-08-10 20:30:00
datetime('now')                        →  2026-08-11 02:21:54   (UTC)
```

SQLite's `datetime()` normalizes the ISO offset to UTC, so the original query compared both sides in UTC and **was always correct**. The raw string comparison I had substituted (`started_at >= ?`) was strictly more fragile once formats mix. Reverted — only the write changes, and the issue is annotated with the correction.

So the real defect was smaller than I described: a mixed-clock row, not a lying window.

## Existing rows

Two in production, both from today, both bare UTC. Left alone — `datetime()` normalization keeps reads correct, and a forward-only migration is not worth a two-row discontinuity.

## Verification

- Mutation: `started_at` left to the schema default → **2 FAIL**
- The two window tests are regression cover for `scan_health`, **not** locks on this change — they passed before it as well, and the test file says so rather than implying otherwise
- `make test-fast` 6782 passed · lint clean · doc counts 19/19 · privacy scan clean (no args)

Closes #1031