### PR TITLE
fix: use canonical price targets in thesis prompt instead of LLM-derived levels

### DIFF
--- a/nuri/llm/thesis_query.py
+++ b/nuri/llm/thesis_query.py
@@ -259,7 +259,10 @@ def _build_prompt(ticker: str, question: str, ctx: dict[str, str]) -> str:
         "- Price levels above are computed by `price_targets.calculate_targets` from "
         "`config/rules.yaml`. They are the only valid levels. Do NOT compute, round, "
         "adjust, or invent entry / stop / TP values of your own.",
-        "- 3:1 reward-to-risk, growth ladder: stop -7% / TP1 +20% / TP2 +40%.",
+        "- 3:1 reward-to-risk. The ladder percentages live in `config/rules.yaml` and are "
+        "already applied in the 'Price levels' section above. Do not restate them from "
+        "memory or re-apply them to the current price — if that section gives no levels "
+        "(leader trail, or unavailable), there are no TP levels to report.",
         "- VIX gate: > 30 block buys, 25-30 half size.",
         "- Position cap: max 15% per ticker (core), 25% (active).",
         "- Korean retail investor — risk-averse after 4월 손실 cascade.",

--- a/nuri/llm/thesis_query.py
+++ b/nuri/llm/thesis_query.py
@@ -191,6 +191,42 @@ def _fetch_db_context(ticker: str) -> dict[str, str]:
     except Exception as e:
         sections["recent_calls"] = f"(error: {e})"
 
+    # 7. Price levels — canonical, config-driven. LLM 이 직접 유도하면 안 된다
+    #    (invariants.md "No ad-hoc buy/sell calls" + recommend/CLAUDE.md
+    #    "price_targets.py is the canonical source — do not re-derive in callers").
+    #    deferred import: nuri/llm 은 stage 가 아니라 cross-stage 규칙 대상은 아니나,
+    #    price_targets 는 config/DB 를 끌어오므로 import 비용을 호출 시점으로 미룬다.
+    try:
+        from nuri.trading.recommend.price_targets import calculate_targets
+
+        t = calculate_targets(ticker)
+        if t.get("error"):
+            sections["price_levels"] = f"(unavailable — {t['error']})"
+        elif t.get("is_leader"):
+            # 리더(성장주)는 고정 익절 폐기 → target_1/2 = None, 50일선 트레일이 유일한 exit
+            sections["price_levels"] = "\n".join(
+                [
+                    f"  - stock_type: {t['stock_type']} (**leader** — 고정 익절 없음)",
+                    f"  - entry: ${t['entry_price']:.2f} (current ${t['current_price']:.2f})",
+                    f"  - stop_loss: ${t['stop_loss']:.2f} ({t['stop_loss_pct']}%)",
+                    f"  - exit: {t['leader_ma_period']}일선 트레일 ${t['leader_ma']:.2f} 이탈",
+                    f"  - trailing_stop: {t['trailing_stop_pct']}%",
+                ]
+            )
+        else:
+            sections["price_levels"] = "\n".join(
+                [
+                    f"  - stock_type: {t['stock_type']}",
+                    f"  - entry: ${t['entry_price']:.2f} (current ${t['current_price']:.2f})",
+                    f"  - stop_loss: ${t['stop_loss']:.2f} ({t['stop_loss_pct']}%)",
+                    f"  - target_1: ${t['target_1']:.2f} (+{t['target_1_pct']}%, sell {t['target_1_sell_pct']}%)",
+                    f"  - target_2: ${t['target_2']:.2f} (+{t['target_2_pct']}%, sell {t['target_2_sell_pct']}%)",
+                    f"  - trailing_stop: {t['trailing_stop_pct']}%",
+                ]
+            )
+    except Exception as e:
+        sections["price_levels"] = f"(error: {e})"
+
     return sections
 
 
@@ -213,9 +249,16 @@ def _build_prompt(ticker: str, question: str, ctx: dict[str, str]) -> str:
         "",
         ctx.get("recent_calls", "(no calls)"),
         "",
+        "## Price levels (system-computed — DO NOT derive your own)",
+        "",
+        ctx.get("price_levels", "(unavailable)"),
+        "",
         "## Constraints",
         "",
         "- STRATEGY §7.1: recommendation only, no auto-trade.",
+        "- Price levels above are computed by `price_targets.calculate_targets` from "
+        "`config/rules.yaml`. They are the only valid levels. Do NOT compute, round, "
+        "adjust, or invent entry / stop / TP values of your own.",
         "- 3:1 reward-to-risk, growth ladder: stop -7% / TP1 +20% / TP2 +40%.",
         "- VIX gate: > 30 block buys, 25-30 half size.",
         "- Position cap: max 15% per ticker (core), 25% (active).",
@@ -227,7 +270,9 @@ def _build_prompt(ticker: str, question: str, ctx: dict[str, str]) -> str:
         "2. **Thesis** (3-5 sentences — what is the company's actual position in the value chain?)",
         "3. **Beneficiary analysis** (if relevant — who benefits from what trend? rank 5+)",
         "4. **Risk** (top 2 specific risks with quantified probability if possible)",
-        "5. **Entry / Stop / TP** (if BUY/STRONG BUY — concrete prices)",
+        "5. **Price levels** (if BUY/STRONG BUY — restate the system-computed levels "
+        "from the 'Price levels' section verbatim. If that section says unavailable, "
+        "say so and omit — never substitute your own numbers)",
         "6. **Portfolio implications** (given user's actual holdings + cash situation)",
         "7. **Confidence** (0-100, honest calibration)",
         "",

--- a/tests/llm/test_thesis_query.py
+++ b/tests/llm/test_thesis_query.py
@@ -283,6 +283,16 @@ class TestPriceLevelsCanonical:
         # 옛 문구가 되살아나면 FAIL
         assert "concrete prices" not in prompt
 
+    def test_prompt_has_no_hardcoded_ladder(self) -> None:
+        """ladder 수치를 프롬프트에 박으면 leader/unavailable 케이스에서 모델이
+        현재가에 그 %를 곱해 가격을 재생성할 수 있다 (codex review [P2]).
+        수치는 `config/rules.yaml` → `calculate_targets` 경로로만 들어온다.
+        """
+        prompt = tq._build_prompt("AAA", "?", {"price_levels": "(unavailable — 가격 데이터 없음)"})
+        for literal in ("-7%", "+20%", "+40%"):
+            assert literal not in prompt, f"hardcoded ladder value {literal} leaked into prompt"
+        assert "config/rules.yaml" in prompt
+
 
 # ─── thesis_query (subprocess + filename rename) ───────────────────
 

--- a/tests/llm/test_thesis_query.py
+++ b/tests/llm/test_thesis_query.py
@@ -204,6 +204,86 @@ class TestBuildPrompt:
         assert "(no calls)" in prompt
 
 
+# ─── price levels: canonical source only ───────────────────────────
+
+
+class TestPriceLevelsCanonical:
+    """가격 레벨은 `price_targets.calculate_targets` 만이 만든다.
+
+    `.claude/rules/invariants.md` "No ad-hoc buy/sell calls" + `nuri/trading/
+    recommend/CLAUDE.md` "price_targets.py is the canonical source — do not
+    re-derive in callers". 이전에는 프롬프트가 LLM 에게 `Entry / Stop / TP
+    (concrete prices)` 를 **직접 만들라**고 요구했다 — 실시간 가격도 ladder 도
+    모르는 쪽이 숫자를 지어내는 경로였다.
+    """
+
+    _TARGETS = {
+        "ticker": "AAA",
+        "stock_type": "value",
+        "current_price": 100.0,
+        "entry_price": 100.0,
+        "stop_loss": 90.0,
+        "stop_loss_pct": -10,
+        "target_1": 115.0,
+        "target_1_pct": 15,
+        "target_1_sell_pct": 50,
+        "target_2": 130.0,
+        "target_2_pct": 30,
+        "target_2_sell_pct": 25,
+        "trailing_stop_pct": -15,
+        "is_leader": False,
+    }
+
+    def test_levels_come_from_calculate_targets(self, mock_query_df) -> None:
+        with patch("nuri.trading.recommend.price_targets.calculate_targets", return_value=self._TARGETS):
+            ctx = tq._fetch_db_context("AAA")
+        assert "$90.00" in ctx["price_levels"]
+        assert "$115.00" in ctx["price_levels"]
+        assert "$130.00" in ctx["price_levels"]
+        assert "sell 50%" in ctx["price_levels"]
+
+    def test_leader_has_no_fixed_targets(self, mock_query_df) -> None:
+        """리더는 고정 익절 폐기 → target_1/2 = None. 그 None 을 렌더하면 안 된다."""
+        leader = {
+            **self._TARGETS,
+            "stock_type": "growth",
+            "is_leader": True,
+            "target_1": None,
+            "target_2": None,
+            "leader_ma": 95.0,
+            "leader_ma_period": 50,
+        }
+        with patch("nuri.trading.recommend.price_targets.calculate_targets", return_value=leader):
+            ctx = tq._fetch_db_context("AAA")
+        assert "leader" in ctx["price_levels"]
+        assert "50일선 트레일 $95.00" in ctx["price_levels"]
+        assert "target_1" not in ctx["price_levels"]
+        assert "None" not in ctx["price_levels"]
+
+    def test_missing_price_data_reports_unavailable(self, mock_query_df) -> None:
+        with patch(
+            "nuri.trading.recommend.price_targets.calculate_targets",
+            return_value={"ticker": "AAA", "error": "가격 데이터 없음"},
+        ):
+            ctx = tq._fetch_db_context("AAA")
+        assert "unavailable" in ctx["price_levels"]
+
+    def test_calculate_targets_exception_is_absorbed(self, mock_query_df) -> None:
+        with patch("nuri.trading.recommend.price_targets.calculate_targets", side_effect=RuntimeError("boom")):
+            ctx = tq._fetch_db_context("AAA")
+        assert ctx["price_levels"].startswith("(error:")
+
+    def test_prompt_forbids_llm_derived_levels(self) -> None:
+        """회귀 잠금 — 프롬프트가 LLM 에게 가격을 만들라고 되돌아가면 FAIL."""
+        prompt = tq._build_prompt("AAA", "?", {"price_levels": "  - stop_loss: $90.00"})
+        assert "$90.00" in prompt
+        assert "DO NOT derive your own" in prompt
+        assert "Do NOT compute, round, adjust, or invent" in prompt
+        assert "restate the system-computed levels" in prompt
+        # 옛 문구가 되살아나면 FAIL
+        assert "concrete prices" not in prompt
+
+
 # ─── thesis_query (subprocess + filename rename) ───────────────────
 
 


### PR DESCRIPTION
## Problem

`nuri/llm/thesis_query.py:_build_prompt` asked the local LLM (codex + Qwen3.5) to produce:

```
5. **Entry / Stop / TP** (if BUY/STRONG BUY — concrete prices)
```

Two rules forbid that:

- `.claude/rules/invariants.md` **No ad-hoc buy/sell calls** — "가격 레벨(entry · stop · TP1 · TP2 · trailing)을 붙이라는 요구는 그 시스템 산출물에 적용되는 형식이지 LLM 추측을 정당화하지 않는다."
- `nuri/trading/recommend/CLAUDE.md` — "`price_targets.py` is the canonical source — **do not re-derive in callers**."

Nothing validated whether the emitted numbers came from the ladder or were invented. `make thesis` / `/nuri-thesis` output is read as manual-judgment input, so an invented stop is a real-money failure path.

Surfaced by `/codex` consult while auditing the local LLM stack.

## Change

`_fetch_db_context` gains a 7th section that calls `price_targets.calculate_targets(ticker)` and renders the `config/rules.yaml`-driven levels. The prompt restates them and is barred from computing its own.

| Case | Rendered |
|------|----------|
| normal | entry / stop_loss / target_1 (+sell %) / target_2 (+sell %) / trailing |
| leader (growth) | entry / stop_loss / **50d MA trail** / trailing — no fixed TP, matching `calculate_targets` returning `target_1/2 = None` |
| no price data | `(unavailable — ...)`, LLM told to say so and omit |
| exception | `(error: ...)`, absorbed per-section like the other six |

Second commit removes `growth ladder: stop -7% / TP1 +20% / TP2 +40%` from the constraints block. In the leader and unavailable branches no levels are injected, so those literals were enough to regenerate prices from the current price. Also a Config-over-code fix — the values were duplicated out of `rules.yaml` into a prompt string.

## Not a cross-stage import

`nuri/llm` is not in `STAGES` (`tests/core/test_cross_stage_imports.py:31`), so no allowlist entry is needed. The same edge already exists for a stage caller: `nuri/trading/engine/decisions.py -> nuri.trading.recommend.price_targets`, "결정 기록 시 가격 레벨 계산". Import is deferred anyway since `price_targets` pulls config + DB.

## Verification

```
tests/llm/test_thesis_query.py            19 -> 25 tests (+6), all passing
make verify-quick                       6817 passed, 6 skipped (102s)
tests/core/test_cross_stage_imports.py     6 passed
tests/core/test_sqlite3_sole_importer.py   3 passed
ruff check / ruff format --check           clean
```

**Gotcha-Test Pair** (STRATEGY §5.3.1), mutation-verified:

- `TestPriceLevelsCanonical::test_prompt_forbids_llm_derived_levels` — restoring the old `"concrete prices"` wording gives **1 failed / 4 passed**.
- `TestPriceLevelsCanonical::test_prompt_has_no_hardcoded_ladder` — locks the `-7% / +20% / +40%` literals out of the prompt.

## Review

`/codex review` raised one **[P2]** (the hardcoded ladder). Fixed in commit 2. No P1.

## Out of scope

The constraints block also hardcodes `VIX > 30 / 25-30` and `15% / 25%` position caps, duplicated from `config/rules.yaml`. Same Config-over-code smell, but they constrain the verdict rather than generate prices, so they are a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)