### PR TITLE
fix(scheduler): schedule the factor composite and date it by market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 50 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
+    SCHED["APScheduler · 51 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 26 jobs"]
@@ -106,7 +106,7 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 50 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 51 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,076 collected across 323 files | |
+| **Backend tests** | 7,093 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -280,7 +280,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 50 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 51 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 50 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 51 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,076 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,093 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,076 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,093 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -20,6 +20,15 @@ FRESHNESS_POLICIES = {
         "fail_hours": 72,
         "label": "VIX",
     },
+    "factors": {
+        # BUY 후보 점수의 최대 입력(`buy_signals.yaml` 가중치 0.40)인데 정책이 없어서
+        # 2026-04-14 → 2026-08-18 넉 달간 낡은 채로도 어떤 화면에도 안 떴다 (#1071).
+        # 잡은 매일 08:10 이라 24h 이면 한 번 거른 것, 72h 면 사흘 연속 실패다.
+        "query": "SELECT MAX(date) FROM factors",
+        "warn_hours": 24,
+        "fail_hours": 72,
+        "label": "멀티팩터 스코어",
+    },
     "macro_fear_greed": {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
         "warn_hours": 24,

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -23,10 +23,14 @@ FRESHNESS_POLICIES = {
     "factors": {
         # BUY 후보 점수의 최대 입력(`buy_signals.yaml` 가중치 0.40)인데 정책이 없어서
         # 2026-04-14 → 2026-08-18 넉 달간 낡은 채로도 어떤 화면에도 안 떴다 (#1071).
-        # 잡은 매일 08:10 이라 24h 이면 한 번 거른 것, 72h 면 사흘 연속 실패다.
+        # `factors.date` 는 쓴 날이 아니라 **시장 데이터 날짜**다 (`_market_as_of`) — 그래서
+        # 이 검사는 잡의 생존과 입력의 신선도를 **동시에** 본다. 잡이 멈추면 날짜가 얼고,
+        # 가격이 멈춰도 날짜가 얼기 때문이다. `today_kst()` 로 찍던 시절엔 주말·휴장에도
+        # 당일 행이 생겨 이 정책이 낡음을 잡는 게 아니라 세탁했다 (#1071 Codex P1).
+        # 그래서 임계도 `prices` 와 같다 — 재료가 같으니 주말/공휴일 여유도 같아야 한다.
         "query": "SELECT MAX(date) FROM factors",
-        "warn_hours": 24,
-        "fail_hours": 72,
+        "warn_hours": 48,
+        "fail_hours": 120,
         "label": "멀티팩터 스코어",
     },
     "macro_fear_greed": {

--- a/nuri/quant/factors/composite.py
+++ b/nuri/quant/factors/composite.py
@@ -143,11 +143,31 @@ def print_composite(df: pd.DataFrame) -> None:
     print()
 
 
-def save_composite(df: pd.DataFrame) -> int:
-    """팩터 스코어를 factors 테이블에 멱등 저장 (date+ticker UNIQUE)."""
+def _market_as_of() -> str | None:
+    """이 스냅샷이 근거한 **시장 데이터 날짜** (없으면 None).
+
+    `factors.date` 는 쓴 날이 아니라 **재료의 날짜**여야 한다. 잡이 매일 08:10 에 도는데
+    `today_kst()` 를 찍으면 주말·휴장에도 금요일 종가로 계산한 행이 "당일" 라벨을 달고
+    들어간다. 그러면 신선도 정책이 낡음을 잡는 게 아니라 **세탁한다** — 가격 수집이
+    멈춰도 파생 테이블은 매일 갱신돼 PASS 로 보이고, 그 사이 가중치 0.40 짜리 입력이
+    옛 가격으로 BUY 점수를 만든다 (#1071 Codex P1).
+
+    시장일로 찍으면 주말 실행은 금요일 행을 **덮어쓰기만** 하므로(멱등, date+ticker
+    UNIQUE) 가짜 신선도가 생기지 않고, 소비자의 `MAX(date)` 는 그대로 최신을 집는다.
+    """
+    rows = query("SELECT MAX(date) AS d FROM prices")
+    return dict(rows[0])["d"] if rows else None
+
+
+def save_composite(df: pd.DataFrame, as_of: str | None = None) -> int:
+    """팩터 스코어를 factors 테이블에 멱등 저장 (date+ticker UNIQUE).
+
+    `as_of` 미지정 시 시장 데이터 날짜(`_market_as_of`)를 쓴다. 가격이 한 행도 없으면
+    계산 자체가 비어 있어 여기 도달하지 않지만, 방어적으로 `today_kst()` 로 떨어진다.
+    """
     if df.empty:
         return 0
-    date = today_kst()
+    date = as_of or _market_as_of() or today_kst()
     rows = [
         {
             "ticker": ticker,

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -120,6 +120,9 @@ _STAGE_OF_JOB = {
     "estimates": "collect",
     "etf_flows": "collect",
     "wallstreet": "collect",
+    # analyze — `factors` 하나뿐. 이게 붙기 전까지 `pipeline_events.step` 에 analyze 가
+    # **0건**이었다: 5스테이지 중 하나가 관측상 존재하지 않았다는 뜻이다 (#1071).
+    "factors": "analyze",
     # consensus — 하나뿐이며, 그 안에서 certify(record_decisions)까지 in-memory 로 이어진다
     "consensus": "consensus",
     # track
@@ -172,6 +175,12 @@ def _dispatch_collector(name: str, **kwargs):
         from nuri.collectors.fundamental import FundamentalCollector
 
         FundamentalCollector().run()
+    elif name == "factors":
+        # 수집이 아니라 **분석** 단계다 (`_STAGE_OF_JOB` 에서 analyze). `_run_collector` 를
+        # 재사용하는 건 그쪽이 예외 격리 · 실행 기록 · 스테이지 이벤트를 이미 갖고 있어서다.
+        from nuri.quant.factors.composite import compute_composite, save_composite
+
+        return save_composite(compute_composite())
     elif name == "cboe":
         from nuri.collectors.cboe import CBOECollector
 
@@ -690,6 +699,13 @@ SCHEDULES = [
     {"name": "technical", "func": _run_collector, "args": ("technical",), "cron": "0 7 * * 2-6"},
     # Fear & Greed (매일 08:00)
     {"name": "fear_greed", "func": _run_collector, "args": ("fear_greed",), "cron": "0 8 * * *"},
+    # 멀티팩터 합성 스코어 (매일 08:10) — `buy_signals.yaml` 에서 가중치 0.40 인 최대 입력인데
+    # 2026-04-14 이후 갱신이 끊겨 있었다. 잡이 없어서지 버그가 아니었다 (#1071).
+    # 08:10 인 이유: 입력 셋이 모두 그 앞에 끝난다 — prices(`stock_us_dawn` ~06:00) ·
+    # signals(`technical` 07:00) · `macro.fear_greed`(08:00, 바로 위 줄). 소비자는
+    # `buy_candidate_emitter` 하나이고 `premarket_brief`(09:00 ET ≈ 22시 KST)에서 불리므로
+    # 14시간 여유. 실측 1.1초 / 773종목이라 슬롯 압박은 없다.
+    {"name": "factors", "func": _run_collector, "args": ("factors",), "cron": "10 8 * * *"},
     # ARK 매매 (미장 마감 후 07:30)
     {"name": "ark", "func": _run_collector, "args": ("ark",), "cron": "30 7 * * 2-6"},
     # 이벤트 캘린더 (매일 07:00)

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -201,8 +201,12 @@ class TestCheckFreshness:
         assert result["status"] == "FAIL"
         assert result["label"] == "멀티팩터 스코어"
 
-    def test_same_day_factors_pass(self, db_path):
-        """정상 갱신(당일)은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다."""
+    def test_recent_factors_pass(self, db_path):
+        """정상 갱신은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다.
+
+        `prices` 와 같은 48h/120h 를 쓴다: `factors.date` 가 시장 데이터 날짜라서
+        주말이면 금요일에 머무는 게 정상이기 때문이다.
+        """
         from nuri.core.db import get_db
         from nuri.core.freshness import check_freshness
         from nuri.core.timezone import kst_now
@@ -214,6 +218,18 @@ class TestCheckFreshness:
             )
 
         assert check_freshness("factors", db_path=db_path)["status"] == "PASS"
+
+    def test_thresholds_match_prices_because_the_date_is_a_market_date(self):
+        """`factors` 와 `prices` 임계가 같아야 한다 (#1071 Codex P1).
+
+        `factors.date` 는 쓴 날이 아니라 **시장 데이터 날짜**다. 그래서 주말이면 금요일에
+        머무는 게 정상이고, `prices` 와 같은 주말 여유가 필요하다. 24h/72h 로 좁히면
+        월요일 아침마다(금→월 = 72h) 상시 발화한다.
+        """
+        from nuri.core.freshness import FRESHNESS_POLICIES
+
+        assert FRESHNESS_POLICIES["factors"]["warn_hours"] == FRESHNESS_POLICIES["prices"]["warn_hours"]
+        assert FRESHNESS_POLICIES["factors"]["fail_hours"] == FRESHNESS_POLICIES["prices"]["fail_hours"]
 
     def test_fail_on_query_exception(self, db_path):
         """쿼리 실행 실패 → FAIL."""

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -47,7 +47,17 @@ class TestFreshnessPolicies:
         """예상되는 정책 키 목록 확인."""
         from nuri.core.freshness import FRESHNESS_POLICIES
 
-        expected = {"prices", "macro_vix", "macro_fear_greed", "consensus", "certification", "portfolio"}
+        # `factors` 는 #1071 에서 추가 — 정책이 없어서 2026-04-14 → 08-18 넉 달간 낡은 채로도
+        # 어떤 화면에도 안 떴다. BUY 점수의 가중치 0.40 짜리 최대 입력이다.
+        expected = {
+            "prices",
+            "factors",
+            "macro_vix",
+            "macro_fear_greed",
+            "consensus",
+            "certification",
+            "portfolio",
+        }
         assert expected == set(FRESHNESS_POLICIES.keys())
 
 
@@ -167,6 +177,43 @@ class TestCheckFreshness:
         assert result["status"] == "FAIL"
         assert result["last_updated"] is None
         assert "데이터 없음" in result["message"]
+
+    def test_stale_factors_surface_instead_of_going_unnoticed(self, db_path):
+        """낡은 팩터가 FAIL 로 뜬다 (#1071).
+
+        프로덕션에서 `factors` 는 2026-04-14 → 08-18 넉 달간 낡아 있었는데 정책이 없어서
+        어떤 화면에도 안 떴다. 그 사이 BUY 후보 점수는 가중치 0.40 짜리 4월 값으로 계산됐다.
+
+        Mutation lock: `FRESHNESS_POLICIES` 에서 `factors` 를 빼면 KeyError 로 FAIL.
+        """
+        from nuri.core.db import get_db
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now
+
+        old = (kst_now() - timedelta(days=40)).strftime("%Y-%m-%d")
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO factors (ticker, date, composite_score) VALUES (?, ?, 0.7)",
+                ("AAA", old),
+            )
+
+        result = check_freshness("factors", db_path=db_path)
+        assert result["status"] == "FAIL"
+        assert result["label"] == "멀티팩터 스코어"
+
+    def test_same_day_factors_pass(self, db_path):
+        """정상 갱신(당일)은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다."""
+        from nuri.core.db import get_db
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO factors (ticker, date, composite_score) VALUES (?, ?, 0.7)",
+                ("AAA", kst_now().strftime("%Y-%m-%d")),
+            )
+
+        assert check_freshness("factors", db_path=db_path)["status"] == "PASS"
 
     def test_fail_on_query_exception(self, db_path):
         """쿼리 실행 실패 → FAIL."""

--- a/tests/core/test_pipeline_events.py
+++ b/tests/core/test_pipeline_events.py
@@ -279,24 +279,36 @@ class TestCheckFreshness:
 
 class TestCheckAllFreshness:
     def test_returns_all_policies(self, db_path):
-        """모든 정책 결과 반환."""
+        """정책 하나당 결과 하나 — 개수는 `FRESHNESS_POLICIES` 에서 파생한다.
+
+        여기 상수 `6` 을 박아 두면 정책을 추가할 때마다 이 파일이 같이 깨진다 (#1071 에서
+        `factors` 추가로 3건 FAIL). 어떤 키가 있어야 하는지의 **lock 은
+        `tests/core/test_freshness.py::TestFreshnessPolicies::test_expected_policy_keys`** 가
+        따로 갖고 있으므로, 여기서 중복으로 잠글 이유가 없다. 이 테스트의 계약은 개수가
+        아니라 "빠짐없이 하나씩 돌려준다" 이다.
+        """
+        from nuri.core.freshness import FRESHNESS_POLICIES
+
         results = check_all_freshness(db_path)
-        assert len(results) == 6
-        keys = {r["key"] for r in results}
-        assert keys == {"prices", "macro_vix", "macro_fear_greed", "consensus", "certification", "portfolio"}
+        assert {r["key"] for r in results} == set(FRESHNESS_POLICIES)
 
 
 class TestGetFreshnessSummary:
     def test_summary_counts(self, db_path):
-        """pass/warn/fail 카운트 합계."""
+        """pass/warn/fail 카운트 합계 = 정책 수 (어느 정책도 집계에서 새지 않는다)."""
+        from nuri.core.freshness import FRESHNESS_POLICIES
+
+        n = len(FRESHNESS_POLICIES)
         summary = get_freshness_summary(db_path)
-        assert summary["pass"] + summary["warn"] + summary["fail"] == 6
-        assert len(summary["details"]) == 6
+        assert summary["pass"] + summary["warn"] + summary["fail"] == n
+        assert len(summary["details"]) == n
 
     def test_all_fail_when_empty(self, db_path):
-        """빈 DB → 전부 FAIL."""
+        """빈 DB → 전부 FAIL (입력이 없을 때 PASS 로 새는 정책이 하나도 없어야 한다)."""
+        from nuri.core.freshness import FRESHNESS_POLICIES
+
         summary = get_freshness_summary(db_path)
-        assert summary["fail"] == 6
+        assert summary["fail"] == len(FRESHNESS_POLICIES)
         assert summary["pass"] == 0
         assert summary["warn"] == 0
 

--- a/tests/core/test_pipeline_observability.py
+++ b/tests/core/test_pipeline_observability.py
@@ -170,6 +170,39 @@ class TestSchedulerWiring:
         orphan = sorted(set(sch._STAGE_OF_JOB) - scheduled)
         assert not orphan, f"_STAGE_OF_JOB 에 있으나 SCHEDULES 에 없는 잡: {orphan}"
 
+    def test_every_dispatch_branch_is_scheduled(self):
+        """반대 방향 — `_dispatch_collector` 가 아는 잡은 전부 cron 이 있어야 한다 (#1071).
+
+        위 테스트는 "매핑 → SCHEDULES" 만 본다. **코드는 있는데 잡이 없는** 반대 구멍은
+        아무 신호도 내지 않는다: `factors` 는 `save_composite()` 가 멀쩡히 있고 `python -m`
+        으로 돌리면 동작했는데 cron 이 없어 프로덕션에서 **넉 달간 갱신이 끊겼고**
+        (2026-04-14 → 08-18) 그동안 BUY 후보 점수의 가중치 0.40 짜리 입력이 4월 값이었다.
+        #900(reddit/finviz/institutional 미스케줄) · #975(collector_runs) 와 같은 계열이다.
+
+        비교는 AST 로 한다 — `_dispatch_collector` 를 실행하면 실제 수집이 돈다.
+        """
+        import ast
+        from pathlib import Path
+
+        import nuri.scheduler as sch
+
+        source = Path(sch.__file__).read_text(encoding="utf-8")
+        branches: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.FunctionDef) and node.name == "_dispatch_collector":
+                for cmp in ast.walk(node):
+                    if isinstance(cmp, ast.Compare) and isinstance(cmp.left, ast.Name) and cmp.left.id == "name":
+                        branches |= {c.value for c in cmp.comparators if isinstance(c, ast.Constant)}
+
+        # 카나리아: 스윕이 눈이 멀면(파싱 실패·함수 rename) 빈 집합이라 조용히 통과한다.
+        assert len(branches) >= 25, f"_dispatch_collector 분기를 {len(branches)}개밖에 못 찾았다 — 스윕이 깨졌다"
+
+        scheduled = {j["args"][0] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
+        orphan = sorted(branches - scheduled)
+        assert not orphan, (
+            f"_dispatch_collector 에 있으나 cron 이 없는 잡: {orphan} — 코드만 있고 프로덕션에서는 영영 안 도는 상태다"
+        )
+
 
 class TestTelemetryFailureDoesNotGate:
     """이벤트 기록이 실패해도 감싼 함수는 실행된다.

--- a/tests/core/test_pipeline_observability.py
+++ b/tests/core/test_pipeline_observability.py
@@ -33,6 +33,47 @@ def db_path(tmp_path):
     return path
 
 
+def _dispatch_branch_names(source: str | None = None) -> set[str]:
+    """`_dispatch_collector` 가 분기하는 잡 이름 (AST 추출).
+
+    별도 함수인 이유: 스윕 로직 자체를 합성 소스로 테스트할 수 있어야 한다. 프로덕션
+    코드가 현재 `==` 만 쓰므로, `in` / `match` 처리 분기는 프로덕션 대조만으로는
+    **한 번도 실행되지 않은 채** 들어간다 (#1071 뮤테이션 실측: 그 분기를 꺼도 통과했다).
+    """
+    import ast
+    from pathlib import Path
+
+    if source is None:
+        import nuri.scheduler as sch
+
+        source = Path(sch.__file__).read_text(encoding="utf-8")
+
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not (isinstance(node, ast.FunctionDef) and node.name == "_dispatch_collector"):
+            continue
+        for sub in ast.walk(node):
+            # `name == "x"` 와 `name in ("x", "y")` 둘 다.
+            if isinstance(sub, ast.Compare) and isinstance(sub.left, ast.Name) and sub.left.id == "name":
+                for c in sub.comparators:
+                    if isinstance(c, ast.Constant) and isinstance(c.value, str):
+                        names.add(c.value)
+                    elif isinstance(c, (ast.Tuple, ast.List, ast.Set)):
+                        names |= {e.value for e in c.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+            # `match name: case "x":`
+            elif isinstance(sub, ast.match_case) and isinstance(sub.pattern, ast.MatchValue):
+                v = sub.pattern.value
+                if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                    names.add(v.value)
+    return names
+
+
+def _scheduled_collector_names() -> set[str]:
+    import nuri.scheduler as sch
+
+    return {j["args"][0] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
+
+
 class TestVocabularyIsShared:
     def test_dag_and_event_steps_use_the_same_names(self):
         """두 어휘가 갈라지면 스케줄러가 남긴 이벤트를 DAG 가 못 읽는다.
@@ -170,8 +211,8 @@ class TestSchedulerWiring:
         orphan = sorted(set(sch._STAGE_OF_JOB) - scheduled)
         assert not orphan, f"_STAGE_OF_JOB 에 있으나 SCHEDULES 에 없는 잡: {orphan}"
 
-    def test_every_dispatch_branch_is_scheduled(self):
-        """반대 방향 — `_dispatch_collector` 가 아는 잡은 전부 cron 이 있어야 한다 (#1071).
+    def test_no_dispatch_branch_lacks_a_cron(self):
+        """`_dispatch_collector` 가 아는 잡은 전부 cron 이 있어야 한다 (#1071).
 
         위 테스트는 "매핑 → SCHEDULES" 만 본다. **코드는 있는데 잡이 없는** 반대 구멍은
         아무 신호도 내지 않는다: `factors` 는 `save_composite()` 가 멀쩡히 있고 `python -m`
@@ -181,27 +222,81 @@ class TestSchedulerWiring:
 
         비교는 AST 로 한다 — `_dispatch_collector` 를 실행하면 실제 수집이 돈다.
         """
-        import ast
-        from pathlib import Path
-
         import nuri.scheduler as sch
 
-        source = Path(sch.__file__).read_text(encoding="utf-8")
-        branches: set[str] = set()
-        for node in ast.walk(ast.parse(source)):
-            if isinstance(node, ast.FunctionDef) and node.name == "_dispatch_collector":
-                for cmp in ast.walk(node):
-                    if isinstance(cmp, ast.Compare) and isinstance(cmp.left, ast.Name) and cmp.left.id == "name":
-                        branches |= {c.value for c in cmp.comparators if isinstance(c, ast.Constant)}
+        orphan = sorted(_dispatch_branch_names() - _scheduled_collector_names())
+        assert not orphan, f"cron 이 없는 dispatch 분기: {orphan} — 프로덕션에서 영영 안 도는 코드다"
+        assert sch  # import 가 실제로 쓰였음을 명시 (헬퍼가 내부에서 다시 import 한다)
 
-        # 카나리아: 스윕이 눈이 멀면(파싱 실패·함수 rename) 빈 집합이라 조용히 통과한다.
-        assert len(branches) >= 25, f"_dispatch_collector 분기를 {len(branches)}개밖에 못 찾았다 — 스윕이 깨졌다"
+    def test_the_sweep_sees_every_scheduled_job(self):
+        """반대 방향 — 스케줄된 잡은 전부 스윕에 잡혀야 한다.
 
-        scheduled = {j["args"][0] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
-        orphan = sorted(branches - scheduled)
-        assert not orphan, (
-            f"_dispatch_collector 에 있으나 cron 이 없는 잡: {orphan} — 코드만 있고 프로덕션에서는 영영 안 도는 상태다"
-        )
+        이게 위 테스트의 **자체 카나리아**다. 개수 임계(`>= 25`)로는 스윕이 새 분기 문법을
+        못 읽어도 옛 분기가 그대로면 통과한다. 이 방향은 스윕이 눈이 머는 순간 즉시 FAIL 한다.
+        (Codex P3 — 원래 한 assert 로 묶여 있었는데, 묶여 있으면 한쪽을 지워도 다른 쪽이
+        안 잡아준다. 별개 테스트로 쪼개야 서로를 지킨다.)
+        """
+        blind = sorted(_scheduled_collector_names() - _dispatch_branch_names())
+        assert not blind, f"스케줄됐는데 스윕이 못 본 잡: {blind} — 분기 문법을 스윕이 모른다"
+
+
+class TestDispatchSweepReadsEveryBranchShape:
+    """스윕 자체를 합성 소스로 검증한다 (#1071 Codex P3).
+
+    프로덕션 `_dispatch_collector` 는 현재 `==` 만 쓴다. 그래서 `in` / `match` 처리
+    분기는 프로덕션 대조만으로는 **한 번도 실행되지 않는다** — 뮤테이션 실측에서 그
+    분기를 통째로 꺼도 전체 스위트가 통과했다. 나중에 누가 분기를 묶어 쓰거나 `match`
+    로 바꾸는 순간 스윕이 조용히 눈이 멀고, 그러면 "cron 없는 잡" 가드가 무력해진다.
+    """
+
+    def test_reads_equality_branches(self):
+        src = """
+def _dispatch_collector(name):
+    if name == "alpha":
+        pass
+    elif name == "beta":
+        pass
+"""
+        assert _dispatch_branch_names(src) == {"alpha", "beta"}
+
+    def test_reads_in_branches(self):
+        """Mutation lock: Tuple/List/Set 처리 분기를 꺼면 FAIL."""
+        src = """
+def _dispatch_collector(name):
+    if name in ("alpha", "beta"):
+        pass
+    elif name in ["gamma"]:
+        pass
+    elif name in {"delta"}:
+        pass
+"""
+        assert _dispatch_branch_names(src) == {"alpha", "beta", "gamma", "delta"}
+
+    def test_reads_match_branches(self):
+        """Mutation lock: match_case 처리 분기를 꺼면 FAIL."""
+        src = """
+def _dispatch_collector(name):
+    match name:
+        case "alpha":
+            pass
+        case "beta":
+            pass
+"""
+        assert _dispatch_branch_names(src) == {"alpha", "beta"}
+
+    def test_ignores_other_functions(self):
+        """다른 함수의 `name ==` 비교를 주워오면 가드가 오탐한다."""
+        src = """
+def _dispatch_collector(name):
+    if name == "alpha":
+        pass
+
+
+def something_else(name):
+    if name == "not_a_job":
+        pass
+"""
+        assert _dispatch_branch_names(src) == {"alpha"}
 
 
 class TestTelemetryFailureDoesNotGate:

--- a/tests/quant/test_factors_composite.py
+++ b/tests/quant/test_factors_composite.py
@@ -191,3 +191,88 @@ class TestSentimentIsNotFabricated:
         monkeypatch.setattr(db_mod, "DB_PATH", path)
         upsert_macro([{"indicator": "fear_greed", "date": "not-a-date", "value": 50.0, "source": "test"}], path)
         assert comp._market_sentiment() is None
+
+
+class TestFactorDateIsAMarketDate:
+    """`factors.date` 는 쓴 날이 아니라 **시장 데이터 날짜**다 (#1071, Codex P1).
+
+    잡은 매일 08:10 KST 에 돈다. `today_kst()` 로 찍으면 주말·휴장에도 금요일 종가로
+    계산한 행이 "당일" 라벨을 달고 들어가고, 소비자(`buy_candidate_emitter`)는
+    `WHERE date = (SELECT MAX(date) FROM factors)` 로 무조건 그걸 집는다. 그러면
+    신선도 정책이 낡음을 잡는 게 아니라 **세탁한다** — 가격 수집이 멈춰도 파생 테이블은
+    매일 갱신돼 PASS 로 보이고, 그 사이 가중치 0.40 짜리 입력이 옛 가격으로 점수를 만든다.
+
+    시장일로 찍으면 주말 실행은 같은 행을 덮어쓰기만 하므로(date+ticker UNIQUE) 가짜
+    신선도가 안 생기고, `MAX(date)` 는 그대로 최신을 집는다.
+    """
+
+    @staticmethod
+    def _df():
+        df = pd.DataFrame(
+            [
+                {
+                    "momentum_score": 0.7,
+                    "value_score": 0.5,
+                    "quality_score": 0.6,
+                    "sentiment_score": 0.5,
+                    "composite_score": 0.58,
+                }
+            ],
+            index=["AAA"],
+        )
+        df.index.name = "ticker"
+        return df
+
+    def test_uses_the_latest_price_date_not_today(self, db_path_mp):
+        """Mutation lock: `_market_as_of()` 를 `today_kst()` 로 되돌리면 FAIL."""
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.quant.factors.composite import save_composite
+
+        with get_db(db_path_mp) as conn:
+            conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('SPY', '2026-08-14', 100)")
+
+        save_composite(self._df())
+
+        with get_db(db_path_mp) as conn:
+            dates = [r[0] for r in conn.execute("SELECT DISTINCT date FROM factors").fetchall()]
+        assert dates == ["2026-08-14"]
+        assert today_kst() not in dates, "쓴 날짜로 찍혔다 — 주말이면 가짜 신선도가 된다"
+
+    def test_repeat_runs_on_the_same_market_date_are_idempotent(self, db_path_mp):
+        """주말 이틀 연속 실행이 행을 늘리지 않는다 — 같은 시장일이면 덮어쓴다."""
+        from nuri.core.db import get_db
+        from nuri.quant.factors.composite import save_composite
+
+        with get_db(db_path_mp) as conn:
+            conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('SPY', '2026-08-14', 100)")
+
+        save_composite(self._df())
+        save_composite(self._df())
+
+        with get_db(db_path_mp) as conn:
+            assert conn.execute("SELECT COUNT(*) FROM factors").fetchone()[0] == 1
+
+    def test_explicit_as_of_wins(self, db_path_mp):
+        """호출자가 명시하면 그걸 쓴다 (백필 경로)."""
+        from nuri.core.db import get_db
+        from nuri.quant.factors.composite import save_composite
+
+        with get_db(db_path_mp) as conn:
+            conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('SPY', '2026-08-14', 100)")
+
+        save_composite(self._df(), as_of="2026-01-02")
+
+        with get_db(db_path_mp) as conn:
+            assert [r[0] for r in conn.execute("SELECT DISTINCT date FROM factors").fetchall()] == ["2026-01-02"]
+
+    def test_falls_back_to_today_when_no_prices(self, db_path_mp):
+        """가격이 하나도 없으면 오늘로 떨어진다 — 계산이 비어 여기 도달하지 않지만 방어."""
+        from nuri.core.db import get_db
+        from nuri.core.timezone import today_kst
+        from nuri.quant.factors.composite import save_composite
+
+        save_composite(self._df())
+
+        with get_db(db_path_mp) as conn:
+            assert [r[0] for r in conn.execute("SELECT DISTINCT date FROM factors").fetchall()] == [today_kst()]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1325,3 +1325,67 @@ class TestOrphanCollectorsWired:
             assert _minute_of_day(jobs[name]) < consensus_at, (
                 f"{name}({jobs[name]}) 가 consensus({jobs['consensus']}) 보다 늦다"
             )
+
+
+class TestFactorCompositeWired:
+    """멀티팩터 합성에 cron 이 없어 넉 달간 갱신이 끊겼다 (#1071).
+
+    `save_composite()` 는 멀쩡히 있었고 `python -m nuri.quant.factors.composite` 로
+    돌리면 동작했다. 없던 건 잡뿐이라 프로덕션 `factors` 는 2026-04-14 에 멈춰 있었고
+    (31행 / 31종목 — `compute_composite()` 실측 773종목의 일부), 그 사이 발행된 모든
+    BUY 후보가 `buy_signals.yaml` 가중치 **0.40** 짜리 4월 팩터로 점수를 받았다.
+    위 `TestOrphanCollectorsWired`(#900) 와 같은 drift 클래스, 같은 정지 날짜.
+    """
+
+    def test_dispatch_computes_and_saves(self):
+        """`_dispatch_collector("factors")` 가 compute → save 를 잇는다.
+
+        compute 만 부르고 save 를 빠뜨리면 잡은 초록인데 테이블은 그대로다 —
+        `scripts/verify/verify.py:200` 이 정확히 그 형태(compute 만)라 선례가 있다.
+        """
+        from nuri.scheduler import _dispatch_collector
+
+        sentinel = object()
+        with (
+            patch("nuri.quant.factors.composite.compute_composite", return_value=sentinel) as comp,
+            patch("nuri.quant.factors.composite.save_composite", return_value=773) as save,
+        ):
+            _dispatch_collector("factors")
+
+        comp.assert_called_once()
+        save.assert_called_once_with(sentinel)
+
+    def test_registered_in_schedules(self):
+        from nuri.scheduler import SCHEDULES
+
+        jobs = [j for j in SCHEDULES if j["name"] == "factors"]
+        assert len(jobs) == 1, "factors job 이 정확히 1개여야 함"
+        assert jobs[0]["args"] == ("factors",)
+
+    def test_stage_is_analyze(self):
+        """`analyze` 스테이지의 유일한 잡 — 이게 빠지면 5스테이지 중 하나가 관측상 사라진다.
+
+        프로덕션 `pipeline_events.step` 에 analyze 가 **0건**이었던 이유가 이것이다.
+        """
+        from nuri.scheduler import _STAGE_OF_JOB
+
+        assert _STAGE_OF_JOB["factors"] == "analyze"
+
+    def test_runs_after_its_sentiment_input(self):
+        """fear_greed(08:00) **뒤**에 돈다 — 앞서면 센티먼트가 하루 묵은 값이 된다.
+
+        `composite._market_sentiment()` 는 없으면 성분을 빼고 비중을 재배분하므로
+        조용히 죽지는 않지만, 같은 날 값을 두고 전날 값을 쓸 이유가 없다.
+        """
+        from nuri.scheduler import SCHEDULES
+
+        crons = {j["name"]: j["cron"] for j in SCHEDULES if j["name"] in ("factors", "fear_greed")}
+
+        def _minute_of_day(cron: str) -> int:
+            minute, hour = cron.split()[:2]
+            return int(hour) * 60 + int(minute)
+
+        assert _minute_of_day(crons["factors"]) > _minute_of_day(crons["fear_greed"]), (
+            f"factors({crons['factors']}) 가 fear_greed({crons['fear_greed']}) 보다 이르다"
+        )
+        assert crons["factors"].split()[2:] == ["*", "*", "*"], "매일 돌아야 한다 (소비자는 매 거래일 발행)"


### PR DESCRIPTION
Closes #1071

## 무엇이 문제였나

BUY 후보 점수의 **최대 입력이 넉 달 낡아 있었다.** 프로덕션 실측 2026-08-18:

```
factors      최신 2026-04-14 / 31행 / 31종목   ← compute_composite() 는 773종목 산출
signals      최신 2026-08-14                   ← 입력은 최신
fear_greed   최신 2026-08-17                   ← 입력은 최신
```

`buy_signals.yaml` 에서 `composite_score` 가중치는 **0.40** — 4개 성분 중 가장 크다.
`buy_candidate_emitter.py:181` 이 `WHERE date = (SELECT MAX(date) FROM factors)` 로 읽으므로,
2026-04-14 이후 발행된 **모든 BUY 후보가 4월 팩터로 점수를 받았다.**

## 원인 — 버그가 아니라 부재

`save_composite()` 를 부르는 곳이 모듈 자신의 `__main__` 뿐이었다:

```
$ grep -rn "save_composite" nuri/ scripts/ --include="*.py" | grep -v "def "
nuri/quant/factors/composite.py:178:    save_composite(df)     ← python -m 으로 직접 실행할 때만
scripts/verify/verify.py:200:    df = compute_composite()     ← compute 만, save 안 함
```

`SCHEDULES` 에 잡이 없고 `_dispatch_collector` 에 분기가 없다. 마지막 갱신 2026-04-14 는
#900 이 기록한 "마지막 수동 `make collect`" 날짜와 정확히 같다 — 자동화가 이 단계를
가져가지 않았다. #900 · #975 와 같은 계열의 마지막 잔여물이다.

아무도 모른 이유는 `FRESHNESS_POLICIES` 에 `factors` 가 없어서다. prices · macro_vix ·
fear_greed · consensus · certification · portfolio 는 전부 등재돼 브리핑 신선도 3-tier 에
뜨는데, factors 만 빠져 있었다.

## 무엇을 했나

1. **스케줄링** — `_dispatch_collector` 에 `factors` 분기, `SCHEDULES` 에 `10 8 * * *` (KST).
   입력이 전부 그 앞에 끝난다: prices(~06:00) · signals(`technical` 07:00) · fear_greed(08:00).
   소비자(`premarket_brief`, 09:00 ET)까지 14시간 여유. 실측 **1.1초 / 773종목**.
2. **`_STAGE_OF_JOB["factors"] = "analyze"`** — `pipeline_events.step` 에 analyze 가 **0건**이었다.
   5스테이지 중 하나가 관측상 존재하지 않았다는 뜻이다.
3. **신선도 정책** 추가 → 낡으면 브리핑에 뜬다.

## Codex 리뷰 — NEEDS_REWORK, P1 2건 반영

### P1 — 정책이 낡음을 잡는 게 아니라 **세탁**한다

잡이 매일 도는데 `save_composite` 가 `today_kst()` 를 찍으면, **주말·휴장에도 금요일 종가로
계산한 행이 "당일" 라벨을 달고 들어간다.** 소비자는 `MAX(date)` 를 무조건 집으므로 그 행은
없느니만 못하다 — 가중치 0.40 짜리 입력이 신선한 척하며 BUY 점수를 만들고, 새로 넣은 정책은
그걸 PASS 로 보고한다. 즉 정책이 낡음을 **놓치는** 게 아니라 **가려준다.**

→ `factors.date` 를 **시장 데이터 날짜**로 바꿨다 (`_market_as_of()` = `MAX(date) FROM prices`).
주말 실행은 금요일 행을 덮어쓰기만 하므로(date+ticker UNIQUE, 멱등) 가짜 신선도가 안 생기고,
`MAX(date)` 는 그대로 최신을 집는다. 임계도 `prices` 와 같은 48h/120h 로 — 재료가 같으니
주말 여유도 같아야 한다. (24h/72h 로 두면 월요일 아침마다 금→월 = 72h 로 상시 발화한다.)

부수 효과로 이 검사는 이제 **잡의 생존과 입력의 신선도를 동시에** 본다. 잡이 멈춰도,
가격이 멈춰도 날짜가 언다.

### P3 — AST 계약 테스트가 조용히 통과할 수 있다

`elif name in {...}` 이나 `match name: case ...` 로 리팩터하면 스윕이 눈이 먼다. 개수
카나리아(`>= 25`)는 옛 분기가 그대로면 통과하므로 그걸 못 잡는다.

→ 스윕이 `in` 비교(tuple/list/set)와 `match/case` 를 읽게 하고, **양방향**으로 나눠 잠갔다.
역방향(`scheduled - branches`)이 자체 카나리아다 — 스윕이 눈이 머는 순간 스케줄된 잡이
안 잡혀 즉시 FAIL 한다. 두 방향을 **별개 테스트**로 쪼갠 이유는 한 assert 로 묶으면 한쪽을
지워도 다른 쪽이 안 지켜주기 때문이다.

그리고 스윕 로직 자체를 헬퍼로 빼서 **합성 소스로 직접 테스트**한다. 프로덕션 코드는
현재 `==` 만 쓰므로, 그 대조만으로는 새 분기 처리가 한 번도 실행되지 않는다 — 실제로
뮤테이션에서 그 분기를 통째로 꺼도 전체 스위트가 통과했다.

## 검증

- **뮤테이션 실측**: 배선 6종 생존 0 → 리워크 후 6종 중 2종 생존(스윕 신문법 미검증) →
  헬퍼 분리 + 합성 소스 테스트 추가 후 재측정해 3종 추가로 잡힘.
  마지막까지 남은 1종은 **역방향 테스트의 단언을 항진명제로 바꾸는 것**인데, 테스트 자신을
  무력화하는 뮤테이션이라 원리상 다른 테스트로 잡을 수 없다 (뮤테이션 테스트의 알려진 한계).
- `pre_push_check.sh` 전 항목 통과 — **7,078 passed**, lint/shellcheck/doc-count/privacy clean
- 신규 테스트: 팩터 시장일 4종 · 신선도 3종 · 스케줄 배선 4종 · 스윕 4종

## 배포 후 확인할 것

- 다음날 `factors.MAX(date)` 가 직전 거래일, 행 수가 700 대
- `pipeline_events.step='analyze'` 첫 행

## 남은 별건

`signals` 에 신선도 정책이 없다 (Codex P1 두 번째 절반). 이 PR 의 시장일 dating 으로
가격발 낡음은 전파되지만, `technical` 이 멈춰 RSI 만 낡는 경우는 여전히 안 보인다.
사전에 존재하던 갭이라 별도 이슈로 뺀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
