### PR TITLE
feat(thesis): roll criteria checks up into a thesis verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,208 collected across 329 files | |
+| **Backend tests** | 7,231 collected across 330 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,208 backend tests across 329 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,231 backend tests across 330 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,208 tests, 329 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,231 tests, 330 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -270,9 +270,55 @@ describe("DecisionProvenance", () => {
     await act(async () => {
       render(await DecisionProvenance({ id: "531" }));
     });
-    expect(screen.getByText(/v1 · 2026-04-01 · user · superseded · held/)).toBeInTheDocument();
+    expect(screen.getByText(/v1 · 2026-04-01 · user · superseded/)).toBeInTheDocument();
+    expect(screen.getByText("지켜짐").className).toContain("emerald");
     expect(screen.getByRole("link", { name: /^filing$/ })).toHaveAttribute("href", "https://example.invalid/k");
     expect(screen.getByText(/analyst\/note-4/)).toBeInTheDocument();
+  });
+
+  // verdict 뱃지만 보는 최소 논지 — 근거·기준은 다른 테스트가 덮는다.
+  const baseThesis = {
+    id: 9,
+    ticker: "AAA",
+    version: 1,
+    author: "user",
+    stance: "bullish",
+    bull_case: "수요 우위",
+    bear_case: "점유율 하락",
+    effective_date: "2026-04-01",
+    status: "active",
+    verdict: null as string | null,
+    evidence: [],
+    criteria: [],
+  };
+
+  it("never paints an unevaluable verdict as a survived thesis", async () => {
+    // 논지 층에서도 같은 규율 — 측정 못 한 것을 초록으로 칠하면 채점이 자기 편이 된다.
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      thesis: { ...baseThesis, verdict: "unevaluable" },
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const badge = screen.getByText("측정 불가");
+    expect(badge.className).toContain("text-muted-foreground");
+    expect(badge.className).not.toContain("emerald");
+  });
+
+  it("shows a blank verdict as in-progress, not as a pass", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      thesis: { ...baseThesis, verdict: null },
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const badge = screen.getByText("진행 중");
+    expect(badge.className).toContain("text-muted-foreground");
+    expect(badge.className).not.toContain("emerald");
   });
 
   it("renders falsification criteria and never paints unevaluable as passing", async () => {

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -79,6 +79,22 @@ const CRITERION_LABEL: Record<string, string> = {
   unevaluable: "측정 불가",
 };
 
+// 논지 verdict (#1096). `unevaluable` 은 회색이다 — 초록으로 칠하면 "측정 못 했다" 가
+// 화면에서 "지켜졌다" 로 읽히고, 그게 이 원장이 막으려는 것 자체다.
+const VERDICT_TONE: Record<string, string> = {
+  broken: "bg-rose-500/15 text-rose-400",
+  held: "bg-emerald-500/15 text-emerald-400",
+  abandoned: "bg-amber-500/15 text-amber-400",
+  unevaluable: "bg-muted text-muted-foreground",
+};
+
+const VERDICT_LABEL: Record<string, string> = {
+  broken: "반증됨",
+  held: "지켜짐",
+  abandoned: "철회됨",
+  unevaluable: "측정 불가",
+};
+
 interface DecisionDetail {
   id: number;
   date: string;
@@ -216,7 +232,15 @@ export async function DecisionProvenance({ id }: { id: string }) {
             {d.thesis && (
               <span className="text-[10px] text-muted-foreground/70">
                 v{d.thesis.version} · {d.thesis.effective_date} · {d.thesis.author} · {d.thesis.status}
-                {d.thesis.verdict ? ` · ${d.thesis.verdict}` : ""}
+              </span>
+            )}
+            {d.thesis && (
+              <span
+                className={`ml-auto text-[10px] px-1.5 py-0.5 rounded ${
+                  VERDICT_TONE[d.thesis.verdict ?? ""] ?? "bg-muted text-muted-foreground"
+                }`}
+              >
+                {d.thesis.verdict ? VERDICT_LABEL[d.thesis.verdict] : "진행 중"}
               </span>
             )}
           </div>

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -102,6 +102,7 @@ from .thesis_ops import (  # noqa: F401, E402
     get_active_thesis,
     get_criteria,
     get_thesis_history,
+    record_human_check,
     upsert_thesis,
 )
 from .trades import upsert_trade  # noqa: F401, E402

--- a/nuri/core/db/thesis_ops.py
+++ b/nuri/core/db/thesis_ops.py
@@ -223,6 +223,68 @@ def get_criteria(thesis_id: int, db_path: Optional[Path] = None) -> list[dict]:
         ]
 
 
+#: 사람이 남길 수 있는 판정. `unevaluable` 은 기본 상태라 손으로 적을 이유가 없다.
+HUMAN_CHECK_RESULTS = ("holding", "breached")
+
+
+def record_human_check(
+    criterion_id: int,
+    result: str,
+    detail: Optional[str] = None,
+    check_date: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """`human` 기준을 사람이 판정한 것을 기록 (#1096). 그날 기록이 이미 있으면 `False`.
+
+    **`machine` 기준은 손으로 못 뒤집는다.** 기계가 `breached` 를 적은 뒤 사람이 같은 날
+    `holding` 으로 덮을 수 있으면 원장이 취향대로 다듬어지고, 사후 채점은 다시 서사가 된다.
+    그래서 kind 를 확인하고 거부한다.
+
+    이 writer 가 없으면 `human` 기준은 영원히 `unevaluable` 이라 그 논지는 `held` 에
+    닿을 수 없다 — verdict 롤업이 도달 불가능한 판정을 갖게 된다.
+
+    **자리표시자는 덮고, 판정은 안 덮는다.** 일별 점검이 `human` 기준에 매일
+    `unevaluable(manual)` 을 적으므로, 그것까지 append-only 로 지키면 사람은 그날 판정을
+    남길 수 없고 다음날도 마찬가지라 **영원히 못 남긴다**. 기계는 애초에 이 기준에 의견이
+    없었고 그 행은 "사람 기다리는 중" 이라는 뜻이므로 갱신해도 기록이 소실되지 않는다.
+    반면 이미 사람이 남긴 판정은 덮지 않는다 — 그게 실제 기록이다.
+
+    Raises: `ThesisValidationError` — 없는 기준 · machine 기준 · 허용되지 않는 result.
+    """
+    from nuri.core.timezone import today_kst
+
+    if result not in HUMAN_CHECK_RESULTS:
+        raise ThesisValidationError(f"result 는 {'|'.join(HUMAN_CHECK_RESULTS)} 중 하나여야 한다: {result!r}")
+
+    d = check_date or today_kst()
+    note = detail or "human — 사람 판정"
+    with get_db(db_path) as conn:
+        row = conn.execute("SELECT kind FROM thesis_criteria WHERE id = ?", (criterion_id,)).fetchone()
+        if row is None:
+            raise ThesisValidationError(f"기준 {criterion_id} 이 없다")
+        if row[0] != "human":
+            raise ThesisValidationError(
+                f"기준 {criterion_id} 은 machine 이다 — 기계 판정을 손으로 덮으면 원장이 취향대로 다듬어진다"
+            )
+        existing = conn.execute(
+            "SELECT result FROM thesis_criteria_checks WHERE criterion_id = ? AND check_date = ?",
+            (criterion_id, d),
+        ).fetchone()
+        if existing is not None:
+            if existing[0] != "unevaluable":
+                return False
+            conn.execute(
+                "UPDATE thesis_criteria_checks SET result = ?, detail = ? WHERE criterion_id = ? AND check_date = ?",
+                (result, note, criterion_id, d),
+            )
+            return True
+        conn.execute(
+            "INSERT INTO thesis_criteria_checks (criterion_id, check_date, result, detail) VALUES (?, ?, ?, ?)",
+            (criterion_id, d, result, note),
+        )
+        return True
+
+
 def get_thesis_history(ticker: str, db_path: Optional[Path] = None) -> list[dict]:
     """한 티커의 논지 전 버전 (최신 우선). 근거는 붙이지 않는다 — 목록용."""
     with get_db(db_path) as conn:

--- a/nuri/core/thesis_cli.py
+++ b/nuri/core/thesis_cli.py
@@ -10,6 +10,7 @@
 ```bash
 python -m nuri.core.thesis_cli write docs/theses/nvda.yaml
 python -m nuri.core.thesis_cli show NVDA
+python -m nuri.core.thesis_cli judge 7 breached --note "가이던스 철회"
 ```
 
 기본은 `status: draft` 다. `active` 승격은 파일에 명시할 때만 — LLM 초안이 사람 손을
@@ -30,6 +31,7 @@ from nuri.core.db import (
     add_criteria,
     get_active_thesis,
     get_thesis_history,
+    record_human_check,
     upsert_thesis,
 )
 
@@ -108,14 +110,31 @@ def _cmd_show(ticker: str, db_path: Optional[Path]) -> int:
         print(f"\n상승: {active['bull_case']}")
         print(f"하락: {active['bear_case']}")
         print(f"근거 {len(active['evidence'])}건")
+        # verdict 는 롤업이 쓴 값이다 — 비어 있으면 손 라벨링이 아니라 **진행 중**이다.
+        print(f"판정: {active['verdict'] or '진행 중 (마감 전이거나 반증 없음)'}")
         criteria = active.get("criteria") or []
         print(f"반증 기준 {len(criteria)}건 — 이게 사실이면 이 판단은 틀린 것:")
         for c in criteria:
             state = c["last_result"] or "미점검"
             expr = f"{c['metric']} {c['op']} {c['threshold']:g}" if c["kind"] == "machine" else "사람 판정"
-            print(f"  [{state:11s}] {c['statement']}  ({expr})")
+            due = c["deadline_date"] or "마감 없음"
+            print(f"  #{c['id']:<4} [{state:11s}] {c['statement']}  ({expr}, ~{due})")
     else:
         print("\n현재 유효한 논지 없음 (draft 만 있거나 effective_date 가 미래)")
+    return 0
+
+
+def _cmd_judge(criterion_id: int, result: str, note: Optional[str], db_path: Optional[Path]) -> int:
+    """`human` 기준을 사람이 판정한다 — 이게 없으면 그 논지는 영영 `held` 에 못 닿는다."""
+    try:
+        wrote = record_human_check(criterion_id, result, detail=note, db_path=db_path)
+    except ThesisValidationError as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 1
+    if not wrote:
+        print(f"기준 #{criterion_id}: 오늘 판정이 이미 있다 — 덮어쓰지 않는다 (판정 이력은 append-only)")
+        return 0
+    print(f"✓ 기준 #{criterion_id} → {result}")
     return 0
 
 
@@ -130,9 +149,16 @@ def main(argv: list[str] | None = None) -> int:
     s = sub.add_parser("show", help="티커의 논지 이력 + 현재 유효 논지")
     s.add_argument("ticker")
 
+    j = sub.add_parser("judge", help="human 반증 기준을 사람이 판정 (기준 번호는 show 에)")
+    j.add_argument("criterion_id", type=int)
+    j.add_argument("result", choices=("holding", "breached"))
+    j.add_argument("--note", default=None, help="판정 근거 한 줄")
+
     args = parser.parse_args(argv)
     if args.command == "write":
         return _cmd_write(args.path, args.db_path)
+    if args.command == "judge":
+        return _cmd_judge(args.criterion_id, args.result, args.note, args.db_path)
     return _cmd_show(args.ticker.upper(), args.db_path)
 
 

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -190,10 +190,14 @@ def _dispatch_collector(name: str, **kwargs):
         # 안 도는" 상태를 관측할 수 없다.
         #
         # **Surface 전용**: breach 는 알림·뱃지까지고 주문을 만들지 않는다 (§7.1).
-        from nuri.trading.engine.thesis_criteria import run_daily_checks
+        from nuri.trading.engine.thesis_criteria import roll_up_verdicts, run_daily_checks
 
         counts = run_daily_checks()
-        return counts["holding"] + counts["breached"] + counts["unevaluable"]
+        # 롤업은 판정 **뒤에** — 같은 잡 안에서 도는 이유는 오늘 판정이 오늘 verdict 에
+        # 반영돼야 하기 때문이다. 별도 잡으로 두면 하루 시차가 생기고, 그 시차 동안
+        # 화면의 verdict 가 기준 판정과 어긋난다.
+        verdicts = roll_up_verdicts()
+        return counts["holding"] + counts["breached"] + counts["unevaluable"] + sum(verdicts.values())
     elif name == "cboe":
         from nuri.collectors.cboe import CBOECollector
 

--- a/nuri/trading/engine/CLAUDE.md
+++ b/nuri/trading/engine/CLAUDE.md
@@ -25,6 +25,28 @@ These are operational details unique to this directory; the canonical sources ab
   ⚠️ **스냅샷 접근자의 fallback 도 `db_path` 를 받아야 한다.** `_snapshot_portfolio()` / `_current_regime()` / `_snapshot_portfolio_raw()` 는 스냅샷이 없으면 fresh DB read 로 떨어지는데, 앞의 둘만 `db_path` 를 안 받아서 `_check_position_limits(db_path=X)` 같은 직접 호출이 기본 DB 를 읽었다(#1052). **이 결함은 기존 테스트로 보이지 않는다** — `certify()` 안에서는 ContextVar 가 DB 읽기를 통째로 건너뛰어 그 배선이 dead code 이기 때문에, 배선 6곳을 되돌려도 `tests/trading/engine` + `tests/llm` 611개가 초록이었다(2026-08-14 실측). 게이트를 **스냅샷 밖에서** 직접 부르는 테스트만 이걸 잡는다.
   **Test:** `tests/trading/engine/test_certify_db_path_isolation.py::TestGatesReadOnlyTheGivenDbOutsideCertify` — 배선을 되돌리면 8개 중 4개 FAIL. 구조 쪽 짝은 `tests/core/test_db_path_forwarding.py`.
 
+## 논지 verdict 롤업 (`thesis_criteria.py`, #1096)
+
+`theses.verdict` 의 **유일한 writer** 다. 값은 전부 `thesis_criteria_checks` 에서 나오며 손
+라벨링이 아니다. 우선순위: 반증(마감 무관) → 철회/교체(`abandoned`) → 마감 미도달(판정 보류)
+→ 전 기준 측정됨(`held`) / 아니면 `unevaluable`. **부분 측정은 `held` 가 아니다** — #1092 가
+기준 층에서 잠근 "`unevaluable` 은 `holding` 이 아니다" 의 논지 층 대응물이다.
+
+⚠️ **빈 컬렉션에 `all()` 을 쓰면 공허참으로 만점이 나온다.** 기준 0건인 논지가
+`all([]) is True` 로 `held` 를 받았다. 도달하지 않았던 건 롤업 쿼리가 INNER JOIN 이어서지
+방어가 있어서가 아니었고, LEFT JOIN 뮤테이션은 테스트를 전부 초록으로 통과했다. 채점·게이트에
+`all(...)` 을 쓸 땐 빈 입력을 **먼저** 걷어낼 것.
+⚠️ **효력을 가진 적 없는 논지는 채점 대상이 아니다.** `draft` 와 `effective_date` 가 미래인
+논지가 verdict 를 받고 있었다 — 특히 9월 발효 논지가 5월부터 판정이 쌓여 **유효해지기도 전에
+`broken`** 이 됐다(Codex 리뷰 2026-08-18 재현). 근본 원인은 롤업이 아니라 `run_daily_checks`
+가 `effective_date` 를 안 본 것이라 두 곳을 같이 막는다.
+**Test:** `::TestOnlyInForceThesesAreScored` — 필터 2개를 각각 지우면 FAIL, 카나리아
+`test_the_same_thesis_is_scored_once_effective` 가 필터가 논지를 영영 묻지 않는지 확인한다.
+
+**Test:** `tests/trading/engine/test_thesis_verdict.py::TestInProgressStaysBlank::test_zero_criteria_is_not_a_vacuous_pass`
+— 가드를 지우면 FAIL. 나머지 규칙은 같은 파일에서 뮤테이션 9종(측정 완결성 · 철회 · 우선순위 ·
+마감 없음 · machine 손판정 · 사람판정 덮어쓰기 · 자리표시자 · 스케줄러 배선 · 공허참) 전부 FAIL 실측.
+
 ## Execution Priority
 
 Mechanical ordering when emitting actions: `stop_loss → take_profit → trailing_stop_set → new_buy`.

--- a/nuri/trading/engine/thesis_criteria.py
+++ b/nuri/trading/engine/thesis_criteria.py
@@ -230,6 +230,11 @@ _ABANDONED_STATUS = ("superseded", "retired")
 
 def _verdict_for(status: str, criteria: list[dict], stats: dict[int, dict], as_of: str) -> Optional[str]:
     """논지 1건의 verdict. `None` 이면 진행 중 — **기존 verdict 를 지우지 않는다.**"""
+    # 기준 0건은 채점 대상이 아니다. 이 줄이 없으면 아래 `all([])` 이 **공허참**으로
+    # `held` 를 돌려준다 — 반증 기준 없는 논지가 만점을 받는 셈이다. 지금은 쿼리가
+    # INNER JOIN 이라 도달하지 않지만, 방어가 우연이면 다음 리팩터가 걷어간다.
+    if not criteria:
+        return None
     if any(stats.get(c["id"], {}).get("breached") for c in criteria):
         return "broken"
     if status in _ABANDONED_STATUS:

--- a/nuri/trading/engine/thesis_criteria.py
+++ b/nuri/trading/engine/thesis_criteria.py
@@ -211,3 +211,92 @@ def run_daily_checks(as_of: Optional[str] = None, db_path: Optional[Path] = None
     if counts["breached"]:
         logger.warning("thesis criteria breached: %d (surface only — 주문 만들지 않음)", counts["breached"])
     return counts
+
+
+#: 사후 채점의 4값. `theses.verdict` CHECK 와 동일해야 한다 — 여기가 사람이 읽는 정본.
+#:
+#: `held` 가 가장 얻기 어렵게 설계돼 있다. 그래야 채점이 자기 편이 아니다:
+#:   - 기준 **1건이라도** 반증되면 `broken` (마감을 기다리지 않는다 — 반증은 반증이다)
+#:   - 논지가 교체(`superseded`)되거나 접히면(`retired`) `abandoned` — 중간에 갈아탄 논지를
+#:     "지켜졌다" 로 적으면 갈아타기가 공짜가 된다
+#:   - 마감이 하나라도 안 지났으면(또는 마감이 없으면) **판정하지 않는다** — 진행 중
+#:   - 마감이 전부 지났고 반증 0건이어도, **모든 기준이 실제로 한 번은 측정됐어야** `held`
+#:     이고 아니면 `unevaluable`. 부분 측정은 `held` 가 아니다
+VERDICTS = ("broken", "held", "abandoned", "unevaluable")
+
+#: 논지가 더 이상 살아 있지 않은 상태 → `abandoned` (단, 반증이 먼저다).
+_ABANDONED_STATUS = ("superseded", "retired")
+
+
+def _verdict_for(status: str, criteria: list[dict], stats: dict[int, dict], as_of: str) -> Optional[str]:
+    """논지 1건의 verdict. `None` 이면 진행 중 — **기존 verdict 를 지우지 않는다.**"""
+    if any(stats.get(c["id"], {}).get("breached") for c in criteria):
+        return "broken"
+    if status in _ABANDONED_STATUS:
+        return "abandoned"
+    # 마감 없는 기준은 영원히 끝나지 않는다. `held` 를 원하면 마감을 박아야 한다 —
+    # 끝나지 않는 관찰을 "지켜졌다" 로 결산할 수는 없다.
+    if any(not c["deadline_date"] or c["deadline_date"] > as_of for c in criteria):
+        return None
+    if all(stats.get(c["id"], {}).get("measured") for c in criteria):
+        return "held"
+    return "unevaluable"
+
+
+def roll_up_verdicts(as_of: Optional[str] = None, db_path: Optional[Path] = None) -> dict[str, int]:
+    """기준 판정 이력에서 논지 verdict 를 굴려 올린다 (#1096). verdict 별 건수 반환.
+
+    `theses.verdict` 는 migration 51 이래 아무도 쓰지 않던 컬럼이다. 이 함수가 유일한
+    writer 이고, 값은 전부 `thesis_criteria_checks` 에서 나온다 — 손 라벨링이 아니다.
+
+    기준이 0건인 논지(#1092 이전 유물)는 건너뛴다. 반증 기준 없는 논지는 채점 대상이
+    아니라 서사이고, 그걸 `held` 로 적으면 정확히 이 시스템이 막으려는 것이 된다.
+    """
+    from nuri.core.db import get_db, query
+    from nuri.core.timezone import today_kst
+
+    d = as_of or today_kst()
+    rows = query(
+        """SELECT t.id AS thesis_id, t.status, t.verdict,
+                  c.id AS criterion_id, c.deadline_date
+             FROM theses t
+             JOIN thesis_criteria c ON c.thesis_id = t.id AND c.status = 'active'""",
+        db_path=db_path,
+    )
+    # 집계를 조인 안에서 하지 않는 이유: checks 는 기준당 여러 행이라 같은 쿼리에서
+    # SUM 하면 기준 수가 체크 수만큼 부풀어 `all(...)` 판정이 조용히 틀어진다.
+    stats = {
+        r["criterion_id"]: {"breached": r["n_breached"], "measured": r["n_measured"]}
+        for r in query(
+            """SELECT criterion_id,
+                      SUM(result = 'breached') AS n_breached,
+                      SUM(result IN ('holding', 'breached')) AS n_measured
+                 FROM thesis_criteria_checks
+                GROUP BY criterion_id""",
+            db_path=db_path,
+        )
+    }
+
+    by_thesis: dict[int, dict[str, Any]] = {}
+    for r in rows:
+        entry = by_thesis.setdefault(r["thesis_id"], {"status": r["status"], "verdict": r["verdict"], "criteria": []})
+        entry["criteria"].append({"id": r["criterion_id"], "deadline_date": r["deadline_date"]})
+
+    counts = dict.fromkeys(VERDICTS, 0)
+    updates = []
+    for thesis_id, entry in by_thesis.items():
+        verdict = _verdict_for(entry["status"], entry["criteria"], stats, d)
+        if verdict is None:
+            continue
+        counts[verdict] += 1
+        if verdict != entry["verdict"]:
+            updates.append((verdict, thesis_id))
+    if updates:
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "UPDATE theses SET verdict = ?, updated_at = datetime('now') WHERE id = ?",
+                updates,
+            )
+    if counts["broken"]:
+        logger.warning("thesis verdict broken: %d (surface only — 주문 만들지 않음)", counts["broken"])
+    return counts

--- a/nuri/trading/engine/thesis_criteria.py
+++ b/nuri/trading/engine/thesis_criteria.py
@@ -179,11 +179,15 @@ def run_daily_checks(as_of: Optional[str] = None, db_path: Optional[Path] = None
     from nuri.core.timezone import today_kst
 
     d = as_of or today_kst()
+    # `effective_date` 를 안 보면 **발효 전 기간이 채점에 들어간다.** 9월 1일부터 유효한
+    # 논지를 오늘 써 두면 오늘부터 판정이 쌓이고, 그 중 반증 하나면 논지는 유효해지기도
+    # 전에 `broken` 이 된다 (2026-08-18 재현). 논지는 유효한 기간에 대해서만 채점한다.
     rows = query(
         """SELECT c.id, c.kind, c.metric, c.op, c.threshold, t.ticker
            FROM thesis_criteria c
            JOIN theses t ON t.id = c.thesis_id
-           WHERE c.status = 'active' AND t.status = 'active'""",
+           WHERE c.status = 'active' AND t.status = 'active' AND t.effective_date <= ?""",
+        (d,),
         db_path=db_path,
     )
     counts = {"holding": 0, "breached": 0, "unevaluable": 0}
@@ -261,11 +265,16 @@ def roll_up_verdicts(as_of: Optional[str] = None, db_path: Optional[Path] = None
     from nuri.core.timezone import today_kst
 
     d = as_of or today_kst()
+    # **효력을 가진 적 없는 논지는 채점하지 않는다.** `draft` 는 사람이 승격한 적 없는
+    # 초안이고, `effective_date` 가 미래면 아직 시작도 안 한 판단이다. 둘 다 verdict 를
+    # 받으면 원장이 "있지도 않았던 판단의 성적표" 를 갖게 된다 (Codex 리뷰 2026-08-18).
     rows = query(
         """SELECT t.id AS thesis_id, t.status, t.verdict,
                   c.id AS criterion_id, c.deadline_date
              FROM theses t
-             JOIN thesis_criteria c ON c.thesis_id = t.id AND c.status = 'active'""",
+             JOIN thesis_criteria c ON c.thesis_id = t.id AND c.status = 'active'
+            WHERE t.status <> 'draft' AND t.effective_date <= ?""",
+        (d,),
         db_path=db_path,
     )
     # 집계를 조인 안에서 하지 않는 이유: checks 는 기준당 여러 행이라 같은 쿼리에서
@@ -287,7 +296,7 @@ def roll_up_verdicts(as_of: Optional[str] = None, db_path: Optional[Path] = None
         entry = by_thesis.setdefault(r["thesis_id"], {"status": r["status"], "verdict": r["verdict"], "criteria": []})
         entry["criteria"].append({"id": r["criterion_id"], "deadline_date": r["deadline_date"]})
 
-    counts = dict.fromkeys(VERDICTS, 0)
+    counts: dict[str, int] = dict.fromkeys(VERDICTS, 0)
     updates = []
     for thesis_id, entry in by_thesis.items():
         verdict = _verdict_for(entry["status"], entry["criteria"], stats, d)

--- a/tests/core/test_thesis_cli.py
+++ b/tests/core/test_thesis_cli.py
@@ -175,3 +175,77 @@ class TestShow:
         assert "상승: 가속기 수요가 공급을 앞선다" in out
         assert "하락: 고객사 자체 칩 전환이 점유율을 깎는다" in out
         assert "근거 1건" in out
+
+
+class TestJudge:
+    """`human` 기준의 유일한 사람 입력 경로 (#1096).
+
+    이게 없으면 human 기준을 단 하나라도 가진 논지는 영영 `held` 에 못 닿는다 — 롤업이
+    **도달 불가능한 판정**을 갖게 되고, 그건 게이트가 있는데 안 잡는 상태와 같은 종류다.
+    """
+
+    _WITH_HUMAN = (
+        _YAML
+        + """  - kind: human
+    statement: 경영진이 교체되면 논지 전제가 깨진다
+    deadline_date: "2026-12-31"
+"""
+    )
+
+    def _human_id(self, db_path):
+        from nuri.core.db import query
+
+        return query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id "
+            "WHERE t.ticker = 'ZZZZ' AND c.kind = 'human'",
+            db_path=db_path,
+        )[0]["id"]
+
+    def test_a_human_verdict_reaches_the_ledger(self, tmp_path, db_path, capsys):
+        main(["--db-path", str(db_path), "write", str(_write_file(tmp_path, self._WITH_HUMAN))])
+        capsys.readouterr()
+        cid = self._human_id(db_path)
+
+        assert main(["--db-path", str(db_path), "judge", str(cid), "breached", "--note", "CEO 사임"]) == 0
+
+        from nuri.core.db import query
+
+        rows = query("SELECT result, detail FROM thesis_criteria_checks", db_path=db_path)
+        assert len(rows) == 1, "CLI 가 돌았는데 판정 행이 없다 — 도달 불가"
+        assert (rows[0]["result"], rows[0]["detail"]) == ("breached", "CEO 사임")
+
+    def test_judging_a_machine_criterion_is_refused(self, tmp_path, db_path, capsys):
+        from nuri.core.db import query
+
+        main(["--db-path", str(db_path), "write", str(_write_file(tmp_path, self._WITH_HUMAN))])
+        capsys.readouterr()
+        machine_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id "
+            "WHERE t.ticker = 'ZZZZ' AND c.kind = 'machine'",
+            db_path=db_path,
+        )[0]["id"]
+
+        assert main(["--db-path", str(db_path), "judge", str(machine_id), "holding"]) == 1
+        assert "machine" in capsys.readouterr().err
+        assert query("SELECT COUNT(*) AS n FROM thesis_criteria_checks", db_path=db_path)[0]["n"] == 0
+
+    def test_a_second_judgement_the_same_day_is_reported_not_silent(self, tmp_path, db_path, capsys):
+        main(["--db-path", str(db_path), "write", str(_write_file(tmp_path, self._WITH_HUMAN))])
+        capsys.readouterr()
+        cid = self._human_id(db_path)
+        main(["--db-path", str(db_path), "judge", str(cid), "breached"])
+        capsys.readouterr()
+
+        assert main(["--db-path", str(db_path), "judge", str(cid), "holding"]) == 0
+        assert "덮어쓰지 않는다" in capsys.readouterr().out
+
+    def test_show_prints_the_criterion_number_needed_to_judge(self, tmp_path, db_path, capsys):
+        """번호를 안 보여주면 `judge` 는 있으나 마나다 — 사용자가 인자를 알 수 없다."""
+        main(["--db-path", str(db_path), "write", str(_write_file(tmp_path, self._WITH_HUMAN))])
+        capsys.readouterr()
+        cid = self._human_id(db_path)
+
+        main(["--db-path", str(db_path), "show", "zzzz"])
+        out = capsys.readouterr().out
+        assert f"#{cid}" in out
+        assert "판정: 진행 중" in out

--- a/tests/trading/engine/test_thesis_verdict.py
+++ b/tests/trading/engine/test_thesis_verdict.py
@@ -1,0 +1,374 @@
+"""논지 verdict 롤업 — 기준 판정 이력에서 굴려 올린 사후 채점 (#1096).
+
+이 파일이 잠그는 축은 하나다:
+
+> **`held` 는 얻기 어려워야 한다.** 측정하지 못한 것, 중간에 갈아탄 것, 부분만 측정된 것이
+> "지켜졌다" 로 흘러가면 채점이 자기 편이 되고 원장은 다시 서사가 된다.
+
+`unevaluable` 을 `holding` 으로 적지 않는 규율(#1092)의 논지 층 대응물이다. 아래
+`TestHeldIsHardToGet` 이 그 축이고, 나머지는 우선순위(반증 > 철회 > 마감)와 append-only.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nuri.core.db import (
+    ThesisValidationError,
+    add_criteria,
+    get_db,
+    init_db,
+    query,
+    record_human_check,
+    upsert_prices,
+    upsert_thesis,
+)
+from nuri.trading.engine import thesis_criteria as tc
+
+#: 전부 과거로 앵커된 날짜다 — 마감 경과 여부가 이 파일의 판정 축이라 `today_kst()`
+#: 앵커링이 오히려 의미를 흐린다. 대신 `as_of` 를 명시로 넘겨 wall-clock 을 배제한다.
+DEADLINE = "2026-06-01"
+BEFORE = "2026-05-30"
+AFTER = "2026-06-02"
+
+MACHINE = {
+    "kind": "machine",
+    "statement": "종가가 100 아래로 무너지면 논지는 틀렸다",
+    "metric": "close",
+    "op": "<",
+    "threshold": 100.0,
+    "deadline_date": DEADLINE,
+}
+HUMAN = {"kind": "human", "statement": "경영진이 교체되면 논지는 틀렸다", "deadline_date": DEADLINE}
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _thesis(db_path, ticker, criteria, status="active"):
+    tid = upsert_thesis(
+        ticker=ticker,
+        author="user",
+        stance="bullish",
+        bull_case="수요가 공급을 앞선다",
+        bear_case="고객사 자체 칩 전환이 점유율을 깎는다",
+        evidence=[{"side": "bull", "claim": "매출 증가", "source_type": "filing"}],
+        effective_date="2026-05-01",
+        status=status,
+        db_path=db_path,
+    )
+    add_criteria(tid, criteria, db_path=db_path)
+    return tid
+
+
+def _seed_close(db_path, ticker, close):
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": ticker,
+                    "date": BEFORE,
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": 1000,
+                    "adj_close": close,
+                }
+            ]
+        ),
+        db_path=db_path,
+    )
+
+
+def _verdict(db_path, ticker):
+    return query("SELECT verdict FROM theses WHERE ticker = ?", (ticker,), db_path=db_path)[0]["verdict"]
+
+
+class TestHeldIsHardToGet:
+    """`held` 로 새는 경로를 전부 막는다 — 이 클래스가 이 파일의 이유다."""
+
+    def test_all_criteria_measured_and_clean_is_held(self, db_path):
+        _thesis(db_path, "AAAA", [dict(MACHINE)])
+        _seed_close(db_path, "AAAA", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "AAAA") == "held"
+
+    def test_partially_measured_is_unevaluable_not_held(self, db_path):
+        """machine 은 유지, human 은 아무도 판정 안 함 → `held` 가 아니라 `unevaluable`.
+
+        이걸 `held` 로 적으면 "사람 기준은 늘 지켜지고 있다" 는 거짓말이 채점에 들어간다.
+        """
+        _thesis(db_path, "BBBB", [dict(MACHINE), dict(HUMAN)])
+        _seed_close(db_path, "BBBB", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "BBBB") == "unevaluable"
+
+    def test_nothing_measurable_is_unevaluable(self, db_path):
+        """가격이 없어 machine 기준도 `unevaluable` → 논지도 `unevaluable`."""
+        _thesis(db_path, "CCCC", [dict(MACHINE)])
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "CCCC") == "unevaluable"
+
+    def test_human_judgement_unblocks_held(self, db_path):
+        """사람이 판정을 남기면 그때 비로소 `held` — 없으면 도달 불가능한 판정이 된다."""
+        _thesis(db_path, "DDDD", [dict(MACHINE), dict(HUMAN)])
+        _seed_close(db_path, "DDDD", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        human_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id "
+            "WHERE t.ticker = 'DDDD' AND c.kind = 'human'",
+            db_path=db_path,
+        )[0]["id"]
+
+        record_human_check(human_id, "holding", check_date=BEFORE, db_path=db_path)
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "DDDD") == "held"
+
+
+class TestVerdictPriority:
+    def test_breach_wins_and_does_not_wait_for_deadline(self, db_path):
+        """반증은 마감을 기다리지 않는다 — 틀린 건 그날 틀린 것이다."""
+        _thesis(db_path, "EEEE", [dict(MACHINE)])
+        _seed_close(db_path, "EEEE", 50.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        tc.roll_up_verdicts(as_of=BEFORE, db_path=db_path)
+
+        assert _verdict(db_path, "EEEE") == "broken"
+
+    def test_superseded_thesis_is_abandoned_not_held(self, db_path):
+        """v2 를 쓰면 v1 은 `abandoned` — 갈아탄 논지를 "지켜졌다" 로 결산하면 갈아타기가 공짜다."""
+        _thesis(db_path, "FFFF", [dict(MACHINE)])
+        _seed_close(db_path, "FFFF", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        _thesis(db_path, "FFFF", [dict(MACHINE)])  # v2 → v1 이 superseded
+
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        v1 = query("SELECT verdict FROM theses WHERE ticker = 'FFFF' ORDER BY version", db_path=db_path)[0]
+        assert v1["verdict"] == "abandoned"
+
+    def test_breach_outranks_abandonment(self, db_path):
+        """반증된 뒤 갈아탄 논지는 `broken` 으로 남는다 — 반증 사실이 지워지면 안 된다."""
+        _thesis(db_path, "GGGG", [dict(MACHINE)])
+        _seed_close(db_path, "GGGG", 50.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        _thesis(db_path, "GGGG", [dict(MACHINE)])
+
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        v1 = query("SELECT verdict FROM theses WHERE ticker = 'GGGG' ORDER BY version", db_path=db_path)[0]
+        assert v1["verdict"] == "broken"
+
+
+class TestInProgressStaysBlank:
+    def test_before_deadline_writes_no_verdict(self, db_path):
+        _thesis(db_path, "HHHH", [dict(MACHINE, deadline_date="2027-01-01")])
+        _seed_close(db_path, "HHHH", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        counts = tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "HHHH") is None
+        assert sum(counts.values()) == 0
+
+    def test_criterion_without_deadline_never_terminates(self, db_path):
+        """마감 없는 기준은 영원히 진행 중 — 끝나지 않는 관찰을 결산할 수는 없다."""
+        _thesis(db_path, "IIII", [dict(MACHINE, deadline_date=None)])
+        _seed_close(db_path, "IIII", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        tc.roll_up_verdicts(as_of="2030-01-01", db_path=db_path)
+
+        assert _verdict(db_path, "IIII") is None
+
+    def test_thesis_without_criteria_is_never_scored(self, db_path):
+        """#1092 이전 유물 — 반증 기준 없는 논지를 `held` 로 적으면 서사가 채점을 통과한다."""
+        upsert_thesis(
+            ticker="JJJJ",
+            author="user",
+            stance="bullish",
+            bull_case="좋다",
+            bear_case="나쁠 수도 있다",
+            evidence=[{"side": "bull", "claim": "c", "source_type": "filing"}],
+            effective_date="2026-05-01",
+            status="active",
+            db_path=db_path,
+        )
+
+        counts = tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "JJJJ") is None
+        assert sum(counts.values()) == 0
+
+
+class TestHumanCheckIsNotAnEditButton:
+    def test_machine_criterion_cannot_be_hand_judged(self, db_path):
+        """기계 판정을 손으로 덮을 수 있으면 원장이 취향대로 다듬어진다."""
+        _thesis(db_path, "KKKK", [dict(MACHINE)])
+        machine_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id WHERE t.ticker = 'KKKK'",
+            db_path=db_path,
+        )[0]["id"]
+
+        with pytest.raises(ThesisValidationError, match="machine"):
+            record_human_check(machine_id, "holding", db_path=db_path)
+
+    def test_same_day_rejudgement_does_not_overwrite(self, db_path):
+        """판정 이력은 append-only — 하루에 두 번 부르면 두 번째는 무시된다."""
+        _thesis(db_path, "LLLL", [dict(MACHINE), dict(HUMAN)])
+        human_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id "
+            "WHERE t.ticker = 'LLLL' AND c.kind = 'human'",
+            db_path=db_path,
+        )[0]["id"]
+
+        assert record_human_check(human_id, "breached", check_date=BEFORE, db_path=db_path) is True
+        assert record_human_check(human_id, "holding", check_date=BEFORE, db_path=db_path) is False
+
+        rows = query("SELECT result FROM thesis_criteria_checks WHERE criterion_id = ?", (human_id,), db_path=db_path)
+        assert [r["result"] for r in rows] == ["breached"]
+
+    def test_daily_placeholder_is_upgraded_not_appended(self, db_path):
+        """일별 점검이 적은 `unevaluable(manual)` 은 자리표시자다 — 사람 판정이 그걸 대체한다.
+
+        이걸 append-only 로 지키면 사람은 그날도, 다음날도 판정을 못 남긴다. 일별 점검이
+        매일 먼저 적기 때문이다 — 규율이 아니라 잠금이 된다.
+        """
+        _thesis(db_path, "PPPP", [dict(MACHINE), dict(HUMAN)])
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        human_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id "
+            "WHERE t.ticker = 'PPPP' AND c.kind = 'human'",
+            db_path=db_path,
+        )[0]["id"]
+
+        assert record_human_check(human_id, "breached", "감사보고서", check_date=BEFORE, db_path=db_path) is True
+        # 사람 판정이 앉은 뒤에는 같은 날 재판정이 거부된다 — 자리표시자와 판정의 차이.
+        assert record_human_check(human_id, "holding", check_date=BEFORE, db_path=db_path) is False
+
+        rows = query(
+            "SELECT result, detail FROM thesis_criteria_checks WHERE criterion_id = ?",
+            (human_id,),
+            db_path=db_path,
+        )
+        assert len(rows) == 1, "자리표시자 위에 행이 하나 더 쌓였다"
+        assert rows[0]["result"] == "breached"
+        assert rows[0]["detail"] == "감사보고서"
+
+    def test_unevaluable_is_not_a_recordable_human_verdict(self, db_path):
+        """`unevaluable` 은 기본 상태다 — 손으로 적을 수 있게 하면 판정 회피가 기록이 된다."""
+        _thesis(db_path, "MMMM", [dict(MACHINE), dict(HUMAN)])
+        human_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id "
+            "WHERE t.ticker = 'MMMM' AND c.kind = 'human'",
+            db_path=db_path,
+        )[0]["id"]
+
+        with pytest.raises(ThesisValidationError, match="holding"):
+            record_human_check(human_id, "unevaluable", db_path=db_path)
+
+
+class TestRollupIsTheOnlyVerdictWriter:
+    def test_counts_reflect_every_scored_thesis_not_only_changes(self, db_path):
+        """두 번 돌려도 건수가 줄지 않는다 — 이 값은 '오늘 바뀐 수' 가 아니라 현재 상태다."""
+        _thesis(db_path, "NNNN", [dict(MACHINE)])
+        _seed_close(db_path, "NNNN", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+
+        first = tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+        second = tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert first == second == {"broken": 0, "held": 1, "abandoned": 0, "unevaluable": 0}
+
+    def test_late_breach_flips_held_back_to_broken(self, db_path):
+        """마감 뒤 반증이 들어와도 반증이 이긴다 — `held` 가 최종 방패가 되면 안 된다."""
+        _thesis(db_path, "OOOO", [dict(MACHINE)])
+        _seed_close(db_path, "OOOO", 120.0)
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+        assert _verdict(db_path, "OOOO") == "held"
+
+        criterion_id = query(
+            "SELECT c.id FROM thesis_criteria c JOIN theses t ON t.id = c.thesis_id WHERE t.ticker = 'OOOO'",
+            db_path=db_path,
+        )[0]["id"]
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO thesis_criteria_checks (criterion_id, check_date, result) VALUES (?, ?, 'breached')",
+                (criterion_id, AFTER),
+            )
+
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "OOOO") == "broken"
+
+    def test_verdict_values_match_the_schema_check(self, db_path):
+        """`VERDICTS` 가 문서용 상수로 굳지 않게 — 스키마 CHECK 와 실제로 대조한다."""
+        ddl = query("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'theses'", db_path=db_path)[0]["sql"]
+
+        for verdict in tc.VERDICTS:
+            assert f"'{verdict}'" in ddl
+
+
+class TestSchedulerRunsTheRollup:
+    """등록 확인이 아니라 **분기를 실행**해서 verdict 가 실제로 앉는지 본다.
+
+    `run_daily_checks` 만 부르고 롤업을 빠뜨려도 잡은 성공하고 카운트도 그럴듯하다 —
+    `theses.verdict` 만 영원히 NULL 이다. 그게 이 레포가 반복해 온 "도는 줄 아는데 안 도는"
+    모양이라, 구조가 아니라 산출물로 잠근다. 전역 DB 격리(`tests/conftest.py`)를 쓰므로
+    dispatch 가 `db_path` 없이 불려도 프로덕션에 닿지 않는다.
+    """
+
+    def test_dispatch_writes_a_verdict(self):
+        import nuri.scheduler as sch
+        from nuri.core.timezone import today_kst
+
+        today = today_kst()
+        tid = upsert_thesis(
+            ticker="QQQQ",
+            author="user",
+            stance="bullish",
+            bull_case="수요가 공급을 앞선다",
+            bear_case="점유율이 깎인다",
+            evidence=[{"side": "bull", "claim": "매출 증가", "source_type": "filing"}],
+            effective_date=today,
+            status="active",
+        )
+        add_criteria(tid, [dict(MACHINE, deadline_date="2026-01-01")])
+        upsert_prices(
+            pd.DataFrame(
+                [
+                    {
+                        "ticker": "QQQQ",
+                        "date": today,
+                        "open": 120.0,
+                        "high": 120.0,
+                        "low": 120.0,
+                        "close": 120.0,
+                        "volume": 1000,
+                        "adj_close": 120.0,
+                    }
+                ]
+            )
+        )
+
+        sch._dispatch_collector("thesis_criteria")
+
+        assert query("SELECT verdict FROM theses WHERE id = ?", (tid,))[0]["verdict"] == "held"

--- a/tests/trading/engine/test_thesis_verdict.py
+++ b/tests/trading/engine/test_thesis_verdict.py
@@ -198,6 +198,14 @@ class TestInProgressStaysBlank:
 
         assert _verdict(db_path, "IIII") is None
 
+    def test_zero_criteria_is_not_a_vacuous_pass(self):
+        """`all([])` 은 True 다 — 기준 0건이 만점으로 읽히는 공허참을 직접 잠근다.
+
+        쿼리가 INNER JOIN 이라 지금은 도달하지 않는 경로지만, 방어가 **우연**이면
+        다음 리팩터가 걷어간다. 그래서 판정 함수 자체를 직접 부른다.
+        """
+        assert tc._verdict_for("active", [], {}, AFTER) is None
+
     def test_thesis_without_criteria_is_never_scored(self, db_path):
         """#1092 이전 유물 — 반증 기준 없는 논지를 `held` 로 적으면 서사가 채점을 통과한다."""
         upsert_thesis(

--- a/tests/trading/engine/test_thesis_verdict.py
+++ b/tests/trading/engine/test_thesis_verdict.py
@@ -335,6 +335,62 @@ class TestRollupIsTheOnlyVerdictWriter:
             assert f"'{verdict}'" in ddl
 
 
+class TestOnlyInForceThesesAreScored:
+    """효력을 가진 적 없는 판단에 성적표를 붙이지 않는다 (Codex 리뷰 2026-08-18).
+
+    두 경로가 있었고 둘 다 재현했다: `draft` 는 사람이 승격한 적 없는 초안인데 verdict 를
+    받았고, `effective_date` 가 미래인 논지는 **발효 3개월 전부터 판정이 쌓여** `broken`
+    이 됐다. 뒤쪽이 더 나쁘다 — 있지도 않았던 기간의 반증으로 판단이 틀렸다고 적힌다.
+    """
+
+    def test_a_draft_never_gets_a_verdict(self, db_path):
+        upsert_thesis(
+            ticker="RRRR",
+            author="user",
+            stance="bullish",
+            bull_case="수요 우위",
+            bear_case="점유율 하락",
+            evidence=[{"side": "bull", "claim": "매출 증가", "source_type": "filing"}],
+            effective_date="2026-05-01",
+            status="draft",
+            db_path=db_path,
+        )
+        add_criteria(
+            query("SELECT id FROM theses WHERE ticker = 'RRRR'", db_path=db_path)[0]["id"],
+            [dict(MACHINE)],
+            db_path=db_path,
+        )
+
+        counts = tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "RRRR") is None
+        assert sum(counts.values()) == 0
+
+    def test_a_future_thesis_is_neither_checked_nor_scored(self, db_path):
+        _thesis(db_path, "SSSS", [dict(MACHINE)])
+        with get_db(db_path) as conn:
+            conn.execute("UPDATE theses SET effective_date = '2026-09-01' WHERE ticker = 'SSSS'")
+        _seed_close(db_path, "SSSS", 50.0)  # 반증 조건을 만족하는 가격
+
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert query("SELECT COUNT(*) AS n FROM thesis_criteria_checks", db_path=db_path)[0]["n"] == 0, (
+            "발효 전 기간이 판정에 쌓였다"
+        )
+        assert _verdict(db_path, "SSSS") is None
+
+    def test_the_same_thesis_is_scored_once_effective(self, db_path):
+        """필터가 논지를 영영 묻어버리지 않는다는 카나리아 — 발효일이 지나면 채점된다."""
+        _thesis(db_path, "TTTT", [dict(MACHINE)])
+        _seed_close(db_path, "TTTT", 50.0)
+
+        tc.run_daily_checks(as_of=BEFORE, db_path=db_path)
+        tc.roll_up_verdicts(as_of=AFTER, db_path=db_path)
+
+        assert _verdict(db_path, "TTTT") == "broken"
+
+
 class TestSchedulerRunsTheRollup:
     """등록 확인이 아니라 **분기를 실행**해서 verdict 가 실제로 앉는지 본다.
 


### PR DESCRIPTION
Closes #1096. 승인된 계획 Stage 4 (전반부).

## 무엇

`theses.verdict` 는 migration 51 이래 **writer 가 없던 컬럼**이었다. #1092 로 일별 기준
판정이 쌓이기 시작해서, 이제 판정이 손 라벨링이 아니라 **원장에서** 나온다.

| verdict | 조건 |
|---|---|
| `broken` | 기준 1건이라도 `breached` — **마감을 기다리지 않는다** |
| `abandoned` | 논지가 교체(`superseded`)되거나 접힘(`retired`) |
| (미설정) | 마감이 하나라도 안 지났거나 없음 — 진행 중 |
| `held` | 마감 전부 경과 + 반증 0 + **모든 기준이 최소 1회 측정됨** |
| `unevaluable` | 위 조건에서 측정이 부분적이거나 전무 |

## 굽히지 않은 것 셋

1. **부분 측정은 `held` 가 아니다.** #1092 가 기준 층에서 잠근 "`unevaluable` 은
   `holding` 이 아니다" 의 논지 층 대응물이다. 측정 못 한 것이 "지켜졌다" 로 흘러가면
   채점이 자기 편이 된다.
2. **`judge` 는 machine 기준을 못 건드린다.** 기계가 적은 `breached` 를 사람이 덮을 수
   있으면 원장이 취향대로 다듬어진다. 단 일별 점검이 human 기준에 매일 적는
   `unevaluable(manual)` **자리표시자**는 갱신한다 — 그것까지 append-only 로 지키면 사람은
   그날도 다음날도 판정을 못 남겨 `held` 가 **도달 불가능한 판정**이 된다.
3. **효력을 가진 적 없는 논지는 채점 안 함** (Codex P2). 아래 참조.

## 리뷰가 잡은 것

**Codex P2 — 발효 전 채점** (재현 후 수정): `draft` 가 verdict 를 받았고, 더 나쁘게는
`effective_date=2026-09-01` 논지가 **2026-05-30 부터 판정이 쌓여 `broken`** 이 됐다.
근본 원인은 롤업이 아니라 `run_daily_checks` 가 `effective_date` 를 안 본 것이라 두 곳을
같이 막았다. 카나리아가 필터가 논지를 영영 묻지 않는지 확인한다.

**자체 발견 — 공허참**: 기준 0건 논지가 `all([]) is True` 로 `held` 를 받았다. 도달하지
않았던 건 쿼리가 INNER JOIN 이어서지 방어가 있어서가 아니었고, LEFT JOIN 뮤테이션이 테스트를
전부 초록으로 통과했다. 명시 가드로 고치고 판정 함수를 직접 부르는 테스트로 잠갔다.

## Surface 천장

verdict 는 라벨이다. 주문·축을 만들지 않고 §3.11 표본을 건드리지 않는다 (§7.1).

## 검증

- 뮤테이션 **12종 중 11종 FAIL 실측** — 측정 완결성 · 철회 · 우선순위 · 마감 없음 ·
  machine 손판정 · 사람판정 덮어쓰기 · 자리표시자 · 스케줄러 배선 · 공허참 · in-force 필터 2종.
  생존 1종(INNER→LEFT JOIN)은 공허참 가드 추가 후 equivalent mutant.
- 백엔드 7,201 passed / 프론트 1,455 passed / `verify-doc-counts` 19 passed / privacy 클린
- 스케줄러 분기를 **실행해서** `theses.verdict` 가 실제로 앉는지 확인 (등록 확인이 아니라 산출물)

## 남은 것 (별도)

"실행 vs 미실행 alpha" 비교는 `candidate_ledger`(#1094) 행이 며칠 쌓여야 의미가 있어 분리한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)