### PR TITLE
feat(wallstreet): ingest big-four 13F without contaminating the conviction signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 52 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
+    SCHED["APScheduler · 53 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 26 jobs"]
@@ -106,7 +106,7 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 52 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 53 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,231 collected across 330 files | |
+| **Backend tests** | 7,245 collected across 331 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -280,12 +280,12 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 52 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 53 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 57 tables (53 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 57 tables (54 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,245 collected across 331 files | |
+| **Backend tests** | 7,253 collected across 331 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,245 backend tests across 331 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,253 backend tests across 331 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 52 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 53 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (53 migrations as of 2026-07-30). Key tables:
+51 tables total (54 migrations as of 2026-07-30). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,231 backend tests across 330 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,245 backend tests across 331 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,231 tests, 330 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,245 tests, 331 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,245 tests, 331 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,253 tests, 331 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/analysis/charts.py
+++ b/nuri/analysis/charts.py
@@ -161,7 +161,9 @@ def _get_info_panel(ticker: str) -> dict:
 
     # 슈퍼투자자
     si = query(
-        "SELECT investor, portfolio_pct FROM superinvestors WHERE ticker = ? ORDER BY portfolio_pct DESC", (ticker,)
+        "SELECT investor, portfolio_pct FROM superinvestors "
+        "WHERE ticker = ? AND investor_class = 'conviction' ORDER BY portfolio_pct DESC",
+        (ticker,),
     )
     if si:
         info["superinvestors"] = [(r["investor"], r["portfolio_pct"]) for r in si[:3]]

--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -304,7 +304,7 @@ def get_ticker_detail(symbol: str):
     # 8. 슈퍼투자자 보유
     si = query(
         "SELECT investor, portfolio_pct, filing_date FROM superinvestors "
-        "WHERE ticker=? ORDER BY portfolio_pct DESC LIMIT 5",
+        "WHERE ticker=? AND investor_class = 'conviction' ORDER BY portfolio_pct DESC LIMIT 5",
         (ticker,),
     )
     result["superinvestors"] = [dict(s) for s in si]

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -123,6 +123,36 @@ API 가 죽은 뒤 스크래핑이 **예외 없이 점수를 못 찾은** 경우
 **Test:** `tests/collectors/test_cboe.py::TestCBOEFailedVsNoData::test_db_stale_still_counts_as_success`
 — 이 한계를 명시적으로 잠근다(조용히 바꾸면 라이브 소스가 흔들릴 때마다 수집기가 죽는다).
 
+## 13F: 확신 보유 vs 딜러 보유 (`superinvestors.py`, #1098)
+
+한 테이블(`superinvestors`)에 두 종류가 산다. `investor_class` 로 갈린다:
+
+| | `conviction` (기본) | `dealer` |
+|---|---|---|
+| 누구 | 버핏·달리오·애크먼·국민연금 등 8곳 | JPM·BAC·GS·Citi 4곳 (`BANK_13F`) |
+| 수집기 | `SuperinvestorCollector` | `Bank13FCollector` (같은 코드, 클래스 속성만 교체) |
+| 의미 | 판단 | 마켓메이킹·수탁·인덱스 혼재 + **45일 지연** |
+| 저장 범위 | 전량 | `config/universe.yaml` us 로 제한 |
+
+⚠️ **은행을 확신 신호에 섞으면 틀린 값이 아니라 "변별력 0인 값"이 나온다.** 그래서 화면이
+멀쩡해 보인다. `smart_money.py` 는 `score += min(2, 보유 투자자 수)` 인데 은행 4곳은 사실상
+미국 유니버스 전체를 들고 있어(실측 2026-08-18: JPM 34,064 · BAC 18,318 · GS 14,070 ·
+Citi 11,343 포지션 / 이 테이블 **전체**는 8명 × 10분기 15,600 행) 그 항이 거의 모든 티커에서
+상수 2가 된다. `config/rules.yaml min_superinvestors` 도 같이 죽는다. 커버리지 임계(0.80)도
+딜러 행이 대신 밟아 확신 13F 수집이 죽어도 초록이 된다.
+
+⚠️ **`INSERT OR REPLACE` 는 컬럼을 빼면 기본값으로 되돌린다.** 재수집마다 `dealer` 행이
+조용히 `conviction` 으로 승격됐을 자리다 — upsert 는 `investor_class` 를 반드시 함께 쓴다.
+
+⚠️ **universe 필터는 `portfolio_pct` 계산 뒤**에 건다. 먼저 걸면 분모가 우리 유니버스 합이
+되어 비중이 부풀고 "JPM 포트폴리오의 12%" 같은 거짓이 화면에 실린다.
+
+**Test:** `tests/core/test_superinvestor_class_isolation.py` — 동작(딜러 행을 심어도
+점수·커버리지 불변)과 구조(`superinvestors` 를 읽는 모든 SQL 리터럴이 `investor_class` 를
+걸거나 사유와 함께 allowlist, 양방향)를 같이 잠근다. 뮤테이션 8종 전부 FAIL 실측.
+스윕의 한계는 명시돼 있다 — 테이블명이 f-string 변수인 쿼리(`coverage.py::_table_tickers`)는
+리터럴에 이름이 없어 안 보이므로 `_COVERAGE_FILTERS` 로 따로 처리했다.
+
 ## Macro Data Quirk
 
 `us_3m_yield` (FRED) is absent in yfinance fallback — `^IRX` (13-week T-Bill) is stored as `us_2y_yield`. `merge_macro_data()` queries `us_2y_yield` when `us_3m_yield` is empty.

--- a/nuri/collectors/superinvestors.py
+++ b/nuri/collectors/superinvestors.py
@@ -12,7 +12,7 @@ API 키 불필요. 분기별 갱신.
 """
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import pandas as pd
 
@@ -33,6 +33,25 @@ SUPERINVESTORS = {
     "Vivek Ramaswamy (Strive)": "0001954109",  # Strive Asset Management
 }
 
+#: 대형 은행 13F (#1098). **확신 포트폴리오가 아니다** — 마켓메이킹·수탁·인덱스가
+#: 섞여 있고 분기 공시라 45일 지연된다. 버핏의 NEW 와 JPM 의 NEW 는 같은 뜻이 아니므로
+#: 읽는 쪽에 반드시 그 단서를 붙인다.
+#:
+#: CIK 는 2026-08-18 EDGAR `company_tickers.json` + `submissions` API 로 **직접 확인**했다
+#: (넷 다 13F-HR 실적 있음). 한 분기 포지션 수 실측: JPM 34,064 · BAC 18,318 ·
+#: GS 14,070 · Citi 11,343 — 그래서 `dealer` 로 격리하고 universe 로 좁혀 저장한다.
+BANK_13F = {
+    "JPMorgan Chase": "0000019617",
+    "Bank of America": "0000070858",
+    "Goldman Sachs": "0000886982",
+    "Citigroup": "0000831001",
+}
+
+#: `superinvestors.investor_class` 값. `conviction` 이 기본이라 기존 행과 기존 수집기가
+#: 전부 자동으로 옳은 쪽에 앉는다.
+CONVICTION = "conviction"
+DEALER = "dealer"
+
 # edgartools User-Agent (SEC 정책 준수)
 EDGAR_IDENTITY = "Nuri-Quant research@nuri-quant.dev"
 
@@ -40,8 +59,14 @@ EDGAR_IDENTITY = "Nuri-Quant research@nuri-quant.dev"
 class SuperinvestorCollector(BaseCollector):
     """SEC EDGAR 13F로 슈퍼투자자 포트폴리오 수집."""
 
-    def __init__(self):
-        super().__init__("superinvestors")
+    #: 수집 대상과 분류. 서브클래스가 갈아끼운다.
+    investors: dict = SUPERINVESTORS
+    investor_class: str = CONVICTION
+    #: `None` 이면 전량 저장. set 이면 그 티커만 — 은행 13F 전량 미러를 막는다.
+    universe: Optional[set] = None
+
+    def __init__(self, name: str = "superinvestors"):
+        super().__init__(name)
 
     def collect(self, **kwargs) -> list[dict]:
         """전체 슈퍼투자자의 13F 수집.
@@ -59,8 +84,11 @@ class SuperinvestorCollector(BaseCollector):
         succeeded: list[str] = []
         failed: list[str] = []
 
-        investors_list = list(SUPERINVESTORS.items())
-        self.logger.info(f"슈퍼투자자 13F 수집: {len(investors_list)}명, 최근 {num_quarters}분기")
+        investors_list = list(self.investors.items())
+        self.logger.info(
+            f"13F 수집({self.investor_class}): {len(investors_list)}곳, 최근 {num_quarters}분기"
+            + (f", universe {len(self.universe)}종목으로 제한" if self.universe is not None else "")
+        )
         iterator = tqdm(investors_list, desc="  superinvestors", unit="inv", disable=len(investors_list) < 5)
 
         for investor_name, cik in iterator:
@@ -104,9 +132,15 @@ class SuperinvestorCollector(BaseCollector):
                     if total_value == 0:
                         continue
 
+                    kept = 0
                     for _, row in grouped.iterrows():
                         ticker = row["Ticker"]
                         if not ticker or pd.isna(ticker):
+                            continue
+                        # universe 필터는 **비중 계산 뒤**다. 먼저 걸러 버리면 분모가
+                        # 우리 유니버스 합이 되어 `portfolio_pct` 가 실제 비중보다
+                        # 부풀고, 화면에서 "JPM 포트폴리오의 12%" 같은 거짓이 된다.
+                        if self.universe is not None and ticker not in self.universe:
                             continue
 
                         pct = row["Value"] / total_value * 100
@@ -120,11 +154,15 @@ class SuperinvestorCollector(BaseCollector):
                                 "market_value": float(row["Value"]),
                                 "portfolio_pct": round(pct, 4),
                                 "issuer_name": row["Issuer"],
+                                "investor_class": self.investor_class,
                             }
                         )
+                        kept += 1
 
                     count += 1
-                    self.logger.info(f"  {investor_name} {filing_date}: {len(grouped)}종목, 총 ${total_value:,.0f}")
+                    self.logger.info(
+                        f"  {investor_name} {filing_date}: {len(grouped)}종목 중 {kept}건 저장, 총 ${total_value:,.0f}"
+                    )
 
                 self.logger.debug(f"{investor_name}: {count}분기 수집 완료")
                 succeeded.append(investor_name)
@@ -153,20 +191,46 @@ class SuperinvestorCollector(BaseCollector):
         return _upsert_superinvestors(data)
 
 
-def _upsert_superinvestors(records: list[dict]) -> int:
-    """superinvestors 테이블에 upsert."""
+def _upsert_superinvestors(records: list[dict], db_path=None) -> int:
+    """superinvestors 테이블에 upsert.
+
+    ⚠️ `investor_class` 를 **반드시** 함께 쓴다. `INSERT OR REPLACE` 는 충돌 시 기존 행을
+    지우고 새로 넣으므로, 컬럼을 빼면 재수집 때마다 `dealer` 행이 컬럼 기본값인
+    `conviction` 으로 조용히 되돌아간다 — 그러면 은행 보유가 확신 신호에 섞인다.
+    """
     if not records:
         return 0
-    with get_db() as conn:
+    with get_db(db_path) as conn:
         conn.executemany(
             """INSERT OR REPLACE INTO superinvestors
                (investor, filing_date, ticker, shares, market_value,
-                portfolio_pct, issuer_name)
+                portfolio_pct, issuer_name, investor_class)
                VALUES (:investor, :filing_date, :ticker, :shares, :market_value,
-                       :portfolio_pct, :issuer_name)""",
-            records,
+                       :portfolio_pct, :issuer_name, :investor_class)""",
+            [{"investor_class": CONVICTION, **r} for r in records],
         )
         return len(records)
+
+
+class Bank13FCollector(SuperinvestorCollector):
+    """대형 은행 4곳 13F — `dealer` 로 격리 저장 (#1098).
+
+    같은 테이블에 넣되 `investor_class='dealer'` 라 `smart_money` / `min_superinvestors`
+    같은 확신 신호는 이 행을 보지 못한다. 그 분리가 이 클래스의 존재 이유다 — 섞으면
+    거의 모든 티커가 "슈퍼투자자 4명 보유" 가 되어 그 항의 변별력이 0이 된다.
+
+    universe 로 좁히는 이유: 한 분기 77,795 포지션 중 대부분은 우리가 판단하지 않는
+    종목·채권·옵션이다. 전량 미러는 8분기에 622K 행을 쌓고 어떤 질문에도 답하지 않는다.
+    """
+
+    investors = BANK_13F
+    investor_class = DEALER
+
+    def __init__(self):
+        super().__init__("bank_13f")
+        from nuri.core.coverage import _load_universe
+
+        self.universe = _load_universe()["us"]
 
 
 def detect_changes(investor: str, db_path=None) -> pd.DataFrame:
@@ -268,7 +332,9 @@ def detect_changes(investor: str, db_path=None) -> pd.DataFrame:
 
 def print_summary():
     """슈퍼투자자 보유 현황 출력."""
-    investors = query("SELECT DISTINCT investor FROM superinvestors ORDER BY investor")
+    investors = query(
+        "SELECT DISTINCT investor FROM superinvestors WHERE investor_class = 'conviction' ORDER BY investor"
+    )
     if not investors:
         print("슈퍼투자자 데이터가 없습니다.")
         return
@@ -310,6 +376,7 @@ def print_summary():
         """SELECT s.ticker, GROUP_CONCAT(DISTINCT s.investor) as investors
            FROM superinvestors s
            WHERE s.ticker IN (SELECT DISTINCT ticker FROM portfolio)
+             AND s.investor_class = 'conviction'
            GROUP BY s.ticker
            ORDER BY s.ticker"""
     )

--- a/nuri/collectors/superinvestors.py
+++ b/nuri/collectors/superinvestors.py
@@ -59,8 +59,11 @@ EDGAR_IDENTITY = "Nuri-Quant research@nuri-quant.dev"
 class SuperinvestorCollector(BaseCollector):
     """SEC EDGAR 13F로 슈퍼투자자 포트폴리오 수집."""
 
-    #: 수집 대상과 분류. 서브클래스가 갈아끼운다.
-    investors: dict = SUPERINVESTORS
+    #: 수집 대상. **`None` 이면 호출 시점에 `SUPERINVESTORS` 를 읽는다** — 클래스 속성에
+    #: 상수를 바로 박으면 정의 시점 바인딩이라 모듈 상수를 갈아끼워도 반영되지 않는다
+    #: (테스트 18곳이 그 방식으로 레지스트리를 좁힌다. 조용히 8명 전체를 돌면서 통과한다).
+    #: 서브클래스는 명시로 덮는다.
+    investors: Optional[dict] = None
     investor_class: str = CONVICTION
     #: `None` 이면 전량 저장. set 이면 그 티커만 — 은행 13F 전량 미러를 막는다.
     universe: Optional[set] = None
@@ -84,7 +87,7 @@ class SuperinvestorCollector(BaseCollector):
         succeeded: list[str] = []
         failed: list[str] = []
 
-        investors_list = list(self.investors.items())
+        investors_list = list((self.investors if self.investors is not None else SUPERINVESTORS).items())
         self.logger.info(
             f"13F 수집({self.investor_class}): {len(investors_list)}곳, 최근 {num_quarters}분기"
             + (f", universe {len(self.universe)}종목으로 제한" if self.universe is not None else "")

--- a/nuri/core/coverage.py
+++ b/nuri/core/coverage.py
@@ -91,9 +91,18 @@ def _load_universe(path: Optional[Path] = None) -> dict[str, set[str]]:
     return {"us": us, "kr": kr}
 
 
+#: 테이블별 추가 필터. 커버리지는 **우리가 판단에 쓰는 행**만 세야 한다.
+#: `superinvestors` 에는 은행 13F(`dealer`)가 섞이는데(#1098), 은행은 사실상 유니버스
+#: 전체를 들고 있어 이걸 포함하면 커버리지가 0.80 임계를 자동 통과한다 — 확신 13F 수집이
+#: 죽어도 초록인 계기판이 된다.
+_COVERAGE_FILTERS: dict[str, str] = {"superinvestors": "investor_class = 'conviction'"}
+
+
 def _table_tickers(table: str, db_path: Optional[Path] = None) -> set[str]:
     """DB에서 해당 table의 unique ticker set 조회."""
-    rows = query(f"SELECT DISTINCT ticker FROM {table}", db_path=db_path)
+    where = _COVERAGE_FILTERS.get(table)
+    sql = f"SELECT DISTINCT ticker FROM {table}" + (f" WHERE {where}" if where else "")
+    rows = query(sql, db_path=db_path)
     return {r["ticker"] for r in rows if r["ticker"]}
 
 

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1721,4 +1721,26 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
             ON candidate_ledger(ticker, acted);
     """,
     ),
+    (
+        54,
+        "superinvestors.investor_class — 확신 보유와 딜러 보유를 분리 (#1098)",
+        # 은행 13F 를 같은 테이블에 넣되 **같은 신호로 읽히지 않게** 한다.
+        #
+        # 실측(2026-08-18 EDGAR): JPM 34,064 · BAC 18,318 · GS 14,070 · Citi 11,343 =
+        # 한 분기 77,795 포지션. 현재 이 테이블 **전체**가 8명 × 10분기 15,600 행이다.
+        #
+        # 용량보다 심각한 건 신호 파괴다. `smart_money.py` 는 `min(2, 보유 투자자 수)` 를
+        # 점수에 더하는데, 은행 4곳은 마켓메이킹·수탁·인덱스로 사실상 모든 미국 상장
+        # 티커를 들고 있다 → 그 항이 거의 모든 티커에서 상수 2가 되어 **변별력이 0**이
+        # 된다. `config/rules.yaml min_superinvestors: 3` 도 같이 무력화된다.
+        #
+        # 기본값이 `conviction` 인 것이 핵심이다: 기존 15,600 행과 새로 들어오는 기존
+        # 수집기의 행이 전부 자동으로 옳은 쪽에 앉는다. `dealer` 는 명시할 때만.
+        """
+        ALTER TABLE superinvestors ADD COLUMN investor_class TEXT NOT NULL
+            DEFAULT 'conviction';
+        CREATE INDEX IF NOT EXISTS idx_superinvestors_class
+            ON superinvestors(investor_class, ticker);
+    """,
+    ),
 ]

--- a/nuri/quant/validation/superinvestor_backtest.py
+++ b/nuri/quant/validation/superinvestor_backtest.py
@@ -67,7 +67,10 @@ class InvestorScorecard:
 
 def _check_data_readiness(db_path=None) -> bool:
     """과거 다분기 13F 데이터가 있는지 확인."""
-    quarters = query("SELECT DISTINCT filing_date FROM superinvestors ORDER BY filing_date", db_path=db_path)
+    quarters = query(
+        "SELECT DISTINCT filing_date FROM superinvestors WHERE investor_class = 'conviction' ORDER BY filing_date",
+        db_path=db_path,
+    )
     if len(quarters) < 2:
         logger.warning(
             f"슈퍼투자자 13F가 {len(quarters)}분기만 있습니다. "

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -117,6 +117,7 @@ _STAGE_OF_JOB = {
     "fundamental": "collect",
     "kis_analyst_opinion": "collect",
     "superinvestors": "collect",
+    "bank_13f": "collect",
     "estimates": "collect",
     "etf_flows": "collect",
     "wallstreet": "collect",
@@ -230,6 +231,13 @@ def _dispatch_collector(name: str, **kwargs):
         from nuri.collectors.superinvestors import SuperinvestorCollector
 
         SuperinvestorCollector().run()
+    elif name == "bank_13f":
+        # 대형 은행 4곳 13F (#1098). 확신 투자자와 **같은 테이블 다른 class** 라
+        # 잡을 나눠 둔다 — 은행 쪽 EDGAR 실패가 확신 13F 수집을 같이 죽이면 안 된다.
+        # 분기 공시라 주 1회면 충분하고, 확신 수집(01:00) 뒤에 둬 EDGAR 부하를 겹치지 않는다.
+        from nuri.collectors.superinvestors import Bank13FCollector
+
+        Bank13FCollector().run(quarters=4)
     elif name == "estimates":
         from nuri.collectors.estimates import EstimatesCollector
 
@@ -780,6 +788,7 @@ SCHEDULES = [
     {"name": "kis_analyst_opinion", "func": _run_collector, "args": ("kis_analyst_opinion",), "cron": "30 0 * * 0"},
     # 슈퍼투자자 13F (주 1회 일요일 01:00)
     {"name": "superinvestors", "func": _run_collector, "args": ("superinvestors",), "cron": "0 1 * * 0"},
+    {"name": "bank_13f", "func": _run_collector, "args": ("bank_13f",), "cron": "0 2 * * 0"},
     # 애널리스트 컨센서스 (주 1회 일요일 02:00) — universe 전체 (#420).
     # universe 543 US tickers ~27s elapsed (2026-04-28 live probe 96.7% OK / 0 rate-limit).
     # universe ⊃ portfolio 이므로 별도 portfolio entry 없어도 보유종목 자동 갱신.

--- a/nuri/trading/agents/smart_money.py
+++ b/nuri/trading/agents/smart_money.py
@@ -21,7 +21,8 @@ class SmartMoneyAgent(BaseAgent):
 
         # 1. 슈퍼투자자 보유 여부
         si_rows = self._safe_query(
-            "SELECT investor, portfolio_pct FROM superinvestors WHERE ticker = ? ORDER BY portfolio_pct DESC",
+            "SELECT investor, portfolio_pct FROM superinvestors "
+            "WHERE ticker = ? AND investor_class = 'conviction' ORDER BY portfolio_pct DESC",
             (ticker,),
             db_path,
         )
@@ -37,7 +38,7 @@ class SmartMoneyAgent(BaseAgent):
         # 2. 슈퍼투자자 포지션 변화 (NEW/INCREASED)
         change_rows = self._safe_query(
             "SELECT DISTINCT investor FROM superinvestors s1 "
-            "WHERE ticker = ? AND filing_date = ("
+            "WHERE ticker = ? AND investor_class = 'conviction' AND filing_date = ("
             "  SELECT MAX(filing_date) FROM superinvestors WHERE investor = s1.investor"
             ") AND NOT EXISTS ("
             "  SELECT 1 FROM superinvestors s2 "

--- a/nuri/trading/engine/gate.py
+++ b/nuri/trading/engine/gate.py
@@ -138,7 +138,10 @@ def _check_signal_scorecard(db_path=None) -> GateCondition:
 
 
 def _check_superinvestor_quarters(db_path=None) -> GateCondition:
-    rows = query("SELECT COUNT(DISTINCT filing_date) as c FROM superinvestors", db_path=db_path)
+    rows = query(
+        "SELECT COUNT(DISTINCT filing_date) as c FROM superinvestors WHERE investor_class = 'conviction'",
+        db_path=db_path,
+    )
     count = _safe_count(rows)
     ok = count >= 2
     return GateCondition(

--- a/tests/collectors/test_superinvestors.py
+++ b/tests/collectors/test_superinvestors.py
@@ -179,10 +179,7 @@ class TestSuperinvestorCollectorEdgarFlow:
         mock_company = MagicMock()
         mock_company.get_filings.return_value = mock_filings
 
-        # 모듈 상수가 아니라 **클래스 속성**을 패치한다 — `collect()` 가 `self.investors`
-        # 를 읽으므로(#1098 은행 수집기가 같은 코드를 재사용한다) 모듈 상수 패치는
-        # 클래스 정의 시점에 이미 바인딩된 값을 바꾸지 못한다.
-        with patch.object(SuperinvestorCollector, "investors", {"TestInvestor": "0001234567"}):
+        with patch("nuri.collectors.superinvestors.SUPERINVESTORS", {"TestInvestor": "0001234567"}):
             with patch("edgar.set_identity"):
                 with patch("edgar.Company", return_value=mock_company):
                     c = SuperinvestorCollector()

--- a/tests/collectors/test_superinvestors.py
+++ b/tests/collectors/test_superinvestors.py
@@ -179,7 +179,10 @@ class TestSuperinvestorCollectorEdgarFlow:
         mock_company = MagicMock()
         mock_company.get_filings.return_value = mock_filings
 
-        with patch("nuri.collectors.superinvestors.SUPERINVESTORS", {"TestInvestor": "0001234567"}):
+        # 모듈 상수가 아니라 **클래스 속성**을 패치한다 — `collect()` 가 `self.investors`
+        # 를 읽으므로(#1098 은행 수집기가 같은 코드를 재사용한다) 모듈 상수 패치는
+        # 클래스 정의 시점에 이미 바인딩된 값을 바꾸지 못한다.
+        with patch.object(SuperinvestorCollector, "investors", {"TestInvestor": "0001234567"}):
             with patch("edgar.set_identity"):
                 with patch("edgar.Company", return_value=mock_company):
                     c = SuperinvestorCollector()
@@ -577,16 +580,16 @@ class TestSuperinvestorCollectorEdgarMoreScenarios:
 
         with get_db(db_with_portfolio) as conn:
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Buffett', '2025-01-15', 'AAPL', 1000, 200000, 25.0, 'Apple Inc')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Buffett', '2025-01-15', 'AAPL', 1000, 200000, 25.0, 'Apple Inc')"
             )
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Buffett', '2025-01-15', 'MSFT', 500, 100000, 12.0, 'Microsoft')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Buffett', '2025-01-15', 'MSFT', 500, 100000, 12.0, 'Microsoft')"
             )
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Buffett', '2025-04-15', 'AAPL', 2000, 400000, 50.0, 'Apple Inc')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Buffett', '2025-04-15', 'AAPL', 2000, 400000, 50.0, 'Apple Inc')"
             )
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Buffett', '2025-04-15', 'NVDA', 300, 60000, 15.0, 'NVIDIA')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Buffett', '2025-04-15', 'NVDA', 300, 60000, 15.0, 'NVIDIA')"
             )
         df = detect_changes("Buffett", db_path=db_with_portfolio)
         changes = set(df["change_type"].unique())
@@ -605,10 +608,10 @@ class TestSuperinvestorDetectChangesEdgeCases:
 
         with get_db(db_with_portfolio) as conn:
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'X', '2025-01-15', 'AAPL', 1000, 200000, 50.0, 'Apple')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'X', '2025-01-15', 'AAPL', 1000, 200000, 50.0, 'Apple')"
             )
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'X', '2025-04-15', 'AAPL', 1000, 200000, 50.0, 'Apple')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'X', '2025-04-15', 'AAPL', 1000, 200000, 50.0, 'Apple')"
             )
         assert "UNCHANGED" in detect_changes("X", db_path=db_with_portfolio)["change_type"].values
 
@@ -617,10 +620,10 @@ class TestSuperinvestorDetectChangesEdgeCases:
 
         with get_db(db_with_portfolio) as conn:
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Y', '2025-01-15', 'AAPL', 1000, 200000, 50.0, 'Apple')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Y', '2025-01-15', 'AAPL', 1000, 200000, 50.0, 'Apple')"
             )
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Y', '2025-04-15', 'AAPL', 500, 100000, 25.0, 'Apple')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Y', '2025-04-15', 'AAPL', 500, 100000, 25.0, 'Apple')"
             )
         assert "DECREASED" in detect_changes("Y", db_path=db_with_portfolio)["change_type"].values
 
@@ -628,9 +631,11 @@ class TestSuperinvestorDetectChangesEdgeCases:
         from nuri.collectors.superinvestors import detect_changes
 
         with get_db(db_with_portfolio) as conn:
-            conn.execute("INSERT INTO superinvestors VALUES (NULL, 'Z', '2025-01-15', 'AAPL', 0, 0, 0, 'Apple')")
             conn.execute(
-                "INSERT INTO superinvestors VALUES (NULL, 'Z', '2025-04-15', 'AAPL', 500, 100000, 50.0, 'Apple')"
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Z', '2025-01-15', 'AAPL', 0, 0, 0, 'Apple')"
+            )
+            conn.execute(
+                "INSERT INTO superinvestors (id, investor, filing_date, ticker, shares, market_value, portfolio_pct, issuer_name) VALUES (NULL, 'Z', '2025-04-15', 'AAPL', 500, 100000, 50.0, 'Apple')"
             )
         assert "INCREASED" in detect_changes("Z", db_path=db_with_portfolio)["change_type"].values
 

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,7 +29,7 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_53(self, db_path):
+    def test_schema_version_at_54(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
@@ -40,8 +40,9 @@ class TestSchemaMigrations:
         recommendations.source — emit 경로 구분 (#1078) +
         theses / thesis_evidence — 상승·하락 논지 원장 (#1083) +
         thesis_criteria / thesis_criteria_checks — 사전등록 반증 기준 (#1092) +
-        candidate_runs / candidate_ledger — 미실행 거래 원장 (#1094) → 53."""
-        assert get_schema_version(db_path) == 53
+        candidate_runs / candidate_ledger — 미실행 거래 원장 (#1094) +
+        superinvestors.investor_class — 확신/딜러 13F 분리 (#1098) → 54."""
+        assert get_schema_version(db_path) == 54
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/core/test_superinvestor_class_isolation.py
+++ b/tests/core/test_superinvestor_class_isolation.py
@@ -249,3 +249,120 @@ class TestDealerRowsAreStillReachable:
         with get_db(db_path) as conn:
             n = conn.execute("SELECT COUNT(*) FROM superinvestors WHERE investor_class = ?", (DEALER,)).fetchone()[0]
         assert n == 4
+
+
+class TestRegistryResolvesAtRuntime:
+    """`investors` 는 호출 시점에 읽는다 — 클래스 속성에 상수를 박으면 안 된다 (Codex P1).
+
+    `investors: dict = SUPERINVESTORS` 는 **클래스 정의 시점** 바인딩이라 모듈 상수를
+    갈아끼워도 `collect()` 가 못 본다. 레지스트리를 좁히는 테스트 18곳이 그러면 조용히
+    8명 전체를 돌면서 **통과**한다 — 틀린 결과가 아니라 무의미한 결과라 눈에 안 띈다.
+    """
+
+    def test_patching_the_module_constant_narrows_collect(self, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        from nuri.collectors.superinvestors import SuperinvestorCollector
+
+        monkeypatch.setattr("nuri.collectors.superinvestors.SUPERINVESTORS", {"Only One": "0000000001"})
+        seen = []
+
+        def _company(cik):
+            seen.append(cik)
+            m = MagicMock()
+            m.get_filings.return_value = []
+            return m
+
+        with patch("edgar.set_identity"), patch("edgar.Company", side_effect=_company):
+            SuperinvestorCollector().collect(quarters=1)
+
+        assert seen == ["0000000001"], f"레지스트리가 안 좁혀졌다 — {len(seen)}곳을 돌았다"
+
+    def test_the_bank_collector_still_overrides_it(self):
+        from nuri.collectors.superinvestors import BANK_13F, Bank13FCollector
+
+        assert Bank13FCollector().investors == BANK_13F
+
+
+class TestUniverseFilterRunsAfterTheWeight:
+    """universe 로 좁히되 `portfolio_pct` 는 **실제 포트폴리오 대비** 비중이어야 한다.
+
+    필터를 비중 계산 **앞**에 두면 분모가 우리 유니버스 합이 되어 비중이 부풀고, 화면에
+    "JPM 포트폴리오의 12%" 같은 거짓이 실린다. 실제로는 0.3% 인데 말이다. 그 오류는
+    숫자가 그럴듯해서 검토로는 절대 안 걸린다.
+    """
+
+    def _collect(self, universe):
+        from unittest.mock import MagicMock, patch
+
+        import pandas as pd
+
+        from nuri.collectors.superinvestors import Bank13FCollector
+
+        infotable = pd.DataFrame(
+            {
+                "Ticker": ["AAAA", "BBBB", "CCCC"],
+                "Value": [10e6, 30e6, 60e6],
+                "SharesPrnAmount": [100.0, 300.0, 600.0],
+                "Issuer": ["A Corp", "B Corp", "C Corp"],
+            }
+        )
+        filing = MagicMock()
+        filing.filing_date = "2026-05-15"
+        filing.obj.return_value = MagicMock(infotable=infotable)
+        filings = MagicMock()
+        filings.__len__ = lambda self: 1
+        filings.__getitem__ = lambda self, i: [filing][i]
+        filings.__bool__ = lambda self: True
+        company = MagicMock()
+        company.get_filings.return_value = filings
+
+        collector = Bank13FCollector()
+        collector.investors = {"Test Bank": "0000000001"}
+        collector.universe = universe
+        with patch("edgar.set_identity"), patch("edgar.Company", return_value=company):
+            return collector.collect(quarters=1)
+
+    def test_out_of_universe_tickers_are_dropped(self):
+        got = self._collect({"AAAA"})
+
+        assert [r["ticker"] for r in got] == ["AAAA"]
+
+    def test_the_kept_weight_is_of_the_whole_portfolio(self):
+        """AAAA 는 전체 1억 중 1천만 = 10%. 유니버스만 세면 100% 로 부푼다."""
+        got = self._collect({"AAAA"})
+
+        assert got[0]["portfolio_pct"] == pytest.approx(10.0)
+        assert got[0]["investor_class"] == DEALER
+
+    def test_no_universe_keeps_everything(self):
+        assert len(self._collect(None)) == 3
+
+
+class TestSchedulerRunsTheBankCollector:
+    """잡을 등록만 하고 dispatcher 분기가 없으면 조용히 안 돈다 — 분기를 실행해서 본다."""
+
+    def test_dispatch_reaches_the_bank_collector(self):
+        from unittest.mock import patch
+
+        import nuri.scheduler as sch
+
+        with patch("nuri.collectors.superinvestors.Bank13FCollector.run") as run:
+            sch._dispatch_collector("bank_13f")
+
+        run.assert_called_once()
+        assert run.call_args.kwargs.get("quarters"), "분기 수를 안 넘기면 기본 8분기가 돈다"
+
+    def test_the_job_is_registered_and_staged(self):
+        import nuri.scheduler as sch
+
+        assert sch._STAGE_OF_JOB["bank_13f"] == "collect"
+        scheduled = {j["args"][0] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
+        assert "bank_13f" in scheduled
+
+    def test_the_bank_job_is_separate_from_the_conviction_job(self):
+        """한 잡에 합치면 은행 쪽 EDGAR 실패가 확신 13F 수집까지 같이 죽인다."""
+        import nuri.scheduler as sch
+
+        jobs = {j["args"][0]: j["cron"] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
+        assert jobs["bank_13f"] != jobs["superinvestors"]

--- a/tests/core/test_superinvestor_class_isolation.py
+++ b/tests/core/test_superinvestor_class_isolation.py
@@ -1,0 +1,251 @@
+"""은행 13F(`dealer`)가 확신 신호에 섞이지 않는지 (#1098).
+
+## 왜 필터가 규율이 아니라 **기계 검사**여야 하나
+
+은행 4곳은 마켓메이킹·수탁·인덱스로 사실상 미국 유니버스 전체를 들고 있다(2026-08-18
+EDGAR 실측: JPM 34,064 · BAC 18,318 · GS 14,070 · Citi 11,343 포지션). 그래서 필터를 한
+군데만 빠뜨려도 그 소비자는 **거의 모든 티커에서 같은 값**을 내고, 그건 틀린 값이 아니라
+**변별력이 0인 값**이라 화면에서 정상으로 보인다. `smart_money` 의 `min(2, 보유 수)` 가
+정확히 그 모양이다 — 상수 2가 되어도 아무도 모른다.
+
+그래서 두 층으로 잠근다:
+- **동작** — 딜러 행을 심어도 점수·표시·커버리지가 변하지 않는다
+- **구조** — `superinvestors` 를 읽는 모든 SQL 리터럴이 `investor_class` 를 걸거나
+  allowlist 에 사유와 함께 등재. 양방향이라 낡은 항목도 FAIL
+
+⚠️ 구조 스윕의 한계를 알고 쓴다: 테이블명이 f-string 변수인 쿼리는 리터럴에
+`superinvestors` 가 없어 **보이지 않는다**(`coverage.py::_table_tickers`). 그래서 그쪽은
+`_COVERAGE_FILTERS` 로 명시 처리하고 동작 테스트로 따로 잠갔다.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from nuri.collectors.superinvestors import CONVICTION, DEALER, _upsert_superinvestors
+from nuri.core.db import get_db, init_db, query
+
+NURI = Path(__file__).resolve().parents[2] / "nuri"
+
+#: `investor_class` 를 안 거는 것이 옳은 쿼리. **사유 필수**.
+ALLOWED: dict[tuple[str, str], str] = {
+    (
+        "collectors/superinvestors.py",
+        "INSERT OR REPLACE INTO superinvestors",
+    ): "writer — 컬럼을 직접 쓴다",
+    (
+        "collectors/superinvestors.py",
+        "SELECT DISTINCT filing_date FROM superinvestors WHERE investor = ?",
+    ): "detect_changes — investor 이름으로 이미 좁혀져 class 가 중복",
+    (
+        "collectors/superinvestors.py",
+        "SELECT ticker, shares, issuer_name FROM superinvestors WHERE investor = ? AND filing_date = ?",
+    ): "detect_changes — 위와 같은 이유",
+    (
+        "collectors/superinvestors.py",
+        "SELECT ticker, issuer_name, portfolio_pct, market_value, filing_date FROM superinvestors WHERE investor = ?",
+    ): "print_summary — 구동 쿼리가 conviction 만 뽑아 넘긴 이름으로 좁혀진다",
+    (
+        "collectors/superinvestors.py",
+        "SELECT market_value FROM superinvestors WHERE investor = ?",
+    ): "print_summary — 위와 같은 이유",
+}
+
+
+def _sql_literals() -> list[tuple[str, str]]:
+    """`nuri/` 안의 SQL 문자열 리터럴 중 superinvestors 를 건드리는 것.
+
+    파이썬은 인접 문자열 리터럴을 **파싱 시점에 하나로 접으므로** 여러 줄로 쪼갠 SQL 도
+    하나의 `Constant` 로 잡힌다 — 조각마다 따로 검사해 놓치는 일이 없다.
+    """
+    found = []
+    for path in sorted(NURI.rglob("*.py")):
+        rel = str(path.relative_to(NURI))
+        if rel == "core/db_migrations.py":  # 스키마 정의 자체
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            sql = " ".join(node.value.split())
+            if "superinvestors" not in sql:
+                continue
+            if not any(v in sql.upper() for v in ("SELECT", "INSERT", "UPDATE", "DELETE")):
+                continue
+            found.append((rel, sql))
+    return found
+
+
+class TestEveryQueryDecides:
+    def test_the_sweep_actually_finds_queries(self):
+        """스윕이 0건을 찾고도 통과하면 이 파일 전체가 장식이다."""
+        assert len(_sql_literals()) >= 5
+
+    def test_every_superinvestor_query_filters_or_is_allowlisted(self):
+        offenders = []
+        for rel, sql in _sql_literals():
+            if "investor_class" in sql:
+                continue
+            if any(rel == a_rel and sql.startswith(a_sql) for a_rel, a_sql in ALLOWED):
+                continue
+            offenders.append(f"{rel}: {sql[:110]}")
+        assert not offenders, (
+            "`superinvestors` 를 읽는데 investor_class 를 안 건 쿼리:\n  "
+            + "\n  ".join(offenders)
+            + "\n확신 신호면 investor_class='conviction' 을 걸고, 아니면 ALLOWED 에 사유와 함께 등재."
+        )
+
+    def test_allowlist_has_no_stale_entries(self):
+        """해소된 항목이 남아 있으면 다음 위반을 조용히 통과시킨다."""
+        live = {(rel, sql) for rel, sql in _sql_literals()}
+        stale = [
+            f"{rel}: {sql[:80]}"
+            for rel, sql in ALLOWED
+            if not any(a_rel == rel and a_sql.startswith(sql) for a_rel, a_sql in live)
+        ]
+        assert not stale, "ALLOWED 에 더 이상 존재하지 않는 쿼리:\n  " + "\n  ".join(stale)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, ticker="ZZZZ"):
+    """확신 1명 + 딜러 4곳. 딜러가 신호를 오염시키면 아래 단언들이 깨진다."""
+    _upsert_superinvestors(
+        [
+            {
+                "investor": "Conviction One",
+                "filing_date": "2026-05-15",
+                "ticker": ticker,
+                "shares": 1000.0,
+                "market_value": 1_000_000.0,
+                "portfolio_pct": 8.0,
+                "issuer_name": "Example Corp",
+                "investor_class": CONVICTION,
+            }
+        ]
+        + [
+            {
+                "investor": f"Dealer {i}",
+                "filing_date": "2026-05-15",
+                "ticker": ticker,
+                "shares": 500.0,
+                "market_value": 500_000.0,
+                "portfolio_pct": 0.01,
+                "issuer_name": "Example Corp",
+                "investor_class": DEALER,
+            }
+            for i in range(4)
+        ],
+        db_path=db_path,
+    )
+
+
+class TestDealerRowsDoNotReachConvictionSignals:
+    def test_smart_money_counts_only_conviction_holders(self, db_path):
+        """`min(2, 보유 수)` 항이 딜러로 채워지면 거의 모든 티커에서 상수가 된다."""
+        from nuri.trading.agents.smart_money import SmartMoneyAgent
+
+        _seed(db_path)
+        verdict = SmartMoneyAgent().analyze("ZZZZ", db_path=db_path)
+
+        assert verdict.data_points["n_superinvestors"] == 1, "딜러 4곳이 확신 보유로 세어졌다"
+
+    def test_coverage_counts_only_conviction_tickers(self, db_path):
+        """딜러는 유니버스 전체를 들고 있어, 세면 커버리지가 자동으로 임계를 넘는다."""
+        from nuri.core.coverage import _table_tickers
+
+        _upsert_superinvestors(
+            [
+                {
+                    "investor": "Dealer One",
+                    "filing_date": "2026-05-15",
+                    "ticker": t,
+                    "shares": 1.0,
+                    "market_value": 1.0,
+                    "portfolio_pct": 0.0,
+                    "issuer_name": t,
+                    "investor_class": DEALER,
+                }
+                for t in ("AAAA", "BBBB", "CCCC")
+            ],
+            db_path=db_path,
+        )
+        _seed(db_path, ticker="DDDD")
+
+        assert _table_tickers("superinvestors", db_path=db_path) == {"DDDD"}
+
+
+class TestUpsertKeepsTheClass:
+    def test_reupserting_a_dealer_row_does_not_reset_it(self, db_path):
+        """`INSERT OR REPLACE` 는 행을 지우고 새로 넣는다 — 컬럼을 빼면 기본값으로 되돌아간다.
+
+        그러면 재수집 때마다 은행 보유가 조용히 확신 신호로 승격된다.
+        """
+        _seed(db_path)
+        _seed(db_path)  # 같은 (investor, filing_date, ticker) → REPLACE 경로
+
+        rows = query(
+            "SELECT investor_class, COUNT(*) AS n FROM superinvestors GROUP BY investor_class",
+            db_path=db_path,
+        )
+        assert {r["investor_class"]: r["n"] for r in rows} == {CONVICTION: 1, DEALER: 4}
+
+    def test_a_record_without_a_class_defaults_to_conviction(self, db_path):
+        """기존 수집기는 이 키를 안 보낸다 — 기본값이 틀리면 15,600 행이 오분류된다."""
+        _upsert_superinvestors(
+            [
+                {
+                    "investor": "Legacy",
+                    "filing_date": "2026-05-15",
+                    "ticker": "EEEE",
+                    "shares": 1.0,
+                    "market_value": 1.0,
+                    "portfolio_pct": 1.0,
+                    "issuer_name": "E",
+                }
+            ],
+            db_path=db_path,
+        )
+
+        assert query("SELECT investor_class FROM superinvestors", db_path=db_path)[0]["investor_class"] == CONVICTION
+
+
+class TestBankRegistry:
+    def test_banks_are_not_in_the_conviction_registry(self):
+        """한 dict 에 섞이면 기존 수집기가 은행을 확신으로 저장한다."""
+        from nuri.collectors.superinvestors import BANK_13F, SUPERINVESTORS
+
+        assert not set(BANK_13F) & set(SUPERINVESTORS)
+
+    def test_bank_collector_is_a_dealer_and_is_universe_bounded(self):
+        """universe 를 안 걸면 한 분기 77,795 포지션이 그대로 들어온다."""
+        from nuri.collectors.superinvestors import Bank13FCollector
+
+        c = Bank13FCollector()
+        assert c.investor_class == DEALER
+        assert c.universe, "universe 필터가 비어 있다 — 전량 미러가 된다"
+
+    def test_ciks_are_ten_digit_strings(self):
+        """EDGAR 는 0 패딩 10자리를 쓴다 — 잘리면 조용히 다른 회사이거나 404 다."""
+        from nuri.collectors.superinvestors import BANK_13F
+
+        for name, cik in BANK_13F.items():
+            assert len(cik) == 10 and cik.isdigit(), f"{name}: {cik!r}"
+
+
+class TestDealerRowsAreStillReachable:
+    def test_a_dealer_row_can_be_read_back(self, db_path):
+        """격리가 은닉이 되면 안 된다 — 은행 보유는 전용 경로로 읽을 수 있어야 한다."""
+        _seed(db_path)
+
+        with get_db(db_path) as conn:
+            n = conn.execute("SELECT COUNT(*) FROM superinvestors WHERE investor_class = ?", (DEALER,)).fetchone()[0]
+        assert n == 4


### PR DESCRIPTION
Closes #1098. 월가 트랙 1/2.

## CIK — 추측이 아니라 EDGAR 확인 (2026-08-18)

| | CIK | 최근 13F-HR | 한 분기 포지션 |
|---|---|---|---|
| JPMorgan Chase | `0000019617` | 2026-08-12 | **34,064** |
| Bank of America | `0000070858` | 2026-08-14 | **18,318** |
| Goldman Sachs | `0000886982` | 2026-08-14 | **14,070** |
| Citigroup | `0000831001` | 2026-08-03 | **11,343** |

`company_tickers.json` 으로 CIK 를, `submissions` API 로 13F-HR 실적을, edgartools 로
포지션 수를 각각 실측했다.

## 왜 `SUPERINVESTORS` 에 그냥 넣으면 안 되나

한 분기 **77,795 포지션**이다. 이 테이블 **전체**가 8명 × 10분기 15,600 행이다.

용량보다 심각한 건 **신호 파괴**다. `smart_money.py` 는 `score += min(2, 보유 투자자 수)`
인데 은행 4곳은 마켓메이킹·수탁·인덱스로 사실상 미국 유니버스 전체를 들고 있다. 섞으면
그 항이 거의 모든 티커에서 **상수 2**가 된다 — 틀린 값이 아니라 **변별력 0인 값**이라
화면 어디도 이상해 보이지 않는다. `min_superinvestors: 3` 도, 커버리지 임계 0.80 도
같이 죽는다(딜러 행이 대신 밟아 확신 13F 수집이 끊겨도 초록).

## 그래서

- **migration 54** — `superinvestors.investor_class` (기본 `conviction`, 은행은 `dealer`).
  기본값 덕에 기존 15,600 행과 기존 수집기가 자동으로 옳은 쪽에 앉는다
- **소비자 7곳 전부 `conviction` 필터** — smart_money(2) · charts · ticker API · gate ·
  backtest · print_summary(2) · coverage
- **universe 제한** — 34,064 행 대부분은 우리가 판단하지 않는 종목·채권·옵션이다.
  전량 미러는 8분기에 622K 행을 쌓고 아무 질문에도 답하지 않는다.
  ⚠️ 필터는 **비중 계산 뒤**에 건다 — 먼저 걸면 분모가 우리 유니버스 합이 되어
  "JPM 포트폴리오의 12%" 같은 거짓이 나온다
- **`INSERT OR REPLACE` 에 컬럼 포함** — 빼면 재수집마다 `dealer` 가 기본값
  `conviction` 으로 조용히 승격된다
- **스케줄러 잡 분리** (`0 2 * * 0`) — 은행 쪽 EDGAR 실패가 확신 13F 수집을 같이 죽이면 안 된다

## 리뷰가 잡은 것

**Codex P1** — `investors = SUPERINVESTORS` 를 클래스 속성에 박으면 정의 시점 바인딩이라
모듈 상수 패치가 `collect()` 에 안 닿는다. 레지스트리를 좁히는 테스트 18곳이 조용히 8명
전체를 돌면서 **통과**한다. 호출 시점 해소로 고치고 카나리아로 잠갔다.
(Codex 가 같이 지목한 `tests/quant/test_validation_superinvestor.py` 는 해당 없음 —
함수 안 import 라 원래 호출 시점 해소다. 확인 후 회신.)

## 검증

- 뮤테이션 **9종 전부 FAIL 실측** — 필터 3종(smart_money · coverage · ticker API) ·
  upsert 컬럼 · upsert 기본값 · 은행 class · universe · CIK 자릿수 · 정의시점 바인딩
- 구조 스윕: `superinvestors` 를 읽는 모든 SQL 리터럴이 `investor_class` 를 걸거나
  사유와 함께 allowlist. 양방향이라 낡은 항목도 FAIL. 실제로 이 스윕이 제가 놓친
  `print_summary` 쿼리 4개를 잡았다
- 스윕의 한계도 테스트에 적어뒀다: 테이블명이 f-string 변수인 쿼리는 안 보인다
- 백엔드 7,214 passed

## 은행 13F 는 확신 포트폴리오가 아니다

읽는 쪽 라벨("분기 공시 + 45일 지연 · 마켓메이킹/수탁/인덱스 혼재")은 다음 PR —
13F 변동 + 애널리스트 등급 델타를 `thesis_evidence` 로 흘리는 리더에서 붙는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)