### PR TITLE
feat(recommend): record the trades that were not executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,207 collected across 329 files | |
+| **Backend tests** | 7,208 collected across 329 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ flowchart TB
         ANA(["22 signals · 10 regimes · 4-factor composite"]):::lazy
     end
 
-    DB[("SQLite WAL · 55 tables<br/>audit · evidence · pipeline events")]:::sink
+    DB[("SQLite WAL · 57 tables<br/>audit · evidence · pipeline events")]:::sink
 
     SCHED --> Collect
     SCHED --> Decide
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,192 collected across 328 files | |
+| **Backend tests** | 7,207 collected across 329 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -285,7 +285,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 55 tables (52 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 57 tables (53 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,207 backend tests across 329 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,208 backend tests across 329 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (52 migrations as of 2026-07-30). Key tables:
+51 tables total (53 migrations as of 2026-07-30). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,192 backend tests across 328 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,207 backend tests across 329 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,207 tests, 329 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,208 tests, 329 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,192 tests, 328 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,207 tests, 329 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -101,6 +101,16 @@ def _collect_context(db_path=None) -> dict:
             save_buy_candidates(emitted, db_path=db_path)
         except Exception:
             logger.warning("buy candidates 영속화 실패 (브리핑은 계속)", exc_info=True)
+        # 미실행 원장 (#1094) — 위 `save_buy_candidates` 는 **발행된 후보만** 남긴다.
+        # 차단된 날(오늘처럼 regime=recovery 로 0건)은 그쪽에 아무것도 안 남아 원장에서
+        # "아무 일도 없던 날" 로 보인다. 이건 그 반대편을 남긴다: 실행하지 않은 것과
+        # 그 사유. 없으면 사후 채점이 실행한 것만 보게 되어 생존 편향이 된다.
+        try:
+            from nuri.core.db import record_candidate_run
+
+            record_candidate_run(emitted, db_path=db_path)
+        except Exception:
+            logger.warning("candidate run 기록 실패 (브리핑은 계속)", exc_info=True)
     except Exception:
         logger.warning("buy candidates emit 실패", exc_info=True)
 

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -30,6 +30,11 @@ from .audit import (  # noqa: F401, E402
     audit_log,
     log_external_llm_call,
 )
+from .candidate_ledger_ops import (  # noqa: F401, E402
+    get_candidate_run,
+    mark_acted,
+    record_candidate_run,
+)
 from .connection import (  # noqa: F401 — facade re-exports for back-compat
     DB_PATH,
     DatabaseError,

--- a/nuri/core/db/candidate_ledger_ops.py
+++ b/nuri/core/db/candidate_ledger_ops.py
@@ -1,0 +1,174 @@
+"""미실행 거래 원장 writes/reads — candidate_runs / candidate_ledger (#1094).
+
+## 왜 이게 채점보다 먼저인가
+
+실행하지 않은 거래가 기록되지 않으면 사후 채점이 **실행한 것만** 보게 되고, 그 성적표는
+실제 실력보다 좋게 나온다. Codex(2026-08-18): *"Without the 'did not execute' baseline,
+later post-hoc scoring will select only acted-on trades and quietly bias the evidence."*
+
+## 테이블이 둘인 이유
+
+**막힌 실행이 가장 정보량 많은 미실행 기록**인데 걸어 둘 티커가 없다. "왜 오늘 후보가
+0이었나"(regime 차단 · VIX 차단 · 임계 미달)는 티커 단위로 표현되지 않는다. run 을 따로
+두지 않으면 그 날은 원장에서 **아무 일도 없던 날**로 보인다 — 실제로는 시스템이 돌았고
+차단 판단을 내렸는데도.
+
+## `acted` 는 파생하지 않는다
+
+`trades` 0행 · `portfolio.first_buy_date` 18/18 동일 상수(2026-08-18 실측)라 체결을 알
+방법이 없다. `acted` 는 **사람이 켜는 값**이고, 자동으로 채우면 "실행 vs 미실행" 비교가
+조용히 거짓이 된다.
+
+## Surface 천장
+
+이건 기록이지 신호가 아니다. `alpha_action`/`portfolio_action` 을 만들지 않고, §3.11 판정
+표본(`recommendations` where `source IS NULL`)과도 별개 테이블이다.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from .connection import get_db
+
+logger = logging.getLogger(__name__)
+
+#: 티커별 처분. `skipped` 는 게이트에 걸린 것(보유·쿨다운·레버리지), `below_threshold` 는
+#: 채점은 됐지만 임계를 못 넘은 것. 둘을 합치면 "왜 안 샀나" 의 결이 사라진다.
+DISPOSITIONS = ("emitted", "skipped", "below_threshold")
+
+
+def record_candidate_run(result: Any, run_date: Optional[str] = None, db_path: Optional[Path] = None) -> int:
+    """`EmitResult` 1건 → `candidate_runs` + `candidate_ledger`. run_id 반환.
+
+    **후보가 0건이어도 run 행을 남긴다.** 그게 이 기능의 요점이다 — 차단된 날이야말로
+    기록할 가치가 가장 큰 미실행 기록이다.
+
+    같은 날 재실행은 `UNIQUE(run_date)` 로 갱신한다(하루 1행). 원장이 append-only 가
+    아닌 이유: run 은 그날의 **최종 상태**를 뜻하고, 하루에 두 번 돌면 두 번째가 그날의
+    결론이다. 티커 행도 같은 run 에 대해 `INSERT OR REPLACE` 로 맞춘다.
+    """
+    from nuri.core.timezone import today_kst
+
+    d = run_date or today_kst()
+    candidates = list(getattr(result, "candidates", None) or [])
+    skipped: dict[str, str] = dict(getattr(result, "skipped", None) or {})
+
+    with get_db(db_path) as conn:
+        conn.execute(
+            """INSERT INTO candidate_runs
+               (run_date, regime, vix, threshold, blocked_reason,
+                n_scored, n_qualified, n_emitted, n_skipped)
+               VALUES (:run_date, :regime, :vix, :threshold, :blocked_reason,
+                       :n_scored, :n_qualified, :n_emitted, :n_skipped)
+               ON CONFLICT(run_date) DO UPDATE SET
+                   regime = excluded.regime,
+                   vix = excluded.vix,
+                   threshold = excluded.threshold,
+                   blocked_reason = excluded.blocked_reason,
+                   n_scored = excluded.n_scored,
+                   n_qualified = excluded.n_qualified,
+                   n_emitted = excluded.n_emitted,
+                   n_skipped = excluded.n_skipped""",
+            {
+                "run_date": d,
+                "regime": getattr(result, "regime", None) or None,
+                "vix": getattr(result, "vix", None),
+                "threshold": getattr(result, "threshold", None),
+                "blocked_reason": getattr(result, "blocked_reason", None),
+                "n_scored": int(getattr(result, "n_scored", 0) or 0),
+                "n_qualified": int(getattr(result, "n_qualified", 0) or 0),
+                "n_emitted": len(candidates),
+                "n_skipped": len(skipped),
+            },
+        )
+        row = conn.execute("SELECT id FROM candidate_runs WHERE run_date = ?", (d,)).fetchone()
+        run_id = row[0]
+
+        records = [
+            {
+                "run_id": run_id,
+                "ticker": c.ticker,
+                "disposition": "emitted",
+                "reason": getattr(c, "why_now", None),
+                "score": getattr(c, "score", None),
+                "entry": getattr(c, "entry", None),
+                "stop": getattr(c, "stop", None),
+                "tp1": getattr(c, "tp1", None),
+                "tp2": getattr(c, "tp2", None),
+            }
+            for c in candidates
+        ]
+        records += [
+            {
+                "run_id": run_id,
+                "ticker": ticker,
+                "disposition": "skipped",
+                "reason": reason,
+                "score": None,
+                "entry": None,
+                "stop": None,
+                "tp1": None,
+                "tp2": None,
+            }
+            for ticker, reason in skipped.items()
+        ]
+        if records:
+            # `acted` 는 여기서 건드리지 않는다 — 사람이 켠 값을 재실행이 지우면 안 된다.
+            conn.executemany(
+                """INSERT INTO candidate_ledger
+                   (run_id, ticker, disposition, reason, score, entry, stop, tp1, tp2)
+                   VALUES (:run_id, :ticker, :disposition, :reason, :score, :entry, :stop, :tp1, :tp2)
+                   ON CONFLICT(run_id, ticker) DO UPDATE SET
+                       disposition = excluded.disposition,
+                       reason = excluded.reason,
+                       score = excluded.score,
+                       entry = excluded.entry,
+                       stop = excluded.stop,
+                       tp1 = excluded.tp1,
+                       tp2 = excluded.tp2""",
+                records,
+            )
+    logger.info(
+        "candidate run recorded: %s emitted=%d skipped=%d blocked=%s",
+        d,
+        len(candidates),
+        len(skipped),
+        getattr(result, "blocked_reason", None) or "-",
+    )
+    return run_id
+
+
+def mark_acted(run_date: str, ticker: str, acted: bool = True, db_path: Optional[Path] = None) -> bool:
+    """체결 여부를 **사람이** 표시한다. 갱신되면 True.
+
+    파생하지 않는 이유는 모듈 docstring 참조 — 체결을 알 방법이 시스템에 없다.
+    """
+    from nuri.core.timezone import kst_now
+
+    with get_db(db_path) as conn:
+        cur = conn.execute(
+            """UPDATE candidate_ledger SET acted = ?, acted_at = ?
+                WHERE ticker = ? AND run_id = (SELECT id FROM candidate_runs WHERE run_date = ?)""",
+            (1 if acted else 0, kst_now().isoformat() if acted else None, ticker, run_date),
+        )
+        return (cur.rowcount or 0) > 0
+
+
+def get_candidate_run(run_date: str, db_path: Optional[Path] = None) -> Optional[dict]:
+    """하루치 run + 티커별 원장."""
+    with get_db(db_path) as conn:
+        row = conn.execute("SELECT * FROM candidate_runs WHERE run_date = ?", (run_date,)).fetchone()
+        if row is None:
+            return None
+        run = dict(row)
+        run["ledger"] = [
+            dict(r)
+            for r in conn.execute(
+                "SELECT * FROM candidate_ledger WHERE run_id = ? ORDER BY disposition, score DESC, ticker",
+                (run["id"],),
+            ).fetchall()
+        ]
+        return run

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1667,4 +1667,58 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
             ON thesis_criteria_checks(check_date, result);
     """,
     ),
+    (
+        53,
+        "candidate_runs / candidate_ledger — 미실행 거래 원장 (#1094)",
+        # 실행하지 않은 거래가 기록되지 않으면 사후 채점이 **실행한 것만** 보게 되고,
+        # 그 성적표는 실제 실력보다 좋게 나온다(생존 편향).
+        #
+        # 테이블이 둘인 이유: **막힌 실행이 가장 정보량 많은 미실행 기록**인데 걸어 둘
+        # 티커가 없다. "왜 오늘 후보가 0이었나"(regime 차단·VIX 차단·임계 미달)는 티커
+        # 단위로 표현할 수 없어서, run 을 따로 두지 않으면 그 날은 원장에서 **아무 일도
+        # 없던 날**로 보인다.
+        #
+        # `acted` 는 **수동 토글**이다. `trades` 0행 · `portfolio.first_buy_date` 18/18
+        # 동일 상수(2026-08-18 실측)라 체결을 알 방법이 없다. 자동으로 채우면
+        # "실행 vs 미실행" 비교가 조용히 거짓이 된다 — 파생되는 척하지 않는다.
+        """
+        CREATE TABLE IF NOT EXISTS candidate_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_date TEXT NOT NULL,
+            regime TEXT,
+            vix REAL,
+            threshold REAL,
+            blocked_reason TEXT,
+            n_scored INTEGER NOT NULL DEFAULT 0,
+            n_qualified INTEGER NOT NULL DEFAULT 0,
+            n_emitted INTEGER NOT NULL DEFAULT 0,
+            n_skipped INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(run_date)
+        );
+        CREATE INDEX IF NOT EXISTS idx_candidate_runs_date ON candidate_runs(run_date);
+
+        CREATE TABLE IF NOT EXISTS candidate_ledger (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL REFERENCES candidate_runs(id) ON DELETE CASCADE,
+            ticker TEXT NOT NULL,
+            disposition TEXT NOT NULL
+                CHECK (disposition IN ('emitted', 'skipped', 'below_threshold')),
+            reason TEXT,
+            score REAL,
+            entry REAL,
+            stop REAL,
+            tp1 REAL,
+            tp2 REAL,
+            acted INTEGER NOT NULL DEFAULT 0 CHECK (acted IN (0, 1)),
+            acted_at TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(run_id, ticker)
+        );
+        CREATE INDEX IF NOT EXISTS idx_candidate_ledger_run
+            ON candidate_ledger(run_id, disposition);
+        CREATE INDEX IF NOT EXISTS idx_candidate_ledger_ticker
+            ON candidate_ledger(ticker, acted);
+    """,
+    ),
 ]

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -76,6 +76,12 @@ class EmitResult:
     total_deploy_pct: float = 0.0
     blocked_reason: str | None = None  # if 0 candidates, why?
     timestamp_kst: str = ""
+    # 미실행 원장(#1094)이 "왜 0건이었나" 를 답하려면 분모가 필요하다. 후보 목록만으로는
+    # "채점 대상이 0" 과 "200개를 채점했는데 아무도 임계를 못 넘음" 이 구분되지 않는다.
+    # 차단 경로(VIX/regime)에서는 채점 자체를 안 하므로 0 으로 남는다 — 그것도 정보다.
+    n_scored: int = 0
+    n_qualified: int = 0
+    threshold: float | None = None
 
 
 def format_vix(vix: float | None) -> str:
@@ -412,6 +418,7 @@ def emit_buy_candidates(
     # Quality threshold (regime-adjusted)
     threshold = quality.get("base_threshold", 70)
     threshold += quality.get("per_regime", {}).get(regime, 0)
+    result.threshold = threshold
     if threshold >= 999:
         result.blocked_reason = f"regime={regime} threshold={threshold} (사실상 차단)"
         return result
@@ -460,6 +467,8 @@ def emit_buy_candidates(
     # Filter by quality bar, sort, top-N
     qualified = [s for s in scored if s[1] >= threshold]
     qualified.sort(key=lambda x: x[1], reverse=True)
+    result.n_scored = len(scored)
+    result.n_qualified = len(qualified)
     max_cand = limit if limit is not None else quality.get("max_candidates", 5)
     top = qualified[:max_cand]
 

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -1029,6 +1029,62 @@ class TestBuyCandidatesArePersisted:
         assert [r["ticker"] for r in rows] == ["AAA"]
         assert rows[0]["source"] == "buy_candidate_emitter"
 
+    def test_a_blocked_run_still_reaches_the_candidate_ledger(self, tmp_path, monkeypatch):
+        """후보 0건이어도 미실행 원장에는 run + 사유가 남는다 (#1094).
+
+        `save_buy_candidates` 는 **발행된 후보만** 남기므로 차단된 날은 그쪽에 아무것도
+        안 남는다 — 2026-08-18 프로덕션이 정확히 그 케이스였다(regime=recovery, 후보 0).
+        그 날이 원장에서 사라지면 사후 채점이 실행한 것만 보게 된다.
+
+        Mutation lock: `record_candidate_run` 호출을 지우면 run 이 None 이라 FAIL.
+        """
+        from nuri.alerts import premarket_brief as pb
+        from nuri.core.db import get_candidate_run, init_db
+        from nuri.trading.recommend.buy_candidate_emitter import EmitResult
+
+        db = tmp_path / "brief.db"
+        init_db(db)
+
+        blocked = EmitResult(
+            regime="recovery",
+            skipped={"AAA": "held (보유 중)", "BBB": "cooldown 5d"},
+            blocked_reason="regime=recovery (방어 모드, 신규 매수 차단)",
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.buy_candidate_emitter.emit_buy_candidates",
+            lambda *a, **k: blocked,
+        )
+
+        pb._collect_context(db_path=db)
+
+        from nuri.core.timezone import today_kst
+
+        run = get_candidate_run(today_kst(), db_path=db)
+        assert run is not None, "차단된 날이 원장에 안 남았다"
+        assert run["n_emitted"] == 0 and run["n_skipped"] == 2
+        assert {r["ticker"] for r in run["ledger"]} == {"AAA", "BBB"}
+
+    def test_a_ledger_failure_does_not_break_the_brief(self, tmp_path, monkeypatch):
+        """관측이 본 작업을 게이트하면 안 된다 (#894) — 원장 실패가 브리핑을 죽이지 않는다."""
+        from nuri.alerts import premarket_brief as pb
+        from nuri.core.db import init_db
+        from nuri.trading.recommend.buy_candidate_emitter import EmitResult
+
+        db = tmp_path / "brief.db"
+        init_db(db)
+
+        def boom(*a, **k):
+            raise RuntimeError("ledger down")
+
+        monkeypatch.setattr(
+            "nuri.trading.recommend.buy_candidate_emitter.emit_buy_candidates",
+            lambda *a, **k: EmitResult(regime="bull_low_vol"),
+        )
+        monkeypatch.setattr("nuri.core.db.record_candidate_run", boom)
+
+        ctx = pb._collect_context(db_path=db)
+        assert ctx is not None, "원장 실패가 브리핑을 죽였다"
+
     def test_a_persistence_failure_does_not_break_the_brief(self, tmp_path, monkeypatch):
         """관측이 본 작업을 게이트하면 안 된다 (#894) — 기록이 터져도 브리핑은 나간다."""
         from nuri.alerts import premarket_brief as pb

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,7 +29,7 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_52(self, db_path):
+    def test_schema_version_at_53(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
@@ -39,8 +39,9 @@ class TestSchemaMigrations:
         incidents enum 확장 — health_check.sh 흡수 3종 (#939) +
         recommendations.source — emit 경로 구분 (#1078) +
         theses / thesis_evidence — 상승·하락 논지 원장 (#1083) +
-        thesis_criteria / thesis_criteria_checks — 사전등록 반증 기준 (#1092) → 52."""
-        assert get_schema_version(db_path) == 52
+        thesis_criteria / thesis_criteria_checks — 사전등록 반증 기준 (#1092) +
+        candidate_runs / candidate_ledger — 미실행 거래 원장 (#1094) → 53."""
+        assert get_schema_version(db_path) == 53
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/core/test_candidate_ledger.py
+++ b/tests/core/test_candidate_ledger.py
@@ -1,0 +1,172 @@
+"""미실행 거래 원장 — candidate_runs / candidate_ledger (#1094).
+
+이 파일이 잠그는 것은 **기록되지 않는 날이 없다**는 것이다.
+
+`save_buy_candidates`(#1078)는 발행된 후보만 남긴다. 그래서 차단된 날 — 2026-08-18 이
+정확히 그랬다, `regime=recovery` 로 후보 0건 — 은 원장에서 "아무 일도 없던 날" 로 보인다.
+실제로는 시스템이 돌았고 18종목을 건너뛴다는 판단을 내렸는데도.
+
+없으면 사후 채점이 **실행한 것만** 보게 되고 그 성적표는 실제 실력보다 좋다(생존 편향).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nuri.core.db import (
+    get_candidate_run,
+    init_db,
+    mark_acted,
+    query,
+    record_candidate_run,
+)
+from nuri.core.timezone import today_kst
+from nuri.trading.recommend.buy_candidate_emitter import BuyCandidate, EmitResult
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _candidate(ticker="ZZZZ", score=88.0):
+    return BuyCandidate(
+        ticker=ticker,
+        score=score,
+        deploy_pct=6.0,
+        entry=100.0,
+        stop=93.0,
+        tp1=121.0,
+        tp2=142.0,
+        why_now="breakout",
+        sources={"factor": 0.9},
+    )
+
+
+def _emitted(**over):
+    r = EmitResult(candidates=[_candidate()], regime="bull_low_vol", vix=16.2, **over)
+    r.n_scored, r.n_qualified, r.threshold = 200, 3, 70.0
+    return r
+
+
+class TestBlockedDaysAreRecorded:
+    """이 클래스가 이 기능의 존재 이유다."""
+
+    def test_a_regime_blocked_run_still_leaves_a_row(self, db_path):
+        """후보 0건이어도 run 이 남는다 — 차단된 날이 가장 정보량 많은 미실행 기록이다.
+
+        Mutation lock: 0건일 때 조기 return 하면 FAIL. 2026-08-18 프로덕션이 이 케이스였다.
+        """
+        blocked = EmitResult(
+            regime="recovery",
+            vix=None,
+            skipped={f"T{i:02d}": "held (보유 중)" for i in range(18)},
+            blocked_reason="regime=recovery (방어 모드, 신규 매수 차단)",
+        )
+        record_candidate_run(blocked, "2026-08-18", db_path=db_path)
+
+        run = get_candidate_run("2026-08-18", db_path=db_path)
+        assert run is not None, "차단된 날이 원장에서 사라졌다"
+        assert run["n_emitted"] == 0 and run["n_skipped"] == 18
+        assert run["blocked_reason"].startswith("regime=recovery")
+        assert len(run["ledger"]) == 18
+        assert {r["disposition"] for r in run["ledger"]} == {"skipped"}
+
+    def test_the_reason_is_kept_per_ticker(self, db_path):
+        """티커별 사유를 뭉뚱그리면 '왜 안 샀나' 의 결이 사라진다."""
+        blocked = EmitResult(
+            regime="bull_low_vol",
+            skipped={"AAA": "held (보유 중)", "BBB": "cooldown 5d", "CCC": "leverage ETF"},
+        )
+        record_candidate_run(blocked, "2026-08-18", db_path=db_path)
+        reasons = {r["ticker"]: r["reason"] for r in get_candidate_run("2026-08-18", db_path=db_path)["ledger"]}
+        assert reasons == {"AAA": "held (보유 중)", "BBB": "cooldown 5d", "CCC": "leverage ETF"}
+
+    def test_an_empty_run_with_no_skips_still_records(self, db_path):
+        """VIX 차단은 채점 전에 끊기므로 skipped 도 비어 있다 — 그래도 run 은 남아야 한다."""
+        record_candidate_run(
+            EmitResult(regime="bull_high_vol", vix=33.0, blocked_reason="VIX 33.0 > 30 (신규 매수 차단)"),
+            "2026-08-18",
+            db_path=db_path,
+        )
+        run = get_candidate_run("2026-08-18", db_path=db_path)
+        assert run is not None and run["ledger"] == []
+        assert run["vix"] == 33.0
+
+
+class TestDenominator:
+    def test_scored_and_qualified_distinguish_two_kinds_of_zero(self, db_path):
+        """'채점 대상이 0' 과 '200개 채점했는데 아무도 임계를 못 넘음' 은 다른 상태다."""
+        r = EmitResult(regime="bull_low_vol", blocked_reason="top scorer 61/100 < threshold 70")
+        r.n_scored, r.n_qualified, r.threshold = 200, 0, 70.0
+        record_candidate_run(r, "2026-08-18", db_path=db_path)
+
+        run = get_candidate_run("2026-08-18", db_path=db_path)
+        assert (run["n_scored"], run["n_qualified"], run["n_emitted"]) == (200, 0, 0)
+        assert run["threshold"] == 70.0
+
+    def test_emitter_fills_the_denominator(self):
+        """`EmitResult` 가 분모를 안 실으면 원장은 늘 0 을 적는다 — 배선 축."""
+        r = EmitResult()
+        assert hasattr(r, "n_scored") and hasattr(r, "n_qualified") and hasattr(r, "threshold")
+
+
+class TestActedIsManual:
+    def test_acted_defaults_to_zero(self, db_path):
+        """체결을 알 방법이 없다 — `trades` 0행, `first_buy_date` 전부 동일 상수."""
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+        row = get_candidate_run("2026-08-19", db_path=db_path)["ledger"][0]
+        assert row["acted"] == 0 and row["acted_at"] is None
+
+    def test_a_person_can_mark_it(self, db_path):
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+        assert mark_acted("2026-08-19", "ZZZZ", db_path=db_path) is True
+        row = get_candidate_run("2026-08-19", db_path=db_path)["ledger"][0]
+        assert row["acted"] == 1 and row["acted_at"]
+
+    def test_rerunning_the_day_does_not_erase_it(self, db_path):
+        """재실행이 사람이 켠 값을 지우면 '실행 vs 미실행' 비교가 조용히 거짓이 된다.
+
+        Mutation lock: UPSERT 에 `acted = excluded.acted` 를 넣으면 FAIL.
+        """
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+        mark_acted("2026-08-19", "ZZZZ", db_path=db_path)
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+
+        row = get_candidate_run("2026-08-19", db_path=db_path)["ledger"][0]
+        assert row["acted"] == 1, "재실행이 사람이 켠 체결 표시를 지웠다"
+
+    def test_marking_an_unknown_ticker_reports_failure(self, db_path):
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+        assert mark_acted("2026-08-19", "NOPE", db_path=db_path) is False
+
+
+class TestOneRowPerDay:
+    def test_rerun_updates_rather_than_duplicates(self, db_path):
+        """run 은 그날의 **최종 상태**다 — 두 번 돌면 두 번째가 그날의 결론이다."""
+        record_candidate_run(EmitResult(regime="recovery", blocked_reason="차단"), "2026-08-19", db_path=db_path)
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+
+        assert query("SELECT COUNT(*) c FROM candidate_runs", db_path=db_path)[0]["c"] == 1
+        run = get_candidate_run("2026-08-19", db_path=db_path)
+        assert run["blocked_reason"] is None and run["n_emitted"] == 1
+
+    def test_defaults_to_today(self, db_path):
+        record_candidate_run(_emitted(), db_path=db_path)
+        assert get_candidate_run(today_kst(), db_path=db_path) is not None
+
+
+class TestSurfaceCeiling:
+    def test_the_ledger_writes_no_trading_row(self, db_path):
+        """기록이지 신호가 아니다 — 축도 주문도 만들지 않고 §3.11 표본도 안 건드린다.
+
+        Mutation lock: `recommendations` 로 흘리면 FAIL.
+        """
+        record_candidate_run(_emitted(), "2026-08-19", db_path=db_path)
+        for table in ("recommendations", "agent_decisions", "decisions"):
+            assert query(f"SELECT COUNT(*) c FROM {table}", db_path=db_path)[0]["c"] == 0, table
+
+    def test_missing_run_reads_as_none(self, db_path):
+        assert get_candidate_run("2020-01-01", db_path=db_path) is None

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -459,6 +459,26 @@ def test_below_threshold_blocked(db, cfg_path):
 # --- Happy path: emit + risk levels ----------------------------------------
 
 
+def test_emit_reports_the_denominator(db, cfg_path):
+    """채점 규모와 임계를 결과에 실어야 미실행 원장이 "왜 0건이었나" 를 답할 수 있다 (#1094).
+
+    이게 없으면 원장은 늘 `n_scored=0` 을 적고, "채점 대상이 0" 과 "200개 채점했는데
+    아무도 임계를 못 넘음" 이 구분되지 않는다.
+
+    Mutation lock: `result.n_scored`/`n_qualified` 대입을 지우면 0 이 되어 FAIL.
+    """
+    _seed_factor(db, "STRONG", 0.95)
+    _seed_prices(db, "STRONG", [100.0] * 25 + [110.0, 115.0, 120.0, 125.0, 130.0, 135.0])
+    _seed_rsi(db, "STRONG", 55)
+    _seed_vix(db, 20.0)
+    _seed_regime(db, "neutral")
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.n_scored >= 1, "채점 규모가 결과에 안 실렸다"
+    assert res.n_qualified >= 1
+    assert res.threshold is not None, "임계가 결과에 안 실렸다"
+
+
 def test_emit_above_threshold(db, cfg_path):
     _seed_factor(db, "STRONG", 0.95)
     _seed_prices(db, "STRONG", [100.0] * 25 + [110.0, 115.0, 120.0, 125.0, 130.0, 135.0])


### PR DESCRIPTION
Closes #1094

코덱스 순서의 **3번 — 채점(4번)보다 먼저**.

> *"Without the 'did not execute' baseline, later post-hoc scoring will select
> only acted-on trades and quietly bias the evidence."*

## 무엇이 없었나

#1078 로 **발행된 후보**는 원장에 남기 시작했다. 그런데 시스템이 돌아서 "오늘은 아무것도
사지 않는다" 고 판단한 날은 **아무 흔적이 없다.**

2026-08-18 프로덕션이 정확히 그 케이스였다:

```
regime=recovery → 방어 모드, 신규 매수 차단
후보 0건 · skipped 18종목 (사유 각각 존재)
원장에 남은 것: 없음
```

그 기록 위에서 채점하면 **실행한 거래만** 보게 되고, 성적표가 실제보다 좋게 나온다.

## 테이블이 둘인 이유

**막힌 실행이 가장 정보량 많은 미실행 기록인데 걸어 둘 티커가 없다.** "왜 오늘 후보가
0이었나" 는 run 의 성질이지 어느 종목의 성질이 아니다. `candidate_runs` 를 따로 두지
않으면 그 날은 원장에서 **아무 일도 없던 날**이 된다.

`candidate_ledger` 는 티커 쪽이고 `skipped` 와 `below_threshold` 를 **구분**한다 —
전자는 채점 전에 게이트에 걸린 것(보유·쿨다운·레버리지), 후자는 채점됐는데 임계 미달.
합치면 "왜 안 샀나" 의 결이 사라진다.

`n_scored`/`n_qualified` 를 같이 싣는 이유: **"채점 대상이 0"** 과 **"200개 채점했는데
아무도 임계를 못 넘음"** 은 다른 상태다.

## `acted` 는 사람이 켠다

`trades` **0행**, `portfolio.first_buy_date` **18/18 동일 상수** (2026-08-18 실측) —
체결을 알 방법이 시스템에 없다. 파생하면 "실행 vs 미실행" 비교가 **조용히 거짓**이 된다.
같은 날 재실행은 run 과 후보 행을 갱신하지만 **`acted` 는 건드리지 않는다.**

## Surface 천장

기록이지 신호가 아니다 — 축도 주문도 만들지 않고, §3.11 판정 표본(`recommendations`
where `source IS NULL`)과 별개 테이블이다. 테스트가 세 테이블이 비어 있는지 직접 단언한다.

## 검증 — 뮤테이션 5종 전부 검출

| 뮤테이션 | 떨어지는 테스트 |
|---|---|
| 0건이면 기록 안 함 (차단된 날 소실) | `test_scored_and_qualified_distinguish_two_kinds_of_zero` |
| 재실행이 `acted` 를 덮음 | `test_rerunning_the_day_does_not_erase_it` |
| skipped 사유를 버림 | `test_the_reason_is_kept_per_ticker` |
| 프리마켓 배선 제거 | `test_a_blocked_run_still_reaches_the_candidate_ledger` |
| 분모(`n_scored`) 배선 제거 | `test_emit_reports_the_denominator` |

⚠️ 분모 뮤테이션은 **1라운드에서 살아남았다** — 필드 존재만 보면 dataclass 선언으로 통과한다.
실제 실행이 채우는지로 다시 잠갔다.

배선 테스트는 grep 이 아니라 **실행**이다 (`_collect_context` 를 돌려 원장 행을 확인).

## 남긴 것 (별도 이슈 대상)

레거시 `data/reports/buy_tracking/candidate_ledger.jsonl` (4,278 bytes, 최종 2026-04-30)
과 유일 소비자 `scripts/analysis/compare_buy_candidates.py` 는 **백필하지 않았다** —
3.5개월 낡았고 스키마 의미가 달라 새 원장을 반쪽 데이터로 오염시킨다. 정리는 별도로.

## 살아있음 증명

프리마켓 1회 → `candidate_runs` 오늘 행 + `candidate_ledger` 티커별 사유.
오늘처럼 0건이어도 run 1행 + skipped 18행이 남아야 한다 — 그게 이 기능의 요점이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)