### PR TITLE
fix(tests): isolate every test from the production database

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,131 @@
-"""Global test fixtures — yfinance mock + CI tmpfs SQLite 호환성."""
+"""Global test fixtures — yfinance mock + CI tmpfs SQLite 호환성 + 프로덕션 DB 격리."""
+
+import shutil
+from pathlib import Path
+
 import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 프로덕션 DB 격리 — 모든 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture(scope="session")
+def _schema_db(tmp_path_factory):
+    """스키마만 있는 빈 DB 를 세션당 **한 번** 만든다.
+
+    테스트마다 `init_db()` 를 부르면 70.8ms × 약 6,900 테스트 = 8분이 그냥
+    날아간다 (2026-08-14 실측). 파일 복사는 0.5ms 라 100배 이상 싸다.
+    """
+    from nuri.core.db import init_db
+
+    path = tmp_path_factory.mktemp("schema") / "schema.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_from_production_db(_schema_db, tmp_path_factory, monkeypatch):
+    """모든 테스트의 기본 DB 를 tmp 사본으로 돌린다.
+
+    왜 전역인가
+    -----------
+    `db_path` 인자를 안 받는 프로덕션 함수가 많아서, 테스트가 아무리 조심해도
+    전역 `DB_PATH` 로 새어 들어간다. 2026-08-14 실측: `tests/quant` 를 고친
+    **뒤에도** 223개 테스트가 실제 `data/portfolio.db` 를 **7,587회** 열고
+    있었다 (35개 파일, 11개 디렉터리).
+
+    그게 낳은 실제 피해:
+    - `test_high_vol_no_stats_truncates` 간헐 실패. 다른 워커가 `init_db()` 로
+      EXCLUSIVE 락을 `busy_timeout=5000` 보다 오래 잡으면
+      `sqlite3.OperationalError: database is locked` 가 난다 (재현 확인).
+    - `test_macro_payload_carries_coverage` 는 tmp DB 에 seed 해놓고
+      **프로덕션 데이터를 보고 통과**하고 있었다 — 초록이 거짓이었다.
+    - `tests/agents/test_execution_firewall.py` 가 로컬 `discord_outbox` 에
+      가짜 incident 17행을 몇 달간 써넣었다 (Mac mini 는 무사).
+
+    223건을 하나씩 고치는 대신 기본값을 바꾼다. `_resolve_db_path` 가 매번
+    `nuri.core.db.DB_PATH` 를 조회하므로(connection.py:39-43) 이 한 줄이
+    `db_path` 를 안 받는 함수까지 전부 덮는다.
+
+    개별 `db_path` / `db_path_mp` 픽스처는 그대로 동작한다 — 명시 인자가 우선이고,
+    `db_path_mp` 는 같은 전역을 자기 것으로 다시 덮는다.
+
+    ⚠️ 격리 DB 는 `tmp_path` 가 **아닌** 곳에 둔다. `tmp_path` 에 두면 "이 작업으로
+    파일이 안 생겼는지" 를 `list(dir.iterdir()) == []` 로 확인하는 테스트가 우리
+    DB 파일을 보고 깨진다 (`test_discord_inbound.py::test_returns_none_for_off_channel`
+    에서 실제로 발생). 테스트가 들여다보는 공간을 픽스처가 침범하면 안 된다.
+    """
+    import nuri.core.db as db_mod
+
+    path = tmp_path_factory.mktemp("isolated_db") / "portfolio.db"
+    shutil.copy(_schema_db, path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 프로덕션 DB 접근 금지 가드
+# ─────────────────────────────────────────────────────────────────────────────
+_REAL_DB = Path(__file__).resolve().parents[1] / "data" / "portfolio.db"
+
+
+class _ProductionDBTouched(BaseException):
+    """`Exception` 이 아니라 `BaseException` 을 상속한다 — **일부러**.
+
+    프로덕션 코드에는 광범위 `except Exception` 이 많다(`gather_context` 는
+    섹션마다 감싼다). `AssertionError` 로 던지면 그 핸들러가 가드를 삼켜서,
+    테스트는 초록인데 프로덕션 DB 는 그대로 읽힌다 — 실제로 그렇게 통과하는 걸
+    확인했다 (2026-08-14, `test_gather_context_all_failures_graceful`).
+
+    백스톱이 삼켜지면 백스톱이 아니다. `BaseException` 은 `except Exception` 을
+    통과해 pytest 까지 올라간다.
+    """
+
+
+@pytest.fixture(autouse=True)
+def _forbid_production_db(monkeypatch):
+    """실 `data/portfolio.db` 를 여는 순간 그 테스트를 **즉시** 실패시킨다.
+
+    왜 관측이 아니라 차단인가
+    -------------------------
+    프로덕션 DB 를 읽는 테스트는 조용히 통과한다. 초록이라 아무도 안 본다.
+    실제로 일어난 일 (2026-08-14 실측):
+
+    - `tests/quant` 의 `TestMapStrategySpecialAndFallback` 7개가 `map_regime_to_strategy()` 를
+      `db_path` 없이 불러 `analyze_signal_by_regime(None)` → `_get_vix()` 가
+      SPY 행마다 도는 바람에 **테스트당 커넥션 1,118회 / 2.25초**를 썼다.
+      그리고 다른 테스트가 같은 파일에 **쓴다** (`tests/CLAUDE.md`) — `-n auto`
+      로 워커가 붙으면 읽는 쪽이 깨진다. `test_high_vol_no_stats_truncates` 가
+      전체 실행 5회 중 1회 실패했고 단독 실행은 늘 통과했다. 원인을 찾는 데
+      든 시간이 고치는 데 든 시간보다 훨씬 길었다.
+    - `test_macro_payload_carries_coverage` 는 tmp DB 에 seed 해놓고 정작
+      **프로덕션 데이터를 보고 통과**하고 있었다. 통과가 거짓이었다.
+
+    이 가드는 `_isolate_from_production_db` 의 **백스톱**이다. 격리가 어떤 이유로든
+    안 걸리는 경로가 생기면, 조용히 프로덕션으로 새는 대신 여기서 터진다.
+
+    쓰기가 아니라 **여는 순간** 터뜨린다 — 읽기만 해도 위 두 문제가 다 생기고,
+    쓰기까지 기다리면 이미 느려진 뒤다. (`tests/verify/conftest.py` 의 문서
+    fixer 가드와 같은 설계: 피해가 난 뒤가 아니라 겨눈 순간.)
+
+    빠져나갈 구멍: 정말 프로덕션 DB 가 필요하면 이 픽스처를 override 할 것.
+    조용히 우회하지 말고 이유를 그 자리에 적어야 한다.
+    """
+    import nuri.core.db.connection as conn_mod
+
+    real = str(_REAL_DB)
+    original = conn_mod.sqlite3.connect
+
+    def guarded(path, *args, **kwargs):
+        if str(path) == real:
+            raise _ProductionDBTouched(
+                f"테스트가 프로덕션 DB 를 열었다: {path}\n"
+                "tmp DB 를 쓸 것 — 대상 함수가 db_path 인자를 받으면 `db_path` 픽스처를,\n"
+                "전역 DB_PATH 를 읽으면 `db_path_mp` 픽스처를 쓴다."
+            )
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(conn_mod.sqlite3, "connect", guarded)
 
 
 @pytest.fixture(autouse=True)
@@ -57,7 +183,53 @@ def mock_yfinance(monkeypatch):
 
     try:
         import yfinance
+
         monkeypatch.setattr(yfinance, "download", mock_download)
         monkeypatch.setattr(yfinance, "Ticker", MockTicker)
     except ImportError:
         pass
+
+
+def test_the_guard_actually_bites(tmp_path, monkeypatch):
+    """가드가 **실제로 예외를 던지는지** — 등록만 되고 안 무는 걸 막는다.
+
+    이 레포는 훅 2개가 3.5개월간 조용히 무력했던 전례가 있다
+    (`.claude/rules/enforcement.md`). autouse 픽스처도 같은 방식으로 죽을 수
+    있으므로, 가드가 켜진 상태에서 실 DB 경로를 열어 보고 터지는지 확인한다.
+
+    ⚠️ 이 파일에 테스트를 두는 건 예외적이다. 가드가 conftest 에 있고 그
+    autouse 효과 자체를 검증해야 해서, 같은 스코프 안이어야 의미가 있다.
+    """
+    import sqlite3
+
+    with pytest.raises(_ProductionDBTouched, match="프로덕션 DB"):
+        sqlite3.connect(str(_REAL_DB))
+
+
+def test_the_guard_leaves_other_paths_alone(tmp_path):
+    """tmp DB 는 막지 않는다 — 막으면 전 스위트가 죽는다."""
+    import sqlite3
+
+    p = tmp_path / "ok.db"
+    sqlite3.connect(str(p)).close()
+    assert p.exists()
+
+
+def test_the_guard_survives_a_broad_except(tmp_path):
+    """광범위 `except Exception` 이 가드를 삼키면 안 된다.
+
+    프로덕션 코드는 섹션마다 `except Exception` 으로 감싸는 곳이 많다
+    (`nuri/llm/report.py::gather_context`). 가드가 `AssertionError` 였을 때
+    실제로 삼켜져서, 격리를 꺼도 테스트가 초록이었다 (2026-08-14 실측).
+    """
+    import sqlite3
+
+    swallowed = False
+    try:
+        try:
+            sqlite3.connect(str(_REAL_DB))
+        except Exception:  # noqa: BLE001 — 프로덕션 코드의 실제 패턴을 재현
+            swallowed = True
+    except _ProductionDBTouched:
+        pass
+    assert not swallowed, "가드가 `except Exception` 에 삼켜졌다 — 백스톱이 아니다"

--- a/tests/quant/conftest.py
+++ b/tests/quant/conftest.py
@@ -2,12 +2,11 @@
 
 Auto-loaded by pytest. Helpers live in _helpers.py to be importable.
 
-⚠️ 이 디렉터리의 테스트는 **프로덕션 DB 를 열 수 없다** — `_forbid_production_db`
-autouse 가드가 강제한다. 왜 필요한지는 그 픽스처의 docstring 참조.
+프로덕션 DB 격리와 접근 금지 가드는 **`tests/conftest.py`** 에 있다 — 이 디렉터리만이
+아니라 전 스위트에 적용된다.
 """
 
 from datetime import timedelta
-from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -24,56 +23,6 @@ from tests.quant._helpers import (  # noqa: F401
     _seed_prices,
     _seed_spy_data,
 )
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 프로덕션 DB 접근 금지 가드
-# ─────────────────────────────────────────────────────────────────────────────
-_REAL_DB = Path(__file__).resolve().parents[2] / "data" / "portfolio.db"
-
-
-@pytest.fixture(autouse=True)
-def _forbid_production_db(monkeypatch):
-    """실 `data/portfolio.db` 를 여는 순간 그 테스트를 **즉시** 실패시킨다.
-
-    왜 관측이 아니라 차단인가
-    -------------------------
-    프로덕션 DB 를 읽는 테스트는 조용히 통과한다. 초록이라 아무도 안 본다.
-    실제로 일어난 일 (2026-08-14 실측):
-
-    - `TestMapStrategySpecialAndFallback` 7개가 `map_regime_to_strategy()` 를
-      `db_path` 없이 불러 `analyze_signal_by_regime(None)` → `_get_vix()` 가
-      SPY 행마다 도는 바람에 **테스트당 커넥션 1,118회 / 2.25초**를 썼다.
-      그리고 다른 테스트가 같은 파일에 **쓴다** (`tests/CLAUDE.md`) — `-n auto`
-      로 워커가 붙으면 읽는 쪽이 깨진다. `test_high_vol_no_stats_truncates` 가
-      전체 실행 5회 중 1회 실패했고 단독 실행은 늘 통과했다. 원인을 찾는 데
-      든 시간이 고치는 데 든 시간보다 훨씬 길었다.
-    - `test_macro_payload_carries_coverage` 는 tmp DB 에 seed 해놓고 정작
-      **프로덕션 데이터를 보고 통과**하고 있었다. 통과가 거짓이었다.
-
-    가드를 걷어내면 tests/quant 실행 시간이 41s → 105s 로 돌아간다.
-
-    쓰기가 아니라 **여는 순간** 터뜨린다 — 읽기만 해도 위 두 문제가 다 생기고,
-    쓰기까지 기다리면 이미 느려진 뒤다. (`tests/verify/conftest.py` 의 문서
-    fixer 가드와 같은 설계: 피해가 난 뒤가 아니라 겨눈 순간.)
-
-    빠져나갈 구멍: 정말 프로덕션 DB 가 필요하면 이 픽스처를 override 할 것.
-    조용히 우회하지 말고 이유를 그 자리에 적어야 한다.
-    """
-    import nuri.core.db.connection as conn_mod
-
-    real = str(_REAL_DB)
-    original = conn_mod.sqlite3.connect
-
-    def guarded(path, *args, **kwargs):
-        if str(path) == real:
-            raise AssertionError(
-                f"테스트가 프로덕션 DB 를 열었다: {path}\n"
-                "tmp DB 를 쓸 것 — 대상 함수가 db_path 인자를 받으면 `db_path` 픽스처를,\n"
-                "전역 DB_PATH 를 읽으면 `db_path_mp` 픽스처를 쓴다."
-            )
-        return original(path, *args, **kwargs)
-
-    monkeypatch.setattr(conn_mod.sqlite3, "connect", guarded)
 
 
 @pytest.fixture
@@ -629,28 +578,3 @@ def short_squeeze_data(db_path):
                 (d.strftime("%Y-%m-%d"), "shortinterest", "SQZZ", "short_interest", "15%", 15.0, "2025-01-01"),
             )
     return db_path
-
-
-def test_the_guard_actually_bites(tmp_path, monkeypatch):
-    """가드가 **실제로 예외를 던지는지** — 등록만 되고 안 무는 걸 막는다.
-
-    이 레포는 훅 2개가 3.5개월간 조용히 무력했던 전례가 있다
-    (`.claude/rules/enforcement.md`). autouse 픽스처도 같은 방식으로 죽을 수
-    있으므로, 가드가 켜진 상태에서 실 DB 경로를 열어 보고 터지는지 확인한다.
-
-    ⚠️ 이 파일에 테스트를 두는 건 예외적이다. 가드가 conftest 에 있고 그
-    autouse 효과 자체를 검증해야 해서, 같은 스코프 안이어야 의미가 있다.
-    """
-    import sqlite3
-
-    with pytest.raises(AssertionError, match="프로덕션 DB"):
-        sqlite3.connect(str(_REAL_DB))
-
-
-def test_the_guard_leaves_other_paths_alone(tmp_path):
-    """tmp DB 는 막지 않는다 — 막으면 전 스위트가 죽는다."""
-    import sqlite3
-
-    p = tmp_path / "ok.db"
-    sqlite3.connect(str(p)).close()
-    assert p.exists()


### PR DESCRIPTION
#1047 fixed 9 tests in `tests/quant`. Measuring the rest of the repo found **223 more**, opening `data/portfolio.db` **7,587 times** across 35 files and 11 directories.

Fixing 223 tests one at a time is the wrong shape. The default is what is wrong.

## The fix

`tests/conftest.py` points `nuri.core.db.DB_PATH` at a per-test copy of an empty schema DB. `_resolve_db_path` re-reads that global on every connection (`connection.py:39-43`), so one fixture covers the functions that **take no `db_path` argument at all** — which is most of the leak. Explicit `db_path` arguments and the existing `db_path`/`db_path_mp` fixtures keep working; they win over the default.

**The schema DB is built once per session and copied per test.** This was the one thing the survey left unmeasured, and it decided the design:

| | cost | × ~6,900 tests |
|---|---|---|
| `init_db()` per test | 70.8 ms | **8 minutes** |
| file copy per test | 0.5 ms | 3 s |

Measured overhead in practice: **0.34s across 1,666 tests** (0.2ms/test).

## Results

| | before | after |
|---|---|---|
| Production DB opens, repo-wide | 7,587 | **0** |
| Full suite | ~105-120s | **87s** |
| Tests passing | 6,988 | 6,988 |

All 6,988 pass with isolation active, so **nothing was relying on production data to be correct** — measured, not assumed.

## Two things this surfaced

**The isolated DB must not live in `tmp_path`.** Tests that assert "this operation created no files" do `list(dir.iterdir()) == []`, and our DB file breaks them. `test_discord_inbound::test_returns_none_for_off_channel` caught it. A fixture must not write into the space the test inspects.

**The guard from #1047 was being swallowed.** It moves here as a backstop and is promoted from `AssertionError` to `BaseException`, because `nuri/llm/report.py` wraps each section in `except Exception`:

```
guard raises AssertionError → gather_context's except Exception eats it
→ test green, production DB read anyway
```

Verified directly: with isolation off, five `TestGatherContext` tests **passed** before the promotion and **all five fail** after it. A backstop a broad `except` can eat is not a backstop.

## The guard has its own tests

An autouse fixture can die silently — this repo had two PreToolUse hooks dead for 3.5 months while the docs asserted they blocked things. Three tests, each mutation-checked:

| Test | Mutation that breaks it |
|---|---|
| raises on the production path | drop `autouse=True` |
| leaves tmp paths alone | (guards against over-broad matching) |
| survives `except Exception` | `BaseException` → `Exception` |

## Deliberately not included

The production-code plumbing that makes the leak possible:

- `nuri/analysis/risk.py::analyze_risk()` takes no `db_path`, and `report.py:185` calls it inside `gather_context`, which threads `db_path` correctly to its ten other sections.
- `nuri/alerts/premarket_brief.py` has no `db_path` plumbing at all.
- `certification.py:876` `_capture_snapshot(db_path=db_path)` threads it to `_read_portfolio_raw` but **not** to `_classify_regime_fresh()` or `analyze_portfolio()`, so a snapshot is part `db_path` and part production — while its docstring claims "Single-source-of-truth" and "R2/R4 rigor". Harmless today (production passes `None`) but it is the exact call shape the planned replay pack will use.

Those are production changes and get their own PRs. This one is tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)