### PR TITLE
feat(alerts): surface a FAILing critical input as a card instead of only a color

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -62,6 +62,7 @@
     "Calmar",
     "Chriss",
     "Chronos",
+    "Citi",
     "Cooldown",
     "Creds",
     "DALBAR",

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ docs/OPERATIONS.md
 docs/HARNESS_AUDIT.md
 docs/TRADING_AUDIT.md
 docs/SOURCE_OF_TRUTH.md
+# 의사결정 시스템 로드맵 — 사용자 목표·계좌 전략·미배선 약점 서술이라 public 가치 없고
+# 취약점 지도에 가깝다. 사용자 결정 (2026-08-18): local-only.
+docs/DECISION_SYSTEM_ROADMAP.md
 
 # TLS/SSL 인증서 + 개인 키 (defense-in-depth)
 *.pem

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,171 collected across 327 files | |
+| **Backend tests** | 7,172 collected across 327 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,169 collected across 327 files | |
+| **Backend tests** | 7,171 collected across 327 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,163 collected across 327 files | |
+| **Backend tests** | 7,169 collected across 327 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,163 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,169 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,171 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,172 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,169 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,171 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,169 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,171 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,163 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,169 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,171 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,172 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -15,6 +15,11 @@ stop/target price_levels 금지**(REBALANCE 는 alpha exit 가 아님). 문구�
 재사용(per-account, 통화정확, 팩터정렬). 손절/레버리지 위반은 여기서 제외
 (손절 = Tier 1a alpha 축, 중복 방지).
 
+Tier 1e (`INPUT_STALE`, #1090) 는 이 셋과 성격이 다르다 — **포지션 신호가 아니라 관측
+신뢰도 경고**다. 그래서 축(`alpha_action`/`portfolio_action`)을 만들지 않는다. 포트폴리오가
+15일(360.5h) 낡은 채로 지나간 적이 있는데, `get_freshness_summary` 는 정상 동작했지만 결과가
+프리마켓 임베드 **색**으로만 표현돼 사용자가 매일 읽는 카드 스트림에 안 떴다.
+
 Privacy: Discord private 채널이므로 ticker+비중 노출 OK. 테스트는 합성 티커만.
 """
 
@@ -246,6 +251,98 @@ def stage_sleeve_briefs(date: Optional[str] = None, db_path: Optional[Path] = No
     return staged
 
 
+#: 낡아도 카드를 내지 않는 소스. 여기 있는 것은 "낡음이 판단을 왜곡하지 않는다" 는
+#: 주장이므로 추가할 때는 왜 그런지 같이 적을 것. 지금은 비어 있다 — 7개 정책 전부
+#: 판단 입력이다.
+FRESHNESS_CARD_EXEMPT: tuple[str, ...] = ()
+
+
+def scan_stale_inputs(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
+    """신선도 FAIL 인 데이터 소스 목록 (Tier 1e, #1090).
+
+    **매매 신호가 아니라 관측 신뢰도 경고다.** 포트폴리오·가격·팩터는 방어 규칙 전부의
+    입력이라, 낡은 입력 위에서 계산된 비중·섹터·손절 판단은 정밀한 헛소리가 된다.
+
+    WARN 은 카드로 내지 않는다 — 주가/팩터가 주말이면 정상적으로 WARN 에 머무르므로
+    매주 발화하는 소음이 되고, 소음이 된 알림은 읽히지 않는다. FAIL 만 낸다.
+    """
+    from nuri.core.freshness import check_all_freshness
+
+    return [d for d in check_all_freshness(db_path) if d["status"] == "FAIL" and d["key"] not in FRESHNESS_CARD_EXEMPT]
+
+
+#: 소스별 조치. 카드에 **틀린 조치**를 적으면 없느니만 못하다 — 가격이 낡은데
+#: "portfolio.yaml 을 갱신하라" 고 하면 사용자가 엉뚱한 곳을 보고 진짜 원인은 남는다.
+#: 미등재 키는 일반 문구로 떨어진다(새 정책이 추가돼도 죽지 않는다).
+_REMEDY: dict[str, str] = {
+    "portfolio": "config/portfolio.yaml 을 실제 잔고로 갱신 후 재동기화 (수동 원장 — 자동 import 는 낡은 값을 최신으로 재기록할 뿐)",
+    "prices": "가격 수집 잡 상태 확인 (scheduler collect)",
+    "factors": "팩터 합성 잡 상태 확인 — BUY 점수의 최대 입력이다",
+    "macro_vix": "VIX 수집 확인 — VIX 게이트가 이 값으로 신규 매수를 막는다",
+    "macro_fear_greed": "Fear & Greed 수집 확인",
+    "consensus": "합의 잡(07:05) 실행 여부 확인",
+    "certification": "SIEGE 인증 실행 여부 확인",
+}
+
+
+def _remedy(key: str) -> str:
+    return _REMEDY.get(key, "해당 수집 경로 점검")
+
+
+def _build_stale_input_payload(entry: dict[str, Any], date: str) -> dict[str, Any]:
+    """신선도 FAIL 1건 → #brief INPUT_STALE payload.
+
+    **축을 만들지 않는다.** `alpha_action`/`portfolio_action` 둘 다 없다 — 이건 종목에
+    대한 판단이 아니라 "지금 나오는 판단을 믿지 말라" 는 메타 경고다. 축을 붙이면
+    렌더러와 소비자가 이것을 매매 신호로 읽고, 관측이 본 작업을 게이트하게 된다 (#894).
+
+    Privacy: `label` 은 config 의 공개 라벨(`주가 데이터` / `포트폴리오 sync`)이고
+    age 는 시간 수치라 계좌·보유·금액이 섞이지 않는다.
+    """
+    age = entry.get("age_hours")
+    if not isinstance(age, (int, float)):
+        # `age_hours=None` 은 "낡음" 이 아니라 **행이 하나도 없음**(또는 날짜 파싱 실패)이다.
+        # 둘을 같은 문구로 내면 "며칠 지났나" 를 찾다가 실제 상태(수집 자체가 안 됨)를
+        # 놓친다. 여기서 죽던 것을 스모크 테스트가 잡았다 — 빈 소스가 흔한 FAIL 이다.
+        state = "데이터 없음"
+    else:
+        state = f"{age / 24:.0f}일 낡음" if age >= 48 else f"{age:.0f}시간 낡음"
+    return {
+        "kind": "INPUT_STALE",
+        "ticker": f"입력({entry['label']})",
+        "reason": f"{state} — 이 입력에 기대는 판단을 그대로 믿지 말 것. {_remedy(entry['key'])}",
+        "date": date,
+    }
+
+
+def stage_stale_input_briefs(date: Optional[str] = None, db_path: Optional[Path] = None) -> int:
+    """신선도 FAIL 을 #brief outbox 에 INPUT_STALE 로 stage. staged 건수 반환.
+
+    dedupe_key=`input-stale:{key}:{date}` — 소스 × 하루 1건. priority="high": 낡은 입력은
+    그날 나온 **모든** 다른 카드의 신뢰도를 깎으므로 개별 REBALANCE 보다 먼저 읽혀야 한다.
+
+    이 카드가 없던 동안 포트폴리오가 15일(360.5h) 낡은 채로 지나갔다 — `get_freshness_summary`
+    는 정상 동작했지만 결과가 프리마켓 임베드 **색**으로만 표현돼 카드 스트림에 안 떴다.
+    """
+    from nuri.agents.discord.outbox import stage_brief
+
+    d = date or today_kst()
+    staged = 0
+    for entry in scan_stale_inputs(db_path=db_path):
+        outbox_id = stage_brief(
+            payload=_build_stale_input_payload(entry, d),
+            dedupe_key=f"input-stale:{entry['key']}:{d}",
+            priority="high",
+            actor_name="portfolio-signals",
+            db_path=db_path,
+        )
+        if outbox_id is not None:
+            staged += 1
+    if staged:
+        logger.info("stale input briefs staged: %d", staged)
+    return staged
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="포트폴리오 드리프트(집중도·섹터·슬리브) → #brief REBALANCE (Tier 1b/1c/1d)"
@@ -256,9 +353,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     conc = scan_concentration_drift()
     sect = scan_sector_drift()
     sleeve = scan_sleeve_breach()
-    if not conc and not sect and not sleeve:
-        print("포트폴리오 드리프트 없음 (집중도·섹터·슬리브)")
+    stale = scan_stale_inputs()
+    if not conc and not sect and not sleeve and not stale:
+        print("포트폴리오 드리프트 없음 (집중도·섹터·슬리브) · 낡은 입력 없음")
         return 0
+    for e in stale:
+        print(f"  [입력낡음] {e['label']} {e['message']}")
     for v in conc:
         print(
             f"  [집중도] {v['ticker']} [{v.get('account', '?')}] {v['current_value']:.1f}% > 한도 {v['limit_value'] * 100:.0f}%"
@@ -268,10 +368,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     for v in sleeve:
         print(f"  [슬리브] {v['strategy']} {v['used_pct']:.1f}% > 상한 {v['cap_pct']:.0f}%")
     if args.dry_run:
-        print(f"[dry-run] 집중도 {len(conc)}건 · 섹터 {len(sect)}건 · 슬리브 {len(sleeve)}건 — stage 안 함")
+        print(
+            f"[dry-run] 집중도 {len(conc)}건 · 섹터 {len(sect)}건 · 슬리브 {len(sleeve)}건 "
+            f"· 낡은 입력 {len(stale)}건 — stage 안 함"
+        )
         return 0
-    staged = stage_concentration_briefs() + stage_sector_briefs() + stage_sleeve_briefs()
-    print(f"staged {staged}건 → #brief (REBALANCE)")
+    staged = stage_stale_input_briefs() + stage_concentration_briefs() + stage_sector_briefs() + stage_sleeve_briefs()
+    print(f"staged {staged}건 → #brief (INPUT_STALE + REBALANCE)")
     return 0
 
 

--- a/nuri/alerts/postmarket_brief.py
+++ b/nuri/alerts/postmarket_brief.py
@@ -687,6 +687,14 @@ def write_brief(
     # 다른 쪽 stage 를 막지 않게 — Tier 1a stop-breach 와 동일 per-concern 패턴).
     if session == "us":
         try:
+            # 먼저 stage 한다 — 낡은 입력은 뒤따르는 카드 전부의 신뢰도를 깎으므로
+            # 그것들보다 위에서 읽혀야 한다 (priority="high").
+            from nuri.alerts.portfolio_signals import stage_stale_input_briefs
+
+            stage_stale_input_briefs(d, db_path=db_path)
+        except Exception:
+            logger.warning("stale input brief staging 실패 (브리프 자체는 생성됨)", exc_info=True)
+        try:
             from nuri.alerts.portfolio_signals import stage_concentration_briefs
 
             stage_concentration_briefs(d, db_path=db_path)

--- a/tests/alerts/conftest.py
+++ b/tests/alerts/conftest.py
@@ -2,6 +2,7 @@
 
 Auto-loaded by pytest.
 """
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -28,28 +29,54 @@ def rich_db(tmp_path, monkeypatch):
     path = tmp_path / "test.db"
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10,
-         "avg_price": 190, "currency": "USD", "sector": "Tech"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5,
-         "avg_price": 130, "currency": "USD", "sector": "Semiconductor"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 190,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 130,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+        ],
+        path,
+    )
     dates = pd.date_range("2024-06-01", periods=500, freq="B")
     rows = []
     for t in ["SPY", "AAPL", "NVDA"]:
         base = {"SPY": 450, "AAPL": 170, "NVDA": 120}[t]
         for i, d in enumerate(dates):
             p = base + i * 0.2 + np.sin(i / 20) * 5
-            rows.append({"ticker": t, "date": d.strftime("%Y-%m-%d"),
-                         "open": p, "high": p + 3, "low": p - 2,
-                         "close": p + 1, "volume": 50000000, "adj_close": p + 1})
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 3,
+                    "low": p - 2,
+                    "close": p + 1,
+                    "volume": 50000000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
-    vix = [{"indicator": "vix", "date": d.strftime("%Y-%m-%d"),
-            "value": 15 + np.sin(i / 30) * 8, "source": "test"}
-           for i, d in enumerate(dates)]
-    fg = [{"indicator": "fear_greed", "date": d.strftime("%Y-%m-%d"),
-           "value": 50 + np.sin(i / 25) * 30, "source": "test"}
-          for i, d in enumerate(dates)]
+    vix = [
+        {"indicator": "vix", "date": d.strftime("%Y-%m-%d"), "value": 15 + np.sin(i / 30) * 8, "source": "test"}
+        for i, d in enumerate(dates)
+    ]
+    fg = [
+        {"indicator": "fear_greed", "date": d.strftime("%Y-%m-%d"), "value": 50 + np.sin(i / 25) * 30, "source": "test"}
+        for i, d in enumerate(dates)
+    ]
     upsert_macro(vix + fg, path)
     return path
 
@@ -63,14 +90,35 @@ def db_with_portfolio(tmp_path, monkeypatch):
     init_db(path)
     monkeypatch.setattr(db_mod, "DB_PATH", path)
 
-    upsert_portfolio([
-        {"account": "test", "ticker": "AAPL", "quantity": 10, "avg_price": 190,
-         "currency": "USD", "sector": "Tech"},
-        {"account": "test", "ticker": "NVDA", "quantity": 5, "avg_price": 130,
-         "currency": "USD", "sector": "Semiconductor"},
-        {"account": "test", "ticker": "005930.KS", "quantity": 4, "avg_price": 60000,
-         "currency": "KRW", "sector": "Semiconductor"},
-    ], path)
+    upsert_portfolio(
+        [
+            {
+                "account": "test",
+                "ticker": "AAPL",
+                "quantity": 10,
+                "avg_price": 190,
+                "currency": "USD",
+                "sector": "Tech",
+            },
+            {
+                "account": "test",
+                "ticker": "NVDA",
+                "quantity": 5,
+                "avg_price": 130,
+                "currency": "USD",
+                "sector": "Semiconductor",
+            },
+            {
+                "account": "test",
+                "ticker": "005930.KS",
+                "quantity": 4,
+                "avg_price": 60000,
+                "currency": "KRW",
+                "sector": "Semiconductor",
+            },
+        ],
+        path,
+    )
 
     dates = pd.date_range("2025-01-01", periods=30, freq="B")
     rows = []
@@ -78,16 +126,26 @@ def db_with_portfolio(tmp_path, monkeypatch):
         base = {"AAPL": 190, "NVDA": 130, "SPY": 550, "005930.KS": 60000}.get(t, 100)
         for i, d in enumerate(dates):
             p = base + i * 0.5
-            rows.append({
-                "ticker": t, "date": d.strftime("%Y-%m-%d"),
-                "open": p, "high": p + 2, "low": p - 1,
-                "close": p + 1, "volume": 1_000_000, "adj_close": p + 1,
-            })
+            rows.append(
+                {
+                    "ticker": t,
+                    "date": d.strftime("%Y-%m-%d"),
+                    "open": p,
+                    "high": p + 2,
+                    "low": p - 1,
+                    "close": p + 1,
+                    "volume": 1_000_000,
+                    "adj_close": p + 1,
+                }
+            )
     upsert_prices(pd.DataFrame(rows), path)
 
-    upsert_macro([
-        {"indicator": "fear_greed", "date": "2025-01-30", "value": 55.0, "source": "CNN"},
-        {"indicator": "vix", "date": "2025-01-30", "value": 18.5, "source": "test"},
-    ], path)
+    upsert_macro(
+        [
+            {"indicator": "fear_greed", "date": "2025-01-30", "value": 55.0, "source": "CNN"},
+            {"indicator": "vix", "date": "2025-01-30", "value": 18.5, "source": "test"},
+        ],
+        path,
+    )
 
     return path

--- a/tests/alerts/test_daily_report.py
+++ b/tests/alerts/test_daily_report.py
@@ -1,4 +1,5 @@
 """Tests for nuri.alerts.daily_report."""
+
 import sys
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,7 @@ class TestGenerateReport:
         monkeypatch.setattr("nuri.alerts.daily_report.analyze_risk", lambda **kw: {})
 
         from nuri.alerts.daily_report import generate_report
+
         embed = generate_report()
         assert isinstance(embed, dict)
         assert "fields" in embed
@@ -33,6 +35,7 @@ class TestGenerateReport:
         upsert_macro([{"indicator": "fear_greed", "date": today, "value": 55.0, "source": "test"}], db_path)
 
         from nuri.alerts.daily_report import generate_report
+
         embed = generate_report()
         assert isinstance(embed, dict)
 
@@ -48,12 +51,21 @@ class TestGenerateReport:
             "has_critical": True,
             "total_violations": 1,
             "total_recovery_usd": 1100,
-            "actions": [{"ticker": "TSLL", "severity": "critical", "action": "SELL_ALL",
-                         "sell_shares": 96, "reason": "레버리지 ETF", "sell_value_usd": 1100}],
+            "actions": [
+                {
+                    "ticker": "TSLL",
+                    "severity": "critical",
+                    "action": "SELL_ALL",
+                    "sell_shares": 96,
+                    "reason": "레버리지 ETF",
+                    "sell_value_usd": 1100,
+                }
+            ],
         }
 
         with patch("nuri.analysis.rebalance_advisor.generate_advisor_report", return_value=mock_report):
             from nuri.alerts.daily_report import generate_report
+
             embed = generate_report()
 
         assert any("규칙 위반" in f.get("name", "") for f in embed.get("fields", []))
@@ -63,6 +75,7 @@ class TestSendDiscord:
     def test_no_webhook(self, monkeypatch):
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         from nuri.alerts.daily_report import send_discord
+
         result = send_discord({"title": "test"})
         assert result is False
 
@@ -70,6 +83,7 @@ class TestSendDiscord:
 class TestPrintReport:
     def test_output(self, capsys):
         from nuri.alerts.daily_report import print_report
+
         embed = {"title": "Test Report", "fields": [{"name": "X", "value": "Y"}]}
         print_report(embed)
         output = capsys.readouterr().out
@@ -87,17 +101,16 @@ class TestDailyReport:
         mock_df = pd.DataFrame({"ticker": ["AAPL"], "value": [1900]})
         mock_df.attrs["total_value_usd"] = 1900
         mock_df.attrs["warnings"] = ["Single position too large"]
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio",
-                            lambda: mock_df)
+        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio", lambda: mock_df)
 
         # Mock analyze_risk
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_risk",
-                            lambda: {"sharpe_ratio": 1.5, "max_drawdown_pct": -8.0,
-                                     "var_95_daily_pct": -2.5, "stop_loss_alerts": []})
+        monkeypatch.setattr(
+            "nuri.alerts.daily_report.analyze_risk",
+            lambda: {"sharpe_ratio": 1.5, "max_drawdown_pct": -8.0, "var_95_daily_pct": -2.5, "stop_loss_alerts": []},
+        )
 
         # Mock rebalance advisor
-        monkeypatch.setattr("nuri.alerts.daily_report.generate_report.__module__",
-                            "nuri.alerts.daily_report")
+        monkeypatch.setattr("nuri.alerts.daily_report.generate_report.__module__", "nuri.alerts.daily_report")
 
         embed = generate_report()
         assert "title" in embed
@@ -107,10 +120,8 @@ class TestDailyReport:
     def test_generate_report_empty_portfolio(self, monkeypatch, db_with_portfolio):
         from nuri.alerts.daily_report import generate_report
 
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio",
-                            lambda: pd.DataFrame())
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_risk",
-                            lambda: {})
+        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio", lambda: pd.DataFrame())
+        monkeypatch.setattr("nuri.alerts.daily_report.analyze_risk", lambda: {})
 
         embed = generate_report()
         assert embed["fields"][0]["value"] == "$0"
@@ -121,11 +132,11 @@ class TestDailyReport:
         mock_df = pd.DataFrame({"ticker": ["AAPL"]})
         mock_df.attrs["total_value_usd"] = 1900
         mock_df.attrs["warnings"] = []
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio",
-                            lambda: mock_df)
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_risk",
-                            lambda: {"sharpe_ratio": 1.0, "max_drawdown_pct": -5.0,
-                                     "var_95_daily_pct": -1.5, "stop_loss_alerts": []})
+        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio", lambda: mock_df)
+        monkeypatch.setattr(
+            "nuri.alerts.daily_report.analyze_risk",
+            lambda: {"sharpe_ratio": 1.0, "max_drawdown_pct": -5.0, "var_95_daily_pct": -1.5, "stop_loss_alerts": []},
+        )
 
         # Mock rebalance_advisor — it is lazy-imported inside generate_report
         mock_rebalance = {
@@ -133,9 +144,14 @@ class TestDailyReport:
             "total_violations": 2,
             "total_recovery_usd": 5000,
             "actions": [
-                {"severity": "critical", "action": "SELL_ALL",
-                 "ticker": "AAPL", "sell_shares": 10, "reason": "stop-loss",
-                 "sell_value_usd": 1900},
+                {
+                    "severity": "critical",
+                    "action": "SELL_ALL",
+                    "ticker": "AAPL",
+                    "sell_shares": 10,
+                    "reason": "stop-loss",
+                    "sell_value_usd": 1900,
+                },
             ],
         }
         mock_module = MagicMock()
@@ -148,6 +164,7 @@ class TestDailyReport:
 
     def test_send_discord_no_webhook(self, monkeypatch, db_with_portfolio):
         from nuri.alerts.daily_report import send_discord
+
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
         result = send_discord({"title": "test", "fields": []})
         assert result is False
@@ -161,6 +178,7 @@ class TestDailyReport:
         mock_resp.raise_for_status = MagicMock()
 
         import requests as req_mod
+
         monkeypatch.setattr(req_mod, "post", MagicMock(return_value=mock_resp))
 
         result = send_discord({"title": "test", "fields": []})
@@ -168,6 +186,7 @@ class TestDailyReport:
 
     def test_print_report(self, capsys, db_with_portfolio):
         from nuri.alerts.daily_report import print_report
+
         embed = {
             "title": "Test Report",
             "fields": [
@@ -182,8 +201,7 @@ class TestDailyReport:
     def test_main(self, monkeypatch, db_with_portfolio, capsys):
         from nuri.alerts.daily_report import main
 
-        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio",
-                            lambda: pd.DataFrame())
+        monkeypatch.setattr("nuri.alerts.daily_report.analyze_portfolio", lambda: pd.DataFrame())
         monkeypatch.setattr("nuri.alerts.daily_report.analyze_risk", lambda: {})
         monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
 

--- a/tests/alerts/test_formatters.py
+++ b/tests/alerts/test_formatters.py
@@ -7,7 +7,12 @@ class TestFormatters:
 
         embed = format_daily_report(
             portfolio_summary={"total_value_usd": 50000, "warnings": []},
-            risk_metrics={"sharpe_ratio": 1.5, "max_drawdown_pct": -5.0, "var_95_daily_pct": -2.0, "stop_loss_alerts": []},
+            risk_metrics={
+                "sharpe_ratio": 1.5,
+                "max_drawdown_pct": -5.0,
+                "var_95_daily_pct": -2.0,
+                "stop_loss_alerts": [],
+            },
             fear_greed=45.0,
         )
         assert "title" in embed
@@ -29,9 +34,11 @@ class TestFormatters:
     def test_ark_alert(self):
         from nuri.alerts.formatters import format_ark_alert
 
-        embed = format_ark_alert([
-            {"ticker": "TSLA", "direction": "Buy", "shares": 50000, "fund": "ARKK"},
-        ])
+        embed = format_ark_alert(
+            [
+                {"ticker": "TSLA", "direction": "Buy", "shares": 50000, "fund": "ARKK"},
+            ]
+        )
         assert "ARK" in embed["title"]
         assert "TSLA" in embed["description"]
 
@@ -61,6 +68,7 @@ class TestFormatters:
 class TestAlerts_R10:
     def test_format_daily_report(self, rich_db):
         from nuri.alerts.formatters import format_daily_report
+
         report = format_daily_report(
             portfolio_summary={"total_value": 10000, "holdings": 2},
             risk_metrics={"sharpe": 1.5, "mdd": -0.05},
@@ -70,6 +78,7 @@ class TestAlerts_R10:
 
     def test_format_price_alert(self):
         from nuri.alerts.formatters import format_price_alert
+
         alert = format_price_alert("AAPL", 5.2, 200.0)
         assert isinstance(alert, dict)
 
@@ -79,21 +88,25 @@ class TestFormatters_R24:
 
     def test_format_daily_report_basic(self):
         from nuri.alerts.formatters import format_daily_report
+
         embed = format_daily_report(
             {"total_value_usd": 10000, "warnings": []},
-            {"sharpe_ratio": 1.5, "max_drawdown_pct": -8.0,
-             "var_95_daily_pct": -2.5, "stop_loss_alerts": []},
+            {"sharpe_ratio": 1.5, "max_drawdown_pct": -8.0, "var_95_daily_pct": -2.5, "stop_loss_alerts": []},
         )
         assert embed["title"].startswith("📋")
         assert len(embed["fields"]) >= 1
 
     def test_format_daily_report_with_warnings(self):
         from nuri.alerts.formatters import format_daily_report
+
         embed = format_daily_report(
             {"total_value_usd": 10000, "warnings": ["Warning 1"]},
-            {"sharpe_ratio": 0.5, "max_drawdown_pct": -15.0,
-             "var_95_daily_pct": -4.0,
-             "stop_loss_alerts": [{"ticker": "AAPL", "pnl_pct": -8.5}]},
+            {
+                "sharpe_ratio": 0.5,
+                "max_drawdown_pct": -15.0,
+                "var_95_daily_pct": -4.0,
+                "stop_loss_alerts": [{"ticker": "AAPL", "pnl_pct": -8.5}],
+            },
         )
         field_names = [f["name"] for f in embed["fields"]]
         assert any("경고" in n for n in field_names)
@@ -101,10 +114,10 @@ class TestFormatters_R24:
 
     def test_format_daily_report_with_fear_greed(self):
         from nuri.alerts.formatters import format_daily_report
+
         embed = format_daily_report(
             {"total_value_usd": 10000, "warnings": []},
-            {"sharpe_ratio": 1.0, "max_drawdown_pct": -5.0,
-             "var_95_daily_pct": -1.5, "stop_loss_alerts": []},
+            {"sharpe_ratio": 1.0, "max_drawdown_pct": -5.0, "var_95_daily_pct": -1.5, "stop_loss_alerts": []},
             fear_greed=75.0,
         )
         field_names = [f["name"] for f in embed["fields"]]
@@ -112,11 +125,11 @@ class TestFormatters_R24:
 
     def test_format_daily_report_with_events(self):
         from nuri.alerts.formatters import format_daily_report
+
         events = [{"date": "2025-01-31", "description": "FOMC Meeting"}]
         embed = format_daily_report(
             {"total_value_usd": 10000, "warnings": []},
-            {"sharpe_ratio": 1.0, "max_drawdown_pct": -5.0,
-             "var_95_daily_pct": -1.5, "stop_loss_alerts": []},
+            {"sharpe_ratio": 1.0, "max_drawdown_pct": -5.0, "var_95_daily_pct": -1.5, "stop_loss_alerts": []},
             events=events,
         )
         field_names = [f["name"] for f in embed["fields"]]
@@ -124,18 +137,21 @@ class TestFormatters_R24:
 
     def test_format_price_alert_up(self):
         from nuri.alerts.formatters import format_price_alert
+
         embed = format_price_alert("AAPL", 5.0, 200.0)
         assert "급등" in embed["title"]
         assert embed["color"] == 0x2ECC71  # Green
 
     def test_format_price_alert_down(self):
         from nuri.alerts.formatters import format_price_alert
+
         embed = format_price_alert("AAPL", -5.0, 180.0)
         assert "급락" in embed["title"]
         assert embed["color"] == 0xE74C3C  # Red
 
     def test_format_ark_alert(self):
         from nuri.alerts.formatters import format_ark_alert
+
         trades = [
             {"ticker": "AAPL", "direction": "BUY", "shares": 1000, "fund": "ARKK"},
             {"ticker": "NVDA", "direction": "SELL", "shares": 500, "fund": "ARKW"},
@@ -146,18 +162,20 @@ class TestFormatters_R24:
 
     def test_format_ark_alert_empty(self):
         from nuri.alerts.formatters import format_ark_alert
+
         embed = format_ark_alert([])
         assert "매매 내역 없음" in embed["description"]
 
     def test_format_event_reminder(self):
         from nuri.alerts.formatters import format_event_reminder
-        event = {"date": "2025-03-17", "description": "FOMC", "event_type": "fomc",
-                 "ticker": None}
+
+        event = {"date": "2025-03-17", "description": "FOMC", "event_type": "fomc", "ticker": None}
         embed = format_event_reminder(event)
         assert "FOMC" in embed["title"]
 
     def test_fear_greed_labels(self):
         from nuri.alerts.formatters import _fear_greed_label
+
         assert _fear_greed_label(10) == "극단적 공포"
         assert _fear_greed_label(30) == "공포"
         assert _fear_greed_label(50) == "중립"

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -461,11 +461,39 @@ def _stale_portfolio(db_path, days: int):
 
 
 def test_stale_scan_reports_fail_sources(db_path):
-    """FAIL 만 카드가 된다 — WARN 은 주말마다 발화해 소음이 되고, 소음은 읽히지 않는다."""
+    """FAIL 은 카드가 된다."""
     _stale_portfolio(db_path, 15)
     keys = {e["key"] for e in portfolio_signals.scan_stale_inputs(db_path=db_path)}
     assert "portfolio" in keys
     assert all(e["status"] == "FAIL" for e in portfolio_signals.scan_stale_inputs(db_path=db_path))
+
+
+def test_warn_never_becomes_a_card(db_path):
+    """WARN 은 카드가 아니다 — 주가/팩터는 주말마다 정상적으로 WARN 이라 매주 발화하면
+    소음이 되고, 소음이 된 알림은 읽히지 않는다.
+
+    빈 fixture 는 모든 소스가 FAIL("데이터 없음") 이라 WARN 을 하나 **만들어야** 이 축이
+    검증된다. certification 은 정책이 24h WARN / 48h FAIL 이고 컬럼이 ISO datetime 이라
+    30시간을 정확히 심을 수 있다. 이 테스트가 없으면 필터를 `("FAIL", "WARN")` 으로
+    넓혀도 스위트가 초록이다 (뮤테이션 실측 2026-08-18).
+    """
+    from datetime import timedelta
+
+    from nuri.core.db import get_db
+    from nuri.core.freshness import check_freshness
+    from nuri.core.timezone import kst_now
+
+    stamp = (kst_now() - timedelta(hours=30)).isoformat()
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO certifications (timestamp, certified, score, total_conditions, passed, failed,"
+            " warnings, conditions_json) VALUES (?, 0, 0, 0, 0, 0, 0, '[]')",
+            (stamp,),
+        )
+    assert check_freshness("certification", db_path=db_path)["status"] == "WARN", "전제 — WARN 을 못 만들었다"
+
+    keys = {e["key"] for e in portfolio_signals.scan_stale_inputs(db_path=db_path)}
+    assert "certification" not in keys, "WARN 이 카드가 됐다 — 매주 발화하는 소음이 된다"
 
 
 def test_stale_payload_carries_no_axis(db_path):

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -315,7 +315,14 @@ def test_cli_stages_when_not_dry_run(db_path, capsys):
     ):
         rc = portfolio_signals.main([])
     out = capsys.readouterr().out
-    assert rc == 0 and "staged 1" in out
+    # 총계가 아니라 **이 카드가 stage 됐는지**를 본다. 빈 fixture DB 는 신선도 FAIL 이
+    # 7건이라 Tier 1e 카드가 같이 나가므로 총계 단언은 무관한 이유로 깨진다 (#1090).
+    assert rc == 0 and "staged" in out
+    staged = query(
+        "SELECT COUNT(*) c FROM discord_outbox WHERE dedupe_key LIKE 'rebalance:position:TST_A:%'",
+        db_path=db_path,
+    )
+    assert staged[0]["c"] == 1
 
 
 def test_cli_no_breach(db_path, capsys):
@@ -337,7 +344,10 @@ def test_cli_shows_concentration_and_sector(db_path, capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "[집중도] TST_A" in out and "[섹터] Semiconductor" in out
-    assert "staged 2" in out  # 집중도 1 + 섹터 1
+    # 총계가 아니라 두 카드의 존재를 본다 (#1090 이 Tier 1e 를 같은 CLI 에 추가).
+    for pattern in ("rebalance:position:TST_A:%", "rebalance:sector:Semiconductor:%"):
+        rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE dedupe_key LIKE ?", (pattern,), db_path=db_path)
+        assert rows[0]["c"] == 1, pattern
 
 
 # ═══════════════════════════════════════════════════════
@@ -422,4 +432,94 @@ def test_cli_shows_sleeve_breach(db_path, capsys):
         rc = portfolio_signals.main([])
     out = capsys.readouterr().out
     assert rc == 0
-    assert "[슬리브] core" in out and "staged 1" in out
+    assert "[슬리브] core" in out
+    rows = query("SELECT COUNT(*) c FROM discord_outbox WHERE dedupe_key LIKE 'rebalance:sleeve:%'", db_path=db_path)
+    assert rows[0]["c"] == 1
+
+
+# ─── Tier 1e — 낡은 입력 → INPUT_STALE (#1090) ────────────────────────────────
+#
+# 포트폴리오가 15일(360.5h) 낡은 채로 지나간 적이 있다. `get_freshness_summary` 는
+# 정상 동작했지만 결과가 프리마켓 임베드 **색**으로만 표현돼, 사용자가 매일 읽는 카드
+# 스트림에는 한 줄도 뜨지 않았다. 그 사이 비중·섹터·손절 판단이 전부 낡은 보유 위에서
+# 계산됐다. 아래는 그 카드가 실제로 나가는지 · 축을 만들지 않는지 · 틀린 조치를 적지
+# 않는지를 잠근다.
+
+
+def _stale_portfolio(db_path, days: int):
+    from datetime import timedelta
+
+    from nuri.core.db import get_db
+    from nuri.core.timezone import kst_now
+
+    stamp = (kst_now() - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO portfolio (ticker, account, quantity, avg_price, updated_at) VALUES (?,?,?,?,?)",
+            ("TST_STALE", "Brokerage Alpha", 1, 1.0, stamp),
+        )
+
+
+def test_stale_scan_reports_fail_sources(db_path):
+    """FAIL 만 카드가 된다 — WARN 은 주말마다 발화해 소음이 되고, 소음은 읽히지 않는다."""
+    _stale_portfolio(db_path, 15)
+    keys = {e["key"] for e in portfolio_signals.scan_stale_inputs(db_path=db_path)}
+    assert "portfolio" in keys
+    assert all(e["status"] == "FAIL" for e in portfolio_signals.scan_stale_inputs(db_path=db_path))
+
+
+def test_stale_payload_carries_no_axis(db_path):
+    """축을 붙이면 소비자가 이걸 매매 신호로 읽는다 — 관측이 본 작업을 게이트하면 안 된다 (#894).
+
+    Mutation lock: payload 에 alpha_action/portfolio_action 을 넣으면 FAIL.
+    """
+    _stale_portfolio(db_path, 15)
+    entry = [e for e in portfolio_signals.scan_stale_inputs(db_path=db_path) if e["key"] == "portfolio"][0]
+    payload = portfolio_signals._build_stale_input_payload(entry, today_kst())
+    assert payload["kind"] == "INPUT_STALE"
+    assert "alpha_action" not in payload and "portfolio_action" not in payload
+    assert "price_levels" not in payload
+    assert "일 낡음" in payload["reason"]
+
+
+def test_stale_payload_gives_the_remedy_for_that_source(db_path):
+    """카드에 **틀린 조치**를 적으면 없느니만 못하다 — 가격이 낡은데 yaml 을 고치라고 하면 안 된다."""
+    _stale_portfolio(db_path, 15)
+    by_key = {e["key"]: e for e in portfolio_signals.scan_stale_inputs(db_path=db_path)}
+    port = portfolio_signals._build_stale_input_payload(by_key["portfolio"], today_kst())["reason"]
+    price = portfolio_signals._build_stale_input_payload(by_key["prices"], today_kst())["reason"]
+    assert "portfolio.yaml" in port
+    assert "portfolio.yaml" not in price, "가격 카드에 포트폴리오 조치가 붙었다"
+    assert "가격 수집" in price
+
+
+def test_missing_data_is_not_reported_as_staleness(db_path):
+    """`age_hours=None` 은 '낡음' 이 아니라 '행이 없음' 이다 — 같은 문구면 진짜 상태를 놓친다.
+
+    Mutation lock: None 분기를 지우면 포맷 문자열이 TypeError 로 죽어 FAIL.
+    """
+    entry = [e for e in portfolio_signals.scan_stale_inputs(db_path=db_path) if e["key"] == "prices"][0]
+    assert entry["age_hours"] is None
+    assert "데이터 없음" in portfolio_signals._build_stale_input_payload(entry, today_kst())["reason"]
+
+
+def test_stale_staging_is_high_priority_and_dedupes(db_path):
+    """낡은 입력은 그날 다른 카드 전부의 신뢰도를 깎으므로 REBALANCE(normal) 보다 먼저 읽혀야 한다."""
+    _stale_portfolio(db_path, 15)
+    d = today_kst()
+    first = portfolio_signals.stage_stale_input_briefs(d, db_path=db_path)
+    assert first > 0
+    assert portfolio_signals.stage_stale_input_briefs(d, db_path=db_path) == 0, "하루 1건 dedupe 안 됨"
+
+    rows = query(
+        "SELECT priority, payload_json FROM discord_outbox WHERE dedupe_key LIKE 'input-stale:portfolio:%'",
+        db_path=db_path,
+    )
+    assert rows and rows[0]["priority"] == "high"
+    assert json.loads(rows[0]["payload_json"])["kind"] == "INPUT_STALE"
+
+
+def test_fresh_inputs_stage_nothing(db_path):
+    """상시 발화하면 우회당한다 — 전부 PASS 면 카드가 없어야 한다."""
+    with patch.object(portfolio_signals, "scan_stale_inputs", return_value=[]):
+        assert portfolio_signals.stage_stale_input_briefs(today_kst(), db_path=db_path) == 0

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -326,9 +326,20 @@ def test_cli_stages_when_not_dry_run(db_path, capsys):
 
 
 def test_cli_no_breach(db_path, capsys):
-    with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]):
+    """위반도 낡은 입력도 없으면 조기 종료한다.
+
+    `scan_stale_inputs` 도 같이 비워야 한다 — 빈 fixture 는 모든 소스가 FAIL 이라
+    Tier 1e 가 "데이터 없음" 줄을 찍고, 그 안의 "없음" 에 단언이 우연히 걸려 통과했다
+    (#1090 이후 실측). 조기 종료 경로 자체는 밟히지 않은 채였다.
+    """
+    with (
+        patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]),
+        patch.object(portfolio_signals, "scan_stale_inputs", return_value=[]),
+    ):
         rc = portfolio_signals.main([])
-    assert rc == 0 and "없음" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "포트폴리오 드리프트 없음" in out and "낡은 입력 없음" in out
 
 
 def test_cli_shows_concentration_and_sector(db_path, capsys):

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -250,6 +250,30 @@ def test_write_brief_stages_stale_input_cards(seeded_db, portfolio_yaml):
     assert stale_spy.call_args[0][0] == "2026-05-01"
 
 
+def test_write_brief_survives_stale_input_staging_error(seeded_db, portfolio_yaml):
+    """Tier 1e staging 이 raise 해도 (1) write_brief 는 정상 반환 + (2) 뒤따르는
+    집중도 stage 는 여전히 시도된다.
+
+    관측(입력 신선도)이 본 작업(브리프 생성)을 죽이면 안 된다 — #894 와 같은 형태다.
+    per-concern best-effort 패턴을 Tier 1e 에도 적용했는지 잠근다.
+    """
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    conc_spy = MagicMock(return_value=0)
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_stale_input_briefs", side_effect=RuntimeError("boom")),
+        patch("nuri.alerts.portfolio_signals.stage_concentration_briefs", conc_spy),
+    ):
+        path = write_brief("us", date="2026-05-01")
+
+    assert path is not None, "관측 실패가 브리프 생성을 죽였다"
+    conc_spy.assert_called_once(), "앞 tier 실패가 뒤 tier 를 막았다"
+
+
 def test_write_brief_survives_portfolio_drift_staging_error(seeded_db, portfolio_yaml):
     """집중도 staging 이 raise 해도 (1) write_brief 는 정상 반환 + (2) 섹터는 여전히
     시도됨 (독립 best-effort — 한쪽 실패가 다른 쪽을 막지 않음)."""

--- a/tests/alerts/test_postmarket_brief.py
+++ b/tests/alerts/test_postmarket_brief.py
@@ -227,6 +227,29 @@ def test_write_brief_stages_portfolio_drift_us_only(seeded_db, portfolio_yaml):
     assert sect_spy.call_args[0][0] == "2026-05-01"
 
 
+def test_write_brief_stages_stale_input_cards(seeded_db, portfolio_yaml):
+    """Tier 1e 배선 (#1090) — 낡은 입력 카드가 브리프에서 stage 되는가.
+
+    배선을 지우면 FAIL. 이게 없던 동안 포트폴리오가 15일 낡은 채로 지나갔고, 카드
+    스트림에는 한 줄도 안 떴다 (freshness 는 임베드 색으로만 표현됐다).
+    """
+    from unittest.mock import MagicMock
+
+    from nuri.alerts.postmarket_brief import write_brief
+
+    stale_spy = MagicMock(return_value=0)
+    with (
+        patch("nuri.agents.discord.outbox._privacy_gate_payload", return_value=[]),
+        patch("nuri.agents.discord.outbox.stage_brief", return_value=None),
+        patch("nuri.alerts.portfolio_signals.stage_stale_input_briefs", stale_spy),
+    ):
+        write_brief("us", date="2026-05-01")
+        write_brief("kr", date="2026-05-01")
+
+    stale_spy.assert_called_once()  # US 만
+    assert stale_spy.call_args[0][0] == "2026-05-01"
+
+
 def test_write_brief_survives_portfolio_drift_staging_error(seeded_db, portfolio_yaml):
     """집중도 staging 이 raise 해도 (1) write_brief 는 정상 반환 + (2) 섹터는 여전히
     시도됨 (독립 best-effort — 한쪽 실패가 다른 쪽을 막지 않음)."""

--- a/tests/alerts/test_telegram.py
+++ b/tests/alerts/test_telegram.py
@@ -1,15 +1,18 @@
 """Tests for nuri.alerts.telegram."""
+
 from unittest.mock import MagicMock
 
 
 class TestTelegram:
     def test_send_no_token(self):
         from nuri.alerts.telegram import send_telegram
+
         result = send_telegram("test message")
         assert result is False
 
     def test_format_regime_alert(self):
         from nuri.alerts.telegram import format_regime_alert
+
         msg = format_regime_alert("bull_low_vol", "sideways_high_vol", 75.0)
         assert "레짐 전환" in msg
         assert "bull_low_vol" in msg
@@ -17,6 +20,7 @@ class TestTelegram:
 
     def test_format_violation_alert(self):
         from nuri.alerts.telegram import format_violation_alert
+
         violations = [
             {"ticker": "TSLL", "severity": "critical", "reason": "레버리지 ETF"},
             {"ticker": "BAD", "severity": "warning", "violation_type": "stop_loss"},
@@ -27,12 +31,14 @@ class TestTelegram:
 
     def test_format_violation_many(self):
         from nuri.alerts.telegram import format_violation_alert
+
         violations = [{"ticker": f"T{i}", "severity": "warning", "reason": "test"} for i in range(8)]
         msg = format_violation_alert(violations)
         assert "외" in msg
 
     def test_format_signal_alert(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("AAPL", "BUY", 75.0, 155.0)
         assert "AAPL" in msg
         assert "BUY" in msg
@@ -40,6 +46,7 @@ class TestTelegram:
 
     def test_format_signal_sell(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("TSLA", "SELL", 80.0, 350.0)
         assert "SELL" in msg
 
@@ -48,6 +55,7 @@ class TestTelegramSend:
     def test_no_token(self, monkeypatch):
         """send_telegram returns False when token not set."""
         import nuri.alerts.telegram as mod
+
         monkeypatch.setattr(mod, "_BOT_TOKEN", "")
         monkeypatch.setattr(mod, "_CHAT_ID", "")
         assert mod.send_telegram("test") is False
@@ -55,6 +63,7 @@ class TestTelegramSend:
     def test_send_success(self, monkeypatch):
         """send_telegram returns True on successful POST."""
         import nuri.alerts.telegram as mod
+
         monkeypatch.setattr(mod, "_BOT_TOKEN", "fake_token")
         monkeypatch.setattr(mod, "_CHAT_ID", "12345")
 
@@ -63,12 +72,14 @@ class TestTelegramSend:
                 pass
 
         import requests
+
         monkeypatch.setattr(requests, "post", lambda url, **kw: FakeResp())
         assert mod.send_telegram("test message") is True
 
     def test_send_failure(self, monkeypatch):
         """send_telegram returns False on exception."""
         import nuri.alerts.telegram as mod
+
         monkeypatch.setattr(mod, "_BOT_TOKEN", "fake_token")
         monkeypatch.setattr(mod, "_CHAT_ID", "12345")
 
@@ -76,12 +87,14 @@ class TestTelegramSend:
             raise ConnectionError("fail")
 
         import requests
+
         monkeypatch.setattr(requests, "post", _raise)
         assert mod.send_telegram("test") is False
 
     def test_send_with_markdown(self, monkeypatch):
         """send_telegram with Markdown parse mode."""
         import nuri.alerts.telegram as mod
+
         monkeypatch.setattr(mod, "_BOT_TOKEN", "fake_token")
         monkeypatch.setattr(mod, "_CHAT_ID", "12345")
 
@@ -105,6 +118,7 @@ class TestTelegramSend:
 class TestTelegramFormatters:
     def test_format_regime_alert(self):
         from nuri.alerts.telegram import format_regime_alert
+
         msg = format_regime_alert("bull_low_vol", "bear_high_vol", 85.0)
         assert "레짐 전환" in msg
         assert "bear_high_vol" in msg
@@ -112,6 +126,7 @@ class TestTelegramFormatters:
 
     def test_format_violation_alert(self):
         from nuri.alerts.telegram import format_violation_alert
+
         violations = [
             {"ticker": "TSLA", "severity": "critical", "reason": "stop loss exceeded"},
             {"ticker": "AAPL", "severity": "warning", "violation_type": "position limit"},
@@ -122,23 +137,27 @@ class TestTelegramFormatters:
 
     def test_format_violation_alert_many(self):
         from nuri.alerts.telegram import format_violation_alert
+
         violations = [{"ticker": f"T{i}", "severity": "warning", "reason": "test"} for i in range(8)]
         msg = format_violation_alert(violations)
         assert "외 3건" in msg
 
     def test_format_signal_alert_buy(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("AAPL", "BUY", 85.0, 175.50)
         assert "BUY" in msg
         assert "AAPL" in msg
 
     def test_format_signal_alert_sell(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("MSFT", "SELL", 70.0, 380.00)
         assert "SELL" in msg
 
     def test_format_signal_alert_hold(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("GOOG", "HOLD", 50.0, 150.00)
         assert "HOLD" in msg
 
@@ -148,6 +167,7 @@ class TestTelegram_R24:
 
     def test_send_telegram_no_config(self, monkeypatch):
         import nuri.alerts.telegram as tg
+
         monkeypatch.setattr(tg, "_BOT_TOKEN", "")
         monkeypatch.setattr(tg, "_CHAT_ID", "")
         result = tg.send_telegram("test message")
@@ -155,10 +175,12 @@ class TestTelegram_R24:
 
     def test_send_telegram_success(self, monkeypatch):
         import nuri.alerts.telegram as tg
+
         monkeypatch.setattr(tg, "_BOT_TOKEN", "test_token")
         monkeypatch.setattr(tg, "_CHAT_ID", "123456")
 
         import requests as req_mod
+
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         monkeypatch.setattr(req_mod, "post", MagicMock(return_value=mock_resp))
@@ -168,10 +190,12 @@ class TestTelegram_R24:
 
     def test_send_telegram_failure(self, monkeypatch):
         import nuri.alerts.telegram as tg
+
         monkeypatch.setattr(tg, "_BOT_TOKEN", "test_token")
         monkeypatch.setattr(tg, "_CHAT_ID", "123456")
 
         import requests as req_mod
+
         monkeypatch.setattr(req_mod, "post", MagicMock(side_effect=Exception("network error")))
 
         result = tg.send_telegram("test message")
@@ -179,10 +203,12 @@ class TestTelegram_R24:
 
     def test_send_telegram_markdown_mode(self, monkeypatch):
         import nuri.alerts.telegram as tg
+
         monkeypatch.setattr(tg, "_BOT_TOKEN", "test_token")
         monkeypatch.setattr(tg, "_CHAT_ID", "123456")
 
         import requests as req_mod
+
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_post = MagicMock(return_value=mock_resp)
@@ -194,6 +220,7 @@ class TestTelegram_R24:
 
     def test_format_regime_alert(self):
         from nuri.alerts.telegram import format_regime_alert
+
         msg = format_regime_alert("bull_low_vol", "bear_high_vol", 85.0)
         assert "레짐 전환" in msg
         assert "bull_low_vol" in msg
@@ -202,6 +229,7 @@ class TestTelegram_R24:
 
     def test_format_violation_alert(self):
         from nuri.alerts.telegram import format_violation_alert
+
         violations = [
             {"ticker": "AAPL", "severity": "critical", "reason": "stop-loss hit"},
             {"ticker": "NVDA", "severity": "warning", "violation_type": "position limit"},
@@ -213,12 +241,14 @@ class TestTelegram_R24:
 
     def test_format_violation_alert_many(self):
         from nuri.alerts.telegram import format_violation_alert
+
         violations = [{"ticker": f"T{i}", "severity": "warning", "reason": f"r{i}"} for i in range(10)]
         msg = format_violation_alert(violations)
         assert "외 5건" in msg
 
     def test_format_signal_alert_buy(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("AAPL", "BUY", 85.0, 190.0)
         assert "AAPL" in msg
         assert "BUY" in msg
@@ -226,10 +256,12 @@ class TestTelegram_R24:
 
     def test_format_signal_alert_sell(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("AAPL", "SELL", 70.0, 180.0)
         assert "SELL" in msg
 
     def test_format_signal_alert_hold(self):
         from nuri.alerts.telegram import format_signal_alert
+
         msg = format_signal_alert("AAPL", "HOLD", 50.0, 190.0)
         assert "HOLD" in msg


### PR DESCRIPTION
Closes #1090

코덱스가 지목한 순서의 1번: *"fix portfolio-state freshness before adding more gates.
New gates on stale state just create precise nonsense."*

## 실측 — 15일 낡은 보유 위에서 판단이 나가고 있었다

```
FAIL  포트폴리오 sync   오래됨 (360.5h)   ← 2026-08-03 이후 미갱신
WARN  VIX             (33.1h)
PASS  주가/팩터/F&G/합의/인증
```

`get_freshness_summary()` 는 **내내 정상 동작했다.** 그런데 유일한 소비자가 프리마켓
임베드의 **색**이었고, 사장님이 매일 읽는 것은 `discord_outbox` 카드다. 최근 4일 카드
34건 = `SELL 18 · REBALANCE 12 · INFO 4` — 낡음은 **한 줄도** 없었다.

그 15일 동안 비중·섹터·손절·슬리브 판단이 전부 그 낡은 보유 위에서 계산됐다.

## Tier 1e — 축이 없는 카드

`kind:"INPUT_STALE"`, **`alpha_action`/`portfolio_action` 둘 다 없다.**
종목에 대한 판단이 아니라 "오늘 나온 다른 판단들을 믿을 수 있느냐"에 대한 메타 경고이고,
축을 붙이면 소비자가 매매 신호로 읽는다 — 관측이 본 작업을 게이트하게 되는 #894 형태다.

`priority="high"`: 낡은 입력은 그날 **다른 카드 전부**의 신뢰도를 깎으므로 개별
REBALANCE(normal) 보다 먼저 읽혀야 한다.

## 세 가지 설계 판단

**FAIL 만 카드가 된다.** 주가·팩터는 주말마다 정상적으로 WARN 이라 WARN 을 포함하면
매주 발화하는 소음이 되고, 소음이 된 알림은 읽히지 않는다.

**조치는 소스별이다.** 가격이 낡았는데 "portfolio.yaml 을 갱신하라"고 하면 엉뚱한 곳을
보게 하고 진짜 원인은 남는다. 틀린 조치를 적은 카드는 없느니만 못하다.

**포트폴리오 조치는 "yaml 을 고쳐라" 이지 "import 를 다시 돌려라" 가 아니다.** yaml 은
손으로 유지하는 원장이라 재import 는 내용은 그대로 둔 채 `updated_at` 만 새로 찍어
**계기판을 초록으로 위조**한다. 그래서 스케줄러 자동화도 하지 않는다.

**"데이터 없음" 은 "낡음" 이 아니다.** `age_hours=None` 은 행이 하나도 없다는 뜻이고,
같은 문구로 내면 "며칠 지났나"를 찾다가 수집 자체가 안 되는 실제 상태를 놓친다.
스모크 테스트가 포맷 문자열 크래시로 이걸 잡았다.

## 검증 — 뮤테이션 6종 전부 검출

| 뮤테이션 | 떨어지는 테스트 |
|---|---|
| WARN 도 카드로 (소음화) | `test_warn_never_becomes_a_card` |
| payload 에 축 부착 | `test_stale_payload_carries_no_axis` |
| 소스별 조치 → 단일 문구 | `test_stale_payload_gives_the_remedy_for_that_source` |
| priority high → normal | `test_stale_staging_is_high_priority_and_dedupes` |
| None 분기 제거 | 같은 테스트 (TypeError) |
| postmarket 배선 제거 | `test_write_brief_stages_stale_input_cards` |

앞의 1라운드에서는 **WARN 축과 배선 축이 살아남았다.** 빈 fixture 는 모든 소스가
FAIL("데이터 없음")이라 샐 WARN 자체가 없었기 때문이다. `certifications` 가 ISO
timestamp 컬럼이라 30시간을 정확히 심어(24h WARN / 48h FAIL 사이) 그 축을 만들었다.

기존 CLI 테스트 3건이 `"staged N"` 정확한 총계를 단언해 깨졌다 — 총계는 원래 취약하므로
**해당 카드의 존재**를 보도록 바꿨다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)