### PR TITLE
fix(agents): surface a rate-limited retry as WARN, not PASS (carry-over P0 N4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 6,998 collected across 316 files | |
+| **Backend tests** | 7,001 collected across 316 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-6,998 backend tests across 316 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+7,001 backend tests across 316 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 6,998 tests, 316 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,001 tests, 316 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/CLAUDE.md
+++ b/nuri/agents/CLAUDE.md
@@ -28,6 +28,9 @@ def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult: .
 
 `ActorResult(output, outcome=None, sample_n=None, input_summary=None, llm_narrative=None)`; `Outcome ∈ {PASS, BLOCK, WARN, ERROR}`.
 
+**`WARN` 은 "작업은 됐지만 그대로 두면 안 되는 상태"다** — 실패가 아니라서 호출자가 계속 가도 되지만, 기록으로 남아야 한다. `CollectorOrchestrator` 가 rate limit 을 맞고 재시도로 살아난 런을 `PASS` 가 아니라 `WARN` 으로 돌리는 이유가 이것이다: 재시도가 성공을 만들어 주는 동안 IP ban 은 가까워지는데, `PASS` 로 적으면 그 카운트다운이 보이지 않는다.
+**Test:** `tests/agents/test_collector_orchestrator.py::TestOrchestrateRetry::test_rate_limited_then_finished_is_warn_not_pass`
+
 **`execute()` may raise** — `run()` records the failure (`status="failed"` + an `ERROR` audit row) and then **re-raises**. Failure isolation is the *caller's* responsibility: every `_run_*` wrapper in `nuri/scheduler.py` try/excepts, which is why one actor dying doesn't take the fleet down.
 
 **`ActorRegistry.CANONICAL_15` is a closed roster.** `@REGISTRY.register` raises if `name` isn't in that tuple — adding a 16th actor means editing the tuple deliberately, not incidentally. Registration is idempotent for the same `module:qualname` so the `python -m` double-import (`__main__` reload) doesn't blow up.

--- a/nuri/agents/actors/collector_orchestrator.py
+++ b/nuri/agents/actors/collector_orchestrator.py
@@ -11,7 +11,8 @@ Layer B 설계 (Codex Round 5):
 - 100% deterministic — 통계 + retry, ZERO LLM.
 - Outcome 매핑 (Round 5 Layer B):
     PASS  — orchestrate 성공 + scan_health 모두 healthy
-    WARN  — orchestrate under-fetch (rows < expected) / scan_health 1+ unhealthy
+    WARN  — orchestrate under-fetch (rows < expected) / **rate limit 을 맞고 재시도로
+            살아난 런** / scan_health 1+ unhealthy
     BLOCK — orchestrate retry 소진 / scan_health 모두 catastrophic / invalid input
 
 Design rationale:
@@ -249,9 +250,14 @@ class CollectorOrchestrator(Actor):
         timeout_s: float,
         ctx: RunContext,
     ) -> ActorResult:
-        """orchestrate finished 케이스 — under-fetch 판정 + Outcome 결정."""
+        """orchestrate finished 케이스 — under-fetch / rate-limit 판정 + Outcome 결정."""
         # under-fetch: expected_rows 가 주어지면 90% threshold.
         warn_under_fetch = expected_rows is not None and expected_rows > 0 and rows_collected < expected_rows * 0.9
+        # rate limit 을 맞고 재시도로 살아난 런은 **성공이 아니라 경고**다.
+        # PASS 로 기록하면 IP ban 직전까지 아무 신호가 없다 — 재시도가 벌어준
+        # 시간이 그대로 사라진다. rate_limit_hits 는 이미 세어서 DB 에 넣고
+        # 있었고, 빠져 있던 건 그걸 **Outcome 에 드러내는 것**뿐이다.
+        warn_rate_limit = rate_limit_hits > 0
         if warn_under_fetch:
             outcome = Outcome.WARN
             self._publish_orchestrate_failure(
@@ -260,6 +266,11 @@ class CollectorOrchestrator(Actor):
                 attempts=len(attempts),
                 run_id=ctx.run_id,
             )
+        elif warn_rate_limit:
+            # 발행은 하지 않는다. under-fetch 와 dedupe_key 가 같아
+            # (`collector_failure:{name}`, strategy='skip') 먼저 온 쪽이 이기고,
+            # rate limit 은 매일 흔해 #ops 를 채운다. Outcome 과 DB 행이면 족하다.
+            outcome = Outcome.WARN
         else:
             outcome = Outcome.PASS
 

--- a/tests/agents/test_collector_orchestrator.py
+++ b/tests/agents/test_collector_orchestrator.py
@@ -254,7 +254,13 @@ class TestOrchestrateWarn:
 
 
 class TestOrchestrateRetry:
-    def test_rate_limited_then_finished(self, patched_db):
+    def test_rate_limited_then_finished_is_warn_not_pass(self, patched_db):
+        """재시도로 살아났어도 rate limit 을 맞았으면 **WARN** 이다.
+
+        PASS 로 적으면 IP ban 직전까지 아무 신호가 없다 — 재시도가 벌어준 시간이
+        그대로 사라진다. `rate_limit_hits` 는 예전에도 세어서 DB 에 넣고 있었고,
+        빠져 있던 건 그걸 Outcome 에 드러내는 것뿐이었다 (carry-over audit N4).
+        """
         call_count = {"n": 0}
 
         def flaky():
@@ -272,7 +278,7 @@ class TestOrchestrateRetry:
                 "max_retries": 3,
             }
         )
-        assert result.outcome == Outcome.PASS
+        assert result.outcome == Outcome.WARN, "rate limit 을 맞은 런이 PASS 로 기록되면 안 된다"
         assert call_count["n"] == 3
         assert result.output["rate_limit_hits"] == 2
         # 2 rate_limited attempts + 1 finished
@@ -694,3 +700,50 @@ class TestExtractRowCount:
             }
         )
         assert result.output["rows_collected"] == 0
+
+
+class TestRateLimitIsSurfacedNotSwallowed:
+    """rate limit 신호가 Outcome 까지 올라오는지 (carry-over audit N4).
+
+    DB 에는 예전부터 `rate_limit_hits` 가 들어가고 있었다. 빠져 있던 건 그걸
+    **읽는 쪽**이다 — Outcome 이 PASS 면 아무도 안 본다.
+    """
+
+    def test_clean_run_stays_pass(self, patched_db):
+        """rate limit 이 없으면 WARN 으로 올리지 않는다 — 경보 피로 방지."""
+        actor = CollectorOrchestrator()
+        result = actor.run({"action": "orchestrate", "collector_name": "yfinance", "collector_fn": lambda: [1, 2, 3]})
+        assert result.outcome == Outcome.PASS
+        assert result.output["rate_limit_hits"] == 0
+
+    def test_single_rate_limit_hit_is_enough_to_warn(self, patched_db):
+        """한 번만 맞아도 신호다. 임계값을 두면 그 값이 또 하나의 매직넘버가 된다."""
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise RuntimeError("HTTP 429")
+            return [1]
+
+        result = CollectorOrchestrator().run(
+            {"action": "orchestrate", "collector_name": "yfinance", "collector_fn": flaky, "max_retries": 3}
+        )
+        assert result.outcome == Outcome.WARN
+        assert result.output["rate_limit_hits"] == 1
+
+    def test_non_rate_limit_retry_stays_pass(self, patched_db):
+        """일시적 timeout 은 rate limit 이 아니다 — 여기까지 WARN 으로 올리면 노이즈다."""
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise TimeoutError("slow")
+            return [1]
+
+        result = CollectorOrchestrator().run(
+            {"action": "orchestrate", "collector_name": "yfinance", "collector_fn": flaky, "max_retries": 3}
+        )
+        assert result.outcome == Outcome.PASS
+        assert result.output["rate_limit_hits"] == 0


### PR DESCRIPTION
Carry-over P0 **N4**, shipped stripped rather than deferred.

## The bug

When a collector hits a rate limit and a retry then succeeds, the orchestrator recorded `Outcome.PASS`. The IP-ban countdown ran with **no signal** — the retry bought time, and the fact that it was needed vanished.

`rate_limit_hits` was already counted and already written to `collector_runs`. The only thing missing was reading it back into the Outcome. One expression in `_finalize_orchestrate`.

## It is a contract change, and is labelled as one

Spelled out in three places so the diff cannot read as a refactor:

1. the module docstring's Outcome table
2. `nuri/agents/CLAUDE.md`'s actor contract, with a Gotcha-Test Pair cite
3. `test_rate_limited_then_finished` — which **deliberately locked** `PASS` together with `rate_limit_hits == 2` — flips to WARN and is renamed accordingly

That flip is the point of the PR, not a test edited to fit the code.

## No config key, on purpose

`rate_limit_hits > 0` is a knob with one usable value: `0` is guarded out by the check itself, `>= 2` is arbitrary. Adding one would mean a `rules.yaml` block, a loader entry, and a CI doc-count bump — for a boolean.

The two sibling thresholds in the same function (`under-fetch 0.9`, `BACKOFF_BASE_S`) stay hardcoded as well. Moving one of three is the half-fix a config-over-code reviewer rejects.

## The WARN branch does not publish

It would share `dedupe_key = collector_failure:{name}` with the under-fetch branch under `dedupe_strategy='skip'`, so whichever fires first wins and the other is silently dropped. Rate limits are also common enough to bury #ops. The Outcome and the DB row are the signal.

## Verified by mutation

| Mutation | Result |
|---|---|
| drop the `elif warn_rate_limit` branch (revert) | 2 tests fail |
| `rate_limit_hits > 0` → `> 1` (sneak in a threshold) | single-hit test fails |

A timeout-then-success run still returns `PASS`, so ordinary transient retries do not become noise — that is its own test.

## Known limitation, stated because it changes the value

**`orchestrate` has no production caller.** `nuri/scheduler.py:317` `_record_collector_run` bypasses the actor deliberately (#894 — observation must not gate collection), and its docstring says so explicitly.

So this makes the ledger correct for when the path is wired up; it does **not** start alerting today. Wiring the same signal into `_record_collector_run` is the follow-up that would, and that is where the rate-limit signal is actually missing in production.

The alternative was deferring N4 entirely. Shipping it stripped costs one expression and closes the audit row honestly; deferring leaves a P0 open against code nobody runs.

## Verification

Full suite **6,982 passed** · `ruff` clean · `make verify-doc-counts` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)