### PR TITLE
fix(collectors): correct cpi_yoy units and wire gdp_growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,045 collected across 322 files | |
+| **Backend tests** | 7,048 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,042 collected across 322 files | |
+| **Backend tests** | 7,045 collected across 322 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,045 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,048 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,042 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,045 backend tests across 322 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,045 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,048 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,042 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,045 tests, 322 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/macro.py
+++ b/nuri/collectors/macro.py
@@ -42,6 +42,12 @@ FRED_SERIES = {
     # 추가 경제 지표
     "consumer_sentiment": "UMCSENT",  # 미시건대 소비자 심리
     "ism_manufacturing": "MANEMP",  # ISM 제조업 고용
+    # 실질 GDP 성장률 (전기 대비, 연율 환산). 분기 시리즈라 5년 창에 20개 남짓.
+    # `classifier._detect_stagflation` 의 유일한 GDP 입력 — 이게 없으면 그 함수가
+    # `gdp_growth` 미수집으로 조기 return 해 **스태그플레이션 판정 자체가 도달 불가**
+    # 였다 (#1025). 원본이 이미 "Percent Change from Preceding Period, SAAR" 라
+    # FRED_UNITS 오버라이드가 필요 없다.
+    "gdp_growth": "A191RL1Q225SBEA",
     # PR C (codex bubble-bear #3): crash precursor data.
     # BofA US High Yield Option-Adjusted Spread — 신용 스트레스 조기 신호.
     # Gilchrist-Zakrajsek 2012: HY OAS > 500bps + 63d 변화 > +150bps 경기침체 경고.

--- a/nuri/collectors/macro.py
+++ b/nuri/collectors/macro.py
@@ -49,6 +49,21 @@ FRED_SERIES = {
     "hy_oas": "BAMLH0A0HYM2",
 }
 
+# FRED 단위 오버라이드 — 시리즈 원본 단위가 지표 **이름이 약속하는 단위와 다를 때**만.
+#
+# `CPIAUCSL` 은 "Index 1982-1984=100" 이라 원본을 그대로 담으면 `cpi_yoy` 에 332.8 이
+# 들어간다. 이름은 YoY 인데 값은 인덱스 — 소비처는 이름을 믿는다. `_score_inflation`
+# 은 `abs(332.8 - 2.0)` 을 편차로 계산해 **0 점에 영구 고정**됐고(가중치 0.117),
+# `_detect_stagflation` 의 `cpi > 4` 는 **항상 참**이었다 (#1065).
+#
+# 하필 FRED 키가 없을 때보다 나빴다: 결측이면 #1026 의 coverage 재정규화가 성분을
+# 제외해 정직한데, 값이 있으면 0 점이 만점 가중치로 들어가 총점을 끌어내린다.
+#
+# `pc1` = Percent Change from Year Ago. FRED 가 서버에서 계산해 준다.
+FRED_UNITS = {
+    "cpi_yoy": "pc1",
+}
+
 # yfinance fallback 심볼 매핑 (FRED 없을 때 사용)
 YFINANCE_SYMBOLS = {
     "us_10y_yield": "^TNX",  # 10Y Treasury Yield
@@ -153,7 +168,10 @@ class MacroCollector(BaseCollector):
         records = []
         for indicator, series_id in FRED_SERIES.items():
             try:
-                series = fred.get_series(series_id, observation_start=start_date)
+                # units 는 FRED_UNITS 에 등재된 지표만 붙인다 — 나머지는 원본 단위가
+                # 이름과 일치하므로 기본값(`lin`)이 맞다.
+                extra = {"units": FRED_UNITS[indicator]} if indicator in FRED_UNITS else {}
+                series = fred.get_series(series_id, observation_start=start_date, **extra)
                 for date, value in series.dropna().items():
                     records.append(
                         {

--- a/tests/collectors/test_macro.py
+++ b/tests/collectors/test_macro.py
@@ -422,3 +422,73 @@ class TestPartAIndicatorRegistry:
         assert "dxy" in indicators, "yfinance-only indicator 보충 안 됨 — P1 회귀"
         assert indicators["sp500"] == "yfinance"
         assert indicators["dxy"] == "yfinance"
+
+
+class TestFredUnitsMatchIndicatorNames:
+    """지표 **이름이 약속하는 단위**와 FRED 원본 단위가 어긋나지 않는지 잠근다 (#1065).
+
+    `cpi_yoy` 는 `CPIAUCSL` 에 매핑돼 있는데 그건 "Index 1982-1984=100" 이다. 원본을
+    그대로 담으면 332.8 이 들어가고, 이름을 믿는 소비처 둘이 조용히 망가진다:
+
+    - `_score_inflation` 은 `abs(332.8 - 2.0)` 을 편차로 써서 **0 점 고정** (가중치 0.117)
+    - `_detect_stagflation` 의 `cpi > 4` 는 **항상 참**
+
+    특히 첫 번째는 FRED 키가 **없을 때보다 나쁘다** — 결측이면 #1026 재정규화가 성분을
+    제외해 정직한데, 값이 있으면 0 점이 만점 가중치로 총점을 끌어내린다. 즉 이 계열은
+    "데이터가 생기면 좋아진다"는 직관이 뒤집히는 자리라, 이름-단위 정합을 기계로 잠근다.
+    """
+
+    def test_cpi_yoy_is_requested_as_percent_change_from_year_ago(self):
+        """Gotcha-Test Pair: `FRED_UNITS` 에서 `cpi_yoy` 를 빼면 FAIL."""
+        from nuri.collectors.macro import FRED_UNITS
+
+        assert FRED_UNITS.get("cpi_yoy") == "pc1", (
+            "cpi_yoy 는 `units='pc1'` (Percent Change from Year Ago) 로 받아야 한다. "
+            "빼면 CPIAUCSL 원본인 인덱스 레벨(약 332)이 들어가 inflation 점수가 0 에 고정된다."
+        )
+
+    def test_every_yoy_indicator_declares_a_percent_change_unit(self):
+        """카나리아 — 새 `*_yoy` 지표를 추가하고 단위를 안 붙이면 FAIL.
+
+        이름에 `_yoy` 를 달아놓고 원본 단위로 받으면 같은 사고가 반복된다.
+        """
+        from nuri.collectors.macro import FRED_SERIES, FRED_UNITS
+
+        yoy = [k for k in FRED_SERIES if k.endswith("_yoy")]
+        assert yoy, "`_yoy` 지표가 하나도 없다 — 이 테스트가 공허하게 통과한다"
+        missing = [k for k in yoy if FRED_UNITS.get(k) not in ("pc1", "pch")]
+        assert not missing, (
+            f"`_yoy` 인데 percent-change 단위가 없는 지표: {missing}\n"
+            "FRED 원본이 이미 YoY 인 시리즈라면 FRED_UNITS 에 이유와 함께 예외를 적을 것."
+        )
+
+    def test_units_reach_the_fred_call(self, monkeypatch, db_with_portfolio):
+        """구조가 아니라 **동작** 잠금 — `_collect_fred` 가 units 를 실제로 넘기는지.
+
+        `FRED_UNITS` 만 채우고 `get_series` 호출부에서 안 쓰면 딕셔너리는 장식이 된다.
+        """
+        import sys
+
+        from nuri.collectors.macro import MacroCollector
+
+        calls = []
+
+        def fake_get_series(series_id, **kwargs):
+            calls.append((series_id, kwargs.get("units")))
+            return pd.Series([3.3], index=pd.to_datetime(["2026-07-01"]))
+
+        mock_fred = MagicMock()
+        mock_fred.get_series.side_effect = fake_get_series
+        monkeypatch.setitem(sys.modules, "fredapi", MagicMock(Fred=MagicMock(return_value=mock_fred)))
+
+        collector = MacroCollector()
+        collector.api_key = "real_key"
+        collector._collect_fred(days=30)
+
+        by_series = dict(calls)
+        assert by_series.get("CPIAUCSL") == "pc1", (
+            f"CPIAUCSL 이 units 없이 호출됐다 (units={by_series.get('CPIAUCSL')!r}) — "
+            "FRED_UNITS 가 호출부에 닿지 않는다"
+        )
+        # 오버라이드가 없는 지표에는 units 를 붙이면 안 된다 (원본 단위가 맞다).
+        assert by_series.get("UNRATE") is None, "UNRATE 는 이미 퍼센트라 units 를 붙이면 안 된다"

--- a/tests/test_macro_indicator_parity.py
+++ b/tests/test_macro_indicator_parity.py
@@ -1,0 +1,90 @@
+"""매크로 지표의 **소비/생산 짝**이 맞는지 잠근다 (#1025).
+
+`classifier._detect_stagflation` 은 `macro.gdp_growth` 를 읽는다. 그런데 그 지표를
+**쓰는 수집기가 하나도 없었다.** 함수는 매번 `if not gdp_rows: return False` 로 조기
+탈출했고, 그래서 스태그플레이션 판정은 코드가 존재한 내내 **한 번도 도달하지 못했다.**
+
+이게 조용했던 이유가 이 테스트의 존재 이유다:
+
+- 단위 테스트는 통과한다. `tests/quant/test_regime_classifier.py::TestStagflation` 이
+  `cpi_yoy=5.5` · `gdp_growth=0.5` 를 **직접 seed** 하므로 로직은 초록이다. 로직이
+  맞다는 것과 입력이 도착한다는 것은 별개인데, 테스트는 앞엣것만 봤다.
+- 런타임도 조용하다. 조기 탈출이 `logger.debug` 한 줄이라 아무 신호가 없다.
+- 반환값도 조용하다. 데이터가 없어서 `False` 인 것과 재보니 아니어서 `False` 인 것이
+  호출자 눈에 똑같다.
+
+그래서 여기서 보는 것은 로직이 아니라 **배선**이다: 소비되는 지표는 전부 생산자가 있어야
+한다. 짝이 없으면 그 소비처는 도달 불가 코드다.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# 매크로 지표를 이름으로 읽는 소비처.
+CONSUMERS = [
+    REPO_ROOT / "nuri" / "quant" / "regime" / "classifier.py",
+    REPO_ROOT / "nuri" / "quant" / "regime" / "macro_score.py",
+]
+
+COLLECTORS_DIR = REPO_ROOT / "nuri" / "collectors"
+
+# 소비 형태 3종: SQL 리터럴 · `_get_latest_macro(...)` · `_get_macro_trend(...)`
+_CONSUME_PATTERNS = (
+    r"indicator\s*=\s*'([a-z0-9_]+)'",
+    r"_get_latest_macro\(\s*\"([a-z0-9_]+)\"",
+    r"_get_macro_trend\(\s*\"([a-z0-9_]+)\"",
+)
+
+# 생산 형태: 수집기가 dict 로 쓰는 `"indicator": "..."`
+_PRODUCE_PATTERN = r'"indicator":\s*"([a-z0-9_]+)"'
+
+
+def _consumed() -> set[str]:
+    found: set[str] = set()
+    for path in CONSUMERS:
+        text = path.read_text()
+        for pat in _CONSUME_PATTERNS:
+            found.update(re.findall(pat, text))
+    return found
+
+
+def _produced() -> set[str]:
+    from nuri.collectors.macro import FRED_SERIES, YFINANCE_SYMBOLS
+
+    found = set(FRED_SERIES) | set(YFINANCE_SYMBOLS)
+    # macro.py 밖의 수집기들 (cboe → put_call_ratio, fear_greed, coingecko 등)
+    for path in COLLECTORS_DIR.glob("*.py"):
+        found.update(re.findall(_PRODUCE_PATTERN, path.read_text()))
+    return found
+
+
+class TestEveryConsumedIndicatorHasAProducer:
+    def test_no_orphan_indicator(self):
+        """Gotcha-Test Pair: `FRED_SERIES` 에서 `gdp_growth` 를 빼면 FAIL.
+
+        그 상태가 정확히 #1025 이전이며, `_detect_stagflation` 이 도달 불가였다.
+        """
+        orphans = _consumed() - _produced()
+        assert not orphans, (
+            f"읽히는데 아무 수집기도 쓰지 않는 지표: {sorted(orphans)}\n"
+            "해당 소비처는 데이터가 없어 조기 탈출하는 도달 불가 코드다. "
+            "수집기에 배선하거나 소비처를 지울 것."
+        )
+
+    def test_consumption_scan_actually_finds_known_reads(self):
+        """카나리아 — 소비 추출이 깨지면 위 테스트가 공허하게 통과한다."""
+        consumed = _consumed()
+        for known in ("cpi_yoy", "gdp_growth", "vix"):
+            assert known in consumed, (
+                f"소비처 스캔이 `{known}` 을 못 찾았다 — 읽는 형태가 바뀌었으면 _CONSUME_PATTERNS 도 같이 고칠 것"
+            )
+
+    def test_production_scan_actually_finds_known_writes(self):
+        """카나리아 — 생산 추출이 비면 모든 지표가 고아로 잡혀 오탐만 난다."""
+        produced = _produced()
+        for known in ("cpi_yoy", "put_call_ratio", "fear_greed"):
+            assert known in produced, f"수집기 스캔이 `{known}` 을 못 찾았다"


### PR DESCRIPTION
Closes #1065 · Part of #1025

`gdp_growth` 배선을 하려다 그 앞에 막아선 결함을 먼저 고쳐야 했다. 두 커밋이고 순서가 의미를 갖는다 — 반대로 하면 프로덕션이 나빠진다.

## 커밋 1 — `cpi_yoy` 가 YoY 가 아니었다 (#1065)

`cpi_yoy` 는 FRED `CPIAUCSL` 에 매핑돼 있는데 그건 "Index 1982-1984=100" 이다. `_collect_fred` 는 변환 없이 저장하므로 프로덕션에 **332.813** 이 들어 있었다. 같은 시리즈를 `units="pc1"` 로 받으면 실제 YoY 는 **3.30%** 다.

이름을 믿는 소비처 둘이 조용히 망가져 있었다:

| 소비처 | 지금 | 올바른 값이면 |
|---|---|---|
| `_score_inflation` (가중치 **0.117**) | `abs(332.8-2.0)=330.8` → **0 점 고정** | `deviation=1.30` → **66 점** |
| `_detect_stagflation` 의 `cpi > 4` | **항상 참** | 3.30 < 4 → 정상적으로 거짓 |

⚠️ 이 축에서는 **FRED 키를 켠 것이 회귀였다.** 키가 없을 땐 `cpi_yoy` 가 결측이라 #1026 의 coverage 재정규화가 성분을 **제외**해서 정직했다. 값이 생기자 0 점이 만점 가중치로 포함돼 총점을 끌어내린다.

임계값(`cpi > 4`, target 2.0)은 **건드리지 않았다.** 그건 연구 질문이고 #1025 에서도 별건으로 분리돼 있다.

## 커밋 2 — `gdp_growth` 배선 (#1025)

`_detect_stagflation` 이 `macro.gdp_growth` 를 읽는데 **그걸 쓰는 수집기가 없었다.** 매번 `if not gdp_rows: return False` 로 조기 탈출했으니 스태그플레이션 판정은 코드가 존재한 내내 **한 번도 도달하지 못했다.**

FRED `A191RL1Q225SBEA` (Real GDP, % Change from Preceding Period, SAAR). 원본이 이미 성장률이라 units 오버라이드 불필요. 분기 시리즈.

**순서가 중요하다:** `cpi_yoy` 가 인덱스인 채로 이것만 배선했으면 `cpi > 4` 가 항상 참이라 스태그플레이션이 **`gdp < 1` 단독 조건**으로 발화한다.

## 왜 아무도 몰랐나

`TestStagflation` 은 `cpi_yoy=5.5` · `gdp_growth=0.5` 를 **직접 seed** 해서 통과한다. 로직이 맞다는 것과 입력이 도착한다는 것은 다른 주장인데 테스트는 앞엣것만 봤다. 조기 탈출은 `logger.debug` 라 런타임도 조용하고, "데이터 없어서 False" 와 "재보니 아니라서 False" 가 호출자 눈에 똑같다.

그래서 로직이 아니라 **배선**을 잠근다:

1. `FRED_UNITS["cpi_yoy"] == "pc1"`
2. 앞으로 어떤 `*_yoy` 지표든 percent-change 단위 선언 강제 (계열 재발 차단)
3. units 가 **실제로 `get_series` 에 도달**하는지 — 딕셔너리만 채우고 호출부가 무시하면 장식이다
4. `classifier`/`macro_score` 가 이름으로 읽는 지표는 **전부 생산자가 있어야 함**. 이 커밋 전 열 개 중 `gdp_growth` 하나만 고아였다

### 뮤테이션 실측

| # | 뮤테이션 | 결과 |
|---|---|---|
| M1 | `FRED_UNITS` 에서 `cpi_yoy` 제거 | 3 FAIL |
| M2 | 딕셔너리는 두고 호출부에서 무시 | 1 FAIL |
| M3 | 오버라이드 없는 지표에도 units 부착 | 1 FAIL |
| M4 | `FRED_SERIES` 에서 `gdp_growth` 제거 | 1 FAIL |
| M5 | 소비 스캔 정규식 전부 무력화 (카나리아) | 1 FAIL |

M5 는 처음 두 번 **치환이 no-op** 이라 가짜 통과가 나왔고 `assert mutated != t` 가드로 잡아 다시 돌렸다.

## 배포 후 필요한 것

프로덕션 `cpi_yoy` 59행이 인덱스 레벨로 남아 있어 **재수집이 필요하다** (`--days 1825`).

## 검증

- 920 passed, 2 skipped · `make verify-doc-counts` 19/19 · ruff clean · privacy clean
- FRED `units="pc1"` 실응답 확인: 최근 4개 `[3.78, 4.17, 3.46, 3.30]`

## 스코프 밖 (소비처 0개라 휴면)

`ism_manufacturing` ← `MANEMP` 는 ISM 지수가 아니라 **제조업 고용자 수(천 명, 약 12,700)** 다. #1065 에 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
