### PR TITLE
docs: fix stale llm_consult.py path references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ OLLAMA_MODEL=qwen3.5
 # llama.cpp (GGUF 직접 실행)
 # LLAMA_MODEL_PATH=/path/to/model.gguf
 
-# scripts/llm_consult.py — codex + Qwen3.5 dual-LLM consult helper.
+# scripts/dev/llm_consult.py — codex + Qwen3.5 dual-LLM consult helper.
 # OpenAI-compat endpoint; default LM Studio :1234 (MLX, M5 Max dev).
 # Mac mini production override: llama.cpp :8081 (headless, smaller footprint).
 # Both unset → uses LM Studio default. See docs/OPERATIONS.md "Local LLM stack".

--- a/nuri/llm/thesis_query.py
+++ b/nuri/llm/thesis_query.py
@@ -12,7 +12,7 @@ Why this exists (2026-04-30 user escalation):
 
 Phase 1 (이 PR):
   - DB context (factors / signals / prices / fundamentals / portfolio overlap)
-  - LLM synthesis via `scripts/llm_consult.py` (codex + Qwen3.5)
+  - LLM synthesis via `scripts/dev/llm_consult.py` (codex + Qwen3.5)
   - structured markdown output → `data/thesis_query/{date}_{ticker}_{slug}.md`
   - CLI: `make thesis ticker=INTC question="..."`
 
@@ -258,7 +258,7 @@ def thesis_query(
     slug = _slugify(question)
     out_path = out / f"{today_kst()}_{ticker.lower()}_{slug}.md"
 
-    # Pipe to scripts/llm_consult.py via stdin (it accepts --slug + stdin)
+    # Pipe to scripts/dev/llm_consult.py via stdin (it accepts --slug + stdin)
     cmd = [
         sys.executable,
         str(LLM_CONSULT_SCRIPT),

--- a/scripts/dev/llm_consult.py
+++ b/scripts/dev/llm_consult.py
@@ -14,9 +14,9 @@ env vars `NURI_LLM_QWEN_URL` / `NURI_LLM_QWEN_MODEL` to point elsewhere
 (e.g. llama.cpp at :8081 — historical default until 2026-04-29).
 
 Usage:
-    .venv/bin/python scripts/llm_consult.py --slug <slug> --prompt-file <path>
-    .venv/bin/python scripts/llm_consult.py --slug <slug> < prompt.md
-    .venv/bin/python scripts/llm_consult.py --slug <slug> --codex-only --prompt-file <path>
+    .venv/bin/python scripts/dev/llm_consult.py --slug <slug> --prompt-file <path>
+    .venv/bin/python scripts/dev/llm_consult.py --slug <slug> < prompt.md
+    .venv/bin/python scripts/dev/llm_consult.py --slug <slug> --codex-only --prompt-file <path>
 
 The slug becomes the filename suffix; keep it kebab-case + descriptive
 (e.g. `e3-phase2-shelve-decision`).


### PR DESCRIPTION
## Summary

The dual-LLM consult helper lives at `scripts/dev/llm_consult.py`, but five comment and docstring references still pointed at `scripts/llm_consult.py`. Comment-only drift — no executable code changed.

Found while verifying the local LLM stack after a `brew upgrade` on the M5 Max dev box.

## Changes

| File | Line | Kind |
|------|------|------|
| `.env.example` | 97 | comment |
| `nuri/llm/thesis_query.py` | 15 | module docstring |
| `nuri/llm/thesis_query.py` | 261 | inline comment |
| `scripts/dev/llm_consult.py` | 17-19 | its own Usage examples |

## Why executable code was already correct

- `nuri/llm/thesis_query.py:43` — `LLM_CONSULT_SCRIPT = Path("scripts/dev/llm_consult.py")`
- `Makefile:346` — `$(PYTHON) scripts/dev/llm_consult.py --slug ...`
- `docs/OPERATIONS.md:179` — already accurate

So `make llm-consult` and `/nuri-thesis` were never broken. Only the guidance text was wrong, including the script telling users the wrong path to invoke itself.

## Verification

```
grep -rn "scripts/llm_consult\.py"        -> none remaining
tests/test_script_path_lock.py            -> 4 passed
make verify-quick                         -> 6811 passed, 6 skipped (170s)
ruff check / ruff format --check          -> clean
```

## Scope note

Three unrelated findings surfaced during this work and are deliberately **not** in this PR (1 issue = 1 PR):

1. `nuri/llm/openai_client.py:19-24` docstring claims the §4.4.3 whitelist permits Tier 0 only, but the same module implements `chat_text(..., data_tier="tier2")` and `report.py` uses it. The docstring declares itself the source of truth.
2. `docs/STRATEGY.md:329` says the Tier 2 -> local LLM transition was dropped 2026-07-08, but `nuri/llm/report.py:680` still carries local Tier 2 fallbacks.
3. `nuri/llm/thesis_query.py:226` asks the LLM for concrete `Entry / Stop / TP` prices, which sits in tension with the `No ad-hoc buy/sell calls` invariant. Needs a STRATEGY-level decision, not a drive-by fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)