### PR TITLE
fix(db): finish db_path forwarding and collect the guard tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,013 collected across 318 files | |
+| **Backend tests** | 7,025 collected across 320 files | |
 | **Backend statement coverage** | 100% — 0 of 22,560 statements uncovered (full local suite, 2026-07-29; `make ci-cov` / Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,013 backend tests across 318 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
+7,025 backend tests across 320 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 100% (2026-07-29)** — 0 of 22,560 statements uncovered (#926). 57 partial branches remain. Full closure held on 2026-05-06 and regressed after; `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth, not a local run.
 **Slow marker**: 24 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally.
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,013 tests, 318 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,025 tests, 320 files (statement coverage **100%** — 0/22,560 미커버, partial branch 57, 2026-07-29) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -80,7 +80,7 @@ def _collect_context(db_path=None) -> dict:
     try:
         from nuri.core.freshness import get_freshness_summary
 
-        ctx["freshness"] = get_freshness_summary()
+        ctx["freshness"] = get_freshness_summary(db_path)
     except Exception:
         logger.warning("freshness summary 실패", exc_info=True)
 
@@ -106,7 +106,7 @@ def _collect_context(db_path=None) -> dict:
                 "threshold": s.threshold,
                 "detail": s.detail,
             }
-            for s in detect_all()
+            for s in detect_all(db_path=db_path)
         ]
     except Exception:
         logger.warning("shadow signals detect 실패", exc_info=True)

--- a/nuri/analysis/evidence_charts.py
+++ b/nuri/analysis/evidence_charts.py
@@ -232,7 +232,7 @@ def generate_portfolio_heatmap(output_dir: Path, db_path=None) -> Path:
     """포트폴리오 트리맵: 크기=포지션 가치, 색상=손익%."""
     from nuri.analysis.portfolio import analyze_portfolio
 
-    df = analyze_portfolio()
+    df = analyze_portfolio(db_path=db_path)
     output_path = output_dir / "portfolio_heatmap.html"
 
     if df.empty:
@@ -722,7 +722,7 @@ def _detect_portfolio_violations(db_path=None) -> list[dict]:
     try:
         from nuri.analysis.portfolio import analyze_portfolio
 
-        df = analyze_portfolio()
+        df = analyze_portfolio(db_path=db_path)
     except Exception:
         return []
 

--- a/nuri/analysis/rebalance_advisor.py
+++ b/nuri/analysis/rebalance_advisor.py
@@ -77,7 +77,7 @@ def detect_violations(db_path: Optional[Path] = None) -> list[dict]:
     Returns:
         위반 사항 리스트 (priority 순 정렬). 위반 없으면 빈 리스트.
     """
-    df = analyze_portfolio()
+    df = analyze_portfolio(db_path=db_path)
     if df.empty:
         logger.info("포트폴리오가 비어 있습니다")
         return []

--- a/nuri/analysis/sleeve.py
+++ b/nuri/analysis/sleeve.py
@@ -93,9 +93,7 @@ def sleeve_utilization(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
     from nuri.analysis.portfolio import analyze_portfolio
     from nuri.core.rules import get_account_strategy_name
 
-    # analyze_portfolio() 는 db_path 를 받지 않는다 (기본 DB 고정). 테스트는
-    # 이 함수를 patch 하거나 sleeve_members/caps 를 직접 검증한다.
-    df = analyze_portfolio()
+    df = analyze_portfolio(db_path=db_path)
     if df.empty:
         return []
 

--- a/nuri/quant/factors/quality.py
+++ b/nuri/quant/factors/quality.py
@@ -36,7 +36,7 @@ def compute_quality(tickers: list[str] | None = None, db_path=None) -> pd.DataFr
 
         # KR(.KS) 포함 — 정규화는 시장별로 분리한다 (#757). 과거엔 KR 을 제외해
         # composite 의 quality(25%) 가 KR 종목에서 flat 0.5 상수였다.
-        tickers = get_tickers()
+        tickers = get_tickers(db_path=db_path)
 
     if not tickers:
         return pd.DataFrame()

--- a/nuri/quant/factors/value.py
+++ b/nuri/quant/factors/value.py
@@ -39,7 +39,7 @@ def compute_value(tickers: list[str] | None = None, db_path=None) -> pd.DataFram
 
         # KR(.KS) 포함 — 정규화는 시장별로 분리한다 (#757). 과거엔 KR 을 제외해
         # composite 의 value(25%) 가 KR 종목에서 flat 0.5 상수였다.
-        tickers = get_tickers()
+        tickers = get_tickers(db_path=db_path)
 
     if not tickers:
         return pd.DataFrame()

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -150,17 +150,20 @@ def _classify_regime_fresh(db_path=None) -> str | None:
         return None
 
 
-def _current_regime() -> str | None:
+def _current_regime(db_path=None) -> str | None:
     """현재 regime label. certify() scope 내에서 호출되면 snapshot regime, 아니면 fresh.
 
     **Rigor invariant (R2 P2 full fix)**: certify() 실행 중 모든 `_current_regime()`
     호출 (gate eval + _persist_certification) 은 **같은 값** 반환 → audit row regime
     과 gate eval 에서 사용된 regime 이 identically 일치.
+
+    snapshot 이 없는 경로(게이트를 직접 호출하는 테스트/감사 헬퍼)에서는 `db_path`
+    가 실제로 쓰인다 — 없으면 호출자가 격리 DB 를 넘겨도 기본 DB 로 샜다 (#1052).
     """
     snap = _CERT_SNAPSHOT.get()
     if snap is not None:
         return snap.regime
-    return _classify_regime_fresh()
+    return _classify_regime_fresh(db_path=db_path)
 
 
 def _snapshot_portfolio_raw(db_path=None) -> list[dict]:
@@ -189,7 +192,7 @@ def _read_portfolio_raw(db_path=None) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-def _snapshot_portfolio() -> "pd.DataFrame":
+def _snapshot_portfolio(db_path=None) -> "pd.DataFrame":
     """Certify() scope 내에서 호출되면 snapshot portfolio_df, 아니면 fresh analyze_portfolio().
 
     **Rigor invariant (R2 P2 full fix)**: certify() 실행 중 모든 gate 가 호출하는
@@ -197,6 +200,9 @@ def _snapshot_portfolio() -> "pd.DataFrame":
     → snapshot_hash 와 gate eval portfolio 가 identically 일치.
 
     Empty portfolio 는 빈 DataFrame 으로 정상 반환 (analyze_portfolio 와 shape 일치).
+
+    형제인 `_snapshot_portfolio_raw` 는 처음부터 `db_path` 를 받았다. 이쪽만 빠져
+    있어서, snapshot 이 없는 경로에서 게이트를 직접 부르면 기본 DB 로 샜다 (#1052).
     """
     snap = _CERT_SNAPSHOT.get()
     if snap is not None:
@@ -208,7 +214,7 @@ def _snapshot_portfolio() -> "pd.DataFrame":
         return snap.portfolio_df
     from nuri.analysis.portfolio import analyze_portfolio
 
-    return analyze_portfolio()
+    return analyze_portfolio(db_path=db_path)
 
 
 def _get_position_multiplier(regime: str | None) -> float:
@@ -249,11 +255,11 @@ def _check_position_limits(db_path=None) -> CertCondition:
     try:
         from nuri.core.rules import get_account_strategy
 
-        df = _snapshot_portfolio()
+        df = _snapshot_portfolio(db_path=db_path)
         if df.empty:
             return CertCondition("position_limit", "종목 비중 한도", True, "포트폴리오 비어있음")
 
-        regime = _current_regime()
+        regime = _current_regime(db_path=db_path)
         multiplier = _get_position_multiplier(regime)
 
         # 종목별 합산 비중 + 해당 종목이 속한 계좌들의 가장 관대한 한도
@@ -282,7 +288,7 @@ def _check_position_limits(db_path=None) -> CertCondition:
 def _check_sector_limits(db_path=None) -> CertCondition:
     """2. 섹터 비중 <= 35%. Portfolio snapshot 참조 (R2 P2 rigor)."""
     try:
-        df = _snapshot_portfolio()
+        df = _snapshot_portfolio(db_path=db_path)
         if df.empty:
             return CertCondition("sector_limit", "섹터 비중 <= 35%", True, "포트폴리오 비어있음")
 
@@ -518,7 +524,7 @@ def _check_stop_loss_compliance(db_path=None) -> CertCondition:
     try:
         from nuri.core.rules import get_account_strategy
 
-        df = _snapshot_portfolio()
+        df = _snapshot_portfolio(db_path=db_path)
         if df.empty:
             return CertCondition("stop_loss", "손절선 준수", True, "포트폴리오 비어있음")
 

--- a/nuri/trading/recommend/candidates.py
+++ b/nuri/trading/recommend/candidates.py
@@ -427,7 +427,7 @@ def screen_candidates(lookback_days: int = 5, db_path=None) -> list[Candidate]:
     try:
         from nuri.trading.engine.conflicts import detect_conflicts
 
-        conflicts = detect_conflicts(candidates)
+        conflicts = detect_conflicts(candidates, db_path=db_path)
         # 충돌 종목 세트
         conflict_tickers = {}
         for cf in conflicts:

--- a/nuri/trading/recommend/rebalance.py
+++ b/nuri/trading/recommend/rebalance.py
@@ -88,7 +88,7 @@ def regime_aware_rebalance(method: str = "rp", db_path=None) -> list[RebalanceAc
 
         from nuri.trading.engine.conflicts import detect_conflicts
 
-        conflicts = detect_conflicts(candidates)
+        conflicts = detect_conflicts(candidates, db_path=db_path)
         conflict_tickers = {
             cf.ticker for cf in conflicts if cf.conflict_type == "direction_conflict" and cf.severity == "high"
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,46 +190,7 @@ def mock_yfinance(monkeypatch):
         pass
 
 
-def test_the_guard_actually_bites(tmp_path, monkeypatch):
-    """가드가 **실제로 예외를 던지는지** — 등록만 되고 안 무는 걸 막는다.
-
-    이 레포는 훅 2개가 3.5개월간 조용히 무력했던 전례가 있다
-    (`.claude/rules/enforcement.md`). autouse 픽스처도 같은 방식으로 죽을 수
-    있으므로, 가드가 켜진 상태에서 실 DB 경로를 열어 보고 터지는지 확인한다.
-
-    ⚠️ 이 파일에 테스트를 두는 건 예외적이다. 가드가 conftest 에 있고 그
-    autouse 효과 자체를 검증해야 해서, 같은 스코프 안이어야 의미가 있다.
-    """
-    import sqlite3
-
-    with pytest.raises(_ProductionDBTouched, match="프로덕션 DB"):
-        sqlite3.connect(str(_REAL_DB))
-
-
-def test_the_guard_leaves_other_paths_alone(tmp_path):
-    """tmp DB 는 막지 않는다 — 막으면 전 스위트가 죽는다."""
-    import sqlite3
-
-    p = tmp_path / "ok.db"
-    sqlite3.connect(str(p)).close()
-    assert p.exists()
-
-
-def test_the_guard_survives_a_broad_except(tmp_path):
-    """광범위 `except Exception` 이 가드를 삼키면 안 된다.
-
-    프로덕션 코드는 섹션마다 `except Exception` 으로 감싸는 곳이 많다
-    (`nuri/llm/report.py::gather_context`). 가드가 `AssertionError` 였을 때
-    실제로 삼켜져서, 격리를 꺼도 테스트가 초록이었다 (2026-08-14 실측).
-    """
-    import sqlite3
-
-    swallowed = False
-    try:
-        try:
-            sqlite3.connect(str(_REAL_DB))
-        except Exception:  # noqa: BLE001 — 프로덕션 코드의 실제 패턴을 재현
-            swallowed = True
-    except _ProductionDBTouched:
-        pass
-    assert not swallowed, "가드가 `except Exception` 에 삼켜졌다 — 백스톱이 아니다"
+# ⚠️ 이 가드의 회귀 테스트는 `tests/test_production_db_guard.py` 에 있다.
+# 여기 두면 **수집되지 않는다** — pytest 의 `python_files` 기본값이 `test_*.py` 라
+# conftest.py 는 플러그인으로 import 될 뿐 테스트 모듈이 아니다. 파일을 인자로
+# 명시하면 수집돼서 "돌려서 확인했다"는 착각을 만든다 (2026-08-14 실측).

--- a/tests/core/test_db_path_forwarding.py
+++ b/tests/core/test_db_path_forwarding.py
@@ -1,0 +1,169 @@
+"""`db_path` 를 받는 함수가 하위 호출에 그 값을 넘기는지 고정한다 (#1052).
+
+왜 필요한가
+-----------
+`db_path=` 인자는 **받는 것만으로는 아무것도 보장하지 않는다.** 함수가 인자를
+선언해 놓고 내부에서 `analyze_portfolio()` 를 인자 없이 부르면, 호출자는 격리
+DB 를 넘겼는데 그 한 줄만 기본 DB 로 샌다. 서명은 맞고 타입 체커도 통과하고
+테스트도 초록이다 — 프로덕션 데이터를 읽으면서.
+
+실제로 그렇게 샜다. #1049 가 전역 테스트 격리를 켜자 #1050·#1051 에서 8곳이
+드러났고, 그 두 PR 을 머지한 **뒤에** 같은 계열이 8곳 더 남아 있었다
+(2026-08-14 Codex 리뷰 + AST 스윕). 사람이 훑어서는 반복해서 놓친다.
+
+무엇을 잠그는가
+---------------
+`nuri/` 안에서 `db_path` 파라미터를 가진 함수 F 가, 역시 `db_path` 를 받을 수
+있는 함수 G 를 호출하면서 **위치로도 키워드로도** 그 값을 넘기지 않으면 FAIL.
+호출 형태 세 가지(`g()` · `mod.g()` · `from x import g as h; h()`)를 모두 본다 —
+이름 호출만 검사하면 나머지 둘로 새고, 그 둘은 오늘 0건이라 지금 덮어두는 게
+가장 싸다. 예외는 아래 `ALLOWED` 에 이유와 함께 등재해야 한다. 목록이 낡지
+않도록 **양방향**으로 검사한다 — 해소된 항목이 남아 있어도 FAIL.
+
+한계: 간접 호출(`fn = analyze_portfolio; fn()`)은 정적으로 못 본다. 레포에 현재
+그런 형태는 없다.
+
+Gotcha-Test Pair: 배선된 `db_path=db_path` 를 하나 지우면 FAIL.
+"""
+
+from __future__ import annotations
+
+import ast
+import collections
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NURI = REPO_ROOT / "nuri"
+
+# (파일, 호출하는 함수, 호출되는 함수) → 왜 안 넘겨도 되는가.
+# 줄 번호로 키를 잡지 않는다 — 무관한 편집에도 깨진다.
+ALLOWED: dict[tuple[str, str, str], str] = {
+    (
+        "nuri/trading/engine/certification.py",
+        "_capture_snapshot",
+        "_compute_portfolio_hash",
+    ): "`rows=portfolio_raw` 를 이미 넘긴다 — rows 가 주어지면 DB 를 안 읽는다(codex R4).",
+    (
+        "nuri/trading/engine/decisions.py",
+        "main",
+        "init_db",
+    ): "`init_db(db_path) if db_path is not None else init_db()` 삼항 — 이미 명시 분기.",
+}
+
+
+def _accepts_db_path(tree: ast.Module) -> set[str]:
+    """이 트리에서 `db_path` 파라미터를 가진 함수 이름."""
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            params = node.args.posonlyargs + node.args.args + node.args.kwonlyargs
+            if any(a.arg == "db_path" for a in params):
+                names.add(node.name)
+    return names
+
+
+def _forwards_db_path(call: ast.Call) -> bool:
+    """호출이 `db_path` 를 (위치든 키워드든) **명시적으로** 넘기는가.
+
+    `**kwargs` / `*args` 는 통과로 쳐주지 않는다. `def f(db_path=None, **kw):
+    g(**kw)` 는 `kw` 가 비면 그대로 새는데, unpack 을 forward 로 인정하면 스윕이
+    영영 침묵한다. 레포에 그런 형태가 지금 0건이라 여기서 막는 게 가장 싸다.
+    나중에 정당한 unpack 이 생기면 `ALLOWED` 에 이유와 함께 올리면 된다.
+    """
+    for kw in call.keywords:
+        if kw.arg == "db_path":
+            return True
+        if isinstance(kw.value, ast.Name) and kw.value.id == "db_path":
+            return True
+    return any(isinstance(arg, ast.Name) and arg.id == "db_path" for arg in call.args)
+
+
+# 커넥션 객체의 메서드. 이름이 우연히 `db_path` 를 받는 모듈 함수와 겹쳐도
+# `conn.execute(...)` 는 이미 경로가 정해진 커넥션 위의 호출이라 판정 대상이 아니다.
+_CONNECTION_METHODS = frozenset(
+    {"execute", "executemany", "executescript", "cursor", "commit", "close", "fetchall", "fetchone"}
+)
+
+
+def _aliased_imports(tree: ast.Module, accepts: set[str]) -> dict[str, str]:
+    """`from x import f as g` — 별칭으로 부르면 def 이름과 안 맞아 스윕을 빠져나간다."""
+    return {
+        alias.asname: alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+        if alias.asname and alias.name in accepts
+    }
+
+
+def _callee_name(call: ast.Call, aliases: dict[str, str]) -> str | None:
+    """호출 대상 이름. 세 형태를 모두 본다 — 하나만 보면 나머지 둘로 샌다.
+
+    `f()` · `mod.f()` (속성 호출) · `g()` (별칭 import). 오늘 레포에는 뒤 둘이
+    0건이지만, 이름 호출만 검사하면 다음에 그렇게 쓰는 순간 조용히 통과한다.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        return aliases.get(func.id, func.id)
+    if isinstance(func, ast.Attribute) and func.attr not in _CONNECTION_METHODS:
+        return func.attr
+    return None
+
+
+def _scan() -> list[tuple[str, int, str, str]]:
+    """(파일, 줄, 호출자, 피호출자) — db_path 를 안 넘긴 지점."""
+    trees: dict[Path, ast.Module] = {}
+    accepts: set[str] = set()
+    for path in sorted(NURI.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        trees[path] = tree
+        accepts |= _accepts_db_path(tree)
+
+    findings = []
+    for path, tree in trees.items():
+        rel = str(path.relative_to(REPO_ROOT))
+        aliases = _aliased_imports(tree, accepts)
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            params = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
+            if not any(a.arg == "db_path" for a in params):
+                continue
+            for call in ast.walk(fn):
+                if not isinstance(call, ast.Call):
+                    continue
+                callee = _callee_name(call, aliases)
+                if callee is None or callee not in accepts or callee == fn.name:  # 재귀 제외
+                    continue
+                if _forwards_db_path(call):
+                    continue
+                findings.append((rel, call.lineno, fn.name, callee))
+    return findings
+
+
+class TestDbPathIsForwarded:
+    def test_every_db_path_aware_call_receives_it(self):
+        leaks = [f for f in _scan() if (f[0], f[2], f[3]) not in ALLOWED]
+        assert not leaks, "db_path 를 받고도 하위 호출에 안 넘기는 지점:\n" + "\n".join(
+            f"  {rel}:{line}  {caller}() -> {callee}()" for rel, line, caller, callee in leaks
+        )
+
+    def test_allowlist_has_no_stale_entries(self):
+        """해소된 항목이 목록에 남아 있으면 FAIL — 목록이 낡지 않게."""
+        seen = {(rel, caller, callee) for rel, _, caller, callee in _scan()}
+        stale = sorted(set(ALLOWED) - seen)
+        assert not stale, "ALLOWED 에 있으나 더는 발생하지 않는 항목 (지울 것):\n" + "\n".join(
+            f"  {rel}  {caller}() -> {callee}()" for rel, caller, callee in stale
+        )
+
+    def test_the_scan_finds_something_to_look_at(self):
+        """스윕이 조용히 0건을 훑고 통과하는 걸 막는다.
+
+        `_accepts_db_path` 나 경로 glob 이 깨지면 findings 가 빈 리스트가 되고 위
+        두 테스트가 **아무것도 검사하지 않은 채** 초록이 된다.
+        """
+        trees = [ast.parse(p.read_text(encoding="utf-8")) for p in NURI.rglob("*.py")]
+        accepts = collections.Counter()
+        for t in trees:
+            accepts.update(_accepts_db_path(t))
+        assert len(accepts) > 100, f"db_path 를 받는 함수가 {len(accepts)}개뿐 — 스캐너가 깨졌다"

--- a/tests/quant/test_factors_quality.py
+++ b/tests/quant/test_factors_quality.py
@@ -107,7 +107,7 @@ class TestQualityDbRead:
         """tickers=None + get_tickers() 가 빈 리스트 → empty df (line 24)."""
         from nuri.quant.factors import quality as qmod
 
-        monkeypatch.setattr("nuri.core.db.get_tickers", lambda: [])
+        monkeypatch.setattr("nuri.core.db.get_tickers", lambda **kw: [])
         df = qmod.compute_quality()
         assert df.empty
 
@@ -126,7 +126,7 @@ class TestQualityDbRead:
                 ("000660.KS", "2026-04-15", 0.09, 0.11),
             ],
         )
-        monkeypatch.setattr("nuri.core.db.get_tickers", lambda: ["005930.KS", "000660.KS"])
+        monkeypatch.setattr("nuri.core.db.get_tickers", lambda **kw: ["005930.KS", "000660.KS"])
         df = qmod.compute_quality()
         assert not df.empty
         assert set(df.index) == {"005930.KS", "000660.KS"}

--- a/tests/quant/test_factors_value.py
+++ b/tests/quant/test_factors_value.py
@@ -148,7 +148,7 @@ class TestValueDbRead:
         """get_tickers() 가 빈 리스트 → empty (line 24)."""
         from nuri.quant.factors import value as vmod
 
-        monkeypatch.setattr("nuri.core.db.get_tickers", lambda: [])
+        monkeypatch.setattr("nuri.core.db.get_tickers", lambda **kw: [])
         df = vmod.compute_value()
         assert df.empty
 

--- a/tests/test_production_db_guard.py
+++ b/tests/test_production_db_guard.py
@@ -1,0 +1,80 @@
+"""`tests/conftest.py` 의 프로덕션 DB 접근 금지 가드가 **실제로 무는지** 검증한다.
+
+⚠️ 이 테스트들은 원래 `tests/conftest.py` 안에 있었다. **pytest 는 conftest.py 를
+테스트 모듈로 수집하지 않는다** — `python_files` 기본값이 `test_*.py` 라서, 파일을
+인자로 명시할 때만 수집된다. 그래서 "돌려서 확인했다"던 게 사실은 `pytest
+tests/conftest.py` 명시 실행이었고, `make test-fast` 와 CI 는 이 3개를 **한 번도
+실행한 적이 없었다** (2026-08-14 Codex 리뷰 지적, `pytest tests/ --collect-only`
+로 0건 실측).
+
+가드를 검증하는 테스트가 조용히 안 돌면 가드가 죽어도 초록이다 — 이 레포는 훅 2개가
+3.5개월간 무력했던 전례가 있다(`.claude/rules/enforcement.md`). 그래서 여기,
+수집되는 파일에 둔다.
+
+conftest 에서 `_ProductionDBTouched` / `_REAL_DB` 를 import 하지 않는다 (`tests/` 는
+패키지가 아니라 import 경로가 실행 방식에 따라 달라진다). 대신 **성질**을 직접
+단언한다 — 어차피 중요한 건 클래스 이름이 아니라 "`except Exception` 을 통과한다" 다.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+# conftest 의 `_REAL_DB` 와 같은 경로. 한쪽만 바뀌면 가드가 안 물어 이 테스트가
+# FAIL 한다 — 드리프트가 조용히 넘어가지 않는 방향이다.
+REAL_DB = Path(__file__).resolve().parents[1] / "data" / "portfolio.db"
+
+
+class TestProductionDBGuard:
+    def test_the_guard_actually_bites(self):
+        """가드가 등록만 되고 안 무는 상태를 막는다."""
+        with pytest.raises(BaseException, match="프로덕션 DB") as exc_info:
+            sqlite3.connect(str(REAL_DB))
+
+        assert not isinstance(exc_info.value, Exception), (
+            "가드 예외가 `Exception` 하위다 — 프로덕션의 광범위 `except Exception` 에 "
+            "삼켜진다. `BaseException` 을 직접 상속해야 한다."
+        )
+
+    def test_the_guard_leaves_other_paths_alone(self, tmp_path):
+        """tmp DB 는 막지 않는다 — 막으면 전 스위트가 죽는다."""
+        p = tmp_path / "ok.db"
+        sqlite3.connect(str(p)).close()
+        assert p.exists()
+
+    def test_the_guard_survives_a_broad_except(self):
+        """광범위 `except Exception` 이 가드를 삼키면 안 된다.
+
+        프로덕션 코드는 섹션마다 `except Exception` 으로 감싸는 곳이 많다
+        (`nuri/llm/report.py::gather_context`). 가드가 `AssertionError` 였을 때
+        실제로 삼켜져서, 격리를 꺼도 테스트 5개가 초록이었다 (2026-08-14 실측).
+        """
+        swallowed = False
+        try:
+            try:
+                sqlite3.connect(str(REAL_DB))
+            except Exception:  # noqa: BLE001 — 프로덕션 코드의 실제 패턴을 재현
+                swallowed = True
+        except BaseException:  # noqa: BLE001 — 가드가 여기까지 올라와야 정상
+            pass
+        assert not swallowed, "가드가 `except Exception` 에 삼켜졌다 — 백스톱이 아니다"
+
+
+class TestIsolationFixture:
+    def test_db_path_points_away_from_production(self):
+        """autouse 격리가 `nuri.core.db.DB_PATH` 를 실제로 갈아끼웠는지."""
+        import nuri.core.db as db_mod
+
+        assert Path(db_mod.DB_PATH).resolve() != REAL_DB.resolve()
+
+    def test_isolated_db_has_the_schema(self):
+        """세션 템플릿 복사본이 빈 파일이 아니라 스키마를 갖고 있는지.
+
+        복사가 조용히 실패하면 모든 테스트가 "테이블 없음" 으로 죽는 대신
+        빈 결과를 받아 통과할 수 있다.
+        """
+        from nuri.core.db import query
+
+        rows = query("SELECT name FROM sqlite_master WHERE type='table' AND name='portfolio'")
+        assert rows, "격리 DB 에 portfolio 테이블이 없다 — 스키마 템플릿 복사 실패"

--- a/tests/trading/engine/test_certification.py
+++ b/tests/trading/engine/test_certification.py
@@ -440,7 +440,7 @@ class TestCertification_R23:
                 "account": ["test", "test"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         cond = _check_position_limits(db_path)
         assert cond.passed is True
         assert "최대 비중" in cond.detail
@@ -455,7 +455,7 @@ class TestCertification_R23:
                 "account": ["test", "test"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         cond = _check_position_limits(db_path)
         assert cond.passed is False
         assert "위반" in cond.detail
@@ -464,7 +464,7 @@ class TestCertification_R23:
         from nuri.trading.engine.certification import _check_position_limits
 
         monkeypatch.setattr(
-            "nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError("fail"))
+            "nuri.analysis.portfolio.analyze_portfolio", lambda **kw: (_ for _ in ()).throw(RuntimeError("fail"))
         )
         cond = _check_position_limits(db_path)
         assert cond.passed is False
@@ -480,7 +480,7 @@ class TestCertification_R23:
                 "weight_pct": [20.0, 15.0],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         cond = _check_sector_limits(db_path)
         assert cond.passed is True
 
@@ -488,7 +488,7 @@ class TestCertification_R23:
         from nuri.trading.engine.certification import _check_sector_limits
 
         monkeypatch.setattr(
-            "nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError("fail"))
+            "nuri.analysis.portfolio.analyze_portfolio", lambda **kw: (_ for _ in ()).throw(RuntimeError("fail"))
         )
         cond = _check_sector_limits(db_path)
         assert cond.passed is True
@@ -503,7 +503,7 @@ class TestCertification_R23:
                 "pnl_pct": [-25.0, 5.0],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         cond = _check_stop_loss_compliance(db_path)
         assert cond.passed is False
         assert "위반" in cond.detail
@@ -511,7 +511,9 @@ class TestCertification_R23:
     def test_check_stop_loss_exception(self, db_path, monkeypatch):
         from nuri.trading.engine.certification import _check_stop_loss_compliance
 
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: (_ for _ in ()).throw(RuntimeError()))
+        monkeypatch.setattr(
+            "nuri.analysis.portfolio.analyze_portfolio", lambda **kw: (_ for _ in ()).throw(RuntimeError())
+        )
         cond = _check_stop_loss_compliance(db_path)
         assert cond.passed is True
         assert "스킵" in cond.detail
@@ -764,7 +766,7 @@ class TestAccountStrategyIntegration:
                 "account": ["sub_account"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         # swing 전략: stop_loss -15%
         monkeypatch.setattr(
             "nuri.core.rules.get_account_strategy", lambda a: {"stop_loss": -15, "max_single_position": 0.30}
@@ -784,7 +786,7 @@ class TestAccountStrategyIntegration:
                 "account": ["sub_account"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         monkeypatch.setattr(
             "nuri.core.rules.get_account_strategy", lambda a: {"stop_loss": -15, "max_single_position": 0.30}
         )
@@ -804,7 +806,7 @@ class TestAccountStrategyIntegration:
                 "account": ["main_account"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         monkeypatch.setattr(
             "nuri.core.rules.get_account_strategy", lambda a: {"stop_loss": -7, "max_single_position": 0.15}
         )
@@ -823,7 +825,7 @@ class TestAccountStrategyIntegration:
                 "account": ["main", "sub"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         monkeypatch.setattr(
             "nuri.core.rules.get_account_strategy",
             lambda a: (
@@ -847,7 +849,7 @@ class TestAccountStrategyIntegration:
                 "account": ["main", "sub"],
             }
         )
-        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr("nuri.analysis.portfolio.analyze_portfolio", lambda **kw: mock_df)
         monkeypatch.setattr(
             "nuri.core.rules.get_account_strategy",
             lambda a: (
@@ -860,7 +862,7 @@ class TestAccountStrategyIntegration:
         # neutral 로 고정 (테스트 의도는 base cap 30% < 35% 위반 검증).
         monkeypatch.setattr(
             "nuri.trading.engine.certification._current_regime",
-            lambda: "neutral",
+            lambda **kw: "neutral",
         )
 
         cond = _check_position_limits(db_path)

--- a/tests/trading/engine/test_certify_db_path_isolation.py
+++ b/tests/trading/engine/test_certify_db_path_isolation.py
@@ -107,3 +107,72 @@ class TestCertifyReadsOnlyTheGivenDb:
 
         assert "db_path" in inspect.signature(analyze_portfolio).parameters
         assert "db_path" in inspect.signature(get_exchange_rate).parameters
+
+
+class TestGatesReadOnlyTheGivenDbOutsideCertify:
+    """게이트를 `certify()` **밖에서** 직접 부를 때도 `db_path` 만 읽어야 한다.
+
+    위 클래스는 `_capture_snapshot()` 경로를 덮는다. 그 경로에서는 `CertSnapshot`
+    ContextVar 가 세팅돼 있어서 `_snapshot_portfolio()` / `_current_regime()` 이
+    DB 를 아예 안 읽고 스냅샷을 반환한다 — 그래서 그 둘의 `db_path` 배선이
+    빠져 있어도 위 테스트가 전부 통과했다 (2026-08-14 실측: 배선 6곳을 되돌려도
+    `tests/trading/engine/` + `tests/llm/` 611개가 초록이었다).
+
+    스냅샷이 없는 경로 — 테스트·감사 헬퍼가 게이트를 직접 부르는 형태 — 만이
+    그 배선을 실제로 실행한다. AST 스윕(`tests/core/test_db_path_forwarding.py`)
+    은 구조만 보므로, 동작으로 잠그는 건 여기다.
+    """
+
+    @staticmethod
+    def _seed_violating_position(db_path) -> None:
+        """단일 종목이 포트폴리오의 100% — position_limit 를 확실히 위반시킨다."""
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("test", "AAA", 100, 100.0, "USD", "Technology"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("AAA", "2026-08-14", 100.0, 101.0, 99.0, 100.0, 1000),
+            )
+            conn.execute(
+                "INSERT INTO macro (indicator, date, value, source) VALUES (?, ?, ?, ?)",
+                ("usd_krw", "2026-08-14", 1400.0, "test"),
+            )
+
+    @pytest.mark.parametrize(
+        "gate_name",
+        ["_check_position_limits", "_check_sector_limits", "_check_stop_loss_compliance"],
+    )
+    def test_gate_touches_no_other_database(self, gate_name: str, db_path, monkeypatch):
+        import nuri.core.db.connection as conn_mod
+        from nuri.trading.engine import certification as cert
+
+        self._seed_violating_position(db_path)
+
+        opened: list[str] = []
+        original = conn_mod.sqlite3.connect
+
+        def spy(path, *args, **kwargs):
+            opened.append(str(path))
+            return original(path, *args, **kwargs)
+
+        monkeypatch.setattr(conn_mod.sqlite3, "connect", spy)
+        getattr(cert, gate_name)(db_path=db_path)
+
+        others = {p for p in opened if p != str(db_path)}
+        assert not others, f"{gate_name} 이 db_path 외의 DB 를 열었다: {sorted(others)}"
+        assert opened, f"{gate_name} 이 아무 DB 도 안 열었다 — 경로를 안 탄 것"
+
+    def test_position_limit_sees_the_seeded_violation(self, db_path):
+        """경로가 실제로 데이터를 읽는지 — 열기만 하고 안 읽으면 위 테스트가 공허하다."""
+        from nuri.trading.engine import certification as cert
+
+        self._seed_violating_position(db_path)
+        cond = cert._check_position_limits(db_path=db_path)
+
+        assert cond.passed is False, f"단일 종목 100% 인데 통과했다: {cond.detail}"
+        assert "AAA" in cond.detail


### PR DESCRIPTION
#1049 turned on global test isolation, #1050 and #1051 threaded `db_path` into certify / analyze_risk / premarket_brief. This finishes that work and fixes a hole in how it was verified.

## What was wrong

**The guard tests never ran.** The three regression tests for the production-DB guard lived in `tests/conftest.py`. pytest imports conftest as a plugin but does not collect it as a test module — `python_files` defaults to `test_*.py`. They only ran when the file was named explicitly on the command line, which is exactly how they were "verified". `pytest tests/ --collect-only` found zero of them, so `make test-fast` and CI never executed the tests proving the guard bites.

**Thirteen call sites still read the default DB.** A `db_path` parameter guarantees nothing by itself. These functions accepted one and then called a DB reader with no argument:

| Site | Callee |
|---|---|
| `premarket_brief._collect_context` | `get_freshness_summary`, `detect_all` |
| `evidence_charts` (2 sites) | `analyze_portfolio` |
| `rebalance_advisor.detect_violations`, `sleeve.sleeve_utilization` | `analyze_portfolio` |
| `factors.quality`, `factors.value` | `get_tickers` |
| `certification` `_current_regime` / `_snapshot_portfolio` (+3 gate sites) | `_classify_regime_fresh`, `analyze_portfolio` |
| `candidates.screen_candidates`, `rebalance.regime_aware_rebalance` | `detect_conflicts` |

`_snapshot_portfolio_raw` already threaded `db_path`; its two siblings did not, so a gate called outside a `certify()` snapshot read the default DB. Inside `certify()` the snapshot ContextVar short-circuits the read, which is why #1050's tests passed.

## The verification gap this exposed

With all six certification wirings reverted, **611 tests in `tests/trading/engine` and `tests/llm` still passed**. The existing tests only exercise the in-snapshot path, where the wiring is dead code. `test_certify_db_path_isolation.py` gains a class for the out-of-snapshot gate path; four of its eight tests now fail when the wiring is reverted.

## The durable fix

`tests/core/test_db_path_forwarding.py` — an AST sweep that fails when a `db_path`-aware function calls a `db_path`-aware function without forwarding. Three escapes are closed, each measured at zero occurrences today (which is what makes closing them free):

- all three call shapes (`f()`, `mod.f()`, aliased import), not just plain names
- `**kwargs` / `*args` do **not** count as forwarding — `def f(db_path=None, **kw): g(**kw)` leaks when `kw` is empty
- bidirectional allowlist, so a stale entry fails too (same shape as `test_cross_stage_imports.py`)

## Codex review

Two rounds. Round 1 (on the merged #1049–#1051) found the uncollected guard tests and the `certification.py` sibling gap. Round 2 (on this branch) found two wrong allowlist entries and the `**kwargs` false negative — both fixed here.

The allowlist mistake is worth naming: `detect_conflicts(candidates)` looks like it avoids the DB, and that is what reading the top of the function suggested. `conflicts.py:145` calls `classify_regime(db_path=db_path)` unconditionally, well below the auto-fetch branch. Reading a function's first ten lines is not reading the function. Both surviving allowlist entries were re-verified end to end.

## Verification

- `pytest` — **7,010 passed**, 6 skipped
- `ruff check nuri tests` — clean
- `make verify-doc-counts` — 19/19
- Mutations verified: reverting `BaseException` → `Exception` fails 2 guard tests; neutering the guard fails 1; dropping the `DB_PATH` monkeypatch fails 2; dropping one `db_path=db_path` fails the sweep; a phantom allowlist entry fails the staleness check; rewriting a fixed site as `mod.f()` or an aliased call fails the sweep again; reverting the certification wiring fails 4 behavioral tests

## Out of scope

- `_build_actions` / `_build_opportunities` (`nuri/api/routes/actions.py`) and `emit_buy_candidates` take no `db_path` at all, so `premarket_brief` still mixes DBs for those three sections. Threading them means wiring whole subsystems.
- `make verify-doc-counts` checks the backend test **file** count but not the test count, so a stale `7,021 tests` claim passes the gate. Noticed while syncing docs here; not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)