### PR TITLE
fix(privacy): scope exemptions to a category, and fill the broker list

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,815 collected across 311 files | |
+| **Backend tests** | 6,826 collected across 312 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,815 backend tests across 311 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,826 backend tests across 312 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,815 tests, 311 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,826 tests, 312 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
@@ -293,11 +293,11 @@ PR 전 확인.
 #### 4.4.1 개인 금융 데이터 enforcement (#138)
 **권위 있는 차단 기준**: `scripts/verify/check_privacy_leak.py` 가 ground truth.
 | 카테고리 | 차단 대상 | 허용 placeholder |
-| Korean broker name | 카카오페이, 미래에셋, 키움증권, 삼성증권, NH투자증권, 토스증권, KB증권, 신한투자증권, 하나증권, 메리츠증권, 유안타증권, 대신증권, 이베스트투자증권, 흥국증권, IBK투자증권 | `Brokerage Alpha/Beta` 등 |
+| Korean broker name | 카카오페이, 미래에셋, 키움증권, 삼성증권, NH투자증권, 토스증권, KB증권, 신한투자증권, 하나증권, 메리츠증권, 유안타증권, 대신증권, 이베스트투자증권, 흥국증권, IBK투자증권 | `Brokerage Alpha/Beta` 등 | <!-- privacy-allow: broker_name — §4.4.1 패턴 표 자체 (#981) -->
 <!-- cspell:disable-next-line -->
-| Romanized broker | kakaopay, mirae, kiwoom, samsung_securities, nh_invest, toss_securities, shinhan_invest, hana_securities, meritz_securities (case-insensitive substring) | `brokerage_alpha` 등 |
+| Romanized broker | kakaopay, mirae, kiwoom, samsung_securities, nh_invest, toss_securities, shinhan_invest, hana_securities, meritz_securities (case-insensitive substring) | `brokerage_alpha` 등 | <!-- privacy-allow: broker_name — §4.4.1 패턴 표 자체 (#981) -->
 | Suspect monetary literal | 7자리 이상 정수 + `total_invested`/`cash_balance`/`deposit`/`withdraw`/`principal`/`net_worth`/`buying_power` 키 | round million (`1_000_000`...`100_000_000`) 자동 허용 |
-| **Ticker + PnL 조합** (PR #202) | (a) `[-+]\d+(\.\d+)?%\s*(TICKER)` (`-34% (TEM)`) (b) 인접 `TICKER <signed %>` (`PL +43%`). 소스 + unpushed commit message 스캔. | 규칙 threshold text (`손절 -7%`) ticker 컨텍스트 없으면 통과. `TICKER_FALSE_POSITIVES` frozenset (HWM/SL/MDD/CPI/VIX/BTC/ETH 등 120개). |
+| **Ticker + PnL 조합** (PR #202) | (a) `[-+]\d+(\.\d+)?%\s*(TICKER)` (`-34% (TEM)`) (b) 인접 `TICKER <signed %>` (`PL +43%`). 소스 + unpushed commit message 스캔. | 규칙 threshold text (`손절 -7%`) ticker 컨텍스트 없으면 통과. `TICKER_FALSE_POSITIVES` frozenset (HWM/SL/MDD/CPI/VIX/BTC/ETH 등 120개). | <!-- privacy-allow: ticker_pnl — §4.4.1 패턴 표 자체 (#981) -->
 **의도적 제외**: `한국투자증권` (KIS) 은 Open API 통합 대상 (`nuri/collectors/kis_*`, `docs/KIS_INTEGRATION.md`). 자격 증명은 `config/kis/kis_devlp.yaml` (gitignored by `config/kis/*`, `~/KIS/` legacy 호환).
 **Plan / spec 노트 보호 (2026-04-30 Session 8 통합)**: `docs/plans/` 디렉토리 전체가 `.gitignore` 처리됨. 이전에는 개별 파일 (`E3_symmetric_amplifier_design.md`, `507_buy_candidate_emitter_phase1.md`)만 등록됐으나, 새 spec 추가 시 누락 위험 — 디렉토리 단위로 통합. 기존 tracked 3건 (`E3_phase2_paired_counterfactual.md`, `E3_symmetric_amplifier_design.md`, `e4_0b.md`)는 `git rm --cached` 처리. 사용자 본인 spec 노트의 broker name / financial figure 누설 방어. **새 spec 작성 시 broker name placeholder 사용** (`Brokerage Alpha Main` 등) — gitignored 라도 future commit 사고 회피.
 **방어 layer 3개** (defense in depth):

--- a/scripts/verify/check_privacy_leak.py
+++ b/scripts/verify/check_privacy_leak.py
@@ -99,6 +99,29 @@ BROKER_NAMES_KO: tuple[str, ...] = (
     "이베스트투자증권",
     "흥국증권",
     "IBK투자증권",
+    # KOFIA 회원사 보강 (#981) — #980 스윕에서 잡힌 증권사가 목록에 **없었다**.
+    # 즉 파일 면제(구멍 1)를 막아도 이 목록이 얇아서 그대로 통과했을 것이다.
+    # 회사명 자체는 공개 정보라 스캐너에 적는 건 안전하다.
+    "신영증권",
+    "교보증권",
+    "현대차증권",
+    "SK증권",
+    "DB금융투자",
+    "LS증권",
+    "다올투자증권",
+    "iM증권",
+    "부국증권",
+    "유진투자증권",
+    "한양증권",
+    "케이프투자증권",
+    "상상인증권",
+    "BNK투자증권",
+    "하이투자증권",
+    "한화투자증권",
+    # ⚠️ `한국투자증권`(KIS) 은 여기 넣지 않는다 — 위 docstring 의 의도적 제외 결정.
+    # Open API 통합 대상이라 `nuri/collectors/kis_*` 에 정당하게 등장하고, 자격증명은
+    # 이름이 아니라 파일 패턴(`config/kis/*`)으로 막는다. 이번에 한 번 넣었다가
+    # `kis_realtime.py` docstring 이 걸려서 되돌렸다.
 )
 
 # Romanized aliases — case-insensitive substring match.
@@ -271,22 +294,56 @@ TICKER_FALSE_POSITIVES: frozenset[str] = frozenset(
     }
 )
 
-# Allow-list: paths the scanner should NEVER block on.
-ALLOWLIST_PATHS: tuple[str, ...] = (
-    "scripts/verify/check_privacy_leak.py",  # this file (documents patterns)
-    "tests/scripts/test_check_privacy_leak.py",  # tests for this file (moved from top-level in #163)
-    "tests/agents/test_discord_outbox.py",  # E3 #579 — privacy gate tests need leak fixtures (NVDA +57%, kakaopay) to verify detection
-    "tests/trading/recommend/test_held_add_mode.py",  # #518 phase 2a — spec §4.6 acceptance test fixtures use NVDA/MSFT for multi-account scenarios
-    "tests/alerts/test_postmarket_brief.py",  # #596 Phase 1 — privacy gate lock-test fixture uses ticker+PnL combo to verify gate blocks publish
-    "docs/STRATEGY.md",  # may codify pattern names
-    "CONTRIBUTING.md",  # references placeholder names as guidance
-    "SECURITY.md",  # references privacy policy
-    ".claude/projects/",  # private memory dir (git-ignored anyway)
-    "node_modules/",
-    ".git/",
-    ".venv/",
-    "frontend/package-lock.json",  # npm hash collisions look like words
-)
+# Allow-list — **파일 전체가 아니라 카테고리 단위** (#981).
+#
+# 예전엔 경로 하나가 그 파일의 **모든** 규칙을 껐다. 그래서 `docs/STRATEGY.md` 가
+# "패턴 이름을 적을 수도 있어서" 라는 사유로 500줄 통째로 빠졌고, 실제로는 451행의
+# 증권사명 + 연금 보유 3종이 거기 숨어 있었다. `test_held_add_mode.py` 도 사유는
+# "다계좌 NVDA/MSFT 시나리오" 인데 정작 가려진 건 픽스처 9곳의 증권사명이었다 —
+# **적어둔 사유와 실제로 면제된 것이 달랐다.**
+#
+# 이제 값은 그 경로에서 끌 규칙의 집합이다. `ALL` 은 스캐너 자신처럼 세 카테고리를
+# 전부 문서화하는 파일에만 쓴다. 사유에 적은 카테고리만 끄면, 사유 밖의 유출은
+# 계속 걸린다.
+ALL_CATEGORIES: frozenset[str] = frozenset({"broker_name", "suspect_numeric", "ticker_pnl"})
+
+ALLOWLIST: dict[str, frozenset[str]] = {
+    # 스캐너 본체와 그 테스트 — 세 카테고리의 패턴을 전부 적어 둔다.
+    "scripts/verify/check_privacy_leak.py": ALL_CATEGORIES,
+    "tests/scripts/test_check_privacy_leak.py": ALL_CATEGORIES,
+    # E3 #579 — privacy gate 테스트가 탐지를 검증하려면 leak 픽스처가 필요하다.
+    "tests/agents/test_discord_outbox.py": frozenset({"ticker_pnl", "broker_name"}),
+    # #518 phase 2a — 다계좌 시나리오라 ticker+PnL 조합만. 증권사명은 **면제 아님**
+    # (예전에 여기로 9곳이 새 나갔다).
+    "tests/trading/recommend/test_held_add_mode.py": frozenset({"ticker_pnl"}),
+    # #596 Phase 1 — gate lock-test 가 ticker+PnL 조합을 쓴다.
+    "tests/alerts/test_postmarket_brief.py": frozenset({"ticker_pnl"}),
+    # 정책 문서 — 플레이스홀더 이름을 가이드로 인용한다. 숫자·티커는 계속 검사.
+    "CONTRIBUTING.md": frozenset({"broker_name"}),
+    "SECURITY.md": frozenset({"broker_name"}),
+    # 스캔 대상이 아닌 경로.
+    ".claude/projects/": ALL_CATEGORIES,
+    "node_modules/": ALL_CATEGORIES,
+    ".git/": ALL_CATEGORIES,
+    ".venv/": ALL_CATEGORIES,
+    "frontend/package-lock.json": ALL_CATEGORIES,
+}
+
+# 줄 단위 탈출구 — 파일을 통째로 끄지 않고 그 줄만 면제한다.
+#   `<something>  # privacy-allow: broker_name`  또는  `# privacy-allow`(전 카테고리)
+# 파일 면제를 좁히면서 정당한 예외를 남길 수단이 필요했다 (#981).
+_INLINE_ALLOW = re.compile(r"privacy-allow(?::\s*([a-z_,\s]+))?")
+
+
+def line_allows(line: str, category: str) -> bool:
+    """그 줄에 면제 마커가 있고 이 카테고리를 덮는가."""
+    m = _INLINE_ALLOW.search(line)
+    if not m:
+        return False
+    cats = m.group(1)
+    if not cats:
+        return True
+    return category in {c.strip() for c in cats.split(",")}
 
 
 @dataclass
@@ -298,14 +355,24 @@ class Finding:
     category: str  # "broker_name" | "suspect_numeric" | "ticker_pnl"
 
 
-def is_allowlisted(path: Path) -> bool:
-    """True if path matches any allowlisted prefix."""
+def is_allowlisted(path: Path, category: str | None = None) -> bool:
+    """이 경로에서 `category` 가 면제되는가. category=None 이면 '전 카테고리 면제' 인지.
+
+    예전 시그니처는 경로만 받아 **파일 전체**를 껐다 (#981). 호출부가 카테고리를
+    넘기지 않으면 ALL 면제인 경로에서만 True — 좁아진 쪽으로 기본값을 둔다.
+    """
     try:
         rel = str(path.relative_to(ROOT)) if path.is_absolute() else str(path)
     except ValueError:
         # Path is outside the repo (e.g., /tmp/* in tests) — never allowlisted.
         return False
-    return any(rel.startswith(p.rstrip("/")) for p in ALLOWLIST_PATHS)
+    for prefix, cats in ALLOWLIST.items():
+        if rel.startswith(prefix.rstrip("/")):
+            if category is None:
+                return cats == ALL_CATEGORIES
+            if category in cats:
+                return True
+    return False
 
 
 def scan_text_for_brokers(text: str, source: Path | str = "<input>") -> list[Finding]:
@@ -449,13 +516,31 @@ def scan_file_for_ticker_pnl(path: Path) -> list[Finding]:
 
 def scan_path(path: Path) -> list[Finding]:
     """Scan one file for all categories. Skips allowlisted/binary."""
-    if is_allowlisted(path):
+    if is_allowlisted(path):  # 전 카테고리 면제인 경로만 통째로 건너뛴다
         return []
     if not path.is_file():
         return []
     if path.suffix in {".png", ".jpg", ".jpeg", ".gif", ".pdf", ".pyc", ".woff", ".woff2", ".ttf", ".eot", ".ico"}:
         return []
-    return scan_file_for_brokers(path) + scan_file_for_numerics(path) + scan_file_for_ticker_pnl(path)
+    # 카테고리별로 따로 묻는다 (#981). 한 파일이 한 규칙만 면제받을 수 있어야
+    # "사유에 적은 것" 과 "실제로 가려지는 것" 이 어긋나지 않는다.
+    out: list[Finding] = []
+    if not is_allowlisted(path, "broker_name"):
+        out += scan_file_for_brokers(path)
+    if not is_allowlisted(path, "suspect_numeric"):
+        out += scan_file_for_numerics(path)
+    if not is_allowlisted(path, "ticker_pnl"):
+        out += scan_file_for_ticker_pnl(path)
+    # 줄 단위 면제 마커 적용 — 파일 면제를 좁힌 대신 남긴 정당한 탈출구.
+    lines = _read_lines(path)
+    return [f for f in out if not (0 < f.line <= len(lines) and line_allows(lines[f.line - 1], f.category))]
+
+
+def _read_lines(path: Path) -> list[str]:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return []
 
 
 def iter_repo_files() -> list[Path]:

--- a/tests/scripts/test_privacy_allowlist_is_per_category.py
+++ b/tests/scripts/test_privacy_allowlist_is_per_category.py
@@ -1,0 +1,88 @@
+"""면제는 파일 전체가 아니라 카테고리 단위 (#981).
+
+두 방어선이 **독립적으로** 뚫려 있었다:
+  1. `ALLOWLIST_PATHS` 가 `startswith` 로 **파일 전체**를 껐다. `docs/STRATEGY.md` 는
+     "패턴 이름을 적을 수도 있어서" 500줄 통째로 빠졌는데, 실제로 451행에 증권사명과
+     연금 보유가 숨어 있었다. `test_held_add_mode.py` 는 사유가 "다계좌 NVDA/MSFT"
+     인데 정작 가려진 건 픽스처 9곳의 증권사명이었다 — **사유와 실제가 달랐다.**
+  2. `BROKER_NAMES_KO` 가 15개뿐이라 #980 에서 잡힌 증권사가 목록에 없었다.
+
+한쪽만 고치면 다른 쪽이 통과시킨다. 그래서 둘 다 잠근다.
+
+⚠️ 증권사명은 **런타임 조립**한다 — 리터럴로 적으면 이 파일을 저장하는 순간
+PreToolUse 훅과 CI privacy-scan 이 이 테스트 자체를 차단한다 (`tests/CLAUDE.md`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.verify.check_privacy_leak import (
+    ALL_CATEGORIES,
+    ALLOWLIST,
+    BROKER_NAMES_KO,
+    is_allowlisted,
+    line_allows,
+    scan_text_for_brokers,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestExemptionIsNarrow:
+    def test_held_add_mode_exempts_ticker_pnl_but_not_broker_names(self):
+        """예전에 증권사명 9곳이 새 나간 바로 그 경로."""
+        p = ROOT / "tests/trading/recommend/test_held_add_mode.py"
+        assert is_allowlisted(p, "ticker_pnl") is True, "사유에 적힌 면제는 유지돼야 한다"
+        assert is_allowlisted(p, "broker_name") is False, (
+            "사유는 다계좌 ticker 시나리오인데 증권사명까지 면제되면 사유와 실제가 어긋난다"
+        )
+
+    def test_strategy_doc_is_no_longer_wholly_exempt(self):
+        """정책 문서 전체 면제가 451행 유출을 숨겼다."""
+        assert "docs/STRATEGY.md" not in ALLOWLIST, (
+            "문서를 통째로 면제하면 그 안의 실제 유출이 영원히 안 보인다 — "
+            "패턴 표 줄만 `privacy-allow` 마커로 면제할 것"
+        )
+
+    def test_only_the_scanner_itself_gets_a_blanket_exemption(self):
+        """ALL 면제는 세 카테고리를 전부 문서화하는 파일에만."""
+        blanket = {k for k, v in ALLOWLIST.items() if v == ALL_CATEGORIES}
+        unexpected = {
+            k
+            for k in blanket
+            if not (
+                k.startswith((".git", ".venv", ".claude", "node_modules")) or "privacy_leak" in k or "package-lock" in k
+            )
+        }
+        assert not unexpected, f"근거 없는 전면 면제: {sorted(unexpected)}"
+
+
+class TestInlineMarker:
+    def test_marker_scopes_to_the_named_category(self):
+        assert line_allows("x  # privacy-allow: broker_name", "broker_name") is True
+        assert line_allows("x  # privacy-allow: broker_name", "ticker_pnl") is False
+
+    def test_bare_marker_covers_everything(self):
+        assert line_allows("x  <!-- privacy-allow -->", "suspect_numeric") is True
+
+    def test_absent_marker_allows_nothing(self):
+        assert line_allows("plain line", "broker_name") is False
+
+
+class TestBrokerListCoversTheOnesThatSlipped:
+    @pytest.mark.parametrize("parts", [("신영", "증권"), ("교보", "증권"), ("현대차", "증권"), ("DB금융", "투자")])
+    def test_previously_missing_brokers_are_detected(self, parts):
+        name = "".join(parts)
+        assert name in BROKER_NAMES_KO, f"{name} 가 목록에 없다 — #980 계열이 다시 통과한다"
+        assert scan_text_for_brokers(f"계좌: {name}"), f"{name} 를 탐지하지 못했다"
+
+    def test_kis_stays_deliberately_excluded(self):
+        """`한국투자증권` 은 Open API 통합 대상이라 의도적 제외 — 넣으면 정상 코드가 걸린다."""
+        kis = "한국" + "투자증권"
+        assert kis not in BROKER_NAMES_KO, (
+            "KIS 를 넣으면 nuri/collectors/kis_*.py docstring 이 걸린다. "
+            "자격증명은 이름이 아니라 config/kis/* 파일 패턴으로 막는다"
+        )


### PR DESCRIPTION
Closes #981. Two blind spots, **independent** — either one alone let the #980 leaks through, so fixing one would have changed nothing.

## 1. The allowlist switched off every rule for a file

`ALLOWLIST_PATHS` matched by prefix and disabled all three categories.

- `docs/STRATEGY.md` was exempt wholesale because it *"may codify pattern names"* — 500 lines unscanned, with a real broker name and pension holdings sitting in them.
- `test_held_add_mode.py` was exempt for *"multi-account NVDA/MSFT scenarios"*, while what it actually hid was **nine broker names in fixtures**.

In both cases **the stated reason and the thing being hidden were different**, which is the part that made it invisible.

Exemptions are now per category: `test_held_add_mode` keeps `ticker_pnl` and loses `broker_name`; `STRATEGY.md` loses its file exemption outright. For genuinely legitimate cases there is a line-level `privacy-allow[: category]` marker — needed on exactly **three lines**, the §4.4.1 pattern table that enumerates the patterns by definition. That is what the issue asked for ("최소한 패턴 표 블록만 면제").

## 2. The broker list was thin

15 entries, and the broker from #980 was not among them. Added the KOFIA members the sweep named.

**`한국투자증권` stays out.** I added it, and it flagged `nuri/collectors/kis_realtime.py` — the module docstring already documents that exclusion, because KIS is an Open API integration target and its credentials are blocked by the `config/kis/*` path pattern rather than the name. Reverted; the existing reasoning was right.

## Verified by injecting violations, not by a green run

The issue is explicit that a passing scanner never meant "no leaks", so I checked the failure direction:

```
기준선                                          rc = 0
STRATEGY.md 비마커 줄 + 신영증권                rc = 1
test_held_add_mode.py + 메리츠증권              rc = 1
일반 파일 + 신영증권 (신규 등록)                rc = 1
복원 후                                         rc = 0
```

Mutations: `held_add_mode` back to blanket → 2 FAIL · `STRATEGY.md` blanket restored → 2 FAIL · one new broker removed → 1 FAIL · marker ignoring its category → 1 FAIL.

Broker names in the test file are assembled at runtime, per `tests/CLAUDE.md` — writing them as literals would make the hook and CI block the test itself.

`make test-fast` 6793 passed · lint clean · doc counts 19/19 · privacy scan clean (no args, CI parity).