### PR TITLE
fix(validation): count an outcome missing only after its window settles

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,052 collected across 323 files | |
+| **Backend tests** | 7,065 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,065 collected across 323 files | |
+| **Backend tests** | 7,076 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 595 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 601 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -273,6 +273,12 @@ measurement_mode:
   permutation_n: 1000            # null 표본 수
   robustness_split: median_split_halves  # median decision date 등분 — 반기 n 균형 (VIX 게이트 accrual 비대칭 대비)
   missing_outcome_max_pct: 15    # 추적 결측 비율 상한 — 초과 시 판정 무효 (결측 편향)
+  max_settlement_lag_days: 7     # 벤치마크 종가 프런티어가 기준일보다 이만큼 뒤처지면 판정 무효 (#1068).
+                                 # 결측은 **정산된 창만** 세므로 벤치마크 수집이 멈추면 미해소 행이 결측에서
+                                 # 빠져나가 결측률이 조용히 내려간다. 이 조건은 판정을 **더 어렵게만** 만들며
+                                 # (§3.11 "하향/동결은 상시 허용" — prudential 방향), 통과를 쉽게 하지 않는다.
+                                 # 7 인 이유: 주말+공휴일 정상 지연 실측 4일(2026-08-18, 금요일 bar → 화요일)
+                                 # 위 여유. 이보다 길면 수집 장애지 달력이 아니다.
   sleeve_max_equity_pct:         # account_strategy 별 실험 슬리브 상한 (us_equity+kr_equity 합산 대비 %)
                                  # 확정 2026-07-08 (#848) — 이후 상향은 판정 통과 + STRATEGY PR (lock test 동시 개정)
     core: 10

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,065 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,076 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,052 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,065 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -266,7 +266,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,052 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,065 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -251,6 +251,15 @@ base = regime_win_rate × 60% + profit_factor × 40%
 **1) 성적표 단일 원장 (ledger of record)**: 판정에 쓰이는 측정 기록 (`decision_outcomes` 등) 의 원장은 **production (Mac mini) DB 단일** (#824) — dev 머신 DB 는 read-replica 이며, 판정·리포트는 원장 쿼리만 인용한다 (2026-07-07 두 원장 혼용 오탐이 계기). 운영 상세 (sync 방향, writer-job 금지) 는 `docs/SOURCE_OF_TRUTH.md` (local), 원장 스냅샷/백업 정책은 미구축 ⑥.
 **2) 슬리브 × SAA 결합 규칙** (§3.10 TAA×SAA 패턴 준용): 슬리브는 자산 클래스가 아니라 equity bucket **내부** 구획 (상한 분모 = us_equity+kr_equity **합산** 대비 %) — SAA target/drift ±5% 계산은 슬리브 포함 통상 계산 (이중 계상 없음). 상한 값은 `config/rules.yaml measurement_mode.sleeve_max_equity_pct` (account_strategy 별, canonical). 집행은 §7.1 대로 사용자 수동 — 본 절은 §3.6 Phase 3 (alpha-amplified live) 의 우회 부활이 아니다.
 **3) 판정 기준 (2026-07-08 사전 고정 — 사후 amend 거부, §3.6 선례)**:
+
+**사후 추가가 허용되는 유일한 종류 — prudential invalidator** (2026-08-18, #1068 계기로 명문화):
+판정을 **보류만 시킬 수 있고 승격은 시킬 수 없는** 조건은 사전등록 이후에도 추가할 수 있다.
+사전등록의 목적은 *긍정적 결과의 사후 정당화*를 막는 것인데, 한 방향으로만 작동해 verdict 를
+withhold 하기만 하는 조건은 그 남용에 쓰일 수 없기 때문이다 (§2.6 "하향/동결은 상시 허용" 과
+같은 논리). 조건 완화·표본 규약 변경·3조건 수정은 여기 해당하지 않으며 종전대로 STRATEGY PR +
+재승인 대상이다. **추가 시 의무**: (a) 본 절에 조건과 도입일을 기록, (b) `config/rules.yaml
+measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 막고, (c) 그 조건이 무효화를
+만드는 시나리오를 회귀 테스트로 고정. 첫 사례가 아래 `max_settlement_lag_days` 다.
 | 항목 | 값 | 근거 |
 |---|---|---|
 | 판정일 | 2027-06-30. 조기 승격 금지 (하향은 상시). 표본 emit cutoff = 2027-05-15 (30d 창 완결 보장) | pre-registration — Harvey, Liu & Zhu (2016) multiple testing / p-hacking |
@@ -258,7 +267,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 | 벤치마크 | SPY (`forward_outcome_tracker.py` `DEFAULT_BENCHMARK_TICKER` = `measurement_mode.benchmark`). **본 판정은 US-only 로 고정.** #833 착륙 후 KR 결정의 **기록 기준**은 KOSPI (`measurement_mode.benchmark_by_market`, 매 outcome 행의 `benchmark_ticker` 에 자기기술) — 기록 기준이 바뀌었을 뿐 **판정 대상 여부는 그대로**이며, KR 은 **별도 사전등록** 전까지 진단 전용 | #675 caveat: SPY 는 growth 대비 과대평가. KR 을 SPY 로 재면 FX + 시장 스타일이 alpha 에 섞여 부호까지 뒤집힘 |
 | 승격 조건 (3개 동시) | mean 30d alpha > 0 · 순열 p < 0.05 (**ticker-block placebo**: 실 표본의 ticker→emit일 구조 유지, 동일 시장 eligible universe 에서 ticker 치환, N=1000, 통계량 = mean 30d alpha, one-sided — 중첩 창·동일일 배치·반복 종목 의존성을 null 이 상속) · **median-decision-date 등분 2분할** 모두 mean alpha > 0 (반기 n 균형 보장) | López de Prado (2018) PBO/deflated-Sharpe 정신 — 단일 통계 아닌 강건성 요구. naive iid 순열은 클러스터링으로 anti-conservative |
 | regime 축 | 내부 10-regime 분류는 진단 Surface 전용, 판정 비사용 — 원장 라벨 커버리지 3% (12/383, #828 코멘트 쿼리), 2026-04 이후 transition 1회 (판정 교착 위험), 자기 분류기 순환성 | 실측 2026-07-07 (production 원장) |
-| 오염 방지 | `decision_id` 없는 ad-hoc 체결은 표본 제외 (#715 사전등록 원칙의 자본 버전). missing outcome (추적 실패/가격 결측) 은 제외하되 비율을 판정 리포트에 공시 — **15% 초과 시 판정 무효 (측정 연장)** | Shefrin & Statman (1985) — ad-hoc 개입이 처분효과 재유입 경로. 결측 편향 (탈락은 나쁜 outcome 과 상관 가능) |
+| 오염 방지 | `decision_id` 없는 ad-hoc 체결은 표본 제외 (#715 사전등록 원칙의 자본 버전). missing outcome (추적 실패/가격 결측) 은 제외하되 비율을 판정 리포트에 공시 — **15% 초과 시 판정 무효 (측정 연장)** **결측 계상은 창이 *정산*된 것만** — 벤치마크가 만기일 이후 종가를 가진 상태 (#1068, 2026-08-18). 아직 안 온 bar 는 추적 실패도 가격 결측도 아니다; 프로덕션 실측 달력 50.0% vs 정산 9.1%. emit cutoff 가 판정일 46일 전이라 **판정일에는 두 기준이 일치**하므로 사전등록 개정이 아니다 — 바뀌는 것은 측정 중 월간 진행 리포트다. 짝 가드: 정산 프런티어가 `max_settlement_lag_days`(7 — 위 prudential invalidator 정책의 첫 사례, 2026-08-18 도입) 넘게 뒤처지면 `INVALID_STALE_BENCHMARK` 로 판정 차단 (결측률은 정산분만 세므로 수집이 멈추면 오히려 깨끗해 보인다) | Shefrin & Statman (1985) — ad-hoc 개입이 처분효과 재유입 경로. 결측 편향 (탈락은 나쁜 outcome 과 상관 가능) |
 **판정 결과 처리**: 3조건 통과 → **US 집행분 슬리브에 한해** 상한 상향 STRATEGY PR (새 상한도 본 표 개정으로 사전 고정). 미달 → 슬리브 유지/축소 + 측정 연장 또는 §3.10 passive 로 수렴 — "조금만 더" 없이 본 표가 답이다. 사전등록 대상은 판정 **기준**이지 상한 초기값이 아니다 — 슬리브 초기값은 판정 표본에 영향이 없으므로 최초 사용자 확정 PR 까지 placeholder 로 두며 일반 PR 로 정정 가능. 확정 이후부터 상향-sticky 발효.
 **미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 — #832 구현 완료 (`scripts/ops/backfill_regime_labels.py` + emit 경로 canonical-or-NULL, 진단용) ② 순열 판정 도구 — #842 구현 완료 (`nuri/quant/validation/decision_alpha.py`, 설계는 본 표에 사전 고정; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 — #833 구현 완료 (`benchmark_by_market` + `decision_outcomes.benchmark_ticker`, 기록 기준만; KR 판정 사전등록은 미착수) ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall, #834) ⑥ 원장 스냅샷/백업 정책 (#835). 월간 알파 진행 리포트 표출 = #856.
 **참조**: `config/rules.yaml measurement_mode` (canonical 값), `nuri/agents/actors/forward_outcome_tracker.py` (측정 파이프라인, 매일 17:00 KST), `docs/SOURCE_OF_TRUTH.md` (원장 매핑, local-only).
@@ -266,7 +275,7 @@ base = regime_win_rate × 60% + profit_factor × 40%
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,065 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,076 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/_brief_common.py
+++ b/nuri/alerts/_brief_common.py
@@ -96,8 +96,4 @@ def _filter_actionable_accounts(holdings: dict[str, Any]) -> dict[str, Any]:
     pension 은 장기 연금성 buy-and-hold — daily action 대상이 아니므로
     postmarket brief 출력에서 제외.
     """
-    return {
-        acct: data
-        for acct, data in holdings.items()
-        if (data.get("strategy") or "core") != "pension"
-    }
+    return {acct: data for acct, data in holdings.items() if (data.get("strategy") or "core") != "pension"}

--- a/nuri/alerts/alpha_report.py
+++ b/nuri/alerts/alpha_report.py
@@ -47,8 +47,12 @@ def is_production() -> bool:
     return os.getenv("NURI_ROLE", "").strip().lower() == PRODUCTION_ROLE
 
 
-def _days_until(target: str, today: str) -> Optional[int]:
-    """`today` → `target` 남은 일수. 파싱 실패 시 None (표시 생략)."""
+def _days_until(target: Optional[str], today: str) -> Optional[int]:
+    """`today` → `target` 남은 일수. 파싱 실패·`None` 이면 None (표시 생략).
+
+    호출부가 `report.get("evaluation_date")` 를 그대로 넘기므로 `None` 은 정상 입력이다
+    (아래 `except` 가 이미 처리한다). 시그니처를 `str` 로 두면 그 사실이 거짓이 된다.
+    """
     try:
         return (date.fromisoformat(str(target)) - date.fromisoformat(str(today))).days
     except (ValueError, TypeError):
@@ -95,8 +99,21 @@ def format_progress_reason(report: dict[str, Any]) -> str:
     else:
         parts.append(report.get("reason", "표본 부족 — 순열 미실행"))
 
-    if missing is not None:
-        parts.append(f"결측 {missing}%/{missing_max}%")
+    # 결측률이 `None` = 측정 대상 0 건. 필드를 통째로 생략하면 "결측 없음"과
+    # 구분이 안 되고, `0.0` 으로 찍으면 사전 등록된 무효화 기준이 통과처럼 읽힌다
+    # (2026-07-28 · 08-01 프로덕션 #brief 가 실제로 `결측 0.0%/15%` 를 내보냈다).
+    if "missing_rate_pct" in report:
+        parts.append(f"결측 {missing}%/{missing_max}%" if missing is not None else f"결측 n/a (한도 {missing_max}%)")
+
+    # 결측률은 **정산된 창만** 세므로, 벤치마크 수집이 멈추면 결측률이 조용히 내려간다.
+    # 프런티어를 같이 찍어야 "결측 낮음"과 "측정 멈춤"이 구분된다 (판정은 안 바꾼다).
+    if "settled_through" in report:
+        frontier = report["settled_through"]
+        lag = report.get("settlement_lag_days")
+        if frontier is None:
+            parts.append("정산 n/a (벤치마크 종가 없음)")
+        else:
+            parts.append(f"정산 {frontier}" + (f" (지연 {lag}d)" if lag is not None else ""))
 
     d = _days_until(report.get("evaluation_date"), report.get("as_of") or today_kst())
     if d is not None:

--- a/nuri/alerts/daily_report.py
+++ b/nuri/alerts/daily_report.py
@@ -6,6 +6,7 @@ Discord 전송 또는 stdout 출력.
 사용법:
     python -m nuri.alerts.daily_report
 """
+
 import logging
 import os
 from datetime import timedelta
@@ -35,9 +36,7 @@ def generate_report() -> dict:
     risk_metrics = analyze_risk()
 
     # Fear & Greed
-    fg_rows = query(
-        "SELECT value FROM macro WHERE indicator = 'fear_greed' ORDER BY date DESC LIMIT 1"
-    )
+    fg_rows = query("SELECT value FROM macro WHERE indicator = 'fear_greed' ORDER BY date DESC LIMIT 1")
     fear_greed = fg_rows[0]["value"] if fg_rows else None
 
     # 내일 이벤트
@@ -51,6 +50,7 @@ def generate_report() -> dict:
     rebalance_info = None
     try:
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         rebalance_info = generate_advisor_report()
     except Exception as e:
         logger.debug("리밸런스 어드바이저 실패: %s", e)
@@ -68,16 +68,20 @@ def generate_report() -> dict:
                 f"→ {a['reason']} (회수 ~${a['sell_value_usd']:,.0f})"
                 for a in critical
             ]
-            embed["fields"].append({
-                "name": f"🚨 규칙 위반 {rebalance_info['total_violations']}건 (즉시 조치)",
-                "value": "\n".join(lines),
-                "inline": False,
-            })
-            embed["fields"].append({
-                "name": "💵 총 회수 가능",
-                "value": f"~${rebalance_info['total_recovery_usd']:,.0f}",
-                "inline": True,
-            })
+            embed["fields"].append(
+                {
+                    "name": f"🚨 규칙 위반 {rebalance_info['total_violations']}건 (즉시 조치)",
+                    "value": "\n".join(lines),
+                    "inline": False,
+                }
+            )
+            embed["fields"].append(
+                {
+                    "name": "💵 총 회수 가능",
+                    "value": f"~${rebalance_info['total_recovery_usd']:,.0f}",
+                    "inline": True,
+                }
+            )
             embed["color"] = 0xE74C3C  # 빨강
 
     return embed
@@ -91,6 +95,7 @@ def send_discord(embed: dict) -> bool:
         return False
 
     import requests
+
     resp = requests.post(
         webhook_url,
         json={"embeds": [embed]},

--- a/nuri/alerts/discord_bot.py
+++ b/nuri/alerts/discord_bot.py
@@ -12,6 +12,7 @@ Discord 알림 봇 — send-only 방식.
     # Bot 방식
     python -m nuri.alerts.discord_bot --bot
 """
+
 import argparse
 import logging
 import os

--- a/nuri/alerts/formatters.py
+++ b/nuri/alerts/formatters.py
@@ -34,58 +34,68 @@ def format_daily_report(
     ]
 
     if risk_metrics:
-        fields.extend([
-            {
-                "name": "📊 Sharpe Ratio",
-                "value": f"{risk_metrics.get('sharpe_ratio', 0):.2f}",
-                "inline": True,
-            },
-            {
-                "name": "📉 Max Drawdown",
-                "value": f"{risk_metrics.get('max_drawdown_pct', 0):+.1f}%",
-                "inline": True,
-            },
-            {
-                "name": "⚡ VaR 95%",
-                "value": f"{risk_metrics.get('var_95_daily_pct', 0):+.2f}%",
-                "inline": True,
-            },
-        ])
+        fields.extend(
+            [
+                {
+                    "name": "📊 Sharpe Ratio",
+                    "value": f"{risk_metrics.get('sharpe_ratio', 0):.2f}",
+                    "inline": True,
+                },
+                {
+                    "name": "📉 Max Drawdown",
+                    "value": f"{risk_metrics.get('max_drawdown_pct', 0):+.1f}%",
+                    "inline": True,
+                },
+                {
+                    "name": "⚡ VaR 95%",
+                    "value": f"{risk_metrics.get('var_95_daily_pct', 0):+.2f}%",
+                    "inline": True,
+                },
+            ]
+        )
 
     if fear_greed is not None:
         fg_label = _fear_greed_label(fear_greed)
-        fields.append({
-            "name": "😱 Fear & Greed",
-            "value": f"{fear_greed:.0f} ({fg_label})",
-            "inline": True,
-        })
+        fields.append(
+            {
+                "name": "😱 Fear & Greed",
+                "value": f"{fear_greed:.0f} ({fg_label})",
+                "inline": True,
+            }
+        )
 
     # 경고
     if warnings:
-        fields.append({
-            "name": "⚠️ 투자규칙 경고",
-            "value": "\n".join(warnings[:5]),
-            "inline": False,
-        })
+        fields.append(
+            {
+                "name": "⚠️ 투자규칙 경고",
+                "value": "\n".join(warnings[:5]),
+                "inline": False,
+            }
+        )
 
     # 손절선 경고
     stop_alerts = risk_metrics.get("stop_loss_alerts", [])
     if stop_alerts:
         alert_text = "\n".join(f"{a['ticker']}: {a['pnl_pct']:+.1f}%" for a in stop_alerts[:5])
-        fields.append({
-            "name": "🚨 손절선 도달",
-            "value": alert_text,
-            "inline": False,
-        })
+        fields.append(
+            {
+                "name": "🚨 손절선 도달",
+                "value": alert_text,
+                "inline": False,
+            }
+        )
 
     # 이벤트
     if events:
         event_text = "\n".join(f"{e['date']} {e['description']}" for e in events[:5])
-        fields.append({
-            "name": "📅 예정 이벤트",
-            "value": event_text,
-            "inline": False,
-        })
+        fields.append(
+            {
+                "name": "📅 예정 이벤트",
+                "value": event_text,
+                "inline": False,
+            }
+        )
 
     color = COLOR_RED if warnings or stop_alerts else COLOR_GREEN
 

--- a/nuri/alerts/telegram.py
+++ b/nuri/alerts/telegram.py
@@ -9,6 +9,7 @@ Telegram 봇 알림 — 레짐 전환, 규칙 위반, 매매 시그널 알림.
     from nuri.alerts.telegram import send_telegram
     send_telegram("레짐 전환: bull → sideways_high_vol")
 """
+
 import logging
 import os
 
@@ -36,11 +37,15 @@ def send_telegram(message: str, parse_mode: str = "HTML") -> bool:
 
     url = f"https://api.telegram.org/bot{_BOT_TOKEN}/sendMessage"
     try:
-        resp = requests.post(url, json={
-            "chat_id": _CHAT_ID,
-            "text": message,
-            "parse_mode": parse_mode,
-        }, timeout=10)
+        resp = requests.post(
+            url,
+            json={
+                "chat_id": _CHAT_ID,
+                "text": message,
+                "parse_mode": parse_mode,
+            },
+            timeout=10,
+        )
         resp.raise_for_status()
         logger.info("Telegram 알림 전송 완료")
         return True
@@ -51,11 +56,7 @@ def send_telegram(message: str, parse_mode: str = "HTML") -> bool:
 
 def format_regime_alert(from_regime: str, to_regime: str, confidence: float) -> str:
     """레짐 전환 Telegram 메시지."""
-    return (
-        f"🔄 <b>레짐 전환</b>\n"
-        f"{from_regime} → <b>{to_regime}</b>\n"
-        f"신뢰도: {confidence:.0f}%"
-    )
+    return f"🔄 <b>레짐 전환</b>\n{from_regime} → <b>{to_regime}</b>\n신뢰도: {confidence:.0f}%"
 
 
 def format_violation_alert(violations: list[dict]) -> str:
@@ -72,7 +73,4 @@ def format_violation_alert(violations: list[dict]) -> str:
 def format_signal_alert(ticker: str, action: str, confidence: float, price: float) -> str:
     """매매 시그널 Telegram 메시지."""
     emoji = "🟢" if action == "BUY" else "🔴" if action == "SELL" else "⚪"
-    return (
-        f"{emoji} <b>{ticker}</b> {action}\n"
-        f"신뢰도: {confidence:.0f} | 가격: ${price:,.2f}"
-    )
+    return f"{emoji} <b>{ticker}</b> {action}\n신뢰도: {confidence:.0f} | 가격: ${price:,.2f}"

--- a/nuri/analysis/sentiment.py
+++ b/nuri/analysis/sentiment.py
@@ -7,6 +7,7 @@ sentiment 컬럼을 업데이트한다. (-1.0 ~ +1.0)
 사용법:
     python -m nuri.analysis.sentiment
 """
+
 import logging
 import re
 
@@ -16,34 +17,133 @@ logger = logging.getLogger(__name__)
 
 # 긍정 키워드 (영어)
 POSITIVE = {
-    "surge", "surges", "surging", "soar", "soars", "soaring",
-    "rally", "rallies", "rallying", "jump", "jumps", "jumping",
-    "beat", "beats", "beating", "exceed", "exceeds", "exceeded",
-    "upgrade", "upgrades", "upgraded", "bullish",
-    "record", "high", "growth", "grow", "grows", "growing",
-    "gain", "gains", "gaining", "profit", "profitable",
-    "strong", "stronger", "strength", "boom", "booming",
-    "outperform", "outperforms", "buy", "positive",
-    "optimistic", "optimism", "recovery", "recover",
-    "breakout", "breakthrough", "innovation", "innovative",
-    "best", "top", "upside", "up", "rise", "rises", "rising",
+    "surge",
+    "surges",
+    "surging",
+    "soar",
+    "soars",
+    "soaring",
+    "rally",
+    "rallies",
+    "rallying",
+    "jump",
+    "jumps",
+    "jumping",
+    "beat",
+    "beats",
+    "beating",
+    "exceed",
+    "exceeds",
+    "exceeded",
+    "upgrade",
+    "upgrades",
+    "upgraded",
+    "bullish",
+    "record",
+    "high",
+    "growth",
+    "grow",
+    "grows",
+    "growing",
+    "gain",
+    "gains",
+    "gaining",
+    "profit",
+    "profitable",
+    "strong",
+    "stronger",
+    "strength",
+    "boom",
+    "booming",
+    "outperform",
+    "outperforms",
+    "buy",
+    "positive",
+    "optimistic",
+    "optimism",
+    "recovery",
+    "recover",
+    "breakout",
+    "breakthrough",
+    "innovation",
+    "innovative",
+    "best",
+    "top",
+    "upside",
+    "up",
+    "rise",
+    "rises",
+    "rising",
 }
 
 # 부정 키워드 (영어)
 NEGATIVE = {
-    "crash", "crashes", "crashing", "plunge", "plunges", "plunging",
-    "drop", "drops", "dropping", "fall", "falls", "falling",
-    "miss", "misses", "missed", "decline", "declines", "declining",
-    "downgrade", "downgrades", "downgraded", "bearish",
-    "loss", "losses", "losing", "lose", "deficit",
-    "weak", "weaker", "weakness", "slump", "slumps", "slumping",
-    "underperform", "underperforms", "sell", "negative",
-    "pessimistic", "pessimism", "recession", "recessionary",
-    "bankruptcy", "bankrupt", "default", "defaults",
-    "worst", "bottom", "downside", "down", "risk", "risky",
-    "cut", "cuts", "cutting", "layoff", "layoffs",
-    "warning", "warns", "warned", "concern", "concerns",
-    "fear", "fears", "investigation", "lawsuit", "fraud",
+    "crash",
+    "crashes",
+    "crashing",
+    "plunge",
+    "plunges",
+    "plunging",
+    "drop",
+    "drops",
+    "dropping",
+    "fall",
+    "falls",
+    "falling",
+    "miss",
+    "misses",
+    "missed",
+    "decline",
+    "declines",
+    "declining",
+    "downgrade",
+    "downgrades",
+    "downgraded",
+    "bearish",
+    "loss",
+    "losses",
+    "losing",
+    "lose",
+    "deficit",
+    "weak",
+    "weaker",
+    "weakness",
+    "slump",
+    "slumps",
+    "slumping",
+    "underperform",
+    "underperforms",
+    "sell",
+    "negative",
+    "pessimistic",
+    "pessimism",
+    "recession",
+    "recessionary",
+    "bankruptcy",
+    "bankrupt",
+    "default",
+    "defaults",
+    "worst",
+    "bottom",
+    "downside",
+    "down",
+    "risk",
+    "risky",
+    "cut",
+    "cuts",
+    "cutting",
+    "layoff",
+    "layoffs",
+    "warning",
+    "warns",
+    "warned",
+    "concern",
+    "concerns",
+    "fear",
+    "fears",
+    "investigation",
+    "lawsuit",
+    "fraud",
 }
 
 
@@ -52,7 +152,7 @@ def compute_sentiment(title: str) -> float:
     if not title:
         return 0.0
 
-    words = set(re.findall(r'[a-zA-Z]+', title.lower()))
+    words = set(re.findall(r"[a-zA-Z]+", title.lower()))
     pos = len(words & POSITIVE)
     neg = len(words & NEGATIVE)
     total = pos + neg
@@ -126,9 +226,9 @@ def print_sentiment(stats: dict) -> None:
     print(f"{'=' * 50}")
     print(f"  전체 뉴스:  {total}건")
     print(f"  평균 점수:  {avg:+.3f} ({label})")
-    print(f"  긍정:       {pos}건 ({pos/total*100:.1f}%)")
-    print(f"  부정:       {neg}건 ({neg/total*100:.1f}%)")
-    print(f"  중립:       {neu}건 ({neu/total*100:.1f}%)")
+    print(f"  긍정:       {pos}건 ({pos / total * 100:.1f}%)")
+    print(f"  부정:       {neg}건 ({neg / total * 100:.1f}%)")
+    print(f"  중립:       {neu}건 ({neu / total * 100:.1f}%)")
 
     # 종목별 센티먼트
     by_ticker = query("""

--- a/nuri/api/auth.py
+++ b/nuri/api/auth.py
@@ -17,6 +17,7 @@ API 인증 모듈 — JWT 토큰 + API 키 인증.
     def write_data(user=Depends(require_write_auth)):
         ...
 """
+
 import logging
 import os
 import secrets

--- a/nuri/api/routes/decisions.py
+++ b/nuri/api/routes/decisions.py
@@ -1,4 +1,5 @@
 """Decision Intelligence API — 의사결정 저널 조회 + lineage."""
+
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query

--- a/nuri/api/routes/engine.py
+++ b/nuri/api/routes/engine.py
@@ -1,4 +1,5 @@
 """SIEGE-inspired engine API: gate, conflicts, memory, certifications."""
+
 import json
 from dataclasses import asdict
 from typing import Optional
@@ -15,16 +16,16 @@ router = APIRouter(tags=["engine"])
 def get_gate():
     """파이프라인 게이트 상태 (전 단계)."""
     from nuri.trading.engine.gate import check_all_gates
+
     gates = check_all_gates()
-    return {
-        phase: asdict(result) for phase, result in gates.items()
-    }
+    return {phase: asdict(result) for phase, result in gates.items()}
 
 
 @router.get("/gate/{phase}")
 def get_gate_phase(phase: str):
     """특정 단계 게이트 상태."""
     from nuri.trading.engine.gate import check_gate
+
     result = check_gate(phase)
     return asdict(result)
 
@@ -33,6 +34,7 @@ def get_gate_phase(phase: str):
 def get_conflicts():
     """시그널 충돌 감지."""
     from nuri.trading.engine.conflicts import detect_conflicts
+
     conflicts = detect_conflicts()
     return {
         "conflicts": [asdict(c) for c in conflicts],
@@ -45,6 +47,7 @@ def get_conflicts():
 def get_memory():
     """전략 학습 메모리 — 성과 변화 감지."""
     from nuri.trading.engine.memory import detect_drift
+
     drifts = detect_drift()
     return {
         "drifts": [asdict(d) for d in drifts],
@@ -57,6 +60,7 @@ def get_memory():
 def post_memory_snapshot(user=Depends(require_write_auth)):
     """전략 성과 스냅샷 저장 (인증 필요)."""
     from nuri.trading.engine.memory import save_snapshot
+
     n = save_snapshot()
     return {"saved": n}
 
@@ -150,8 +154,7 @@ def get_certifications_summary(days: int = Query(30, ge=1, le=365)):
     """
     from nuri.core.timezone import kst_now
 
-    cutoff = (kst_now().replace(tzinfo=None) -
-              __import__("datetime").timedelta(days=days)).isoformat()
+    cutoff = (kst_now().replace(tzinfo=None) - __import__("datetime").timedelta(days=days)).isoformat()
 
     rows = query(
         """SELECT certified, score, regime, caller, timestamp FROM certifications

--- a/nuri/api/routes/evidence.py
+++ b/nuri/api/routes/evidence.py
@@ -1,4 +1,5 @@
 """증거 차트 API — Plotly HTML 차트 서빙 + 메타데이터."""
+
 import logging
 from datetime import date
 from pathlib import Path
@@ -46,12 +47,14 @@ def list_evidence():
             evidence_dir / f"{chart_id}_evidence.html",
         ]
         exists = any(p.exists() for p in candidates)
-        available.append({
-            "id": chart_id,
-            "description": description,
-            "available": exists,
-            "date": evidence_dir.parent.name,
-        })
+        available.append(
+            {
+                "id": chart_id,
+                "description": description,
+                "available": exists,
+                "date": evidence_dir.parent.name,
+            }
+        )
 
     return {"charts": available, "date": evidence_dir.parent.name}
 

--- a/nuri/api/routes/external.py
+++ b/nuri/api/routes/external.py
@@ -1,4 +1,5 @@
 """외부 분석 데이터 API — TipRanks, Dataroma, Macrotrends 등 저장/조회."""
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
@@ -20,6 +21,7 @@ class ExternalInput(BaseModel):
 def get_external_summary():
     """외부 데이터 전체 요약."""
     from nuri.collectors.external import get_external_summary
+
     return get_external_summary()
 
 
@@ -27,6 +29,7 @@ def get_external_summary():
 def get_ticker_external(ticker: str):
     """종목별 외부 데이터 조회."""
     from nuri.collectors.external import get_external
+
     data = get_external(ticker.upper())
     return {"ticker": ticker.upper(), "data": data, "count": len(data)}
 
@@ -46,9 +49,13 @@ def save_external_data(item: ExternalInput, user=Depends(require_write_auth)):
         details=item.details,
     )
     if ok:
-        audit_log("INSERT", "external_analysis", item.ticker.upper(),
-                  f"{item.source}/{item.data_type}={item.value}",
-                  user_id=user.get("sub", "unknown"))
+        audit_log(
+            "INSERT",
+            "external_analysis",
+            item.ticker.upper(),
+            f"{item.source}/{item.data_type}={item.value}",
+            user_id=user.get("sub", "unknown"),
+        )
     return {"ok": ok}
 
 

--- a/nuri/api/routes/learning_memory.py
+++ b/nuri/api/routes/learning_memory.py
@@ -7,6 +7,7 @@
 
 Read-only. No mutation. 5-min in-memory cache (consensus 패턴 일관).
 """
+
 import time
 
 from fastapi import APIRouter

--- a/nuri/api/routes/portfolio.py
+++ b/nuri/api/routes/portfolio.py
@@ -1,4 +1,5 @@
 """포트폴리오 + 리스크 API."""
+
 import csv
 import io
 import json
@@ -88,6 +89,7 @@ class HoldingInput(BaseModel):
 
 class HoldingUpdate(BaseModel):
     """보유 종목 수정용 모델. 모든 필드 optional — 전달된 필드만 업데이트."""
+
     quantity: Optional[float] = None
     avg_price: Optional[float] = None
     currency: Optional[CurrencyEnum] = None
@@ -176,6 +178,7 @@ def get_portfolio():
     """종목별 보유 현황 + 계좌별 cash 잔액 (#213) + 일변/sparkline (#214)."""
     from nuri.api.routes.dashboard import _get_cash_balances
     from nuri.core.ticker_names import get_ticker_name
+
     rows = query("""
         SELECT p.ticker, p.account, p.quantity, p.avg_price, p.currency, p.sector,
                p.first_buy_date,
@@ -210,9 +213,13 @@ def add_holding(holding: HoldingInput, user=Depends(require_write_auth)):
     if record.get("metadata") is not None:
         record["metadata"] = json.dumps(record["metadata"], ensure_ascii=False)
     upsert_portfolio([record])
-    audit_log("INSERT", "portfolio", record["ticker"],
-              f"account={record['account']} qty={record['quantity']} avg={record['avg_price']}",
-              user_id=user.get("sub", "unknown"))
+    audit_log(
+        "INSERT",
+        "portfolio",
+        record["ticker"],
+        f"account={record['account']} qty={record['quantity']} avg={record['avg_price']}",
+        user_id=user.get("sub", "unknown"),
+    )
     _try_sync_yaml()
     return {"ok": True, "ticker": record["ticker"]}
 
@@ -237,8 +244,7 @@ def delete_holding(account: str, ticker: str, user=Depends(require_write_auth)):
         )
     if cur.rowcount == 0:
         raise HTTPException(status_code=404, detail="종목 미발견")
-    audit_log("DELETE", "portfolio", ticker,
-              f"account={account}", user_id=user.get("sub", "unknown"))
+    audit_log("DELETE", "portfolio", ticker, f"account={account}", user_id=user.get("sub", "unknown"))
     _try_sync_yaml()
     return {"ok": True, "deleted": ticker}
 
@@ -283,9 +289,7 @@ def update_holding(account: str, ticker: str, update: HoldingUpdate, user=Depend
     if cur.rowcount == 0:
         raise HTTPException(status_code=404, detail="종목 미발견")
 
-    audit_log("UPDATE", "portfolio", ticker,
-              f"account={account} changes={changes}",
-              user_id=user.get("sub", "unknown"))
+    audit_log("UPDATE", "portfolio", ticker, f"account={account} changes={changes}", user_id=user.get("sub", "unknown"))
     _try_sync_yaml()
     return {"ok": True, "ticker": ticker, "updated": changes}
 
@@ -358,21 +362,22 @@ def import_portfolio(file: UploadFile, user=Depends(require_write_auth)):
             errors.append(f"행 {i}: quantity/avg_price는 0보다 커야 합니다")
             continue
 
-        records.append({
-            "account": account,
-            "ticker": ticker,
-            "quantity": qty,
-            "avg_price": avg,
-            "currency": row.get("currency", "USD").upper() or "USD",
-            "sector": row.get("sector", ""),
-        })
+        records.append(
+            {
+                "account": account,
+                "ticker": ticker,
+                "quantity": qty,
+                "avg_price": avg,
+                "currency": row.get("currency", "USD").upper() or "USD",
+                "sector": row.get("sector", ""),
+            }
+        )
 
     if not records and errors:
         raise HTTPException(status_code=400, detail=f"유효한 행 없음: {'; '.join(errors[:5])}")
 
     count = upsert_portfolio(records)
-    audit_log("IMPORT", "portfolio", f"{count} records",
-              f"file={file.filename}", user_id=user.get("sub", "unknown"))
+    audit_log("IMPORT", "portfolio", f"{count} records", f"file={file.filename}", user_id=user.get("sub", "unknown"))
     _try_sync_yaml()
     return {"ok": True, "imported": count, "errors": errors}
 
@@ -381,8 +386,7 @@ def import_portfolio(file: UploadFile, user=Depends(require_write_auth)):
 def export_portfolio(format: str = "csv"):
     """포트폴리오 CSV/YAML 다운로드."""
     rows = query(
-        "SELECT account, ticker, quantity, avg_price, currency, sector "
-        "FROM portfolio ORDER BY account, ticker"
+        "SELECT account, ticker, quantity, avg_price, currency, sector FROM portfolio ORDER BY account, ticker"
     )
 
     if format == "yaml":
@@ -392,16 +396,22 @@ def export_portfolio(format: str = "csv"):
             acct = r["account"]
             if acct not in accounts:
                 accounts[acct] = {"currency": r["currency"], "holdings": []}
-            accounts[acct]["holdings"].append({
-                "ticker": r["ticker"],
-                "qty": r["quantity"],
-                "avg": r["avg_price"],
-                **({"sector": r["sector"]} if r["sector"] else {}),
-            })
+            accounts[acct]["holdings"].append(
+                {
+                    "ticker": r["ticker"],
+                    "qty": r["quantity"],
+                    "avg": r["avg_price"],
+                    **({"sector": r["sector"]} if r["sector"] else {}),
+                }
+            )
         from nuri.core.portfolio_sync import _HoldingFlowDumper
+
         content = yaml.dump(
-            {"accounts": accounts}, Dumper=_HoldingFlowDumper,
-            allow_unicode=True, default_flow_style=False, sort_keys=False,
+            {"accounts": accounts},
+            Dumper=_HoldingFlowDumper,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
         )
         return StreamingResponse(
             io.BytesIO(content.encode("utf-8")),
@@ -416,14 +426,16 @@ def export_portfolio(format: str = "csv"):
     writer = csv.DictWriter(output, fieldnames=["account", "ticker", "quantity", "avg_price", "currency", "sector"])
     writer.writeheader()
     for r in rows:
-        writer.writerow({
-            "account": r["account"],
-            "ticker": r["ticker"],
-            "quantity": r["quantity"],
-            "avg_price": r["avg_price"],
-            "currency": r["currency"],
-            "sector": r["sector"] or "",
-        })
+        writer.writerow(
+            {
+                "account": r["account"],
+                "ticker": r["ticker"],
+                "quantity": r["quantity"],
+                "avg_price": r["avg_price"],
+                "currency": r["currency"],
+                "sector": r["sector"] or "",
+            }
+        )
     return StreamingResponse(
         io.BytesIO(output.getvalue().encode("utf-8")),
         media_type="text/csv",
@@ -435,7 +447,14 @@ def export_portfolio(format: str = "csv"):
 
 _SAMPLE_PORTFOLIO = [
     {"account": "sample", "ticker": "AAPL", "quantity": 10, "avg_price": 190.0, "currency": "USD", "sector": "BigTech"},
-    {"account": "sample", "ticker": "NVDA", "quantity": 5, "avg_price": 130.0, "currency": "USD", "sector": "Semiconductor"},
+    {
+        "account": "sample",
+        "ticker": "NVDA",
+        "quantity": 5,
+        "avg_price": 130.0,
+        "currency": "USD",
+        "sector": "Semiconductor",
+    },
     {"account": "sample", "ticker": "GOOGL", "quantity": 3, "avg_price": 170.0, "currency": "USD", "sector": "BigTech"},
     {"account": "sample", "ticker": "TSLA", "quantity": 8, "avg_price": 250.0, "currency": "USD", "sector": "EV"},
     {"account": "sample", "ticker": "VOO", "quantity": 2, "avg_price": 500.0, "currency": "USD", "sector": "ETF"},
@@ -452,8 +471,7 @@ def load_sample_portfolio(user=Depends(require_write_auth)):
         conn.execute("DELETE FROM portfolio WHERE account='sample'")
 
     count = upsert_portfolio(_SAMPLE_PORTFOLIO)
-    audit_log("SAMPLE", "portfolio", f"{count} records",
-              "loaded sample portfolio", user_id=user.get("sub", "unknown"))
+    audit_log("SAMPLE", "portfolio", f"{count} records", "loaded sample portfolio", user_id=user.get("sub", "unknown"))
     _try_sync_yaml()
     return {"ok": True, "loaded": count}
 
@@ -463,6 +481,7 @@ def get_risk():
     """리스크 지표."""
     try:
         from nuri.analysis.risk import analyze_risk
+
         metrics = analyze_risk()
         # numpy → Python 변환
         result = {}

--- a/nuri/api/routes/rebalance.py
+++ b/nuri/api/routes/rebalance.py
@@ -1,4 +1,5 @@
 """리밸런싱 API."""
+
 import logging
 from dataclasses import asdict
 
@@ -13,6 +14,7 @@ def get_rebalance(method: str = Query("rp", pattern="^(mvo|rp)$")):
     """레짐 적응 리밸런싱 제안."""
     try:
         from nuri.trading.recommend.rebalance import regime_aware_rebalance
+
         actions = regime_aware_rebalance(method=method)
         return {
             "actions": [asdict(a) for a in actions],
@@ -29,4 +31,5 @@ def get_rebalance(method: str = Query("rp", pattern="^(mvo|rp)$")):
 def get_tracking():
     """추천 추적 리포트."""
     from nuri.trading.recommend.tracker import get_tracking_report
+
     return get_tracking_report()

--- a/nuri/api/routes/regime.py
+++ b/nuri/api/routes/regime.py
@@ -1,4 +1,5 @@
 """레짐 + 매크로 + LLM 리포트 API."""
+
 import logging
 from dataclasses import asdict
 
@@ -12,6 +13,7 @@ router = APIRouter(tags=["regime"])
 def get_regime():
     """현재 시장 레짐."""
     from nuri.quant.regime.classifier import classify_regime
+
     state = classify_regime()
     if state is None:
         return {"error": "SPY 데이터 부족"}
@@ -22,6 +24,7 @@ def get_regime():
 def get_macro():
     """매크로 스코어."""
     from nuri.quant.regime.macro_score import compute_macro_score
+
     score = compute_macro_score()
     return asdict(score)
 
@@ -30,6 +33,7 @@ def get_macro():
 def get_report():
     """LLM 리포트 (Gate → Context → Generate → Validate)."""
     from nuri.llm.report import generate_llm_report
+
     try:
         return generate_llm_report()
     except Exception:
@@ -42,6 +46,7 @@ def get_report():
 def get_report_context():
     """LLM 리포트 컨텍스트 (프롬프트 입력 데이터)."""
     from nuri.llm.report import format_prompt, gather_context
+
     ctx = gather_context()
     return {
         "prompt": format_prompt(ctx),
@@ -54,6 +59,7 @@ def get_report_context():
 def get_strategy():
     """레짐별 전략 추천."""
     from nuri.quant.regime.strategy_map import map_regime_to_strategy
+
     rec = map_regime_to_strategy()
     if rec is None:
         return {"error": "데이터 부족"}

--- a/nuri/api/routes/signals.py
+++ b/nuri/api/routes/signals.py
@@ -1,4 +1,5 @@
 """시그널 후보 + 스코어카드 API."""
+
 from dataclasses import asdict
 
 from fastapi import APIRouter, Query
@@ -10,6 +11,7 @@ router = APIRouter(tags=["signals"])
 def get_candidates(days: int = Query(5, ge=1, le=30)):
     """시그널 기반 매매 후보. buy/sell 카운트는 actionable tier 만 (B-2-ext)."""
     from nuri.trading.recommend.candidates import TIER_ACTIONABLE, screen_candidates
+
     candidates = screen_candidates(lookback_days=days)
     actionable = [c for c in candidates if c.tier == TIER_ACTIONABLE and c.regime_fit]
     return {
@@ -51,6 +53,7 @@ def get_scorecard():
 def get_cross_analysis():
     """시그널 × 레짐 교차분석."""
     from nuri.quant.regime.strategy_map import analyze_signal_by_regime
+
     df = analyze_signal_by_regime()
     if df.empty:
         return {"error": "교차분석 데이터 없음"}

--- a/nuri/api/routes/swing.py
+++ b/nuri/api/routes/swing.py
@@ -1,4 +1,5 @@
 """스윙 트레이드 API."""
+
 from dataclasses import asdict
 from time import monotonic
 
@@ -14,6 +15,7 @@ _interactive_backtest_cache: dict[tuple[int, str, int, int], tuple[float, dict]]
 def get_scan(market: str = Query("us", pattern="^(us|kr)$"), top: int = Query(20, ge=1, le=50)):
     """시장 스캔."""
     from nuri.trading.swing.scanner import scan_market
+
     results = scan_market(market=market, top_n=top)
     return {"results": [asdict(r) for r in results], "count": len(results)}
 
@@ -24,10 +26,15 @@ def get_swing_entries(market: str = Query("us", pattern="^(us|kr)$")):
     import json
 
     from nuri.trading.swing.rules import evaluate_entries
+
     entries = evaluate_entries(market=market)
     # numpy 타입 → Python 네이티브 변환
     raw = [asdict(e) for e in entries]
-    cleaned = json.loads(json.dumps(raw, default=lambda x: x.item() if hasattr(x, 'item') else bool(x) if isinstance(x, type(True)) else str(x)))
+    cleaned = json.loads(
+        json.dumps(
+            raw, default=lambda x: x.item() if hasattr(x, "item") else bool(x) if isinstance(x, type(True)) else str(x)
+        )
+    )
     return {
         "entries": cleaned,
         "approved": len([e for e in entries if e.approved]),
@@ -39,6 +46,7 @@ def get_swing_entries(market: str = Query("us", pattern="^(us|kr)$")):
 def get_swing_positions():
     """오픈 포지션 청산 체크."""
     from nuri.trading.swing.rules import check_exits
+
     exits = check_exits()
     return {"positions": [asdict(e) for e in exits], "count": len(exits)}
 
@@ -53,6 +61,7 @@ def get_backtest():
         run_backtest,
         stress_test,
     )
+
     regimes = classify_historical_regimes()
     if regimes.empty:
         return {"error": "SPY data insufficient"}
@@ -62,15 +71,26 @@ def get_backtest():
     stress = stress_test(regimes)
     import json
     from dataclasses import asdict
+
     # numpy 타입 → Python 네이티브 변환
     def _clean(obj):
-        return json.loads(json.dumps(obj, default=lambda x: x.item() if hasattr(x, 'item') else (bool(x) if isinstance(x, (type(True),)) else str(x))))
-    return _clean({
-        "result": asdict(result),
-        "regimes": [asdict(p) for p in perfs],
-        "timing": asdict(timing) if timing else None,
-        "stress": stress,
-    })
+        return json.loads(
+            json.dumps(
+                obj,
+                default=lambda x: (
+                    x.item() if hasattr(x, "item") else (bool(x) if isinstance(x, (type(True),)) else str(x))
+                ),
+            )
+        )
+
+    return _clean(
+        {
+            "result": asdict(result),
+            "regimes": [asdict(p) for p in perfs],
+            "timing": asdict(timing) if timing else None,
+            "stress": stress,
+        }
+    )
 
 
 @router.get("/backtest/equity")
@@ -127,21 +147,23 @@ def get_backtest_equity(
         dd_pct = ((val - peak) / peak * 100) if peak > 0 else 0
         drawdown.append({"date": pt.get("date"), "drawdown": round(dd_pct, 2)})
 
-    response = _clean({
-        "equity": equity,
-        "drawdown": drawdown,
-        "metrics": {
-            "total_return": result.total_return,
-            "annual_return": result.annual_return,
-            "sharpe": result.sharpe,
-            "max_drawdown": result.max_drawdown,
-            "win_rate": result.win_rate,
-            "spy_total_return": result.spy_total_return,
-            "spy_sharpe": result.spy_sharpe,
-            "spy_max_drawdown": result.spy_max_drawdown,
-            "excess_return": result.excess_return,
-        },
-    })
+    response = _clean(
+        {
+            "equity": equity,
+            "drawdown": drawdown,
+            "metrics": {
+                "total_return": result.total_return,
+                "annual_return": result.annual_return,
+                "sharpe": result.sharpe,
+                "max_drawdown": result.max_drawdown,
+                "win_rate": result.win_rate,
+                "spy_total_return": result.spy_total_return,
+                "spy_sharpe": result.spy_sharpe,
+                "spy_max_drawdown": result.spy_max_drawdown,
+                "excess_return": result.excess_return,
+            },
+        }
+    )
     _interactive_backtest_cache[cache_key] = (now, response)
     return response
 

--- a/nuri/api/routes/trades.py
+++ b/nuri/api/routes/trades.py
@@ -1,4 +1,5 @@
 """매매 실행 추적 API — 추천에 대한 실제 매매 기록."""
+
 from datetime import datetime
 from typing import Optional
 
@@ -13,6 +14,7 @@ router = APIRouter(tags=["trades"])
 
 class TradeInput(BaseModel):
     """매매 실행 기록 입력."""
+
     recommendation_id: Optional[int] = None
     ticker: str
     action: str
@@ -55,6 +57,7 @@ class TradeInput(BaseModel):
 
 class TradeUpdateInput(BaseModel):
     """매매 종료 정보 업데이트."""
+
     exit_price: Optional[float] = None
     exit_date: Optional[str] = None
     exit_reason: Optional[str] = None
@@ -66,9 +69,13 @@ def create_trade(trade: TradeInput, user=Depends(require_write_auth)):
     """매매 실행 기록 저장."""
     data = trade.model_dump(exclude_none=True)
     trade_id = upsert_trade(data)
-    audit_log("INSERT", "trades", trade.ticker,
-              f"action={trade.action} shares={trade.shares}",
-              user_id=user.get("sub", "unknown"))
+    audit_log(
+        "INSERT",
+        "trades",
+        trade.ticker,
+        f"action={trade.action} shares={trade.shares}",
+        user_id=user.get("sub", "unknown"),
+    )
     return {"ok": True, "trade_id": trade_id}
 
 
@@ -87,6 +94,5 @@ def update_trade(trade_id: int, update: TradeUpdateInput, user=Depends(require_w
         raise HTTPException(status_code=400, detail="업데이트할 필드 없음")
     data["id"] = trade_id
     upsert_trade(data)
-    audit_log("UPDATE", "trades", "",
-              f"trade_id={trade_id}", user_id=user.get("sub", "unknown"))
+    audit_log("UPDATE", "trades", "", f"trade_id={trade_id}", user_id=user.get("sub", "unknown"))
     return {"ok": True, "trade_id": trade_id}

--- a/nuri/core/agent_config.py
+++ b/nuri/core/agent_config.py
@@ -6,6 +6,7 @@
     rsi_oversold = cfg["rsi_oversold"]   # 30
     conf_cap = cfg["confidence"]["cap"]  # 90
 """
+
 from pathlib import Path
 
 import yaml

--- a/nuri/core/alerts_config.py
+++ b/nuri/core/alerts_config.py
@@ -4,6 +4,7 @@
     from nuri.core.alerts_config import ALERTS_CONFIG
     fg_low = ALERTS_CONFIG["alerts"]["fear_greed_low"]   # 20
 """
+
 from pathlib import Path
 
 import yaml

--- a/nuri/core/axis.py
+++ b/nuri/core/axis.py
@@ -16,6 +16,7 @@ Semantic (codex Plan Q1-B dual-accept):
   사용해야 한다 (codex Plan Scope 검증). 중복 구현 피하려면 shared helper 가 필수.
 - Strict mode 전환 시 한 곳만 수정하면 모든 consumer 가 자동 반영.
 """
+
 from __future__ import annotations
 
 

--- a/nuri/core/catalyst.py
+++ b/nuri/core/catalyst.py
@@ -13,6 +13,7 @@ Non-emergency SELL 추천은 이유(catalyst)가 있어야 한다. stop-loss bre
     if not ok:
         # downgrade SELL to advisory
 """
+
 from __future__ import annotations
 
 from nuri.core.db import query

--- a/nuri/core/live_price.py
+++ b/nuri/core/live_price.py
@@ -22,6 +22,7 @@ Usage:
         log.warning("TSLA diverged %+.2f%% — stored=%.2f live=%.2f",
                     pct, stored_price, live_val)
 """
+
 from __future__ import annotations
 
 import logging
@@ -52,6 +53,7 @@ def is_market_open_us(now=None) -> bool:
       (codex Round 1 P2 수정: 이전엔 오늘 기준으로만 평일 check → 일→월 새벽 오판)
     """
     from datetime import timedelta
+
     now = now or kst_now()
     t = now.time()
     if t >= _US_OPEN_KST:
@@ -94,6 +96,7 @@ def fetch_live_price(ticker: str) -> float | None:
 
     try:
         import yfinance as yf
+
         info = yf.Ticker(ticker).fast_info
         price = info.last_price
         if price is None or price <= 0:

--- a/nuri/core/portfolio_sync.py
+++ b/nuri/core/portfolio_sync.py
@@ -5,6 +5,7 @@ YAML에만 존재하는 메타데이터(name, broker, total_invested, cash_*, au
 holdings dict는 flow style로 출력하여 원본 포맷과 일치시킨다.
 metadata JSON 컬럼의 추가 필드(flag 등)도 YAML에 복원.
 """
+
 import json
 import logging
 from pathlib import Path
@@ -29,6 +30,7 @@ _YAML_HEADER = """\
 
 class _HoldingFlowDumper(yaml.Dumper):
     """holdings 항목(ticker 키가 있는 dict)만 flow style로 출력."""
+
     pass
 
 
@@ -121,8 +123,7 @@ def sync_portfolio_to_yaml(config_path: Path | None = None, db_path=None) -> int
 
     with open(config_path, "w", encoding="utf-8") as f:
         f.write(_YAML_HEADER)
-        yaml.dump(existing, f, Dumper=_HoldingFlowDumper,
-                  allow_unicode=True, default_flow_style=False, sort_keys=False)
+        yaml.dump(existing, f, Dumper=_HoldingFlowDumper, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
     total = sum(len(h) for h in db_holdings.values())
     logger.info("portfolio.yaml 동기화 완료: %d 종목", total)

--- a/nuri/core/signal_config.py
+++ b/nuri/core/signal_config.py
@@ -14,6 +14,7 @@
     - detector 함수 자체는 코드 (실행 가능 로직)
     - signal_backtest.py의 SIGNAL_DEFINITIONS는 YAML + detectors로 빌드
 """
+
 from pathlib import Path
 
 import yaml
@@ -52,7 +53,8 @@ def is_enabled(signal_id: str) -> bool:
 def list_buy_signals() -> set[str]:
     """type=BUY로 분류된 모든 시그널 ID."""
     return {
-        sid for sid, meta in SIGNAL_CONFIG.get("signals", {}).items()
+        sid
+        for sid, meta in SIGNAL_CONFIG.get("signals", {}).items()
         if meta.get("type") == "BUY" and meta.get("enabled", True)
     }
 
@@ -60,7 +62,8 @@ def list_buy_signals() -> set[str]:
 def list_sell_signals() -> set[str]:
     """type=SELL로 분류된 모든 시그널 ID."""
     return {
-        sid for sid, meta in SIGNAL_CONFIG.get("signals", {}).items()
+        sid
+        for sid, meta in SIGNAL_CONFIG.get("signals", {}).items()
         if meta.get("type") == "SELL" and meta.get("enabled", True)
     }
 
@@ -85,6 +88,7 @@ def list_shadow_signals() -> set[str]:
     용으로만 사용, candidates/confidence 에 영향 없음. scorecard 집계는 계속.
     """
     return {
-        sid for sid, meta in SIGNAL_CONFIG.get("signals", {}).items()
+        sid
+        for sid, meta in SIGNAL_CONFIG.get("signals", {}).items()
         if meta.get("enabled", True) and meta.get("actionable", True) is False
     }

--- a/nuri/core/timezone.py
+++ b/nuri/core/timezone.py
@@ -1,4 +1,5 @@
 """타임존 유틸리티 -- UTC 기반 내부 시간, KST 표시용 변환."""
+
 from datetime import datetime, timedelta, timezone
 
 KST = timezone(timedelta(hours=9))

--- a/nuri/llm/event_classifier.py
+++ b/nuri/llm/event_classifier.py
@@ -22,6 +22,7 @@ OpenAI gpt-5.4-nano로 교체. regex는 per-headline graceful degradation으로 
     result = classify_event("Iran and Israel agree to ceasefire after 2 weeks of strikes")
     # → {'category': 'geopolitical_de_escalation', 'sentiment': 0.5, ...}
 """
+
 import logging
 import re
 
@@ -34,21 +35,21 @@ logger = logging.getLogger(__name__)
 
 # 카테고리 — 새 카테고리 추가 시 REGIME_HINT 매핑도 반드시 함께 추가.
 CATEGORIES: tuple[str, ...] = (
-    "geopolitical_escalation",     # war, sanctions, missile strike, invasion
+    "geopolitical_escalation",  # war, sanctions, missile strike, invasion
     "geopolitical_de_escalation",  # ceasefire, treaty, peace talks
-    "fed_dovish",                  # rate cut, dovish, pause, easing
-    "fed_hawkish",                 # rate hike, hawkish, tightening
-    "oil_supply_shock",            # opec cut, sanctions on oil, refinery shutdown
-    "oil_demand_drop",             # oil oversupply, recession-driven demand fall
-    "earnings_beat",               # beat estimates, raised guidance
-    "earnings_miss",               # missed, cut guidance, profit warning
-    "sector_rally",                # broad sector surge / rotation
-    "sector_selloff",              # sector plunge / crash
-    "trade_war",                   # tariff, retaliation, trade deal collapse
-    "export_surge",                # Korea/global export boom, trade surplus, shipment growth
-    "currency_shift",              # FX major move (USD/KRW, yen carry unwind, DXY)
-    "demand_growth",               # semiconductor demand, chip shortage, AI capex, global PMI up
-    "neutral",                     # default — no actionable signal
+    "fed_dovish",  # rate cut, dovish, pause, easing
+    "fed_hawkish",  # rate hike, hawkish, tightening
+    "oil_supply_shock",  # opec cut, sanctions on oil, refinery shutdown
+    "oil_demand_drop",  # oil oversupply, recession-driven demand fall
+    "earnings_beat",  # beat estimates, raised guidance
+    "earnings_miss",  # missed, cut guidance, profit warning
+    "sector_rally",  # broad sector surge / rotation
+    "sector_selloff",  # sector plunge / crash
+    "trade_war",  # tariff, retaliation, trade deal collapse
+    "export_surge",  # Korea/global export boom, trade surplus, shipment growth
+    "currency_shift",  # FX major move (USD/KRW, yen carry unwind, DXY)
+    "demand_growth",  # semiconductor demand, chip shortage, AI capex, global PMI up
+    "neutral",  # default — no actionable signal
 )
 
 # 카테고리 → 레짐 힌트 (Phase B에서 special_regime promotion 후보로 사용 예정).
@@ -75,42 +76,33 @@ REGIME_HINT_BY_CATEGORY: dict[str, str | None] = {
 # (regex_pattern, category, sentiment_default)
 # 패턴은 case-insensitive, 학습이 아닌 키워드 매칭 — false positive 있을 수 있음.
 _KEYWORD_PATTERNS: list[tuple[str, str, float]] = [
-    (r"\b(ceasefire|truce|peace deal|treaty signed|de[- ]?escalat\w*|talks resume)\b",
-     "geopolitical_de_escalation", 0.5),
-    (r"\b(missile strike|invasion|attack|escalat\w*|sanctions imposed|retaliat\w*|airstrike|war)\b",
-     "geopolitical_escalation", -0.6),
-    (r"\b(rate cut|dovish|fed pause|easing cycle|cut rates)\b",
-     "fed_dovish", 0.4),
-    (r"\b(rate hike|hawkish|tightening|raise rates|hike rates)\b",
-     "fed_hawkish", -0.3),
-    (r"\b(opec[+]? cut|oil supply|refinery shut|crude shortage)\b",
-     "oil_supply_shock", -0.4),
-    (r"\b(oil price drop|crude plunge|oil oversupply|wti tumbl)\b",
-     "oil_demand_drop", 0.2),
-    (r"\b(beat estimates|earnings beat|raised guidance|crushed estimates|tops forecast)\b",
-     "earnings_beat", 0.5),
-    (r"\b(earnings miss|missed estimates|cut guidance|profit warn|guidance lower)\b",
-     "earnings_miss", -0.5),
+    (
+        r"\b(ceasefire|truce|peace deal|treaty signed|de[- ]?escalat\w*|talks resume)\b",
+        "geopolitical_de_escalation",
+        0.5,
+    ),
+    (
+        r"\b(missile strike|invasion|attack|escalat\w*|sanctions imposed|retaliat\w*|airstrike|war)\b",
+        "geopolitical_escalation",
+        -0.6,
+    ),
+    (r"\b(rate cut|dovish|fed pause|easing cycle|cut rates)\b", "fed_dovish", 0.4),
+    (r"\b(rate hike|hawkish|tightening|raise rates|hike rates)\b", "fed_hawkish", -0.3),
+    (r"\b(opec[+]? cut|oil supply|refinery shut|crude shortage)\b", "oil_supply_shock", -0.4),
+    (r"\b(oil price drop|crude plunge|oil oversupply|wti tumbl)\b", "oil_demand_drop", 0.2),
+    (r"\b(beat estimates|earnings beat|raised guidance|crushed estimates|tops forecast)\b", "earnings_beat", 0.5),
+    (r"\b(earnings miss|missed estimates|cut guidance|profit warn|guidance lower)\b", "earnings_miss", -0.5),
     # 한국/글로벌 수출 + 반도체 수요 (#137) — sector_rally보다 먼저 매칭되어야 함 (구체적 패턴 우선)
-    (r"(export[s ].*surge|export[s ].*boom|export[s ].*jump|trade surplus|shipment.*grow)",
-     "export_surge", 0.6),
-    (r"(Korea.*export|Korean.*export|KR.*export|KOSPI.*export)",
-     "export_surge", 0.5),
-    (r"(semiconductor.*demand|chip.*demand|AI.*capex|chip.*shortage|fab.*expansion|HBM.*demand)",
-     "demand_growth", 0.5),
-    (r"(TSMC.*revenue|TSMC.*record|chip.*boom|foundry.*demand)",
-     "demand_growth", 0.5),
-    (r"\b(won.*weak|dollar.*strong|USD.*KRW.*rise|yen.*carry|DXY.*surge|currency.*depreciat)",
-     "currency_shift", -0.3),
-    (r"\b(won.*strong|dollar.*weak|USD.*KRW.*fall|DXY.*drop|currency.*appreciat)",
-     "currency_shift", 0.3),
+    (r"(export[s ].*surge|export[s ].*boom|export[s ].*jump|trade surplus|shipment.*grow)", "export_surge", 0.6),
+    (r"(Korea.*export|Korean.*export|KR.*export|KOSPI.*export)", "export_surge", 0.5),
+    (r"(semiconductor.*demand|chip.*demand|AI.*capex|chip.*shortage|fab.*expansion|HBM.*demand)", "demand_growth", 0.5),
+    (r"(TSMC.*revenue|TSMC.*record|chip.*boom|foundry.*demand)", "demand_growth", 0.5),
+    (r"\b(won.*weak|dollar.*strong|USD.*KRW.*rise|yen.*carry|DXY.*surge|currency.*depreciat)", "currency_shift", -0.3),
+    (r"\b(won.*strong|dollar.*weak|USD.*KRW.*fall|DXY.*drop|currency.*appreciat)", "currency_shift", 0.3),
     # 일반 섹터 랠리/셀오프 — 위의 구체적 패턴에 안 걸린 경우만
-    (r"\b(rall(y|ies|ied)|surges?|jumps?|soars?|rebounds?|sector rotation)\b",
-     "sector_rally", 0.3),
-    (r"\b(plunges?|sell[- ]?off|crash(es)?|tumbles?|sinks?|rout)\b",
-     "sector_selloff", -0.4),
-    (r"\b(tariff|trade war|trade deal|retaliatory)\b",
-     "trade_war", -0.3),
+    (r"\b(rall(y|ies|ied)|surges?|jumps?|soars?|rebounds?|sector rotation)\b", "sector_rally", 0.3),
+    (r"\b(plunges?|sell[- ]?off|crash(es)?|tumbles?|sinks?|rout)\b", "sector_selloff", -0.4),
+    (r"\b(tariff|trade war|trade deal|retaliatory)\b", "trade_war", -0.3),
 ]
 
 

--- a/nuri/quant/chart_analysis.py
+++ b/nuri/quant/chart_analysis.py
@@ -21,6 +21,7 @@
     52주 고저     ⇄ distance_from_52w_*() ⇄ near_52w_low_bounce 시그널
     매물대        ⇄ volume_profile_poc()   ⇄ volume_profile_resistance 시그널
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -32,37 +33,38 @@ from nuri.core.db import query_df
 
 # ── 상수 ──
 
-LOOKBACK_52W = 252      # 거래일 기준 52주
-POC_LOOKBACK = 120      # 매물대 계산 기본 lookback (약 6개월)
-POC_BINS = 50           # 매물대 가격 구간 수
-TREND_WINDOW = 9        # 추세선 (KIS 앱과 동일한 9일)
+LOOKBACK_52W = 252  # 거래일 기준 52주
+POC_LOOKBACK = 120  # 매물대 계산 기본 lookback (약 6개월)
+POC_BINS = 50  # 매물대 가격 구간 수
+TREND_WINDOW = 9  # 추세선 (KIS 앱과 동일한 9일)
 MIN_DATA_POINTS = 30
 
 
 @dataclass
 class ChartAnalysis:
     """단일 종목 차트 패턴 종합."""
+
     ticker: str
     price: float
     # MACD 히스토그램 전환
-    macd_turn: str | None              # "bullish" | "bearish" | None
-    macd_hist: float                   # 현재 histogram 값
+    macd_turn: str | None  # "bullish" | "bearish" | None
+    macd_hist: float  # 현재 histogram 값
     # Bollinger Band 위치
-    bb_position: float                 # 0(lower) ~ 100(upper)
-    bb_width_pct: float                # band width / middle (squeeze 감지)
+    bb_position: float  # 0(lower) ~ 100(upper)
+    bb_width_pct: float  # band width / middle (squeeze 감지)
     # 52주 고저
-    dist_from_52w_high: float          # 음수 percent (-15.0 = 고점 대비 -15%)
-    dist_from_52w_low: float           # 양수 percent
+    dist_from_52w_high: float  # 음수 percent (-15.0 = 고점 대비 -15%)
+    dist_from_52w_low: float  # 양수 percent
     high_52w: float
     low_52w: float
     # 매물대 (Volume Profile Point of Control)
-    poc_price: float                   # 가장 거래 활발했던 가격대
-    dist_from_poc: float               # percent (현재가 vs POC)
+    poc_price: float  # 가장 거래 활발했던 가격대
+    dist_from_poc: float  # percent (현재가 vs POC)
     # 추세선
-    trend_strength: float              # -100 ~ +100
+    trend_strength: float  # -100 ~ +100
     # 종합 시각 점수
-    visual_bias: str                   # "bullish" | "bearish" | "neutral"
-    reasons: list[str]                 # 시각 패턴 사람이 읽기 쉬운 설명
+    visual_bias: str  # "bullish" | "bearish" | "neutral"
+    reasons: list[str]  # 시각 패턴 사람이 읽기 쉬운 설명
 
 
 # ═══════════════════════════════════════════════════════
@@ -220,12 +222,20 @@ def analyze_chart(ticker: str, db_path=None, lookback_days: int = 365) -> ChartA
 
     if df.empty or len(df) < MIN_DATA_POINTS:
         return ChartAnalysis(
-            ticker=ticker, price=0.0,
-            macd_turn=None, macd_hist=0.0,
-            bb_position=50.0, bb_width_pct=0.0,
-            dist_from_52w_high=0.0, dist_from_52w_low=0.0, high_52w=0.0, low_52w=0.0,
-            poc_price=0.0, dist_from_poc=0.0,
-            trend_strength=0.0, visual_bias="neutral",
+            ticker=ticker,
+            price=0.0,
+            macd_turn=None,
+            macd_hist=0.0,
+            bb_position=50.0,
+            bb_width_pct=0.0,
+            dist_from_52w_high=0.0,
+            dist_from_52w_low=0.0,
+            high_52w=0.0,
+            low_52w=0.0,
+            poc_price=0.0,
+            dist_from_poc=0.0,
+            trend_strength=0.0,
+            visual_bias="neutral",
             reasons=["데이터 부족"],
         )
 
@@ -289,15 +299,21 @@ def analyze_chart(ticker: str, db_path=None, lookback_days: int = 365) -> ChartA
         bias = "neutral"
 
     return ChartAnalysis(
-        ticker=ticker, price=price,
-        macd_turn=turn, macd_hist=hist,
-        bb_position=round(bbpos, 1), bb_width_pct=round(bbw, 2),
+        ticker=ticker,
+        price=price,
+        macd_turn=turn,
+        macd_hist=hist,
+        bb_position=round(bbpos, 1),
+        bb_width_pct=round(bbw, 2),
         dist_from_52w_high=round(dist_high, 2),
         dist_from_52w_low=round(dist_low, 2),
-        high_52w=round(high, 2), low_52w=round(low, 2),
-        poc_price=round(poc, 2), dist_from_poc=round(dist_poc, 2),
+        high_52w=round(high, 2),
+        low_52w=round(low, 2),
+        poc_price=round(poc, 2),
+        dist_from_poc=round(dist_poc, 2),
         trend_strength=round(trend, 1),
-        visual_bias=bias, reasons=reasons,
+        visual_bias=bias,
+        reasons=reasons,
     )
 
 

--- a/nuri/quant/exits/atr.py
+++ b/nuri/quant/exits/atr.py
@@ -42,6 +42,7 @@ bucket / certification / risk_agent semantic 변경 없음.
 - Volume-low ticker: ATR 계산은 되지만 noise 높음 — PR F2 에서 `atr_valid`
   flag 추가 (e.g. ATR/close < 0.5% → invalidate).
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -67,9 +68,9 @@ REGIME_MULTIPLIER = {
     "stagflation": 1.3,
 }
 
-DEFAULT_K = 2.0         # validation 전 default — validation 통과 후 변경
-DEFAULT_PERIOD = 14     # ATR period (talib standard)
-MIN_ROWS_FOR_ATR = 14   # OHLC row 최소 개수 — 미달 시 None
+DEFAULT_K = 2.0  # validation 전 default — validation 통과 후 변경
+DEFAULT_PERIOD = 14  # ATR period (talib standard)
+MIN_ROWS_FOR_ATR = 14  # OHLC row 최소 개수 — 미달 시 None
 
 
 @dataclass
@@ -85,6 +86,7 @@ class AtrStopResult:
         - breached: current_price <= stop_price (live 실측).
         - basis: "entry_atr_fixed" (이 PR) — 승격 시 "trailing_atr_dynamic" 추가 예정.
     """
+
     ticker: str
     account: str | None
     entry_price: float
@@ -115,6 +117,7 @@ def compute_atr(df: pd.DataFrame, period: int = DEFAULT_PERIOD) -> Optional[pd.S
         return None
 
     import talib
+
     try:
         high = df["high"].astype(float).values
         low = df["low"].astype(float).values
@@ -147,8 +150,7 @@ def compute_atr_stop(
     from nuri.core.db import query_df
 
     df = query_df(
-        "SELECT date, high, low, close FROM prices WHERE ticker = ? "
-        "ORDER BY date DESC LIMIT ?",
+        "SELECT date, high, low, close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT ?",
         (ticker, period * 3),  # 3x 로 padding — talib 초기 NaN 고려
         db_path=db_path,
     )
@@ -156,12 +158,18 @@ def compute_atr_stop(
     if df is None or df.empty or len(df) < MIN_ROWS_FOR_ATR:
         rows = 0 if df is None else len(df)
         return AtrStopResult(
-            ticker=ticker, account=account,
-            entry_price=entry_price, current_price=current_price,
-            atr=None, atr_pct_of_price=None,
-            k=k, regime=regime,
+            ticker=ticker,
+            account=account,
+            entry_price=entry_price,
+            current_price=current_price,
+            atr=None,
+            atr_pct_of_price=None,
+            k=k,
+            regime=regime,
             regime_multiplier=REGIME_MULTIPLIER.get(regime, 1.0),
-            stop_price=None, stop_pct=None, breached=False,
+            stop_price=None,
+            stop_pct=None,
+            breached=False,
             detail=f"OHLC 부족 ({rows} rows < 필요 {MIN_ROWS_FOR_ATR}) — legacy percent stop fallback 권장",
         )
 
@@ -169,24 +177,36 @@ def compute_atr_stop(
     atr_series = compute_atr(df, period=period)
     if atr_series is None:
         return AtrStopResult(
-            ticker=ticker, account=account,
-            entry_price=entry_price, current_price=current_price,
-            atr=None, atr_pct_of_price=None,
-            k=k, regime=regime,
+            ticker=ticker,
+            account=account,
+            entry_price=entry_price,
+            current_price=current_price,
+            atr=None,
+            atr_pct_of_price=None,
+            k=k,
+            regime=regime,
             regime_multiplier=REGIME_MULTIPLIER.get(regime, 1.0),
-            stop_price=None, stop_pct=None, breached=False,
+            stop_price=None,
+            stop_pct=None,
+            breached=False,
             detail="ATR 계산 실패 — talib 에러 또는 insufficient NaN 제거",
         )
 
     atr_latest = atr_series.iloc[-1]
     if pd.isna(atr_latest) or atr_latest <= 0:
         return AtrStopResult(
-            ticker=ticker, account=account,
-            entry_price=entry_price, current_price=current_price,
-            atr=None, atr_pct_of_price=None,
-            k=k, regime=regime,
+            ticker=ticker,
+            account=account,
+            entry_price=entry_price,
+            current_price=current_price,
+            atr=None,
+            atr_pct_of_price=None,
+            k=k,
+            regime=regime,
             regime_multiplier=REGIME_MULTIPLIER.get(regime, 1.0),
-            stop_price=None, stop_pct=None, breached=False,
+            stop_price=None,
+            stop_pct=None,
+            breached=False,
             detail="ATR NaN/0 — 데이터 품질 점검 필요",
         )
 
@@ -200,11 +220,18 @@ def compute_atr_stop(
     atr_pct = atr_val / entry_price * 100 if entry_price > 0 else 0.0
 
     return AtrStopResult(
-        ticker=ticker, account=account,
-        entry_price=entry_price, current_price=current_price,
-        atr=atr_val, atr_pct_of_price=atr_pct,
-        k=k, regime=regime, regime_multiplier=regime_mult,
-        stop_price=stop_price, stop_pct=stop_pct, breached=breached,
+        ticker=ticker,
+        account=account,
+        entry_price=entry_price,
+        current_price=current_price,
+        atr=atr_val,
+        atr_pct_of_price=atr_pct,
+        k=k,
+        regime=regime,
+        regime_multiplier=regime_mult,
+        stop_price=stop_price,
+        stop_pct=stop_pct,
+        breached=breached,
         detail=(
             f"entry={entry_price:.2f}, ATR{period}={atr_val:.2f} ({atr_pct:.1f}%), "
             f"k={k}×{regime_mult} ({regime}), stop={stop_price:.2f} ({stop_pct:+.1f}%)"

--- a/nuri/quant/factors/momentum.py
+++ b/nuri/quant/factors/momentum.py
@@ -1,4 +1,5 @@
 """모멘텀 팩터 — 12개월 수익률, RSI, 52주 고점 근접도."""
+
 import pandas as pd
 
 from nuri.core.db import query_df
@@ -52,10 +53,6 @@ def compute_momentum(tickers: list[str] | None = None) -> pd.DataFrame:
         else:
             df[col + "_norm"] = 0.5
 
-    df["momentum_score"] = (
-        df["period_return_norm"] * 0.4 +
-        df["rsi_14_norm"] * 0.3 +
-        df["high_proximity_norm"] * 0.3
-    )
+    df["momentum_score"] = df["period_return_norm"] * 0.4 + df["rsi_14_norm"] * 0.3 + df["high_proximity_norm"] * 0.3
 
     return df[["period_return", "rsi_14", "high_proximity", "momentum_score"]].round(4)

--- a/nuri/quant/validation/decision_alpha.py
+++ b/nuri/quant/validation/decision_alpha.py
@@ -163,11 +163,16 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
     alpha 가 원장에 없는 결정 (추적 실패/가격 결측). 정산 = 벤치마크가 만기일 이후의
     종가를 갖고 있는 상태 — `_benchmark_settled_through` 참조.
 
-    표본 모집단은 `recommendations` 다. 예전에는 `agent_decisions` 와 INNER JOIN 해
-    미러된 추천만 셌는데, 그 미러를 쓰는 주체가 측정 대상인 tracker 자신이라
-    **미러가 밀리면 보고 결측률이 내려가고 실제는 올라간다** (게이트가 감시 대상과
-    반대로 움직인다). 프로덕션 실측(2026-08-18)상 두 테이블의 action 은 미러된 525건
-    전부 일치하므로 표본 구성은 그대로이고, 의존성만 끊는다.
+    표본 모집단은 `recommendations` 다 — emit 기록 자체가 원장이기 때문이다. 예전에는
+    `agent_decisions` 와 INNER JOIN 해 미러된 추천만 셌는데, 그 미러를 쓰는 주체가 측정
+    대상인 tracker 자신이라 **미러가 밀리면 보고 결측률이 내려가고 실제는 올라간다**
+    (게이트가 감시 대상과 반대로 움직인다).
+
+    분자(n)는 이 변경에 영향받지 않는다 — `decision_outcomes.decision_id` 가
+    `agent_decisions` 를 FK 로 참조하므로 미러 없는 결정은 alpha 행을 가질 수 없다
+    (`db_migrations.py`). 즉 INNER JOIN 이 숨길 수 있었던 행은 전부 결측이었다.
+    미러의 `action` 은 `recommendations.action` 의 복사본이고 프로덕션 실측(2026-08-18)
+    상 미러된 525건 전부 일치했으나, 그건 현재 백필 구현의 성질이지 스키마 제약이 아니다.
     """
     mm = _criteria()
     window = int(mm["primary_window_days"])
@@ -373,10 +378,37 @@ def adjudicate(
         # 조용히 낮아진다. 판정을 바꾸진 않지만 그 상태를 리포트에서 볼 수 있어야 한다.
         "settled_through": sample.settled_through,
         "settlement_lag_days": sample.settlement_lag_days,
+        "max_settlement_lag_days": int(mm["max_settlement_lag_days"]),
         "missing_max_pct": int(mm["missing_outcome_max_pct"]),
         "pre_evaluation": today < str(mm["evaluation_date"]),
         "evaluation_date": mm["evaluation_date"],
     }
+
+    # 정산 정지는 **표본 유무보다 앞**이다. 뒤에 두면 벤치마크가 얼어 확정 alpha 가 하나도
+    # 없을 때 `NO_SAMPLE` 로 빠져나가는데, 그건 "아직 쌓이는 중"으로 읽힌다 — 실제로는
+    # 측정이 멈춘 것이다. 프로덕션이 지금 대부분의 시간을 보내는 상태가 정확히 n=0 이라
+    # (2026-07-28 · 08-01 브리핑) 이 순서가 뒤집혀 있으면 피드가 죽어도 아무도 모른다.
+    lag = sample.settlement_lag_days
+    max_lag = int(mm["max_settlement_lag_days"])
+    stale_benchmark = lag is None or lag > max_lag
+    if stale_benchmark:
+        report.update(
+            {
+                "verdict": "INVALID_STALE_BENCHMARK",
+                "criteria_verdict_if_final": "INVALID_STALE_BENCHMARK",
+                # `None` 을 문자열에 그대로 흘리면 브리핑에 "프런티어 None" 이 찍힌다.
+                # 종가가 아예 없는 상태와 뒤처진 상태는 문장 자체를 나눈다.
+                "reason": (
+                    f"벤치마크({mm['benchmark']}) 종가가 원장에 없다 — 측정 불가"
+                    if lag is None
+                    else (
+                        f"벤치마크 정산 프런티어 {sample.settled_through} — "
+                        f"기준일 {today} 대비 {lag}일 뒤처짐 (한도 {max_lag}일). 측정 중단."
+                    )
+                ),
+            }
+        )
+        return report
 
     if sample.n == 0:
         report.update({"verdict": "NO_SAMPLE", "reason": "표본 0건 (declared_date 이후 확정 alpha 없음)"})
@@ -411,7 +443,11 @@ def adjudicate(
         }
     )
 
-    # 판정 우선순위: 결측 무효 > 표본 미달 > 3조건
+    # 판정 우선순위: (정산 정지 무효 — 위에서 이미 return) > 결측 무효 > 표본 미달 > 3조건
+    #
+    # 정산 정지가 여기 없는 이유: 결측률은 **정산된 창만** 세므로 벤치마크 수집이 멈추면
+    # 미해소 결정이 결측에서 빠져나가 결측률이 조용히 **내려간다** — 측정이 망가질수록
+    # 결측 게이트가 깨끗해 보인다. 그래서 그 검사는 표본 유무보다도 앞에 둔다.
     # `None` = 측정 대상 0 건 → 무효화할 판정이 없다 (위 NO_SAMPLE 조기 return 이
     # 이미 걸러내므로 여기선 항상 실수지만, 비교 전에 의미를 명시한다).
     if missing_pct is not None and missing_pct > float(mm["missing_outcome_max_pct"]):

--- a/nuri/quant/validation/decision_alpha.py
+++ b/nuri/quant/validation/decision_alpha.py
@@ -107,36 +107,80 @@ class Sample:
     """판정 표본 (US BUY, primary window, alpha 확정분) + 결측 집계."""
 
     decisions: list[dict] = field(default_factory=list)  # {decision_id, ticker, emit_date, alpha}
-    n_missing_closed: int = 0  # 창이 닫혔는데 alpha 미기록 (결측 편향 공시 대상)
+    n_missing_closed: int = 0  # 창이 정산됐는데 alpha 미기록 (결측 편향 공시 대상)
+    settled_through: Optional[str] = None  # 벤치마크 마지막 종가일 = 측정 프런티어
+    as_of: Optional[str] = None  # 표본을 뜬 기준일 (프런티어 지연 계산용)
 
     @property
     def n(self) -> int:
         return len(self.decisions)
 
     @property
-    def missing_rate_pct(self) -> float:
+    def settlement_lag_days(self) -> Optional[int]:
+        """기준일과 정산 프런티어의 격차 (일). 둘 중 하나라도 없으면 None.
+
+        정산 기준은 미도착 bar 를 결측으로 세지 않는 대신 **반대 방향으로 거짓말할 수
+        있다** — 벤치마크 수집이 통째로 멈추면 프런티어가 얼어붙고, 그 뒤 만기가 온
+        결정은 영원히 "아직 미정산"이 되어 결측률이 조용히 낮아진다. 그래서 프런티어
+        자체를 리포트에 싣는다 (Surface — 판정을 바꾸지 않고 보이게만 한다).
+        """
+        if self.settled_through is None or self.as_of is None:
+            return None
+        return (date.fromisoformat(self.as_of) - date.fromisoformat(self.settled_through)).days
+
+    @property
+    def missing_rate_pct(self) -> Optional[float]:
+        """결측 비율. **측정 대상이 0 건이면 `None`** — `0.0` 이 아니다.
+
+        `0.0` 은 "결측 없음"으로 읽히는데 실제 상태는 "아직 아무것도 측정되지
+        않음"이다. 프로덕션 #brief 가 2026-07-28 · 08-01 두 번 `결측 0.0%/15%` 를
+        내보냈고, 그때 n 은 0 이었다 — 사전 등록된 무효화 기준이 통과처럼 보였다.
+        """
         total = self.n + self.n_missing_closed
-        return (self.n_missing_closed / total * 100.0) if total else 0.0
+        return (self.n_missing_closed / total * 100.0) if total else None
+
+
+def _benchmark_settled_through(benchmark: str, as_of: str, db_path: Optional[Path] = None) -> Optional[str]:
+    """`as_of` 시점에 원장이 갖고 있는 벤치마크 마지막 종가 날짜 (없으면 None).
+
+    "창이 닫혔다"와 "창이 정산됐다"는 다르다. 만기일이 달력상 지나도 그날의 종가가
+    아직 수집되지 않았으면 alpha 는 **계산될 수 없다** — 추적 실패가 아니라 미도착이다.
+    `date <= as_of` 로 자르는 이유는 `as_of` 를 과거로 주고 리포트를 재현할 때
+    미래 bar 가 정산 판정에 새어 들어가지 않게 하기 위함 (PIT).
+    """
+    rows = query(
+        "SELECT MAX(date) AS d FROM prices WHERE ticker = ? AND close IS NOT NULL AND date <= ?",
+        (benchmark, as_of),
+        db_path=db_path,
+    )
+    return dict(rows[0])["d"] if rows else None
 
 
 def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) -> Sample:
     """§3.11 표본 규약 구현 — declared_date~emit_cutoff 의 US BUY, distinct decision.
 
-    결측 정의: 창 (emit + window calendar days) 이 as_of 이전에 닫혔는데
-    primary window 의 alpha 가 원장에 없는 결정 (추적 실패/가격 결측).
+    결측 정의: 창 (emit + window calendar days) 이 **정산**됐는데 primary window 의
+    alpha 가 원장에 없는 결정 (추적 실패/가격 결측). 정산 = 벤치마크가 만기일 이후의
+    종가를 갖고 있는 상태 — `_benchmark_settled_through` 참조.
+
+    표본 모집단은 `recommendations` 다. 예전에는 `agent_decisions` 와 INNER JOIN 해
+    미러된 추천만 셌는데, 그 미러를 쓰는 주체가 측정 대상인 tracker 자신이라
+    **미러가 밀리면 보고 결측률이 내려가고 실제는 올라간다** (게이트가 감시 대상과
+    반대로 움직인다). 프로덕션 실측(2026-08-18)상 두 테이블의 action 은 미러된 525건
+    전부 일치하므로 표본 구성은 그대로이고, 의존성만 끊는다.
     """
     mm = _criteria()
     window = int(mm["primary_window_days"])
     today = as_of or today_kst()
+    settled_through = _benchmark_settled_through(str(mm["benchmark"]), today, db_path=db_path)
 
     rows = query(
         """
         SELECT r.id AS rec_id, r.ticker AS ticker, r.date AS emit_date, o.alpha AS alpha
         FROM recommendations r
-        JOIN agent_decisions ad ON ad.decision_id = 'rec_' || r.id
         LEFT JOIN decision_outcomes o
                ON o.decision_id = 'rec_' || r.id AND o.observation_window = ?
-        WHERE ad.action = 'BUY'
+        WHERE r.action = 'BUY'
           AND r.date >= ? AND r.date <= ?
         ORDER BY r.date, r.id
         """,
@@ -144,7 +188,7 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
         db_path=db_path,
     )
 
-    sample = Sample()
+    sample = Sample(settled_through=settled_through, as_of=today)
     for raw in rows:
         r = dict(raw)
         # §3.11 판정은 US-only 고정 — KR(.KS + .KQ) 은 별도 사전등록 전까지 진단 전용.
@@ -161,9 +205,9 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
                 }
             )
             continue
-        # 창이 닫혔는데 미기록 → 결측 (lookahead 미도래분은 결측 아님)
+        # 창이 정산됐는데 미기록 → 결측 (미도래분·미정산분은 결측 아님)
         target = (date.fromisoformat(r["emit_date"]) + timedelta(days=window)).isoformat()
-        if target <= today:
+        if settled_through is not None and target <= settled_through:
             sample.n_missing_closed += 1
     return sample
 
@@ -183,7 +227,11 @@ def _placebo_alpha(book: PriceBook, ticker: str, emit_date: str, window: int, be
     exit_p = book.close_on_or_after(ticker, target)
     b_entry = book.close(benchmark, emit_date)
     b_exit = book.close_on_or_after(benchmark, target)
-    if None in (entry, exit_p, b_entry, b_exit) or entry <= 0 or b_entry <= 0:
+    # `None in (...)` 는 타입을 좁히지 못한다 — 아래 산술이 `float | None` 으로 남아
+    # 미래의 실수를 타입 체커가 못 잡는다. 명시 비교로 좁힌다 (동작 동일).
+    if entry is None or exit_p is None or b_entry is None or b_exit is None:
+        return None
+    if entry <= 0 or b_entry <= 0:
         return None
     return (exit_p - entry) / entry - (b_exit - b_entry) / b_entry
 
@@ -263,7 +311,12 @@ def ticker_block_placebo(
             sub = cands[int(rng.integers(len(cands)))]
             for dt in dates:
                 a = _placebo_alpha(book, sub, dt, window, benchmark)
-                total += a  # eligible 검증으로 None 불가
+                if a is None:
+                    # `_eligible_substitutes` 가 블록의 **모든** 날짜에서 해소되는
+                    # ticker 만 남기므로 도달 불가. 건너뛰면 count 만 줄어 null 평균이
+                    # 조용히 편향되므로, 계약이 깨지면 조용히 가지 말고 터뜨린다.
+                    raise RuntimeError(f"placebo alpha 미해소: {sub} @ {dt} — eligible 계약 위반")
+                total += a
                 count += 1
         null_means.append(total / count)
 
@@ -307,6 +360,7 @@ def adjudicate(
     n_perm = int(n_perm if n_perm is not None else mm["permutation_n"])
 
     sample = fetch_sample(db_path=db_path, as_of=today)
+    missing_pct = sample.missing_rate_pct
     report: dict = {
         "as_of": today,
         "criteria_source": "config/rules.yaml measurement_mode (§3.11 사전 고정)",
@@ -314,7 +368,11 @@ def adjudicate(
         "benchmark": mm["benchmark"],
         "n": sample.n,
         "min_n_required": int(mm["min_n_us_buy_decisions"]),
-        "missing_rate_pct": round(sample.missing_rate_pct, 1),
+        "missing_rate_pct": None if missing_pct is None else round(missing_pct, 1),
+        # 측정 프런티어 — 결측률이 "정산된 것만" 세므로, 프런티어가 멈추면 결측률이
+        # 조용히 낮아진다. 판정을 바꾸진 않지만 그 상태를 리포트에서 볼 수 있어야 한다.
+        "settled_through": sample.settled_through,
+        "settlement_lag_days": sample.settlement_lag_days,
         "missing_max_pct": int(mm["missing_outcome_max_pct"]),
         "pre_evaluation": today < str(mm["evaluation_date"]),
         "evaluation_date": mm["evaluation_date"],
@@ -354,7 +412,9 @@ def adjudicate(
     )
 
     # 판정 우선순위: 결측 무효 > 표본 미달 > 3조건
-    if sample.missing_rate_pct > float(mm["missing_outcome_max_pct"]):
+    # `None` = 측정 대상 0 건 → 무효화할 판정이 없다 (위 NO_SAMPLE 조기 return 이
+    # 이미 걸러내므로 여기선 항상 실수지만, 비교 전에 의미를 명시한다).
+    if missing_pct is not None and missing_pct > float(mm["missing_outcome_max_pct"]):
         verdict = "INVALID_MISSING"  # 판정 무효 — 측정 연장 (§3.11 오염 방지 행)
     elif sample.n < int(mm["min_n_us_buy_decisions"]):
         verdict = "INSUFFICIENT_N"

--- a/nuri/quant/validation/market_signals.py
+++ b/nuri/quant/validation/market_signals.py
@@ -12,6 +12,7 @@ scorecard/UI 가 "insufficient data" 로 graceful degrade.
 
 STRATEGY §2.6 Surface 단계. 승격은 human judgment (별도 PR).
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -30,11 +31,12 @@ class MarketSignalState:
 
     Shadow 신호는 single point-in-time 판정. backtest 는 `_history` 함수로 별도.
     """
+
     signal_id: str
     fired: bool
-    level: float | None        # 현재 값 (inversion=spread bps, oas=percent)
-    threshold: float | None    # 임계 (fired 판정용 1차 threshold)
-    detail: str                # 인간 가독 설명 ("3M=5.52 > 10Y=4.28, 역전")
+    level: float | None  # 현재 값 (inversion=spread bps, oas=percent)
+    threshold: float | None  # 임계 (fired 판정용 1차 threshold)
+    detail: str  # 인간 가독 설명 ("3M=5.52 > 10Y=4.28, 역전")
 
 
 def detect_yield_curve_inversion(db_path=None) -> MarketSignalState:
@@ -62,13 +64,17 @@ def detect_yield_curve_inversion(db_path=None) -> MarketSignalState:
     except Exception:
         return MarketSignalState(
             signal_id="yield_curve_inversion",
-            fired=False, level=None, threshold=0.0,
+            fired=False,
+            level=None,
+            threshold=0.0,
             detail=f"DB 조회 실패 ({short_indicator} / {long_indicator}) — macro 테이블 확인",
         )
     if not row or row[0]["short_v"] is None or row[0]["long_v"] is None:
         return MarketSignalState(
             signal_id="yield_curve_inversion",
-            fired=False, level=None, threshold=0.0,
+            fired=False,
+            level=None,
+            threshold=0.0,
             detail=f"데이터 부족 ({short_indicator} 또는 {long_indicator})",
         )
 
@@ -82,7 +88,10 @@ def detect_yield_curve_inversion(db_path=None) -> MarketSignalState:
     )
     return MarketSignalState(
         signal_id="yield_curve_inversion",
-        fired=fired, level=spread_bps, threshold=0.0, detail=detail,
+        fired=fired,
+        level=spread_bps,
+        threshold=0.0,
+        detail=detail,
     )
 
 
@@ -98,21 +107,24 @@ def detect_hy_oas_widening(db_path=None) -> MarketSignalState:
 
     try:
         rows = query(
-            "SELECT date, value FROM macro WHERE indicator = 'hy_oas' "
-            "ORDER BY date DESC LIMIT :limit",
+            "SELECT date, value FROM macro WHERE indicator = 'hy_oas' ORDER BY date DESC LIMIT :limit",
             {"limit": lookback + 1},  # type: ignore[arg-type]
             db_path=db_path,
         )
     except Exception:
         return MarketSignalState(
             signal_id="hy_oas_widening",
-            fired=False, level=None, threshold=level_pct,
+            fired=False,
+            level=None,
+            threshold=level_pct,
             detail="DB 조회 실패 (macro 테이블) — 환경 확인",
         )
     if not rows:
         return MarketSignalState(
             signal_id="hy_oas_widening",
-            fired=False, level=None, threshold=level_pct,
+            fired=False,
+            level=None,
+            threshold=level_pct,
             detail="데이터 부족 (hy_oas) — FRED_API_KEY 확인 필요 (BAMLH0A0HYM2)",
         )
     # codex PR #436 Review CONCERN: partial history (< lookback+1 rows) 시 rows[-1]
@@ -122,7 +134,9 @@ def detect_hy_oas_widening(db_path=None) -> MarketSignalState:
         current = float(rows[0]["value"])
         return MarketSignalState(
             signal_id="hy_oas_widening",
-            fired=False, level=current, threshold=level_pct,
+            fired=False,
+            level=current,
+            threshold=level_pct,
             detail=(
                 f"HY OAS 현재 {current:.2f}% — 히스토리 부족 ({len(rows)} rows "
                 f"< 필요 {lookback + 1}). {lookback}d 변화 측정 불가."
@@ -142,7 +156,10 @@ def detect_hy_oas_widening(db_path=None) -> MarketSignalState:
     )
     return MarketSignalState(
         signal_id="hy_oas_widening",
-        fired=fired, level=current, threshold=level_pct, detail=detail,
+        fired=fired,
+        level=current,
+        threshold=level_pct,
+        detail=detail,
     )
 
 

--- a/nuri/trading/agents/crypto_agent.py
+++ b/nuri/trading/agents/crypto_agent.py
@@ -4,6 +4,7 @@ BTC는 위험자산 선행지표. BTC 급등 = 리스크온, BTC 급락 = 리스
 BTC 지배력(dominance) 하락 = 알트코인 강세 = 투기 심리 과열.
 데이터 없으면 graceful HOLD 반환.
 """
+
 from nuri.core.agent_config import AGENT_CONFIG
 from nuri.trading.agents.base import AgentVerdict, BaseAgent
 
@@ -18,20 +19,17 @@ class CryptoAgent(BaseAgent):
     def analyze(self, ticker: str, db_path=None) -> AgentVerdict:
         # BTC 24h 변화율
         change_rows = self._safe_query(
-            "SELECT value FROM macro WHERE indicator='btc_24h_change_pct' "
-            "ORDER BY date DESC LIMIT 1",
+            "SELECT value FROM macro WHERE indicator='btc_24h_change_pct' ORDER BY date DESC LIMIT 1",
             db_path=db_path,
         )
         # BTC 지배력
         dom_rows = self._safe_query(
-            "SELECT value FROM macro WHERE indicator='btc_dominance' "
-            "ORDER BY date DESC LIMIT 1",
+            "SELECT value FROM macro WHERE indicator='btc_dominance' ORDER BY date DESC LIMIT 1",
             db_path=db_path,
         )
         # BTC 가격
         btc_rows = self._safe_query(
-            "SELECT value FROM macro WHERE indicator='btc_usd_cg' "
-            "ORDER BY date DESC LIMIT 1",
+            "SELECT value FROM macro WHERE indicator='btc_usd_cg' ORDER BY date DESC LIMIT 1",
             db_path=db_path,
         )
 
@@ -91,20 +89,29 @@ class CryptoAgent(BaseAgent):
         score_sell = _CFG.get("score_sell", -2)
 
         if score >= score_buy:
-            action, confidence = "BUY", min(
-                _CONF.get("cap", 80),
-                _CONF.get("buy_base", 40) + score * _CONF.get("buy_multiplier", 10),
+            action, confidence = (
+                "BUY",
+                min(
+                    _CONF.get("cap", 80),
+                    _CONF.get("buy_base", 40) + score * _CONF.get("buy_multiplier", 10),
+                ),
             )
         elif score <= score_sell:
-            action, confidence = "SELL", min(
-                _CONF.get("cap", 80),
-                _CONF.get("sell_base", 40) + abs(score) * _CONF.get("sell_multiplier", 10),
+            action, confidence = (
+                "SELL",
+                min(
+                    _CONF.get("cap", 80),
+                    _CONF.get("sell_base", 40) + abs(score) * _CONF.get("sell_multiplier", 10),
+                ),
             )
         else:
             action, confidence = "HOLD", _CONF.get("hold_base", 30) + abs(score) * _CONF.get("hold_multiplier", 8)
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons),
             data,
         )

--- a/nuri/trading/agents/fundamental.py
+++ b/nuri/trading/agents/fundamental.py
@@ -1,4 +1,5 @@
 """펀더멘탈 분석 에이전트 — PE, ROE, 성장률, 부채 기반 판정."""
+
 from nuri.core.agent_config import AGENT_CONFIG
 from nuri.trading.agents.base import AgentVerdict, BaseAgent
 
@@ -13,7 +14,8 @@ class FundamentalAgent(BaseAgent):
     def analyze(self, ticker: str, db_path=None) -> AgentVerdict:
         rows = self._safe_query(
             "SELECT * FROM fundamentals WHERE ticker = ? ORDER BY date DESC LIMIT 1",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
         if not rows:
             return AgentVerdict(self.name, ticker, "HOLD", 0, "펀더멘탈 데이터 없음")
@@ -51,13 +53,13 @@ class FundamentalAgent(BaseAgent):
         if roe:
             if roe > roe_excellent:
                 score += 2
-                reasons.append(f"ROE {roe*100:.0f}% (우수)")
+                reasons.append(f"ROE {roe * 100:.0f}% (우수)")
             elif roe > roe_good:
                 score += 1
-                reasons.append(f"ROE {roe*100:.0f}%")
+                reasons.append(f"ROE {roe * 100:.0f}%")
             elif roe < 0:
                 score -= 1
-                reasons.append(f"ROE {roe*100:.0f}% (적자)")
+                reasons.append(f"ROE {roe * 100:.0f}% (적자)")
 
         # 성장률
         growth_strong = _CFG.get("growth_strong", 0.20)
@@ -65,10 +67,10 @@ class FundamentalAgent(BaseAgent):
         if growth:
             if growth > growth_strong:
                 score += 1
-                reasons.append(f"매출성장 {growth*100:.0f}%")
+                reasons.append(f"매출성장 {growth * 100:.0f}%")
             elif growth < growth_decline:
                 score -= 1
-                reasons.append(f"매출감소 {growth*100:.0f}%")
+                reasons.append(f"매출감소 {growth * 100:.0f}%")
 
         # 부채
         if debt and debt > _CFG.get("debt_high", 2.0):
@@ -93,7 +95,10 @@ class FundamentalAgent(BaseAgent):
             action, confidence = "HOLD", hold_base + abs(score) * hold_mult
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons) or "데이터 제한적",
             {"pe": pe, "roe": roe, "growth": growth, "debt": debt},
         )

--- a/nuri/trading/agents/korean_market.py
+++ b/nuri/trading/agents/korean_market.py
@@ -6,6 +6,7 @@ KOSPI/KOSDAQ 구분, 환율 영향, 외국인/기관 수급,
 
 US 종목에는 HOLD(중립)을 반환하여 합의에 영향을 주지 않는다.
 """
+
 import logging
 
 from nuri.core.agent_config import AGENT_CONFIG
@@ -27,6 +28,7 @@ def _calibrate_fx_thresholds(db_path=None) -> tuple[float, float]:
     fx_strong_default = _CFG.get("fx_strong_default", 1250)
 
     from nuri.core.db import query_df
+
     df = query_df(
         "SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 90",
         db_path=db_path,
@@ -40,10 +42,16 @@ def _calibrate_fx_thresholds(db_path=None) -> tuple[float, float]:
     strong = round(mean - std, 0)
     return max(weak, _CFG.get("fx_weak_floor", 1300)), min(strong, _CFG.get("fx_strong_ceil", 1350))
 
+
 # KOSPI/KOSDAQ 구분
 KOSDAQ_TICKERS = {
-    "247540.KS", "068270.KS", "035720.KS", "035420.KS",
-    "263750.KS", "293490.KS", "112040.KS",
+    "247540.KS",
+    "068270.KS",
+    "035720.KS",
+    "035420.KS",
+    "263750.KS",
+    "293490.KS",
+    "112040.KS",
 }
 
 # 수출 비중 높은 섹터
@@ -61,8 +69,10 @@ class KoreanMarketAgent(BaseAgent):
         # US 종목은 패스
         if not ticker.endswith(".KS"):
             return AgentVerdict(
-                agent_name=self.name, ticker=ticker,
-                action="HOLD", confidence=_CFG.get("us_confidence", 50.0),
+                agent_name=self.name,
+                ticker=ticker,
+                action="HOLD",
+                confidence=_CFG.get("us_confidence", 50.0),
                 reasoning="US ticker — Korean market agent neutral",
                 data_points={"is_korean": False},
             )
@@ -138,8 +148,10 @@ class KoreanMarketAgent(BaseAgent):
             action = "HOLD"
 
         return AgentVerdict(
-            agent_name=self.name, ticker=ticker,
-            action=action, confidence=round(self.normalize_confidence(min(abs(score - score_base) * 2, 100)), 1),
+            agent_name=self.name,
+            ticker=ticker,
+            action=action,
+            confidence=round(self.normalize_confidence(min(abs(score - score_base) * 2, 100)), 1),
             reasoning="; ".join(reasons) if reasons else "Korean market neutral",
             data_points=data,
         )
@@ -156,16 +168,17 @@ class KoreanMarketAgent(BaseAgent):
         """종목 섹터 조회."""
         rows = self._safe_query(
             "SELECT sector FROM portfolio WHERE ticker=? LIMIT 1",
-            (ticker,), db_path=db_path,
+            (ticker,),
+            db_path=db_path,
         )
         return rows[0]["sector"] if rows else ""
 
     def _get_foreign_flow(self, ticker: str, db_path=None) -> float | None:
         """최근 외국인 순매수."""
         rows = self._safe_query(
-            "SELECT foreign_net FROM institutional_flows "
-            "WHERE ticker=? ORDER BY date DESC LIMIT 1",
-            (ticker,), db_path=db_path,
+            "SELECT foreign_net FROM institutional_flows WHERE ticker=? ORDER BY date DESC LIMIT 1",
+            (ticker,),
+            db_path=db_path,
         )
         return rows[0]["foreign_net"] if rows else None
 
@@ -204,7 +217,8 @@ class KoreanMarketAgent(BaseAgent):
         """20일 가격 모멘텀."""
         rows = self._safe_query(
             "SELECT close FROM prices WHERE ticker=? ORDER BY date DESC LIMIT 21",
-            (ticker,), db_path=db_path,
+            (ticker,),
+            db_path=db_path,
         )
         if len(rows) < 21:
             return None

--- a/nuri/trading/agents/options_agent.py
+++ b/nuri/trading/agents/options_agent.py
@@ -5,6 +5,7 @@ PCR 높음(≥1.2) = 극도 공포 → 역발상 매수 신호.
 PCR 낮음(≤0.7) = 과도한 낙관 → 경계 신호.
 데이터 없으면 graceful HOLD 반환.
 """
+
 from nuri.core.agent_config import AGENT_CONFIG
 from nuri.trading.agents.base import AgentVerdict, BaseAgent
 
@@ -19,9 +20,9 @@ class OptionsAgent(BaseAgent):
     def analyze(self, ticker: str, db_path=None) -> AgentVerdict:
         lookback = _CFG.get("lookback_days", 5)
         rows = self._safe_query(
-            "SELECT value FROM macro WHERE indicator='put_call_ratio' "
-            "ORDER BY date DESC LIMIT ?",
-            (lookback,), db_path,
+            "SELECT value FROM macro WHERE indicator='put_call_ratio' ORDER BY date DESC LIMIT ?",
+            (lookback,),
+            db_path,
         )
         if not rows:
             return AgentVerdict(self.name, ticker, "HOLD", _CONF.get("no_data", 0), "PCR 데이터 없음")
@@ -72,21 +73,33 @@ class OptionsAgent(BaseAgent):
         score_sell = _CFG.get("score_sell", -2)
 
         if score >= score_buy:
-            action, confidence = "BUY", min(
-                _CONF.get("cap", 80),
-                _CONF.get("buy_base", 45) + score * _CONF.get("buy_multiplier", 12),
+            action, confidence = (
+                "BUY",
+                min(
+                    _CONF.get("cap", 80),
+                    _CONF.get("buy_base", 45) + score * _CONF.get("buy_multiplier", 12),
+                ),
             )
         elif score <= score_sell:
-            action, confidence = "SELL", min(
-                _CONF.get("cap", 80),
-                _CONF.get("sell_base", 45) + abs(score) * _CONF.get("sell_multiplier", 12),
+            action, confidence = (
+                "SELL",
+                min(
+                    _CONF.get("cap", 80),
+                    _CONF.get("sell_base", 45) + abs(score) * _CONF.get("sell_multiplier", 12),
+                ),
             )
         else:
             action, confidence = "HOLD", _CONF.get("hold_base", 35) + abs(score) * _CONF.get("hold_multiplier", 8)
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons),
-            {"pcr_avg": round(pcr, 3), "pcr_latest": round(values[0], 3) if values else None,
-             "lookback_count": len(values)},
+            {
+                "pcr_avg": round(pcr, 3),
+                "pcr_latest": round(values[0], 3) if values else None,
+                "lookback_count": len(values),
+            },
         )

--- a/nuri/trading/agents/retail_agent.py
+++ b/nuri/trading/agents/retail_agent.py
@@ -4,6 +4,7 @@ WSB 언급 급증 = 과열 경계 (역발상 매도 신호).
 WSB 전체 활동 증가 = 시장 관심도 과열.
 데이터 없으면 graceful HOLD 반환.
 """
+
 from nuri.core.agent_config import AGENT_CONFIG
 from nuri.trading.agents.base import AgentVerdict, BaseAgent
 
@@ -19,12 +20,12 @@ class RetailAgent(BaseAgent):
         # 종목별 WSB 언급 횟수
         mention_rows = self._safe_query(
             "SELECT value FROM macro WHERE indicator=? ORDER BY date DESC LIMIT 1",
-            (f"wsb_mention_{ticker}",), db_path,
+            (f"wsb_mention_{ticker}",),
+            db_path,
         )
         # WSB 전체 게시물 수
         post_rows = self._safe_query(
-            "SELECT value FROM macro WHERE indicator='wsb_post_count' "
-            "ORDER BY date DESC LIMIT 1",
+            "SELECT value FROM macro WHERE indicator='wsb_post_count' ORDER BY date DESC LIMIT 1",
             db_path=db_path,
         )
 
@@ -70,20 +71,29 @@ class RetailAgent(BaseAgent):
         score_sell = _CFG.get("score_sell", -2)
 
         if score >= score_buy:
-            action, confidence = "BUY", min(
-                _CONF.get("cap", 80),
-                _CONF.get("buy_base", 35) + score * _CONF.get("buy_multiplier", 10),
+            action, confidence = (
+                "BUY",
+                min(
+                    _CONF.get("cap", 80),
+                    _CONF.get("buy_base", 35) + score * _CONF.get("buy_multiplier", 10),
+                ),
             )
         elif score <= score_sell:
-            action, confidence = "SELL", min(
-                _CONF.get("cap", 80),
-                _CONF.get("sell_base", 35) + abs(score) * _CONF.get("sell_multiplier", 10),
+            action, confidence = (
+                "SELL",
+                min(
+                    _CONF.get("cap", 80),
+                    _CONF.get("sell_base", 35) + abs(score) * _CONF.get("sell_multiplier", 10),
+                ),
             )
         else:
             action, confidence = "HOLD", _CONF.get("hold_base", 30) + abs(score) * _CONF.get("hold_multiplier", 8)
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons),
             data,
         )

--- a/nuri/trading/agents/smart_money.py
+++ b/nuri/trading/agents/smart_money.py
@@ -1,4 +1,5 @@
 """스마트머니 에이전트 — 슈퍼투자자 + ARK + 애널리스트 컨센서스 기반 판정."""
+
 from nuri.core.agent_config import AGENT_CONFIG
 from nuri.trading.agents.base import AgentVerdict, BaseAgent
 
@@ -20,9 +21,9 @@ class SmartMoneyAgent(BaseAgent):
 
         # 1. 슈퍼투자자 보유 여부
         si_rows = self._safe_query(
-            "SELECT investor, portfolio_pct FROM superinvestors "
-            "WHERE ticker = ? ORDER BY portfolio_pct DESC",
-            (ticker,), db_path,
+            "SELECT investor, portfolio_pct FROM superinvestors WHERE ticker = ? ORDER BY portfolio_pct DESC",
+            (ticker,),
+            db_path,
         )
         if si_rows:
             investors = [r["investor"] for r in si_rows[:3]]
@@ -43,7 +44,8 @@ class SmartMoneyAgent(BaseAgent):
             "  WHERE s2.investor = s1.investor AND s2.ticker = s1.ticker "
             "  AND s2.filing_date < s1.filing_date"
             ")",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
         if change_rows:
             score += 1
@@ -53,7 +55,8 @@ class SmartMoneyAgent(BaseAgent):
         est_rows = self._safe_query(
             "SELECT recommendation, target_mean, current_price, num_analysts "
             "FROM estimates WHERE ticker = ? ORDER BY date DESC LIMIT 1",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
         if est_rows:
             est = est_rows[0]
@@ -80,7 +83,8 @@ class SmartMoneyAgent(BaseAgent):
         # 4. ARK 최근 매매
         ark_rows = self._safe_query(
             "SELECT direction, shares FROM ark WHERE ticker = ? ORDER BY date DESC LIMIT 5",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
         if ark_rows:
             buys = sum(1 for r in ark_rows if r["direction"] == "Buy")
@@ -99,20 +103,29 @@ class SmartMoneyAgent(BaseAgent):
         score_sell = _CFG.get("score_sell", -1)
 
         if score >= score_buy:
-            action, confidence = "BUY", min(
-                _CONF.get("buy_cap", 80),
-                _CONF.get("buy_base", 40) + score * _CONF.get("buy_multiplier", 12),
+            action, confidence = (
+                "BUY",
+                min(
+                    _CONF.get("buy_cap", 80),
+                    _CONF.get("buy_base", 40) + score * _CONF.get("buy_multiplier", 12),
+                ),
             )
         elif score <= score_sell:
-            action, confidence = "SELL", min(
-                _CONF.get("sell_cap", 70),
-                _CONF.get("sell_base", 40) + abs(score) * _CONF.get("sell_multiplier", 12),
+            action, confidence = (
+                "SELL",
+                min(
+                    _CONF.get("sell_cap", 70),
+                    _CONF.get("sell_base", 40) + abs(score) * _CONF.get("sell_multiplier", 12),
+                ),
             )
         else:
             action, confidence = "HOLD", _CONF.get("hold_base", 35) + abs(score) * _CONF.get("hold_multiplier", 8)
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons),
             {"score": score, "n_superinvestors": len(si_rows)},
         )

--- a/nuri/trading/agents/technical.py
+++ b/nuri/trading/agents/technical.py
@@ -3,6 +3,7 @@
 
 FINVIZ 스크리너 데이터를 보조 시그널로 활용 (external_analysis 테이블).
 """
+
 import logging
 
 import pandas as pd
@@ -33,12 +34,14 @@ class TechnicalAgent(BaseAgent):
         min_dp = _CFG.get("min_data_points", 50)
         df = query_df(
             "SELECT date, close FROM prices WHERE ticker = ? ORDER BY date",
-            (ticker,), db_path=db_path,
+            (ticker,),
+            db_path=db_path,
         )
         # prices에 없으면 yfinance fallback (스캐너 종목 대응)
         if (df.empty or len(df) < min_dp) and db_path is None:
             try:
                 import yfinance as yf
+
                 _df = yf.download(ticker, period="6mo", progress=False)
                 if not _df.empty and len(_df) >= min_dp:
                     close_col = _df["Close"].squeeze() if hasattr(_df["Close"], "squeeze") else _df["Close"]
@@ -166,24 +169,32 @@ class TechnicalAgent(BaseAgent):
             confidence = conf_hold
 
         data_points = {
-            "rsi": round(rsi, 1), "sma50": round(sma50, 2), "sma200": round(sma200, 2),
-            "macd": round(macd, 4), "price": round(latest, 2),
+            "rsi": round(rsi, 1),
+            "sma50": round(sma50, 2),
+            "sma200": round(sma200, 2),
+            "macd": round(macd, 4),
+            "price": round(latest, 2),
         }
         if chart is not None and chart.price > 0:
-            data_points.update({
-                "bb_pos": chart.bb_position,
-                "macd_turn": chart.macd_turn,
-                "dist_high_52w": chart.dist_from_52w_high,
-                "dist_low_52w": chart.dist_from_52w_low,
-                "poc": chart.poc_price,
-                "trend": chart.trend_strength,
-                "visual_bias": chart.visual_bias,
-            })
+            data_points.update(
+                {
+                    "bb_pos": chart.bb_position,
+                    "macd_turn": chart.macd_turn,
+                    "dist_high_52w": chart.dist_from_52w_high,
+                    "dist_low_52w": chart.dist_from_52w_low,
+                    "poc": chart.poc_price,
+                    "trend": chart.trend_strength,
+                    "visual_bias": chart.visual_bias,
+                }
+            )
         if finviz_signals:
             data_points["finviz_signals"] = sorted(finviz_signals)
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons) or "혼조",
             data_points,
         )
@@ -194,6 +205,7 @@ class TechnicalAgent(BaseAgent):
         max_age_days 이내의 데이터만 사용. 데이터 없으면 빈 리스트 (graceful fallback).
         """
         from datetime import timedelta
+
         max_age = _FINVIZ_CFG.get("max_age_days", 3)
         cutoff = (kst_now() - timedelta(days=max_age)).strftime("%Y-%m-%d")
         try:

--- a/nuri/trading/agents/wallstreet.py
+++ b/nuri/trading/agents/wallstreet.py
@@ -10,6 +10,7 @@ yfinance에서 직접 데이터를 가져오며 별도 API 키 불필요.
 3. Insider 매매 패턴 (순매수 vs 순매도)
 4. 애널리스트 컨센서스 분포 (strongBuy~strongSell)
 """
+
 import logging
 from datetime import timedelta
 
@@ -25,10 +26,33 @@ _CONF = _CFG.get("confidence", {})
 
 # yfinance에서 데이터가 없는 종목 (ETF, 한국주, 레버리지) — 스킵하여 속도 개선
 SKIP_TICKERS = {
-    "VOO", "SH", "SDS", "PSQ", "IWM", "EFA", "EEM", "ARKK",  # ETFs
-    "TSLL", "TQQQ", "SQQQ", "UPRO", "SPXU", "BULL",           # Leveraged
-    "SPY", "QQQ",                                                # Index ETFs
-    "XLK", "XLF", "XLV", "XLE", "XLI", "XLY", "XLP", "XLU", "XLB", "XLRE", "XLC",  # Sector ETFs
+    "VOO",
+    "SH",
+    "SDS",
+    "PSQ",
+    "IWM",
+    "EFA",
+    "EEM",
+    "ARKK",  # ETFs
+    "TSLL",
+    "TQQQ",
+    "SQQQ",
+    "UPRO",
+    "SPXU",
+    "BULL",  # Leveraged
+    "SPY",
+    "QQQ",  # Index ETFs
+    "XLK",
+    "XLF",
+    "XLV",
+    "XLE",
+    "XLI",
+    "XLY",
+    "XLP",
+    "XLU",
+    "XLB",
+    "XLRE",
+    "XLC",  # Sector ETFs
 }
 
 
@@ -48,6 +72,7 @@ class WallStreetAgent(BaseAgent):
 
         try:
             import yfinance as yf
+
             t = yf.Ticker(ticker)
         except Exception:
             return AgentVerdict(self.name, ticker, "HOLD", 0, "yfinance 로드 실패")
@@ -61,7 +86,7 @@ class WallStreetAgent(BaseAgent):
             ud = t.upgrades_downgrades
             if ud is not None and not ud.empty:
                 cutoff = kst_now().replace(tzinfo=None) - timedelta(days=90)
-                recent = ud[ud.index >= cutoff] if hasattr(ud.index[0], 'year') else ud.tail(10)
+                recent = ud[ud.index >= cutoff] if hasattr(ud.index[0], "year") else ud.tail(10)
 
                 upgrades = 0
                 downgrades = 0
@@ -109,12 +134,12 @@ class WallStreetAgent(BaseAgent):
                 earn_th = _CFG.get("earnings_surprise", 0.05)
                 if surprise > earn_th:
                     score += 2
-                    reasons.append(f"실적 서프라이즈 +{surprise*100:.0f}%")
+                    reasons.append(f"실적 서프라이즈 +{surprise * 100:.0f}%")
                 elif surprise < -earn_th:
                     score -= 2
-                    reasons.append(f"실적 미스 {surprise*100:.0f}%")
+                    reasons.append(f"실적 미스 {surprise * 100:.0f}%")
                 elif abs(surprise) <= earn_th:
-                    reasons.append(f"실적 부합 ({surprise*100:+.1f}%)")
+                    reasons.append(f"실적 부합 ({surprise * 100:+.1f}%)")
 
                 data_points["earnings_surprise"] = round(float(surprise), 4)
                 data_points["eps_actual"] = float(latest.get("epsActual", 0) or 0)
@@ -167,16 +192,19 @@ class WallStreetAgent(BaseAgent):
 
                     if bull_pct > _CFG.get("consensus_bull", 0.60):
                         score += 1
-                        reasons.append(f"컨센서스 매수 {bull_pct:.0%}({strong_buy+buy}/{total}명)")
+                        reasons.append(f"컨센서스 매수 {bull_pct:.0%}({strong_buy + buy}/{total}명)")
                     elif bear_pct > _CFG.get("consensus_bear", 0.30):
                         score -= 1
-                        reasons.append(f"컨센서스 매도 {bear_pct:.0%}({sell+strong_sell}/{total}명)")
+                        reasons.append(f"컨센서스 매도 {bear_pct:.0%}({sell + strong_sell}/{total}명)")
                     else:
-                        reasons.append(f"컨센서스 중립({strong_buy+buy}B/{hold}H/{sell+strong_sell}S)")
+                        reasons.append(f"컨센서스 중립({strong_buy + buy}B/{hold}H/{sell + strong_sell}S)")
 
                     data_points["consensus"] = {
-                        "strong_buy": strong_buy, "buy": buy, "hold": hold,
-                        "sell": sell, "strong_sell": strong_sell,
+                        "strong_buy": strong_buy,
+                        "buy": buy,
+                        "hold": hold,
+                        "sell": sell,
+                        "strong_sell": strong_sell,
                     }
         except Exception:
             pass
@@ -186,20 +214,29 @@ class WallStreetAgent(BaseAgent):
 
         # 판정
         if score >= _CFG.get("score_buy", 3):
-            action, confidence = "BUY", min(
-                _CONF.get("buy_cap", 85),
-                _CONF.get("buy_base", 45) + score * _CONF.get("buy_multiplier", 10),
+            action, confidence = (
+                "BUY",
+                min(
+                    _CONF.get("buy_cap", 85),
+                    _CONF.get("buy_base", 45) + score * _CONF.get("buy_multiplier", 10),
+                ),
             )
         elif score <= _CFG.get("score_sell", -2):
-            action, confidence = "SELL", min(
-                _CONF.get("sell_cap", 80),
-                _CONF.get("sell_base", 45) + abs(score) * _CONF.get("sell_multiplier", 10),
+            action, confidence = (
+                "SELL",
+                min(
+                    _CONF.get("sell_cap", 80),
+                    _CONF.get("sell_base", 45) + abs(score) * _CONF.get("sell_multiplier", 10),
+                ),
             )
         else:
             action, confidence = "HOLD", _CONF.get("hold_base", 35) + abs(score) * _CONF.get("hold_multiplier", 8)
 
         return AgentVerdict(
-            self.name, ticker, action, round(self.normalize_confidence(confidence), 1),
+            self.name,
+            ticker,
+            action,
+            round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons),
             data_points,
         )
@@ -208,15 +245,18 @@ class WallStreetAgent(BaseAgent):
         """DB에 캐시된 Wall Street 데이터로 판정 (yfinance 호출 없이)."""
         ratings = self._safe_query(
             "SELECT action, target_price FROM analyst_ratings WHERE ticker=? ORDER BY date DESC LIMIT 10",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
         earnings = self._safe_query(
             "SELECT surprise_pct FROM earnings_surprises WHERE ticker=? ORDER BY quarter DESC LIMIT 1",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
         insiders = self._safe_query(
             "SELECT transaction_type FROM insider_trades WHERE ticker=? ORDER BY date DESC LIMIT 10",
-            (ticker,), db_path,
+            (ticker,),
+            db_path,
         )
 
         if not ratings and not earnings and not insiders:
@@ -229,8 +269,16 @@ class WallStreetAgent(BaseAgent):
         ins_sell_margin = _CFG.get("insider_sell_margin", 3)
 
         if ratings:
-            ups = sum(1 for r in ratings if r.get("action") in ("up", "upgrade") or "raise" in str(r.get("action", "")).lower())
-            downs = sum(1 for r in ratings if r.get("action") in ("down", "downgrade") or "lower" in str(r.get("action", "")).lower())
+            ups = sum(
+                1
+                for r in ratings
+                if r.get("action") in ("up", "upgrade") or "raise" in str(r.get("action", "")).lower()
+            )
+            downs = sum(
+                1
+                for r in ratings
+                if r.get("action") in ("down", "downgrade") or "lower" in str(r.get("action", "")).lower()
+            )
             if ups > downs + 1:
                 score += 1
                 reasons.append(f"등급↑({ups}↑/{downs}↓, cached)")
@@ -242,10 +290,10 @@ class WallStreetAgent(BaseAgent):
             sp = earnings[0].get("surprise_pct")
             if sp and sp > earn_th:
                 score += 1
-                reasons.append(f"실적+{sp*100:.0f}%(cached)")
+                reasons.append(f"실적+{sp * 100:.0f}%(cached)")
             elif sp and sp < -earn_th:
                 score -= 1
-                reasons.append(f"실적{sp*100:.0f}%(cached)")
+                reasons.append(f"실적{sp * 100:.0f}%(cached)")
 
         if insiders:
             sells = sum(1 for i in insiders if i.get("transaction_type") == "sale")
@@ -264,5 +312,6 @@ class WallStreetAgent(BaseAgent):
         else:
             action, conf = "HOLD", _CONF.get("cached_hold", 40)
 
-        return AgentVerdict(self.name, ticker, action, round(self.normalize_confidence(conf), 1),
-                           "; ".join(reasons), {"cached": True})
+        return AgentVerdict(
+            self.name, ticker, action, round(self.normalize_confidence(conf), 1), "; ".join(reasons), {"cached": True}
+        )

--- a/nuri/trading/engine/decisions.py
+++ b/nuri/trading/engine/decisions.py
@@ -8,6 +8,7 @@
 사용:
     from nuri.trading.engine.decisions import record_decision, track_decision_outcomes
 """
+
 import json
 import logging
 from datetime import datetime, timedelta
@@ -37,7 +38,8 @@ def record_decision(consensus_result, db_path=None) -> int:
     # 현재가 조회
     price_row = query(
         "SELECT close FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",
-        (ticker,), db_path,
+        (ticker,),
+        db_path,
     )
     entry_price = price_row[0]["close"] if price_row else 0.0
 
@@ -99,18 +101,22 @@ def record_decision(consensus_result, db_path=None) -> int:
 
     # 시장 컨텍스트도 evidence로 기록
     if context.get("regime"):
-        evidence_records.append({
-            "source_type": "regime",
-            "source_key": "current",
-            "action": None,
-            "confidence": None,
-            "detail": json.dumps(context, ensure_ascii=False),
-        })
+        evidence_records.append(
+            {
+                "source_type": "regime",
+                "source_key": "current",
+                "action": None,
+                "confidence": None,
+                "detail": json.dumps(context, ensure_ascii=False),
+            }
+        )
 
     upsert_decision_evidence(decision_id, evidence_records, db_path)
 
-    logger.info(f"Decision recorded: {ticker} {consensus_result.final_action} "
-                f"(conf={consensus_result.final_confidence:.0f}, id={decision_id})")
+    logger.info(
+        f"Decision recorded: {ticker} {consensus_result.final_action} "
+        f"(conf={consensus_result.final_confidence:.0f}, id={decision_id})"
+    )
     return decision_id
 
 
@@ -153,7 +159,8 @@ def track_decision_outcomes(db_path=None) -> int:
                 target_date = (dec_date + timedelta(days=days)).strftime("%Y-%m-%d")
                 price = query(
                     "SELECT close FROM prices WHERE ticker = ? AND date <= ? ORDER BY date DESC LIMIT 1",
-                    (ticker, target_date), db_path,
+                    (ticker, target_date),
+                    db_path,
                 )
                 if price and entry > 0:
                     ret = (price[0]["close"] - entry) / entry * 100
@@ -227,8 +234,7 @@ def _snapshot_market_context(db_path=None) -> dict:
 
     # Regime — pipeline_events에서 최신 regime_changed 이벤트
     regime_row = query(
-        "SELECT payload FROM pipeline_events WHERE event_type = 'regime_changed' "
-        "ORDER BY timestamp DESC LIMIT 1",
+        "SELECT payload FROM pipeline_events WHERE event_type = 'regime_changed' ORDER BY timestamp DESC LIMIT 1",
         db_path=db_path,
     )
     if regime_row:
@@ -241,6 +247,7 @@ def _snapshot_market_context(db_path=None) -> dict:
     # Macro score — event_score 포함
     try:
         from nuri.quant.regime.macro_score import compute_macro_score
+
         ms = compute_macro_score(db_path=db_path)
         context["macro_score"] = ms.total_score
         context["event_score"] = ms.event_score
@@ -270,8 +277,7 @@ def compute_agent_accuracy(db_path=None) -> dict:
     from nuri.core.db import query
 
     rows = query(
-        "SELECT agent_verdicts, outcome FROM decisions "
-        "WHERE outcome IN ('success', 'failure')",
+        "SELECT agent_verdicts, outcome FROM decisions WHERE outcome IN ('success', 'failure')",
         db_path=db_path,
     )
 
@@ -304,8 +310,7 @@ def compute_agent_accuracy(db_path=None) -> dict:
             agent_stats[agent_name]["total"] += 1
 
             # BUY + success = hit, SELL + failure = hit
-            if (action == "BUY" and outcome == "success") or \
-               (action == "SELL" and outcome == "failure"):
+            if (action == "BUY" and outcome == "success") or (action == "SELL" and outcome == "failure"):
                 agent_stats[agent_name]["hits"] += 1
 
     # 적중률 + weight_adjustment 계산
@@ -345,16 +350,18 @@ def save_agent_accuracy_snapshot(db_path=None) -> int:
     today = today_kst()
     records = []
     for name, stats in accuracy.items():
-        records.append({
-            "snapshot_date": today,
-            "signal_id": f"agent_{name}_accuracy",
-            "regime": "all",
-            "period": "all_time",
-            "trades": stats["total"],
-            "win_rate": stats["hit_rate"],
-            "profit_factor": stats["weight_adjustment"],  # weight_adjustment 저장
-            "avg_return": 0.0,
-        })
+        records.append(
+            {
+                "snapshot_date": today,
+                "signal_id": f"agent_{name}_accuracy",
+                "regime": "all",
+                "period": "all_time",
+                "trades": stats["total"],
+                "win_rate": stats["hit_rate"],
+                "profit_factor": stats["weight_adjustment"],  # weight_adjustment 저장
+                "avg_return": 0.0,
+            }
+        )
 
     with get_db(db_path) as conn:
         conn.executemany(
@@ -374,6 +381,7 @@ def _get_price_targets(ticker: str, entry_price: float, db_path=None) -> dict:
         return {}
     try:
         from nuri.trading.recommend.price_targets import calculate_targets
+
         return calculate_targets(ticker, entry_price=entry_price, db_path=db_path)
     except Exception:
         return {}
@@ -417,8 +425,10 @@ def main(argv: list[str] | None = None, db_path=None) -> int:
             print(f"  {'Agent':<18} {'Total':>6} {'Hits':>6} {'Rate':>8} {'Adj':>8}")
             print(f"  {'-' * 50}")
             for name, stats in sorted(acc.items(), key=lambda x: x[1]["hit_rate"], reverse=True):
-                print(f"  {name:<18} {stats['total']:>6} {stats['hits']:>6} "
-                      f"{stats['hit_rate']:>7.1%} {stats['weight_adjustment']:>+7.2f}")
+                print(
+                    f"  {name:<18} {stats['total']:>6} {stats['hits']:>6} "
+                    f"{stats['hit_rate']:>7.1%} {stats['weight_adjustment']:>+7.2f}"
+                )
             print()
         else:
             print("완료된 decisions 없음 (outcome = success/failure 필요)")
@@ -429,9 +439,11 @@ def main(argv: list[str] | None = None, db_path=None) -> int:
 
     if args.summary:
         summary = get_decision_summary(db_path=db_path)
-        print(f"\n의사결정 요약: total={summary['total']}, "
-              f"pending={summary['pending']}, success={summary['success']}, "
-              f"failure={summary['failure']}, neutral={summary['neutral']}")
+        print(
+            f"\n의사결정 요약: total={summary['total']}, "
+            f"pending={summary['pending']}, success={summary['success']}, "
+            f"failure={summary['failure']}, neutral={summary['neutral']}"
+        )
 
     return 0
 

--- a/nuri/trading/swing/rules.py
+++ b/nuri/trading/swing/rules.py
@@ -16,6 +16,7 @@
     python -m nuri.trading.swing.rules
     python -m nuri.trading.swing.rules --check   # 보유 포지션 청산 체크
 """
+
 import argparse
 import logging
 from dataclasses import dataclass
@@ -43,6 +44,7 @@ MIN_AGENT_CONFIDENCE = int(SWING_MIN_AGENT_CONFIDENCE)
 @dataclass
 class SwingEntry:
     """스윙 진입 판정."""
+
     ticker: str
     price: float
     scan_signal: str
@@ -57,12 +59,13 @@ class SwingEntry:
 @dataclass
 class SwingExit:
     """스윙 청산 판정."""
+
     ticker: str
     entry_price: float
     current_price: float
     return_pct: float
     hold_days: int
-    exit_reason: str        # "take_profit", "stop_loss", "max_hold", "agent_sell", "hold"
+    exit_reason: str  # "take_profit", "stop_loss", "max_hold", "agent_sell", "hold"
     should_exit: bool
 
 
@@ -70,6 +73,7 @@ def evaluate_entries(scan_results=None, market: str = "us", db_path=None) -> lis
     """스캐너 결과 → 멀티 에이전트 분석 → 진입 판정."""
     if scan_results is None:
         from nuri.trading.swing.scanner import scan_market
+
         scan_results = scan_market(market=market)
 
     if not scan_results:
@@ -85,7 +89,8 @@ def evaluate_entries(scan_results=None, market: str = "us", db_path=None) -> lis
         # 이미 오픈 포지션이 있는지 확인
         existing = query(
             "SELECT id FROM swing_trades WHERE ticker = ? AND status = 'open'",
-            (sr.ticker,), db_path=db_path,
+            (sr.ticker,),
+            db_path=db_path,
         )
         if existing:
             continue
@@ -100,24 +105,28 @@ def evaluate_entries(scan_results=None, market: str = "us", db_path=None) -> lis
         )
 
         reason_parts = [f"scan: {sr.signal}(score={sr.score:.0f})"]
-        reason_parts.append(f"agents: {consensus.final_action}(conf={consensus.final_confidence:.0f}, agree={consensus.agreement_rate:.0%})")
+        reason_parts.append(
+            f"agents: {consensus.final_action}(conf={consensus.final_confidence:.0f}, agree={consensus.agreement_rate:.0%})"
+        )
         if not approved:
             if consensus.final_action != "BUY":
                 reason_parts.append(f"거부: 에이전트 {consensus.final_action}")
             if consensus.final_confidence < MIN_AGENT_CONFIDENCE:
                 reason_parts.append(f"거부: 신뢰도 {consensus.final_confidence:.0f} < {MIN_AGENT_CONFIDENCE}")
 
-        entries.append(SwingEntry(
-            ticker=sr.ticker,
-            price=sr.price,
-            scan_signal=sr.signal,
-            scan_score=sr.score,
-            agent_action=consensus.final_action,
-            agent_confidence=consensus.final_confidence,
-            agent_agreement=consensus.agreement_rate,
-            approved=approved,
-            reason="; ".join(reason_parts),
-        ))
+        entries.append(
+            SwingEntry(
+                ticker=sr.ticker,
+                price=sr.price,
+                scan_signal=sr.signal,
+                scan_score=sr.score,
+                agent_action=consensus.final_action,
+                agent_confidence=consensus.final_confidence,
+                agent_agreement=consensus.agreement_rate,
+                approved=approved,
+                reason="; ".join(reason_parts),
+            )
+        )
 
     return entries
 
@@ -129,15 +138,18 @@ def save_entries(entries: list[SwingEntry], db_path=None) -> int:
         return 0
 
     today = today_kst()
-    records = [{
-        "ticker": e.ticker,
-        "entry_date": today,
-        "entry_price": e.price,
-        "entry_signal": e.scan_signal,
-        "agent_action": e.agent_action,
-        "agent_confidence": e.agent_confidence,
-        "agent_agreement": e.agent_agreement,
-    } for e in approved]
+    records = [
+        {
+            "ticker": e.ticker,
+            "entry_date": today,
+            "entry_price": e.price,
+            "entry_signal": e.scan_signal,
+            "agent_action": e.agent_action,
+            "agent_confidence": e.agent_confidence,
+            "agent_agreement": e.agent_agreement,
+        }
+        for e in approved
+    ]
 
     with get_db(db_path) as conn:
         conn.executemany(
@@ -161,6 +173,7 @@ def check_exits(db_path=None) -> list[SwingExit]:
         return []
 
     from nuri.trading.agents.consensus import analyze_ticker
+
     today = kst_now().replace(tzinfo=None)
     exits = []
 
@@ -173,13 +186,15 @@ def check_exits(db_path=None) -> list[SwingExit]:
         # 현재 가격
         price_row = query(
             "SELECT close, date FROM prices WHERE ticker = ? ORDER BY date DESC LIMIT 1",
-            (ticker,), db_path=db_path,
+            (ticker,),
+            db_path=db_path,
         )
 
         # prices에 없으면 yfinance에서 직접 가져오기
         if not price_row or not price_row[0]["close"]:
             try:
                 import yfinance as yf
+
                 data = yf.download(ticker, period="5d", progress=False)
                 if not data.empty:
                     current_price = float(data["Close"].squeeze().iloc[-1])
@@ -215,15 +230,17 @@ def check_exits(db_path=None) -> list[SwingExit]:
             except Exception:
                 pass
 
-        exits.append(SwingExit(
-            ticker=ticker,
-            entry_price=entry_price,
-            current_price=round(current_price, 2),
-            return_pct=round(return_pct, 2),
-            hold_days=hold_days,
-            exit_reason=exit_reason,
-            should_exit=should_exit,
-        ))
+        exits.append(
+            SwingExit(
+                ticker=ticker,
+                entry_price=entry_price,
+                current_price=round(current_price, 2),
+                return_pct=round(return_pct, 2),
+                hold_days=hold_days,
+                exit_reason=exit_reason,
+                should_exit=should_exit,
+            )
+        )
 
         # 청산 실행
         if should_exit:
@@ -231,8 +248,7 @@ def check_exits(db_path=None) -> list[SwingExit]:
                 conn.execute(
                     "UPDATE swing_trades SET status='closed', exit_date=?, exit_price=?, "
                     "exit_reason=?, return_pct=? WHERE id=?",
-                    (today.strftime("%Y-%m-%d"), current_price, exit_reason, round(return_pct, 2),
-                     trade["id"]),
+                    (today.strftime("%Y-%m-%d"), current_price, exit_reason, round(return_pct, 2), trade["id"]),
                 )
 
     return exits
@@ -255,8 +271,10 @@ def print_entries(entries: list[SwingEntry]) -> None:
         print(f"  {'Ticker':<8} {'Price':>10} {'Signal':<14} {'Score':>6} {'Agent':>6} {'Conf':>5} {'Agree':>6}")
         print(f"  {'-' * 58}")
         for e in approved:
-            print(f"  {e.ticker:<8} ${e.price:>9,.2f} {e.scan_signal:<14} {e.scan_score:>5.0f} "
-                  f"{e.agent_action:>6} {e.agent_confidence:>4.0f} {e.agent_agreement:>5.0%}")
+            print(
+                f"  {e.ticker:<8} ${e.price:>9,.2f} {e.scan_signal:<14} {e.scan_score:>5.0f} "
+                f"{e.agent_action:>6} {e.agent_confidence:>4.0f} {e.agent_agreement:>5.0%}"
+            )
 
     if rejected:
         print(f"\n  REJECTED ({len(rejected)}):")
@@ -279,8 +297,10 @@ def print_exits(exits: list[SwingExit]) -> None:
     for e in exits:
         action = e.exit_reason.upper() if e.should_exit else "HOLD"
         color_prefix = "+" if e.return_pct > 0 else ""
-        print(f"  {e.ticker:<8} ${e.entry_price:>9,.2f} ${e.current_price:>9,.2f} "
-              f"{color_prefix}{e.return_pct:.1f}% {e.hold_days:>5} {action:<12}")
+        print(
+            f"  {e.ticker:<8} ${e.entry_price:>9,.2f} ${e.current_price:>9,.2f} "
+            f"{color_prefix}{e.return_pct:.1f}% {e.hold_days:>5} {action:<12}"
+        )
     print()
 
 

--- a/tests/alerts/test_alpha_report.py
+++ b/tests/alerts/test_alpha_report.py
@@ -402,6 +402,33 @@ class TestConfigDriven:
         assert "n=42/999" in line
         assert "결측 3.5%/42%" in line
 
+    def test_unmeasured_missing_rate_renders_as_na(self):
+        """결측률이 `None` (측정 대상 0 건) 이면 `n/a` — 숫자로도, 생략으로도 안 된다 (#1068).
+
+        `0.0` 으로 찍으면 사전 등록된 무효화 기준(15%)이 통과처럼 읽히고, 필드를
+        생략하면 "결측 없음"과 구분되지 않는다. 프로덕션 #brief 가 2026-07-28 ·
+        08-01 두 번 `결측 0.0%/15%` 를 내보냈고 그때 n 은 0 이었다.
+
+        Mutation lock: `missing_rate_pct` 를 `0.0` 으로 되돌리거나 `if missing is
+        not None` 생략 분기로 되돌리면 FAIL.
+        """
+        line = alpha_report.format_progress_reason(_report(missing_rate_pct=None, missing_max_pct=15))
+        assert "결측 n/a (한도 15%)" in line
+        assert "결측 0" not in line
+
+    def test_settlement_frontier_is_rendered(self):
+        """결측률 옆에 정산 프런티어가 같이 나온다 (#1068).
+
+        결측률은 정산된 창만 세므로, 벤치마크 수집이 멈추면 결측률이 조용히 내려간다.
+        프런티어가 안 보이면 "결측 낮음"과 "측정 멈춤"이 화면에서 구분되지 않는다.
+        """
+        line = alpha_report.format_progress_reason(_report(settled_through="2026-07-20", settlement_lag_days=43))
+        assert "정산 2026-07-20 (지연 43d)" in line
+
+    def test_missing_benchmark_frontier_renders_na(self):
+        line = alpha_report.format_progress_reason(_report(settled_through=None, settlement_lag_days=None))
+        assert "정산 n/a (벤치마크 종가 없음)" in line
+
 
 class TestRendererPath:
     """payload 가 실제 #brief 렌더러를 통과했을 때 무엇이 보이는가.

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -217,6 +217,19 @@ class TestMeasurementMode:
         assert mm["robustness_split"] == "median_split_halves"
         assert mm["missing_outcome_max_pct"] == 15
 
+    def test_settlement_lag_guard_is_locked_but_is_not_a_preregistered_criterion(self):
+        """정산 정지 가드 임계 (#1068). §3.11 **prudential invalidator** 의 첫 사례다 —
+        판정을 보류만 시키고 승격은 못 시키므로 사후 추가가 허용된 종류다 (§3.11 명문 정책).
+
+        그래도 잠그는 이유: 결측률은 정산된 창만 세므로, 이 값을 조용히 늘리면 벤치마크
+        수집이 멈춘 채로도 판정이 흘러간다 (측정이 망가질수록 결측 게이트는 깨끗해 보인다).
+        완화는 위 `test_adjudication_params_locked` 와 달리 STRATEGY PR 까지는 아니지만,
+        이 줄을 같이 고치도록 강제해 우발적 완화를 막는다.
+        """
+        from nuri.core.rules import RULES
+
+        assert RULES["measurement_mode"]["max_settlement_lag_days"] == 7
+
     def test_benchmark_matches_tracker_constant(self):
         """rules.yaml benchmark 와 tracker 코드 상수의 silent 분기 방지 (SSoT lock)."""
         from nuri.agents.actors.forward_outcome_tracker import DEFAULT_BENCHMARK_TICKER

--- a/tests/quant/validation/test_decision_alpha.py
+++ b/tests/quant/validation/test_decision_alpha.py
@@ -84,6 +84,13 @@ def _seed_decision(db_path, rec_id: int, ticker: str, emit: str, action: str = "
         conn.commit()
 
 
+def _truncate_benchmark(db_path, last_date: str) -> None:
+    """벤치마크(SPY) 시계열을 `last_date` 까지로 자른다 — 수집 정지 재현."""
+    with get_db(db_path) as conn:
+        conn.execute("DELETE FROM prices WHERE ticker = 'SPY' AND date > ?", (last_date,))
+        conn.commit()
+
+
 @pytest.fixture
 def seeded(db_path):
     """SPY + 치환 universe 3종 + 실표본 2 ticker 4 decision."""
@@ -163,12 +170,6 @@ class TestMissingIsSettlementNotCalendar:
     미도착인 상태였다 (SPY 마지막 bar 2026-08-14, 오늘 2026-08-18).
     """
 
-    @staticmethod
-    def _truncate_benchmark(db_path, last_date: str) -> None:
-        with get_db(db_path) as conn:
-            conn.execute("DELETE FROM prices WHERE ticker = 'SPY' AND date > ?", (last_date,))
-            conn.commit()
-
     def test_unsettled_window_is_not_missing(self, seeded):
         """만기일은 지났지만 벤치마크 bar 가 아직 없으면 결측 아님.
 
@@ -176,7 +177,7 @@ class TestMissingIsSettlementNotCalendar:
         결측 1건으로 세어져 FAIL.
         """
         _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
-        self._truncate_benchmark(seeded, "2026-08-05")  # 만기 이후 bar 미도착
+        _truncate_benchmark(seeded, "2026-08-05")  # 만기 이후 bar 미도착
         s = da.fetch_sample(db_path=seeded, as_of=AS_OF)  # as_of 9/1 — 달력상은 닫힘
         assert s.n_missing_closed == 0
         assert s.missing_rate_pct == 0.0
@@ -205,7 +206,7 @@ class TestMissingIsSettlementNotCalendar:
         Mutation lock: `settled_through` / `settlement_lag_days` 를 리포트에서 빼면 FAIL.
         """
         _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
-        self._truncate_benchmark(seeded, "2026-07-20")  # 수집 정지
+        _truncate_benchmark(seeded, "2026-07-20")  # 수집 정지
         s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
         assert s.n_missing_closed == 0  # 조용해진다 — 그래서 아래가 필요하다
         assert s.settled_through == "2026-07-20"
@@ -214,6 +215,8 @@ class TestMissingIsSettlementNotCalendar:
         report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
         assert report["settled_through"] == "2026-07-20"
         assert report["settlement_lag_days"] == 43
+        # 보이기만 해서는 부족하다 — 판정 자체가 막혀야 한다 (아래 클래스가 잠근다).
+        assert report["criteria_verdict_if_final"] == "INVALID_STALE_BENCHMARK"
 
     def test_settlement_frontier_without_benchmark_is_none(self, db_path):
         """벤치마크 종가가 아예 없으면 프런티어는 None — 0 이나 오늘로 위장하지 않는다."""
@@ -227,9 +230,165 @@ class TestMissingIsSettlementNotCalendar:
         위 두 테스트가 "안 센다"만 잠그면 결측 계상을 통째로 없애도 통과한다.
         """
         _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
-        self._truncate_benchmark(seeded, "2026-08-14")  # 만기 이후 bar 도착
+        _truncate_benchmark(seeded, "2026-08-14")  # 만기 이후 bar 도착
         s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
         assert s.n_missing_closed == 1
+
+
+class TestStaleBenchmarkBlocksTheVerdict:
+    """정산 기준이 반대 방향으로 거짓말하는 경로를 판정으로 막는다 (#1068, Codex P1).
+
+    결측률은 정산된 창만 세므로, 벤치마크 수집이 멈추면 미해소 결정이 결측에서 빠져나가
+    결측률이 **내려간다** — 측정이 망가질수록 게이트가 통과처럼 보인다. 프런티어를
+    리포트에 싣는 것은 사람이 봐야 발화하므로 게이트가 아니다.
+
+    이 조건은 판정을 **더 어렵게만** 만든다 (§3.11 "하향/동결은 상시 허용" — prudential
+    방향이라 사전등록 개정 대상이 아니다). 임계는 `measurement_mode.max_settlement_lag_days`.
+    """
+
+    def test_stale_benchmark_invalidates_before_missing_rate(self, seeded):
+        """Mutation lock: 정산 정지 분기를 지우면 낮아진 결측률로 통과해 FAIL."""
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)
+        with get_db(seeded) as conn:
+            conn.execute("DELETE FROM prices WHERE ticker = 'SPY' AND date > ?", ("2026-07-20",))
+            conn.commit()
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["criteria_verdict_if_final"] == "INVALID_STALE_BENCHMARK"
+        # 결측률은 오히려 깨끗해 보인다 — 그게 이 게이트가 필요한 이유다.
+        assert report["missing_rate_pct"] == 0.0
+
+    def test_stale_benchmark_beats_the_empty_sample_short_circuit(self, seeded):
+        """확정 alpha 가 0 건이어도 "표본 0건"이 아니라 "측정 중단"으로 보고한다.
+
+        Codex 2차 리뷰가 짚은 제어흐름 결함: 게이트를 `NO_SAMPLE` 조기 return **뒤**에
+        두면, 벤치마크가 얼어 alpha 가 하나도 안 쌓인 상태가 정상 accrual 로 읽힌다.
+        프로덕션이 지금 대부분의 시간을 보내는 상태가 정확히 n=0 이라(2026-07-28 ·
+        08-01 브리핑 둘 다 `표본 0건`) 이 순서가 뒤집혀 있으면 피드가 죽어도 모른다.
+
+        Mutation lock: 정산 검사를 `if sample.n == 0` 아래로 내리면 `NO_SAMPLE` 이 나와 FAIL.
+        """
+        with get_db(seeded) as conn:
+            conn.execute("DELETE FROM decision_outcomes")  # 확정 alpha 0 건
+            conn.commit()
+        _truncate_benchmark(seeded, "2026-07-20")
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["n"] == 0
+        assert report["verdict"] == "INVALID_STALE_BENCHMARK"
+        assert "측정 중단" in report["reason"]
+
+    def test_empty_sample_with_fresh_benchmark_is_still_no_sample(self, seeded):
+        """정산이 정상이면 표본 0 건은 그대로 `NO_SAMPLE` — 가드가 정상 상태를 덮지 않는다."""
+        with get_db(seeded) as conn:
+            conn.execute("DELETE FROM decision_outcomes")
+            conn.commit()
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["n"] == 0
+        assert report["verdict"] == "NO_SAMPLE"
+
+    def test_stale_benchmark_wins_over_a_high_missing_rate(self, seeded):
+        """둘 다 성립할 때 보고되는 사유는 "측정이 멈췄다" 여야 한다.
+
+        결측률이 높은 **이유**가 벤치마크 정지일 수 있는데 `INVALID_MISSING` 으로 적으면
+        추적 실패를 쫓게 된다. 둘 다 무효라도 사유가 틀리면 다음 행동이 틀린다.
+
+        Mutation lock: 두 분기의 순서를 바꾸면 `INVALID_MISSING` 이 나와 FAIL.
+        """
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target 2026-08-09 — 정산됨
+        _truncate_benchmark(seeded, "2026-08-20")  # lag 12d > 7d 임계
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["missing_rate_pct"] == 20.0  # 15% 초과 — 결측 게이트도 성립
+        assert report["settlement_lag_days"] == 12
+        assert report["criteria_verdict_if_final"] == "INVALID_STALE_BENCHMARK"
+
+    def test_no_benchmark_at_all_is_invalid_not_passable(self, seeded):
+        """벤치마크 종가가 아예 없으면 무효다 — "지연 없음"으로 통과시키지 않는다.
+
+        Mutation lock: `lag is None or ...` 을 `lag is not None and ...` 로 바꾸면
+        표본이 그대로 판정에 흘러 FAIL.
+        """
+        with get_db(seeded) as conn:
+            conn.execute("DELETE FROM prices WHERE ticker = 'SPY'")
+            conn.commit()
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["settled_through"] is None
+        assert report["settlement_lag_days"] is None
+        assert report["criteria_verdict_if_final"] == "INVALID_STALE_BENCHMARK"
+
+    def test_threshold_change_changes_behavior(self, seeded, monkeypatch):
+        """임계를 늘리면 같은 지연이 통과한다 — 값이 코드에 박혀 있으면 안 된다.
+
+        Mutation lock: `max_lag = 7` 로 하드코딩하면 config 를 늘려도 계속 발화해 FAIL.
+        (`test_threshold_comes_from_config` 는 리포트 필드만 봐서 이걸 못 잡는다.)
+        """
+        _truncate_benchmark(seeded, "2026-08-20")  # lag 12d
+        loosened = {**da.RULES, "measurement_mode": {**da.RULES["measurement_mode"], "max_settlement_lag_days": 30}}
+        monkeypatch.setattr(da, "RULES", loosened)
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["max_settlement_lag_days"] == 30
+        assert report["criteria_verdict_if_final"] != "INVALID_STALE_BENCHMARK"
+
+    def test_fresh_benchmark_does_not_trip_the_gate(self, seeded):
+        """정상 지연(주말 등)은 발화하지 않는다 — 가드가 상시 무효를 만들면 무용지물."""
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["settlement_lag_days"] <= report["max_settlement_lag_days"]
+        assert report["criteria_verdict_if_final"] != "INVALID_STALE_BENCHMARK"
+
+    def test_threshold_comes_from_config(self, seeded):
+        """하드코딩 금지 — 임계는 `config/rules.yaml measurement_mode` 에서 온다."""
+        import yaml
+
+        mm = yaml.safe_load(open("config/rules.yaml", encoding="utf-8"))["measurement_mode"]
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["max_settlement_lag_days"] == int(mm["max_settlement_lag_days"])
+
+
+class TestJudgmentDateRulesAgree:
+    """판정일에는 정산 기준과 달력 기준이 **같은 답**을 준다 (#1068, Codex P1 반박 근거).
+
+    §3.11 이 emit cutoff 를 판정일 46일 전으로 잡은 이유가 "30d 창 완결 보장"이다. 창이
+    전부 정산된 상태에서는 두 규칙이 일치하므로, 이 변경은 **사전 등록된 판정의 결과를
+    바꾸지 않는다** — 바뀌는 것은 측정 도중 매달 나가는 진행 리포트뿐이다.
+
+    이 성질이 깨지면 그때는 진짜 사전등록 개정이므로, 여기서 잠근다.
+    """
+
+    def test_settled_sample_matches_the_calendar_rule(self, seeded):
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # 정산된 결측
+        _seed_decision(seeded, 21, "BBB", EMIT_2, alpha=None)  # 정산된 결측
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+
+        # 달력 기준 재현 — 같은 표본에 옛 규칙을 그대로 적용
+        window = 30
+        calendar_missing = 0
+        for rec_id, emit in ((20, EMIT_1), (21, EMIT_2)):
+            target = (date.fromisoformat(emit) + timedelta(days=window)).isoformat()
+            if target <= AS_OF:
+                calendar_missing += 1
+
+        assert s.settled_through is not None and s.settled_through >= "2026-08-27"
+        assert s.n_missing_closed == calendar_missing == 2
+
+    def test_config_guarantees_the_equivalence_at_judgment(self):
+        """동등성은 희망이 아니라 설정 산술의 결과다 — 그 산술을 여기서 잠근다.
+
+        마지막 표본의 창은 `emit_cutoff_date + primary_window_days` 에 닫히고, 정산
+        게이트가 프런티어를 `max_settlement_lag_days` 이내로 강제하므로, 판정일에는
+        그 창이 반드시 정산돼 있다:
+
+            emit_cutoff + window + max_lag <= evaluation_date
+
+        이 부등식이 깨지면 판정일에 미정산 창이 남아 두 기준이 갈라진다 — 그때부터는
+        진짜 사전등록 개정이므로, cutoff·window·임계 중 무엇을 건드려도 여기서 FAIL 한다.
+        """
+        mm = da._criteria()
+        last_window_closes = date.fromisoformat(str(mm["emit_cutoff_date"])) + timedelta(
+            days=int(mm["primary_window_days"])
+        )
+        settled_by = last_window_closes + timedelta(days=int(mm["max_settlement_lag_days"]))
+        assert settled_by <= date.fromisoformat(str(mm["evaluation_date"])), (
+            f"판정일 {mm['evaluation_date']} 에 마지막 창이 정산 보장되지 않는다 "
+            f"(창 종료 {last_window_closes}, 정산 보장 {settled_by})"
+        )
 
 
 class TestDenominatorDoesNotDependOnTheMirror:
@@ -293,6 +452,8 @@ class TestEmptySampleHasNoMissingRate:
         assert s.missing_rate_pct is None
 
     def test_adjudicate_reports_none_not_zero(self, db_path):
+        # 벤치마크는 정상이어야 한다 — 없으면 정산 게이트가 먼저 걸려 NO_SAMPLE 에 못 간다.
+        _seed_prices(db_path, "SPY", "2026-07-01", 60, 100.0, 0.001)
         report = da.adjudicate(db_path=db_path, n_perm=1, as_of=AS_OF)
         assert report["verdict"] == "NO_SAMPLE"
         assert report["missing_rate_pct"] is None
@@ -394,6 +555,9 @@ class TestAdjudicate:
         assert report["criteria_verdict_if_final"] == "INVALID_MISSING"
 
     def test_no_sample(self, db_path):
+        # 벤치마크가 살아 있는데 결정이 없는 상태 — 이게 진짜 "표본 0건" 이다.
+        # (벤치마크마저 없으면 그건 accrual 이 아니라 측정 중단이라 다른 verdict 다.)
+        _seed_prices(db_path, "SPY", "2026-07-01", 60, 100.0, 0.001)
         report = da.adjudicate(db_path=db_path, n_perm=20, as_of=AS_OF)
         assert report["verdict"] == "NO_SAMPLE"
 

--- a/tests/quant/validation/test_decision_alpha.py
+++ b/tests/quant/validation/test_decision_alpha.py
@@ -4,15 +4,18 @@ Gotcha-Test Pair:
 - ticker-block placebo 의 핵심 계약 = "같은 ticker 의 반복 emit 은 null 에서도
   같은 치환 ticker 를 공유" (의존 구조 상속). 이 계약이 깨지면 (iid 화) null
   분산이 과소평가돼 anti-conservative p — §3.11 이 지정한 P1 결함의 재유입.
-- 결측 정의 = "창이 닫혔는데 alpha 미기록" — lookahead 미도래분을 결측으로
-  세면 측정 기간 내내 INVALID_MISSING 오탐.
+- 결측 정의 = "창이 **정산**됐는데 alpha 미기록" — 미도래분(lookahead)이나
+  미정산분(벤치마크 bar 미도착)을 결측으로 세면 측정 기간 내내 INVALID_MISSING
+  오탐. 프로덕션 실측 2026-08-18 에 달력 기준 50.0% vs 정산 기준 9.1% (#1068).
+- 결측률 분모 = emit 된 BUY 전부. `agent_decisions` 미러에 의존하면 그 미러를
+  쓰는 주체가 측정 대상이라 게이트가 감시 대상과 반대로 움직인다 (#1068).
 """
 
 from datetime import date, timedelta
 
 import pytest
 
-from nuri.core.db import get_db, init_db
+from nuri.core.db import DatabaseError, get_db, init_db
 from nuri.core.ticker_names import is_kr_ticker
 from nuri.quant.validation import decision_alpha as da
 
@@ -148,12 +151,174 @@ class TestFetchSample:
         assert round(s.missing_rate_pct, 1) == round(1 / 5 * 100, 1)
 
 
+class TestMissingIsSettlementNotCalendar:
+    """결측은 **정산** 기준이다 — 만기일이 달력상 지난 것만으로는 결측이 아니다 (#1068).
+
+    벤치마크 종가가 아직 안 들어왔으면 alpha 는 계산될 수 없다. 그건 추적 실패가
+    아니라 미도착인데, 달력일로만 세면 사전 등록된 무효화 기준(결측 15% 초과 →
+    판정 무효, §3.11)이 가격 수집 지연 하루 때문에 상시 발화한다.
+
+    프로덕션 실측 2026-08-18: 달력 기준 50.0% → 정산 기준 9.1%. 결측 10건 중 9건이
+    `notes: price missing — entry=<값>, exit=None` 로, entry 는 해소되고 exit 만
+    미도착인 상태였다 (SPY 마지막 bar 2026-08-14, 오늘 2026-08-18).
+    """
+
+    @staticmethod
+    def _truncate_benchmark(db_path, last_date: str) -> None:
+        with get_db(db_path) as conn:
+            conn.execute("DELETE FROM prices WHERE ticker = 'SPY' AND date > ?", (last_date,))
+            conn.commit()
+
+    def test_unsettled_window_is_not_missing(self, seeded):
+        """만기일은 지났지만 벤치마크 bar 가 아직 없으면 결측 아님.
+
+        Mutation lock: `target <= settled_through` 를 `target <= today` 로 되돌리면
+        결측 1건으로 세어져 FAIL.
+        """
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
+        self._truncate_benchmark(seeded, "2026-08-05")  # 만기 이후 bar 미도착
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)  # as_of 9/1 — 달력상은 닫힘
+        assert s.n_missing_closed == 0
+        assert s.missing_rate_pct == 0.0
+
+    def test_settlement_is_point_in_time(self, seeded):
+        """`as_of` 이후의 bar 는 정산 판정에 쓰이지 않는다.
+
+        `as_of` 를 과거로 주고 리포트를 재현할 때 미래 bar 가 새어 들어오면, 그 시점엔
+        아직 닫히지도 않은 창이 결측으로 계상된다.
+
+        Mutation lock: `_benchmark_settled_through` 의 `AND date <= ?` 를 지우면
+        결측 1건으로 세어져 FAIL.
+        """
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
+        # SPY 는 9월까지 있으나 as_of 는 만기 이전 → 그 시점 기준 미정산
+        s = da.fetch_sample(db_path=seeded, as_of="2026-08-05")
+        assert s.n_missing_closed == 0
+
+    def test_frozen_benchmark_is_visible_not_just_quiet(self, seeded):
+        """벤치마크 수집이 멈추면 결측률이 내려가는데, 그 사실이 리포트에 남아야 한다.
+
+        정산 기준은 미도착 bar 를 결측으로 안 세는 대신 **반대 방향으로 거짓말할 수
+        있다** — 프런티어가 얼면 이후 만기분이 영원히 "미정산"이 되어 결측률이 조용히
+        낮아진다. 판정을 바꾸지 않고(Surface) 프런티어를 같이 싣는 이유가 이것이다.
+
+        Mutation lock: `settled_through` / `settlement_lag_days` 를 리포트에서 빼면 FAIL.
+        """
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
+        self._truncate_benchmark(seeded, "2026-07-20")  # 수집 정지
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n_missing_closed == 0  # 조용해진다 — 그래서 아래가 필요하다
+        assert s.settled_through == "2026-07-20"
+        assert s.settlement_lag_days == 43  # 2026-07-20 → 2026-09-01
+
+        report = da.adjudicate(db_path=seeded, n_perm=1, as_of=AS_OF)
+        assert report["settled_through"] == "2026-07-20"
+        assert report["settlement_lag_days"] == 43
+
+    def test_settlement_frontier_without_benchmark_is_none(self, db_path):
+        """벤치마크 종가가 아예 없으면 프런티어는 None — 0 이나 오늘로 위장하지 않는다."""
+        s = da.fetch_sample(db_path=db_path, as_of=AS_OF)
+        assert s.settled_through is None
+        assert s.settlement_lag_days is None
+
+    def test_settled_window_without_alpha_is_missing(self, seeded):
+        """정산까지 끝났는데 alpha 가 없으면 그건 진짜 결측이다 (가드가 과잉이 아님).
+
+        위 두 테스트가 "안 센다"만 잠그면 결측 계상을 통째로 없애도 통과한다.
+        """
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)  # target = 2026-08-09
+        self._truncate_benchmark(seeded, "2026-08-14")  # 만기 이후 bar 도착
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n_missing_closed == 1
+
+
+class TestDenominatorDoesNotDependOnTheMirror:
+    """결측률 분모는 emit 된 BUY 전부다 — `agent_decisions` 미러 여부와 무관 (#1068).
+
+    예전 구현은 `agent_decisions` 와 INNER JOIN 했다. 그 미러를 쓰는 주체가 측정
+    대상인 tracker 자신이라, 미러가 밀리면 누락분이 분자·분모에서 동시에 빠져
+    **보고 결측률이 내려가고 실제는 올라간다** — 무효화 게이트가 감시 대상과 반대로
+    움직인다. 프로덕션 실측(2026-08-18)상 미러된 525건의 action 은 전부 일치하므로
+    표본 구성은 그대로이고, 의존성만 끊긴다.
+    """
+
+    @staticmethod
+    def _unmirror(db_path, rec_id: int) -> None:
+        with get_db(db_path) as conn:
+            conn.execute("DELETE FROM agent_decisions WHERE decision_id = ?", (f"rec_{rec_id}",))
+            conn.commit()
+
+    def test_unmirrored_buy_still_counts_as_missing(self, seeded):
+        """Mutation lock: INNER JOIN 으로 되돌리면 결측이 0 으로 보여 FAIL."""
+        _seed_decision(seeded, 20, "AAA", EMIT_1, alpha=None)
+        self._unmirror(seeded, 20)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n_missing_closed == 1
+        rate = s.missing_rate_pct
+        assert rate is not None and rate > 0
+
+    def test_outcome_cannot_exist_without_a_mirror(self, seeded):
+        """`decision_outcomes` → `agent_decisions` FK 때문에 미러 없는 결정은 alpha 를
+        가질 수 없다 (`db_migrations.py` 의 세 정의 모두 동일 FK).
+
+        그래서 INNER JOIN 이 숨길 수 있었던 행은 **전부 결측**이었다 — 분자는 영향이
+        없고 분모만 줄었다는 뜻이고, 그게 게이트가 감시 대상과 반대로 움직인 이유다.
+        이 사실이 깨지면 위 수정의 전제도 깨지므로 여기서 잠근다.
+        """
+        _seed_decision(seeded, 22, "CCC", EMIT_2, alpha=None)
+        self._unmirror(seeded, 22)
+        with pytest.raises(DatabaseError):
+            with get_db(seeded) as conn:
+                conn.execute(
+                    """INSERT INTO decision_outcomes
+                       (decision_id, observation_window, tracked_as_of_date, alpha)
+                       VALUES ('rec_22', 30, ?, 0.02)""",
+                    (AS_OF,),
+                )
+                conn.commit()
+
+
+class TestEmptySampleHasNoMissingRate:
+    """측정 대상이 0 건이면 결측률은 `None` — `0.0` 이 아니다 (#1068).
+
+    `0.0` 은 "결측 없음"으로 읽힌다. 프로덕션 #brief 가 2026-07-28 · 08-01 두 번
+    `결측 0.0%/15%` 를 내보냈고 그때 n 은 0 이었다 — 사전 등록된 무효화 기준이
+    통과처럼 보였다.
+    """
+
+    def test_no_decisions_yields_none(self, db_path):
+        """Mutation lock: `else 0.0` 으로 되돌리면 FAIL."""
+        s = da.fetch_sample(db_path=db_path, as_of=AS_OF)
+        assert s.n == 0
+        assert s.missing_rate_pct is None
+
+    def test_adjudicate_reports_none_not_zero(self, db_path):
+        report = da.adjudicate(db_path=db_path, n_perm=1, as_of=AS_OF)
+        assert report["verdict"] == "NO_SAMPLE"
+        assert report["missing_rate_pct"] is None
+
+
 # ═══════════════════════════════════════════════════════
 # 순열 — ticker-block placebo 계약
 # ═══════════════════════════════════════════════════════
 
 
 class TestTickerBlockPlacebo:
+    def test_broken_eligibility_contract_raises_instead_of_skipping(self, seeded, monkeypatch):
+        """치환 후보가 실제로는 해소 안 되면 조용히 건너뛰지 않고 터진다.
+
+        건너뛰면 `count` 만 줄어 null 평균이 조용히 편향되고, 그 편향은 p 값을 통해
+        판정에 그대로 실린다. `_eligible_substitutes` 가 보장하는 계약이라 정상 경로에선
+        도달하지 않지만, 계약이 깨졌을 때 침묵하는 것이 이 레포에서 반복된 실패 형태다.
+        """
+        sample = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        # 가격이 전혀 없는 ticker 를 eligible 로 위장 → _placebo_alpha 가 None
+        monkeypatch.setattr(
+            da, "_eligible_substitutes", lambda *a, **k: {t: ["ZZZ"] for t in {d["ticker"] for d in sample.decisions}}
+        )
+        with pytest.raises(RuntimeError, match="eligible"):
+            da.ticker_block_placebo(sample, n_perm=1, seed=1, db_path=seeded)
+
     def test_block_shares_single_substitute(self, seeded):
         """Gotcha lock: 한 블록(반복 ticker)의 모든 emit 이 같은 치환 ticker 를 쓴다.
 


### PR DESCRIPTION
Closes #1068

## 무엇이 문제였나

§3.11 이 2027-06-30 판정을 위해 **사전 등록**한 무효화 기준(결측 15% 초과 → 판정 무효)이
가격 수집 지연 하루 때문에 상시 발화하고 있었다. 프로덕션 원장 실측 2026-08-18:

| | 결측률 | 판정 |
|---|---|---|
| 현행 (달력 기준) | **50.0%** | `INVALID_MISSING` |
| 정산 기준 | **9.1%** | 임계 이하 |

결측 10건 중 9건이 같은 모양이고, 원장이 그 사실을 그대로 적고 있었다:

```
tracked_as_of_date  hypothesis_validation  notes
2026-08-17          insufficient_data      price missing — entry=<값>, exit=None
```

entry 는 해소, exit 만 미도착. SPY 마지막 bar 는 **2026-08-14**, 오늘은 2026-08-18 이다.
트래커는 정상 동작 중이고(중복행 0 = upsert 정상) 가격이 들어오는 다음 실행에 채운다.
진짜 결측은 1건(시세 시리즈 자체가 끊긴 종목)뿐.

§3.11 의 결측 정의는 "추적 실패 / 가격 결측"이다. **아직 안 온 bar 는 둘 다 아니다.**

## 같은 숫자가 거짓말한 세 방향

1. **미정산 창을 추적 실패로 계상** — 위 표.
2. **분모가 미러 테이블에 의존** — `agent_decisions` INNER JOIN. 그 미러를 쓰는 주체가
   측정 대상인 tracker 자신이라, 미러가 밀리면 보고 결측률이 **내려가고** 실제는 올라간다.
   현재 프로덕션에서는 미발현(측정창 BUY 205건 전부 미러, 누락 262건은 전부 HOLD).
3. **표본 0 건에서 `결측 0.0%`** — 프로덕션 outbox 가 실제로 두 번 그렇게 내보냈다:

```
2026-07-28 sent | n=0/200 | 표본 0건 | 결측 0.0%/15% | 판정일까지 D-337
2026-08-01 sent | n=0/200 | 표본 0건 | 결측 0.0%/15% | 판정일까지 D-333
```

## 사전등록 개정이 아닌 이유

§3.11 이 emit cutoff 를 판정일 **46일 전**으로 잡은 이유가 "30d 창 완결 보장"이다.
창이 전부 정산된 상태에서는 달력 기준과 정산 기준이 **같은 답**을 준다 — 즉 이 변경은
사전 등록된 판정의 결과를 바꾸지 않는다. 바뀌는 것은 측정 도중 매달 나가는 진행 리포트뿐이다.
`TestJudgmentDateRulesAgree` 가 그 성질을 잠근다. §3.11 표에도 기록했다.

## Codex 리뷰 2라운드

### 1라운드 — NEEDS_REWORK

**P1**: 정산 기준은 **반대 방향으로 거짓말할 수 있다** — 벤치마크 피드가 얼면 미해소 결정이
결측에서 영원히 빠져나가, 측정이 망가질수록 게이트가 깨끗해 보인다. 프런티어를 리포트에
싣는 것은 사람이 봐야 발화하므로 게이트가 아니다.

→ `INVALID_STALE_BENCHMARK` 추가. 임계는 `measurement_mode.max_settlement_lag_days`(7).

**P2**: 조인 제거에 대한 주석이 근거보다 넓게 읽힌다.
→ FK 가 보장하는 범위(미러 없는 결정은 alpha 행을 가질 수 없다 → 분자 불변)로 좁히고,
action 일치는 현재 백필 구현의 성질이지 스키마 제약이 아님을 명시.

### 2라운드 — NEEDS_REWORK (1라운드 수정이 만든 새 결함)

**제어흐름 결함**: 정산 게이트를 `NO_SAMPLE` 조기 return **뒤**에 뒀다. 벤치마크가 얼어 확정
alpha 가 하나도 없으면 "표본 0건"으로 빠져나가는데, 그건 정상 accrual 로 읽힌다. 프로덕션이
**지금 대부분의 시간을 보내는 상태가 정확히 n=0** 이라(2026-07-28 · 08-01 브리핑 둘 다
`표본 0건`) 이 순서면 피드가 죽어도 아무도 모른다.

→ 정산 검사를 표본 유무보다 **앞**으로. 벤치마크가 없으면 `NO_SAMPLE` 이 아니라
`INVALID_STALE_BENCHMARK` + `측정 중단` 사유. 정상 정산 상태의 표본 0 건은 그대로 `NO_SAMPLE`.

**사전등록 정당성**: "한 방향으로만 조인다"가 "개정이 아니다"와 같지 않다. prudential
invalidator 를 허용하려면 그 정책이 독립적으로 존재해야 한다.

→ 타당. §3.11 에 정책을 명문화했다 — 판정을 **보류만 시킬 수 있고 승격은 못 시키는** 조건은
사후 추가 가능하며, 추가 시 (a) §3.11 기록 (b) config 임계 + lock test (c) 무효화 시나리오
회귀 테스트가 의무. `max_settlement_lag_days` 가 그 첫 사례로 등재됐다. 조건 완화 · 표본 규약
변경 · 3조건 수정은 여기 해당하지 않으며 종전대로 STRATEGY PR + 재승인 대상.

**P2 는 2라운드에서 해소 확인** ("properly narrow ... fixes the prior overstatement").

## 검증

- **뮤테이션 15종, 생존 0** — 게이트 제거 · `NO_SAMPLE` 뒤로 이동 · `None` 프런티어 통과 ·
  임계 하드코딩 · config 완화 · emit cutoff 이동 · 달력 기준 복귀 · PIT 가드 제거 ·
  INNER JOIN 복귀 · `else 0.0` 복귀 · 프런티어 미전달 · 렌더 생략 등. 중간 라운드에서 3종이
  살아남아(순서 검증 · `None` 경로 · 하드코딩) 테스트를 보강한 뒤 재측정했다.
- **프로덕션 원장 사본에 실제 함수 실행** — 결측 게이트를 통과해 알파 수치가 처음으로 나온다:

```
verdict: PROGRESS_REPORT | if_final: INSUFFICIENT_N
n=10/200 | mean -0.95%p | p=0.900/0.05 | halves -4.85/+2.95%p | 조건 0/3 충족
        | 결측 9.1%/15% | 정산 2026-08-14 (지연 4d) | 판정일까지 D-316
```

(기존 코드로는 결측 50.0% 에서 `INVALID_MISSING` 으로 막혀 이 줄이 나오지 않았다.
표본 10/200 이라 판정이 아니라 진행 리포트다.)

- `pre_push_check.sh` 전 항목 통과 — 7,061 passed, lint/shellcheck/doc-count/privacy clean
- pyright 0 error (수정 파일 5개). 레포 전체 183건 backlog 는 손대지 않음
- 신규 지표 커버리지 100% (`decision_alpha` 194 stmts, `alpha_report` 103 stmts)

## 별건 (이 PR 밖)

`scripts/verify/pre_push_check.sh` 가 **git hook 으로 설치돼 있지 않다** — 실행권한까지 있는데
아무도 부르지 않는다. 이번엔 손으로 돌렸다. 별도 이슈 #1070 으로 올렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
