### PR TITLE
fix(scheduler): record the row count, not the run_step envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,093 collected across 323 files | |
+| **Backend tests** | 7,095 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,093 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,095 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,093 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,095 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -308,7 +308,12 @@ def _run_collector(name: str, **kwargs):
         if stage:
             from nuri.core.pipeline import run_step
 
-            return run_step(stage, _dispatch_collector, warn_only=True, reraise=True, name=name, **kwargs)
+            # `run_step` 은 **봉투**(`{"status", "result", ...}`)를 돌려준다. 그대로
+            # `_record_collector_run` 에 넘기면 `len(dict)` 이 잡혀 스테이지 잡은 전부
+            # `rows_collected=4` 로 기록된다 — 수집량이 아니라 봉투의 키 개수다.
+            # 프로덕션 실측: factors 가 762행을 저장하고 4 로 남았다 (#1074).
+            outcome = run_step(stage, _dispatch_collector, warn_only=True, reraise=True, name=name, **kwargs)
+            return outcome.get("result") if isinstance(outcome, dict) else outcome
         return _dispatch_collector(name, **kwargs)
 
     import time as _time

--- a/tests/test_collector_runs_wiring.py
+++ b/tests/test_collector_runs_wiring.py
@@ -169,3 +169,34 @@ class TestHealthScanIsScheduled:
         finally:
             mod.CollectorOrchestrator = orig
         assert seen.get("action") == "scan_health", f"scan_health 를 부르지 않았다: {seen}"
+
+
+class TestStagedJobRecordsTheRealRowCount:
+    """스테이지 잡의 `rows_collected` 는 봉투가 아니라 수집량이어야 한다 (#1074).
+
+    `_run_collector` 는 스테이지 잡을 `run_step()` 으로 감싸는데, 그건 봉투
+    (`{"status", "result", ...}`)를 돌려준다. 그대로 기록하면 `_record_collector_run` 의
+    `len(result)` 이 잡혀 **모든 스테이지 잡이 상수 4** 를 남긴다.
+
+    프로덕션 실측 2026-08-18: `factors` 가 762행을 저장하고 `rows_collected=4` 로 남았다.
+    `collector_runs` 는 #975 에서 "collector health 관측이 통째로 없었다" 며 되살린
+    테이블이라, 행은 생기는데 안의 수치가 상수면 정확히 그 이슈가 막으려던 상태다.
+    """
+
+    def test_row_count_survives_the_run_step_envelope(self, wired, monkeypatch):
+        """Mutation lock: 봉투를 안 벗기면 4 가 기록돼 FAIL."""
+        monkeypatch.setattr(wired.sched, "_STAGE_OF_JOB", {"factors": "analyze"}, raising=False)
+        monkeypatch.setattr(wired.sched, "_dispatch_collector", lambda name, **kw: 762)
+
+        wired.sched._run_collector("factors")
+
+        rows = query("SELECT rows_collected FROM collector_runs", db_path=wired.db)
+        assert rows[0]["rows_collected"] == 762, (
+            f"봉투가 기록됐다 (dict 키 개수) — 실제 수집량이 아니라 {rows[0]['rows_collected']}"
+        )
+
+    def test_unstaged_job_is_unchanged(self, wired):
+        """스테이지 없는 잡은 기존 경로 그대로 — 봉투가 없으니 반환값이 곧 수집량이다."""
+        wired.sched._run_collector("macro")
+        rows = query("SELECT rows_collected FROM collector_runs", db_path=wired.db)
+        assert rows[0]["rows_collected"] == 7  # 픽스처 스텁의 반환값


### PR DESCRIPTION
Closes #1074

## 증상

프로덕션 실측 2026-08-18 — `factors` 잡이 **762행**을 저장했는데 원장에는 `4` 로 남았다:

```
INFO:nuri.quant.factors.composite:factors 테이블에 762건 저장
collector_runs: {'collector_name': 'factors', 'status': 'finished', 'rows_collected': 4}
```

## 원인

`_run_collector` 는 스테이지 잡을 `run_step()` 으로 감싼다. `run_step` 은 **봉투**를 돌려준다
(`{"status", "result", "dependency_warning", ...}`). 그 봉투가 그대로 기록 함수로 가고:

```python
rows = result if isinstance(result, int) else (len(result) if hasattr(result, "__len__") else 0)
```

`len(봉투)` = **4**. 즉 스테이지 잡은 전부 수집량이 아니라 **봉투의 키 개수**를 남긴다.

사전에 존재하던 결함이지만 `factors`(#1071) 가 실제 행 수를 반환하는 첫 잡이라, 그전까진
잃을 숫자 자체가 없어 보이지 않았다.

`collector_runs` 는 #975 에서 "collector health 관측이 통째로 없었다" 며 되살린 테이블이다.
행은 제때 생기는데 안의 수치가 상수라면, 정확히 그 이슈가 막으려던 상태가 한 겹 안쪽에서
재현된 것이다.

## 수정

봉투를 벗긴 뒤 기록한다. `consensus` 는 4 → 0 이 되는데, 그게 그 dispatch 의 실제 반환값이다.

## 검증

- 스테이지 잡이 762 를 반환하면 `rows_collected == 762` (봉투를 안 벗기면 4 로 FAIL)
- 스테이지 없는 잡은 기존 경로 그대로
- **뮤테이션 2종 전부 FAIL 실측** (봉투 그대로 반환 · 항상 None)
- `pre_push_check.sh` 전 항목 통과 — **7,080 passed**

배포 후 다음 `factors` 실행에서 `rows_collected` 가 700 대로 기록되는지 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
