### PR TITLE
feat(thesis): pre-register falsification criteria and check them daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 51 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
+    SCHED["APScheduler · 52 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 26 jobs"]
@@ -72,7 +72,7 @@ flowchart TB
         ANA(["22 signals · 10 regimes · 4-factor composite"]):::lazy
     end
 
-    DB[("SQLite WAL · 53 tables<br/>audit · evidence · pipeline events")]:::sink
+    DB[("SQLite WAL · 55 tables<br/>audit · evidence · pipeline events")]:::sink
 
     SCHED --> Collect
     SCHED --> Decide
@@ -106,7 +106,7 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 51 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 52 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,172 collected across 327 files | |
+| **Backend tests** | 7,192 collected across 328 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -280,12 +280,12 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 51 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 52 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 53 tables (51 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 55 tables (52 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 51 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 52 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (51 migrations as of 2026-07-30). Key tables:
+51 tables total (52 migrations as of 2026-07-30). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,172 backend tests across 327 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,192 backend tests across 328 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,172 tests, 327 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,192 tests, 328 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -275,6 +275,78 @@ describe("DecisionProvenance", () => {
     expect(screen.getByText(/analyst\/note-4/)).toBeInTheDocument();
   });
 
+  it("renders falsification criteria and never paints unevaluable as passing", async () => {
+    // `unevaluable` 이 초록(유지)으로 보이면 "측정 못 했다" 가 "지켜졌다" 로 읽힌다 —
+    // 그게 이 기능이 막으려는 것 자체다 (#1092).
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      thesis: {
+        id: 9,
+        ticker: "AAA",
+        version: 1,
+        author: "user",
+        stance: "bullish",
+        bull_case: "수요가 공급을 앞선다",
+        bear_case: "자체 칩 전환이 점유율을 깎는다",
+        effective_date: "2026-04-01",
+        status: "active",
+        verdict: null,
+        evidence: [],
+        criteria: [
+          {
+            id: 1,
+            kind: "machine",
+            statement: "50일선 아래로 이탈하면 추세 전제가 깨진다",
+            metric: "close",
+            op: "<",
+            threshold: 90,
+            deadline_date: null,
+            last_result: "breached",
+            last_checked: "2026-08-18",
+          },
+          {
+            id: 2,
+            kind: "machine",
+            statement: "팩터 점수가 하위권으로 내려가면",
+            metric: "composite_score",
+            op: "<",
+            threshold: 0.3,
+            deadline_date: null,
+            last_result: "unevaluable",
+            last_checked: "2026-08-18",
+          },
+          {
+            id: 3,
+            kind: "human",
+            statement: "경영진이 capex 가이던스를 하향하면",
+            metric: null,
+            op: null,
+            threshold: null,
+            deadline_date: null,
+            last_result: null,
+            last_checked: null,
+          },
+        ],
+      },
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText(/반증 기준 \(3\)/)).toBeInTheDocument();
+    expect(screen.getByText("반증됨")).toBeInTheDocument();
+    expect(screen.getByText("사람 판정")).toBeInTheDocument();
+    expect(screen.getByText("close < 90 · 2026-08-18")).toBeInTheDocument();
+
+    // 측정 불가는 회색이어야 한다 — 유지(emerald)와 같은 색이면 안 된다.
+    const unevaluable = screen.getByText("측정 불가");
+    expect(unevaluable.className).toContain("text-muted-foreground");
+    expect(unevaluable.className).not.toContain("emerald");
+    expect(screen.queryByText("유지")).not.toBeInTheDocument();
+    // 미점검(한 번도 안 돈 기준)도 통과처럼 보이면 안 된다.
+    expect(screen.getByText("미점검").className).toContain("text-muted-foreground");
+  });
+
   it("says the thesis is missing instead of hiding the card", async () => {
     // 논지가 비어 있다는 사실이 곧 판단 근거의 부재다 — 카드가 사라지면 그 부재가 안 보인다.
     mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, thesis: null });

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -38,6 +38,18 @@ interface ThesisEvidence {
   quote: string | null;
 }
 
+interface ThesisCriterion {
+  id: number;
+  kind: "machine" | "human";
+  statement: string;
+  metric: string | null;
+  op: string | null;
+  threshold: number | null;
+  deadline_date: string | null;
+  last_result: "holding" | "breached" | "unevaluable" | null;
+  last_checked: string | null;
+}
+
 interface Thesis {
   id: number;
   ticker: string;
@@ -50,7 +62,22 @@ interface Thesis {
   status: string;
   verdict: string | null;
   evidence: ThesisEvidence[];
+  criteria: ThesisCriterion[];
 }
+
+// 반증 기준 판정 색. `unevaluable` 을 회색으로 두는 것이 핵심 — 초록(이상 없음)으로
+// 보이면 "측정 못 했다" 가 "지켜졌다" 로 읽히고, 그게 이 기능이 막으려는 것이다.
+const CRITERION_TONE: Record<string, string> = {
+  breached: "text-rose-500",
+  holding: "text-emerald-500",
+  unevaluable: "text-muted-foreground",
+};
+
+const CRITERION_LABEL: Record<string, string> = {
+  breached: "반증됨",
+  holding: "유지",
+  unevaluable: "측정 불가",
+};
 
 interface DecisionDetail {
   id: number;
@@ -209,6 +236,29 @@ export async function DecisionProvenance({ id }: { id: string }) {
                   <p className="text-xs text-foreground/90 whitespace-pre-wrap">{d.thesis.bear_case}</p>
                 </div>
               </div>
+              {/* 반증 기준 (#1092) — 논지보다 이게 먼저 눈에 들어와야 한다. 무엇이
+                  사실이면 이 판단이 틀린 것인지가 사후 채점의 유일한 기준이다. */}
+              {d.thesis.criteria?.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-[10px] text-muted-foreground">
+                    반증 기준 ({d.thesis.criteria.length}) — 이게 사실이면 이 판단은 틀린 것
+                  </p>
+                  {d.thesis.criteria.map((c) => (
+                    <div key={c.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                      <span className={`w-14 shrink-0 ${CRITERION_TONE[c.last_result ?? ""] ?? "text-muted-foreground"}`}>
+                        {c.last_result ? CRITERION_LABEL[c.last_result] : "미점검"}
+                      </span>
+                      <span className="text-foreground/90">{c.statement}</span>
+                      <span className="ml-auto shrink-0 text-[10px] text-muted-foreground font-mono">
+                        {c.kind === "machine" && c.metric
+                          ? `${c.metric} ${c.op} ${c.threshold}`
+                          : "사람 판정"}
+                        {c.last_checked ? ` · ${c.last_checked}` : ""}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
               {d.thesis.evidence.length > 0 && (
                 <div className="space-y-1.5">
                   <p className="text-[10px] text-muted-foreground">논지 근거 ({d.thesis.evidence.length})</p>

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -93,7 +93,9 @@ from .research_ops import (  # noqa: F401, E402
 )
 from .thesis_ops import (  # noqa: F401, E402
     ThesisValidationError,
+    add_criteria,
     get_active_thesis,
+    get_criteria,
     get_thesis_history,
     upsert_thesis,
 )

--- a/nuri/core/db/thesis_ops.py
+++ b/nuri/core/db/thesis_ops.py
@@ -151,7 +151,76 @@ def get_active_thesis(
                 (thesis["id"],),
             ).fetchall()
         ]
-        return thesis
+    # 기준은 별도 커넥션에서 — `get_criteria` 가 자체 `get_db` 를 열기 때문.
+    thesis["criteria"] = get_criteria(thesis["id"], db_path=db_path)
+    return thesis
+
+
+def add_criteria(thesis_id: int, criteria: list[dict], db_path: Optional[Path] = None) -> int:
+    """반증 기준을 논지에 붙인다 (#1092). 등록 건수 반환.
+
+    **machine 기준 최소 1개를 강제한다.** 전부 `human` 이면 자동 점검이 아무것도 안 하고,
+    등록한 사람은 도는 줄 안다 — 그게 게이트가 있는데 안 잡는 상태다.
+
+    metric 해소 가능성은 `thesis_criteria.validate_criterion` 이 본다: 스키마 CHECK 는
+    `machine` 이면 metric/op/threshold 가 **있는지**만 보고, 그 metric 을 실제로 **해소할
+    수 있는지**는 모른다. 오타 하나면 매일 `unevaluable` 만 쌓인다.
+
+    Raises: `ThesisValidationError` — 내용 검증 실패.
+    """
+    from nuri.trading.engine.thesis_criteria import CriterionValidationError, validate_criterion
+
+    if not criteria:
+        raise ThesisValidationError("반증 기준이 0건이다 — 틀렸음을 확인할 방법 없는 논지는 서사다")
+    if not any(c.get("kind") == "machine" for c in criteria):
+        raise ThesisValidationError("machine 기준이 최소 1개 필요하다 — 전부 human 이면 자동 점검이 장식이다")
+
+    for c in criteria:
+        if not (c.get("statement") or "").strip():
+            raise ThesisValidationError("statement 가 비었다 — 무엇이 반증인지 문장으로 남길 것")
+        try:
+            validate_criterion(c.get("kind", ""), c.get("metric"), c.get("op"), c.get("threshold"))
+        except CriterionValidationError as e:
+            raise ThesisValidationError(str(e)) from e
+
+    with get_db(db_path) as conn:
+        conn.executemany(
+            """INSERT INTO thesis_criteria
+               (thesis_id, kind, statement, metric, op, threshold, deadline_date)
+               VALUES (:thesis_id, :kind, :statement, :metric, :op, :threshold, :deadline_date)""",
+            [
+                {
+                    "thesis_id": thesis_id,
+                    "kind": c["kind"],
+                    "statement": c["statement"],
+                    "metric": c.get("metric"),
+                    "op": c.get("op"),
+                    "threshold": c.get("threshold"),
+                    "deadline_date": c.get("deadline_date"),
+                }
+                for c in criteria
+            ],
+        )
+    return len(criteria)
+
+
+def get_criteria(thesis_id: int, db_path: Optional[Path] = None) -> list[dict]:
+    """논지의 기준 + 최신 판정 (없으면 `last_result=None`)."""
+    with get_db(db_path) as conn:
+        return [
+            dict(r)
+            for r in conn.execute(
+                """SELECT c.*,
+                          (SELECT k.result FROM thesis_criteria_checks k
+                            WHERE k.criterion_id = c.id ORDER BY k.check_date DESC LIMIT 1) AS last_result,
+                          (SELECT k.check_date FROM thesis_criteria_checks k
+                            WHERE k.criterion_id = c.id ORDER BY k.check_date DESC LIMIT 1) AS last_checked
+                     FROM thesis_criteria c
+                    WHERE c.thesis_id = ? AND c.status = 'active'
+                    ORDER BY c.kind, c.id""",
+                (thesis_id,),
+            ).fetchall()
+        ]
 
 
 def get_thesis_history(ticker: str, db_path: Optional[Path] = None) -> list[dict]:

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1616,4 +1616,55 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         CREATE INDEX IF NOT EXISTS idx_thesis_evidence_thesis ON thesis_evidence(thesis_id, side);
     """,
     ),
+    (
+        52,
+        "thesis_criteria / thesis_criteria_checks — 사전등록 반증 기준 (#1092)",
+        # 논지 텍스트만 있으면 사후에 "대체로 맞았다" 로 읽힌다. **무엇이 사실이면 내가
+        # 틀린 것인가**를 미리 박아야 채점이 성립한다.
+        #
+        # `kind='machine'` 이면 metric/op/threshold 가 전부 있어야 한다 — CHECK 로 강제한다.
+        # 없는 채로 machine 을 허용하면 "자동 점검 대상" 인데 해소할 식이 없는 행이 생기고,
+        # 그건 조용히 영원히 unevaluable 이 된다.
+        #
+        # checks 는 append-only 다. 같은 기준의 판정 이력이 곧 채점 재료이므로 덮어쓰지
+        # 않는다. `UNIQUE(criterion_id, check_date)` 로 하루 1건만 둔다(재실행 멱등).
+        #
+        # `result` 에 `unevaluable` 이 **1급 값**인 것이 이 마이그레이션의 핵심이다.
+        # 측정하지 못한 것을 `holding` 으로 적으면 게이트가 있는데 안 잡는 상태가 되고,
+        # 그게 `_check_volatility_for_class` 가 넉 달간 초록이던 이유였다.
+        """
+        CREATE TABLE IF NOT EXISTS thesis_criteria (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            thesis_id INTEGER NOT NULL REFERENCES theses(id) ON DELETE CASCADE,
+            kind TEXT NOT NULL CHECK (kind IN ('machine', 'human')),
+            statement TEXT NOT NULL,
+            metric TEXT,
+            op TEXT CHECK (op IS NULL OR op IN ('<', '<=', '>', '>=')),
+            threshold REAL,
+            deadline_date TEXT,
+            status TEXT NOT NULL DEFAULT 'active'
+                CHECK (status IN ('active', 'retired')),
+            created_at TEXT DEFAULT (datetime('now')),
+            CHECK (
+                kind <> 'machine'
+                OR (metric IS NOT NULL AND op IS NOT NULL AND threshold IS NOT NULL)
+            )
+        );
+        CREATE INDEX IF NOT EXISTS idx_thesis_criteria_thesis
+            ON thesis_criteria(thesis_id, status);
+
+        CREATE TABLE IF NOT EXISTS thesis_criteria_checks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            criterion_id INTEGER NOT NULL REFERENCES thesis_criteria(id) ON DELETE CASCADE,
+            check_date TEXT NOT NULL,
+            result TEXT NOT NULL CHECK (result IN ('holding', 'breached', 'unevaluable')),
+            observed REAL,
+            detail TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(criterion_id, check_date)
+        );
+        CREATE INDEX IF NOT EXISTS idx_thesis_criteria_checks_date
+            ON thesis_criteria_checks(check_date, result);
+    """,
+    ),
 ]

--- a/nuri/core/thesis_cli.py
+++ b/nuri/core/thesis_cli.py
@@ -25,11 +25,26 @@ from typing import Optional
 
 import yaml
 
-from nuri.core.db import ThesisValidationError, get_active_thesis, get_thesis_history, upsert_thesis
+from nuri.core.db import (
+    ThesisValidationError,
+    add_criteria,
+    get_active_thesis,
+    get_thesis_history,
+    upsert_thesis,
+)
+
+
+def _delete_thesis(thesis_id: int, db_path: Optional[Path]) -> None:
+    """기준 등록 실패 시 논지를 되돌린다 — 반증 없는 논지를 남기지 않기 위해."""
+    from nuri.core.db import get_db
+
+    with get_db(db_path) as conn:
+        conn.execute("DELETE FROM theses WHERE id = ?", (thesis_id,))
+
 
 #: 파일에 반드시 있어야 하는 키. 없으면 어떤 것이 빠졌는지 한 번에 말한다 —
 #: KeyError 하나씩 뱉으면 사용자가 파일을 여러 번 고쳐야 한다.
-REQUIRED = ("ticker", "author", "stance", "bull_case", "bear_case", "evidence")
+REQUIRED = ("ticker", "author", "stance", "bull_case", "bear_case", "evidence", "criteria")
 
 
 def load_thesis_file(path: Path) -> dict:
@@ -47,6 +62,7 @@ def load_thesis_file(path: Path) -> dict:
         "bull_case": str(data["bull_case"]),
         "bear_case": str(data["bear_case"]),
         "evidence": list(data["evidence"]),
+        "criteria": list(data["criteria"]),
         "effective_date": data.get("effective_date"),
         "status": str(data.get("status", "draft")),
     }
@@ -58,13 +74,21 @@ def _cmd_write(path: Path, db_path: Optional[Path]) -> int:
     except (OSError, ValueError, yaml.YAMLError) as e:
         print(f"✗ {e}", file=sys.stderr)
         return 2
+    criteria = kwargs.pop("criteria")
     try:
         thesis_id = upsert_thesis(db_path=db_path, **kwargs)
+        # 기준 등록이 실패하면 **반증 없는 논지**가 남는다 — 그건 이 시스템이 막으려는
+        # 상태 자체라, 논지를 되돌리고 통째로 거부한다.
+        try:
+            n_criteria = add_criteria(thesis_id, criteria, db_path=db_path)
+        except ThesisValidationError:
+            _delete_thesis(thesis_id, db_path)
+            raise
     except ThesisValidationError as e:
         # 검증 실패는 사용자 입력 문제지 버그가 아니다 — traceback 없이 이유만.
         print(f"✗ 논지 거부: {e}", file=sys.stderr)
         return 1
-    print(f"✓ {kwargs['ticker']} 논지 기록 — id={thesis_id} status={kwargs['status']}")
+    print(f"✓ {kwargs['ticker']} 논지 기록 — id={thesis_id} status={kwargs['status']} 반증기준 {n_criteria}건")
     if kwargs["status"] == "draft":
         print("  draft 는 결정 화면에 붙지 않는다. 승격하려면 파일에 status: active 로 다시 기록.")
     return 0
@@ -84,6 +108,12 @@ def _cmd_show(ticker: str, db_path: Optional[Path]) -> int:
         print(f"\n상승: {active['bull_case']}")
         print(f"하락: {active['bear_case']}")
         print(f"근거 {len(active['evidence'])}건")
+        criteria = active.get("criteria") or []
+        print(f"반증 기준 {len(criteria)}건 — 이게 사실이면 이 판단은 틀린 것:")
+        for c in criteria:
+            state = c["last_result"] or "미점검"
+            expr = f"{c['metric']} {c['op']} {c['threshold']:g}" if c["kind"] == "machine" else "사람 판정"
+            print(f"  [{state:11s}] {c['statement']}  ({expr})")
     else:
         print("\n현재 유효한 논지 없음 (draft 만 있거나 effective_date 가 미래)")
     return 0

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -125,7 +125,9 @@ _STAGE_OF_JOB = {
     "factors": "analyze",
     # consensus — 하나뿐이며, 그 안에서 certify(record_decisions)까지 in-memory 로 이어진다
     "consensus": "consensus",
-    # track
+    # track — 반증 기준 점검은 사전등록된 기준을 사후에 채점하는 것이므로 track 이다
+    # (판단을 만들지 않는다 — Surface 전용, #1092).
+    "thesis_criteria": "track",
     "decision_pnl": "track",
     "recommendation_outcomes": "track",
     "alpha_tracking": "track",
@@ -181,6 +183,17 @@ def _dispatch_collector(name: str, **kwargs):
         from nuri.quant.factors.composite import compute_composite, save_composite
 
         return save_composite(compute_composite())
+    elif name == "thesis_criteria":
+        # 수집이 아니라 **사후 채점** 단계다 (`_STAGE_OF_JOB` 에서 track). `factors` 와
+        # 같은 이유로 이 경로를 쓴다 — 예외 격리 · 실행 기록 · 스테이지 이벤트를 공짜로
+        # 얻는다. 전용 러너로 두면 `pipeline_events` 에 아무것도 안 남아 "도는 줄 아는데
+        # 안 도는" 상태를 관측할 수 없다.
+        #
+        # **Surface 전용**: breach 는 알림·뱃지까지고 주문을 만들지 않는다 (§7.1).
+        from nuri.trading.engine.thesis_criteria import run_daily_checks
+
+        counts = run_daily_checks()
+        return counts["holding"] + counts["breached"] + counts["unevaluable"]
     elif name == "cboe":
         from nuri.collectors.cboe import CBOECollector
 
@@ -806,6 +819,8 @@ SCHEDULES = [
     # 보유 종목에 대한 add 후보 평가 (3 modes + earnings blackout). shadow_mode_until
     # 까지 held_add_shadow 테이블 only — brief surface 안 함. 14d 누적 후 2c calibration.
     {"name": "held_add_shadow", "func": _run_held_add_shadow, "args": (), "cron": "15 7 * * *"},
+    # 반증 기준 점검 (#1092) — factors(08:10) 이후라야 그날 팩터로 판정한다.
+    {"name": "thesis_criteria", "func": _run_collector, "args": ("thesis_criteria",), "cron": "20 8 * * *"},
     # 수집 데이터 타당성 점검 (07:20 — US 종가·KR 전일 수집이 모두 끝난 뒤).
     {"name": "data_sanity", "func": _run_data_sanity, "args": (), "cron": "20 7 * * *"},
     # Agent accuracy 스냅샷 (주 1회 일요일 08:00)

--- a/nuri/trading/engine/thesis_criteria.py
+++ b/nuri/trading/engine/thesis_criteria.py
@@ -1,0 +1,213 @@
+"""사전등록 반증 기준의 일별 자동 점검 (#1092).
+
+## 왜 이게 논지 다음이고 시나리오 분석보다 먼저인가
+
+`theses` 는 상승·하락 논리를 담지만, **무엇이 사실이면 내가 틀린 것인가**가 없으면 사후에
+"대체로 맞았다" 로 읽힌다. 그건 처분효과를 막지 못하는 서사다. 반증 기준이 먼저 있어야
+나중의 채점(verdict)이 손 라벨링이 아니게 된다.
+
+## 절대 굽히지 않는 규칙 — `unevaluable` 은 `holding` 이 아니다
+
+해소되지 않는 metric 은 `unevaluable` 로 기록한다. 절대 "이상 없음"(`holding`)이 아니다.
+`_check_volatility_for_class` 가 넉 달간 초록이던 이유가 정확히 이것 — 측정 못 한 것을
+통과로 적으면 게이트가 **있는데 안 잡는** 상태가 되고, 그건 게이트가 없는 것보다 나쁘다
+(있다고 믿게 되므로).
+
+`unevaluable` 사유는 셋이고 전부 `detail` 에 남긴다:
+  - `no_metric` — 미등록 metric (writer 가 막지만 기존 행이 있을 수 있다)
+  - `no_data` — 해당 티커의 그 값이 DB 에 없음
+  - `stale` — 값은 있는데 정책상 너무 낡음
+
+## 에스컬레이션 천장 — Surface 전용
+
+breach 는 **알림 + 화면 뱃지**까지다. 주문을 만들지 않고 `alpha_action` 을 건드리지 않는다
+(STRATEGY §7.1 · Escalation Ladder). 승격하려면 STRATEGY PR + 근거가 필요하다.
+
+## METRIC_RESOLVERS 는 실제로 채워진 테이블만
+
+프로덕션 실측(2026-08-18): prices 270,401 · fundamentals 794 · signals 850 · factors 793.
+목록에 없는 metric 은 writer 가 거부한다 — 그리고 **양방향 계약 테스트**가 목록의 모든
+metric 이 실제로 해소되는지도 본다. 한쪽만 있으면 목록과 구현이 조용히 갈린다.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+#: 낡음 판정 기준(일). 값이 이보다 오래됐으면 `holding` 이 아니라 `unevaluable(stale)` 이다.
+#: 가격은 매일 갱신되지만 fundamentals/factors 는 주기가 길어 소스별로 다르다.
+STALE_AFTER_DAYS: dict[str, int] = {
+    "prices": 5,
+    "signals": 5,
+    "factors": 5,
+    "fundamentals": 100,
+}
+
+
+def _latest(table: str, column: str, ticker: str, db_path: Optional[Path]) -> tuple[Optional[float], Optional[str]]:
+    """(값, 날짜) — 없으면 (None, None). 컬럼명은 호출자가 아니라 이 모듈이 정한다."""
+    from nuri.core.db import query
+
+    rows = query(
+        f"SELECT {column} AS v, date FROM {table} WHERE ticker = ? AND {column} IS NOT NULL ORDER BY date DESC LIMIT 1",
+        (ticker,),
+        db_path=db_path,
+    )
+    if not rows:
+        return None, None
+    return float(rows[0]["v"]), rows[0]["date"]
+
+
+def _resolver(table: str, column: str) -> Callable[[str, Optional[Path]], tuple[Optional[float], Optional[str], str]]:
+    def resolve(ticker: str, db_path: Optional[Path]) -> tuple[Optional[float], Optional[str], str]:
+        value, date = _latest(table, column, ticker, db_path)
+        return value, date, table
+
+    return resolve
+
+
+#: metric 이름 → (값, 날짜, 소스테이블) 해소기.
+#: **여기 없는 metric 은 writer 가 거부한다.** 추가할 때는 그 컬럼이 실제로 채워지는지
+#: 프로덕션에서 세어 보고 넣을 것 — 비어 있는 컬럼을 넣으면 그 기준은 영원히 unevaluable 이다.
+METRIC_RESOLVERS: dict[str, Callable[[str, Optional[Path]], tuple[Optional[float], Optional[str], str]]] = {
+    "close": _resolver("prices", "close"),
+    "volume": _resolver("prices", "volume"),
+    "rsi_14": _resolver("signals", "rsi_14"),
+    "sma_50": _resolver("signals", "sma_50"),
+    "sma_200": _resolver("signals", "sma_200"),
+    "composite_score": _resolver("factors", "composite_score"),
+    "momentum_score": _resolver("factors", "momentum_score"),
+    "value_score": _resolver("factors", "value_score"),
+    "quality_score": _resolver("factors", "quality_score"),
+    "pe_ratio": _resolver("fundamentals", "pe_ratio"),
+    "forward_pe": _resolver("fundamentals", "forward_pe"),
+    "revenue_growth": _resolver("fundamentals", "revenue_growth"),
+    "operating_margin": _resolver("fundamentals", "operating_margin"),
+    "debt_to_equity": _resolver("fundamentals", "debt_to_equity"),
+}
+
+_OPS: dict[str, Callable[[float, float], bool]] = {
+    "<": lambda a, b: a < b,
+    "<=": lambda a, b: a <= b,
+    ">": lambda a, b: a > b,
+    ">=": lambda a, b: a >= b,
+}
+
+
+class CriterionValidationError(ValueError):
+    """writer 검증 실패 — 스키마는 통과하지만 자동 점검이 불가능한 기준."""
+
+
+def validate_criterion(kind: str, metric: Optional[str], op: Optional[str], threshold: Optional[float]) -> None:
+    """등록 전 검증. 스키마 CHECK 가 잡지 못하는 것 — **metric 이 해소 가능한가**를 본다.
+
+    스키마는 `machine` 이면 셋이 다 있는지만 본다. 해소기가 없는 metric 이름을 넣으면
+    행은 만들어지고 점검은 매일 `unevaluable` 을 찍는다 — 등록한 사람은 자동 점검이
+    도는 줄 알고, 실제로는 아무것도 검증되지 않는다.
+    """
+    if kind == "human":
+        return
+    if kind != "machine":
+        raise CriterionValidationError(f"kind 는 machine|human 이어야 한다: {kind!r}")
+    if metric not in METRIC_RESOLVERS:
+        raise CriterionValidationError(
+            f"해소기 없는 metric: {metric!r} — 등록 가능: {', '.join(sorted(METRIC_RESOLVERS))}"
+        )
+    if op not in _OPS:
+        raise CriterionValidationError(f"op 는 {'|'.join(_OPS)} 중 하나여야 한다: {op!r}")
+    if threshold is None:
+        raise CriterionValidationError("machine 기준은 threshold 가 필요하다")
+
+
+def evaluate_criterion(
+    criterion: dict[str, Any],
+    ticker: str,
+    as_of: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    """기준 1건 판정 → `{result, observed, detail}`.
+
+    `human` 기준은 기계가 판단할 수 없으므로 항상 `unevaluable(manual)` 이다 — 사람이
+    직접 뒤집는다. 이것을 `holding` 으로 적으면 "사람 기준은 늘 지켜지고 있다" 는
+    거짓말이 매일 원장에 쌓인다.
+    """
+    from nuri.core.timezone import today_kst
+
+    kind = criterion.get("kind")
+    if kind != "machine":
+        return {"result": "unevaluable", "observed": None, "detail": "manual — 사람이 판정"}
+
+    metric = criterion.get("metric")
+    resolver = METRIC_RESOLVERS.get(metric or "")
+    if resolver is None:
+        return {"result": "unevaluable", "observed": None, "detail": f"no_metric:{metric}"}
+
+    value, date, table = resolver(ticker, db_path)
+    if value is None:
+        return {"result": "unevaluable", "observed": None, "detail": f"no_data:{table}"}
+
+    limit = STALE_AFTER_DAYS.get(table)
+    if limit is not None and date:
+        from datetime import date as _date
+
+        try:
+            age = (_date.fromisoformat(as_of or today_kst()) - _date.fromisoformat(date[:10])).days
+        except ValueError:
+            age = None
+        if age is not None and age > limit:
+            return {"result": "unevaluable", "observed": value, "detail": f"stale:{table}:{age}d>{limit}d"}
+
+    breached = _OPS[criterion["op"]](value, float(criterion["threshold"]))
+    return {
+        "result": "breached" if breached else "holding",
+        "observed": value,
+        "detail": f"{metric}={value:g} {criterion['op']} {criterion['threshold']:g} → {breached}",
+    }
+
+
+def run_daily_checks(as_of: Optional[str] = None, db_path: Optional[Path] = None) -> dict[str, int]:
+    """활성 논지의 활성 기준을 전부 판정하고 append-only 로 기록. 결과 카운트 반환.
+
+    같은 (기준, 날짜) 재실행은 `INSERT OR IGNORE` 로 멱등이다 — 하루에 두 번 돌아도
+    판정이 뒤집히지 않는다. 뒤집히면 그날의 판정이 무엇이었는지 사후에 알 수 없다.
+    """
+    from nuri.core.db import get_db, query
+    from nuri.core.timezone import today_kst
+
+    d = as_of or today_kst()
+    rows = query(
+        """SELECT c.id, c.kind, c.metric, c.op, c.threshold, t.ticker
+           FROM thesis_criteria c
+           JOIN theses t ON t.id = c.thesis_id
+           WHERE c.status = 'active' AND t.status = 'active'""",
+        db_path=db_path,
+    )
+    counts = {"holding": 0, "breached": 0, "unevaluable": 0}
+    records = []
+    for row in rows:
+        verdict = evaluate_criterion(dict(row), row["ticker"], as_of=d, db_path=db_path)
+        counts[verdict["result"]] += 1
+        records.append(
+            {
+                "criterion_id": row["id"],
+                "check_date": d,
+                "result": verdict["result"],
+                "observed": verdict["observed"],
+                "detail": verdict["detail"],
+            }
+        )
+    if records:
+        with get_db(db_path) as conn:
+            conn.executemany(
+                """INSERT OR IGNORE INTO thesis_criteria_checks
+                   (criterion_id, check_date, result, observed, detail)
+                   VALUES (:criterion_id, :check_date, :result, :observed, :detail)""",
+                records,
+            )
+    if counts["breached"]:
+        logger.warning("thesis criteria breached: %d (surface only — 주문 만들지 않음)", counts["breached"])
+    return counts

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,7 +29,7 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_51(self, db_path):
+    def test_schema_version_at_52(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
@@ -38,8 +38,9 @@ class TestSchemaMigrations:
         decision_outcomes.benchmark_ticker (#833) +
         incidents enum 확장 — health_check.sh 흡수 3종 (#939) +
         recommendations.source — emit 경로 구분 (#1078) +
-        theses / thesis_evidence — 상승·하락 논지 원장 (#1083) → 51."""
-        assert get_schema_version(db_path) == 51
+        theses / thesis_evidence — 상승·하락 논지 원장 (#1083) +
+        thesis_criteria / thesis_criteria_checks — 사전등록 반증 기준 (#1092) → 52."""
+        assert get_schema_version(db_path) == 52
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/core/test_thesis_cli.py
+++ b/tests/core/test_thesis_cli.py
@@ -27,6 +27,12 @@ evidence:
   - side: bull
     claim: 데이터센터 매출 증가
     source_type: filing
+criteria:
+  - kind: machine
+    statement: 주가가 90 아래로 이탈하면 추세 전제가 깨진다
+    metric: close
+    op: "<"
+    threshold: 90.0
 """
 
 
@@ -65,7 +71,7 @@ class TestWrite:
         rc = main(["--db-path", str(db_path), "write", str(_write_file(tmp_path, body))])
         assert rc == 2
         err = capsys.readouterr().err
-        for key in ("stance", "bull_case", "bear_case", "evidence"):
+        for key in ("stance", "bull_case", "bear_case", "evidence", "criteria"):
             assert key in err, f"{key} 누락이 보고되지 않았다"
         assert get_thesis_history("ZZZZ", db_path=db_path) == []
 
@@ -86,6 +92,43 @@ class TestWrite:
     def test_a_missing_file_is_rejected(self, tmp_path, db_path):
         rc = main(["--db-path", str(db_path), "write", str(tmp_path / "nope.yaml")])
         assert rc == 2
+
+
+class TestCriteriaAreMandatory:
+    """반증 기준 없는 논지는 이 시스템이 막으려는 상태 자체다 (#1092)."""
+
+    def test_criteria_reach_the_ledger(self, tmp_path, db_path, capsys):
+        from nuri.core.db import get_criteria, get_thesis_history
+
+        assert main(["--db-path", str(db_path), "write", str(_write_file(tmp_path))]) == 0
+        tid = get_thesis_history("ZZZZ", db_path=db_path)[0]["id"]
+        crits = get_criteria(tid, db_path=db_path)
+        assert len(crits) == 1 and crits[0]["kind"] == "machine"
+        assert "반증기준 1건" in capsys.readouterr().out
+
+    def test_a_bad_criterion_rolls_the_thesis_back(self, tmp_path, db_path, capsys):
+        """기준 등록이 실패하면 논지도 남지 않아야 한다.
+
+        남으면 **반증 없는 논지**가 원장에 앉는다 — writer 검증을 통째로 우회한 것과
+        같고, 다음 사람은 그게 정상 경로로 들어온 줄 안다.
+
+        Mutation lock: `_delete_thesis` 롤백을 지우면 논지 1행이 남아 FAIL.
+        """
+        body = _YAML.replace("metric: close", "metric: not_a_real_metric")
+        from nuri.core.db import get_thesis_history
+
+        assert main(["--db-path", str(db_path), "write", str(_write_file(tmp_path, body))]) == 1
+        assert "해소기 없는 metric" in capsys.readouterr().err
+        assert get_thesis_history("ZZZZ", db_path=db_path) == [], "반증 없는 논지가 남았다"
+
+    def test_show_lists_criteria_with_their_last_verdict(self, tmp_path, db_path, capsys):
+        main(["--db-path", str(db_path), "write", str(_write_file(tmp_path))])
+        capsys.readouterr()
+        assert main(["--db-path", str(db_path), "show", "zzzz"]) == 0
+        out = capsys.readouterr().out
+        assert "반증 기준 1건" in out
+        assert "미점검" in out, "한 번도 점검 안 된 기준이 통과처럼 보이면 안 된다"
+        assert "close < 90" in out
 
 
 class TestModuleEntryPoint:

--- a/tests/trading/engine/test_thesis_criteria.py
+++ b/tests/trading/engine/test_thesis_criteria.py
@@ -154,14 +154,26 @@ class TestVerdict:
         assert rows["breached"]["observed"] == 80.0
         assert rows["holding"]["observed"] == 80.0
 
-    def test_checks_are_idempotent_per_day(self, db_path, thesis):
-        """append-only 지만 하루 1건이다 — 재실행이 그날 판정을 뒤집으면 사후에 알 수 없다."""
-        _seed_close(db_path, 80.0)
+    def test_rerunning_the_same_day_does_not_overwrite_the_verdict(self, db_path, thesis):
+        """하루 1건이되, **먼저 기록된 판정이 이긴다**.
+
+        행 수만 세면 `INSERT OR REPLACE` 로 바꿔도 통과한다(UNIQUE 가 여전히 1행을 지키므로)
+        — 실측으로 그 뮤테이션이 살아남았다. 진짜 계약은 **그날의 판정이 나중 실행에
+        덮이지 않는 것**이다: 덮이면 그날 무엇으로 판정했는지 사후에 알 수 없고, 채점의
+        근거가 사라진다.
+        """
+        _seed_close(db_path, 80.0)  # close < 90 → breached
         add_criteria(thesis, [_machine()], db_path=db_path)
         d = today_kst()
         tc.run_daily_checks(d, db_path=db_path)
+
+        _seed_close(db_path, 200.0)  # 같은 날 값이 뒤집혀도
         tc.run_daily_checks(d, db_path=db_path)
-        assert query("SELECT COUNT(*) c FROM thesis_criteria_checks", db_path=db_path)[0]["c"] == 1
+
+        rows = query("SELECT result, observed FROM thesis_criteria_checks", db_path=db_path)
+        assert len(rows) == 1, "하루 1건이 아니다"
+        assert rows[0]["result"] == "breached", "나중 실행이 그날 판정을 덮었다"
+        assert rows[0]["observed"] == 80.0
 
     def test_only_active_theses_are_checked(self, db_path):
         """draft/superseded 논지의 기준까지 매일 판정하면 원장이 죽은 기준으로 부푼다."""

--- a/tests/trading/engine/test_thesis_criteria.py
+++ b/tests/trading/engine/test_thesis_criteria.py
@@ -1,0 +1,263 @@
+"""사전등록 반증 기준의 일별 점검 (#1092).
+
+이 파일이 잠그는 것은 계산이 아니라 **한 줄의 규율**이다:
+
+> 해소되지 않는 metric 은 `unevaluable` 이다. 절대 `holding` 이 아니다.
+
+`_check_volatility_for_class` 가 넉 달간 초록이던 이유가 정확히 이것 — 측정하지 못한 것을
+"이상 없음" 으로 적으면 게이트가 **있는데 안 잡는** 상태가 되고, 그건 게이트가 없는 것보다
+나쁘다(있다고 믿게 되므로). 아래 `TestUnevaluableNeverLeaksAsHolding` 이 그 축이다.
+
+나머지 둘:
+- **양방향 계약** — 미등록 metric 은 writer 가 거부하고, 등록된 metric 은 전부 실제로 해소된다.
+  한쪽만 있으면 목록과 구현이 조용히 갈린다.
+- **Surface 천장** — breach 는 알림·뱃지까지고 주문/축을 만들지 않는다 (§7.1).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nuri.core.db import (
+    ThesisValidationError,
+    add_criteria,
+    get_active_thesis,
+    init_db,
+    query,
+    upsert_prices,
+    upsert_thesis,
+)
+from nuri.core.timezone import today_kst
+from nuri.trading.engine import thesis_criteria as tc
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def thesis(db_path):
+    return upsert_thesis(
+        ticker="ZZZZ",
+        author="user",
+        stance="bullish",
+        bull_case="가속기 수요가 공급을 앞선다",
+        bear_case="고객사 자체 칩 전환이 점유율을 깎는다",
+        evidence=[{"side": "bull", "claim": "매출 증가", "source_type": "filing"}],
+        effective_date="2026-05-01",
+        status="active",
+        db_path=db_path,
+    )
+
+
+def _seed_close(db_path, close: float, date: str | None = None):
+    d = date or today_kst()
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": "ZZZZ",
+                    "date": d,
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": 1000,
+                    "adj_close": close,
+                }
+            ]
+        ),
+        db_path=db_path,
+    )
+
+
+def _machine(metric="close", op="<", threshold=90.0, statement="50일선 이탈 시 전제 붕괴"):
+    return {"kind": "machine", "statement": statement, "metric": metric, "op": op, "threshold": threshold}
+
+
+class TestUnevaluableNeverLeaksAsHolding:
+    """이 클래스가 이 기능의 존재 이유다."""
+
+    def test_missing_data_is_unevaluable_not_holding(self, db_path, thesis):
+        """가격이 없으면 '이상 없음' 이 아니라 '측정 불가' 다.
+
+        Mutation lock: `no_data` 분기를 `holding` 으로 바꾸면 FAIL. 그 한 글자가
+        "기준이 매일 지켜지고 있다" 는 거짓말을 원장에 매일 쌓는다.
+        """
+        add_criteria(thesis, [_machine()], db_path=db_path)
+        counts = tc.run_daily_checks(today_kst(), db_path=db_path)
+        assert counts == {"holding": 0, "breached": 0, "unevaluable": 1}
+        row = query("SELECT result, detail FROM thesis_criteria_checks", db_path=db_path)[0]
+        assert row["result"] == "unevaluable"
+        assert row["detail"].startswith("no_data:")
+
+    def test_stale_data_is_unevaluable_not_holding(self, db_path, thesis):
+        """값이 있어도 너무 낡으면 측정 불가다 — 낡은 값으로 '지켜졌다' 고 적으면 안 된다."""
+        from datetime import date, timedelta
+
+        old = (date.fromisoformat(today_kst()) - timedelta(days=30)).isoformat()
+        _seed_close(db_path, 80.0, date=old)
+        add_criteria(thesis, [_machine()], db_path=db_path)
+
+        tc.run_daily_checks(today_kst(), db_path=db_path)
+        row = query("SELECT result, detail FROM thesis_criteria_checks", db_path=db_path)[0]
+        assert row["result"] == "unevaluable", "낡은 값으로 판정했다"
+        assert row["detail"].startswith("stale:")
+
+    def test_human_criteria_are_unevaluable_not_holding(self, db_path, thesis):
+        """사람 기준을 기계가 '지켜졌다' 고 적으면 매일 거짓말이 쌓인다."""
+        add_criteria(
+            db_path=db_path,
+            thesis_id=thesis,
+            criteria=[_machine(), {"kind": "human", "statement": "경영진이 capex 가이던스를 하향하면"}],
+        )
+        _seed_close(db_path, 200.0)
+        counts = tc.run_daily_checks(today_kst(), db_path=db_path)
+        assert counts["unevaluable"] == 1 and counts["holding"] == 1
+        detail = query("SELECT detail FROM thesis_criteria_checks WHERE result = 'unevaluable'", db_path=db_path)[0][
+            "detail"
+        ]
+        assert "manual" in detail
+
+    def test_unregistered_metric_on_an_existing_row_is_unevaluable(self, db_path, thesis):
+        """writer 를 우회해 들어온 행(마이그레이션 이전 데이터 등)도 통과로 새지 않는다."""
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO thesis_criteria (thesis_id, kind, statement, metric, op, threshold)"
+                " VALUES (?, 'machine', 's', 'not_a_metric', '<', 1.0)",
+                (thesis,),
+            )
+        tc.run_daily_checks(today_kst(), db_path=db_path)
+        row = query("SELECT result, detail FROM thesis_criteria_checks", db_path=db_path)[0]
+        assert row["result"] == "unevaluable"
+        assert row["detail"] == "no_metric:not_a_metric"
+
+
+class TestVerdict:
+    def test_breach_and_holding_both_resolve(self, db_path, thesis):
+        _seed_close(db_path, 80.0)
+        add_criteria(
+            thesis,
+            [_machine(op="<", threshold=90.0), _machine(op=">", threshold=200.0, statement="관심 소멸")],
+            db_path=db_path,
+        )
+        counts = tc.run_daily_checks(today_kst(), db_path=db_path)
+        assert counts == {"holding": 1, "breached": 1, "unevaluable": 0}
+
+        rows = {r["result"]: r for r in query("SELECT result, observed FROM thesis_criteria_checks", db_path=db_path)}
+        assert rows["breached"]["observed"] == 80.0
+        assert rows["holding"]["observed"] == 80.0
+
+    def test_checks_are_idempotent_per_day(self, db_path, thesis):
+        """append-only 지만 하루 1건이다 — 재실행이 그날 판정을 뒤집으면 사후에 알 수 없다."""
+        _seed_close(db_path, 80.0)
+        add_criteria(thesis, [_machine()], db_path=db_path)
+        d = today_kst()
+        tc.run_daily_checks(d, db_path=db_path)
+        tc.run_daily_checks(d, db_path=db_path)
+        assert query("SELECT COUNT(*) c FROM thesis_criteria_checks", db_path=db_path)[0]["c"] == 1
+
+    def test_only_active_theses_are_checked(self, db_path):
+        """draft/superseded 논지의 기준까지 매일 판정하면 원장이 죽은 기준으로 부푼다."""
+        draft = upsert_thesis(
+            ticker="WWWW",
+            author="llm",
+            stance="bullish",
+            bull_case="B",
+            bear_case="R",
+            evidence=[{"side": "bull", "claim": "c", "source_type": "filing"}],
+            db_path=db_path,
+        )
+        add_criteria(draft, [_machine()], db_path=db_path)
+        assert tc.run_daily_checks(today_kst(), db_path=db_path) == {
+            "holding": 0,
+            "breached": 0,
+            "unevaluable": 0,
+        }
+
+
+class TestWriterContract:
+    """양방향 — 미등록은 거부되고, 등록된 것은 전부 해소된다."""
+
+    def test_every_registered_metric_actually_resolves(self, db_path):
+        """목록에 있는데 해소가 안 되면 그 기준은 영원히 unevaluable 이다.
+
+        `no_data` 는 티커에 값이 없다는 뜻이라 정상 — 여기서 잡는 것은 **예외로 죽거나
+        no_metric 을 내는 것**, 즉 목록과 구현이 갈린 경우다.
+        """
+        for metric in tc.METRIC_RESOLVERS:
+            value, date, table = tc.METRIC_RESOLVERS[metric]("ZZZZ", db_path)
+            assert value is None and date is None, f"{metric}: 빈 DB 인데 값이 나왔다"
+            assert isinstance(table, str) and table
+
+    def test_unregistered_metric_is_rejected_at_write_time(self, db_path, thesis):
+        with pytest.raises(ThesisValidationError, match="해소기 없는 metric"):
+            add_criteria(thesis, [_machine(metric="made_up_metric")], db_path=db_path)
+
+    def test_all_human_criteria_are_rejected(self, db_path, thesis):
+        """machine 이 하나도 없으면 자동 점검이 장식이다."""
+        with pytest.raises(ThesisValidationError, match="machine 기준이 최소 1개"):
+            add_criteria(thesis, [{"kind": "human", "statement": "감으로"}], db_path=db_path)
+
+    def test_zero_criteria_is_rejected(self, db_path, thesis):
+        with pytest.raises(ThesisValidationError, match="0건"):
+            add_criteria(thesis, [], db_path=db_path)
+
+    def test_blank_statement_is_rejected(self, db_path, thesis):
+        """metric 만 있고 문장이 없으면 나중에 무엇을 반증하려 했는지 알 수 없다."""
+        with pytest.raises(ThesisValidationError, match="statement"):
+            add_criteria(thesis, [_machine(statement="   ")], db_path=db_path)
+
+    def test_bad_operator_is_rejected(self, db_path, thesis):
+        with pytest.raises(ThesisValidationError, match="op"):
+            add_criteria(thesis, [_machine(op="!=")], db_path=db_path)
+
+    def test_a_rejected_batch_writes_nothing(self, db_path, thesis):
+        """검증이 INSERT 앞이어야 한다 — 뒤면 반쪽 기준 집합이 남는다."""
+        with pytest.raises(ThesisValidationError):
+            add_criteria(thesis, [_machine(), _machine(metric="nope")], db_path=db_path)
+        assert query("SELECT COUNT(*) c FROM thesis_criteria", db_path=db_path)[0]["c"] == 0
+
+
+class TestSurfaceCeiling:
+    def test_checks_never_write_an_action_axis(self, db_path, thesis):
+        """반증 발화는 Surface 전용 — 주문도 축도 만들지 않는다 (§7.1 · Escalation Ladder).
+
+        Mutation lock: breach 를 recommendations/agent_decisions 로 흘리면 FAIL.
+        """
+        _seed_close(db_path, 80.0)
+        add_criteria(thesis, [_machine()], db_path=db_path)
+        tc.run_daily_checks(today_kst(), db_path=db_path)
+
+        for table in ("recommendations", "agent_decisions", "decisions"):
+            assert query(f"SELECT COUNT(*) c FROM {table}", db_path=db_path)[0]["c"] == 0, (
+                f"{table} 에 행이 생겼다 — 반증 점검이 매매 축을 건드렸다"
+            )
+
+
+class TestReadPath:
+    def test_criteria_reach_the_decision_read_path(self, db_path, thesis):
+        """배선만 하고 화면에 안 닿으면 `data/thesis_query/` markdown 39개와 같은 운명이다."""
+        _seed_close(db_path, 80.0)
+        add_criteria(thesis, [_machine()], db_path=db_path)
+        tc.run_daily_checks(today_kst(), db_path=db_path)
+
+        got = get_active_thesis("ZZZZ", as_of=today_kst(), db_path=db_path)
+        assert got is not None
+        assert len(got["criteria"]) == 1
+        assert got["criteria"][0]["last_result"] == "breached"
+        assert got["criteria"][0]["last_checked"] == today_kst()
+
+    def test_scheduler_dispatch_reaches_the_checker(self):
+        """`_STAGE_OF_JOB` 에 track 으로 올려 두고 dispatcher 분기가 없으면 조용히 안 돈다."""
+        import nuri.scheduler as sch
+
+        assert sch._STAGE_OF_JOB["thesis_criteria"] == "track"
+        scheduled = {j["args"][0] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
+        assert "thesis_criteria" in scheduled


### PR DESCRIPTION
Closes #1092

코덱스가 확정한 순서의 **2번**. 시나리오 분석보다 먼저인 이유:

> *"Bull/bear text without pre-registered invalidators is narrative storage, not
> disciplined decision support."*

## 무엇을 막는가

논지에 **"무엇이 사실이면 내가 틀린 것인가"** 가 없으면 사후에 "대체로 맞았다" 로 읽힌다.
그건 처분효과를 막지 못하는 서사이고, 이 시스템의 목적과 정반대다.

## 절대 굽히지 않는 한 줄

> **해소되지 않는 metric 은 `unevaluable` 이다. 절대 `holding` 이 아니다.**

측정하지 못한 것을 "이상 없음" 으로 적으면 게이트가 **있는데 안 잡는** 상태가 되고, 그건
게이트가 없는 것보다 나쁘다 — 있다고 믿게 되므로. `_check_volatility_for_class` 가 넉 달간
초록이던 이유가 정확히 이것이다.

`unevaluable` 로 떨어지는 네 경우, 전부 `detail` 에 사유를 남긴다:

| 사유 | 언제 |
|---|---|
| `no_data` | 그 티커의 값이 DB 에 없음 |
| `stale` | 값은 있는데 정책상 너무 낡음 (prices/signals/factors 5일, fundamentals 100일) |
| `no_metric` | 미등록 metric (writer 를 우회해 들어온 행) |
| `manual` | `human` 기준 — 기계가 판정할 수 없다 |

## writer 가 세 가지를 거부한다

- **기준 0건** — 반증 없는 논지는 서사다
- **전부 `human`** — 자동 점검이 장식이 된다
- **해소기 없는 metric** — 스키마 CHECK 는 `machine` 이면 metric/op/threshold 가 **있는지**만
  보고 그 이름이 뭘 뜻하는지는 모른다. 오타 하나면 행은 만들어지고 매일 `unevaluable` 만
  쌓이는데, 등록한 사람은 점검이 도는 줄 안다

CLI 는 기준 등록이 실패하면 **논지를 롤백**한다 — 반증 없는 논지를 원장에 남기지 않는다.

## Surface 천장

breach 는 알림·화면 뱃지까지다. 일별 잡은 `recommendations`/`agent_decisions`/`decisions`
어디에도 쓰지 않고 축(`alpha_action`)을 만들지 않는다 (§7.1 · Escalation Ladder).
승격은 STRATEGY PR 대상이며, 테스트가 세 테이블이 비어 있는지 직접 단언한다.

## 배선

`factors`(08:10) **뒤인 08:20** — 팩터 기준이 전날 값이 아니라 그날 값으로 판정되게.
`_run_collector` 경로를 쓴다(전용 러너 아님): 전용 러너면 `pipeline_events` 에 아무것도
안 남아 "도는 줄 아는데 안 도는" 상태를 관측할 수 없다. `_STAGE_OF_JOB` 에 `track` 으로.

## 도달 가능성

- 결정 상세 화면에 반증 기준 섹션 — `unevaluable`/`미점검` 은 **회색**이다.
  초록(유지)이면 "측정 못 했다" 가 "지켜졌다" 로 읽히고 그게 이 기능이 막으려는 것이다.
- `make thesis-show ticker=<T>` 가 기준 + 최신 판정을 출력
- `get_active_thesis` 가 `criteria` 를 함께 반환 → API 는 `response_model` 이 없어 그대로 흐름

## 검증 — 뮤테이션 9종 전부 검출

| 뮤테이션 | 떨어지는 테스트 |
|---|---|
| `no_data` → holding | `test_missing_data_is_unevaluable_not_holding` |
| `stale` → holding | `test_stale_data_is_unevaluable_not_holding` |
| `human` → holding | `test_human_criteria_are_unevaluable_not_holding` |
| writer 검증 제거 | `test_a_bad_criterion_rolls_the_thesis_back` |
| machine 최소 1개 제거 | `test_all_human_criteria_are_rejected` |
| CLI 롤백 제거 | `test_a_bad_criterion_rolls_the_thesis_back` |
| `INSERT OR IGNORE`→`REPLACE` | `test_rerunning_the_same_day_does_not_overwrite_the_verdict` |
| draft 논지도 점검 | `test_only_active_theses_are_checked` |
| 스케줄러 배선 제거 | `test_no_dispatch_branch_lacks_a_cron` |

⚠️ 멱등성 뮤테이션은 **1라운드에서 살아남았다** — 행 수만 세면 `REPLACE` 도 UNIQUE 로 1행을
지키기 때문. 진짜 계약은 "먼저 기록된 판정이 이긴다" 라 그걸로 다시 잠갔다.

## 살아있음 증명

다음날 `thesis_criteria_checks` 증가 + 의도적으로 현재가 아래로 잡은 기준이 `breached` 로
뒤집히는 것. 로컬에서는 close=80 에 `<90`/`>200` 두 기준으로 breached 1 · holding 1 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)