### PR TITLE
fix(siege): thread db_path through the whole certify snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,003 collected across 316 files | |
+| **Backend tests** | 7,007 collected across 317 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,003 backend tests across 316 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+7,007 backend tests across 317 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,003 tests, 316 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,007 tests, 317 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -27,9 +27,12 @@ class StaleExchangeRateError(Exception):
     """환율 데이터가 DB에 없을 때 발생하는 에러."""
 
 
-def get_exchange_rate() -> float:
+def get_exchange_rate(db_path=None) -> float:
     """USD/KRW 환율 조회. 7일 이상 오래되면 WARNING, DB에 없으면 에러."""
-    rows = query("SELECT value, date FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1")
+    rows = query(
+        "SELECT value, date FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1",
+        db_path=db_path,
+    )
     if rows:
         rate = rows[0]["value"]
         rate_date = rows[0]["date"]
@@ -66,20 +69,29 @@ def get_exchange_rate() -> float:
     )
 
 
-def analyze_portfolio() -> pd.DataFrame:
-    """포트폴리오 전체 현황 분석."""
+def analyze_portfolio(db_path=None) -> pd.DataFrame:
+    """포트폴리오 전체 현황 분석.
+
+    `db_path` 는 선택이다 — 기존 호출자 10곳은 인자 없이 부르고 기본 DB 를 쓴다.
+    받아야 하는 이유는 `certification._capture_snapshot()` 이다: 그쪽이 감사
+    스냅샷을 뜨면서 이 함수만 db_path 를 못 넘겨, 스냅샷이 절반은 지정 DB
+    절반은 기본 DB 에서 오는 상태였다 (#1050).
+    """
     # 보유 종목 조회
-    holdings = query_df("""
+    holdings = query_df(
+        """
         SELECT p.account, p.ticker, p.quantity, p.avg_price, p.currency, p.sector
         FROM portfolio p
         ORDER BY p.account, p.ticker
-    """)
+    """,
+        db_path=db_path,
+    )
 
     if holdings.empty:
         logger.warning("보유 종목이 없습니다")
         return pd.DataFrame()
 
-    usd_krw = get_exchange_rate()
+    usd_krw = get_exchange_rate(db_path=db_path)
 
     # 종목별 최신 가격 조회
     results = []
@@ -88,6 +100,7 @@ def analyze_portfolio() -> pd.DataFrame:
         latest = query(
             "SELECT close, date FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",
             (ticker,),
+            db_path=db_path,
         )
 
         if not latest:

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -137,13 +137,13 @@ class CertSnapshot:
 _CERT_SNAPSHOT: ContextVar[CertSnapshot | None] = ContextVar("cert_snapshot", default=None)
 
 
-def _classify_regime_fresh() -> str | None:
+def _classify_regime_fresh(db_path=None) -> str | None:
     """DB fresh read. certify snapshot 과 무관하게 항상 재조회 (snapshot capture 용)."""
     try:
         from nuri.core.timezone import today_kst
         from nuri.quant.regime.classifier import classify_regime
 
-        state = classify_regime(date=today_kst())
+        state = classify_regime(date=today_kst(), db_path=db_path)
         return state.regime if state else None
     except Exception as e:
         logger.warning(f"regime 조회 실패 — neutral fallback: {e}")
@@ -890,11 +890,11 @@ def _capture_snapshot(db_path=None) -> CertSnapshot:
     """
     from nuri.analysis.portfolio import analyze_portfolio
 
-    regime = _classify_regime_fresh()
+    regime = _classify_regime_fresh(db_path=db_path)
     portfolio_raw = _read_portfolio_raw(db_path=db_path)
     portfolio_hash = _compute_portfolio_hash(rows=portfolio_raw)  # same source
     try:
-        portfolio_df = analyze_portfolio()
+        portfolio_df = analyze_portfolio(db_path=db_path)
         portfolio_error: Exception | None = None
     except Exception as e:
         portfolio_df = None

--- a/tests/analysis/test_portfolio.py
+++ b/tests/analysis/test_portfolio.py
@@ -106,7 +106,7 @@ class TestPortfolioCoverageGaps:
                 ("test", "ZZZNOPRICE", 10, 100.0, "USD", "Tech"),
             )
 
-        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda: 1400.0)
+        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda db_path=None: 1400.0)
         result = port_mod.analyze_portfolio()
         assert result.empty
 
@@ -127,7 +127,7 @@ class TestPortfolioCoverageGaps:
                 ("TSLL", "2026-05-01", 9.0, 11.0, 8.5, 10.5, 1000, 10.5),
             )
 
-        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda: 1400.0)
+        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda db_path=None: 1400.0)
         df = port_mod.analyze_portfolio()
         assert any("TSLL" in w and "레버리지" in w for w in df.attrs.get("warnings", []))
 
@@ -154,7 +154,7 @@ class TestPortfolioCoverageGaps:
                 ("TQQQ", "2026-05-01", 9.0, 11.0, 8.5, 10.5, 1000, 10.5),
             )
 
-        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda: 1400.0)
+        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda db_path=None: 1400.0)
         df = port_mod.analyze_portfolio()
         assert any("TQQQ" in w and "레버리지" in w for w in df.attrs.get("warnings", []))
 
@@ -181,7 +181,7 @@ class TestPortfolioCoverageGaps:
                 ("035720.KQ", "2026-05-01", 70000, 71000, 69000, 70000, 1000, 70000),
             )
 
-        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda: 1400.0)
+        monkeypatch.setattr(port_mod, "get_exchange_rate", lambda db_path=None: 1400.0)
         df = port_mod.analyze_portfolio()
         row = df[df["ticker"] == "035720.KQ"].iloc[0]
         # 70000 KRW / 1400 = 50 USD. suffix 무시 시 70000 USD 로 오변환.

--- a/tests/trading/engine/test_certify_db_path_isolation.py
+++ b/tests/trading/engine/test_certify_db_path_isolation.py
@@ -1,0 +1,109 @@
+"""`certify(db_path=X)` 는 X **만** 읽어야 한다 (audit 무결성).
+
+왜 이게 중요한가
+----------------
+`_capture_snapshot()` 의 docstring 은 "Single-source-of-truth" 와 "audit row
+metadata 와 gate eval state 가 identically 일치 (R2/R4 rigor)" 를 주장한다.
+그런데 2026-08-14 까지 `db_path` 를 `_read_portfolio_raw` 에만 넘기고
+`_classify_regime_fresh()` 와 `analyze_portfolio()` 에는 안 넘겼다. 즉 스냅샷이
+**절반은 지정 DB, 절반은 기본 DB** 에서 왔고, 그 위에서 계산한 감사 해시는
+어느 쪽 상태도 정확히 대표하지 않았다.
+
+프로덕션은 `db_path=None` 이라 지금껏 무해했다. 문제는 **`db_path` 를 넘기는
+순간**이고, 다음 세션 최우선 항목인 replay pack(과거 날짜 고정 스냅샷)이
+정확히 그 호출 형태다 — 고치지 않으면 replay 스냅샷에 오늘의 프로덕션 상태가
+조용히 섞인다.
+
+이 테스트는 값이 아니라 **접근 경로**를 잠근다. 값 비교로는 두 DB 가 우연히
+같은 답을 줄 때 통과해 버린다.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+REAL_DB = Path(__file__).resolve().parents[3] / "data" / "portfolio.db"
+
+
+class TestCertifyReadsOnlyTheGivenDb:
+    @staticmethod
+    def _seed(db_path) -> None:
+        """보유 1종목 + 가격 + 환율. **비면 조기 반환**이라 경로를 안 태운다.
+
+        빈 DB 로 두면 `analyze_portfolio` 이 `holdings.empty` 에서 바로 나가고
+        `get_exchange_rate()` 는 호출조차 안 된다 — 그 배선을 되돌려도 테스트가
+        통과한다(2026-08-14 실측). 잠금이 되려면 전 경로가 실행돼야 한다.
+        """
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("test", "AAA", 10, 100.0, "USD", "Technology"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("AAA", "2026-08-14", 100.0, 101.0, 99.0, 100.5, 1000),
+            )
+            conn.execute(
+                "INSERT INTO macro (indicator, date, value, source) VALUES (?, ?, ?, ?)",
+                ("usd_krw", "2026-08-14", 1400.0, "test"),
+            )
+
+    def test_capture_snapshot_touches_no_other_database(self, db_path, monkeypatch):
+        """스냅샷을 뜨는 동안 열린 DB 파일이 `db_path` 하나뿐이어야 한다."""
+        import nuri.core.db.connection as conn_mod
+        from nuri.trading.engine import certification as cert
+
+        self._seed(db_path)
+
+        opened: list[str] = []
+        original = conn_mod.sqlite3.connect
+
+        def spy(path, *args, **kwargs):
+            opened.append(str(path))
+            return original(path, *args, **kwargs)
+
+        monkeypatch.setattr(conn_mod.sqlite3, "connect", spy)
+        cert._capture_snapshot(db_path=db_path)
+
+        others = {p for p in opened if p != str(db_path)}
+        assert not others, f"db_path 외의 DB 를 열었다: {sorted(others)}"
+        assert opened, "아무 DB 도 안 열었다 — 스파이가 안 걸린 것"
+
+    def test_the_spy_would_notice_a_leak(self, db_path, monkeypatch):
+        """스파이가 실제로 감지하는지 — 0건을 훑고 통과하면 의미가 없다."""
+        import nuri.core.db.connection as conn_mod
+
+        opened: list[str] = []
+        original = conn_mod.sqlite3.connect
+
+        def spy(path, *args, **kwargs):
+            opened.append(str(path))
+            return original(path, *args, **kwargs)
+
+        monkeypatch.setattr(conn_mod.sqlite3, "connect", spy)
+        other = db_path.parent / "other.db"
+        sqlite3.connect(str(other)).close()
+        assert str(other) in opened
+
+    @pytest.mark.parametrize("fn_name", ["_classify_regime_fresh"])
+    def test_snapshot_helpers_accept_db_path(self, fn_name: str) -> None:
+        """시그니처가 좁아지면 배선이 조용히 끊긴다."""
+        import inspect
+
+        from nuri.trading.engine import certification as cert
+
+        assert "db_path" in inspect.signature(getattr(cert, fn_name)).parameters
+
+    def test_analyze_portfolio_accepts_db_path(self) -> None:
+        import inspect
+
+        from nuri.analysis.portfolio import analyze_portfolio, get_exchange_rate
+
+        assert "db_path" in inspect.signature(analyze_portfolio).parameters
+        assert "db_path" in inspect.signature(get_exchange_rate).parameters


### PR DESCRIPTION
Found while measuring the production-DB leak in #1049. This one is production code, not test hygiene.

## The defect

`_capture_snapshot(db_path=X)` passed `X` to `_read_portfolio_raw` — and to **neither** of its other two reads:

| read | got `db_path`? |
|---|---|
| `_read_portfolio_raw(db_path=db_path)` | ✅ |
| `_classify_regime_fresh()` | ❌ default DB |
| `analyze_portfolio()` | ❌ default DB |

So the snapshot was **part X and part default DB**, and the audit hash computed over it represented neither state exactly — while the function's own docstring claims *"Single-source-of-truth"* and *"audit row metadata 와 gate eval state 가 identically 일치 (R2/R4 rigor)"*.

## Why fix it now

**Harmless today.** Production calls `certify(db_path=None)`, so both resolve to the same file.

It stops being harmless the moment anything passes a real path — and the **historical replay pack**, the next session's top priority, is exactly that call shape: pin the pipeline to a past date's data and compare outputs. Left alone, replay snapshots would silently mix in today's production regime and portfolio. That is the one thing a replay pack exists to prevent.

## The change

`analyze_portfolio()` and `get_exchange_rate()` gain an **optional** `db_path`. All 10 existing callers pass nothing and are unaffected — `nuri/analysis/sleeve.py:96` even carries a comment explaining that `analyze_portfolio` cannot take one, which is now stale in the good direction.

Four test lambdas mocking `get_exchange_rate` gained a `db_path` parameter. The behaviour they assert is unchanged; only the call signature widened.

## The lock asserts the access path, not values

Two databases can agree by accident, so a value comparison is not a lock. The test spies on `sqlite3.connect` during `_capture_snapshot` and requires **every opened file** to be the given `db_path`.

**Seeding turned out to be load-bearing.** With an empty DB, `analyze_portfolio` returns early at `holdings.empty` and `get_exchange_rate` is never called — so reverting that wiring *still passed*. The test now seeds a holding, a price and an FX row so the whole path executes.

All six wiring points mutation-checked:

| Mutation | caught |
|---|---|
| `_classify_regime_fresh(db_path=...)` → bare | ✅ |
| inner `classify_regime(..., db_path=...)` → bare | ✅ |
| `analyze_portfolio(db_path=...)` → bare | ✅ |
| `get_exchange_rate(db_path=...)` → bare | ✅ (only after seeding) |
| holdings query | ✅ |
| per-ticker price query | ✅ |

A canary also verifies the spy itself notices a leak, since a spy that sees nothing passes as happily as one that sees everything.

## Not fixed here

`_check_position_limits` and `_check_sector_limits` declare `db_path` and never reference it — they read the ContextVar snapshot instead. The signature lies, but removing a parameter is an API change with its own callers to check, so it is not bundled in.

## Verification

Full suite **6,992 passed** · `ruff` clean · `make verify-doc-counts` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)