### PR TITLE
fix(analysis): give analyze_risk and premarket_brief a db_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,007 collected across 317 files | |
+| **Backend tests** | 7,013 collected across 318 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,007 backend tests across 317 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+7,013 backend tests across 318 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,007 tests, 317 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,013 tests, 318 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -52,7 +52,7 @@ COLOR_RED = 0xFF0000
 COLOR_BLUE = 0x3498DB
 
 
-def _collect_context() -> dict:
+def _collect_context(db_path=None) -> dict:
     """Brief 에 필요한 모든 context 를 DB 에서 수집.
 
     Fault-tolerant: 각 subsystem 실패는 dict key None 으로 degrade, brief 자체
@@ -115,7 +115,7 @@ def _collect_context() -> dict:
     try:
         from nuri.quant.regime.classifier import classify_regime
 
-        r = classify_regime()
+        r = classify_regime(db_path=db_path)
         if r:
             ctx["regime"] = {
                 "regime": r.regime,
@@ -130,7 +130,7 @@ def _collect_context() -> dict:
     try:
         from nuri.quant.regime.macro_score import compute_macro_score
 
-        m = compute_macro_score()
+        m = compute_macro_score(db_path=db_path)
         ctx["macro"] = {"score": round(m.total_score, 1), "interpretation": m.interpretation}
     except Exception:
         logger.warning("macro score 실패", exc_info=True)
@@ -143,6 +143,7 @@ def _collect_context() -> dict:
             rows = query(
                 "SELECT value, date FROM macro WHERE indicator = ? ORDER BY date DESC LIMIT 1",
                 (ind,),
+                db_path=db_path,
             )
             if rows:
                 ctx[key] = {"value": float(rows[0]["value"]), "date": rows[0]["date"]}
@@ -153,7 +154,7 @@ def _collect_context() -> dict:
     try:
         from nuri.trading.engine.certification import certify
 
-        cert = certify(caller="cli:premarket_brief", swallow_persist_errors=True)
+        cert = certify(caller="cli:premarket_brief", swallow_persist_errors=True, db_path=db_path)
         ctx["siege"] = {
             "certified": cert.certified,
             "score": round(cert.score, 1),
@@ -205,6 +206,7 @@ def _collect_context() -> dict:
               AND ABS(sentiment) >= 0.5
             ORDER BY ABS(sentiment) DESC LIMIT 5
             """,
+            db_path=db_path,
         )
         ctx["macro_events"] = [dict(r) for r in rows]
     except Exception:
@@ -222,9 +224,13 @@ def _collect_context() -> dict:
                 SELECT ticker, close FROM prices
                 WHERE (ticker, date) IN (SELECT ticker, MAX(date) FROM prices GROUP BY ticker)
             ) pr ON p.ticker = pr.ticker
-            """
+            """,
+            db_path=db_path,
         )
-        rate_row = query("SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 1")
+        rate_row = query(
+            "SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 1",
+            db_path=db_path,
+        )
         rate = float(rate_row[0]["value"]) if rate_row else 1400.0
         from nuri.core.ticker_names import is_kr_ticker
 
@@ -606,9 +612,14 @@ def send_brief(embed: dict) -> bool:
         return False
 
 
-def generate_brief() -> dict:
-    """Entry point for scheduler / CLI. Context 수집 + embed + markdown + persist."""
-    ctx = _collect_context()
+def generate_brief(db_path=None) -> dict:
+    """Entry point for scheduler / CLI. Context 수집 + embed + markdown + persist.
+
+    `db_path` 는 선택이다 — 스케줄러와 CLI 는 인자 없이 부르고 기본 DB 를 쓴다.
+    받는 이유는 테스트가 이 경로를 명시적으로 격리할 수 있게 하기 위해서다
+    (#1051). 전엔 db_path 배선이 전혀 없어 테스트가 조심해도 새로 들어갔다.
+    """
+    ctx = _collect_context(db_path=db_path)
     embed = format_brief_embed(ctx)
     markdown = format_brief_markdown(ctx)
     path = persist_brief(markdown)

--- a/nuri/analysis/risk.py
+++ b/nuri/analysis/risk.py
@@ -24,12 +24,15 @@ TRADING_DAYS = 252
 from nuri.core.rules import PORTFOLIO_STOP, STOCK_STOP_LOSS
 
 
-def _get_portfolio_returns() -> tuple[pd.DataFrame, dict]:
+def _get_portfolio_returns(db_path=None) -> tuple[pd.DataFrame, dict]:
     """포트폴리오 수익률 데이터 + 비중 계산."""
-    holdings = query_df("""
+    holdings = query_df(
+        """
         SELECT ticker, SUM(quantity) as total_qty
         FROM portfolio GROUP BY ticker
-    """)
+    """,
+        db_path=db_path,
+    )
     if holdings.empty:
         return pd.DataFrame(), {}
 
@@ -39,6 +42,7 @@ def _get_portfolio_returns() -> tuple[pd.DataFrame, dict]:
         latest = query(
             "SELECT close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",
             (row["ticker"],),
+            db_path=db_path,
         )
         if latest and latest[0]["close"]:
             values[row["ticker"]] = latest[0]["close"] * row["total_qty"]
@@ -50,16 +54,22 @@ def _get_portfolio_returns() -> tuple[pd.DataFrame, dict]:
     weights = {t: v / total for t, v in values.items()}
 
     # 일간 수익률
-    prices = query_df("SELECT ticker, date, close FROM prices ORDER BY date")
+    prices = query_df("SELECT ticker, date, close FROM prices ORDER BY date", db_path=db_path)
     pivot = prices.pivot_table(index="date", columns="ticker", values="close")
     returns = pivot.ffill().pct_change(fill_method=None).dropna()
 
     return returns, weights
 
 
-def analyze_risk() -> dict:
-    """Riskfolio-Lib 기반 포트폴리오 리스크 분석."""
-    returns, weights = _get_portfolio_returns()
+def analyze_risk(db_path=None) -> dict:
+    """Riskfolio-Lib 기반 포트폴리오 리스크 분석.
+
+    `db_path` 는 선택이다 — 기존 호출자 5곳은 인자 없이 부른다. 받아야 하는
+    이유는 `nuri/llm/report.py::gather_context` 다: 거기서 다른 10개 섹션에는
+    db_path 를 제대로 넘기면서 이 한 줄만 빠져, 테스트가 격리해도 이 경로만
+    기본 DB 로 샜다 (#1051).
+    """
+    returns, weights = _get_portfolio_returns(db_path=db_path)
     if returns.empty or not weights:
         return {}
 
@@ -71,7 +81,10 @@ def analyze_risk() -> dict:
     port_returns = (returns[common] * w).sum(axis=1)
 
     # 리스크프리 레이트
-    rf_rows = query("SELECT value FROM macro WHERE indicator = 'fed_funds_rate' ORDER BY date DESC LIMIT 1")
+    rf_rows = query(
+        "SELECT value FROM macro WHERE indicator = 'fed_funds_rate' ORDER BY date DESC LIMIT 1",
+        db_path=db_path,
+    )
     rf_annual = rf_rows[0]["value"] / 100 if rf_rows else 0.05
 
     # 연환산 수익률/변동성
@@ -104,12 +117,13 @@ def analyze_risk() -> dict:
 
     # 종목별 손절선 체크
     stop_loss_alerts = []
-    holdings = query_df("SELECT ticker, avg_price FROM portfolio")
+    holdings = query_df("SELECT ticker, avg_price FROM portfolio", db_path=db_path)
     for _, row in holdings.iterrows():
         ticker = row["ticker"]
         latest = query(
             "SELECT close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",
             (ticker,),
+            db_path=db_path,
         )
         if latest and latest[0]["close"] and row["avg_price"]:
             pnl_pct = (latest[0]["close"] - row["avg_price"]) / row["avg_price"] * 100

--- a/nuri/llm/report.py
+++ b/nuri/llm/report.py
@@ -182,7 +182,7 @@ def gather_context(db_path=None) -> ReportContext:
     try:
         from nuri.analysis.risk import analyze_risk
 
-        metrics = analyze_risk()
+        metrics = analyze_risk(db_path=db_path)
         if metrics:
             sharpe = metrics.get("sharpe_ratio", "N/A")
             mdd = metrics.get("max_drawdown_pct", "N/A")

--- a/tests/llm/test_gather_context_db_path.py
+++ b/tests/llm/test_gather_context_db_path.py
@@ -1,0 +1,104 @@
+"""`gather_context(db_path=X)` / `generate_brief(db_path=X)` 는 X 만 읽어야 한다.
+
+왜 이게 필요한가
+----------------
+`gather_context` 는 10개 섹션에 db_path 를 제대로 넘기면서 **risk 섹션 한 줄만**
+빠뜨렸다 (`analyze_risk()`). `analyze_risk` 가 애초에 db_path 를 안 받았기
+때문인데, 그 한 줄 때문에 테스트가 tmp DB 를 지정해도 그 경로만 기본 DB 로
+샜다 — 2026-08-14 실측으로 `test_report_branch_coverage.py` 17개 테스트가
+각 60 커넥션씩 프로덕션 DB 를 열고 있었다.
+
+`premarket_brief` 는 db_path 배선이 **아예 없었다**.
+
+전역 격리(#1049)가 이제 프로덕션 접근 자체를 막지만, 그건 백스톱이지 배선이
+아니다. 호출자가 DB 를 지정할 수 있어야 replay/backtest 처럼 **의도적으로 다른
+DB 를 겨누는** 용도가 성립한다. 이 테스트는 값이 아니라 **접근 경로**를 잠근다.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """스키마만 있는 tmp DB. `tests/quant/conftest.py` 의 동명 픽스처는 그쪽 전용이다."""
+    from nuri.core.db import init_db
+
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _spy_connect(monkeypatch) -> list[str]:
+    import nuri.core.db.connection as conn_mod
+
+    opened: list[str] = []
+    original = conn_mod.sqlite3.connect
+
+    def spy(path, *args, **kwargs):
+        opened.append(str(path))
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(conn_mod.sqlite3, "connect", spy)
+    return opened
+
+
+class TestSignaturesAcceptDbPath:
+    @pytest.mark.parametrize(
+        "module,name",
+        [
+            ("nuri.analysis.risk", "analyze_risk"),
+            ("nuri.analysis.risk", "_get_portfolio_returns"),
+            ("nuri.alerts.premarket_brief", "_collect_context"),
+            ("nuri.alerts.premarket_brief", "generate_brief"),
+        ],
+    )
+    def test_accepts_db_path(self, module: str, name: str) -> None:
+        """시그니처가 좁아지면 호출부 배선이 조용히 끊긴다."""
+        import importlib
+
+        fn = getattr(importlib.import_module(module), name)
+        assert "db_path" in inspect.signature(fn).parameters
+
+
+class TestAnalyzeRiskReadsOnlyTheGivenDb:
+    def test_no_other_database_is_opened(self, db_path, monkeypatch) -> None:
+        from nuri.analysis.risk import analyze_risk
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("test", "AAA", 10, 100.0, "USD", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("AAA", "2026-08-14", 100.0, 101.0, 99.0, 100.5, 1000),
+            )
+
+        opened = _spy_connect(monkeypatch)
+        analyze_risk(db_path=db_path)
+
+        others = {p for p in opened if p != str(db_path)}
+        assert not others, f"db_path 외의 DB 를 열었다: {sorted(others)}"
+        assert opened, "아무 DB 도 안 열었다 — 스파이가 안 걸린 것"
+
+
+class TestGatherContextThreadsToRisk:
+    def test_risk_section_receives_db_path(self, db_path, monkeypatch) -> None:
+        """`gather_context` 가 risk 섹션에도 db_path 를 넘기는지 — 그 한 줄이 빠져 있었다."""
+        seen: dict = {}
+
+        def fake_analyze_risk(db_path=None):
+            seen["db_path"] = db_path
+            return {}
+
+        monkeypatch.setattr("nuri.analysis.risk.analyze_risk", fake_analyze_risk)
+        from nuri.llm import report
+
+        report.gather_context(db_path=db_path)
+        assert seen.get("db_path") == db_path, "risk 섹션이 db_path 를 못 받았다"


### PR DESCRIPTION
The last two production functions from the #1049 leak survey that could not be isolated — because they had nowhere to put a database path.

## `analyze_risk` — one dropped line inside a function that gets it right everywhere else

`gather_context` threads `db_path` to **ten** sections and dropped it on exactly one:

```python
metrics = analyze_risk()   # nuri/llm/report.py:185
```

`analyze_risk` did not accept the argument, so the risk section always read the default DB. That single line was the **entire** cost of `tests/llm/test_report_branch_coverage.py` — 17 tests at 60 connections each, measured — even though the file's own `db_path` fixture was correct all along.

## `premarket_brief` — no plumbing at all

`_collect_context` is the only function in the module that reads the DB, and everything it calls (`classify_regime`, `compute_macro_score`, `certify`) already accepted a path. So threading it through is contained: one signature, four queries, three sub-calls, and the entry point.

## Both parameters are optional

All existing callers pass nothing and are unaffected — five for `analyze_risk`, the scheduler and CLI for `generate_brief`.

## Why bother, given #1049

The global isolation from #1049 already stops these paths reaching production. **A backstop is not plumbing.**

A caller has to be able to *aim* at a specific database for replay and backtest work to be possible at all. That is the point of the planned replay pack: pin the pipeline to a past date's data. Without these parameters, two of its sections would silently read today's DB no matter what the caller asked for.

## The lock

Asserts the access path, not values — two databases can agree by accident. It spies on `sqlite3.connect` and requires every file opened during `analyze_risk(db_path=X)` to be `X`, plus a signature check on all four functions and a direct check that `gather_context` hands its `db_path` to the risk section.

Mutation-checked in four places:

| Mutation | caught |
|---|---|
| `report.py`: `analyze_risk(db_path=...)` → bare | ✅ |
| `risk.py`: `_get_portfolio_returns(db_path=...)` → bare | ✅ |
| `analyze_risk` signature loses `db_path` | ✅ (2 tests) |
| `generate_brief` signature loses `db_path` | ✅ |

A canary also verifies the spy notices a leak, since a spy that sees nothing passes as happily as one that sees everything.

## Verification

Full suite **6,994 passed** · `ruff` clean · `make verify-doc-counts` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)