### PR TITLE
fix(ci): allow npm_and_yarn in the dependabot auto-merge policy

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -43,7 +43,17 @@ jobs:
               .map((name) => name.trim())
               .filter(Boolean);
 
-            const supportedEcosystems = new Set(["pip", "npm", "github-actions", "github_actions"]);
+            // ⚠️ 여기 들어가는 문자열은 `.github/dependabot.yml` 의 `package-ecosystem` 값이
+            // 아니라 fetch-metadata 가 내보내는 **dependabot 내부 이름**이다. npm 은
+            // `npm_and_yarn`, github-actions 는 `github_actions` 로 나온다.
+            // 잠금: tests/scripts/test_dependabot_automerge_policy.py
+            const supportedEcosystems = new Set([
+              "pip",
+              "npm",
+              "npm_and_yarn",
+              "github-actions",
+              "github_actions",
+            ]);
             const isGrouped = Boolean(dependencyGroup) || dependencyNames.length > 1;
 
             let shouldMerge = false;

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,025 collected across 320 files | |
+| **Backend tests** | 7,028 collected across 321 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,025 backend tests across 320 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,028 backend tests across 321 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,025 tests, 320 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,028 tests, 321 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/scripts/test_dependabot_automerge_policy.py
+++ b/tests/scripts/test_dependabot_automerge_policy.py
@@ -1,0 +1,99 @@
+"""Dependabot auto-merge 정책이 **실제로 설정된 생태계 전부**를 덮는지 잠근다.
+
+`.github/workflows/dependabot-auto-merge.yml` 의 허용 목록에 들어가는 문자열은
+`.github/dependabot.yml` 의 `package-ecosystem` 값이 **아니라** dependabot 내부 이름이다.
+`dependabot/fetch-metadata` 가 그 내부 이름을 그대로 출력하기 때문이다:
+
+| dependabot.yml    | fetch-metadata 출력 |
+|-------------------|---------------------|
+| `pip`             | `pip`               |
+| `npm`             | `npm_and_yarn`      |
+| `github-actions`  | `github_actions`    |
+
+허용 목록에는 워크플로 도입(#328) 이래 `"npm"` 만 있었다. 그래서 **모든 npm PR 이
+`unsupported ecosystem: npm_and_yarn` 으로 빠져 auto-merge 가 한 번도 켜진 적이 없다.**
+실측 근거는 2026-08-17 의 5개 PR(#1055~#1059) 잡 로그 — 다섯 개 전부 `Skip notice` 로
+끝났고, 같은 기간 `github_actions` 그룹 PR(#881)만 `app/github-actions` 가 머지했다.
+
+이 결함이 조용했던 이유는 **잡이 성공으로 끝나기 때문**이다. 정책이 "머지 안 함"으로
+판정하면 워크플로는 안내 문구만 찍고 exit 0 한다 — 체크는 green 이고 auto-merge 만 없다.
+`.claude/rules/enforcement.md` 가 말하는 *green dead gate* 의 세 번째 사례다.
+
+비용은 조용함에서 그치지 않는다: `.github/dependabot.yml` 의 `open-pull-requests-limit: 5`
+때문에 머지되지 않은 PR 이 5개까지 쌓이면 dependabot 이 **새 PR 을 아예 열지 않는다** —
+프론트엔드 보안 업데이트가 그 시점부터 막힌다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+AUTOMERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "dependabot-auto-merge.yml"
+
+# dependabot.yml 의 `package-ecosystem` → fetch-metadata 가 내보내는 내부 이름.
+# 새 생태계를 dependabot.yml 에 추가하면 여기에도 등재해야 한다 (미등재 시 아래
+# `test_every_configured_ecosystem_is_mapped` 가 FAIL — 조용히 통과하지 않는다).
+METADATA_NAME = {
+    "pip": "pip",
+    "npm": "npm_and_yarn",
+    "github-actions": "github_actions",
+}
+
+
+def _configured_ecosystems() -> set[str]:
+    config = yaml.safe_load(DEPENDABOT_CONFIG.read_text())
+    return {entry["package-ecosystem"] for entry in config["updates"]}
+
+
+def _allowlisted_ecosystems() -> set[str]:
+    """워크플로의 `supportedEcosystems` 집합 리터럴을 읽는다.
+
+    YAML 로 파싱해도 정책 본문은 `script:` 아래의 통짜 JS 문자열이라 어차피 텍스트에서
+    꺼내야 한다. 집합이 비어 파싱되면 호출부 단언이 전부 FAIL 하므로 공허하게 통과하지
+    않는다.
+    """
+    source = AUTOMERGE_WORKFLOW.read_text()
+    match = re.search(r"supportedEcosystems\s*=\s*new Set\(\[(.*?)\]\)", source, re.DOTALL)
+    assert match, "`supportedEcosystems = new Set([...])` 리터럴을 못 찾았다 — 정책이 옮겨졌나?"
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+class TestAutoMergeCoversEveryConfiguredEcosystem:
+    def test_every_configured_ecosystem_is_mapped(self):
+        """카나리아 — 새 생태계를 추가하고 매핑을 빠뜨리면 아래 테스트가 그걸 못 본다."""
+        unmapped = _configured_ecosystems() - set(METADATA_NAME)
+        assert not unmapped, (
+            f"dependabot.yml 에 있는데 METADATA_NAME 에 없는 생태계: {sorted(unmapped)}\n"
+            "fetch-metadata 가 그 생태계를 뭐라고 내보내는지 확인하고 등재할 것."
+        )
+
+    def test_allowlist_contains_the_metadata_name_of_each_ecosystem(self):
+        """Gotcha-Test Pair: `npm_and_yarn` 을 빼면 FAIL.
+
+        `"npm"` 만 남기는 것이 정확히 #328~#1059 동안의 상태였고, 그 상태에서 npm
+        auto-merge 는 영영 켜지지 않는다.
+        """
+        allowlisted = _allowlisted_ecosystems()
+        missing = {
+            ecosystem: METADATA_NAME[ecosystem]
+            for ecosystem in _configured_ecosystems()
+            if METADATA_NAME[ecosystem] not in allowlisted
+        }
+        assert not missing, (
+            "auto-merge 허용 목록에 빠진 생태계: "
+            + ", ".join(f"{k} → {v!r}" for k, v in sorted(missing.items()))
+            + f"\n현재 허용 목록: {sorted(allowlisted)}\n"
+            "빠지면 해당 생태계 PR 은 `unsupported ecosystem` 으로 조용히 스킵된다 "
+            "(잡은 성공하므로 체크는 green)."
+        )
+
+    def test_the_config_actually_declares_ecosystems(self):
+        """카나리아 — dependabot.yml 파싱이 빈 집합을 내면 위 두 테스트가 공허해진다."""
+        configured = _configured_ecosystems()
+        assert len(configured) >= 3, f"dependabot.yml 에서 읽어낸 생태계가 {configured} 뿐이다"


### PR DESCRIPTION
## 왜

`dependabot/fetch-metadata` 는 npm 생태계를 dependabot **내부 이름**인 `npm_and_yarn` 으로
내보낸다. 그런데 `dependabot-auto-merge.yml` 의 허용 목록에는 `.github/dependabot.yml` 의
설정값 `"npm"` 만 들어 있었다. 그래서 **모든 npm dependabot PR 이 `unsupported ecosystem`
으로 빠져 auto-merge 가 한 번도 켜진 적이 없다** — 워크플로가 들어온 #328 이래 계속.

정책이 "머지 안 함"으로 판정하면 워크플로는 안내 문구만 찍고 exit 0 한다. 체크는 green 이고
auto-merge 만 없다. `.claude/rules/enforcement.md` 가 말하는 *green dead gate* 다.

비용은 조용함에서 그치지 않는다: `open-pull-requests-limit: 5` 라 머지되지 않은 PR 이 5개
쌓이면 dependabot 이 **새 PR 을 아예 열지 않는다**. 프론트엔드 보안 업데이트가 그 시점부터
막힌다 — 오늘 #1055~#1059 를 손으로 비우기 직전이 정확히 그 상태였다.

## 근거 (실측)

- #1059 잡 로그: `Auto-merge not enabled: unsupported ecosystem: npm_and_yarn`
- 머지 이력: npm PR 은 전부 사람 계정이 머지, 그룹 github_actions PR #881 만 `app/github-actions` 가 머지
- `git log --follow`: `supportedEcosystems` 는 #328 도입 후 한 번도 바뀐 적 없음
- Codex(gpt-5.4) 독립 확인: fetch-metadata 의 `update_metadata.ts` 가 dependabot 브랜치
  세그먼트에서 값을 도출하며 소스에 `dependabot/npm_and_yarn` 예시가 있다. README 쪽
  설명(설정값과 같다는 서술)이 오래된 것

## 무엇

- `supportedEcosystems` 에 `npm_and_yarn` 추가. `github-actions`/`github_actions` 를 둘 다
  두는 기존 방식대로 `npm` 도 남긴다. 왜 설정값이 아니라 내부 이름인지 인라인 주석으로 못박음
- 회귀 테스트 `tests/scripts/test_dependabot_automerge_policy.py` (3개) — `.github/dependabot.yml`
  의 생태계 3종을 읽어 각각의 metadata 이름이 허용 목록에 있는지 검사. 새 생태계를 추가하고
  매핑을 빠뜨리면 FAIL 하는 카나리아, 파싱이 빈 집합을 내면 FAIL 하는 카나리아 포함
- 문서 카운트 320 -> 321 파일 / 7,025 -> 7,028 테스트 (`make sync-doc-counts`, 손으로 안 고침)

## 검증

- 뮤테이션 실측: `npm_and_yarn` 을 빼면 `test_allowlist_contains_the_metadata_name_of_each_ecosystem` 1건 FAIL
- `make test-fast` 6,995 passed / 6 skipped
- `make verify-doc-counts` 19/19
- `check_privacy_leak.py` (인자 없이, CI 와 동일한 diff 스캔) clean
- `/codex review` **GATE: PASS** — [P1] 0건

## Codex [P2] 2건 — 스코프 밖으로 두고 기록만

1. **테스트가 구조적이다.** 집합 리터럴만 보므로, 리터럴은 그대로 두고 `PACKAGE_ECOSYSTEM`
   배선이나 `supportedEcosystems.has(ecosystem)` 호출을 깨는 리팩터는 못 잡는다. 행동 검증은
   inline JS 를 node 로 실행해야 하는데, 백엔드 pytest 잡에 node 의존을 넣으면 없을 때
   조용히 skip 되는 *또 다른* dead gate 가 된다. 이번 결함(문자열 불일치)은 구조 검사와
   정확히 같은 범위라 판단해 여기서 멈춘다
2. **정책 노출.** 이게 켜지면 npm patch / grouped-minor PR 이 사람 리뷰 없이 squash 머지된다.
   CI 필수 체크 10개는 통과해야 하지만, API 호환인 악성 릴리스는 그걸 다 통과할 수 있다.
   이건 버그가 아니라 워크플로가 원래 의도한 정책이고, 이번에 npm 에도 실제로 적용되는 것뿐
   — 사용자가 인지하고 선택했다

🤖 Generated with [Claude Code](https://claude.com/claude-code)