### PR TITLE
fix(dx): install the pre-push gate and stop it lying when it cannot run

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -1,6 +1,6 @@
 # Mechanical Enforcement
 
-Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-cd.yml`. Pre-push: `scripts/verify/pre_push_check.sh`.
+Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-cd.yml`. Pre-push: `scripts/hooks/pre-push` (installed by `make setup-hooks`) → `scripts/verify/pre_push_check.sh --skip-tests` (0.9s; 테스트는 CI 4-shard 가 미러하고 full 로컬 실행은 320.8s 라 훅에서는 뺀다 — 느린 훅은 우회당한 훅이다). 이 문장은 #1070 까지 **거짓**이었다: 게이트 스크립트는 있었지만 `scripts/hooks/` 에 `pre-push` 소스가 없어 `make setup-hooks` 가 정상 동작하면서 아무것도 설치하지 않았다. **Test:** `tests/test_pre_push_hook.py` — 훅을 grep 하지 않고 임시 레포에서 **실행**해 exit code 를 본다(게이트 rc 0/1 양방향 + 게이트 부재 + 인터프리터 부재).
 
 **PreToolUse hook** blocks: `import sqlite3` outside `nuri/core/db/connection.py`, `git push --force` / `reset --hard` / `clean -f`, privacy ticker+PnL inline writes (`scripts/verify/check_privacy_leak.py --message --quiet`).
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,098 collected across 323 files | |
+| **Backend tests** | 7,098 collected across 324 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,098 backend tests across 323 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,098 backend tests across 324 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -28,20 +28,18 @@ bash scripts/verify/pre_push_check.sh --quick   # smoke (6s)
 | `scripts/verify/check_atomic.sh` | multi-commit branch 각 commit 독립 검증 | `HEAD~3..HEAD` range |
 | `.github/pull_request_template.md` | PR 생성 시 자동 채움 — 패턴 checkbox 강제 | — |
 
-## Optional: git hook 설치
+## git hook 설치
 
 ```bash
-# .git/hooks/pre-push
-#!/bin/bash
-bash scripts/verify/pre_push_check.sh --quick || {
-    echo "Pre-push failed. To bypass: git push --no-verify"
-    exit 1
-}
+make setup-hooks     # `make setup` 에 포함 — pre-commit + pre-push 심볼릭 링크
 ```
 
-```bash
-chmod +x .git/hooks/pre-push
-```
+`scripts/hooks/*` 를 `.git/hooks/` 로 심는다. 훅 본문이 레포에 있으므로 갱신이 `git pull`
+로 따라온다. 우회는 `git push --no-verify`.
+
+여기 원래 적혀 있던 것은 `.git/hooks/pre-push` 를 **손으로** 만들라는 안내였고, 그게
+#1070 의 원인이다 — 손 설치는 새 clone 에 따라오지 않고 잊히며, 실제로 pre-push 는
+설치된 적이 없는 채 `.claude/rules/enforcement.md` 만 게이트가 도는 것처럼 적혀 있었다.
 
 ## Anti-patterns (5)
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,098 tests, 323 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,098 tests, 324 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Pre-push gate — layer 2 of the STRATEGY §4.4.1 privacy defense.
+#
+# Installed by `make setup-hooks` (symlink .git/hooks/pre-push → here). Until
+# #1070 this file simply did not exist, so the installer worked perfectly and
+# installed nothing: an *absent* gate, quieter than the dead gates of #910/#911
+# (rc=127) and #953/#954 (exit 0) because non-execution leaves no exit code at
+# all. `.claude/rules/enforcement.md` meanwhile claimed the gate was running.
+#
+# Why layer 2 cannot be replaced by CI: `privacy-scan` runs *after* the push.
+# A ticker+PnL disclosure in a commit **message** is already in remote history
+# by then — that is exactly what PR #202 cost, and the lesson that created this
+# gate. Only a local hook stops it.
+#
+# Why `--skip-tests`: the test sections are mirrored by CI's 4 shards, while a
+# local full run is 320.8s. A slow hook is a bypassed hook, and a bypassed hook
+# is an absent gate again. Everything CI cannot replace still runs here — drift,
+# lint, doc counts, tracked-file privacy, and the commit-message scan — in 0.9s.
+# Full parity remains `bash scripts/verify/pre_push_check.sh`.
+#
+# Bypass: git push --no-verify   (leaves CI as the only remaining net)
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "pre-push: not inside a git repository — refusing to push unchecked." >&2
+    exit 1
+}
+cd "$REPO_ROOT" || exit 1
+
+GATE="scripts/verify/pre_push_check.sh"
+if [ ! -f "$GATE" ]; then
+    # Missing checker is "unverified", not "clean". Exiting 0 here would recreate
+    # the very failure this hook exists to close.
+    echo "pre-push: $GATE missing — refusing to push unchecked." >&2
+    echo "          override with: git push --no-verify" >&2
+    exit 1
+fi
+
+# stdin carries git's ref list; nothing downstream reads it, and leaving it
+# attached lets a stray `read` in a sub-script swallow the push description.
+exec bash "$GATE" --skip-tests < /dev/null

--- a/scripts/verify/pre_push_check.sh
+++ b/scripts/verify/pre_push_check.sh
@@ -22,6 +22,19 @@ source "$(dirname "$0")/../_common.sh"
 mode="${1:-full}"
 fail=0
 
+# `$PYTHON` 은 존재 확인 없는 경로다 (`_common.sh`). 인터프리터가 없으면 아래 python
+# 단계들이 rc=127 로 죽는데, 각 단계의 `if` 는 그걸 그 단계의 **발견**으로 보고한다 —
+# `.venv` 없는 clone 에서 "Personal financial data leak detected" 가 찍히지만 실제로는
+# 스캐너가 한 번도 돈 적이 없다. 실패와 미실행이 구분 안 되는 형태(#910/#911)이고,
+# 훅으로 돌면 이 거짓말이 곧 `--no-verify` 습관이 된다.
+if ! "$PYTHON" -c '' > /dev/null 2>&1; then
+    echo -e "${RED}✗ python 인터프리터 없음: ${PYTHON}${NC}" >&2
+    echo -e "${RED}  검사를 하나도 실행하지 못했다 — '깨끗함' 이 아니라 '미확인' 이다.${NC}" >&2
+    echo -e "${RED}  'make setup' 으로 venv 를 만들거나 PYTHON=... 로 지정할 것.${NC}" >&2
+    echo -e "${RED}  우회: git push --no-verify${NC}" >&2
+    exit 1
+fi
+
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}  Pre-Push Check (mode: ${mode})${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -1,0 +1,117 @@
+"""git `pre-push` 훅을 **실행해서** 검증 (Gotcha-Test Pair, #1070).
+
+`scripts/verify/pre_push_check.sh` 는 존재했고 정상 동작했고 수동 실행하면 전 항목을
+통과했다. 그런데 `scripts/hooks/` 에 `pre-push` 소스가 없어서, `make setup-hooks` 가
+정상 동작하면서도 **아무것도 설치하지 않았다.** STRATEGY §4.4.1 이 선언한 3층 방어 중
+2층(로컬 pre-push)이 통째로 비어 있었고, `.claude/rules/enforcement.md` 는 그 내내
+게이트가 도는 것처럼 적혀 있었다.
+
+이건 dead gate 가 아니라 **absent gate** 라 더 조용하다 — #910/#911(rc=127) 과
+#953/#954(exit 0) 는 최소한 exit code 라도 남겼지만, 실행 자체가 없으면 로그도
+exit code 도 없다. 그래서 여기서도 훅을 grep 하지 않고 **셸로 실행해 exit code 만**
+믿는다.
+
+세 축:
+- 소스 파일 존재 → 설치기가 심을 것이 있다 (#1070 의 결함 그 자체)
+- 게이트 exit code 전달 (0 → 0, 1 → 1) → 삼키지도, 상시 red 도 아니다
+- 인터프리터 부재 시 **정직한 실패** → "미실행" 을 "깨끗함" 으로도, 다른 발견으로도
+  보고하지 않는다
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "scripts" / "hooks" / "pre-push"
+GATE_REL = "scripts/verify/pre_push_check.sh"
+
+#: git 이 pre-push 훅 stdin 으로 넘기는 한 줄 (`<local ref> <local sha> <remote ref> <remote sha>`).
+_PUSH_LINE = "refs/heads/main 0123456789abcdef0123456789abcdef01234567 refs/heads/main " + "0" * 40
+
+
+def test_hook_source_exists_so_the_installer_can_install_it():
+    """`scripts/dev/install_hooks.sh` 는 `scripts/hooks/*` 를 심는다 — 소스가 없으면 영원히 미설치.
+
+    이 한 줄이 #1070 의 결함 그 자체다. 설치기도 게이트 스크립트도 멀쩡했고, 없는 것은
+    둘을 잇는 파일 하나였다.
+    """
+    assert HOOK.is_file(), f"{HOOK} 부재 — make setup-hooks 가 pre-push 를 설치할 수 없다"
+
+
+@pytest.mark.parametrize("gate_rc", [0, 1])
+def test_hook_propagates_the_gate_exit_code(tmp_path, gate_rc):
+    """게이트가 낸 판정을 그대로 push 차단 여부로 옮긴다.
+
+    두 방향을 다 잠근다 — 1 을 삼키면 게이트가 무력해지고, 0 을 1 로 만들면 상시 red 가
+    되어 `--no-verify` 가 습관이 된다. 둘 다 결과적으로 absent gate 다.
+
+    실제 레포 상태(작업 트리 dirty · lint · 문서 카운트)에 의존하지 않도록 게이트를
+    스텁으로 갈아끼운 임시 레포에서 실행한다.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "scripts" / "verify").mkdir(parents=True)
+    argv_log = tmp_path / "argv.txt"
+    (tmp_path / GATE_REL).write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$@" > {argv_log}\nexit {gate_rc}\n',
+        encoding="utf-8",
+    )
+    hook_copy = tmp_path / "scripts" / "hooks" / "pre-push"
+    hook_copy.parent.mkdir(parents=True)
+    shutil.copy2(HOOK, hook_copy)
+
+    proc = subprocess.run(
+        ["bash", str(hook_copy), "origin", "git@example.invalid:x/y.git"],
+        cwd=tmp_path,
+        input=_PUSH_LINE + "\n",
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == gate_rc, f"게이트 rc={gate_rc} 인데 훅은 rc={proc.returncode}"
+    assert argv_log.read_text(encoding="utf-8").split() == ["--skip-tests"], (
+        "테스트 단계는 CI 4-shard 가 미러한다 — 훅이 full 모드로 돌면 320.8s 라 우회당한다"
+    )
+
+
+def test_missing_gate_blocks_instead_of_passing_silently(tmp_path):
+    """게이트 스크립트가 없으면 통과가 아니라 차단이다 — '미검증' 은 '깨끗함' 이 아니다."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    hook_copy = tmp_path / "scripts" / "hooks" / "pre-push"
+    hook_copy.parent.mkdir(parents=True)
+    shutil.copy2(HOOK, hook_copy)
+
+    proc = subprocess.run(
+        ["bash", str(hook_copy), "origin", "git@example.invalid:x/y.git"],
+        cwd=tmp_path,
+        input=_PUSH_LINE + "\n",
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0, "게이트 부재를 exit 0 으로 넘기면 훅이 있으나 마나다"
+
+
+def test_absent_interpreter_reports_non_execution_not_a_finding():
+    """python 이 없으면 그렇게 말한다 — 다른 단계의 '발견' 으로 위장하지 않는다.
+
+    `$PYTHON` 은 존재 확인 없는 경로라, 없으면 각 단계가 rc=127 로 죽고 그 단계의 `if`
+    가 그것을 자기 발견으로 보고한다. `.venv` 없는 clone 에서 "Personal financial data
+    leak detected" 가 찍히는데 스캐너는 한 번도 돈 적이 없다 — 실패와 미실행이 구분
+    안 되는 형태(#910/#911)다. 훅으로 돌 때 이 거짓말은 곧 `--no-verify` 습관이 된다.
+
+    Mutation lock: preflight 를 걷어내면 출력이 유출 주장으로 바뀌어 FAIL.
+    """
+    proc = subprocess.run(
+        ["bash", GATE_REL, "--skip-tests"],
+        cwd=REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin", "PYTHON": "/nonexistent/python", "HOME": str(Path.home())},
+        capture_output=True,
+        text=True,
+    )
+    out = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, "검사를 못 돌렸는데 통과시키면 안 된다"
+    assert "인터프리터 없음" in out, f"미실행을 미실행이라고 말하지 않는다:\n{out}"
+    assert "leak detected" not in out, f"미실행을 유출 발견으로 보고했다:\n{out}"


### PR DESCRIPTION
Closes #1070

## 증상

`scripts/verify/pre_push_check.sh` 는 존재했고, 실행권한도 있었고, 손으로 돌리면 전 항목을
통과했다. 그런데 `scripts/hooks/` 에 `pre-push` 소스가 없어서 `make setup-hooks` 가
**정상 동작하면서 아무것도 설치하지 않았다.** STRATEGY §4.4.1 이 선언한 3층 방어 중
2층(로컬 pre-push)이 통째로 비어 있었고, `.claude/rules/enforcement.md` 와 `README.md:36`
은 그 내내 게이트가 도는 것처럼 적혀 있었다.

dead gate 가 아니라 **absent gate** 라 더 조용하다 — #910/#911(rc=127) 과 #953/#954(exit 0)
는 최소한 exit code 라도 남겼지만, 실행 자체가 없으면 로그도 exit code 도 없다.

## 변경

1. **`scripts/hooks/pre-push`** — `make setup-hooks` 가 심는 얇은 래퍼.
   `pre_push_check.sh --skip-tests` 를 호출한다.
   - `--skip-tests` 인 이유: 테스트 단계는 CI 4-shard 가 미러하고 로컬 full 은 320.8s 다.
     **느린 훅은 우회당한 훅**이고, 우회당한 훅은 다시 absent gate 다. CI 가 대체할 수 없는
     것(commit message privacy — push 되는 순간 history 에 박힌다, PR #202)은 전부 돈다.
     실측 **0.87s**. full parity 는 `bash scripts/verify/pre_push_check.sh` 로 유지.
   - 게이트 스크립트가 없으면 exit 0 이 아니라 차단한다. "미검증" 은 "깨끗함" 이 아니다.

2. **`pre_push_check.sh` 인터프리터 preflight** — 별개로 발견한 거짓 보고.
   `$PYTHON` 은 존재 확인 없는 경로(`_common.sh`)라, `.venv` 없는 clone 에서는 python
   단계들이 rc=127 로 죽고 각 단계의 `if` 가 그것을 **자기 발견으로 보고**한다. 실제 실측:

   ```
   ━━━ 4. Privacy Leak Scan (files) ━━━
   .venv/bin/python: No such file or directory
   ✗ Personal financial data leak detected — see above
   ```

   스캐너는 한 번도 돈 적이 없다. 훅으로 돌 때 이 거짓말은 곧 `--no-verify` 습관이 된다.

3. **문서** — `docs/DEVELOPER_GUIDE.md` 의 "손으로 `.git/hooks/pre-push` 를 만들어라"
   안내를 `make setup-hooks` 로 교체(손 설치가 이번 누락의 원인이다), `enforcement.md` 에
   실제로 무엇이 도는지 + Gotcha-Test Pair cite.

## 테스트 (Gotcha-Test Pair)

`tests/test_pre_push_hook.py` — 훅을 grep 하지 않고 임시 git 레포에서 **실행해 exit code
만** 본다. 게이트는 스텁이라 실제 레포의 작업 트리 상태에 의존하지 않는다.

뮤테이션 5종 전부 검출 실측:

| 뮤테이션 | 떨어지는 테스트 |
|---|---|
| 훅 소스 삭제 | 3 FAIL |
| `--skip-tests` → full | 2 FAIL |
| 게이트 exit code 삼킴 | 1 FAIL |
| 게이트 부재 가드 `exit 1`→`exit 0` | 1 FAIL |
| 인터프리터 preflight 제거 | 1 FAIL |

`shellcheck` clean (`scripts/hooks/*` 는 `.sh` 가 아니라 CI shell-lint 대상 밖이므로 수동 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)