### PR TITLE
docs: correct Tier 0/Tier 2 egress policy drift in openai_client and STRATEGY

### DIFF
--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -329,7 +329,7 @@ History cleanup (Stage 2 — 별도 작업): main HEAD 는 깨끗하게 유지�
 1. ZDR 승인 완료 후 첫 호출. 미승인 시 `OPENAI_ZDR_APPROVED=1` 미설정으로 wrapper raise.
 2. `NURI_DISABLE_EXTERNAL_LLM=1` 즉시 opt-out.
 3. 프롬프트 로그 금지 — token·latency·error_type 만, **content 금지**.
-4. ~~local LLM 전환 계획~~ — **dropped (2026-07-08, #854)**: 로컬 LLM 상시 가동 폐지 결정으로 Tier 2 는 cloud ZDR 유지.
+4. ~~local LLM 전환 계획~~ — **dropped (2026-07-08, #854)**: 로컬 LLM 상시 가동 폐지 결정으로 Tier 2 **primary** 는 cloud ZDR 유지. 단 `nuri/llm/report.py` 의 **opt-in local fallback 경로는 제거되지 않았다** — OpenAI 실패 또는 `NURI_DISABLE_EXTERNAL_LLM=1` 시 `LLAMA_MODEL_PATH` → `OLLAMA_HOST` 순으로 시도한다 (둘 다 미설정이면 error note). 즉 "cloud 전용"이 아니라 **"cloud primary + local 상시-미가동 fallback"** 이다. 폐지된 것은 상시 가동과 primary 전환이지 fallback 코드가 아니다.
 **필수 운영 룰**:
 1. 모든 외부 LLM 은 wrapper (`openai_client.get_client()`). 직접 `import openai` 금지.
 2. Per-call audit log — `external_llm_calls` 테이블: `timestamp, provider, model, endpoint, prompt_tokens, completion_tokens, latency_ms, success, error_type`. content 금지.

--- a/nuri/llm/openai_client.py
+++ b/nuri/llm/openai_client.py
@@ -16,12 +16,18 @@ module. Direct `import openai` elsewhere in `nuri/` is forbidden so that:
 4. Provider/model substitution — when a future PR adds another provider
    (Anthropic, Gemini, local Ollama as secondary, ...) it slots in here.
 
-The current §4.4.3 whitelist permits **public RSS headline classification
-only** (Tier 0 data). Sending Tier 1 (user narrative) or Tier 2 (portfolio)
-data through this wrapper is a STRATEGY violation that requires a separate
-PR to enable. The wrapper does not enforce that distinction at runtime —
-that's the caller's responsibility — but the wrapper docstrings and the
-STRATEGY.md table are the single source of truth.
+The current §4.4.3 whitelist permits **two** entries, both `gpt-5.4-nano`:
+
+1. **Tier 0** — public RSS headline classification (`event_classifier`). ZDR 권장.
+2. **Tier 2** — 일간 포트폴리오 리포트 (`report.py`), 2026-04-14 사용자 승인.
+   ZDR **필수**: `OPENAI_ZDR_APPROVED=1` 미설정 시 `chat_text(data_tier="tier2")`
+   가 `ExternalLLMPolicyViolation` 을 raise 한다 (fail loud).
+
+**Tier 1** (user narrative) 은 여전히 금지 — 활성화하려면 별도 STRATEGY PR.
+
+Tier 판별은 caller 가 `data_tier=` 로 선언하고 이 wrapper 가 ZDR attestation
+만 강제한다. 어떤 데이터가 어느 Tier 인지는 `docs/STRATEGY.md` §4.4.3 표가
+source of truth — 이 docstring 은 그 사본이므로 표가 바뀌면 같이 고칠 것.
 
 Usage:
 


### PR DESCRIPTION
## Summary

Two descriptions had fallen behind the code. **Descriptive fixes only** — no policy amendment, no runtime behaviour touched. Surfaced by `/codex` consult while auditing the local LLM stack.

## 1. `nuri/llm/openai_client.py` module docstring

Claimed:

> The current §4.4.3 whitelist permits **public RSS headline classification only** (Tier 0 data). Sending Tier 1 (user narrative) or Tier 2 (portfolio) data through this wrapper is a STRATEGY violation that requires a separate PR to enable.

But the same module implements `chat_text(..., data_tier="tier2")` and `report.py` has used it for the daily portfolio report since the **2026-04-14 user approval**, with ZDR enforced through `OPENAI_ZDR_APPROVED`. `docs/STRATEGY.md` §4.4.3 lists that Tier 2 row explicitly.

The docstring declared itself part of the "single source of truth" while contradicting the actual whitelist. Now describes both permitted entries, keeps Tier 1 forbidden, and points at the STRATEGY table as canonical.

## 2. `docs/STRATEGY.md` §4.4.3 Tier 2 precondition 4

Said the local-LLM transition was dropped (2026-07-08, #854) "로컬 LLM 상시 가동 폐지 결정으로 Tier 2 는 cloud ZDR 유지", which reads as *Tier 2 is cloud-only*.

`nuri/llm/report.py:680` still carries opt-in local fallbacks:

```python
raw_report = _generate_openai(SYSTEM_PROMPT, _build_user_payload(ctx))
if not raw_report and LLAMA_MODEL_PATH:
    raw_report = _generate_llamacpp(prompt)
if not raw_report and OLLAMA_HOST:
    raw_report = _generate_ollama(prompt)
```

These fire when OpenAI fails or `NURI_DISABLE_EXTERNAL_LLM=1`. What #854 dropped is **always-on local** and the **primary-path migration**, not the fallback code. The line now says so, so nobody reads the architecture as cloud-only and deletes a live degradation path.

## Verification

```
tests/llm/                253 passed, 1 skipped (145s)
make verify-doc-counts     19 passed (19 checks)
ruff check / format        clean
```

No test changes: both edits are comments/prose. `tests/llm/test_report_branch_coverage.py` already locks the local fallback behaviour that fix 2 describes.

## Related

- #1035 — stale `llm_consult.py` path references
- #1036 — canonical price targets in thesis prompt

## Not included

`docs/OPERATIONS.md` is gitignored (local-only operator runbook), so its `~63 tok/s` claim was corrected locally and cannot appear here. Measured on this box today: **36.8 tok/s mean** (256-in/512-out ×3 = 20.3 / 51.3 / 38.8, LM Studio 0.4.20+1). The documented figure was unsourced and above even the max run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)