### PR TITLE
docs: re-measure every stale timing claim and record the coingecko gotcha

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -16,7 +16,7 @@
 - Reactive: `make recommend` (BUY candidates + tracker) / `/nuri-thesis <T>` skill (`nuri/llm/thesis_query.py`) / `make earnings-preview ticker=<T>`
 - LLM consult dual-archive: `make llm-consult slug=<kebab> prompt=<file>`
 - Lint+Test: `make lint` / `make test-fast` / `.venv/bin/python -m pytest <path>::<test> -v`
-- Gates: `make verify-quick` (~10s pre-commit smoke) / `make verify-all` (~30s pre-push: tests + lint + frontend)
+- Gates: `make verify-quick` (pre-commit smoke, 84.9s) / `make verify-all` (pre-push: tests + lint + frontend, 320.8s) — M5 Max 2026-08-14. 어떤 게이트도 이 숫자를 검사하지 않으므로 조용히 낡는다(직전 값 `~10s`/`~30s` 는 실측의 1/8·1/10 이었다)
 - Deploy: `make start` (API :8001 + Dashboard :3000) / `make deploy-mini` (MBP → Mac mini 7단계 동기화)
 
 Frontend-only commands → `frontend/CLAUDE.md`.

--- a/.claude/skills/nuri-verify/SKILL.md
+++ b/.claude/skills/nuri-verify/SKILL.md
@@ -5,7 +5,7 @@ description: Pre-commit verification. Use when about to commit, asked to "verify
 
 # Verify Before Commit
 
-## Quick check (~10s, no network)
+## Quick check (84.9s, no network — M5 Max 2026-08-14)
 
 ```bash
 make verify-quick
@@ -20,7 +20,7 @@ make verify-all
 ## Manual checklist
 
 - [ ] `make lint` passes (ruff check)
-- [ ] `make test` passes (6,381 tests — integration 9건은 addopts 로 제외, xdist parallel)
+- [ ] `make test` passes (7,025 tests / 320 files — integration 9건은 addopts 로 제외, xdist parallel)
 - [ ] Numbers changed? → `grep -ri "old_value"` across CLAUDE.md, README.md, STRATEGY.md
 - [ ] New rule or threshold? → Added to `config/rules.yaml` or `config/agents.yaml`, not hardcoded
 - [ ] New feature? → "이 기능이 실패하면 어떻게 알 수 있는가?" 답할 것

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,14 @@ Rationale: an LLM has no live prices and no view of the user's cash flow, taxes,
 ```bash
 make setup                   # venv + deps + DB init
 make test                    # full pytest (xdist parallel)
-make test-fast               # exclude slow LLM tests (~24s, PR CI)
-make verify-quick            # ~10s pre-commit smoke
-make verify-all              # ~30s pre-push (tests + lint + frontend)
+make test-fast               # exclude the 27 slow-marked tests (81.2s, PR CI)
+make verify-quick            # pre-commit smoke (84.9s)
+make verify-all              # pre-push: tests + lint + frontend (320.8s)
 make start                   # API(:8001) + Dashboard(:3000)
 ```
+
+Timings: M5 Max, 2026-08-14. Nothing gates these numbers — `make verify-doc-counts`
+checks the backend test **file** count but not durations, the slow-marker count, or
+coverage, so they drift silently (all three above were stale until re-measured).
 
 Full make-target catalog: `CLAUDE.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ before proposing any non-trivial change.
 brew install ta-lib
 make setup                     # creates .venv, installs deps, initializes DB
 cd frontend && npm ci          # frontend deps
-make verify-quick              # ~10s smoke test (no network)
+make verify-quick              # smoke test, no network (84.9s on an M5 Max, 2026-08-14)
 ```
 
 ## The hard rules

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ make scan           # Daily swing scan (us_core, 85 tickers)
 make scan-extended  # Weekly swing scan (us_core + S&P 500 extension, 543 tickers)
 
 make test-fast      # backend, slow tests excluded
-make test           # full backend suite (adds 24 slow-marked tests)
+make test           # full backend suite (adds 27 slow-marked tests)
 make ci-cov         # combine CI shard artifacts — ground-truth coverage
 
 make verify-quick   # pre-commit smoke gate

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -5,8 +5,8 @@
 ## TL;DR — 매 push 전
 
 ```bash
-bash scripts/verify/pre_push_check.sh           # full (~2 min)
-bash scripts/verify/pre_push_check.sh --quick   # smoke (~30 s)
+bash scripts/verify/pre_push_check.sh           # full (106s)
+bash scripts/verify/pre_push_check.sh --quick   # smoke (6s)
 ```
 
 이 한 명령이 4 패턴을 잡는다:
@@ -22,7 +22,7 @@ bash scripts/verify/pre_push_check.sh --quick   # smoke (~30 s)
 
 | Script | 역할 | Quick mode |
 |---|---|---|
-| `scripts/dev/ci_local.sh` | CI parity (`pytest -n auto`, Linux-only flake catch) | `--quick` (~30s), `--lint` (~5s) |
+| `scripts/dev/ci_local.sh` | CI parity (`pytest -n auto`, Linux-only flake catch) | `--quick` (6.4s), `--lint` (0.05s — ruff is that fast) |
 | `scripts/verify/check_drift.py` | uncommitted vs committed 의존성 분석. 0/1-5/6-20/>20 severity band. | `--strict` (exit 1), `--silent` |
 | `scripts/verify/pre_push_check.sh` | drift + lint + tests + commit format 일괄 | `--quick`, `--skip-tests` |
 | `scripts/verify/check_atomic.sh` | multi-commit branch 각 commit 독립 검증 | `HEAD~3..HEAD` range |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -73,6 +73,33 @@ ThreadPoolExecutor caveat: `.result(timeout=)` cancels FUTURE only — underlyin
 | `obb.equity.estimates.price_target` | No | `benzinga` / `fmp` |
 | `obb.equity.ownership.*` | No | `fmp` |
 
+## 전면 실패는 빈 수집과 다르다 (#1043)
+
+수집기가 **모든 엔드포인트에서 실패**했는데 `[]` 를 반환하면, 보고할 게 없던 날과
+DB 기록이 **완전히 같아진다** — 둘 다 warning 만 남기고 `collector_runs.status` 는
+`finished` 다. coingecko 는 `rows_collected` 가 `run_step` 이 돌려주는 4-key dict 의
+길이라 **항상 4**여서, status 가 유일한 판별자인데 그게 성공이라고 말하고 있었다.
+
+전면 실패 시 **raise 한다.** 새 장치를 만드는 게 아니라 이미 있으면서 우회되던 것들을
+되살리는 것이다 — `base.py` 의 3회 재시도, `_send_failure_alert()` 의 `#ops` 알림,
+scheduler 의 `status="failed"` + `error_message`, `step_failed` 파이프라인 이벤트,
+`collector_health` 의 실패 집계.
+
+두 가지가 미묘하다:
+- 조건은 `len(errors) == 2` 가 아니라 **`errors and not records`** — 한쪽이 예외이고
+  다른 쪽이 빈 응답인 경우도 실패다. 반대로 **둘 다 200 인데 본문이 비면** 예외가
+  없어 `[]` 가 그대로 나간다. 그게 NO_DATA 의 정의다.
+- `errors[-1]` 이 아니라 **`errors[0]`** 을 올린다. 둘 다 실패하면 마지막은 항상
+  global 이라, price 의 429 가 알림 문구에서 사라지고 운영자가 엉뚱한 원인을 좇는다.
+
+**Test:** `tests/collectors/test_coingecko.py::TestCoinGeckoFailedVsNoData` —
+`test_total_api_failure_raises_instead_of_returning_empty` (raise 제거 시 FAIL) ·
+`test_empty_payload_is_not_a_failure` (조건을 `errors` 로 넓히면 FAIL) ·
+`test_first_error_is_raised_not_the_last` (`errors[0]`→`errors[-1]` 이면 FAIL).
+
+⚠️ **형제 결함 미해결 — #1042**: `cboe.py:81` 과 `fear_greed.py:39` 가 같은 모양이다.
+새 수집기를 쓰거나 기존 것을 고칠 때 이 구분이 서 있는지 먼저 볼 것.
+
 ## Macro Data Quirk
 
 `us_3m_yield` (FRED) is absent in yfinance fallback — `^IRX` (13-week T-Bill) is stored as `us_2y_yield`. `merge_macro_data()` queries `us_2y_yield` when `us_3m_yield` is empty.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,7 +86,7 @@ scripts/
 | `setup.sh` | venv + deps + DB init | `make setup` |
 | `start.sh` | API + Dashboard start | `make start` |
 | `demo.sh` | demo workflow run | `bash scripts/dev/demo.sh` |
-| `ci_local.sh` | local CI parity (~30s smoke / full) | `bash scripts/dev/ci_local.sh [--lint\|--quick]` |
+| `ci_local.sh` | local CI parity (6.4s smoke / full) | `bash scripts/dev/ci_local.sh [--lint\|--quick]` |
 | `codex_review.sh` | Codex CLI review wrapper | `bash scripts/dev/codex_review.sh` |
 | `install_hooks.sh` | git hooks install | `make setup-hooks` |
 | `llm_consult.py` | codex + local-LLM dual-archive consult | `make llm-consult slug=X prompt=path` |

--- a/scripts/dev/ci_local.sh
+++ b/scripts/dev/ci_local.sh
@@ -7,8 +7,8 @@
 #
 # Usage:
 #   bash scripts/ci_local.sh           # full backend test parity
-#   bash scripts/ci_local.sh --lint    # lint only (10s)
-#   bash scripts/ci_local.sh --quick   # smoke test (~30s)
+#   bash scripts/ci_local.sh --lint    # lint only (0.05s)
+#   bash scripts/ci_local.sh --quick   # smoke test (6.4s)
 
 set -euo pipefail
 

--- a/scripts/verify/pre_push_check.sh
+++ b/scripts/verify/pre_push_check.sh
@@ -8,8 +8,8 @@
 # 4. Massive uncommitted file count (>20 = high drift risk)
 #
 # Usage:
-#   bash scripts/pre_push_check.sh           # full check (~2 min)
-#   bash scripts/pre_push_check.sh --quick   # skip full test run (~30s)
+#   bash scripts/pre_push_check.sh           # full check (106s)
+#   bash scripts/pre_push_check.sh --quick   # skip full test run (6s)
 #   bash scripts/pre_push_check.sh --skip-tests   # lint + drift only
 
 set -euo pipefail
@@ -89,7 +89,7 @@ if [ "$mode" != "--skip-tests" ]; then
             fail=1
         fi
     else
-        echo -e "  ${YELLOW}Mode: full (~2 min, exact CI command)${NC}"
+        echo -e "  ${YELLOW}Mode: full (106s, exact CI command)${NC}"
         if bash scripts/dev/ci_local.sh; then
             echo -e "${GREEN}✓ Full test parity passed${NC}\n"
         else

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -37,7 +37,8 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 banner "Nuri-Quant System Verification"
 
-# 1. Tests (yfinance mocked via conftest.py → ~5s)
+# 1. Tests (yfinance mocked via conftest.py — 네트워크 없음. 287s, M5 Max 2026-08-14:
+#    이 단계는 xdist 없이 단일 프로세스라 `make test-fast`(81.2s)보다 느리다)
 echo ""; echo "━━━ 1/5. Unit Tests ━━━"
 tests_log="$tmpdir/unit_tests.log"
 if $PYTHON -m pytest tests/ -q --tb=line >"$tests_log" 2>&1; then


### PR DESCRIPTION
Follow-up to #1053. Checking whether the `.md` files were actually updated meant re-running the numbers instead of trusting them. **Nine claims across seven files were wrong**, several by an order of magnitude, and no gate covers any of them.

## Timings — all re-measured, M5 Max 2026-08-14

| Claim | Was | Measured |
|---|---|---|
| `make verify-quick` | ~10s | **84.9s** |
| `make verify-all` | ~30s | **320.8s** |
| `make test-fast` | ~24s | **81.2s** |
| `pre_push_check.sh` full | ~2 min | **106s** |
| `pre_push_check.sh --quick` | ~30s | **6s** |
| `ci_local.sh --quick` | ~30s | **6.4s** |
| `ci_local.sh --lint` | 10s / ~5s | **0.05s** — ruff really is that fast (cold cache 0.05s, warm 0.03s) |
| `verify_all.sh` step 1 | ~5s | **287s** — single process, no xdist |

## Counts

- `README.md` — "adds **24** slow-marked tests" → **27**. #1053 grepped for `"24 LLM"` and missed this line because the wording differs. Same defect, second pass.
- `.claude/skills/nuri-verify/SKILL.md` — "**6,381** tests" → **7,025 / 320 files**.

Shell header comments are fixed alongside the docs that quote them — `ci_local.sh`, `pre_push_check.sh`, and `verify_all.sh` are where those numbers originated, so leaving them would re-seed the drift.

## Gotcha-Test Pair that #1043 left open

`nuri/collectors/CLAUDE.md` had **no record** of why coingecko raises on total failure. Per §5.3.1 that makes it folklore — defensive code with no cited reason gets deleted a few sessions later. Two details are not self-evident from the code:

- the guard is `errors and not records`, not `len(errors) == 2`, so one endpoint erroring while the other returns an empty payload still counts as a failure — while two 200s with empty bodies raise nothing, which is the definition of NO_DATA
- it raises `errors[0]`, not the last error, because the last is always the global endpoint, so price's 429 would vanish from the alert and send the operator after the wrong cause

Now documented with its three locking tests (`TestCoinGeckoFailedVsNoData`, verified passing), plus a pointer to the unfixed siblings in **#1042** (`cboe.py:81`, `fear_greed.py:39`).

## Deliberately untouched

Retrospective time estimates (the "~120 min wasted" mapping in `DEVELOPER_GUIDE.md`), network-bound collection durations (`collect-universe ~15분`), and data-shape approximations (`~543 tickers`, `~40% of US universe`). Those are a different kind of claim than "this command takes N seconds" and measuring them is separate work.

## Verification

- `make verify-doc-counts` — 19/19
- `ruff check nuri tests` — clean
- `make lint-sh` (shellcheck) — clean
- Every cited test re-run: `TestCoinGeckoFailedVsNoData` 4 passed
- Docs and shell comments only; no code paths changed

## Standing gap

`make verify-doc-counts` passed at every point above. Its nine checks are `test_files_be/fe`, `collectors`, `db_tables`, `endpoints`, `migrations`, `regimes`, `rules_yaml_lines`, `scheduler_jobs` — **no timing, no slow count, no coverage, no test count**. That is why this drift accumulated silently across two doc-sync passes. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)