### PR TITLE
fix(verify): point ROOT at the repo root so reports stay inside gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,032 collected across 322 files | |
+| **Backend tests** | 7,034 collected across 322 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,032 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,034 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,032 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,034 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/verify/verify.py
+++ b/scripts/verify/verify.py
@@ -16,8 +16,9 @@ Nuri-Quant 기능 검증 스크립트 — 모든 분석을 실행하고 결과�
   └── summary.txt                  # 전체 요약
 
 사용법:
-    python scripts/verify.py
-    python scripts/verify.py --skip-backtest   # 백테스트 제외 (빠르게)
+    python scripts/verify/verify.py
+    python scripts/verify/verify.py --skip-backtest   # 백테스트 제외 (빠르게)
+    make verify / make verify-fast
 """
 
 import argparse
@@ -27,8 +28,13 @@ import sys
 import traceback
 from pathlib import Path
 
-# 프로젝트 루트를 path에 추가
-ROOT = Path(__file__).parent.parent
+# 프로젝트 루트를 path에 추가.
+# `parents[2]` 인 이유: 이 파일은 `<root>/scripts/verify/verify.py` 라 두 단계로는
+# `scripts/` 에서 멈춘다. 예전 위치가 `scripts/verify.py` 였고 옮길 때 이 줄이 같이
+# 안 따라왔다. 그래서 리포트가 `scripts/data/reports/` 로 나갔는데, `data/reports/`
+# 와 달리 거기는 gitignore 가 안 걸려 실보유 종목·수량·손익이 담긴 CSV 가 untracked
+# 로 노출됐다 (#1062).
+ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
 logging.basicConfig(

--- a/tests/test_gitignore_covers_private_derivatives.py
+++ b/tests/test_gitignore_covers_private_derivatives.py
@@ -17,9 +17,13 @@ diff 에 없으므로 이 계열을 못 잡는다 — 방어선이 gitignore 하
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
+from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # 사람이/도구가 실제로 만드는 파생 이름들. 전부 무시돼야 한다.
 MUST_BE_IGNORED = [
@@ -66,3 +70,54 @@ def test_private_file_and_its_derivatives_are_ignored(path):
 def test_shared_config_stays_trackable(path):
     """차단 범위를 넓히다 공유돼야 할 파일까지 삼키면 안 된다."""
     assert not _is_ignored(path), f"{path} 는 추적돼야 하는데 gitignore 가 삼켰다"
+
+
+class TestWritersAimInsideTheIgnoredArea:
+    """위 테스트들은 **알려진 경로**가 막히는지 본다. 이건 반대쪽이다 —
+    **쓰는 쪽이 막힌 경로를 겨누고 있는지** (#1062).
+
+    `scripts/verify/verify.py` 는 `ROOT = Path(__file__).parent.parent` 로 루트를
+    잡았는데, 파일이 `scripts/verify.py` 에서 `scripts/verify/verify.py` 로 옮겨질 때
+    이 줄이 안 따라왔다. `ROOT` 가 `scripts/` 로 해소돼 리포트가
+    `scripts/data/reports/<date>/` 에 쌓였다 — `data/reports/` 와 달리 gitignore 가
+    안 걸리는 자리다.
+
+    그 리포트에 실보유 데이터가 있다. `portfolio.csv` 는
+    `account,ticker,...,quantity,avg_price,...,pnl_usd,pnl_pct` 를 담고,
+    `check_privacy_leak.py` 를 겨누면 증권사명+종목+손익을 줄 단위로 잡아낸다
+    (2026-08-17, 17개 파일 실측). `git add -A` 한 번이면 public repo 로 나간다.
+
+    gitignore 목록을 아무리 늘려도 이 형태는 못 잡는다 — 목록에 **없는** 경로로
+    쓰는 게 결함이기 때문이다. 그래서 writer 가 계산한 경로 자체를 본다.
+    """
+
+    def test_verify_report_dir_is_gitignored(self):
+        """Gotcha-Test Pair: `parents[2]` 를 `parent.parent` 로 되돌리면 FAIL."""
+        root = _verify_module().ROOT
+        report_dir = Path(root) / "data" / "reports"
+        rel = Path(report_dir).resolve().relative_to(REPO_ROOT)
+        assert _is_ignored(f"{rel}/2026-01-01/portfolio.csv"), (
+            f"verify.py 가 리포트를 {rel}/ 에 쓰는데 gitignore 가 거길 안 막는다 — "
+            "실보유 종목·수량·손익 CSV 가 untracked 로 노출된다.\n"
+            "gitignore 에 그 경로를 추가하지 말 것 — verify.py 의 ROOT 를 고칠 것 (#1062)."
+        )
+
+    def test_verify_root_is_the_repo_root(self):
+        """카나리아 — 위 테스트는 `ROOT` 가 엉뚱해도 그 아래가 우연히 ignore 되면 통과한다."""
+        assert Path(_verify_module().ROOT).resolve() == REPO_ROOT, (
+            f"verify.py ROOT = {_verify_module().ROOT} (기대: {REPO_ROOT})"
+        )
+
+
+def _verify_module():
+    """`scripts/verify/verify.py` 를 패키지 밖에서 로드한다 (스크립트라 import 경로가 없다).
+
+    모듈 레벨 부작용은 `sys.path.insert` 와 `logging.basicConfig` 둘뿐이고, 무거운
+    `nuri` import 는 전부 함수 안이라 로드가 싸다.
+    """
+    path = REPO_ROOT / "scripts" / "verify" / "verify.py"
+    spec = importlib.util.spec_from_file_location("_verify_under_test", path)
+    assert spec and spec.loader, f"{path} 를 로드할 수 없다"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
Closes #1062

## 무엇이 새고 있었나

`make verify` / `make verify-fast` 가 리포트를 `data/reports/<date>/` 가 아니라
**`scripts/data/reports/<date>/`** 에 썼다. `.gitignore:171` 은 앞엣것만 막는다. 뒤엣것은
아무것도 안 막는다.

거기 떨어진 17개 파일 중 `portfolio.csv` 의 헤더:

```
account,ticker,sector,quantity,avg_price,current_price,currency,
current_value_usd,cost_basis_usd,pnl_usd,pnl_pct,price_date,weight_pct
```

`check_privacy_leak.py` 를 그 파일에 겨누면 **증권사명 + 종목 + 손익** 조합을 줄 단위로
잡아낸다. `git add -A` 한 번이면 public repo 로 들어간다. (발견 즉시 로컬에서 제거함.)

## 원인

```python
ROOT = Path(__file__).parent.parent   # -> <root>/scripts
```

이 파일은 예전에 `scripts/verify.py` 였다. `scripts/verify/verify.py` 로 옮길 때 부모
개수가 안 따라와서 `ROOT` 가 `scripts/` 로 해소된다. 같은 off-by-one 이
`sys.path.insert(0, str(ROOT))` 도 망가뜨렸지만 — venv 에 `nuri` 가 설치돼 있어
`import nuri` 가 어차피 되므로 조용했다.

## 두 번째 방어선은 남아 있었다 (그래서 아무도 몰랐다)

pre-push 와 CI `privacy-scan` 은 diff 를 본다. 그래서 커밋을 시도하면 막혔을 **가능성이
높다.** 하지만 `data/reports/` 를 gitignore 한 목적은 이것들이 **애초에 git 시야에 안
들어오게** 하는 것이고, 그 1차 방어선이 통째로 우회되고 있었다.

`scripts/data/` 를 gitignore 에 추가하는 방식은 **택하지 않았다** — 잘못된 경로를
정당화할 뿐이다. #996 과 같은 계열이다: 그때는 `*.bak-<timestamp>` 가 다들 막혔다고
믿은 패턴에서 한 칸 옆으로 샜다.

## 잠금 — 질문을 뒤집는다

기존 `tests/test_gitignore_covers_private_derivatives.py` 는 "이 **알려진 경로**가 ignore
되는가"를 묻는다. 목록을 아무리 늘려도 이번 형태는 못 잡는다. **아무도 목록에 안 넣은
경로로 writer 가 쓰는 것**이 결함이기 때문이다.

그래서 같은 파일에 반대쪽 질문을 추가했다: **verify.py 가 실제로 계산하는 경로**가
gitignore 안에 있는가. 여기에 카나리아를 하나 붙였다 — `ROOT` 가 repo root 인지 직접
단언한다. 없으면 엉뚱한 디렉터리가 우연히 ignore 될 때 첫 테스트가 조용히 통과한다.

### 뮤테이션 실측 3종

| # | 뮤테이션 | 결과 |
|---|---|---|
| M1 | `parents[2]` → `parent.parent` (원래 결함 복원) | 2 FAIL |
| M2 | `parents[2]` → `parents[3]` (레포 밖으로) | 2 FAIL |
| M3 | `.gitignore` 에서 `data/reports/` 제거 | 1 FAIL |

baseline 20 passed.

## 검증

- `make verify-fast` 실행 후 실경로 확인: `data/reports/2026-08-17/` 에 생성, `scripts/data/` **미생성**
- `pytest tests/test_gitignore_covers_private_derivatives.py` 20 passed
- `make verify-doc-counts` 19/19
- ruff check + format clean
- `check_privacy_leak.py` (인자 없이 = CI 와 동일한 diff 스캔) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)