### PR TITLE
fix(agents): log outbox staging failures instead of swallowing them (carry-over P0 N3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,994 collected across 315 files | |
+| **Backend tests** | 6,998 collected across 316 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,994 backend tests across 315 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+6,998 backend tests across 316 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,994 tests, 315 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,998 tests, 316 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/actors/audit_ledger.py
+++ b/nuri/agents/actors/audit_ledger.py
@@ -22,10 +22,13 @@ Discord publish:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import query
+
+logger = logging.getLogger(__name__)
 
 # ─── retention 임계값 (config 화 Phase 3+ 예정) ───────────────
 DEFAULT_MAX_ROWS = 1_000_000
@@ -322,7 +325,8 @@ class AuditLedger(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001  # pragma: no cover — best-effort outbox publish
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_incident")
 
     @staticmethod
     def _publish_ops(output: dict[str, Any], run_id: str) -> None:
@@ -348,7 +352,8 @@ class AuditLedger(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001  # pragma: no cover — best-effort outbox publish
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_ops")
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/nuri/agents/actors/brief_auditor.py
+++ b/nuri/agents/actors/brief_auditor.py
@@ -34,11 +34,14 @@ Output gate:
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections import Counter, defaultdict
 from typing import Any, Optional
 
 from nuri.agents.base import Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import query
+
+logger = logging.getLogger(__name__)
 
 # 자가점검 emit/dedupe 채널 — _emit_incident(stage_ops) 와 _dedupe_recent 가
 # 반드시 일치해야 함 (불일치 시 dedupe 미스 → 6h 마다 재emit 스팸).
@@ -285,6 +288,9 @@ def _emit_incident(issue: dict[str, Any], run_id: str, db_path: Optional[Any]) -
         )
         return True
     except Exception:  # noqa: BLE001 — stage must not break audit
+        # 호출자에게 False 로 알리되 **원인은 남긴다** — 반환값만으로는
+        # 왜 실패했는지 알 수 없어 며칠째 발행이 안 돼도 진단이 안 된다.
+        logger.exception("outbox staging 실패: stage_ops")
         return False
 
 

--- a/nuri/agents/actors/causal_factor_auditor.py
+++ b/nuri/agents/actors/causal_factor_auditor.py
@@ -23,6 +23,7 @@ References:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -31,6 +32,8 @@ import numpy as np
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_causal_audit, query
 from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
 
 # ─── 4-test 임계값 (Codex consult + López de Prado 2025) ─────
 MIN_OBS = 100  # < 100 obs → INSUFFICIENT (statistical power 부족)
@@ -512,7 +515,8 @@ class CausalFactorAuditor(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001 — best-effort
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_rollout")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/collector_orchestrator.py
+++ b/nuri/agents/actors/collector_orchestrator.py
@@ -27,12 +27,15 @@ Anti-pattern 방지:
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, Callable, Optional
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_collector_run, query
 from nuri.core.timezone import kst_now
+
+logger = logging.getLogger(__name__)
 
 # 외부 API transient error 패턴 — retry 가능한 케이스만 식별.
 # (rate-limit / timeout 은 별도 분류, 그 외 generic exception 은 'failed'.)
@@ -469,7 +472,8 @@ class CollectorOrchestrator(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001  # pragma: no cover — best-effort outbox publish
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_ops")
 
     @staticmethod
     def _publish_health_alert(
@@ -513,7 +517,8 @@ class CollectorOrchestrator(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001  # pragma: no cover — best-effort outbox publish
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_fn")
 
 
 # ─── helpers ───────────────────────────────────────────────

--- a/nuri/agents/actors/decision_compiler.py
+++ b/nuri/agents/actors/decision_compiler.py
@@ -27,6 +27,7 @@ Anti-pattern 방지 (lock-test):
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -34,6 +35,8 @@ from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunCo
 from nuri.core.db import log_decision, query
 from nuri.core.rules import CONVICTION_EMIT_CUTOFF, CONVICTION_HOLD_CUTOFF, REGIME_FAVOR_PROB
 from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
 
 VALID_ACTIONS_INPUT: tuple[str, ...] = ("BUY", "SELL")  # caller 가 제안하는 방향
 
@@ -565,7 +568,8 @@ class DecisionCompiler(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_ops")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/drift_sentinel.py
+++ b/nuri/agents/actors/drift_sentinel.py
@@ -30,12 +30,15 @@ Anti-pattern 방지:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 import numpy as np
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_drift_alert, query
+
+logger = logging.getLogger(__name__)
 
 # ─── PSI 임계값 (산업 표준) ─────────────────────────────────
 PSI_MINOR = 0.10
@@ -522,7 +525,8 @@ class DriftSentinel(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001 — best-effort
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_fn")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/execution_firewall.py
+++ b/nuri/agents/actors/execution_firewall.py
@@ -33,11 +33,14 @@ Discord publish: hard block 시 → INCIDENTS 채널 (operator urgent)
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_execution_block, query
 from nuri.core.rules import RULES, VIX_BLOCK_ABOVE, VIX_CAUTION_ABOVE
+
+logger = logging.getLogger(__name__)
 
 # ─── 룰 임계값 (config/rules.yaml override 가능) ─────────────
 # VIX 게이트는 canonical entry_rules.vix_gate (nuri.core.rules 로더) 단일 출처를 import.
@@ -457,7 +460,8 @@ class ExecutionFirewall(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_incident")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/forward_outcome_tracker.py
+++ b/nuri/agents/actors/forward_outcome_tracker.py
@@ -29,6 +29,7 @@ Discord publish:
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Optional
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
@@ -42,6 +43,8 @@ from nuri.core.db import (
 from nuri.core.rules import OUTCOME_WINDOW_THRESHOLDS, RULES
 from nuri.core.ticker_names import is_kr_ticker
 from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
 
 # ─── window 별 validation 임계값 — `config/rules.yaml outcome_tracking` ─────────
 # 이름을 유지해 기존 import/테스트가 그대로 돈다. **복사본**을 들고 있는다 —
@@ -535,7 +538,8 @@ class ForwardOutcomeTracker(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_rollout")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/foundation_benchmark.py
+++ b/nuri/agents/actors/foundation_benchmark.py
@@ -28,6 +28,7 @@ Discord publish:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
@@ -35,6 +36,8 @@ from nuri.core.db import (
     log_foundation_benchmark,
     query,
 )
+
+logger = logging.getLogger(__name__)
 
 # higher_is_better 방향 — caller 가 명시 안 하면 metric_name 으로 기본값 산출.
 _DEFAULT_HIGHER_IS_BETTER: dict[str, bool] = {
@@ -399,7 +402,8 @@ class FoundationBenchmark(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_rollout")
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/nuri/agents/actors/hypothesis_registry.py
+++ b/nuri/agents/actors/hypothesis_registry.py
@@ -26,6 +26,7 @@ Discord publish:
 
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from typing import Any
 
@@ -38,6 +39,8 @@ from nuri.core.db import (
     validate_hypothesis,
 )
 from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_EXPIRY_DAYS = 90  # Codex: hypothesis 가 90 일 내 검증 못 받으면 stale
 
@@ -310,7 +313,8 @@ class HypothesisRegistry(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001 — best-effort
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_rollout")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/regime_posterior.py
+++ b/nuri/agents/actors/regime_posterior.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import math
 from dataclasses import dataclass, field
 from typing import Any
@@ -35,6 +36,8 @@ from hmmlearn.hmm import GaussianHMM
 from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
 from nuri.core.db import log_regime_posterior, query
 from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
 
 # ─── Sticky-HMM 기본 파라미터 (Codex consult 합의) ─────────────
 DEFAULT_N_STATES = 3  # bull / bear / sideways 매핑 가능 (해석은 Layer C)
@@ -463,7 +466,8 @@ class RegimePosterior(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001 — best-effort, never block actor
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_rollout")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/nuri/agents/actors/sre_incident_agent.py
+++ b/nuri/agents/actors/sre_incident_agent.py
@@ -44,6 +44,7 @@ Discord routing:
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import socket
 from datetime import datetime, timedelta
@@ -62,6 +63,8 @@ from nuri.core.db import (
     resolve_incident as db_resolve_incident,
 )
 from nuri.core.timezone import kst_now, to_kst
+
+logger = logging.getLogger(__name__)
 
 # ─── 임계값 (config 가능 — 추후 rules.yaml 이관) ──────────
 ORPHAN_WARN_HOURS = 1.0
@@ -818,7 +821,8 @@ class SREIncidentAgent(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_fn")
 
 
 def _missed_eval_days(last_run_utc: str, now: datetime) -> int:

--- a/nuri/agents/actors/state_replicator_dr.py
+++ b/nuri/agents/actors/state_replicator_dr.py
@@ -22,6 +22,7 @@ Docker 이전 까지는 *기록 + 룰 검증* 만, 실제 file copy 는 다음 p
 
 from __future__ import annotations
 
+import logging
 import socket
 from pathlib import Path
 from typing import Any, Optional
@@ -33,6 +34,8 @@ from nuri.core.db import (
     upsert_dr_replica,
 )
 from nuri.core.timezone import kst_now
+
+logger = logging.getLogger(__name__)
 
 # launchd autopull heartbeat 파일 — Mac mini 가 5분 간격 git fetch 성공 시 mtime 갱신.
 # Docker 이전 까지는 placeholder (없으면 unreachable 로 표시).
@@ -348,7 +351,8 @@ class StateReplicatorDR(Actor):
                 run_id=run_id,
             )
         except Exception:  # noqa: BLE001  # pragma: no cover — best-effort outbox publish
-            pass
+            # 발행 실패로 액터를 죽이지 않는다(#894) — 다만 **조용히** 넘기지도 않는다.
+            logger.exception("outbox staging 실패: stage_incident")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/agents/test_outbox_failures_are_logged.py
+++ b/tests/agents/test_outbox_failures_are_logged.py
@@ -1,0 +1,97 @@
+"""액터의 outbox 발행 실패는 **조용히** 넘어가면 안 된다 (carry-over audit N3).
+
+무엇이 문제였나
+---------------
+`nuri/agents/actors/` 의 `stage_*` 호출 14곳이 `except Exception: pass` 로 감싸여
+있었다. 감싸는 것 자체는 옳다 — #894 가 못박은 대로 **관측이 본 작업을 게이트하면
+안 된다**. Discord 발행이 실패했다고 수집이나 판정을 죽일 수는 없다.
+
+틀린 건 `pass` 다. 발행이 며칠째 실패해도 아무 흔적이 없으니, 이 레포가 이미
+두 번 밟은 *"감지는 어디에도 안 닿으면 없는 것과 같다"* 가 된다. 로그 한 줄이면
+액터를 죽이지 않으면서도 흔적은 남는다.
+
+왜 사이트별 테스트가 아니라 스윕인가
+------------------------------------
+14곳을 한 테스트로 고치면 나머지 13곳은 잠금 없이 들어간다 (Gotcha-Test Pair
+위반). 반대로 14개 테스트를 쓰면 15번째 호출부가 생길 때 아무도 안 늘린다.
+그래서 **호출부 집합 자체**를 불변조건으로 만든다 — 새 `stage_*` 를 `pass` 로
+감싸면 그 순간 CI 가 잡는다.
+
+문자열 grep 이 아니라 AST 인 이유는 주석·docstring 의 같은 문구를 오탐하지 않기
+위해서다 (`tests/core/test_sqlite3_sole_importer.py` 와 같은 형태).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ACTORS = Path(__file__).resolve().parents[2] / "nuri" / "agents" / "actors"
+
+# outbox staging 진입점. `stage_fn` 은 채널을 런타임에 고르는 호출부의 지역 별칭이다.
+STAGE_CALLS = {"stage_incident", "stage_ops", "stage_rollout", "stage_fn", "stage_outbox"}
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    return {
+        (c.func.id if isinstance(c.func, ast.Name) else getattr(c.func, "attr", ""))
+        for c in ast.walk(node)
+        if isinstance(c, ast.Call)
+    }
+
+
+def _outbox_try_blocks() -> list[tuple[str, ast.Try]]:
+    out: list[tuple[str, ast.Try]] = []
+    for f in sorted(ACTORS.glob("*.py")):
+        tree = ast.parse(f.read_text(encoding="utf-8"), filename=str(f))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Try) and (_called_names(node) & STAGE_CALLS):
+                out.append((f.name, node))
+    return out
+
+
+def _is_silent(handler: ast.ExceptHandler) -> bool:
+    """본문이 `pass` 뿐이면 조용한 것. docstring 만 있는 경우도 같다."""
+    body = [n for n in handler.body if not (isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant))]
+    return not body or all(isinstance(n, ast.Pass) for n in body)
+
+
+class TestOutboxFailuresAreNeverSilent:
+    def test_no_stage_call_is_wrapped_in_a_bare_pass(self) -> None:
+        offenders = [
+            f"{name}:{h.lineno}" for name, block in _outbox_try_blocks() for h in block.handlers if _is_silent(h)
+        ]
+        assert not offenders, (
+            "outbox 발행 실패를 조용히 삼키는 곳: "
+            + ", ".join(offenders)
+            + " — 액터를 죽이지 말되(#894) 로그는 남길 것 (`logger.exception(...)`)"
+        )
+
+    def test_every_such_handler_logs(self) -> None:
+        """`pass` 가 아니면 됐다가 아니라, **로깅**을 해야 한다."""
+        missing = []
+        for name, block in _outbox_try_blocks():
+            for h in block.handlers:
+                logged = {
+                    getattr(c.func, "attr", "")
+                    for c in ast.walk(h)
+                    if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+                }
+                if not (logged & {"exception", "error", "warning"}):
+                    missing.append(f"{name}:{h.lineno}")
+        assert not missing, f"발행 실패 핸들러가 로그를 남기지 않는다: {', '.join(missing)}"
+
+    def test_modules_with_stage_calls_define_a_logger(self) -> None:
+        files = {name for name, _ in _outbox_try_blocks()}
+        assert files, "스윕이 아무것도 못 찾았다 — 경로가 바뀌었는지 확인할 것"
+        for name in sorted(files):
+            src = (ACTORS / name).read_text(encoding="utf-8")
+            assert "logging.getLogger(__name__)" in src, f"{name} 에 모듈 로거가 없다"
+
+    def test_the_sweep_actually_sees_the_known_sites(self) -> None:
+        """0건을 훑고 통과하면 통과가 아무 의미도 없다.
+
+        14는 2026-08-14 실측치다. 늘어나는 건 정상이고(새 액터), 줄면 스윕이
+        호출부를 놓치기 시작했다는 신호다.
+        """
+        assert len(_outbox_try_blocks()) >= 14


### PR DESCRIPTION
Carry-over P0 **N3** — widened from the one site the audit named to the whole homogeneous class, because the fix is only a lock if it covers the class.

## What was wrong

15 `stage_*` calls across 13 actors sat inside `except Exception: pass`.

**Wrapping is correct.** #894 settled that observation must not gate the real work — a Discord staging failure must not kill collection or adjudication. The `pass` is what was wrong: staging could fail for days leaving no trace, which is this repo's recurring *"감지는 어디에도 안 닿으면 없는 것과 같다"* (#1026, #1028).

Each handler now logs with `logger.exception` (ERROR + traceback) and keeps its original control flow. `brief_auditor` still returns `False` to its caller; it just no longer discards the reason.

## The audit's prescription was wrong, and is amended

`docs/HARNESS_AUDIT.md:157` prescribed **"retry + ERROR log"**. The retry half is dropped:

- The guarded call is `stage_rollout()` → `stage_outbox()` — **one SQLite INSERT**, not a Discord publish. The actual publish happens later in `channel_dispatcher.py`. A retry here sits on the wrong layer entirely.
- DB lock contention is already retried for 5s by `PRAGMA busy_timeout=5000` (`nuri/core/db/connection.py:54`), one layer below.
- The remaining exception types — `ImportError` on the lazy import, `stage_outbox`'s `ValueError` on an invalid channel — are **deterministic**. Retrying reproduces them.

The audit file is amended with this reasoning rather than left to re-propose the same fix next session. (It is gitignored, so the amendment is not in this diff.)

## The lock is a sweep, not a per-site test

This is the part that makes the widened scope defensible:

- Fixing 15 sites behind **one** test leaves 14 unlocked — a Gotcha-Test Pair violation for all but one.
- Writing **15** tests does not cover the 16th call site someone adds next month.

So `tests/agents/test_outbox_failures_are_logged.py` makes the *call-site set itself* the invariant. It walks every `try` block containing a `stage_*` call and asserts: no handler is a bare `pass`, every handler logs, and every such module defines a logger. AST rather than grep, so the same words in a comment or docstring do not register — same form as `test_sqlite3_sole_importer.py`.

**Verified by mutation:**

| Mutation | Result |
|---|---|
| revert one site to `pass` | 2 assertions fail |
| remove only `brief_auditor`'s log line (keep `return False`) | 1 fails |
| delete a module's logger | 2 fail |

A canary asserts the sweep sees ≥14 blocks — a sweep matching zero files passes as happily as one matching everything.

## Scope

Only the `stage_*` class. Six other silent handlers in the same directory guard genuinely different things — price-target computation, `validate_hypothesis`/`reject_hypothesis` DB writes, a float parse — and each needs its own judgement rather than a mechanical copy of this one. Lumping them in is exactly the half-thought fleet change this PR's own structure argues against.

`logger = logging.getLogger(__name__)` is new to `nuri/agents/actors/` (13 files gained it) but not to the repo — `nuri/agents/discord/` and `nuri/quant/factors/` already use it.

## Verification

Full suite **6,983 passed** · `ruff` clean · `make verify-doc-counts` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)