### PR TITLE
fix(collectors): make cboe and fear_greed raise on total failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,034 collected across 322 files | |
+| **Backend tests** | 7,042 collected across 322 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,034 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,042 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,034 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,042 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -97,8 +97,31 @@ scheduler 의 `status="failed"` + `error_message`, `step_failed` 파이프라인
 `test_empty_payload_is_not_a_failure` (조건을 `errors` 로 넓히면 FAIL) ·
 `test_first_error_is_raised_not_the_last` (`errors[0]`→`errors[-1]` 이면 FAIL).
 
-⚠️ **형제 결함 미해결 — #1042**: `cboe.py:81` 과 `fear_greed.py:39` 가 같은 모양이다.
-새 수집기를 쓰거나 기존 것을 고칠 때 이 구분이 서 있는지 먼저 볼 것.
+**형제 둘도 같은 규약으로 정렬됨 (#1042)** — `fear_greed.py` 와 `cboe.py`. 새 수집기를
+쓰거나 기존 것을 고칠 때 이 구분이 서 있는지 먼저 볼 것.
+
+`fear_greed` 는 coingecko 와 같은 `errors and not records` 를 쓴다. API 가 200 인데
+`fear_and_greed` 키가 없으면 예외가 없으니 `[]` 가 그대로 나가고 폴백도 안 탄다(NO_DATA).
+API 가 죽은 뒤 스크래핑이 **예외 없이 점수를 못 찾은** 경우는 실패로 친다 — 앞에서 이미
+예외가 났기 때문이다.
+**Test:** `tests/collectors/test_fear_greed.py::TestFearGreedFailedVsNoData` —
+`test_total_failure_raises_instead_of_returning_empty`(raise 제거 시 FAIL) ·
+`test_empty_payload_is_not_a_failure`(조건을 `not records` 로 넓히면 FAIL) ·
+`test_first_error_is_raised_not_the_last`(`errors[0]`→`errors[-1]` 이면 FAIL) ·
+`test_scrape_fallback_still_rescues_a_dead_api`(과잉 차단 방지).
+
+`cboe` 는 조건이 `errors` 뿐이다 — 5개 티어가 값을 건지면 즉시 return 하므로 마지막 줄에
+닿았다는 것 자체가 이미 "한 건도 못 건졌다" 는 뜻이고, `not records` 를 덧붙이면 records
+가 비지 않을 수도 있다는 잘못된 인상만 준다.
+
+⚠️ **cboe 에서 이 raise 는 좀처럼 안 터진다 — 그리고 그건 의도다.** 5차
+`_collect_db_stale` 이 DB 에 이전 값이 하나라도 있으면 성공으로 돌려주므로, 라이브 소스 4개가
+전부 죽어도 마지막 줄까지 안 온다. 즉 **"DB_STALE 재사용이 영원히 성공으로 집계되는" 축은
+그대로 남아 있다** — `put_call_ratio` 는 `nuri/core/freshness.py FRESHNESS_POLICIES` 에
+항목이 없어 아무도 그 stale 을 감시하지 않고, 실제로 프로덕션에 6주 구멍
+(2026-06-22→2026-08-03)이 무발화로 지나갔다. 별건이며 #1042 밖이다.
+**Test:** `tests/collectors/test_cboe.py::TestCBOEFailedVsNoData::test_db_stale_still_counts_as_success`
+— 이 한계를 명시적으로 잠근다(조용히 바꾸면 라이브 소스가 흔들릴 때마다 수집기가 죽는다).
 
 ## Macro Data Quirk
 

--- a/nuri/collectors/cboe.py
+++ b/nuri/collectors/cboe.py
@@ -36,7 +36,21 @@ class CBOECollector(BaseCollector):
         self.fred_key = os.getenv("FRED_API_KEY", "")
 
     def collect(self, **kwargs) -> list[dict]:
-        """CBOE에서 Put/Call Ratio 수집."""
+        """CBOE에서 Put/Call Ratio 수집.
+
+        전면 실패는 `[]` 가 아니라 **raise** 다 (#1042, coingecko #1043 과 동일 규약).
+        `[]` 로 돌려주면 보고할 게 없던 날과 DB 기록이 같아진다 — 둘 다
+        `collector_runs.status='finished'` 가 박히고 `#ops` 알림도 안 뜬다.
+
+        ⚠️ 이 수집기에서 그 raise 는 **좀처럼 안 터진다.** 5차 `_collect_db_stale` 이
+        DB 에 이전 값이 하나라도 있으면 성공으로 돌려주기 때문에, 라이브 소스 4개가
+        전부 죽어도 여기까지 안 온다. 즉 여기서 고치는 건 "총체적 장애가 성공으로
+        기록되는" 축이고, **"DB_STALE 재사용이 영원히 성공으로 집계되는" 축은 그대로
+        남아 있다** — `put_call_ratio` 는 `freshness.py FRESHNESS_POLICIES` 에 항목이
+        없어서 아무도 그 stale 을 감시하지 않는다. 그건 별건이라 이 PR 밖이다.
+        """
+        errors: list[Exception] = []
+
         # 1차: CBOE daily.json
         try:
             records = self._collect_daily()
@@ -44,6 +58,7 @@ class CBOECollector(BaseCollector):
                 return records
         except Exception as e:
             self.logger.warning("CBOE daily API 실패: %s", e)
+            errors.append(e)
 
         # 2차: CBOE totalpc.json
         try:
@@ -52,6 +67,7 @@ class CBOECollector(BaseCollector):
                 return records
         except Exception as e:
             self.logger.warning("CBOE totalpc 폴백도 실패: %s", e)
+            errors.append(e)
 
         # 3차: FRED ECPCRATIO (CBOE Equity Put/Call Ratio)
         if self.fred_key and self.fred_key != "your_fred_api_key_here":
@@ -61,6 +77,7 @@ class CBOECollector(BaseCollector):
                     return records
             except Exception as e:
                 self.logger.warning("FRED PCR 폴백 실패: %s", e)
+                errors.append(e)
 
         # 4차: yfinance SPY 옵션 체인으로 PCR 직접 계산
         try:
@@ -69,6 +86,7 @@ class CBOECollector(BaseCollector):
                 return records
         except Exception as e:
             self.logger.warning("yfinance SPY PCR 폴백 실패: %s", e)
+            errors.append(e)
 
         # 5차: DB stale 재사용 (graceful degrade)
         try:
@@ -77,8 +95,23 @@ class CBOECollector(BaseCollector):
                 return stale
         except Exception as e:
             self.logger.warning("DB stale fallback 실패: %s", e)
+            errors.append(e)
 
-        self.logger.error("CBOE 모든 소스 실패 (FRED_API_KEY 설정 시 FRED 폴백 가능)")
+        # coingecko 는 `errors and not records` 를 쓰지만 여기는 `errors` 만 본다.
+        # 각 티어가 값을 건지면 즉시 return 하므로, 이 줄에 닿았다는 것 자체가 이미
+        # "한 건도 못 건졌다" 는 뜻이다 — `not records` 를 덧붙이면 records 가 비지
+        # 않을 수도 있다는 잘못된 인상만 준다.
+        if errors:
+            self.logger.error(
+                "CBOE 모든 소스 실패 (%d건) — 첫 원인을 올린다 (FRED_API_KEY 설정 시 FRED 폴백 가능)",
+                len(errors),
+            )
+            # `errors[-1]` 이 아니라 `errors[0]`: 마지막은 항상 DB stale(로컬 DB) 이라
+            # 알림에 올리면 운영자가 네트워크 원인 대신 DB 를 뒤지게 된다.
+            raise errors[0]
+
+        # 예외는 없었는데 전부 빈 응답 = NO_DATA. 그 구분을 지키는 게 이 변경의 요점이다.
+        self.logger.warning("CBOE: 모든 소스가 빈 응답 — NO_DATA (예외 없음)")
         return []
 
     def _collect_yfinance_spy_pcr(self) -> list[dict]:

--- a/nuri/collectors/fear_greed.py
+++ b/nuri/collectors/fear_greed.py
@@ -25,19 +25,41 @@ class FearGreedCollector(BaseCollector):
         super().__init__("fear_greed")
 
     def collect(self, **kwargs) -> list[dict]:
-        """Fear & Greed Index 수집."""
-        # JSON API 시도
+        """Fear & Greed Index 수집.
+
+        전면 실패는 `[]` 가 아니라 **raise** 다 (#1042, coingecko #1043 과 동일 규약).
+        `[]` 로 돌려주면 보고할 게 없던 날과 DB 기록이 같아진다 — 둘 다
+        `collector_runs.status='finished'` 가 박히고 `#ops` 알림도 안 뜬다.
+        """
+        errors: list[Exception] = []
+        records: list[dict] = []
+
         try:
-            return self._collect_api()
+            records = self._collect_api()
         except Exception as e:
             self.logger.warning(f"JSON API 실패, HTML 스크래핑 시도: {e}")
+            errors.append(e)
+            # 폴백은 API 가 **예외로 죽었을 때만** 탄다. 200 인데 내용이 빈 것은
+            # NO_DATA 지 실패가 아니므로 스크래핑으로 재시도하지 않는다.
+            try:
+                records = self._collect_scrape()
+            except Exception as scrape_error:
+                self.logger.error(f"HTML 스크래핑도 실패: {scrape_error}")
+                errors.append(scrape_error)
 
-        # HTML 스크래핑 폴백
-        try:
-            return self._collect_scrape()
-        except Exception as e:
-            self.logger.error(f"HTML 스크래핑도 실패: {e}")
-            return []
+        # 예외가 났는데 한 건도 못 건졌다 = 전면 실패. 스크래핑이 예외 없이 점수를 못
+        # 찾은 경우(`[]`)도 포함된다 — API 가 이미 죽은 마당에 폴백이 빈손이면 그건
+        # "오늘 값이 없다"가 아니라 수집 실패다.
+        #
+        # `errors and` 는 장식이 아니다: API 가 200 빈 응답이면 errors 가 비어 있는데
+        # 그 절을 빼면 `errors[0]` 이 IndexError 로 터진다. 즉 NO_DATA 경로를 지키는
+        # 것이 바로 이 절이다.
+        #
+        # `errors[0]`: 마지막이 아니라 **첫** 원인을 올린다. 마지막은 항상 스크래핑이라
+        # 운영자가 진짜 원인(API 쪽 4xx/5xx)을 못 보게 된다.
+        if errors and not records:
+            raise errors[0]
+        return records
 
     def _collect_api(self) -> list[dict]:
         """CNN JSON API에서 Fear & Greed 데이터 수집."""

--- a/tests/collectors/test_cboe.py
+++ b/tests/collectors/test_cboe.py
@@ -326,6 +326,7 @@ class TestCBOEExtractPCR:
         assert len(result) == 1
 
     def test_collect_all_fail(self, monkeypatch):
+        """전면 실패는 `[]` 가 아니라 raise (#1042). 이전엔 `== []` 를 단언해 결함을 잠그고 있었다."""
         from nuri.collectors.cboe import CBOECollector
 
         c = CBOECollector()
@@ -334,8 +335,8 @@ class TestCBOEExtractPCR:
             with patch.object(c, "_collect_totalpc", side_effect=RuntimeError("fail")):
                 with patch.object(c, "_collect_yfinance_spy_pcr", side_effect=RuntimeError("fail")):
                     with patch.object(c, "_collect_db_stale", side_effect=RuntimeError("fail")):
-                        result = c.collect()
-        assert result == []
+                        with pytest.raises(RuntimeError, match="fail"):
+                            c.collect()
 
     def test_collect_daily_returns_empty(self, monkeypatch):
         from nuri.collectors.cboe import CBOECollector
@@ -357,3 +358,83 @@ class TestCBOEExtractPCR:
         c = CBOECollector()
         records = [{"indicator": "put_call_ratio", "date": "2025-03-15", "value": 0.85, "source": "CBOE"}]
         assert c.save(records) == 1
+
+
+class TestCBOEFailedVsNoData:
+    """전면 실패와 "오늘 값 없음"의 구분을 잠근다 (#1042 — coingecko #1043 과 같은 규약).
+
+    구분이 사라지면 `collector_runs.status` 에 둘 다 `finished` 가 박힌다.
+    `rows_collected` 는 `run_step` 이 돌려주는 4-키 dict 의 길이라 **항상 4** 이므로
+    status 가 유일한 판별 채널인데, 그게 성공이라고 말하고 있었다.
+
+    raise 하면 이미 있으면서 우회되던 것들이 되살아난다 — `base.py` 의 재시도 3회,
+    `_send_failure_alert()` 의 `#ops` 알림, scheduler 의 `status="failed"`,
+    `collector_health` 의 실패 집계.
+    """
+
+    def _collector(self):
+        from nuri.collectors.cboe import CBOECollector
+
+        c = CBOECollector()
+        c.fred_key = ""  # FRED 티어 비활성 — 키 유무에 따라 결과가 갈리지 않게
+        return c
+
+    def test_total_failure_raises_instead_of_returning_empty(self):
+        """raise 를 걷어내면 FAIL."""
+        c = self._collector()
+        with (
+            patch.object(c, "_collect_daily", side_effect=RuntimeError("daily down")),
+            patch.object(c, "_collect_totalpc", side_effect=RuntimeError("totalpc down")),
+            patch.object(c, "_collect_yfinance_spy_pcr", side_effect=RuntimeError("yf down")),
+            patch.object(c, "_collect_db_stale", side_effect=RuntimeError("db down")),
+        ):
+            with pytest.raises(RuntimeError):
+                c.collect()
+
+    def test_every_tier_empty_without_error_is_not_a_failure(self):
+        """조건을 `if errors` 대신 `if not records` 로 넓히면 FAIL.
+
+        전 티어가 200 인데 내용이 비었을 뿐이면 예외가 없다 — 그게 NO_DATA 의 정의고,
+        그대로 `[]` 가 나가야 한다.
+        """
+        c = self._collector()
+        with (
+            patch.object(c, "_collect_daily", return_value=[]),
+            patch.object(c, "_collect_totalpc", return_value=[]),
+            patch.object(c, "_collect_yfinance_spy_pcr", return_value=[]),
+            patch.object(c, "_collect_db_stale", return_value=[]),
+        ):
+            assert c.collect() == []
+
+    def test_first_error_is_raised_not_the_last(self):
+        """`errors[0]` → `errors[-1]` 로 바꾸면 FAIL.
+
+        마지막 티어는 항상 DB stale(로컬 DB)이라, 그걸 올리면 알림이 네트워크 원인을
+        가리고 운영자가 DB 를 뒤지게 된다.
+        """
+        c = self._collector()
+        with (
+            patch.object(c, "_collect_daily", side_effect=RuntimeError("FIRST cboe daily 429")),
+            patch.object(c, "_collect_totalpc", side_effect=RuntimeError("totalpc down")),
+            patch.object(c, "_collect_yfinance_spy_pcr", side_effect=RuntimeError("yf down")),
+            patch.object(c, "_collect_db_stale", side_effect=RuntimeError("LAST db locked")),
+        ):
+            with pytest.raises(RuntimeError, match="FIRST cboe daily 429"):
+                c.collect()
+
+    def test_db_stale_still_counts_as_success(self):
+        """의도된 한계를 명시적으로 잠근다 — DB_STALE 재사용은 여전히 성공이다.
+
+        이 PR 은 "총체적 장애가 성공으로 기록되는" 축만 고친다. stale 재사용이 영원히
+        성공으로 집계되는 축은 별건(`put_call_ratio` 가 `FRESHNESS_POLICIES` 에 없음)이며,
+        여기서 조용히 바꾸면 라이브 소스가 흔들릴 때마다 수집기가 죽는다.
+        """
+        c = self._collector()
+        stale = [{"indicator": "put_call_ratio", "date": "2026-05-12", "value": 0.9, "source": "DB_STALE"}]
+        with (
+            patch.object(c, "_collect_daily", side_effect=RuntimeError("down")),
+            patch.object(c, "_collect_totalpc", side_effect=RuntimeError("down")),
+            patch.object(c, "_collect_yfinance_spy_pcr", side_effect=RuntimeError("down")),
+            patch.object(c, "_collect_db_stale", return_value=stale),
+        ):
+            assert c.collect() == stale

--- a/tests/collectors/test_e4_branch_coverage.py
+++ b/tests/collectors/test_e4_branch_coverage.py
@@ -453,8 +453,10 @@ class TestCboeFallbackChain:
             patch.object(c, "_collect_yfinance_spy_pcr", side_effect=RuntimeError("yf")),
             patch.object(c, "_collect_db_stale", side_effect=RuntimeError("stale")),
         ):
-            result = c.collect()
-        assert result == []
+            # 전면 실패는 `[]` 가 아니라 raise (#1042). FRED 티어까지 켠 5-tier 경로로,
+            # 올라오는 것은 마지막("stale")이 아니라 첫 원인("daily") 이어야 한다.
+            with pytest.raises(RuntimeError, match="daily"):
+                c.collect()
 
 
 class TestCboeFallbackSuccess:

--- a/tests/collectors/test_fear_greed.py
+++ b/tests/collectors/test_fear_greed.py
@@ -2,7 +2,10 @@
 
 Split from tests/test_collectors_all.py for module-level isolation.
 """
+
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestFearGreedCollector:
@@ -16,8 +19,7 @@ class TestFearGreedCollector:
         from nuri.collectors.fear_greed import FearGreedCollector
 
         c = FearGreedCollector()
-        records = [{"indicator": "fear_greed", "date": "2026-03-30",
-                     "value": 55.0, "source": "cnn_api"}]
+        records = [{"indicator": "fear_greed", "date": "2026-03-30", "value": 55.0, "source": "cnn_api"}]
         count = c.save(records)
         assert count == 1
 
@@ -33,7 +35,6 @@ class TestFearGreedCollector:
         result = c._collect_api()
         assert len(result) == 1
         assert result[0]["value"] == 62.5
-
 
 
 class TestFearGreedCollectorAPIAndScrape:
@@ -84,12 +85,19 @@ class TestFearGreedCollectorAPIAndScrape:
         assert results[0]["value"] == 45.0
 
     def test_collect_both_fail(self, monkeypatch):
+        """전면 실패는 `[]` 가 아니라 raise (#1042). 이전엔 `== []` 를 단언해 결함을 잠그고 있었다."""
         from nuri.collectors.fear_greed import FearGreedCollector
 
         monkeypatch.setattr("nuri.collectors.fear_greed.requests.get", MagicMock(side_effect=Exception("all down")))
-        assert FearGreedCollector().collect() == []
+        with pytest.raises(Exception, match="all down"):
+            FearGreedCollector().collect()
 
     def test_scrape_no_score_found(self, monkeypatch):
+        """API 가 죽은 뒤 폴백까지 빈손이면 실패다 — `[]` 가 아니라 raise (#1042).
+
+        API 가 200 인데 내용이 빈 경우(`test_collect_api_no_data`)와 갈리는 지점이다.
+        거긴 예외가 없으니 NO_DATA 고, 여긴 예외가 있었으니 수집 실패다.
+        """
         from nuri.collectors.fear_greed import FearGreedCollector
 
         call_count = [0]
@@ -104,9 +112,94 @@ class TestFearGreedCollectorAPIAndScrape:
             return mock_resp
 
         monkeypatch.setattr("nuri.collectors.fear_greed.requests.get", mock_get)
-        assert FearGreedCollector().collect() == []
+        with pytest.raises(Exception, match="API down"):
+            FearGreedCollector().collect()
 
     def test_save(self, db_with_portfolio):
         from nuri.collectors.fear_greed import FearGreedCollector
 
-        assert FearGreedCollector().save([{"indicator": "fear_greed", "date": "2025-01-30", "value": 55.0, "source": "CNN"}]) == 1
+        assert (
+            FearGreedCollector().save(
+                [{"indicator": "fear_greed", "date": "2025-01-30", "value": 55.0, "source": "CNN"}]
+            )
+            == 1
+        )
+
+
+class TestFearGreedFailedVsNoData:
+    """전면 실패와 "오늘 값 없음"의 구분을 잠근다 (#1042 — coingecko #1043 과 같은 규약).
+
+    구분이 사라지면 `collector_runs.status` 에 둘 다 `finished` 가 박히고 `#ops` 알림도
+    안 뜬다. `fear_greed` 는 composite factor 의 sentiment 성분과 euphoria 감지
+    (vix<12 AND fg>80) 로 들어가므로, 조용히 어두워지면 그 판단이 근거 없이 돌아간다.
+    """
+
+    def test_total_failure_raises_instead_of_returning_empty(self, monkeypatch):
+        """raise 를 걷어내면 FAIL."""
+        from nuri.collectors.fear_greed import FearGreedCollector
+
+        monkeypatch.setattr(
+            "nuri.collectors.fear_greed.requests.get",
+            MagicMock(side_effect=RuntimeError("cnn down")),
+        )
+        with pytest.raises(RuntimeError, match="cnn down"):
+            FearGreedCollector().collect()
+
+    def test_empty_payload_is_not_a_failure(self, monkeypatch):
+        """조건에서 `errors and` 를 빼면 FAIL (IndexError — errors 가 비어 있다).
+
+        API 가 200 인데 `fear_and_greed` 키가 없으면 예외가 없다 — NO_DATA 이므로
+        `[]` 가 그대로 나가야 하고, 폴백 스크래핑도 타면 안 된다. 이 두 성질
+        (반환값 · 폴백 미실행)을 같이 단언해야 `errors and` 절이 실제로 잠긴다.
+        """
+        from nuri.collectors.fear_greed import FearGreedCollector
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {}
+        mock_resp.raise_for_status = MagicMock()
+        get = MagicMock(return_value=mock_resp)
+        monkeypatch.setattr("nuri.collectors.fear_greed.requests.get", get)
+
+        assert FearGreedCollector().collect() == []
+        assert get.call_count == 1, "API 가 성공(빈 응답)했는데 스크래핑 폴백까지 탔다"
+
+    def test_first_error_is_raised_not_the_last(self, monkeypatch):
+        """`errors[0]` → `errors[-1]` 로 바꾸면 FAIL.
+
+        마지막은 항상 스크래핑이라, 그걸 올리면 진짜 원인(API 쪽 4xx/5xx)이 알림에서
+        사라진다.
+        """
+        from nuri.collectors.fear_greed import FearGreedCollector
+
+        call_count = [0]
+
+        def mock_get(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("FIRST cnn api 503")
+            raise RuntimeError("LAST scrape timeout")
+
+        monkeypatch.setattr("nuri.collectors.fear_greed.requests.get", mock_get)
+        with pytest.raises(RuntimeError, match="FIRST cnn api 503"):
+            FearGreedCollector().collect()
+
+    def test_scrape_fallback_still_rescues_a_dead_api(self, monkeypatch):
+        """과잉 차단 방지 — API 가 죽어도 스크래핑이 점수를 찾으면 성공이어야 한다."""
+        from nuri.collectors.fear_greed import FearGreedCollector
+
+        call_count = [0]
+
+        def mock_get(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("api down")
+            mock_resp = MagicMock()
+            mock_resp.text = '<text class="market-fng-gauge__dial-number-value">42.0</text>'
+            mock_resp.raise_for_status = MagicMock()
+            return mock_resp
+
+        monkeypatch.setattr("nuri.collectors.fear_greed.requests.get", mock_get)
+        records = FearGreedCollector().collect()
+        assert len(records) == 1
+        assert records[0]["value"] == 42.0
+        assert records[0]["source"] == "CNN_scrape"


### PR DESCRIPTION
Closes #1042 — coingecko #1043 의 남은 형제 둘.

## 무엇이 조용했나

모든 소스가 실패한 날과 보고할 게 없던 날의 **DB 기록이 완전히 같았다.** 둘 다 로그 한 줄
남기고 `[]` 를 돌려주므로 scheduler 가 `collector_runs.status='finished'` 를 박고 `#ops`
알림도 안 뜬다. `rows_collected` 로는 못 가른다 — `run_step` 이 돌려주는 4-키 dict 의
길이라 **항상 4** 다. status 가 유일한 판별 채널인데 그게 성공이라고 말하고 있었다.

프로덕션 실측이 이걸 뒷받침한다: cboe 101회 / fear_greed 150회 실행에 **status='finished'
100%, 'failed' 0건**. 그동안 `macro.put_call_ratio` 는 4개월간 8행뿐이고
**2026-06-22→2026-08-03 6주 구멍**이 무발화로 지나갔다.

## raise 하면 이미 있던 기계가 살아난다

새로 만드는 장치는 없다. 우회되던 것들이 되살아날 뿐이다 — `base.py` 재시도 3회 + 백오프,
`_send_failure_alert()` 의 Discord `#ops` 메시지, scheduler 의 `status='failed'` +
`error_message`, `step_failed` 파이프라인 이벤트, `collector_health` 실패 집계.

## 두 파일이 서로 다른 이유

**`fear_greed`** — coingecko 와 동일한 `errors and not records` · `errors[0]`.
- API 200 + `fear_and_greed` 키 없음 → 예외 없음 → `[]` 그대로 (NO_DATA), 폴백도 안 탄다
- API 사망 후 스크래핑이 **예외 없이 점수를 못 찾음** → 실패다 (앞에서 이미 예외가 났다)
- 폴백을 `except` 블록 **안**으로 넣었다. 밖에 두면 200-빈응답에도 스크래핑을 타서
  NO_DATA 를 실패 후보로 만든다

**`cboe`** — 조건이 `errors` 뿐이다. 5개 티어가 값을 건지면 즉시 return 하므로 마지막 줄에
닿았다는 것 자체가 "한 건도 못 건졌다"는 뜻이고, `not records` 를 덧붙이면 records 가 비지
않을 수도 있다는 잘못된 인상만 준다. `errors[0]` 인 이유는 마지막 티어가 항상 로컬 DB 읽기라,
그걸 알림에 올리면 운영자가 네트워크 원인 대신 DB 를 뒤지기 때문이다.

## 고치지 **않은** 것 — 명시적으로 테스트로 잠갔다

cboe 에서 이 raise 는 **좀처럼 안 터진다.** 5차 `_collect_db_stale` 이 DB 에 이전 값이
하나라도 있으면 성공으로 돌려주므로 라이브 소스 4개가 다 죽어도 마지막 줄까지 안 온다.
**"DB_STALE 재사용이 영원히 성공으로 집계되는" 축은 그대로 남아 있다** —
`put_call_ratio` 는 `FRESHNESS_POLICIES` 에 항목이 없어 아무도 그 stale 을 감시하지 않는다.
위의 6주 구멍이 그 축의 결과다. 별건이며 스코프 확장을 피해 여기서 건드리지 않았고, 대신
`test_db_stale_still_counts_as_success` 로 **의도된 한계임을 못박았다** (조용히 바꾸면
라이브 소스가 흔들릴 때마다 수집기가 죽는다).

## 결함을 잠그고 있던 테스트 4개를 뒤집었다

`test_collect_all_fail` · `test_all_fallbacks_raise_exceptions` · `test_collect_both_fail` ·
`test_scrape_no_score_found` 가 전부 `assert result == []` 로 **버그를 고정**하고 있었다.

### 뮤테이션 실측 6종

| # | 뮤테이션 | 결과 |
|---|---|---|
| M1 | cboe: `raise` 제거 (원래 결함) | 4 FAIL |
| M2 | cboe: `errors[0]` → `errors[-1]` | 2 FAIL |
| M3 | fear_greed: `raise` 제거 | 4 FAIL |
| M4 | fear_greed: `errors and` 절 제거 | 2 FAIL |
| M5 | fear_greed: `errors[0]` → `errors[-1]` | 1 FAIL |
| M6 | fear_greed: 폴백을 `except` 밖으로 (200-빈응답에도 실행) | 2 FAIL |

baseline 93 passed.

M4 는 처음엔 **통과했다** — 원래 구조가 API 성공 시 조기 반환이라 가드 앞에서 빠져나갔고,
`errors and` 절이 도달 불가라 뮤테이션으로 구분이 안 됐다. 잠기지 않는 절을 남기지 않으려고
`collect()` 구조를 고쳐 가드가 두 경로를 다 지배하게 만들었다. 이제 그 절을 빼면
`errors[0]` 이 IndexError 로 터진다 — 즉 NO_DATA 경로를 지키는 게 바로 그 절이다.

## 검증

- `pytest tests/collectors/` 822 passed, 2 skipped
- `make verify-doc-counts` 19/19
- `ruff check nuri/ tests/` clean, format clean
- `check_privacy_leak.py` (인자 없이 = CI 와 동일) clean
- `make test-fast` 7,006 passed / 3 failed — 실패 3건은 `test_universe_sync_real.py`
  의 실네트워크 KOSPI 조회가 **HTTP 429** 를 받은 것으로, **main 에서 동일 조건으로
  돌려도 같은 3건이 실패**한다 (실측). 이 PR 과 무관하며 로컬 `make collect` 여파로 보인다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)