### PR TITLE
fix(recommend): treat an unmeasured VIX as a veto, not a crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,095 collected across 323 files | |
+| **Backend tests** | 7,098 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,095 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,098 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,095 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,098 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -349,10 +349,19 @@ def _record_collector_run(name: str, status: str, started_monotonic: float, *, r
     import time as _time
 
     try:
+        from collections.abc import Sized
+
         from nuri.core.db import log_collector_run
         from nuri.core.timezone import kst_now
 
-        rows = result if isinstance(result, int) else (len(result) if hasattr(result, "__len__") else 0)
+        # `hasattr(x, "__len__")` 은 타입을 좁히지 못해 `len()` 이 `None` 을 받을 수 있는
+        # 것처럼 읽힌다. `Sized` isinstance 는 런타임 동작이 같으면서 좁혀진다.
+        if isinstance(result, int):
+            rows = result
+        elif isinstance(result, Sized):
+            rows = len(result)
+        else:
+            rows = 0
         log_collector_run(
             collector_name=name,
             status=status,
@@ -572,7 +581,11 @@ def _run_held_add_shadow():
         def _rsi(t: str) -> float | None:
             return rsi_map.get(t)
 
-        def _regime() -> tuple[str, float]:
+        def _regime() -> tuple[str, float | None]:
+            # `_get_regime()` 은 VIX 미측정 시 **None** 을 돌려준다 (#753 — 20.0 으로
+            # 메우면 측정 불가가 '평온'으로 둔갑해 게이트가 열린다). 여기 반환 타입을
+            # `float` 로 적어 둔 탓에 소비자가 None 을 예상하지 않았고, `held_add` 가
+            # `None >= 28` 로 TypeError 를 냈다 (#1076). 선언이 실제와 맞아야 한다.
             return regime, vix
 
         def _sector_mom(t: str) -> float:

--- a/nuri/trading/recommend/held_add.py
+++ b/nuri/trading/recommend/held_add.py
@@ -279,7 +279,7 @@ def _evaluate_average_down(
     score: float,
     rsi: Optional[float],
     regime: str,
-    vix: float,
+    vix: Optional[float],
 ) -> Optional[str]:
     """precedence=3. pullback add (RSI 과매도 + macro veto)."""
     trig = cfg.get("modes", {}).get("average_down", {}).get("trigger", {})
@@ -309,7 +309,13 @@ def _evaluate_average_down(
     if trig.get("macro_veto", True):
         if regime in {"bear", "crash"}:
             return None
-        if vix >= 28:
+        # VIX 미측정(None)은 **veto** 다. `_get_regime()` 이 부재·조회실패·노후를
+        # 20.0 으로 메우지 않고 None 을 돌려주기 때문에(#753) 여기로 들어온다.
+        # macro_veto 의 의미는 "거시가 무서우면 물타기 금지"이고, 미측정은 거시가
+        # 평온하다는 **확인이 안 된** 상태다 — 통과시키면 측정 실패가 조용히 매수
+        # 조건을 여는 그 형태가 된다. 예전엔 `None >= 28` 로 TypeError 를 냈고,
+        # 스케줄러가 그걸 삼켜 VIX 수집이 끊긴 날 잡이 조용히 아무것도 안 했다 (#1076).
+        if vix is None or vix >= 28:
             return None
 
     return "average_down"
@@ -321,7 +327,7 @@ def select_held_mode(
     score: float,
     rsi: Optional[float],
     regime: str,
-    vix: float,
+    vix: Optional[float],
     breakout_above_trim: bool = False,
     sector_mom: float = 0.0,
 ) -> Optional[str]:

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -967,3 +967,79 @@ class TestGetRealAccountsHeldAdd:
 
         result = _get_real_accounts()
         assert isinstance(result, set)
+
+
+class TestUnmeasuredVixIsAVeto:
+    """VIX 미측정(`None`)은 통과가 아니라 **veto** 다 (#1076).
+
+    `_get_regime()` 은 부재·조회실패·노후를 `20.0` 으로 메우지 않고 `None` 을 돌려준다
+    (#753 — 20.0 은 차단(>30)·caution(>=25) 임계 아래라 측정 불가가 '평온'으로 둔갑해
+    게이트를 열었다). 그런데 `held_add` 는 `vix: float` 로 받아 `None >= 28` 에서
+    **TypeError** 를 냈고, 스케줄러가 그걸 삼켜 VIX 수집이 끊긴 날 잡이 조용히 아무것도
+    안 했다 — 관측상 정상, 실제로는 정지.
+
+    `macro_veto` 의 의미는 "거시가 무서우면 물타기 금지"이고, 미측정은 거시가 평온하다는
+    **확인이 안 된** 상태다. 이 레포가 반복해서 도달한 결론과 같다
+    (`_check_volatility_for_class` · `_market_sentiment` · `_get_regime` 자신).
+    """
+
+    @staticmethod
+    def _pos() -> dict:
+        # average_down 윈도우: stop_loss(-7) × 0.3 ~ × 0.7 = -2.1 ~ -4.9
+        return {"ticker": "NVDA", "account": "acct_alpha", "pnl_pct": -3.0, "days_held": 30}
+
+    @staticmethod
+    def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_last_trim_age_days",
+            lambda ticker, max_days=60: None,
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_account_strategy_profile",
+            lambda account: {"stop_loss": -7, "tp1_pct": 21.0},
+        )
+
+    def test_none_vix_vetoes_instead_of_raising(self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict) -> None:
+        """Mutation lock: `vix is None or` 를 빼면 TypeError 로 FAIL."""
+        self._patch(monkeypatch)
+        mode = ha.select_held_mode(
+            self._pos(),
+            cfg_held_add["held_add_mode"],
+            score=90,
+            rsi=20,
+            regime="neutral",
+            vix=None,
+            breakout_above_trim=False,
+            sector_mom=0,
+        )
+        assert mode is None, "VIX 미측정인데 물타기를 허용했다"
+
+    def test_measured_calm_vix_still_triggers(self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict) -> None:
+        """veto 가 상시 발화하면 모드 자체가 죽는다 — 정상 VIX 는 그대로 통과해야 한다."""
+        self._patch(monkeypatch)
+        mode = ha.select_held_mode(
+            self._pos(),
+            cfg_held_add["held_add_mode"],
+            score=90,
+            rsi=20,
+            regime="neutral",
+            vix=15.0,
+            breakout_above_trim=False,
+            sector_mom=0,
+        )
+        assert mode == "average_down"
+
+    def test_high_vix_still_vetoes(self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict) -> None:
+        """기존 계약 보존 — 28 이상은 종전대로 veto."""
+        self._patch(monkeypatch)
+        mode = ha.select_held_mode(
+            self._pos(),
+            cfg_held_add["held_add_mode"],
+            score=90,
+            rsi=20,
+            regime="neutral",
+            vix=30.0,
+            breakout_above_trim=False,
+            sector_mom=0,
+        )
+        assert mode is None


### PR DESCRIPTION
Closes #1076

## 재현

```
$ _evaluate_average_down(pos, cfg, score=90.0, rsi=20.0, regime="neutral", vix=None)
TypeError: '>=' not supported between instances of 'NoneType' and 'int'

$ 같은 호출, vix=15.0
'average_down'
```

`held_add.py:312` 의 `if vix >= 28:` 이다. average-down 윈도우(pnl 이 `stop_loss × 0.3` ~
`× 0.7`) 안의 보유가 나머지 트리거를 통과해야 도달하므로 매일은 아니지만, **VIX 수집이
끊긴 날 그런 보유가 하나라도 있으면** 터진다. 스케줄러가 예외를 삼키므로 그날 잡은
아무것도 안 하고 모든 헬스 신호는 초록으로 남는다.

## None 은 버그가 아니라 의도된 신호였다

`_get_regime()` 이 `float | None` 을 돌려주는 이유가 주석에 적혀 있다:

> 과거엔 부재·조회실패·노후를 전부 `20.0` 으로 메웠다. 20.0 은 차단(>30)과 caution(>=25)
> 임계 **아래**라, 측정 불가가 조용히 '평온'으로 둔갑해 게이트를 열었다 (#753 계열).

소비자 쪽이 `vix: float` 로 받아 그 신호를 받을 준비가 안 돼 있었고, `scheduler._regime()`
이 `tuple[str, float]` 로 **거짓 선언**해 아무도 None 을 예상하지 않게 만들었다.
pyright 가 그 반환 타입을 계속 보고하고 있었다 — 이번에 사장님이 IDE 진단을 붙여 준 게
발견 경로다.

## 무엇이 맞는가

`macro_veto` 의 의미는 "거시가 무서우면 물타기 금지"다. 미측정은 거시가 평온하다는
**확인이 안 된** 상태이므로 통과가 아니라 veto 다. 이 레포가 반복해서 도달한 결론과 같다 —
`_check_volatility_for_class`(입력 없음을 PASS 로 처리해 넉 달간 초록), `_market_sentiment`
(`else 0.5` 로 메우던 것), `_get_regime` 자신.

## 검증

- **뮤테이션 3종 전부 FAIL** — `is None` 가드 제거 · None 을 통과로 · veto 상시화
- `vix=15.0` 은 그대로 `average_down`, `vix=30.0` 은 그대로 veto (기존 계약 보존)
- `pre_push_check.sh` — **7,083 passed**
- `nuri/scheduler.py` · `held_add.py` pyright **0 error**

## 곁가지 — 전수 타입 진단 분류

`make typecheck` 전수 **174건 / 51파일**을 분류했다:

| 분류 | 건수 | 성격 |
|---|---|---|
| pandas/numpy 타입 노이즈 (`Scalar` / `NDArray` / `Series`) | **147** | 런타임 위험 없음. 고치려면 `float()`/`cast()` 를 흩뿌려야 하고 동작은 그대로 |
| None 관련 | **27** | 이 중 **실제 크래시로 재현된 건 이 이슈 하나** |

나머지 26건은 대부분 애노테이션 느슨함(런타임 무영향)이고, `nuri/collectors/etf_flows.py:146`
만 실질 결함 후보다 — `float(total_assets)` 가 무가드인데 바로 아래 두 줄은 `pd.notna` 가드가
있다. `except Exception` 안이라 skip 으로 degrade 하므로 크래시는 아니다. 별도 이슈 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
