### PR TITLE
fix(collectors): make coingecko raise on total failure instead of returning []

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,977 collected across 314 files | |
+| **Backend tests** | 6,981 collected across 314 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,977 backend tests across 314 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,981 backend tests across 314 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,977 tests, 314 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,981 tests, 314 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/coingecko.py
+++ b/nuri/collectors/coingecko.py
@@ -34,6 +34,7 @@ class CoinGeckoCollector(BaseCollector):
         """BTC 가격 + 글로벌 암호화폐 지표 수집."""
         records = []
         today = today_str()
+        errors: list[Exception] = []
 
         # 1. BTC 현재가 + 시가총액 + 24h 거래량
         try:
@@ -41,6 +42,7 @@ class CoinGeckoCollector(BaseCollector):
             records.extend(price_records)
         except Exception as e:
             self.logger.warning("CoinGecko price API 실패: %s", e)
+            errors.append(e)
 
         # 2. 글로벌 시장 지표 (BTC 도미넌스, 총 시가총액)
         try:
@@ -48,6 +50,26 @@ class CoinGeckoCollector(BaseCollector):
             records.extend(global_records)
         except Exception as e:
             self.logger.warning("CoinGecko global API 실패: %s", e)
+            errors.append(e)
+
+        # 한 건도 못 건졌는데 예외가 있었다 = **수집 실패**다. `[]` 로 돌려주면
+        # "오늘 값이 없다"(NO_DATA) 와 구분이 사라진다. 이 수집기는 그 구분을
+        # 잃을 여유가 없다 — `collector_runs.rows_collected` 는 `run_step` 이
+        # 돌려주는 4-키 dict 의 길이라 **항상 4** 이므로, `status` 가 유일한
+        # 판별 채널이다. 지금은 총체적 장애일에도 `finished` 가 박힌다.
+        #
+        # raise 하면 이미 있는 기계가 전부 살아난다 — base.py 의 재시도 3회,
+        # `_send_failure_alert()` 의 #ops 알림, scheduler 의 `status="failed"`,
+        # `collector_health` 의 경고. 새로 만드는 장치는 하나도 없다.
+        #
+        # `errors and not records` 인 이유: 한쪽이 예외이고 다른 쪽이 빈 응답인
+        # 경우도 실패다. 반대로 **둘 다 200 인데 내용이 비면** 예외가 없으므로
+        # `[]` 가 그대로 나간다 — 그게 NO_DATA 의 정의다.
+        # `errors[0]`: 마지막이 아니라 **첫** 원인을 올린다. 둘 다 실패하면
+        # 마지막은 항상 global 이라, price 의 429 가 알림 문구에서 사라지고
+        # 운영자가 엉뚱한 원인을 좇게 된다.
+        if errors and not records:
+            raise errors[0]
 
         return records
 

--- a/tests/collectors/test_coingecko.py
+++ b/tests/collectors/test_coingecko.py
@@ -117,3 +117,74 @@ class TestCoinGeckoCollector:
         # save 는 _last_run 등 다른 것 없이 단순 위임만 — empty list → 0 반환
         result = collector.save([])
         assert result == 0
+
+
+class TestCoinGeckoFailedVsNoData:
+    """수집 **실패**와 "오늘 값 없음"은 다른 사건이고, 다르게 기록돼야 한다.
+
+    이 수집기는 그 구분을 잃을 여유가 없다: `collector_runs.rows_collected` 는
+    `run_step` 이 돌려주는 4-키 dict 의 길이라 **항상 4** 라서, `status` 가
+    유일한 판별 채널이다. 예전에는 총체적 장애일에도 `finished` 가 박혔다.
+
+    아래 두 테스트는 **한 쌍으로만** 잠금이 된다 — 하나는 실패가 조용히
+    지나가지 않는지, 다른 하나는 정상적인 빈 날이 거짓 경보가 되지 않는지 본다.
+    """
+
+    @patch("nuri.collectors.coingecko.requests.get")
+    def test_total_api_failure_raises_instead_of_returning_empty(self, mock_get):
+        """두 API 모두 실패 → 예외. `[]` 로 되돌리면 이 테스트가 FAIL 한다."""
+        from nuri.collectors.coingecko import CoinGeckoCollector
+
+        mock_get.side_effect = [RuntimeError("HTTP 429 rate limit"), RuntimeError("HTTP 429 rate limit")]
+        with pytest.raises(RuntimeError, match="429"):
+            CoinGeckoCollector().collect()
+
+    @patch("nuri.collectors.coingecko.requests.get")
+    def test_empty_payload_is_not_a_failure(self, mock_get):
+        """둘 다 200 인데 내용이 비면 그건 NO_DATA 다 — 예외를 올리면 안 된다.
+
+        가드를 `if not records: raise` 로 "단순화"하면 여기서 FAIL 한다.
+        그 단순화는 정상적인 빈 날을 거짓 장애 알림으로 바꾼다.
+        """
+        from nuri.collectors.coingecko import CoinGeckoCollector
+
+        price_resp = MagicMock()
+        price_resp.json.return_value = {"bitcoin": {}}
+        price_resp.raise_for_status = MagicMock()
+        global_resp = MagicMock()
+        global_resp.json.return_value = {"data": {}}
+        global_resp.raise_for_status = MagicMock()
+        mock_get.side_effect = [price_resp, global_resp]
+
+        assert CoinGeckoCollector().collect() == []
+
+    @patch("nuri.collectors.coingecko.requests.get")
+    def test_partial_success_still_returns_what_it_got(self, mock_get):
+        """한쪽만 죽으면 건진 건 그대로 돌려준다 — 실패로 격상하지 않는다."""
+        from nuri.collectors.coingecko import CoinGeckoCollector
+
+        global_resp = MagicMock()
+        global_resp.json.return_value = {
+            "data": {
+                "market_cap_percentage": {"btc": 54.2},
+                "total_market_cap": {"usd": 2450000000000},
+                "active_cryptocurrencies": 14500,
+            }
+        }
+        global_resp.raise_for_status = MagicMock()
+        mock_get.side_effect = [RuntimeError("HTTP 500"), global_resp]
+
+        assert CoinGeckoCollector().collect(), "부분 성공은 빈 리스트가 아니어야 한다"
+
+    @patch("nuri.collectors.coingecko.requests.get")
+    def test_first_error_is_raised_not_the_last(self, mock_get):
+        """둘 다 실패하면 **첫** 원인을 올린다.
+
+        마지막을 올리면 항상 global 실패가 되어, price 의 진짜 원인(예: 429)이
+        Discord #ops 알림 문구에서 사라진다 — 운영자가 엉뚱한 걸 좇는다.
+        """
+        from nuri.collectors.coingecko import CoinGeckoCollector
+
+        mock_get.side_effect = [RuntimeError("PRICE 429"), RuntimeError("GLOBAL json decode")]
+        with pytest.raises(RuntimeError, match="PRICE 429"):
+            CoinGeckoCollector().collect()


### PR DESCRIPTION
Carry-over P0 **N5**. The only one of the five audit items with a production path — coingecko runs daily at 06:25 KST.

## The bug

A day where both CoinGecko endpoints fail is recorded **exactly like a day with nothing to report**. Both handlers log a warning and `return []`, so scheduler writes `collector_runs.status='finished'` and nothing alerts.

This collector cannot afford to lose that distinction. `rows_collected` is the length of the 4-key dict `run_step` returns, so it is **always 4** for coingecko — `status` is the only surviving discriminator, and today it says the run succeeded.

## The fix

Four lines. Raising re-enables machinery that already exists and is currently bypassed:

| Layer | What turns back on |
|---|---|
| `base.py:89-121` | 3 retries with 2s/4s backoff |
| `base.py:125` | `_send_failure_alert()` → Discord #ops (deduped per collector per day) |
| `scheduler.py:302-304` | `collector_runs.status='failed'` + `error_message` |
| `core/pipeline.py:117` | a `step_failed` pipeline event |
| `collector_orchestrator.py:331` | `collector_health` warns instead of reporting 정상 |

No config key. This is error handling, not a tunable investment rule — `config/rules.yaml` is scoped to investment rules, and adding a knob here would be the wrong kind of "config over code".

Two details that are load-bearing:

- The guard is **`errors and not records`**, not `len(errors) == 2`, so one endpoint erroring while the other returns an empty payload still counts as a failure. Two 200s with empty bodies raise nothing and return `[]` — that is NO_DATA, and it stays NO_DATA.
- **`errors[0]`, not `errors[-1]`**. When both fail the last error is always the global fetch, which would erase a price-side 429 from the alert text and send the operator after the wrong cause.

## The tests are locks, verified by mutation

Passing is not evidence. Three mutations, each caught by a different test:

| Mutation | Caught by |
|---|---|
| delete the guard (revert the fix) | `test_total_api_failure_raises...` + `test_first_error_is_raised_not_the_last` |
| simplify to `if not records: raise` | `test_empty_payload_is_not_a_failure` |
| `errors[0]` → `errors[-1]` | `test_first_error_is_raised_not_the_last` |

The raise-on-failure and empty-payload-is-fine tests only work **as a pair** — either alone leaves the other direction unguarded.

## Tradeoff, stated rather than buried

Raising turns a total outage into **3 attempts + 6s of backoff** against an API that may have just rate-limited you (2 requests become 6). Accepted: the once-daily cron bounds the blast radius, and the alternative is continuing to miss outages entirely. If CoinGecko free-tier 429s prove noisy in practice, the follow-up is a non-retryable exception type, not reverting the distinction.

## Siblings filed, not silently left

`cboe.py:81` and `fear_greed.py:39` have the byte-equivalent defect → **#1042**. Deferred under `1 issue = 1 PR`, and because cboe is a genuinely harder call: its 5-tier fallback includes reusing stale DB rows, so "all tiers exhausted" may legitimately be success.

## Verification

Full suite **6,966 passed** · `ruff` clean · `make verify-doc-counts` 19/19.

## Scope note

The audit listed this as "status code 분리". No new status enum was needed — the repo already distinguishes raise=FAILED from empty=NO_DATA everywhere else; coingecko was simply the one collector not using it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)