### PR TITLE
fix(make): correct the verify tier runtimes and the false fastest-first order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 	@echo ""
 	@echo "  Setup:        make setup"
 	@echo "  Test/Lint:    make test, make test-fast, make lint, make lint-fix, make lint-sh"
-	@echo "  Verify:       make verify-help    (verify-quick → verify-all → verify-fast → verify, fastest first)"
+	@echo "  Verify:       make verify-help    (4 tiers — 사다리가 아니라 서로 다른 것을 본다. 목적으로 고를 것)"
 	@echo "  Data:         make collect, make collect-kis, make wallstreet, make filings"
 	@echo "  Universe:     make universe-sync[-us/-kr/-apply], make collect-universe[-1y], make validate-universe"
 	@echo "  Universe gen: make kr-names (KR 종목명 캐시), make cspell-tickers (cSpell 사전) — sync-apply 가 자동 체이닝"
@@ -47,14 +47,15 @@ help:
 
 verify-help:
 	@printf '\n'
-	@printf '  \033[1;36mNuri-Quant verify tiers\033[0m — pick the cheapest one that satisfies your need\n'
+	@printf '  \033[1;36mNuri-Quant verify tiers\033[0m — 네 티어는 서로 다른 것을 본다. 목적으로 고를 것\n'
 	@printf '\n'
 	@printf '  \033[1m%-14s %-9s %s\033[0m\n' 'TIER' 'RUNTIME' 'WHAT IT DOES'
 	@printf '  \033[2m%s\033[0m\n' '──────────────────────────────────────────────────────────────────'
-	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify-quick' '~10s'  'pytest + regime classifier (no network)'
-	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify-all'   '~30s'  'tests + backend + frontend + file integrity'
-	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify-fast'  '~2min' 'scripts/verify/verify.py --skip-backtest'
-	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify'       '~5min' 'scripts/verify/verify.py (full backtest run)'
+	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify-quick' '84.9s' 'pytest + regime classifier (no network)'
+	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify-fast'  '127s'  'scripts/verify/verify.py --skip-backtest'
+	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify'       '213s'  'scripts/verify/verify.py (full backtest run)'
+	@printf '  \033[36m%-14s\033[0m \033[33m%-9s\033[0m %s\n' 'verify-all'   '320.8s' 'tests + backend + frontend + file integrity'
+	@printf '  \033[2m%s\033[0m\n' 'M5 Max 실측 — quick/all 2026-08-14, fast/verify 2026-08-17. 각 1회'
 	@printf '\n'
 	@printf '  \033[1mWhen to use:\033[0m\n'
 	@printf '    Pre-commit   →  \033[36mmake verify-quick\033[0m\n'
@@ -238,17 +239,17 @@ verify-universe-sync: ## Smoke test universe-sync targets — catches real API b
 
 # Verify tiers — fastest to slowest. See `make verify-help` for the full table.
 
-verify-quick:    ## ~10s pre-commit smoke test (pytest + regime, no network)
+verify-quick:    ## pre-commit smoke test — pytest + regime, no network (84.9s)
 	$(PYTHON) -m pytest tests/ -q --tb=line -n auto --dist worksteal
 	$(PYTHON) -c "from nuri.core.db import query; from nuri.quant.regime.classifier import classify_regime; r=classify_regime(); print(f'Quick: tests + Regime {r.regime if r else \"N/A\"}')"
 
-verify-all:      ## ~30s pre-push (tests + backend + frontend + file integrity)
+verify-all:      ## pre-push — tests + backend + frontend + file integrity (320.8s, 네 티어 중 가장 느리다)
 	bash scripts/verify/verify_all.sh
 
-verify-fast:     ## ~2min pre-deploy (verify.py without backtest)
+verify-fast:     ## pre-deploy — verify.py without backtest (127s)
 	$(PYTHON) scripts/verify/verify.py --skip-backtest
 
-verify:          ## ~5min pre-release (verify.py full, includes backtest)
+verify:          ## pre-release — verify.py full, includes backtest (213s)
 	$(PYTHON) scripts/verify/verify.py
 
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,028 collected across 321 files | |
+| **Backend tests** | 7,032 collected across 322 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,028 backend tests across 321 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,032 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,028 tests, 321 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,032 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/scripts/test_verify_tier_timings_agree.py
+++ b/tests/scripts/test_verify_tier_timings_agree.py
@@ -1,0 +1,151 @@
+"""`make verify-*` 티어의 소요 시간 클레임이 **모든 표기 지점에서 같은 수를 말하는지** 잠근다.
+
+이 수치들은 어떤 게이트도 검사하지 않아서 조용히 낡는다 — `.claude/rules/architecture.md`
+가 그 사실을 본문에 적어두기까지 했다. 실제로 #1054 가 아홉 개 클레임을 재측정해 일곱 개
+`.md` 파일을 고쳤는데 **`Makefile` 은 sweep 에 없었다.** 그래서 문서는 `84.9s`/`320.8s`
+를 말하는 동안 `make verify-help` 와 `make help` 는 `~10s`/`~30s` 를 계속 출력했다 —
+실측의 1/9·1/11 이고, 하필 개발자가 실제로 읽는 쪽이 틀린 값이었다.
+
+한 파일만 고치고 나머지를 잊는 것이 이 결함의 유일한 발생 형태다. 그래서 여기서 잠그는
+것은 "값이 정확한가"(기계가 알 수 없다)가 아니라 **"모든 지점이 서로 같은가"** 다.
+재측정하면 전 지점을 같이 옮겨야 하고, 한 곳만 옮기면 FAIL 한다.
+
+정본은 `.claude/rules/architecture.md` — 항상 로드되는 rules 파일이라 여기가 어긋나면
+에이전트가 먼저 틀린다.
+
+`verify-fast` / `verify` 는 `.md` 정본이 없고 `Makefile` 안에만 두 번(도움말 표 + `##`
+주석) 나오므로, 그 둘이 서로 일치하는지만 본다 — 반쪽 수정을 잡는 데는 그걸로 충분하다.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+MAKEFILE = REPO_ROOT / "Makefile"
+CANONICAL = REPO_ROOT / ".claude" / "rules" / "architecture.md"
+
+# `84.9s` 는 잡고 `%-9s` / `%-14s` (printf 형식 지정자) 와 `~10s` (역사적 서술로 남긴
+# 옛 값)는 잡지 않는다. 앞 문자가 `%` `-` `~` `.` 또는 단어 문자면 배제.
+_SECONDS = r"(?<![%\w.~-])(\d+(?:\.\d+)?)s\b"
+
+
+def _find(path: Path, pattern: str) -> list[str]:
+    return re.findall(pattern, path.read_text())
+
+
+# 정본 두 값을 architecture.md 한 줄에서 뽑는다.
+_CANONICAL_LINE = re.compile(r"`make verify-quick`[^/]*?" + _SECONDS + r"[^/]*?/[^`]*?`make verify-all`.*?" + _SECONDS)
+
+# 등재된 표기 지점. (파일, 그 파일에서 해당 티어의 초 값을 뽑는 정규식).
+# 새 지점을 추가하면 아래 `test_no_unregistered_site` 가 등재를 요구한다.
+SITES: dict[str, list[tuple[Path, str]]] = {
+    "verify-quick": [
+        (REPO_ROOT / "AGENTS.md", r"make verify-quick\s+#[^\n]*?" + _SECONDS),
+        (REPO_ROOT / "CONTRIBUTING.md", r"make verify-quick\s+#[^\n]*?" + _SECONDS),
+        (REPO_ROOT / ".claude/skills/nuri-verify/SKILL.md", r"## Quick check \(" + _SECONDS),
+        (MAKEFILE, r"'verify-quick'\s+'" + _SECONDS + r"'"),
+        (MAKEFILE, r"^verify-quick:[^\n]*?\(" + _SECONDS + r"\)"),
+    ],
+    "verify-all": [
+        (REPO_ROOT / "AGENTS.md", r"make verify-all\s+#[^\n]*?" + _SECONDS),
+        (MAKEFILE, r"'verify-all'\s+'" + _SECONDS + r"'"),
+        (MAKEFILE, r"^verify-all:[^\n]*?\(" + _SECONDS + r"[,)]"),
+    ],
+}
+
+# `.md` 정본이 없어 Makefile 안에서만 교차 검증하는 티어.
+MAKEFILE_ONLY = {
+    "verify-fast": (r"'verify-fast'\s+'" + _SECONDS + r"'", r"^verify-fast:[^\n]*?\(" + _SECONDS + r"\)"),
+    "verify": (r"'verify'\s+'" + _SECONDS + r"'", r"^verify:[^\n]*?\(" + _SECONDS + r"\)"),
+}
+
+
+def _canonical() -> dict[str, str]:
+    m = _CANONICAL_LINE.search(CANONICAL.read_text())
+    assert m, (
+        f"{CANONICAL.relative_to(REPO_ROOT)} 에서 verify-quick/verify-all 정본 수치를 못 찾았다 — "
+        "형식이 바뀌었으면 이 테스트의 _CANONICAL_LINE 도 같이 고칠 것"
+    )
+    return {"verify-quick": m.group(1), "verify-all": m.group(2)}
+
+
+class TestEverySiteQuotesTheSameNumber:
+    def test_canonical_is_parseable(self):
+        """카나리아 — 정본 파싱이 깨지면 아래 비교가 통째로 공허해진다."""
+        canonical = _canonical()
+        assert canonical["verify-quick"] and canonical["verify-all"]
+        assert canonical["verify-quick"] != canonical["verify-all"], (
+            "두 티어가 같은 수일 리 없다 — 정규식이 한 값을 두 번 잡았다"
+        )
+
+    def test_every_registered_site_matches_canonical(self):
+        """Gotcha-Test Pair: 한 지점만 고치면 FAIL.
+
+        #1054 가 `.md` 일곱 개를 고치고 `Makefile` 을 빼먹은 것이 정확히 이 형태다.
+        """
+        canonical = _canonical()
+        mismatches = []
+        for tier, sites in SITES.items():
+            for path, pattern in sites:
+                found = re.findall(pattern, path.read_text(), re.MULTILINE)
+                rel = path.relative_to(REPO_ROOT)
+                if not found:
+                    mismatches.append(f"{rel}: `{tier}` 표기를 못 찾음 (지점이 사라졌거나 형식이 바뀜)")
+                elif any(v != canonical[tier] for v in found):
+                    mismatches.append(f"{rel}: `{tier}` = {found} 인데 정본은 {canonical[tier]}")
+        assert not mismatches, (
+            "verify 티어 수치가 지점마다 다르다:\n  " + "\n  ".join(mismatches) + "\n"
+            f"정본: {CANONICAL.relative_to(REPO_ROOT)}. 재측정했다면 전 지점을 같이 옮길 것."
+        )
+
+    def test_makefile_only_tiers_are_internally_consistent(self):
+        """`verify-fast` / `verify` 는 Makefile 안 두 곳이 서로 맞아야 한다."""
+        text = MAKEFILE.read_text()
+        for tier, (table_re, comment_re) in MAKEFILE_ONLY.items():
+            table = re.findall(table_re, text, re.MULTILINE)
+            comment = re.findall(comment_re, text, re.MULTILINE)
+            assert table, f"Makefile 도움말 표에서 `{tier}` 수치를 못 찾음"
+            assert comment, f"Makefile `##` 주석에서 `{tier}` 수치를 못 찾음"
+            assert table[0] == comment[0], f"`{tier}`: 도움말 표는 {table[0]}, `##` 주석은 {comment[0]} — 반쪽만 고쳤다"
+
+    def test_no_unregistered_site(self):
+        """카나리아 — 새 표기 지점이 생기면 SITES 에 등재될 때까지 FAIL.
+
+        등재를 강제하지 않으면 다음 재측정이 또 한 곳을 빠뜨리고, 이 테스트는
+        모르는 채 초록으로 통과한다.
+        """
+        canonical = _canonical()
+        # `s` 를 붙여서 찾는다 — 맨숫자로 찾으면 무관한 파일의 우연한 `84.9`
+        # (thesis 프롬프트의 예시 수치 등)까지 걸려 오탐만 만든다.
+        needle = canonical["verify-quick"] + "s"
+        tracked = subprocess.run(
+            ["git", "grep", "-lF", "--", needle],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.split()
+        # 제외 둘: 정본 파일(값의 출처라 당연히 등장)과 이 테스트 파일 자신
+        # (docstring 이 결함 서술로 값을 인용한다). 둘 다 "표기 지점"이 아니다.
+        #
+        # ⚠️ `git grep` 은 **추적되는 파일만** 본다. 그래서 이 테스트를 커밋 전에
+        # 돌리면 자기 자신이 안 잡혀 초록이고, 커밋 직후 빨개진다 — 실제로 그렇게
+        # 밟았다. 새 파일을 등재 목록에 넣을 땐 `git add` 후에 확인할 것.
+        excluded = {
+            str(CANONICAL.relative_to(REPO_ROOT)),
+            str(Path(__file__).resolve().relative_to(REPO_ROOT)),
+        }
+        tracked = [f for f in tracked if f not in excluded]
+        registered = {str(p.relative_to(REPO_ROOT)) for p, _ in SITES["verify-quick"]}
+        unregistered = set(tracked) - registered
+        assert not unregistered, (
+            f"`{needle}` 를 말하는데 SITES 에 없는 파일: {sorted(unregistered)}\n"
+            "새 표기 지점은 등재할 것 — 안 그러면 다음 재측정이 여길 빠뜨려도 아무도 모른다."
+        )
+        assert registered <= set(tracked), (
+            f"SITES 에 등재됐는데 실제로는 그 값을 안 쓰는 파일: {sorted(registered - set(tracked))}"
+        )


### PR DESCRIPTION
## 왜

#1054 가 낡은 timing 클레임 아홉 개를 재측정해 `.md` 일곱 개를 고쳤는데 **`Makefile` 은 그
sweep 에 없었다.** 결과: 문서는 `84.9s`/`320.8s` 를 말하는 동안 `make verify-help` 와
`make help` 는 `~10s`/`~30s` 를 계속 출력했다. 실측의 **1/9·1/11** 이고, 하필 개발자가
실제로 읽는 쪽이 틀린 값이었다.

## 재측정이 드러낸 두 번째 문제 — 순서 주장이 거짓

`verify-fast`/`verify` 는 애초에 실측된 적이 없어 같이 쟀다. M5 Max 2026-08-17, 각 1회:

| 티어 | 표기였던 값 | 실측 |
|---|---|---|
| `verify-quick` | `~10s` | **90s** (정본 84.9s 유효) |
| `verify-fast` | `~2min` | **127s** |
| `verify` | `~5min` | **213s** |
| `verify-all` | `~30s` | **337s** (정본 320.8s 유효) |

표 머리말은 "pick the cheapest one" 이라 하고 `make help` 는 "fastest first" 라고 적혀
있었는데 **둘 다 사실이 아니다.** `verify-all` 이 네 티어 중 **가장 느리고**, `verify` 는
자기보다 싼 사촌으로 소개된 `verify-fast` 보다 느릴 뿐 `verify-all` 보다는 빠르다. 이들은
비용 사다리가 아니라 **서로 다른 것을 보는** 티어다. 머리말을 그렇게 고치고 행을 실제
소요 시간 순으로 정렬했다.

## 정본 두 값은 왜 안 바꿨나

90s vs 84.9s, 337s vs 320.8s 는 1회 측정 편차지 드리프트가 아니다. 굳이 갈아끼우면 같은
대상에 두 개의 수가 레포에 남는데, 그 split-brain 을 없애는 게 이 PR 의 목적이다. 정본이
없던 두 티어에만 새 값을 넣었다. 내 재측정은 정본을 **확인**한 것이지 교체 대상이 아니다.

## 잠금

한 파일만 고치고 나머지를 잊는 것이 이 결함의 유일한 발생 형태라, 잠그는 대상은 "값이
정확한가"(기계가 알 수 없다)가 아니라 **"모든 지점이 서로 같은가"** 다.
`.claude/rules/architecture.md` 가 정본이고, 나머지 지점(AGENTS.md · CONTRIBUTING.md ·
nuri-verify SKILL.md · Makefile 2곳)은 같은 수를 말해야 한다. 미등재 지점이 새로 생기면
등재할 때까지 FAIL 한다 — 안 그러면 다음 재측정이 또 한 곳을 빠뜨려도 조용히 초록이다.

`verify-fast`/`verify` 는 `.md` 정본이 없어 Makefile 안 두 곳(도움말 표 ↔ `##` 주석)의
상호 일치만 본다.

### 뮤테이션 실측 5종 — 전부 FAIL 확인

| # | 뮤테이션 | 결과 |
|---|---|---|
| M1 | Makefile 표를 `~10s` 로 되돌림 (= #1054 가 남긴 바로 그 상태) | FAIL |
| M2 | `verify-fast` 를 표에서만 변경 (반쪽 수정) | FAIL |
| M3 | 정본만 재측정하고 나머지 방치 | FAIL |
| M4 | 미등재 파일에 새 표기 추가 | FAIL |
| M5 | 등재된 지점을 삭제 | FAIL |

baseline 4 passed.

## Gotcha — `git grep` 은 추적 파일만 본다

`test_no_unregistered_site` 를 **커밋 전**에 돌리면 자기 자신(docstring 이 값을 인용)이
untracked 라 안 잡혀 초록이고, 커밋 직후 빨개진다. 실제로 그렇게 밟아서 주석에 남겼다.

## 검증

- `make verify-doc-counts` 19/19
- `pytest tests/scripts/` 486 passed
- ruff check + format clean
- `check_privacy_leak.py` (인자 없이 = CI 와 동일한 diff 스캔) clean
- `make verify-help` / `make help` 렌더링 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)