### PR TITLE
refactor(agents): move decision thresholds to config/rules.yaml (carry-over P0 N1+N2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,981 collected across 314 files | |
+| **Backend tests** | 6,994 collected across 315 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 554 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 588 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -552,3 +552,37 @@ brief:
   # 오른 적 없는 종목도 -15% 손실이 트레일링으로 잡힌다 — 그건 손절 소관이다.
   # 최고점이 진입가 대비 이 값 이상 올랐던 포지션만 give-back 알림 대상.
   trailing_min_peak_gain_pct: 10
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DecisionCompiler 의사결정 임계값 (#529 Phase 2 capstone, carry-over audit N1).
+# BUY/SELL emit 여부를 가르는 게이트다 → 투자 룰이다. 값 변경은 STRATEGY PR + 백테스트.
+# 코드(`nuri/agents/actors/decision_compiler.py`)는 import 만 한다.
+#
+# ⚠️ conviction 자체의 가중치(0.50/0.30/0.20, decision_compiler.py:188)는 여기 없다.
+# 그건 **지표의 정의**이고 아래는 그 지표를 재는 **문턱**이다 — 성격이 달라 분리한다.
+# ─────────────────────────────────────────────────────────────────────────────
+decision_compiler:
+  # conviction = 0.50*causal_certainty + 0.30*regime_top_prob + 0.20*top2_margin
+  conviction_emit_cutoff: 0.70   # 이 미만은 HOLD 로 emit (약한 신호를 행동으로 옮기지 않는다)
+  conviction_hold_cutoff: 0.50   # 이 미만은 blocked HOLD (low-signal 자체를 차단)
+  regime_favor_prob: 0.60        # regime posterior top1 prob >= 이 값 → favorable
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Forward outcome tracking 임계값 (#529 Phase 2 closed-loop, carry-over audit N2).
+# HypothesisRegistry validate/reject 문턱이다.
+#
+# ⚠️ **§3.11 사전등록 판정 기준이 아니다.** 판정 경로(`decision_alpha.fetch_sample`)는
+# `decision_outcomes.alpha` 만 읽고 이 값은 보지 않는다. 사전등록 기준은
+# `measurement_mode` 블록에 있고, 그건 STRATEGY PR 없이 못 고친다.
+#
+# ⚠️ window 키 집합은 `decision_outcomes` CHECK 제약(7/14/30)과 같아야 한다.
+# 여기서 키를 지우면 `forward_outcome_tracker` 가 그 window 에서 KeyError 를 내고,
+# 늘리면 `execution_ops.log_decision_outcome` 이 ValueError 를 던진다.
+# 그 대칭을 지키는 건 코드에 남은 `SUPPORTED_WINDOWS` 다 — config 로 옮기지 말 것
+# (옮기면 YAML 한 줄로 사전등록 window 30 을 조용히 끌 수 있게 된다).
+# ─────────────────────────────────────────────────────────────────────────────
+outcome_tracking:
+  window_thresholds:           # window(일): [validate 이상, reject 이하]
+    7: [0.05, -0.05]
+    14: [0.07, -0.07]
+    30: [0.10, -0.10]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,981 backend tests across 314 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,994 backend tests across 315 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,981 tests, 314 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,994 tests, 315 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/decision_compiler.py
+++ b/nuri/agents/actors/decision_compiler.py
@@ -13,9 +13,10 @@ Layer B 설계 (Codex Round 5):
 - HypothesisRegistry.check_emit BLOCK → HOLD (Layer A enforcement 우회 금지)
 - CausalFactorAuditor.last_audit verdict=MIRAGE → HOLD (factor mirage 차단)
 - CausalFactorAuditor.last_audit verdict=INSUFFICIENT → HOLD
-- conviction < CONVICTION_HOLD_CUTOFF (0.5) → HOLD (low-confidence emit 차단)
-- conviction < CONVICTION_EMIT_CUTOFF (0.7) → HOLD (작은 신호 무시)
-- All gates PASS + conviction >= 0.7 + regime favorable → BUY/SELL emit
+- conviction < CONVICTION_HOLD_CUTOFF → HOLD (low-confidence emit 차단)
+- conviction < CONVICTION_EMIT_CUTOFF → HOLD (작은 신호 무시)
+- All gates PASS + conviction >= CONVICTION_EMIT_CUTOFF + regime favorable → BUY/SELL emit
+  (세 임계값은 `config/rules.yaml decision_compiler` — 여기 숫자를 적으면 드리프트가 된다)
 
 Anti-pattern 방지 (lock-test):
 - HypothesisRegistry BLOCK 결과를 무시하고 emit 시도 → 무조건 HOLD + blocked
@@ -31,12 +32,8 @@ from typing import Any
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_decision, query
+from nuri.core.rules import CONVICTION_EMIT_CUTOFF, CONVICTION_HOLD_CUTOFF, REGIME_FAVOR_PROB
 from nuri.core.timezone import today_kst
-
-# ─── 의사결정 임계값 ─────────────────────────────────────
-CONVICTION_EMIT_CUTOFF = 0.70  # emit 최소 conviction
-CONVICTION_HOLD_CUTOFF = 0.50  # 이 미만은 무조건 HOLD (low-signal)
-REGIME_FAVOR_PROB = 0.60  # regime posterior top1 prob >= 이 값 → favorable
 
 VALID_ACTIONS_INPUT: tuple[str, ...] = ("BUY", "SELL")  # caller 가 제안하는 방향
 

--- a/nuri/agents/actors/forward_outcome_tracker.py
+++ b/nuri/agents/actors/forward_outcome_tracker.py
@@ -39,16 +39,18 @@ from nuri.core.db import (
     reject_hypothesis,
     validate_hypothesis,
 )
-from nuri.core.rules import RULES
+from nuri.core.rules import OUTCOME_WINDOW_THRESHOLDS, RULES
 from nuri.core.ticker_names import is_kr_ticker
 from nuri.core.timezone import today_kst
 
-# ─── window 별 validation 임계값 (Codex consult 합의) ─────────
-WINDOW_THRESHOLDS: dict[int, tuple[float, float]] = {
-    7: (0.05, -0.05),  # ±5% within 7 days
-    14: (0.07, -0.07),  # ±7% within 14 days
-    30: (0.10, -0.10),  # ±10% within 30 days
-}
+# ─── window 별 validation 임계값 — `config/rules.yaml outcome_tracking` ─────────
+# 이름을 유지해 기존 import/테스트가 그대로 돈다. **복사본**을 들고 있는다 —
+# 별칭으로 두면 테스트의 `patch.dict` 가 `nuri.core.rules` 의 원본을 제자리에서
+# 바꿔 다른 모듈까지 오염된다.
+WINDOW_THRESHOLDS: dict[int, tuple[float, float]] = dict(OUTCOME_WINDOW_THRESHOLDS)
+# ⚠️ config 로 옮기지 말 것. 이 튜플이 window 키 집합을 `decision_outcomes` CHECK
+# 제약(7/14/30)에 붙들어 매는 유일한 장치다 — config 로 가면 YAML 한 줄로
+# §3.11 사전등록 window 30 을 조용히 끌 수 있게 된다.
 SUPPORTED_WINDOWS: tuple[int, ...] = (7, 14, 30)
 DEFAULT_BENCHMARK_TICKER = "SPY"  # 시장 베타 — alpha 산출 baseline (US, §3.11 사전등록 판정 기준)
 

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -61,6 +61,24 @@ TRAILING_STOP_GROWTH = _ts.get("growth", -15)
 TRAILING_STOP_VALUE = _ts.get("value", -15)
 TRAILING_STOP_VOLATILE = _ts.get("volatile", -20)
 
+# ─── DecisionCompiler 의사결정 임계값 (#529, carry-over audit N1) ───
+# emit/HOLD 를 가르는 게이트라 투자 룰이다 — 코드 하드코딩 금지 조항 대상.
+_dc = RULES.get("decision_compiler", {})
+CONVICTION_EMIT_CUTOFF = _dc.get("conviction_emit_cutoff", 0.70)
+CONVICTION_HOLD_CUTOFF = _dc.get("conviction_hold_cutoff", 0.50)
+REGIME_FAVOR_PROB = _dc.get("regime_favor_prob", 0.60)
+
+# ─── Forward outcome tracking 임계값 (#529, carry-over audit N2) ───
+# PyYAML 은 bare `7:` 를 int 로 파싱하지만 `"7":` 로 인용하면 str 이 된다. 키 타입이
+# 갈리면 `WINDOW_THRESHOLDS[window]`(window 는 int)가 KeyError 를 내고 actor 가 죽는다.
+# 정규화는 여기 한 곳에 둔다 — 소비자마다 방어하게 만들지 않는다.
+# 값도 list → tuple 로 굳힌다. 어노테이션이 tuple 이고, 원소 단위 변형을 막는다.
+_ot = RULES.get("outcome_tracking", {})
+OUTCOME_WINDOW_THRESHOLDS: dict[int, tuple[float, float]] = {
+    int(w): (float(p[0]), float(p[1]))
+    for w, p in (_ot.get("window_thresholds") or {7: [0.05, -0.05], 14: [0.07, -0.07], 30: [0.10, -0.10]}).items()
+}
+
 # ─── 매수 진입 조건 ───
 _entry = RULES.get("entry_rules", {})
 VIX_BLOCK_ABOVE = _entry.get("vix_gate", {}).get("block_above", 30)

--- a/tests/core/test_thresholds_from_config.py
+++ b/tests/core/test_thresholds_from_config.py
@@ -1,0 +1,190 @@
+"""의사결정 임계값은 코드가 아니라 `config/rules.yaml` 에 있다 (carry-over audit N1/N2).
+
+왜 값 비교로는 안 되는가
+------------------------
+"config 값과 상수가 같다"는 테스트는 **부분 되돌림을 못 잡는다**. 누가 액터에
+`CONVICTION_EMIT_CUTOFF = 0.70` 을 다시 인라인하면서 YAML 블록을 그대로 두면,
+두 값이 같으므로 그 테스트는 초록으로 통과한다. 그 순간 config 는 아무도 안 읽는
+장식이 되고, 튜닝은 조용히 무효가 된다.
+
+그래서 **값이 아니라 구조**를 본다: 액터 모듈에 그 이름으로 module-level 대입이
+없어야 하고, 그 이름이 `nuri.core.rules` 에서 import 돼야 한다. 문자열 grep 이
+아니라 AST 를 쓰는 이유는 주석·docstring 안의 같은 문구를 오탐하지 않기 위해서다
+(`tests/core/test_sqlite3_sole_importer.py` 와 같은 형태).
+
+⚠️ 이 잠금은 **일부러 깐깐하다.** `from nuri.core import rules` +
+`rules.CONVICTION_EMIT_CUTOFF` 형태도 거부한다. 그건 버그가 아니라 의도다 —
+잠금이 허용하는 형태가 넓어질수록 되돌림을 놓칠 여지가 커진다. 이 테스트가
+터졌다면 우회로를 찾지 말고, 정말 import 형태를 바꿀 이유가 있는지부터 볼 것.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from nuri.core.rules import (
+    CONVICTION_EMIT_CUTOFF,
+    CONVICTION_HOLD_CUTOFF,
+    OUTCOME_WINDOW_THRESHOLDS,
+    REGIME_FAVOR_PROB,
+    RULES,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_MODULE = "nuri.core.rules"
+
+# (액터 경로, config 에서 와야 하는 이름들)
+CONFIG_BACKED: list[tuple[str, tuple[str, ...]]] = [
+    (
+        "nuri/agents/actors/decision_compiler.py",
+        ("CONVICTION_EMIT_CUTOFF", "CONVICTION_HOLD_CUTOFF", "REGIME_FAVOR_PROB"),
+    ),
+    ("nuri/agents/actors/forward_outcome_tracker.py", ("OUTCOME_WINDOW_THRESHOLDS",)),
+]
+
+
+def _tree(rel: str) -> ast.Module:
+    return ast.parse((REPO_ROOT / rel).read_text(encoding="utf-8"), filename=rel)
+
+
+def _module_level_assignments(tree: ast.Module) -> set[str]:
+    """모듈 최상위에서 대입되는 이름. 함수/클래스 안쪽은 보지 않는다."""
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def _module_level_value(tree: ast.Module, name: str) -> ast.expr | None:
+    """모듈 최상위에서 `name` 에 대입된 **식**. 없으면 None."""
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == name:
+            return node.value
+        if isinstance(node, ast.Assign) and any(isinstance(t, ast.Name) and t.id == name for t in node.targets):
+            return node.value
+    return None
+
+
+def _references(expr: ast.expr | None, names: set[str]) -> bool:
+    """식이 주어진 이름 중 하나라도 참조하는가."""
+    if expr is None:
+        return False
+    return any(isinstance(n, ast.Name) and n.id in names for n in ast.walk(expr))
+
+
+def _imported_from_rules(tree: ast.Module) -> set[str]:
+    return {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == RULES_MODULE
+        for alias in node.names
+    }
+
+
+class TestThresholdsComeFromConfig:
+    @pytest.mark.parametrize("rel,names", CONFIG_BACKED, ids=lambda v: v if isinstance(v, str) else "")
+    def test_no_module_level_literal_reassignment(self, rel: str, names: tuple[str, ...]) -> None:
+        """액터가 그 이름을 스스로 정의하면 config 는 장식이 된다."""
+        assigned = _module_level_assignments(_tree(rel)) & set(names)
+        assert not assigned, f"{rel} 이 {sorted(assigned)} 을(를) 모듈 최상위에서 다시 정의한다 — config 가 무시된다"
+
+    @pytest.mark.parametrize("rel,names", CONFIG_BACKED, ids=lambda v: v if isinstance(v, str) else "")
+    def test_names_are_imported_from_the_rules_loader(self, rel: str, names: tuple[str, ...]) -> None:
+        missing = set(names) - _imported_from_rules(_tree(rel))
+        assert not missing, f"{rel} 이 {sorted(missing)} 을(를) {RULES_MODULE} 에서 import 하지 않는다"
+
+    def test_the_sweep_actually_sees_something(self) -> None:
+        """스윕이 0건을 훑고도 통과하면, 통과가 아무 의미가 없다.
+
+        경로 오타나 파일 이동으로 대상이 사라지면 위 두 테스트는 조용히 초록이
+        된다 — 카나리아를 둔다.
+        """
+        for rel, names in CONFIG_BACKED:
+            assert (REPO_ROOT / rel).exists(), f"{rel} 이 없다 — CONFIG_BACKED 를 갱신할 것"
+            assert names, f"{rel} 의 이름 목록이 비어 있다"
+            assert _imported_from_rules(_tree(rel)), f"{rel} 이 {RULES_MODULE} 를 아예 import 하지 않는다"
+
+
+class TestConfigBlocksExist:
+    """로더 기본값이 YAML 부재를 가려주므로, 블록 자체의 존재를 따로 잠근다."""
+
+    def test_decision_compiler_block_is_present_and_complete(self) -> None:
+        dc = RULES.get("decision_compiler")
+        assert dc, "config/rules.yaml 에 decision_compiler 블록이 없다"
+        assert set(dc) == {"conviction_emit_cutoff", "conviction_hold_cutoff", "regime_favor_prob"}
+
+    def test_outcome_tracking_block_is_present(self) -> None:
+        wt = (RULES.get("outcome_tracking") or {}).get("window_thresholds")
+        assert wt, "config/rules.yaml 에 outcome_tracking.window_thresholds 가 없다"
+
+    def test_loaded_values_match_the_config_file(self) -> None:
+        """로더가 YAML 을 실제로 읽는지 — 기본값으로만 살아 있으면 안 된다."""
+        dc = RULES["decision_compiler"]
+        assert CONVICTION_EMIT_CUTOFF == dc["conviction_emit_cutoff"]
+        assert CONVICTION_HOLD_CUTOFF == dc["conviction_hold_cutoff"]
+        assert REGIME_FAVOR_PROB == dc["regime_favor_prob"]
+
+    def test_window_keys_are_ints_and_values_are_tuples(self) -> None:
+        """YAML 에서 키를 `"7":` 로 인용하면 str 이 되어 소비처가 KeyError 를 낸다.
+
+        정규화는 로더 책임이다 — 소비자마다 방어하게 만들면 하나가 빠진다.
+        """
+        assert all(isinstance(k, int) for k in OUTCOME_WINDOW_THRESHOLDS)
+        assert all(isinstance(v, tuple) and len(v) == 2 for v in OUTCOME_WINDOW_THRESHOLDS.values())
+
+
+class TestPreRegisteredCriteriaStayInCode:
+    """§3.11 사전등록 기준은 **config 로 옮기면 안 된다** — 잠금이 약해진다.
+
+    `DEFAULT_BENCHMARK_TICKER` 를 config 에서 파생시키면
+    `tests/core/test_rules.py::test_benchmark_matches_tracker_constant` 가
+    `x == x` 자기비교로 무너진다. 지금은 코드 리터럴 ↔ config 대조라서 둘 중
+    하나만 바꾸면 CI 가 잡는다. 그 이중 게이트가 사전등록의 실질이다.
+    """
+
+    # config 로 새는 경로는 두 가지다: 로더에서 import 하거나, 로더가 만든 이름을
+    # 참조하는 식으로 유도하거나. 두 번째가 더 조용하다 — `= tuple(sorted(...))` 는
+    # 여전히 module-level 대입이라 "대입이 있는가" 만 보는 검사를 통과한다.
+    # (2026-08-14 실측: 이 테스트의 첫 판이 정확히 그 뮤테이션을 놓쳤다.)
+    _CONFIG_NAMES = {"OUTCOME_WINDOW_THRESHOLDS", "RULES"}
+
+    def _assert_literal(self, name: str, why: str) -> None:
+        tree = _tree("nuri/agents/actors/forward_outcome_tracker.py")
+        value = _module_level_value(tree, name)
+        assert value is not None, f"{name} 이 모듈 최상위에 없다 — {why}"
+        assert name not in _imported_from_rules(tree), f"{name} 을 로더에서 import 한다 — {why}"
+        assert not _references(value, self._CONFIG_NAMES), f"{name} 이 config 파생 식이다 — {why}"
+
+    def test_benchmark_ticker_is_still_a_code_literal(self) -> None:
+        self._assert_literal(
+            "DEFAULT_BENCHMARK_TICKER",
+            "§3.11 사전등록 기준의 이중 게이트(코드 리터럴 ↔ config 대조)가 사라진다",
+        )
+
+    def test_supported_windows_is_still_a_code_literal(self) -> None:
+        self._assert_literal(
+            "SUPPORTED_WINDOWS",
+            "YAML 한 줄로 사전등록 window 30 을 조용히 끌 수 있게 된다",
+        )
+
+    def test_window_key_set_still_matches_supported_windows(self) -> None:
+        """config 로 옮긴 쪽(키 집합)과 코드에 남은 쪽이 갈라지면 KeyError 가 난다."""
+        from nuri.agents.actors.forward_outcome_tracker import SUPPORTED_WINDOWS, WINDOW_THRESHOLDS
+
+        assert set(WINDOW_THRESHOLDS) == set(SUPPORTED_WINDOWS)
+
+
+class TestTrackerHoldsACopyNotAnAlias:
+    def test_patching_the_actor_does_not_mutate_the_loader(self) -> None:
+        """별칭이면 테스트의 patch.dict 가 `nuri.core.rules` 원본을 오염시킨다."""
+        import nuri.agents.actors.forward_outcome_tracker as fot
+        import nuri.core.rules as rules
+
+        assert fot.WINDOW_THRESHOLDS is not rules.OUTCOME_WINDOW_THRESHOLDS
+        assert fot.WINDOW_THRESHOLDS == rules.OUTCOME_WINDOW_THRESHOLDS


### PR DESCRIPTION
Carry-over P0 **N1 + N2**, bundled. `docs/HARNESS_AUDIT.md:203` already sequenced them as one PR, they are the identical mechanical pattern, and both must bump the same `config/CLAUDE.md` line — splitting guarantees a conflict and two red doc-count gates for no benefit. 3 commits, at the gate.

## What moved

| Constant | From | To |
|---|---|---|
| `CONVICTION_EMIT_CUTOFF` 0.70 | `decision_compiler.py:37` | `rules.yaml decision_compiler` |
| `CONVICTION_HOLD_CUTOFF` 0.50 | `decision_compiler.py:38` | 〃 |
| `REGIME_FAVOR_PROB` 0.60 | `decision_compiler.py:39` | 〃 |
| `WINDOW_THRESHOLDS` ±5/7/10% | `forward_outcome_tracker.py:47-51` | `rules.yaml outcome_tracking` |

These gate whether a BUY/SELL is emitted at all, so they are investment rules — squarely the "Config over code" clause. Values are unchanged; `yaml.safe_load` returns the identical floats.

## What deliberately did NOT move

This is the important half, and it is enforced by tests rather than by comments alone.

- **`DEFAULT_BENCHMARK_TICKER`** stays a code literal. It is a §3.11 **pre-registered** criterion. Today `tests/core/test_rules.py:220` asserts `RULES["measurement_mode"]["benchmark"] == DEFAULT_BENCHMARK_TICKER` — a code literal checked against config. Config-deriving it collapses that into `x == x`, and `test_benchmark_by_market_us_equals_the_locked_criterion` into a self-comparison, taking the surviving locks from 3 assertions to 1. The hardcoding is a **double gate**, not an oversight.
- **`SUPPORTED_WINDOWS`** stays a code literal. It is the only thing binding the window key set to the `decision_outcomes` CHECK constraint. In config, one YAML edit could silently disable the pre-registered 30-day window.
- **`decision_compiler.py:188`'s 0.50/0.30/0.20 weights** stay. Those define *what conviction is*; the cutoffs define *where the gate sits*. Metric definition vs threshold — different kinds. Raised explicitly so the omission reads as a decision, not a miss.
- **`measurement_mode`** is untouched. `outcome_tracking` is a new top-level key rather than nested inside it, following the precedent at `rules.yaml:250-254`: merging them means editing an ordinary tunable puts you inside the pre-registered block.

## The tests are structural, and that matters

A value-equality lock does not catch a **partial revert**: re-inline `CONVICTION_EMIT_CUTOFF = 0.70` in the actor while leaving the YAML alone and both values still agree, so the test stays green while config becomes decoration.

So the sweep asserts structure (AST, not grep, following `test_sqlite3_sole_importer.py`): no module-level assignment of the name in the actor, and the name imported from `nuri.core.rules`.

**Verified by mutation — five, each caught:**

| Mutation | Result |
|---|---|
| re-inline the literals in the actor (partial revert) | 3 tests fail |
| `SUPPORTED_WINDOWS = tuple(sorted(OUTCOME_WINDOW_THRESHOLDS))` | fails |
| `DEFAULT_BENCHMARK_TICKER = RULES[...]` | fails |
| alias the tracker dict instead of copying | fails |
| delete the YAML block (loader defaults cover) | 2 tests fail |

The second mutation is why this file has a second pass. **The first version of the test missed it** — it only asked "is the name assigned at module level", which `= tuple(sorted(...))` satisfies, since that is still an assignment. The exact defect class the test exists to prevent was in the test. It now checks that the assigned expression references no loader name.

## Other details

- `WINDOW_THRESHOLDS` binds a `dict()` **copy**. Aliasing would let the existing tests' `patch.dict` mutate `nuri.core.rules` in place and leak into any other module reading the canonical name.
- The loader normalises window keys to `int` and freezes pairs to tuples. PyYAML parses bare `7:` as int, but a reviewer quoting it as `"7":` would produce a silent `KeyError` at the only consumer — normalising once beats defending in every consumer.
- `decision_compiler`'s module docstring restated the numbers (`(0.5)`, `(0.7)`, `>= 0.7`). Removed and replaced with the config path; leaving them would make the docstring wrong the first time the YAML is tuned.
- `config/CLAUDE.md` rules.yaml count 554 → 588 in commit 1 (CI-checked).

## Verification

Full suite **6,979 passed** · `ruff` clean · `make verify-doc-counts` 19/19. No test needed editing for the move: `from nuri.core.rules import X` rebinds X as a module attribute, so the existing `from ...decision_compiler import CONVICTION_EMIT_CUTOFF` still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)