### PR TITLE
feat(recommend): persist emitted BUY candidates to the recommendations ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,098 collected across 323 files | |
+| **Backend tests** | 7,115 collected across 323 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -285,7 +285,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 51 tables (49 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 51 tables (50 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (49 migrations as of 2026-07-30). Key tables:
+51 tables total (50 migrations as of 2026-07-30). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,098 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,115 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,098 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,115 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -89,7 +89,18 @@ def _collect_context(db_path=None) -> dict:
     try:
         from nuri.trading.recommend.buy_candidate_emitter import emit_buy_candidates
 
-        ctx["buy_candidates"] = emit_buy_candidates()
+        emitted = emit_buy_candidates(db_path=db_path)
+        ctx["buy_candidates"] = emitted
+        # 발행한 후보를 원장에 남긴다 (#1078). 여기서 부르는 이유: `emit_buy_candidates`
+        # 자체는 CLI 로도 돌려 보는 함수라 호출만으로 기록하면 조회가 원장을 오염시킨다.
+        # **발행하는 지점이 기록하는 지점**이다. 기록 실패가 브리핑을 막지 않도록 자체
+        # try 로 감싼다 — 관측이 본 작업을 게이트하면 안 된다 (#894).
+        try:
+            from nuri.trading.recommend.tracker import save_buy_candidates
+
+            save_buy_candidates(emitted, db_path=db_path)
+        except Exception:
+            logger.warning("buy candidates 영속화 실패 (브리핑은 계속)", exc_info=True)
     except Exception:
         logger.warning("buy candidates emit 실패", exc_info=True)
 

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -422,7 +422,11 @@ def _get_recommendations() -> list[dict]:
                r.scoring_detail, r.agent_verdicts,
                r.alpha_action, r.portfolio_action
         FROM recommendations r
-        WHERE r.date = (SELECT MAX(date) FROM recommendations)
+        -- `source IS NULL` = 합의 파이프라인 산출물. `buy_candidate_emitter` 행이
+        -- 같은 테이블에 들어오면서(#1078) 필터 없이는 emitter 후보가 합의 결과처럼
+        -- 액션 카드에 섞인다. 이 화면의 계약은 '합의가 오늘 낸 결론' 이다.
+        WHERE r.source IS NULL
+          AND r.date = (SELECT MAX(date) FROM recommendations WHERE source IS NULL)
           AND (
               r.action NOT IN ('SELL', 'TRIM', 'REDUCE', 'HOLD')
               OR r.ticker IN (SELECT ticker FROM portfolio WHERE quantity > 0)

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -273,7 +273,9 @@ def _get_latest_actions() -> list[dict]:
             SELECT ticker, action, confidence, regime, signals, date,
                    scoring_detail, agent_verdicts, alpha_action, portfolio_action
             FROM recommendations
-            WHERE date = (SELECT MAX(date) FROM recommendations)
+            -- emitter 행 제외 — 이 카드는 합의 결과다 (#1078).
+            WHERE source IS NULL
+              AND date = (SELECT MAX(date) FROM recommendations WHERE source IS NULL)
             ORDER BY confidence DESC
         """)
         if not rows:

--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -38,8 +38,10 @@ def _read_consensus_from_db(ticker: str) -> dict | None:
     from nuri.core.timezone import kst_now
 
     rows = query(
+        # emitter 행 제외 — 이 함수는 "최신 **합의**" 를 돌려준다 (#1078). 필터가 없으면
+        # 같은 ticker 의 emitter 후보가 날짜만 최신이라는 이유로 합의 행세를 한다.
         "SELECT action, confidence, signals, agent_verdicts, date "
-        "FROM recommendations WHERE ticker = ? ORDER BY date DESC LIMIT 1",
+        "FROM recommendations WHERE ticker = ? AND source IS NULL ORDER BY date DESC LIMIT 1",
         (ticker,),
     )
     if not rows:

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1560,4 +1560,12 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_incidents_type ON incidents(incident_type, last_detected_at);
     """,
     ),
+    (
+        50,
+        "recommendations.source — emit 경로 구분",
+        """
+        ALTER TABLE recommendations ADD COLUMN source TEXT;
+        CREATE INDEX IF NOT EXISTS idx_recommendations_source ON recommendations(source, date);
+    """,
+    ),
 ]

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -44,7 +44,10 @@ FRESHNESS_POLICIES = {
         # `recommendations.date` (consensus 결과 persist) 를 source of truth 로 변경.
         # save_to_recommendations 가 매 consensus run 마다 today date row 갱신.
         # date 는 'YYYY-MM-DD' string — datetime 비교 위해 datetime() 캐스트.
-        "query": "SELECT datetime(MAX(date)) FROM recommendations",
+        # `source IS NULL` = 합의 산출물. #1078 이후 `buy_candidate_emitter` 도 같은
+        # 테이블에 쓰므로, 필터가 없으면 합의 job 이 죽은 날에도 브리핑이 낸 후보 행
+        # 하나가 "합의 신선함" 으로 읽힌다 — 관측이 거짓말하는 형태다.
+        "query": "SELECT datetime(MAX(date)) FROM recommendations WHERE source IS NULL",
         "warn_hours": 24,
         "fail_hours": 48,
         "label": "에이전트 합의",

--- a/nuri/quant/validation/decision_alpha.py
+++ b/nuri/quant/validation/decision_alpha.py
@@ -173,6 +173,17 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
     (`db_migrations.py`). 즉 INNER JOIN 이 숨길 수 있었던 행은 전부 결측이었다.
     미러의 `action` 은 `recommendations.action` 의 복사본이고 프로덕션 실측(2026-08-18)
     상 미러된 525건 전부 일치했으나, 그건 현재 백필 구현의 성질이지 스키마 제약이 아니다.
+
+    **모집단은 `source IS NULL` — 합의 파이프라인 산출물만이다** (#1078). 사전등록 시점에
+    `recommendations` 를 쓰는 주체는 합의 하나뿐이었고 그 행들은 전부 NULL 이다.
+    `buy_candidate_emitter` 는 declared_date(2026-07-08) 한참 뒤에야 영속화를 시작했고,
+    넣으면 사전등록된 모집단이 측정 도중 205건에서 배 가까이 불어난다. 제외는 모집단을
+    사전등록 시점 그대로 유지하는 선택이며 사용자 결정(2026-08-18)이다.
+
+    ⚠️ **긍정 조건(`IS NULL`)이지 부정 조건(`!= 'emitter'`)이 아니다.** 후자로 쓰면 앞으로
+    추가되는 **모든** 새 writer 가 라벨만 다르면 표본에 조용히 들어온다 — 사전등록된
+    모집단이 코드 변경 없이 넓어지는 경로다 (Codex P1). 새 writer 를 표본에 넣으려면
+    여기를 명시적으로 고쳐야 하고, 그건 STRATEGY 기록이 따르는 사전등록 개정이다.
     """
     mm = _criteria()
     window = int(mm["primary_window_days"])
@@ -186,6 +197,7 @@ def fetch_sample(db_path: Optional[Path] = None, as_of: Optional[str] = None) ->
         LEFT JOIN decision_outcomes o
                ON o.decision_id = 'rec_' || r.id AND o.observation_window = ?
         WHERE r.action = 'BUY'
+          AND r.source IS NULL
           AND r.date >= ? AND r.date <= ?
         ORDER BY r.date, r.id
         """,

--- a/nuri/trading/agents/consensus/persistence.py
+++ b/nuri/trading/agents/consensus/persistence.py
@@ -137,7 +137,11 @@ def save_to_recommendations(results: list[ConsensusResult], db_path=None) -> int
                    agent_verdicts = excluded.agent_verdicts,
                    scoring_detail = excluded.scoring_detail,
                    alpha_action = excluded.alpha_action,
-                   portfolio_action = excluded.portfolio_action""",
+                   portfolio_action = excluded.portfolio_action,
+                   -- 내용을 합의가 덮었으면 라벨도 합의 것이다. emitter 가 먼저 앉은
+                   -- `(date, ticker)` 를 덮을 때 `source` 만 남겨두면 그 행이 `source IS
+                   -- NULL` 읽기 경로 전체에서 사라진다 — §3.11 판정 표본 포함 (#1078).
+                   source = NULL""",
             records,
         )
         return len(records)

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -94,13 +94,13 @@ def _load_config(path: Path | None = None) -> dict[str, Any]:
         return yaml.safe_load(f)
 
 
-def _get_held_tickers() -> set[str]:
+def _get_held_tickers(db_path=None) -> set[str]:
     """Tickers currently in `portfolio` table — exclude from BUY emit."""
-    df = query_df("SELECT DISTINCT ticker FROM portfolio")
+    df = query_df("SELECT DISTINCT ticker FROM portfolio", db_path=db_path)
     return {str(t) for t in df["ticker"].tolist()} if not df.empty else set()
 
 
-def _get_cooldown_tickers(days: int) -> set[str]:
+def _get_cooldown_tickers(days: int, db_path=None) -> set[str]:
     """DEPRECATED — Phase 1 single-window cooldown. Use _get_cooldown_tickers_by_type (#517 Phase 2b).
 
     유지 이유: 호환성 (외부 caller / 테스트 fixture). 다음 세션에 제거 예정.
@@ -111,12 +111,13 @@ def _get_cooldown_tickers(days: int) -> set[str]:
             FROM pipeline_events
             WHERE event_type IN ('holdings_monitor_alert', 'take_profit_trigger', 'trim_recommendation')
               AND timestamp >= datetime('now', '-{days} days')
-              AND json_extract(payload, '$.ticker') IS NOT NULL"""
+              AND json_extract(payload, '$.ticker') IS NOT NULL""",
+        db_path=db_path,
     )
     return {str(t) for t in df["ticker"].dropna().tolist()} if not df.empty else set()
 
 
-def _get_cooldown_tickers_by_type(cooldown_cfg: dict) -> set[str]:
+def _get_cooldown_tickers_by_type(cooldown_cfg: dict, db_path=None) -> set[str]:
     """#517 Phase 2b — Type-aware cooldown.
 
     payload.action_type ∈ {hard_sell, trim_action, position_reduce, divergence_alert}
@@ -146,6 +147,7 @@ def _get_cooldown_tickers_by_type(cooldown_cfg: dict) -> set[str]:
                     AND timestamp >= datetime('now', '-{days} days')
                     AND json_extract(payload, '$.ticker') IS NOT NULL""",
             params=(action_type,),
+            db_path=db_path,
         )
         if not df.empty:
             suppressed.update(str(t) for t in df["ticker"].dropna().tolist())
@@ -165,7 +167,8 @@ def _get_cooldown_tickers_by_type(cooldown_cfg: dict) -> set[str]:
                         'trim_recommendation'
                     )
                     AND timestamp >= datetime('now', '-{fallback} days')
-                    AND json_extract(payload, '$.ticker') IS NOT NULL"""
+                    AND json_extract(payload, '$.ticker') IS NOT NULL""",
+            db_path=db_path,
         )
         if not df_legacy.empty:
             suppressed.update(str(t) for t in df_legacy["ticker"].dropna().tolist())
@@ -173,13 +176,14 @@ def _get_cooldown_tickers_by_type(cooldown_cfg: dict) -> set[str]:
     return suppressed
 
 
-def _get_factor_scores() -> dict[str, dict[str, float]]:
+def _get_factor_scores(db_path=None) -> dict[str, dict[str, float]]:
     """Latest factor snapshot per ticker (date = MAX). Returns ticker → {composite_score, momentum, value, quality, sentiment}."""
     df = query_df(
         """SELECT ticker, momentum_score, value_score, quality_score,
                   sentiment_score, composite_score
            FROM factors
-           WHERE date = (SELECT MAX(date) FROM factors)"""
+           WHERE date = (SELECT MAX(date) FROM factors)""",
+        db_path=db_path,
     )
     if df.empty:
         return {}
@@ -195,7 +199,7 @@ def _get_factor_scores() -> dict[str, dict[str, float]]:
     }
 
 
-def _get_price_signals() -> dict[str, dict[str, float]]:
+def _get_price_signals(db_path=None) -> dict[str, dict[str, float]]:
     """Compute 5d return + 30d high/low + current close from prices table.
 
     Returns ticker → {close, ret_5d, high_30d, low_30d, breakout_pct}.
@@ -204,7 +208,8 @@ def _get_price_signals() -> dict[str, dict[str, float]]:
         """SELECT ticker, date, close
            FROM prices
            WHERE date >= date('now', '-45 days')
-           ORDER BY ticker, date"""
+           ORDER BY ticker, date""",
+        db_path=db_path,
     )
     if df.empty:
         return {}
@@ -231,18 +236,19 @@ def _get_price_signals() -> dict[str, dict[str, float]]:
     return out
 
 
-def _get_rsi_snapshot() -> dict[str, float]:
+def _get_rsi_snapshot(db_path=None) -> dict[str, float]:
     """Latest RSI(14) per ticker."""
     df = query_df(
         """SELECT ticker, rsi_14 FROM signals
-           WHERE date = (SELECT MAX(date) FROM signals)"""
+           WHERE date = (SELECT MAX(date) FROM signals)""",
+        db_path=db_path,
     )
     if df.empty:
         return {}
     return {row["ticker"]: row["rsi_14"] for _, row in df.iterrows() if row["rsi_14"] is not None}
 
 
-def _get_regime() -> tuple[str, float | None]:
+def _get_regime(db_path=None) -> tuple[str, float | None]:
     """Current regime + VIX. VIX 가 없거나 노후하면 **None** — 지어내지 않는다.
 
     과거엔 부재·조회실패·노후를 전부 `20.0` 으로 메웠다. 20.0 은 차단(>30)과
@@ -256,13 +262,14 @@ def _get_regime() -> tuple[str, float | None]:
     try:
         df = query_df(
             """SELECT to_regime FROM regime_transitions
-               ORDER BY date DESC LIMIT 1"""
+               ORDER BY date DESC LIMIT 1""",
+            db_path=db_path,
         )
         regime = df["to_regime"].iloc[0] if not df.empty else "neutral"
     except (OperationalError, DatabaseError):
         logger.warning("regime 조회 실패 — neutral 처리", exc_info=True)
         regime = "neutral"
-    return regime, latest_vix()
+    return regime, latest_vix(db_path=db_path)
 
 
 def _score_ticker(
@@ -371,6 +378,7 @@ def _build_why_now(sources: dict[str, float], price: dict[str, float], rsi: floa
 def emit_buy_candidates(
     config_path: Path | None = None,
     limit: int | None = None,
+    db_path: Path | None = None,
 ) -> EmitResult:
     """Main entry: emit BUY candidates for current snapshot.
 
@@ -384,7 +392,7 @@ def emit_buy_candidates(
     alloc = cfg.get("allocation", {})
     exclude_etfs = set(cfg.get("exclude_etfs", []))  # 레버리지/인버스 ETF — BUY 제외 (#761)
 
-    regime, vix = _get_regime()
+    regime, vix = _get_regime(db_path=db_path)
     result = EmitResult(
         regime=regime,
         vix=vix,
@@ -408,20 +416,20 @@ def emit_buy_candidates(
         result.blocked_reason = f"regime={regime} threshold={threshold} (사실상 차단)"
         return result
 
-    held = _get_held_tickers() if cfg.get("exclude_held", True) else set()
+    held = _get_held_tickers(db_path=db_path) if cfg.get("exclude_held", True) else set()
     # #517 Phase 2b — type-aware cooldown 우선. legacy gates.cooldown_days 는 fallback 용.
     cooldown_cfg = gates.get("cooldown")
     if cooldown_cfg:
-        cooldown = _get_cooldown_tickers_by_type(cooldown_cfg)
+        cooldown = _get_cooldown_tickers_by_type(cooldown_cfg, db_path=db_path)
     else:
         # 호환성: gates.cooldown 미정의 시 legacy single-window
-        cooldown = _get_cooldown_tickers(gates.get("cooldown_days", 5))
-    factors = _get_factor_scores()
-    prices = _get_price_signals()
-    rsi_map = _get_rsi_snapshot()
+        cooldown = _get_cooldown_tickers(gates.get("cooldown_days", 5), db_path=db_path)
+    factors = _get_factor_scores(db_path=db_path)
+    prices = _get_price_signals(db_path=db_path)
+    rsi_map = _get_rsi_snapshot(db_path=db_path)
     # P2 leadership shadow 스냅샷 (weight=0 — sources 노출만, 라이브 점수 무변경)
     lead_cfg = cfg.get("leadership", {})
-    leadership = leadership_snapshot(lead_cfg.get("lookback", 120), lead_cfg.get("surge_window", 20))
+    leadership = leadership_snapshot(lead_cfg.get("lookback", 120), lead_cfg.get("surge_window", 20), db_path=db_path)
 
     if not factors:
         result.blocked_reason = "factors 테이블 비어있음 (composite_score 데이터 부재)"
@@ -529,8 +537,27 @@ def render_markdown(result: EmitResult) -> str:
     return "\n".join(lines)
 
 
-def main() -> int:
-    """CLI entry: print markdown + summary."""
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: print markdown + summary.
+
+    기본은 **조회만** 한다. 원장 기록은 `--persist` 를 줄 때만 — 그래서 후보를 눈으로
+    보려고 돌리는 것이 `recommendations` 를 오염시키지 않는다.
+
+    ⚠️ 즉 "발행한 후보는 전부 원장에 남는다" 가 아니라 **"예약 발행(premarket brief)과
+    명시 `--persist` 만 남는다"** 이다. Discord `/buy-candidates` 는 이 CLI 를 그대로
+    타므로 기록되지 않는다 — 같은 날 브리핑이 이미 같은 계산을 기록했고
+    `UNIQUE(date, ticker)` 로 중복도 막히지만, 규칙을 정확히 적어 둔다 (#1078 Codex P1).
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="BUY 후보 emit (#507)")
+    parser.add_argument(
+        "--persist",
+        action="store_true",
+        help="후보를 recommendations 원장에 기록 (기본: 조회만)",
+    )
+    args = parser.parse_args(argv)
+
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     result = emit_buy_candidates()
     print(render_markdown(result))
@@ -539,6 +566,11 @@ def main() -> int:
         f"Summary: {len(result.candidates)} candidates, "
         f"{len(result.skipped)} skipped, regime={result.regime}, VIX={format_vix(result.vix)}"
     )
+    if args.persist:
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        n = save_buy_candidates(result)
+        print(f"원장 기록: {n}건")
     return 0
 
 

--- a/nuri/trading/recommend/tracker.py
+++ b/nuri/trading/recommend/tracker.py
@@ -40,6 +40,103 @@ def _serialize_verdicts(consensus_results) -> dict[str, list[dict]]:
     return verdicts_map
 
 
+#: `recommendations.source` 에 찍는 emit 경로 라벨. NULL 은 합의 파이프라인(기존 행 전부).
+#: §3.11 판정 표본은 사전등록된 모집단을 유지해야 하므로 `decision_alpha.fetch_sample`
+#: 이 이 값을 **제외**한다 — 사용자 결정 2026-08-18. 포함으로 바꾸려면 그쪽 필터 한 줄과
+#: STRATEGY 기록이 같이 필요하다.
+BUY_CANDIDATE_SOURCE = "buy_candidate_emitter"
+
+
+def save_buy_candidates(result, db_path=None) -> int:
+    """`buy_candidate_emitter` 의 EmitResult 를 `recommendations` 에 영속화 (#1078).
+
+    **왜**: 이 emitter 의 실행에는 지금까지 아무것도 남지 않았다. 후보를 발행하고 브리핑에
+    렌더한 뒤 `EmitResult` 를 통째로 버렸다. 그래서 tracker 백필 · `decision_outcomes` ·
+    `/api/alpha` 까지 이어지는 체인이 이 경로에 대해서만 통째로 비어 있었다.
+
+    행 하나당 `source=BUY_CANDIDATE_SOURCE` 를 찍는다. 합의 파이프라인이 같은 테이블을
+    쓰기 때문에 출처가 구분되지 않으면 §3.11 표본을 어느 쪽으로도 정의할 수 없다.
+
+    ⚠️ `recommendations` 는 `UNIQUE(date, ticker)` + `INSERT OR IGNORE` 다. 합의가 07:05 에
+    쓴 ticker 를 emitter 가 같은 날(브리핑은 09:00 ET) 다시 내면 **조용히 드롭**된다.
+    실제 삽입 수를 `rowcount` 로 재서 드롭을 로그로 남긴다 — 안 그러면 "저장했다" 와
+    "저장된 척했다" 가 구분되지 않는다 (`market_data.py:92` 가 같은 이유로 rowcount 를 쓴다).
+
+    Returns: 실제 삽입된 행 수 (드롭 제외).
+    """
+    from nuri.core.axis import derive_alpha_action
+    from nuri.core.timezone import today_kst
+
+    candidates = getattr(result, "candidates", None) or []
+    if not candidates:
+        return 0
+
+    today = today_kst()
+    batch_regime: str | None = None
+    try:
+        from nuri.quant.regime.classifier import canonical_regime_or_none, classify_regime
+
+        rr = classify_regime(db_path=db_path)
+        if rr is not None:
+            batch_regime = canonical_regime_or_none(rr.regime)
+    except Exception:
+        logger.debug("save_buy_candidates: regime classify 실패, NULL 유지", exc_info=True)
+
+    records = []
+    for c in candidates:
+        records.append(
+            {
+                "date": today,
+                "ticker": c.ticker,
+                "action": "BUY",
+                "alpha_action": derive_alpha_action("BUY"),
+                # portfolio_action 은 NULL — 이건 alpha 축 신호지 포트폴리오 룰이 아니다
+                # (#429 축 분리). 집중도/섹터는 REBALANCE 경로에서만 나온다.
+                "portfolio_action": None,
+                "confidence": c.score,
+                "regime": batch_regime,
+                "signals": json.dumps(c.sources, ensure_ascii=False),
+                "entry_price": c.entry,
+                "source": BUY_CANDIDATE_SOURCE,
+                # 가격 레벨은 recommendations 에 컬럼이 없다 — 사용자 CLAUDE.md 가 요구하는
+                # entry/stop/TP 는 브리핑이 렌더하고, 여기엔 사후 재구성을 위해 남긴다.
+                "scoring_detail": json.dumps(
+                    {
+                        "deploy_pct": c.deploy_pct,
+                        "stop": c.stop,
+                        "tp1": c.tp1,
+                        "tp2": c.tp2,
+                        "why_now": c.why_now,
+                    },
+                    ensure_ascii=False,
+                ),
+            }
+        )
+
+    with get_db(db_path) as conn:
+        cur = conn.executemany(
+            """INSERT OR IGNORE INTO recommendations
+               (date, ticker, action, alpha_action, portfolio_action,
+                confidence, regime, signals, entry_price, source, scoring_detail)
+               VALUES (:date, :ticker, :action, :alpha_action, :portfolio_action,
+                       :confidence, :regime, :signals, :entry_price, :source, :scoring_detail)""",
+            records,
+        )
+        inserted = cur.rowcount if cur.rowcount is not None and cur.rowcount >= 0 else 0
+
+    dropped = len(records) - inserted
+    if dropped > 0:
+        logger.warning(
+            "buy candidates %d건 중 %d건이 UNIQUE(date,ticker) 로 드롭됐다 "
+            "— 같은 날 합의 파이프라인이 먼저 쓴 ticker 다 (%s)",
+            len(records),
+            dropped,
+            today,
+        )
+    logger.info("buy candidates %d건 저장 (드롭 %d)", inserted, dropped)
+    return inserted
+
+
 def save_recommendations(candidates=None, actions=None, verdicts=None, db_path=None) -> int:
     """E-1 후보 + E-2 액션을 recommendations 테이블에 저장.
 

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -984,3 +984,70 @@ class TestPremarketBriefStatementCoverage:
         md = format_brief_markdown({"buy_candidates": FakeBC()})
         assert "blocked" in md
         assert "VIX>30" in md
+
+
+class TestBuyCandidatesArePersisted:
+    """브리핑이 후보를 발행하면 원장에 남는다 (#1078).
+
+    발행 지점이 기록 지점이다. `emit_buy_candidates` 안에서 쓰면 CLI 조회만으로도 원장이
+    오염되고, 안 쓰면 이 경로의 실행에 아무 흔적이 없다 — 후자가 넉 달간의 상태였다.
+    """
+
+    def test_emitted_candidates_reach_the_ledger(self, tmp_path, monkeypatch):
+        """Mutation lock: `save_buy_candidates` 호출을 지우면 행이 0 이라 FAIL."""
+        from nuri.alerts import premarket_brief as pb
+        from nuri.core.db import init_db, query
+        from nuri.trading.recommend.buy_candidate_emitter import BuyCandidate, EmitResult
+
+        db = tmp_path / "brief.db"
+        init_db(db)
+
+        emitted = EmitResult(
+            candidates=[
+                BuyCandidate(
+                    ticker="AAA",
+                    score=88.0,
+                    deploy_pct=6.0,
+                    entry=50.0,
+                    stop=46.5,
+                    tp1=60.0,
+                    tp2=70.0,
+                    why_now="breakout",
+                    sources={"factor": 0.9},
+                )
+            ],
+            regime="bull_low_vol",
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.buy_candidate_emitter.emit_buy_candidates",
+            lambda *a, **k: emitted,
+        )
+
+        pb._collect_context(db_path=db)
+
+        rows = query("SELECT ticker, action, source FROM recommendations", db_path=db)
+        assert [r["ticker"] for r in rows] == ["AAA"]
+        assert rows[0]["source"] == "buy_candidate_emitter"
+
+    def test_a_persistence_failure_does_not_break_the_brief(self, tmp_path, monkeypatch):
+        """관측이 본 작업을 게이트하면 안 된다 (#894) — 기록이 터져도 브리핑은 나간다."""
+        from nuri.alerts import premarket_brief as pb
+        from nuri.core.db import init_db
+        from nuri.trading.recommend.buy_candidate_emitter import EmitResult
+
+        db = tmp_path / "brief.db"
+        init_db(db)
+
+        emitted = EmitResult(regime="bull_low_vol", blocked_reason="threshold")
+        monkeypatch.setattr(
+            "nuri.trading.recommend.buy_candidate_emitter.emit_buy_candidates",
+            lambda *a, **k: emitted,
+        )
+
+        def boom(*a, **k):
+            raise RuntimeError("ledger down")
+
+        monkeypatch.setattr("nuri.trading.recommend.tracker.save_buy_candidates", boom)
+
+        ctx = pb._collect_context(db_path=db)
+        assert ctx["buy_candidates"] is emitted, "기록 실패가 후보 표출까지 날렸다"

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -1890,3 +1890,96 @@ class TestGetRealAccountsActions:
 
         result = _get_real_accounts()
         assert isinstance(result, set)
+
+
+class TestEmitterRowsDoNotPoseAsConsensus:
+    """`buy_candidate_emitter` 행이 합의 결과 행세를 하면 안 된다 (#1078, Codex P1).
+
+    emitter 산출물이 `recommendations` 에 들어오면서 같은 테이블을 두 writer 가 쓴다.
+    "최신 합의" 를 뜻하는 읽기 경로들이 `source` 를 안 보면, 날짜만 최신이라는 이유로
+    emitter 후보가 액션 카드·티커 합의로 표출된다. 사용자에게 보이는 변화라 잠근다.
+    """
+
+    @staticmethod
+    def _seed(db, today):
+        from nuri.core.db import get_db
+
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, source) "
+                "VALUES (?, 'CONS', 'BUY', 70.0, NULL)",
+                (today,),
+            )
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, source) "
+                "VALUES (?, 'EMIT', 'BUY', 95.0, 'buy_candidate_emitter')",
+                (today,),
+            )
+            conn.commit()
+
+    def test_latest_actions_excludes_emitter_rows(self, tmp_path, monkeypatch):
+        """Mutation lock: actions.py 필터를 지우면 EMIT 이 섞여 FAIL."""
+        import nuri.core.db as dbm
+        from nuri.api.routes.actions import _get_recommendations
+        from nuri.core.db import init_db
+        from nuri.core.timezone import today_kst
+
+        db = tmp_path / "a.db"
+        init_db(db)
+        monkeypatch.setattr(dbm, "DB_PATH", db)
+        self._seed(db, today_kst())
+
+        tickers = {r["ticker"] for r in _get_recommendations()}
+        assert "CONS" in tickers
+        assert "EMIT" not in tickers, "emitter 후보가 합의 액션으로 표출됐다"
+
+    def test_dashboard_latest_actions_excludes_emitter_rows(self, tmp_path, monkeypatch):
+        """Mutation lock: dashboard.py 필터를 지우면 EMIT 이 섞여 FAIL."""
+        import nuri.core.db as dbm
+        from nuri.api.routes.dashboard import _get_latest_actions
+        from nuri.core.db import init_db
+        from nuri.core.timezone import today_kst
+
+        db = tmp_path / "d.db"
+        init_db(db)
+        monkeypatch.setattr(dbm, "DB_PATH", db)
+        self._seed(db, today_kst())
+
+        tickers = {r["ticker"] for r in _get_latest_actions()}
+        assert "CONS" in tickers
+        assert "EMIT" not in tickers
+
+    def test_ticker_consensus_ignores_a_newer_emitter_row(self, tmp_path, monkeypatch):
+        """같은 ticker 에 emitter 행이 더 최신이어도 합의 행을 돌려준다.
+
+        Mutation lock: ticker.py 필터를 지우면 emitter 행(conf 95)을 합의로 읽어 FAIL.
+        """
+        from datetime import timedelta
+
+        import nuri.core.db as dbm
+        from nuri.api.routes.ticker import _read_consensus_from_db
+        from nuri.core.db import get_db, init_db
+        from nuri.core.timezone import kst_now
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        monkeypatch.setattr(dbm, "DB_PATH", db)
+        # 리터럴 날짜 금지 — `_read_consensus_from_db` 에 staleness 컷오프가 있어
+        # 고정일로 심으면 시간이 지나며 조용히 None 이 된다 (tests/CLAUDE.md time-bomb).
+        today = kst_now().date()
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, source) "
+                "VALUES (?, 'AAA', 'HOLD', 60.0, NULL)",
+                ((today - timedelta(days=1)).isoformat(),),
+            )
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence, source) "
+                "VALUES (?, 'AAA', 'BUY', 95.0, 'buy_candidate_emitter')",
+                (today.isoformat(),),
+            )
+            conn.commit()
+
+        got = _read_consensus_from_db("AAA")
+        assert got is not None
+        assert got["final_action"] == "HOLD", "emitter 행을 최신 합의로 읽었다"

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,15 +29,16 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_49(self, db_path):
+    def test_schema_version_at_50(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
         incidents alpha_report_stale enum 확장 (#894) +
         execution_blocks sleeve_cap enum 확장 (#834) +
         decision_outcomes.benchmark_ticker (#833) +
-        incidents enum 확장 — health_check.sh 흡수 3종 (#939) → 49."""
-        assert get_schema_version(db_path) == 49
+        incidents enum 확장 — health_check.sh 흡수 3종 (#939) +
+        recommendations.source — emit 경로 구분 (#1078) → 50."""
+        assert get_schema_version(db_path) == 50
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -219,6 +219,34 @@ class TestCheckFreshness:
 
         assert check_freshness("factors", db_path=db_path)["status"] == "PASS"
 
+    def test_emitter_rows_do_not_make_consensus_look_fresh(self, db_path):
+        """오늘 emitter 행이 있어도 합의가 낡았으면 FAIL 이어야 한다 (#1078 Codex P2).
+
+        `buy_candidate_emitter` 가 같은 `recommendations` 테이블에 쓰기 시작한 뒤로는
+        `MAX(date)` 만 보면 합의 job 이 죽은 날에도 브리핑이 낸 후보 한 줄이 "합의 신선함"
+        으로 읽힌다. 관측이 거짓말하면 고장을 아무도 못 본다.
+
+        Mutation lock: `WHERE source IS NULL` 을 빼면 PASS 로 뒤집혀 FAIL.
+        """
+        from nuri.core.db import get_db
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now
+
+        stale = (kst_now() - timedelta(days=5)).strftime("%Y-%m-%d")
+        today = kst_now().strftime("%Y-%m-%d")
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, source) VALUES (?, ?, 'BUY', NULL)",
+                (stale, "AAA"),
+            )
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, source) "
+                "VALUES (?, ?, 'BUY', 'buy_candidate_emitter')",
+                (today, "BBB"),
+            )
+
+        assert check_freshness("consensus", db_path=db_path)["status"] == "FAIL"
+
     def test_thresholds_match_prices_because_the_date_is_a_market_date(self):
         """`factors` 와 `prices` 임계가 같아야 한다 (#1071 Codex P1).
 

--- a/tests/quant/validation/test_decision_alpha.py
+++ b/tests/quant/validation/test_decision_alpha.py
@@ -437,6 +437,65 @@ class TestDenominatorDoesNotDependOnTheMirror:
                 conn.commit()
 
 
+class TestEmitterRowsAreOutsideTheAdjudicationSample:
+    """`buy_candidate_emitter` 산출물은 §3.11 표본에서 제외한다 (#1078).
+
+    그 경로가 영속화되기 시작한 건 declared_date(2026-07-08) 한참 뒤다. 넣으면 사전등록된
+    모집단이 측정 도중 205건에서 배 가까이 불어난다 — 제외는 모집단을 사전등록 시점 그대로
+    유지하는 선택이고 사용자 결정(2026-08-18)이다.
+
+    포함으로 바꾸는 건 `fetch_sample` 필터 한 줄과 STRATEGY 기록이 같이 필요한 사전등록
+    개정이므로, 그 경계를 여기서 잠근다.
+    """
+
+    @staticmethod
+    def _seed_emitter_row(db_path, rec_id: int, ticker: str, emit: str, alpha=None):
+        from nuri.trading.recommend.tracker import BUY_CANDIDATE_SOURCE
+
+        _seed_decision(db_path, rec_id, ticker, emit, alpha=alpha)
+        with get_db(db_path) as conn:
+            conn.execute("UPDATE recommendations SET source = ? WHERE id = ?", (BUY_CANDIDATE_SOURCE, rec_id))
+            conn.commit()
+
+    def test_emitter_rows_do_not_enter_the_numerator(self, seeded):
+        """Mutation lock: `source` 필터를 지우면 n 이 늘어 FAIL."""
+        self._seed_emitter_row(seeded, 40, "AAA", EMIT_2, alpha=0.10)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n == 4
+        assert not any(d["decision_id"] == "rec_40" for d in s.decisions)
+
+    def test_emitter_rows_do_not_enter_the_missing_denominator(self, seeded):
+        """분모에서도 빠져야 한다 — 한쪽만 빼면 결측률이 왜곡된다."""
+        self._seed_emitter_row(seeded, 41, "AAA", EMIT_1, alpha=None)
+        s = da.fetch_sample(db_path=seeded, as_of=AS_OF)
+        assert s.n_missing_closed == 0
+
+    def test_an_unknown_future_source_is_also_excluded(self, seeded):
+        """모집단은 **긍정 조건**(`source IS NULL`)이다 — 새 writer 가 라벨만 다르면
+        들어오는 일이 없어야 한다 (Codex P1).
+
+        `source != 'buy_candidate_emitter'` 로 쓰면 앞으로 추가되는 모든 writer 가
+        사전등록된 모집단을 **코드 변경 없이** 넓힌다. 표본에 넣으려면 여기를 명시적으로
+        고쳐야 하고 그건 STRATEGY 기록이 따르는 사전등록 개정이다.
+
+        Mutation lock: 필터를 부정 조건으로 되돌리면 n 이 늘어 FAIL.
+        """
+        _seed_decision(seeded, 42, "BBB", EMIT_3, alpha=0.07)
+        with get_db(seeded) as conn:
+            conn.execute("UPDATE recommendations SET source = ? WHERE id = ?", ("some_future_writer", 42))
+            conn.commit()
+        assert da.fetch_sample(db_path=seeded, as_of=AS_OF).n == 4
+
+    def test_consensus_rows_have_null_source_and_stay_in(self, seeded):
+        """기존 행은 `source IS NULL` 이라 전부 표본에 남는다 — 필터가 과잉이면 안 된다."""
+        rows = da.query(
+            "SELECT COUNT(*) c FROM recommendations WHERE source IS NULL AND action = 'BUY'",
+            db_path=seeded,
+        )
+        assert dict(rows[0])["c"] == 4
+        assert da.fetch_sample(db_path=seeded, as_of=AS_OF).n == 4
+
+
 class TestEmptySampleHasNoMissingRate:
     """측정 대상이 0 건이면 결측률은 `None` — `0.0` 이 아니다 (#1068).
 

--- a/tests/trading/agents/test_consensus.py
+++ b/tests/trading/agents/test_consensus.py
@@ -1617,6 +1617,54 @@ class TestSaveToRecommendations:
         assert rows[0]["confidence"] == 50.0
         assert rows[0]["id"] == first_id, "ON CONFLICT DO UPDATE 는 id 보존 — FK 안전"
 
+    def test_upsert_over_an_emitter_row_reclaims_the_source_column(self, db_path):
+        """emitter 가 먼저 쓴 `(date, ticker)` 를 합의가 덮으면 `source` 도 같이 지워야 한다.
+
+        `ON CONFLICT DO UPDATE` 가 나머지 컬럼을 전부 덮으면서 `source` 만 건드리지 않으면
+        행은 **내용상 합의 산출물인데 라벨은 emitter** 로 남는다. #1078 이후 합의 읽기
+        경로가 전부 `source IS NULL` 이므로 그 행은 `/actions` · `/dashboard` · `/ticker`
+        에서 사라지고, 더 나쁘게는 §3.11 사전등록 판정 표본에서도 빠진다 — 표본이 조용히
+        줄어드는 건 측정 모드에서 가장 피해야 할 형태다 (Codex 리뷰 P1, 2026-08-18).
+
+        순서는 실제로 발생 가능하다: `buy_candidate_emitter --persist` 수동 실행이나
+        브리핑 재실행이 합의 07:05 보다 앞서면 emitter 행이 먼저 앉는다.
+        """
+        from nuri.core.db import query
+        from nuri.trading.agents.consensus import save_to_recommendations
+        from nuri.trading.recommend.buy_candidate_emitter import BuyCandidate, EmitResult
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        emitted = EmitResult(
+            candidates=[
+                BuyCandidate(
+                    ticker="TEST",
+                    score=85.0,
+                    deploy_pct=6.0,
+                    entry=100.0,
+                    stop=93.0,
+                    tp1=120.0,
+                    tp2=140.0,
+                    why_now="breakout",
+                    sources={"factor": 0.8},
+                )
+            ],
+            regime="bull_low_vol",
+        )
+        assert save_buy_candidates(emitted, db_path=db_path) == 1
+
+        assert save_to_recommendations([self._result(action="SELL", conf=61)], db_path=db_path) == 1
+
+        rows = query("SELECT action, confidence, source FROM recommendations WHERE ticker='TEST'", db_path=db_path)
+        assert len(rows) == 1
+        assert rows[0]["action"] == "SELL", "합의가 내용을 덮었는지 먼저 확인 (전제)"
+        assert rows[0]["source"] is None, "합의가 덮었으면 라벨도 합의 것이어야 한다"
+
+        visible = query(
+            "SELECT COUNT(*) c FROM recommendations WHERE ticker='TEST' AND source IS NULL",
+            db_path=db_path,
+        )[0]["c"]
+        assert visible == 1, "합의 읽기 경로(§3.11 표본 포함)에서 사라지면 안 된다"
+
     def test_regime_label_canonical_only(self, db_path):
         """#832 Gotcha-Test Pair: regime 컬럼은 canonical ALL_REGIMES 값 또는 NULL 만.
 

--- a/tests/trading/recommend/_helpers.py
+++ b/tests/trading/recommend/_helpers.py
@@ -2,6 +2,7 @@
 
 Imported explicitly by test files (conftest.py only auto-loads fixtures).
 """
+
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -20,17 +21,18 @@ def _seed_recommendation(db_path, date, ticker, action, entry_price, confidence=
     """추천 레코드 삽입."""
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO recommendations (date, ticker, action, confidence, entry_price) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO recommendations (date, ticker, action, confidence, entry_price) VALUES (?, ?, ?, ?, ?)",
             (date, ticker, action, confidence, entry_price),
         )
 
 
 def _seed_portfolio_r23(db_path, tickers=None):
     """Insert sample portfolio rows (from test_coverage_round23)."""
-    tickers = tickers or [("test", "AAPL", 10, 150.0, "USD", "Technology"),
-                          ("test", "MSFT", 5, 300.0, "USD", "Technology"),
-                          ("test", "JNJ", 20, 160.0, "USD", "Health")]
+    tickers = tickers or [
+        ("test", "AAPL", 10, 150.0, "USD", "Technology"),
+        ("test", "MSFT", 5, 300.0, "USD", "Technology"),
+        ("test", "JNJ", 20, 160.0, "USD", "Health"),
+    ]
     with get_db(db_path) as conn:
         for account, ticker, qty, avg_price, currency, sector in tickers:
             conn.execute(
@@ -93,8 +95,7 @@ def _seed_prices_nm(db_path, prices=None):
         ]
     with get_db(db_path) as conn:
         conn.executemany(
-            "INSERT OR REPLACE INTO prices (date, ticker, open, high, low, close, volume) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO prices (date, ticker, open, high, low, close, volume) VALUES (?, ?, ?, ?, ?, ?, ?)",
             prices,
         )
 

--- a/tests/trading/recommend/test_conflicts.py
+++ b/tests/trading/recommend/test_conflicts.py
@@ -1,4 +1,5 @@
 """Tests for conflicts — split from test_trading_recommend_all.py."""
+
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -54,6 +55,7 @@ class TestConflictsWithCandidate:
 
     def test_empty_candidates(self):
         from nuri.trading.engine.conflicts import detect_conflicts
+
         assert detect_conflicts([]) == []
 
 
@@ -63,6 +65,7 @@ class TestConflictsStrengthMismatch:
     def test_strength_mismatch_detected(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("AAPL", "rsi_oversold", "2025-03-25", "BUY", 70, 0.60, 5.0, True, 170, ""),
             Candidate("AAPL", "gap_up", "2025-03-25", "BUY", 40, 0.40, 1.2, False, 170, ""),
@@ -75,6 +78,7 @@ class TestConflictsStrengthMismatch:
     def test_no_strength_mismatch_when_similar(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("AAPL", "rsi_oversold", "2025-03-25", "BUY", 70, 0.60, 2.0, True, 170, ""),
             Candidate("AAPL", "bb_bounce", "2025-03-25", "BUY", 65, 0.55, 1.8, True, 170, ""),
@@ -90,6 +94,7 @@ class TestConflictsRegimeContradiction:
     def test_buy_in_bear_market(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("TSLA", "bb_bounce", "2025-03-25", "BUY", 55, 0.50, 1.5, False, 200, ""),
         ]
@@ -104,6 +109,7 @@ class TestConflictsRegimeContradiction:
     def test_sell_in_bull_market(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("TSLA", "macd_dead", "2025-03-25", "SELL", 55, 0.50, 1.5, False, 200, ""),
         ]
@@ -118,6 +124,7 @@ class TestConflictsRegimeContradiction:
     def test_regime_fit_buy_in_bear_skipped(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("TSLA", "bb_bounce", "2025-03-25", "BUY", 55, 0.50, 1.5, True, 200, ""),
         ]
@@ -131,6 +138,7 @@ class TestConflictsRegimeContradiction:
     def test_classify_regime_exception_no_crash(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("TSLA", "bb_bounce", "2025-03-25", "BUY", 55, 0.50, 1.5, False, 200, ""),
         ]
@@ -146,6 +154,7 @@ class TestConflictsMediumSeverity:
     def test_medium_severity_direction_conflict(self):
         from nuri.trading.engine.conflicts import detect_conflicts
         from nuri.trading.recommend.candidates import Candidate
+
         candidates = [
             Candidate("NVDA", "rsi_oversold", "2025-03-25", "BUY", 60, 0.55, 2.0, True, 100, ""),
             Candidate("NVDA", "macd_dead", "2025-03-24", "SELL", 50, 0.45, 1.3, False, 100, ""),

--- a/tests/trading/recommend/test_cooldown_split.py
+++ b/tests/trading/recommend/test_cooldown_split.py
@@ -34,7 +34,10 @@ def isolated_db(tmp_path, monkeypatch):
     db = tmp_path / "test_cooldown.db"
     init_db(db)
     monkeypatch.setattr(
-        "nuri.trading.recommend.buy_candidate_emitter.query_df", lambda sql, params=None: _run_query_df(db, sql, params)
+        "nuri.trading.recommend.buy_candidate_emitter.query_df",
+        # `db_path=` 를 받아 무시한다 — 이 스텁은 이미 tmp DB 로 고정돼 있고,
+        # 시그니처만 맞추면 된다 (#1078 에서 emitter 가 db_path 를 forward 하기 시작).
+        lambda sql, params=None, db_path=None: _run_query_df(db, sql, params),
     )
     yield db
 

--- a/tests/trading/recommend/test_recommend_branch_coverage_v2.py
+++ b/tests/trading/recommend/test_recommend_branch_coverage_v2.py
@@ -298,17 +298,17 @@ class TestBuyCandidateEmitterCooldownBranches:
         # Stub providers so the function flows through cooldown call
         type_aware_called = {"n": 0}
 
-        def fake_type_aware(cooldown_cfg):
+        def fake_type_aware(cooldown_cfg, **_kw):
             type_aware_called["n"] += 1
             return set()
 
         monkeypatch.setattr(bce, "_get_cooldown_tickers_by_type", fake_type_aware)
-        monkeypatch.setattr(bce, "_get_held_tickers", lambda: set())
-        monkeypatch.setattr(bce, "_get_factor_scores", lambda: {})
-        monkeypatch.setattr(bce, "_get_price_signals", lambda: {})
-        monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda: {})
+        monkeypatch.setattr(bce, "_get_held_tickers", lambda **_kw: set())
+        monkeypatch.setattr(bce, "_get_factor_scores", lambda **_kw: {})
+        monkeypatch.setattr(bce, "_get_price_signals", lambda **_kw: {})
+        monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda **_kw: {})
         monkeypatch.setattr(bce, "leadership_snapshot", lambda *a, **k: {})  # P2 shadow (prices 미시드)
-        monkeypatch.setattr(bce, "_get_regime", lambda: ("neutral", 18.0))
+        monkeypatch.setattr(bce, "_get_regime", lambda **_kw: ("neutral", 18.0))
 
         result = bce.emit_buy_candidates(config_path=cfg_path)
         # Lock-in: the type-aware path was taken exactly once
@@ -343,13 +343,13 @@ class TestBuyCandidateEmitterCooldownBranches:
                 }
             )
         )
-        monkeypatch.setattr(bce, "_get_held_tickers", lambda: set())
-        monkeypatch.setattr(bce, "_get_cooldown_tickers", lambda days: set())
-        monkeypatch.setattr(bce, "_get_factor_scores", lambda: {"NOPRICE": {"composite": 0.9}})
-        monkeypatch.setattr(bce, "_get_price_signals", lambda: {})  # NOPRICE missing
-        monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda: {})
+        monkeypatch.setattr(bce, "_get_held_tickers", lambda **_kw: set())
+        monkeypatch.setattr(bce, "_get_cooldown_tickers", lambda days, **_kw: set())
+        monkeypatch.setattr(bce, "_get_factor_scores", lambda **_kw: {"NOPRICE": {"composite": 0.9}})
+        monkeypatch.setattr(bce, "_get_price_signals", lambda **_kw: {})  # NOPRICE missing
+        monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda **_kw: {})
         monkeypatch.setattr(bce, "leadership_snapshot", lambda *a, **k: {})  # P2 shadow (prices 미시드)
-        monkeypatch.setattr(bce, "_get_regime", lambda: ("neutral", 18.0))
+        monkeypatch.setattr(bce, "_get_regime", lambda **_kw: ("neutral", 18.0))
 
         result = bce.emit_buy_candidates(config_path=cfg_path)
 
@@ -440,13 +440,51 @@ class TestBuyCandidateEmitterMain:
         )
         monkeypatch.setattr(bce, "emit_buy_candidates", lambda: fake_result)
 
-        rc = bce.main()
+        # `main()` 이 CLI 인자를 파싱하므로 argv 를 명시한다 (#1078 `--persist` 도입).
+        # 생략하면 argparse 가 **pytest 의 sys.argv** 를 읽어 unrecognized arguments 로
+        # 죽는다 — xdist 워커에서는 argv 가 달라 통과해 버려서 조용히 가려진다.
+        rc = bce.main([])
         assert rc == 0
         out = capsys.readouterr().out
         # Lock summary format
         assert "Summary: 0 candidates, 0 skipped, regime=bull, VIX=15.0" in out
         # Markdown also printed (blocked path)
         assert "BUY Candidates" in out
+
+    def test_main_does_not_persist_by_default(self, monkeypatch, capsys):
+        """CLI 기본은 **조회만** — 후보를 눈으로 보려고 돌리는 게 원장을 오염시키면 안 된다.
+
+        Mutation lock: `--persist` 게이트를 없애고 항상 저장하면 FAIL.
+        """
+        from nuri.trading.recommend import buy_candidate_emitter as bce
+        from nuri.trading.recommend import tracker as tr
+        from nuri.trading.recommend.buy_candidate_emitter import EmitResult
+
+        calls: list = []
+        monkeypatch.setattr(bce, "emit_buy_candidates", lambda: EmitResult(regime="bull"))
+        monkeypatch.setattr(tr, "save_buy_candidates", lambda *a, **k: calls.append(a) or 0)
+
+        assert bce.main([]) == 0
+        assert calls == [], "조회만 했는데 원장에 썼다"
+        assert "원장 기록" not in capsys.readouterr().out
+
+    def test_main_persists_when_asked(self, monkeypatch, capsys):
+        """`--persist` 면 기록하고 건수를 찍는다.
+
+        Mutation lock: 저장 호출을 지우면 FAIL.
+        """
+        from nuri.trading.recommend import buy_candidate_emitter as bce
+        from nuri.trading.recommend import tracker as tr
+        from nuri.trading.recommend.buy_candidate_emitter import EmitResult
+
+        emitted = EmitResult(regime="bull")
+        calls: list = []
+        monkeypatch.setattr(bce, "emit_buy_candidates", lambda: emitted)
+        monkeypatch.setattr(tr, "save_buy_candidates", lambda r: calls.append(r) or 3)
+
+        assert bce.main(["--persist"]) == 0
+        assert calls == [emitted]
+        assert "원장 기록: 3건" in capsys.readouterr().out
 
     def test_module_main_invocation_via_runpy(self, monkeypatch):
         """Line 506: `if __name__ == '__main__': raise SystemExit(main())`.
@@ -455,11 +493,16 @@ class TestBuyCandidateEmitterMain:
         re-executed main() picks up our stub. SystemExit(0) is the expected outcome.
         """
         import runpy
+        import sys
         import tempfile
         from pathlib import Path as _P
 
         import nuri.core.db as _db_mod
         from nuri.core.db import init_db
+
+        # `__main__` 실행은 `main()` 을 인자 없이 부르고, argparse 는 그때 **pytest 의
+        # sys.argv** 를 읽는다 (#1078 `--persist` 도입 이후). 실제 CLI 호출 모양으로 고정한다.
+        monkeypatch.setattr(sys, "argv", ["buy_candidate_emitter"])
 
         _tmp = _P(tempfile.mkdtemp()) / "rp.db"
         init_db(_tmp)

--- a/tests/trading/recommend/test_tracker.py
+++ b/tests/trading/recommend/test_tracker.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -1476,6 +1477,29 @@ class TestSaveBuyCandidates:
         row = query("SELECT ticker, regime FROM recommendations", db_path=db_path)[0]
         assert row["ticker"] == "AAA"
         assert row["regime"] is None
+
+    @pytest.mark.parametrize(
+        ("classified", "expected"),
+        [
+            ("bull_low_vol", "bull_low_vol"),  # canonical → 그대로 행에 박힌다
+            ("[recovery] 비중 축소", None),  # free-text → NULL (#832)
+        ],
+    )
+    def test_regime_label_is_canonical_or_null(self, db_path, monkeypatch, classified, expected):
+        """분류가 성공하면 라벨이 행에 남되, canonical 10종이 아니면 NULL 이다.
+
+        실패 경로만 잠그면 `canonical_regime_or_none` 을 벗겨도(=`rr.regime` 을 그대로
+        대입해도) 초록이다. free-text 유입이 라벨 커버리지를 3% 로 만든 게 #832 였다.
+        """
+        import nuri.quant.regime.classifier as clf
+
+        monkeypatch.setattr(clf, "classify_regime", lambda **k: SimpleNamespace(regime=classified))
+
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        assert save_buy_candidates(self._result("AAA"), db_path=db_path) == 1
+        row = query("SELECT regime FROM recommendations", db_path=db_path)[0]
+        assert row["regime"] == expected
 
     def test_portfolio_action_stays_null(self, db_path):
         """축 분리 (#429) — 이건 alpha 축 신호지 포트폴리오 룰이 아니다."""

--- a/tests/trading/recommend/test_tracker.py
+++ b/tests/trading/recommend/test_tracker.py
@@ -1374,3 +1374,114 @@ class TestRegimeLabelEmit:
 
         row = query("SELECT regime FROM recommendations WHERE ticker='AAPL'", db_path=rich_db)[0]
         assert row["regime"] is None
+
+
+class TestSaveBuyCandidates:
+    """`buy_candidate_emitter` 산출물 영속화 (#1078).
+
+    이 emitter 의 실행에는 지금까지 **아무것도 남지 않았다** — 후보를 발행하고 브리핑에
+    렌더한 뒤 `EmitResult` 를 통째로 버렸다. 그래서 tracker 백필 · `decision_outcomes` ·
+    `/api/alpha` 로 이어지는 체인이 이 경로에 대해서만 비어 있었다.
+    """
+
+    @staticmethod
+    def _result(*tickers):
+        from nuri.trading.recommend.buy_candidate_emitter import BuyCandidate, EmitResult
+
+        return EmitResult(
+            candidates=[
+                BuyCandidate(
+                    ticker=t,
+                    score=85.0,
+                    deploy_pct=6.0,
+                    entry=100.0,
+                    stop=93.0,
+                    tp1=120.0,
+                    tp2=140.0,
+                    why_now="breakout",
+                    sources={"factor": 0.8},
+                )
+                for t in tickers
+            ],
+            regime="bull_low_vol",
+        )
+
+    def test_writes_rows_tagged_with_the_emit_source(self, db_path):
+        """Mutation lock: `source` 를 안 찍으면 §3.11 표본에서 걸러낼 수가 없어 FAIL."""
+        from nuri.trading.recommend.tracker import BUY_CANDIDATE_SOURCE, save_buy_candidates
+
+        n = save_buy_candidates(self._result("AAA", "BBB"), db_path=db_path)
+        assert n == 2
+
+        rows = query("SELECT ticker, action, source, entry_price FROM recommendations", db_path=db_path)
+        assert {r["ticker"] for r in rows} == {"AAA", "BBB"}
+        assert all(r["action"] == "BUY" for r in rows)
+        assert all(r["source"] == BUY_CANDIDATE_SOURCE for r in rows)
+        assert all(r["entry_price"] == 100.0 for r in rows)
+
+    def test_price_levels_survive_in_scoring_detail(self, db_path):
+        """stop/TP 는 `recommendations` 에 컬럼이 없다 — 사후 재구성이 가능해야 한다."""
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        save_buy_candidates(self._result("AAA"), db_path=db_path)
+        detail = json.loads(query("SELECT scoring_detail FROM recommendations", db_path=db_path)[0]["scoring_detail"])
+        assert detail["stop"] == 93.0
+        assert detail["tp1"] == 120.0
+        assert detail["tp2"] == 140.0
+
+    def test_unique_collision_is_reported_not_silently_counted(self, db_path):
+        """같은 날 합의가 먼저 쓴 ticker 는 조용히 드롭된다 — 반환값이 그걸 반영해야 한다.
+
+        `recommendations` 는 `UNIQUE(date, ticker)` + `INSERT OR IGNORE` 다. `len(records)`
+        를 그대로 돌려주면 "저장했다" 와 "저장된 척했다" 가 구분되지 않는다.
+
+        Mutation lock: `rowcount` 대신 `len(records)` 를 돌려주면 FAIL.
+        """
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence) VALUES (?, ?, 'BUY', 60.0)",
+                (today_kst(), "AAA"),
+            )
+
+        n = save_buy_candidates(self._result("AAA", "BBB"), db_path=db_path)
+        assert n == 1, "드롭된 행까지 저장했다고 셌다"
+        assert query("SELECT COUNT(*) c FROM recommendations", db_path=db_path)[0]["c"] == 2
+
+    def test_empty_result_writes_nothing(self, db_path):
+        from nuri.trading.recommend.buy_candidate_emitter import EmitResult
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        assert save_buy_candidates(EmitResult(blocked_reason="VIX 35 > 30"), db_path=db_path) == 0
+        assert query("SELECT COUNT(*) c FROM recommendations", db_path=db_path)[0]["c"] == 0
+
+    def test_regime_classify_failure_does_not_block_persistence(self, db_path, monkeypatch):
+        """레짐 분류가 터져도 후보는 저장된다 — regime 만 NULL 로 남는다.
+
+        관측(레짐 라벨)이 본 작업(원장 기록)을 게이트하면 안 된다 (#894). 이 emitter 의
+        기록이 없어서 체인 전체가 비어 있었던 게 #1078 의 출발점인데, 라벨 하나 때문에
+        다시 비면 같은 자리로 돌아간다.
+        """
+        import nuri.quant.regime.classifier as clf
+
+        def boom(*a, **k):
+            raise RuntimeError("regime down")
+
+        monkeypatch.setattr(clf, "classify_regime", boom)
+
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        assert save_buy_candidates(self._result("AAA"), db_path=db_path) == 1
+        row = query("SELECT ticker, regime FROM recommendations", db_path=db_path)[0]
+        assert row["ticker"] == "AAA"
+        assert row["regime"] is None
+
+    def test_portfolio_action_stays_null(self, db_path):
+        """축 분리 (#429) — 이건 alpha 축 신호지 포트폴리오 룰이 아니다."""
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        save_buy_candidates(self._result("AAA"), db_path=db_path)
+        row = query("SELECT alpha_action, portfolio_action FROM recommendations", db_path=db_path)[0]
+        assert row["alpha_action"] == "LONG"
+        assert row["portfolio_action"] is None


### PR DESCRIPTION
Closes #1078

## 증상

`buy_candidate_emitter` 의 실행에는 **아무것도 남지 않았다.** `premarket_brief` 가 부르고,
마크다운으로 렌더하고, `EmitResult` 를 통째로 버렸다. 그래서 이 경로에 대해서만 아래가
전부 비어 있었다 — 같은 테이블을 합의 파이프라인은 매일 채우는데(측정창 BUY 205건).

```
recommendations → tracker 백필 → agent_decisions → decision_outcomes
                → fetch_sample(§3.11) → /api/alpha · alpha_report · BriefAuditor
```

#1071 로 `factors` 가 되살아나 emitter 점수가 넉 달 만에 신선해졌는데, 그 점수로 발행한
후보가 어디에도 안 남으므로 **개선 여부를 측정할 방법이 없었다.**

## 설계 결정 2건

**1. 발행 지점이 기록 지점이다.** `emit_buy_candidates` 안에서 쓰면 CLI 로 후보를 조회하는
것만으로 원장이 오염된다. `premarket_brief` 가 부른다. 기록 실패는 자체 try 로 감싸 브리핑을
막지 않는다 (#894 — 관측이 본 작업을 게이트하면 안 된다).

**2. §3.11 표본에서는 제외한다** (사용자 결정 2026-08-18). 이 경로가 영속화되기 시작한 건
`declared_date`(2026-07-08) 한참 뒤다. 넣으면 사전등록된 모집단이 측정 도중 205건에서 배
가까이 불어난다. 포함으로 바꾸는 건 `fetch_sample` 필터 한 줄 + STRATEGY 기록이 같이 필요한
사전등록 개정이다.

→ 구분자로 **명시 컬럼** `recommendations.source` (migration 50). `scoring_detail` JSON 마커를
안 쓴 이유는 `json_extract` 가 malformed JSON 한 행에서 `OperationalError` 로 죽고 **무관한
스캔 쿼리까지 같이 죽이기** 때문이다 (`nuri/core/CLAUDE.md` 에 기록된 실제 사고). 기존 행은
`source IS NULL` = 합의 산출물.

## 조용한 드롭을 숫자로 남긴다

`recommendations` 는 `UNIQUE(date, ticker)` + `INSERT OR IGNORE` 다. 합의가 07:05 KST 에 쓴
ticker 를 emitter 가 같은 날(브리핑 09:00 ET) 다시 내면 드롭된다. `len(records)` 를 돌려주면
"저장했다"와 "저장된 척했다"가 구분되지 않으므로 `rowcount` 로 실제 삽입 수를 세고 드롭을
경고로 남긴다 (`market_data.py:92` 가 같은 이유로 rowcount 를 쓴다).

## 직접 확인한 하류 영향

- **쿨다운 자기 차단 없음** — `_get_cooldown_tickers*` 는 `pipeline_events`(SELL/trim alert)를
  읽지 `recommendations` 를 읽지 않는다. BUY 행을 써도 자기 후보를 억제하지 않는다.
- **미러는 의도대로 동작** — `backfill_agent_decisions_from_recommendations` 가 BUY/SELL 을
  전부 가져가므로 emitter 행도 `agent_decisions` → `decision_outcomes` 로 채점된다. 이게
  목적이다.
- **`brief_auditor` 오탐 없음** — 그건 "#brief 에 발행된" 결정을 감사하는데, emitter 후보는
  실제로 브리핑에 렌더된다.
- **축 분리 준수** — `portfolio_action` 은 NULL. alpha 축 신호지 포트폴리오 룰이 아니다 (#429).

## 검증

- **뮤테이션 6종 전부 FAIL 실측** — `source` 미기록 · `rowcount`→`len` · §3.11 필터 제거 ·
  `scoring_detail` 생략 · 영속화 호출 제거 · `portfolio_action` 채움
- `pre_push_check.sh` 전 항목 통과 — **7,093 passed**
- 스키마 버전 lock 49 → 50 (마이그레이션 추가 시 의도된 게이트가 정확히 걸렸다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Codex 리뷰 — NEEDS_REWORK, P1 3건 + P2 1건 반영

**P1 — §3.11 필터가 부정 조건이었다.** `source != 'buy_candidate_emitter'` 는 앞으로 추가되는
**모든** writer 를 라벨만 다르면 표본에 들여보낸다. 사전등록된 모집단이 코드 변경 없이
넓어지는 경로다. → **긍정 조건 `source IS NULL`** 로 바꿨다. 새 writer 를 넣으려면 여기를
명시적으로 고쳐야 하고 그건 사전등록 개정이다.

**P1 — 읽기 소비자가 emitter 행을 합의로 읽는다.** 이게 제일 컸다. `recommendations` 를 두
writer 가 쓰는데 "최신 합의" 를 뜻하는 읽기 경로들이 `source` 를 안 봤다. → 소비자 3곳에
필터 추가: `actions._get_recommendations` · `dashboard._get_latest_actions` ·
`ticker._read_consensus_from_db`. 나머지 소비자는 **의도적으로 그대로 둔다** —
tracker 백필/미러는 emitter 행을 채점해야 하고(그게 목적), `sleeve.py` 는 포함하는 쪽이
슬리브 캡을 보수적으로 보며, `thesis_query` 는 이력 표시라 포함이 맞다.

**P1 — CLI/Discord 경로는 여전히 무기록.** "발행한 후보는 전부 남는다" 가 아니었다.
→ CLI 에 `--persist` 를 두고(기본 조회만), 규칙을 **"예약 발행과 명시 `--persist` 만 남는다"**
로 코드에 정확히 적었다. Discord `/buy-candidates` 는 같은 CLI 를 타므로 기록되지 않는다 —
같은 날 브리핑이 이미 같은 계산을 기록했고 `UNIQUE(date, ticker)` 로 중복도 막힌다.

**P2 — DB 교차 오염.** `save_buy_candidates(db_path=X)` 로 쓰면서 `emit_buy_candidates()` 는
기본 DB 를 읽고 있었다 — A 에서 계산해 B 에 쓰는 형태다. → `emit_buy_candidates` 에 `db_path`
스레딩(헬퍼 7개 + query 8곳). 레포의 forwarding 불변식 테스트가 그 과정에서 누수 2곳
(`latest_vix` · `leadership_snapshot`)을 추가로 잡았다.

**P3 (defect 아님으로 확인)** — `executemany` + `INSERT OR IGNORE` 의 `rowcount` 는 신뢰 가능.

### 재검증

- **뮤테이션 재측정**: 1차에서 소비자 필터 3종이 **생존**했다(테스트 부재) → API 테스트 3개
  추가 후 재측정해 **생존 0**.
- `pre_push_check.sh` — **7,097 passed**

### 곁가지 — 병렬 테스트 flake

`-n auto --dist worksteal` 에서 tracker/portfolio 계열 3건이 간헐 실패한다(실행마다 다른
테스트). 순차 실행·재실행에서는 재현되지 않고 **main 에서도 발생**하므로 이 PR 의 결함이
아니다. `tests/CLAUDE.md` 가 기록한 SQLite visibility 계열로 보이며 별도 이슈 대상이다.
