### PR TITLE
fix(recommend): compare a breakout against the prior high, not one that includes today

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,253 collected across 331 files | |
+| **Backend tests** | 7,259 collected across 332 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,253 backend tests across 331 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,259 backend tests across 332 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,253 tests, 331 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,259 tests, 332 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -230,8 +230,14 @@ def _get_price_signals(db_path=None) -> dict[str, dict[str, float]]:
         recent = closes[-30:] if len(closes) >= 30 else closes
         high_30d = max(recent)
         low_30d = min(recent)
-        # breakout % = (last - high_30d) / high_30d. Positive = above prior high.
-        breakout_pct = (last / high_30d - 1.0) * 100.0 if high_30d else 0.0
+        # 돌파는 **직전** 고점 대비다. 오늘 종가를 포함한 `high_30d` 와 비교하면
+        # `high_30d >= last` 가 항상 참이라 `breakout_pct` 가 **양수가 될 수 없다**.
+        # 그러면 `_score_ticker` 의 `bo >= 0 → 70 + bo*10` 분기가 오직 70 만 반환해
+        # 70~100 구간이 통째로 죽고, 0.20 가중치의 최대 기여가 20 이 아니라 14 가 된다.
+        # 프로덕션 실측(2026-08-18): 753종목 중 `breakout_pct > 0` **0건**, max 정확히
+        # 0.0000. 그 14 가 BUY 임계 70 을 도달 불가로 만든 세 원인 중 하나였다 (#1100).
+        prior_high = max(closes[-31:-1]) if len(closes) >= 2 else last
+        breakout_pct = (last / prior_high - 1.0) * 100.0 if prior_high else 0.0
         out[ticker] = {
             "close": last,
             "ret_5d": ret_5d,

--- a/tests/trading/recommend/test_breakout_arithmetic.py
+++ b/tests/trading/recommend/test_breakout_arithmetic.py
@@ -1,0 +1,111 @@
+"""돌파는 **직전** 고점 대비다 (#1100 결함 A).
+
+## 왜 이 파일이 있나
+
+`high_30d = max(closes[-30:])` 는 **오늘 종가를 포함**한다. 자기를 포함한 max 와 자기를
+비교하므로 `breakout_pct` 가 **양수가 될 수학적 가능성이 없다**. 프로덕션 실측(2026-08-18):
+753종목 중 양수 **0건**, max 정확히 `0.0000`.
+
+그 결과 `_score_ticker` 의
+
+    if bo >= 0: breakout_pct = min(100.0, 70.0 + bo * 10.0)
+
+이 **오직 70.0 만** 반환했다 — 70~100 구간이 통째로 dead range 이고, 0.20 가중치의 최대
+기여가 20 이 아니라 14 였다. 이게 BUY 임계 70 을 도달 불가로 만든 세 원인 중 하나다
+(천장 산술 23.4 + 25.0 + 7.5 + 14.0 = 69.9 < 70, 관측 max 69.3, 후보 0건).
+
+**틀린 값이 아니라 "항상 같은 값"이라 화면 어디도 이상해 보이지 않았다.** 그래서 회귀는
+분포가 아니라 **양수가 나올 수 있는가**로 잠근다.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nuri.core.db import init_db, upsert_prices
+from nuri.core.timezone import today_kst
+from nuri.trading.recommend.buy_candidate_emitter import _get_price_signals, _score_ticker
+
+WEIGHTS = {"factor_composite": 0.40, "momentum_5d": 0.25, "technical_rsi": 0.15, "breakout_30d": 0.20}
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, ticker: str, closes: list[float]):
+    """마지막 봉이 오늘이 되도록 앵커링 — 리터럴 날짜는 이 레포에서 두 번 터졌다."""
+    dates = pd.bdate_range(end=today_kst(), periods=len(closes)).strftime("%Y-%m-%d")
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": ticker,
+                    "date": d,
+                    "open": c,
+                    "high": c,
+                    "low": c,
+                    "close": c,
+                    "volume": 1000,
+                    "adj_close": c,
+                }
+                for d, c in zip(dates, closes)
+            ]
+        ),
+        db_path=db_path,
+    )
+
+
+class TestBreakoutCanBePositive:
+    def test_a_new_high_reads_as_a_positive_breakout(self, db_path):
+        """오늘이 직전 30봉 고점을 넘으면 양수여야 한다 — 고치기 전에는 산술적으로 불가능했다."""
+        _seed(db_path, "AAAA", [100.0] * 34 + [110.0])
+
+        got = _get_price_signals(db_path=db_path)["AAAA"]
+
+        assert got["breakout_pct"] == pytest.approx(10.0), "직전 고점 100 대비 110 = +10%"
+
+    def test_the_dead_score_range_is_now_reachable(self, db_path):
+        """70~100 구간이 실행된다 — 이 단언이 dead range 였는지를 직접 본다."""
+        _seed(db_path, "BBBB", [100.0] * 34 + [110.0])
+        price = _get_price_signals(db_path=db_path)["BBBB"]
+
+        _, sources = _score_ticker("BBBB", {"composite": 0.5}, price, None, WEIGHTS)
+
+        assert sources["breakout"] > 70.0, "돌파 점수가 여전히 70 상한에 붙어 있다"
+
+    def test_sitting_at_the_prior_high_is_exactly_flat(self, db_path):
+        """경계 — 직전 고점과 같으면 0. 양수로 새면 돌파가 아닌 것도 돌파가 된다."""
+        _seed(db_path, "CCCC", [100.0] * 35)
+
+        assert _get_price_signals(db_path=db_path)["CCCC"]["breakout_pct"] == pytest.approx(0.0)
+
+    def test_below_the_prior_high_stays_negative(self, db_path):
+        """카나리아 — 전부 양수로 만들어 버리는 반대 방향 회귀를 잡는다."""
+        _seed(db_path, "DDDD", [100.0] * 34 + [90.0])
+
+        assert _get_price_signals(db_path=db_path)["DDDD"]["breakout_pct"] == pytest.approx(-10.0)
+
+    def test_todays_close_does_not_set_its_own_bar(self, db_path):
+        """오늘이 유일한 최고가여도 직전 고점과 비교한다 — 자기참조 회귀의 직접 잠금.
+
+        오늘을 포함한 max 로 되돌리면 이 종목의 breakout 은 0 이 된다.
+        """
+        _seed(db_path, "EEEE", [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 999.0])
+
+        assert _get_price_signals(db_path=db_path)["EEEE"]["breakout_pct"] > 0
+
+
+class TestTheRangeStaysDescriptive:
+    def test_high_and_low_still_include_today(self, db_path):
+        """`high_30d`/`low_30d` 는 30일 **구간 표시**라 오늘을 포함한다 — 돌파 기준만 바뀐다."""
+        _seed(db_path, "FFFF", [100.0] * 34 + [110.0])
+
+        got = _get_price_signals(db_path=db_path)["FFFF"]
+
+        assert got["high_30d"] == pytest.approx(110.0)
+        assert got["low_30d"] == pytest.approx(100.0)


### PR DESCRIPTION
Closes #1100 (결함 A). B·C·D 는 #1101 / #1102 로 분리.

## 증상

시스템이 **매일 736종목을 채점하고 BUY 후보를 0건 발행**한다. `recommendations` 1,555행이
전부 `source IS NULL`(합의 경로)이고, `decisions` 는 매일 정확히 18건 — 보유 종목 수와 같다.
즉 시스템은 **이미 들고 있는 것에 대해서만** 말한다. 이게 "오늘 시장에서 뭘 해야 하나" 에
답하지 못하던 이유다.

## 원인 — 시장이 아니라 산술

```python
recent = closes[-30:]        # ← 오늘 종가를 포함
high_30d = max(recent)       # ← 따라서 high_30d >= last 가 항상 참
breakout_pct = (last / high_30d - 1.0) * 100.0   # ← 따라서 항상 <= 0
```

자기를 포함한 max 와 자기를 비교한다. 주석은 `Positive = above prior high` 라고 적혀
있으나 **prior 가 아니라 오늘을 포함**한다.

프로덕션 실측(2026-08-18): 753종목 중 `breakout_pct > 0` **0건**, max 정확히 `0.0000`.

그래서 `_score_ticker` 의

```python
if bo >= 0:
    breakout_pct = min(100.0, 70.0 + bo * 10.0)   # ← 오직 70.0 만 반환
```

이 분기의 **70~100 구간이 통째로 dead range** 였고, 0.20 가중치의 최대 기여가 20 이 아니라
**14** 였다.

## 왜 아무도 몰랐나

`breakout` 항이 **틀린 값이 아니라 항상 같은 값**이었다. 점수는 나오고, 로그는 깨끗하고,
모든 헬스가 초록이다. 이 레포가 반복해 밟은 모양(#953/#954 · #1073)과 같다.

## 천장 산술

| 구성요소 | 가중 | 실측 최대 | 최대 기여 |
|---|---|---|---|
| factor | .40 | 58.5 | 23.4 |
| momentum | .25 | 100.0 | 25.0 |
| rsi | .15 | 50.0 (상수) | 7.5 |
| breakout | .20 | **70.0 (상한 고정)** | **14.0** |
| | | | **69.9** |

임계 **70**. 관측 max **69.3**. "시장이 안 준다" 가 아니라 **도달 불가**였다.

## 이 PR 의 효과 — 프로덕션 데이터 실측 (배포 아님, 복제본)

| | 수정 전 | 수정 후 |
|---|---|---|
| n_scored | 736 | 736 |
| **n_qualified** | **0** | **18** |
| 점수 max | 69.3 | 75.3 |
| breakout 점수 > 70 인 종목 | 0 | 106 |
| blocked_reason | `top scorer 58/100 < threshold 70` | `None` |

## 범위 — 하지 않은 것

- **`threshold: 70` 을 건드리지 않았다.** 정책 knob 이고 `config/buy_signals.yaml` 소관이며
  변경은 STRATEGY PR + 백테스트 대상이다. 결함만 고쳤고 임계는 그대로다
- `high_30d` / `low_30d` 는 **오늘을 포함한 채로 둔다** — 30일 구간 표시이고 소비처가 없다
  (grep 확인: 이 dict 밖에서 읽는 곳 0). 돌파 기준만 움직인다
- 결함 B(RSI 99.1% 결측) · C(technical 40종목/0행 성공보고) · D(composite p50 0.482) 는
  각각 #1101 / #1102 로 분리

## ⚠️ §3.11 측정 표본에 미치는 영향

이건 매매 동작 변경이다. 지금까지 emitter 발행분이 **0건**이었으므로 사전등록 표본에는
합의 경로(`source IS NULL`)만 들어 있었다. 이 PR 이후 emitter 행이 들어오기 시작한다.

**사전등록 기준은 손대지 않는다** (§3.6 · §3.11 — 판정일 전 수정 금지). 대신 표본에
before/after 경계가 생겼다는 사실을 기록하고, 2027-06-30 판정 시 그 경계를 명시한다.
`recommendations.source`(#1078)가 두 경로를 이미 구분하므로 사후에 분리 가능하다.

여전히 **추천만** 한다 (§7.1). 후보가 나와도 실행은 사용자가 한다.

## 검증

- 뮤테이션: 오늘 포함 방식으로 되돌리면 **6개 중 3개 FAIL**
- 자기참조 회귀 직접 잠금 (`test_todays_close_does_not_set_its_own_bar`)
- 반대 방향 카나리아 — 전부 양수로 만드는 회귀도 잡는다
- 경계값(직전 고점과 동일 → 정확히 0)
- 백엔드 7,226 passed / `tests/trading/recommend/` 491 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)