### PR TITLE
fix(collectors): run technical over the scoring universe and watch its freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 53 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
+    SCHED["APScheduler · 55 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 26 jobs"]
@@ -106,7 +106,7 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 53 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 55 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,262 collected across 332 files | |
+| **Backend tests** | 7,270 collected across 333 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -280,7 +280,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 53 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 55 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are looking for a backtested strategy with a published Sharpe ratio, this
 
 ```mermaid
 flowchart TB
-    SCHED["APScheduler · 55 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
+    SCHED["APScheduler · 56 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
     CFG[/"config/*.yaml<br/>policies"/]:::source
 
     subgraph Collect["Collect — 26 jobs"]
@@ -106,7 +106,7 @@ flowchart TB
     classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 55 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 56 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,270 collected across 333 files | |
+| **Backend tests** | 7,274 collected across 333 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -280,7 +280,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 55 cron entries (APScheduler, in-process) | |
+| **Scheduler jobs** | 56 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,259 collected across 332 files | |
+| **Backend tests** | 7,262 collected across 332 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,259 backend tests across 332 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,262 backend tests across 332 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 53 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 55 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,262 backend tests across 332 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,270 backend tests across 333 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 55 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 56 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,270 backend tests across 333 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,274 backend tests across 333 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,259 tests, 332 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,262 tests, 332 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,270 tests, 333 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,274 tests, 333 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,262 tests, 332 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,270 tests, 333 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -280,7 +280,10 @@ _REMEDY: dict[str, str] = {
     "factors": "팩터 합성 잡 상태 확인 — BUY 점수의 최대 입력이다",
     "macro_vix": "VIX 수집 확인 — VIX 게이트가 이 값으로 신규 매수를 막는다",
     "macro_fear_greed": "Fear & Greed 수집 확인",
-    "signals": "technical 잡(07:00) 확인 — RSI/SMA 가 BUY 점수와 SIEGE 게이트에 들어간다",
+    # 잡 이름만 적고 시각은 적지 않는다 — cron 은 옮겨 다니고(4차 리뷰에서 실제로 옮겼다),
+    # 낡은 시각은 운영자를 엉뚱한 로그 창으로 보낸다 (Codex 5차 P3).
+    "signals": "technical 잡 확인 — RSI/SMA 가 BUY 점수와 SIEGE 게이트에 들어간다",
+    "signals_kr": "technical_close_kr 잡과 KR 가격 수집(stock_kr_universe_daily) 확인",
     "consensus": "합의 잡(07:05) 실행 여부 확인",
     "certification": "SIEGE 인증 실행 여부 확인",
 }

--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -280,6 +280,7 @@ _REMEDY: dict[str, str] = {
     "factors": "팩터 합성 잡 상태 확인 — BUY 점수의 최대 입력이다",
     "macro_vix": "VIX 수집 확인 — VIX 게이트가 이 값으로 신규 매수를 막는다",
     "macro_fear_greed": "Fear & Greed 수집 확인",
+    "signals": "technical 잡(07:00) 확인 — RSI/SMA 가 BUY 점수와 SIEGE 게이트에 들어간다",
     "consensus": "합의 잡(07:05) 실행 여부 확인",
     "certification": "SIEGE 인증 실행 여부 확인",
 }

--- a/nuri/collectors/technical.py
+++ b/nuri/collectors/technical.py
@@ -34,10 +34,17 @@ class TechnicalCollector(BaseCollector):
             self.logger.warning("계산할 종목 없음")
             return pd.DataFrame()
 
-        # MAX_FAILURE_RATE(10%) 가드 활성화 — prices 데이터 부족 누적 시 save 거부.
-        # technical.collect() 는 1 row/ticker 반환이라 len(df) == ticker count 매칭 가능.
-        # asymmetric data age 방지 (어제 signals 그대로 + 오늘 70% 결손 silent save 차단).
-        self._expected_count = len(tickers)
+        # MAX_FAILURE_RATE(10%) 가드의 분모는 **데이터가 충분한 종목 수**다 (#1101 Codex 5차).
+        # `len(tickers)` 로 두면 universe 배치 추가 직후·주간 backfill 전 콜드 스타트처럼
+        # 데이터 없는 종목이 10% 를 넘는 순간 CollectionFailureError 로 **전체 저장이
+        # 거부**된다 — 멀쩡히 계산된 보유 종목 signals 까지 전멸한다. 데이터 부족은 예상된
+        # 결손이지 수집 실패가 아니므로 분모에서 뺀다. 가드는 여전히 살아 있다: 계산
+        # 가능해야 할 종목이 계산에 실패하면(talib 회귀 등) 그 비율로 잡는다.
+        counts = query_df(
+            "SELECT ticker, COUNT(*) AS n FROM prices GROUP BY ticker",
+        )
+        eligible = {r["ticker"]: int(r["n"]) for _, r in counts.iterrows()}
+        self._expected_count = sum(1 for t in tickers if eligible.get(t, 0) >= 14)
 
         from tqdm import tqdm
 

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -33,6 +33,17 @@ FRESHNESS_POLICIES = {
         "fail_hours": 120,
         "label": "멀티팩터 스코어",
     },
+    "signals": {
+        # BUY 점수의 0.15 가중치(RSI)와 SIEGE 게이트 일부가 읽는 테이블인데 정책이 없어서
+        # 커버리지가 40종목(가격 753 대비)으로 넉 달을 갔고, 오늘 run 이 무엇을 남기든
+        # 어떤 화면에도 안 떴다 (#1101). `factors` 와 같은 이유로 `MAX(date)` 는 잡 생존과
+        # 입력 신선도를 동시에 본다 — technical 은 prices 를 재료로 하는 순수 계산이라
+        # prices 가 멈춰도, 잡이 멈춰도 날짜가 언다. 임계도 재료(prices)와 동일.
+        "query": "SELECT MAX(date) FROM signals",
+        "warn_hours": 48,
+        "fail_hours": 120,
+        "label": "기술 지표",
+    },
     "macro_fear_greed": {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
         "warn_hours": 24,

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -33,21 +33,44 @@ FRESHNESS_POLICIES = {
         "fail_hours": 120,
         "label": "멀티팩터 스코어",
     },
+    # `signals` 는 시장별 두 정책이다 (#1101). BUY 점수의 0.15 가중치(RSI)와 SIEGE 게이트
+    # 일부가 읽는 테이블인데 정책이 없어서 커버리지가 40종목(가격 753 대비)으로 넉 달을
+    # 갔고, 오늘 run 이 무엇을 남기든 어떤 화면에도 안 떴다.
+    #
+    # 맨 `MAX(date)` 로는 부족하다 (Codex 1차): 잡이 보유 18종목만 갱신해도 그 몇 행이
+    # 날짜를 끌어올려 초록이 된다. 그래서 **`config/universe.yaml` 해당 시장 멤버의 60%
+    # 이상이 계산된 날짜 중 최신**만 센다. 멤버 목록·floor 전부 판정 시점에 config 에서
+    # 도출한다 (`check_freshness` 의 `floor_from` 처리):
+    # - 하나로 합치지 않는다 (2차): KR/US 는 서로 다른 날짜로 갈라져 합산 floor 는 US
+    #   단독으로 넘는다 — KR 전면 정지가 US 뒤에 숨는다
+    # - 상수 floor 금지 (6차): universe 를 줄인 설치가 영구 FAIL 이 된다
+    # - **멤버 IN 제한** (7차): 전 행을 세면 universe 밖 보유 종목이 floor 를 떠받쳐
+    #   "구성된 채점 universe 가 낡았는데 PASS" 가 가능하다. 멤버로 제한하면 시장 구분도
+    #   universe 자체가 하므로 별도 LIKE 필터가 필요 없다
+    # - universe 미구성 시장은 검사 생략 — KR 슬리브 없는 설치가 영구 빨강이면 아무도 안 본다
     "signals": {
-        # BUY 점수의 0.15 가중치(RSI)와 SIEGE 게이트 일부가 읽는 테이블인데 정책이 없어서
-        # 커버리지가 40종목(가격 753 대비)으로 넉 달을 갔고, 오늘 run 이 무엇을 남기든
-        # 어떤 화면에도 안 떴다 (#1101).
-        #
-        # 맨 `MAX(date)` 로는 부족하다 (#1101 Codex P2): 잡이 보유 18종목만 갱신해도
-        # 그 몇 행이 날짜를 끌어올려 초록이 된다 — 이 정책이 잡으려는 부분 커버리지
-        # 퇴행을 정확히 못 보는 형태다. 그래서 **행 수 400 이상인 날짜 중 최신**만 센다.
-        # 400 은 US 단독 날짜(~550)와 보유 단독(~18) 사이다 — KR/US 는 서로 다른 날짜로
-        # 갈라지므로 한 날짜가 750 전부를 갖지 않는다. universe 를 400 미만으로 줄이면
-        # 이 정책은 영구 FAIL 로 시끄럽게 죽는다(조용히 초록보다 낫다) — 그때 임계를 같이.
-        "query": "SELECT MAX(date) FROM (SELECT date FROM signals GROUP BY date HAVING COUNT(*) >= 400)",
+        "query": (
+            "SELECT MAX(date) FROM (SELECT date FROM signals "
+            "WHERE ticker IN ({placeholders}) "
+            "GROUP BY date HAVING COUNT(*) >= {floor})"
+        ),
+        "floor_from": "us",
         "warn_hours": 48,
         "fail_hours": 120,
-        "label": "기술 지표",
+        "label": "기술 지표 (US)",
+    },
+    "signals_kr": {
+        # 임계는 prices 와 같은 48/120 — 설날·추석 연휴에는 정직하게 WARN/FAIL 이 뜬다
+        # (시장이 닫혀 지표가 실제로 낡은 상태다).
+        "query": (
+            "SELECT MAX(date) FROM (SELECT date FROM signals "
+            "WHERE ticker IN ({placeholders}) "
+            "GROUP BY date HAVING COUNT(*) >= {floor})"
+        ),
+        "floor_from": "kr",
+        "warn_hours": 48,
+        "fail_hours": 120,
+        "label": "기술 지표 (KR)",
     },
     "macro_fear_greed": {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
@@ -122,8 +145,32 @@ def check_freshness(key: str, db_path: Optional[Path] = None) -> dict:
     policy = FRESHNESS_POLICIES[key]
     now = kst_now()
 
+    sql = policy["query"]
+    params: tuple = ()
+    if "floor_from" in policy:
+        import math
+
+        from nuri.core.coverage import _load_universe
+
+        # 커버리지 검사는 **구성된 universe 멤버**만 센다 — 전 행을 세면 universe 밖
+        # 보유 종목이 floor 를 떠받친다. floor 는 멤버의 60%, **올림** — 내림이면 작은
+        # universe 에서 33~58% 커버리지가 초록으로 통한다 (Codex 7차).
+        members = sorted(_load_universe().get(policy["floor_from"]) or ())
+        if not members:
+            return {
+                "key": key,
+                "label": policy["label"],
+                "status": "PASS",
+                "last_updated": None,
+                "age_hours": None,
+                "message": "해당 시장 universe 미구성 — 검사 생략",
+            }
+        floor = max(1, math.ceil(len(members) * 0.6))
+        sql = sql.format(placeholders=", ".join("?" * len(members)), floor=floor)
+        params = tuple(members)
+
     try:
-        rows = query(policy["query"], db_path=db_path)
+        rows = query(sql, params, db_path=db_path)
     except Exception:
         return {
             "key": key,

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -36,10 +36,15 @@ FRESHNESS_POLICIES = {
     "signals": {
         # BUY 점수의 0.15 가중치(RSI)와 SIEGE 게이트 일부가 읽는 테이블인데 정책이 없어서
         # 커버리지가 40종목(가격 753 대비)으로 넉 달을 갔고, 오늘 run 이 무엇을 남기든
-        # 어떤 화면에도 안 떴다 (#1101). `factors` 와 같은 이유로 `MAX(date)` 는 잡 생존과
-        # 입력 신선도를 동시에 본다 — technical 은 prices 를 재료로 하는 순수 계산이라
-        # prices 가 멈춰도, 잡이 멈춰도 날짜가 언다. 임계도 재료(prices)와 동일.
-        "query": "SELECT MAX(date) FROM signals",
+        # 어떤 화면에도 안 떴다 (#1101).
+        #
+        # 맨 `MAX(date)` 로는 부족하다 (#1101 Codex P2): 잡이 보유 18종목만 갱신해도
+        # 그 몇 행이 날짜를 끌어올려 초록이 된다 — 이 정책이 잡으려는 부분 커버리지
+        # 퇴행을 정확히 못 보는 형태다. 그래서 **행 수 400 이상인 날짜 중 최신**만 센다.
+        # 400 은 US 단독 날짜(~550)와 보유 단독(~18) 사이다 — KR/US 는 서로 다른 날짜로
+        # 갈라지므로 한 날짜가 750 전부를 갖지 않는다. universe 를 400 미만으로 줄이면
+        # 이 정책은 영구 FAIL 로 시끄럽게 죽는다(조용히 초록보다 낫다) — 그때 임계를 같이.
+        "query": "SELECT MAX(date) FROM (SELECT date FROM signals GROUP BY date HAVING COUNT(*) >= 400)",
         "warn_hours": 48,
         "fail_hours": 120,
         "label": "기술 지표",

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -151,9 +151,18 @@ def _dispatch_collector(name: str, **kwargs):
 
         MacroCollector().run()
     elif name == "technical":
+        # `source="all"` (portfolio ∪ universe) — 기본값(portfolio)이면 signals 가 보유
+        # 18종목에 갇혀 BUY 점수의 0.15 가중치(RSI)가 736 채점 대상 중 99.1% 에서 중립
+        # 상수 50 이 된다 (#1101). universe 모드는 #272 부터 있었는데 여기서 안 불러
+        # 도달 불가였다. 이 수집기는 prices 테이블만 읽는 순수 계산이라(네트워크 0)
+        # 확장 비용은 CPU 뿐이고, prices <14일 종목은 0.8% (MAX_FAILURE_RATE 10% 이내,
+        # 2026-08-18 실측 751/757).
+        #
+        # `return` 이 없으면 `_record_collector_run` 에 None 이 넘어가 collector_runs 에
+        # `rows_collected=0` 으로 남는다 — 오늘 17건을 저장하고도 0 으로 기록됐다.
         from nuri.collectors.technical import TechnicalCollector
 
-        TechnicalCollector().run()
+        return TechnicalCollector().run(source="all")
     elif name == "fear_greed":
         from nuri.collectors.fear_greed import FearGreedCollector
 

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -931,6 +931,27 @@ SCHEDULES = [
         "kwargs": {"period": "5d", "source": "freshness"},
         "cron": "10,40 6 * * 2-6",
     },
+    # 일일 universe 가격 refresh (#1101 Codex P1). 주간 backfill 만으로는 universe-only
+    # 727종목의 prices 가 주중 1~6일 stale 로 남는다 (2026-08-18 실측: 727/732 가
+    # 일요일 backfill 이 남긴 금요일 날짜에 정지). 그 위에서 계산한 RSI/SMA 는 날짜가
+    # 어긋나 `_get_rsi_snapshot` 스냅샷에도 못 들어간다 — technical 을 universe 로
+    # 넓혀도(아래 07:00) 이 잡이 없으면 emitter 는 여전히 보유분만 읽는다.
+    # US: 06:20 화~토 (미장 마감 후, technical 07:00 전). 5d/10-thread ≈ 1분.
+    # KR: 15:40 월~금 (KR 마감 15:30 직후). pykrx sequential ≈ 2~4분.
+    {
+        "name": "stock_us_universe_daily",
+        "func": _run_collector,
+        "args": ("stock",),
+        "kwargs": {"period": "5d", "source": "all"},
+        "cron": "20 6 * * 2-6",
+    },
+    {
+        "name": "stock_kr_universe_daily",
+        "func": _run_collector,
+        "args": ("stock_kr",),
+        "kwargs": {"days": 5, "source": "all"},
+        "cron": "40 15 * * 1-5",
+    },
     # 일일 자가 재시작 (#780) — KST 08:40, 모닝 배치(07-08) 종료 후·KR 개장(09:00) 전 idle
     # window. yfinance fd 누수를 fresh 프로세스 교체로 회수 (plist 4096 천장도 결국 고갈).
     {"name": "self_restart", "func": _self_restart, "args": (), "cron": "40 8 * * *"},

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -141,11 +141,13 @@ def _dispatch_collector(name: str, **kwargs):
     if name == "stock":
         from nuri.collectors.stock import StockCollector
 
-        StockCollector().run(**kwargs)
+        # `return` 이 없으면 collector_runs 에 rows_collected=0 으로 남는다 — #1101 이
+        # 추가한 일일 universe refresh 잡이 매일 no-op 처럼 보인다. 나머지 분기는 #1105.
+        return StockCollector().run(**kwargs)
     elif name == "stock_kr":
         from nuri.collectors.stock_kr import StockKRCollector
 
-        StockKRCollector().run(**kwargs)
+        return StockKRCollector().run(**kwargs)
     elif name == "macro":
         from nuri.collectors.macro import MacroCollector
 
@@ -936,22 +938,34 @@ SCHEDULES = [
     # 일요일 backfill 이 남긴 금요일 날짜에 정지). 그 위에서 계산한 RSI/SMA 는 날짜가
     # 어긋나 `_get_rsi_snapshot` 스냅샷에도 못 들어간다 — technical 을 universe 로
     # 넓혀도(아래 07:00) 이 잡이 없으면 emitter 는 여전히 보유분만 읽는다.
-    # US: 06:20 화~토 (미장 마감 후, technical 07:00 전). 5d/10-thread ≈ 1분.
-    # KR: 15:40 월~금 (KR 마감 15:30 직후). pykrx sequential ≈ 2~4분.
+    #
+    # ⚠️ 분(minute)은 기존 폴링과의 충돌을 피해 고른 값이다 (Codex 4차):
+    # - US 06:17 — `stock_us_dawn`(*/5, 0-6시)이 5의 배수 분마다 도는데 06:20 으로 두면
+    #   같은 분에 StockCollector 두 개가 동시 기동한다. 5의 배수가 아닌 분 + 06:15 폴
+    #   (보유 ~8종목, 수 초) 종료 후. yfinance 는 병렬 안전이라 잔여 겹침은 무해하다.
+    # - KR 16:00 — `stock_kr`(*/5, 9-15시)의 시간 범위 **밖**이라 겹침이 0 이다. 15시대에
+    #   두면 pykrx sequential 두 개가 동시에 돌아 KRX 순차 불변식(collectors/CLAUDE.md)을
+    #   그대로 위반한다. 장 마감(15:30) 후라 종가도 확정돼 있다.
     {
         "name": "stock_us_universe_daily",
         "func": _run_collector,
         "args": ("stock",),
         "kwargs": {"period": "5d", "source": "all"},
-        "cron": "20 6 * * 2-6",
+        "cron": "17 6 * * 2-6",
     },
     {
         "name": "stock_kr_universe_daily",
         "func": _run_collector,
         "args": ("stock_kr",),
         "kwargs": {"days": 5, "source": "all"},
-        "cron": "40 15 * * 1-5",
+        "cron": "0 16 * * 1-5",
     },
+    # KR 마감 후 technical 재계산 (#1101 Codex P2). 위 16:00 가격 refresh 는 prices 만
+    # 갱신한다 — signals 를 만드는 technical 이 07:00 하루 한 번이면 KR 종가 반영 지표는
+    # 다음날 아침까지 안 나온다(가격은 갔는데 소비 지점에 안 닿는, 이 PR 이 두 번 밟을 뻔한
+    # 모양). 16:25 는 pykrx sequential(~200종목, 3~7분)의 여유분. 순수 CPU 계산이라
+    # 하루 두 번이 싸고, upsert 라 US 행은 같은 값으로 덮일 뿐이다.
+    {"name": "technical_close_kr", "func": _run_collector, "args": ("technical",), "cron": "25 16 * * 1-5"},
     # 일일 자가 재시작 (#780) — KST 08:40, 모닝 배치(07-08) 종료 후·KR 개장(09:00) 전 idle
     # window. yfinance fd 누수를 fresh 프로세스 교체로 회수 (plist 4096 천장도 결국 고갈).
     {"name": "self_restart", "func": _self_restart, "args": (), "cron": "40 8 * * *"},

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -249,10 +249,19 @@ def _get_price_signals(db_path=None) -> dict[str, dict[str, float]]:
 
 
 def _get_rsi_snapshot(db_path=None) -> dict[str, float]:
-    """Latest RSI(14) per ticker."""
+    """Latest RSI(14) per ticker — 티커별 최신, 7일 컷오프.
+
+    전역 `MAX(date)` 하루치만 읽으면 **시장이 섞이는 순간 한쪽이 통째로 빠진다**:
+    KR 은 KST 당일, US 는 전일 날짜로 signals 가 갈라지므로 최신 날짜 하나를 고르면
+    다른 시장 전부가 스냅샷에서 사라진다 (#1101 — universe 확장 직후엔 backfill 날짜
+    간극 때문에 751행을 쓰고도 보유분만 읽히는 형태로 재현됐다). 그래서 티커별 최신
+    행을 잡되, 7일보다 낡은 값은 버린다 — 낡은 RSI 를 쓰는 것과 없는 값을 중립 50 으로
+    치는 것 사이의 절충이고, 컷오프가 없으면 상장폐지 종목의 마지막 RSI 가 영원히 남는다.
+    """
     df = query_df(
-        """SELECT ticker, rsi_14 FROM signals
-           WHERE date = (SELECT MAX(date) FROM signals)""",
+        """SELECT ticker, rsi_14, MAX(date) AS date FROM signals
+           WHERE date >= date('now', '-7 days') AND rsi_14 IS NOT NULL
+           GROUP BY ticker""",
         db_path=db_path,
     )
     if df.empty:

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -258,10 +258,19 @@ def _get_rsi_snapshot(db_path=None) -> dict[str, float]:
     행을 잡되, 7일보다 낡은 값은 버린다 — 낡은 RSI 를 쓰는 것과 없는 값을 중립 50 으로
     치는 것 사이의 절충이고, 컷오프가 없으면 상장폐지 종목의 마지막 RSI 가 영원히 남는다.
     """
+    from datetime import timedelta
+
+    from nuri.core.timezone import kst_now
+
+    # 컷오프는 KST 로 계산해 파라미터로 넘긴다 — SQLite 의 `date('now')` 는 UTC 라
+    # 09:00 KST 이전(아침 배치 시간대 전부)에는 어제 날짜가 되어 컷오프가 하루
+    # 느슨해진다. 레포 불변식은 KST 단일 시간대다 (Codex 리뷰 3차).
+    cutoff = (kst_now() - timedelta(days=7)).strftime("%Y-%m-%d")
     df = query_df(
         """SELECT ticker, rsi_14, MAX(date) AS date FROM signals
-           WHERE date >= date('now', '-7 days') AND rsi_14 IS NOT NULL
+           WHERE date >= ? AND rsi_14 IS NOT NULL
            GROUP BY ticker""",
+        (cutoff,),
         db_path=db_path,
     )
     if df.empty:

--- a/tests/collectors/test_technical.py
+++ b/tests/collectors/test_technical.py
@@ -270,6 +270,34 @@ class TestSignalEvaluationHeartbeat:
         assert "signal_evaluation_run" in EVENT_TYPES
 
 
+def _seed_eligible(tickers, rows=20):
+    """티커별 rows 개의 price 행 시드 — expected_count 적격(≥14) 판정용."""
+    import pandas as pd
+
+    from nuri.core.db import upsert_prices
+    from nuri.core.timezone import today_kst
+
+    dates = pd.bdate_range(end=today_kst(), periods=rows).strftime("%Y-%m-%d")
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": t,
+                    "date": d,
+                    "open": 10.0,
+                    "high": 10.0,
+                    "low": 10.0,
+                    "close": 10.0,
+                    "volume": 100,
+                    "adj_close": 10.0,
+                }
+                for t in tickers
+                for d in dates
+            ]
+        )
+    )
+
+
 class TestTechnicalExpectedCountGuard:
     """MAX_FAILURE_RATE 가드 활성화 lock-test (PR #590 후속).
 
@@ -281,14 +309,20 @@ class TestTechnicalExpectedCountGuard:
     """
 
     def test_collect_sets_expected_count(self, monkeypatch):
-        """collect() 진입 시 self._expected_count 가 len(tickers) 로 설정됨."""
+        """collect() 의 기대치는 **데이터가 충분한 종목 수**다 (#1101 Codex 5차).
+
+        `len(tickers)` 로 두면 universe 배치 추가 직후·콜드 스타트처럼 데이터 없는
+        종목이 10% 를 넘는 순간 전체 저장이 거부돼 보유 종목 signals 까지 전멸한다.
+        데이터 부족은 예상된 결손이지 수집 실패가 아니다.
+        """
         from nuri.collectors.technical import TechnicalCollector
 
         c = TechnicalCollector()
         # initial state — 0 (불활성)
         assert c._expected_count == 0
 
-        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["AAA", "BBB", "CCC"])
+        _seed_eligible(["AAA", "BBB", "CCC"])  # 적격 3
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: ["AAA", "BBB", "CCC", "NEW1", "NEW2"])
         # _compute_for_ticker 결과는 가드 trigger 와 무관 (count 만 검증)
         monkeypatch.setattr(
             c,
@@ -297,7 +331,35 @@ class TestTechnicalExpectedCountGuard:
         )
 
         c.collect()
-        assert c._expected_count == 3, "collect() 가 ticker 수로 _expected_count 설정 안 함"
+        assert c._expected_count == 3, "기대치가 적격(가격 ≥14일) 종목 수가 아니다"
+
+    def test_cold_start_saves_the_computable_slice_instead_of_refusing(self, monkeypatch):
+        """데이터 없는 종목이 10% 를 넘어도 계산된 종목은 저장된다 (#1101 Codex 5차).
+
+        기대치를 `len(tickers)` 로 되돌리면 이 시나리오(20종목 중 적격 5)가
+        failure_rate 75% 로 읽혀 CollectionFailureError — 멀쩡한 5종목 signals 까지
+        전멸한다. universe 확장 직후가 정확히 이 모양이다.
+        """
+        from nuri.collectors.technical import TechnicalCollector
+
+        c = TechnicalCollector()
+        eligible = [f"E{i}" for i in range(5)]
+        cold = [f"N{i}" for i in range(15)]
+        _seed_eligible(eligible)
+        monkeypatch.setattr(c, "_get_tickers", lambda **kw: eligible + cold)
+
+        def fake_compute(ticker):
+            if ticker in eligible:
+                return pd.DataFrame({"ticker": [ticker], "date": ["2024-01-01"], "rsi_14": [50.0]})
+            return None  # 콜드 스타트 — 가격 데이터 없음
+
+        monkeypatch.setattr(c, "_compute_for_ticker", fake_compute)
+        saved = []
+        monkeypatch.setattr(c, "save", lambda data: saved.append(len(data)) or len(data))
+
+        c.run()
+
+        assert saved == [5], "적격 종목의 signals 가 저장되지 않았다 — 가드가 결손을 실패로 셌다"
 
     def test_run_blocks_save_when_failure_rate_exceeds_threshold(self, monkeypatch):
         """run() 이 80% 실패 시 CollectionFailureError 발생 + save() 미호출."""
@@ -305,8 +367,10 @@ class TestTechnicalExpectedCountGuard:
         from nuri.collectors.technical import TechnicalCollector
 
         c = TechnicalCollector()
-        # 10 ticker 중 2개만 성공 → failure_rate 80% > 10% threshold
+        # 10 ticker **전부 적격**인데 2개만 성공 → failure_rate 80% > 10% threshold.
+        # 적격 시드가 없으면 기대치가 0 이 되어 가드가 아예 안 잰다 (#1101 이후 의미론).
         tickers = [f"T{i}" for i in range(10)]
+        _seed_eligible(tickers)
         monkeypatch.setattr(c, "_get_tickers", lambda **kw: tickers)
 
         def fake_compute(ticker):
@@ -330,8 +394,9 @@ class TestTechnicalExpectedCountGuard:
         from nuri.collectors.technical import TechnicalCollector
 
         c = TechnicalCollector()
-        # 20 ticker 중 19개 성공 → failure_rate 5%
+        # 20 ticker 전부 적격, 19개 성공 → failure_rate 5%
         tickers = [f"T{i}" for i in range(20)]
+        _seed_eligible(tickers)
         monkeypatch.setattr(c, "_get_tickers", lambda **kw: tickers)
 
         def fake_compute(ticker):

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -205,6 +205,15 @@ class TestCheckFreshness:
         assert result["status"] == "FAIL"
         assert result["label"] == "멀티팩터 스코어"
 
+    def _seed_signals(self, db_path, date: str, n: int):
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO signals (ticker, date, rsi_14) VALUES (?, ?, 55.0)",
+                [(f"T{i:04d}", date) for i in range(n)],
+            )
+
     def test_stale_signals_surface_instead_of_going_unnoticed(self, db_path):
         """낡은 기술 지표가 FAIL 로 뜬다 (#1101).
 
@@ -214,20 +223,42 @@ class TestCheckFreshness:
 
         Mutation lock: `FRESHNESS_POLICIES` 에서 `signals` 를 빼면 KeyError 로 FAIL.
         """
-        from nuri.core.db import get_db
         from nuri.core.freshness import check_freshness
         from nuri.core.timezone import kst_now
 
         old = (kst_now() - timedelta(days=40)).strftime("%Y-%m-%d")
-        with get_db(db_path) as conn:
-            conn.execute(
-                "INSERT INTO signals (ticker, date, rsi_14) VALUES (?, ?, 55.0)",
-                ("AAA", old),
-            )
+        self._seed_signals(db_path, old, 450)
 
         result = check_freshness("signals", db_path=db_path)
         assert result["status"] == "FAIL"
         assert result["label"] == "기술 지표"
+
+    def test_partial_coverage_cannot_keep_signals_green(self, db_path):
+        """보유 18종목만 갱신된 날은 신선한 것으로 안 친다 (#1101 Codex P2).
+
+        맨 `MAX(date)` 였다면 이 18행이 날짜를 끌어올려 초록이 됐다 — 이 정책이 잡으려는
+        부분 커버리지 퇴행(40종목으로 넉 달)을 정확히 못 보는 형태다. 커버리지 400 미만
+        날짜는 없는 것으로 취급한다.
+
+        Mutation lock: 쿼리에서 HAVING 절을 빼면 이 테스트가 FAIL 한다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        self._seed_signals(db_path, today_kst(), 18)
+
+        result = check_freshness("signals", db_path=db_path)
+        assert result["status"] == "FAIL", "부분 커버리지가 신선함으로 통했다"
+
+    def test_full_coverage_today_passes(self, db_path):
+        """정상 갱신은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다."""
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        self._seed_signals(db_path, today_kst(), 550)
+
+        result = check_freshness("signals", db_path=db_path)
+        assert result["status"] == "PASS"
 
     def test_recent_factors_pass(self, db_path):
         """정상 갱신은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다.

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -56,6 +56,7 @@ class TestFreshnessPolicies:
             "prices",
             "factors",
             "signals",
+            "signals_kr",
             "macro_vix",
             "macro_fear_greed",
             "consensus",
@@ -205,13 +206,23 @@ class TestCheckFreshness:
         assert result["status"] == "FAIL"
         assert result["label"] == "멀티팩터 스코어"
 
-    def _seed_signals(self, db_path, date: str, n: int):
+    #: 멤버 기반 픽스처 universe — 검사가 **구성된 멤버만** 세므로 시드도 멤버 이름으로.
+    _US = [f"U{i:04d}" for i in range(500)]
+    _KR = [f"K{i:04d}.KS" for i in range(150)] + [f"Q{i:04d}.KQ" for i in range(50)]
+
+    @pytest.fixture(autouse=True)
+    def _fixture_universe(self, monkeypatch):
+        import nuri.core.coverage as cov
+
+        monkeypatch.setattr(cov, "_load_universe", lambda path=None: {"us": set(self._US), "kr": set(self._KR)})
+
+    def _seed_signals(self, db_path, date: str, tickers):
         from nuri.core.db import get_db
 
         with get_db(db_path) as conn:
             conn.executemany(
                 "INSERT INTO signals (ticker, date, rsi_14) VALUES (?, ?, 55.0)",
-                [(f"T{i:04d}", date) for i in range(n)],
+                [(t, date) for t in tickers],
             )
 
     def test_stale_signals_surface_instead_of_going_unnoticed(self, db_path):
@@ -227,35 +238,114 @@ class TestCheckFreshness:
         from nuri.core.timezone import kst_now
 
         old = (kst_now() - timedelta(days=40)).strftime("%Y-%m-%d")
-        self._seed_signals(db_path, old, 450)
+        self._seed_signals(db_path, old, self._US)
 
         result = check_freshness("signals", db_path=db_path)
         assert result["status"] == "FAIL"
-        assert result["label"] == "기술 지표"
+        assert result["label"] == "기술 지표 (US)"
 
     def test_partial_coverage_cannot_keep_signals_green(self, db_path):
-        """보유 18종목만 갱신된 날은 신선한 것으로 안 친다 (#1101 Codex P2).
+        """보유 18종목만 갱신된 날은 신선한 것으로 안 친다 (#1101 Codex 1차).
 
         맨 `MAX(date)` 였다면 이 18행이 날짜를 끌어올려 초록이 됐다 — 이 정책이 잡으려는
-        부분 커버리지 퇴행(40종목으로 넉 달)을 정확히 못 보는 형태다. 커버리지 400 미만
-        날짜는 없는 것으로 취급한다.
-
-        Mutation lock: 쿼리에서 HAVING 절을 빼면 이 테스트가 FAIL 한다.
+        부분 커버리지 퇴행(40종목으로 넉 달)을 정확히 못 보는 형태다.
         """
         from nuri.core.freshness import check_freshness
         from nuri.core.timezone import today_kst
 
-        self._seed_signals(db_path, today_kst(), 18)
+        self._seed_signals(db_path, today_kst(), self._US[:18])
 
         result = check_freshness("signals", db_path=db_path)
         assert result["status"] == "FAIL", "부분 커버리지가 신선함으로 통했다"
+
+    def test_a_dead_kr_slice_cannot_hide_behind_fresh_us_rows(self, db_path):
+        """US 가 신선해도 KR 이 죽었으면 `signals_kr` 은 FAIL (#1101 Codex 2차).
+
+        정책이 하나였다면 US 슬라이스 단독으로 floor 를 넘겨 KR 계산이 전면 정지해도
+        초록이었다 — 한 시장의 outage 가 다른 시장 뒤에 숨는 형태다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now, today_kst
+
+        self._seed_signals(db_path, today_kst(), self._US)  # US 신선
+        old = (kst_now() - timedelta(days=40)).strftime("%Y-%m-%d")
+        self._seed_signals(db_path, old, self._KR)  # KR 40일 정지
+
+        assert check_freshness("signals", db_path=db_path)["status"] == "PASS"
+        assert check_freshness("signals_kr", db_path=db_path)["status"] == "FAIL"
+
+    def test_off_universe_holdings_cannot_prop_up_the_floor(self, db_path):
+        """universe 밖 보유 종목은 커버리지에 안 센다 (#1101 Codex 7차).
+
+        전 행을 세는 방식이면 비상장·개인 보유 이름이 floor 를 떠받쳐 "구성된 채점
+        universe 가 낡았는데 PASS" 가 된다. 멤버 IN 제한이 그 경로를 막는다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        outsiders = [f"X{i:04d}" for i in range(400)]  # universe 밖 400행
+        self._seed_signals(db_path, today_kst(), outsiders)
+
+        assert check_freshness("signals", db_path=db_path)["status"] == "FAIL", "universe 밖 행이 floor 를 떠받쳤다"
+
+    def test_kosdaq_members_count_as_kr(self, db_path):
+        """`.KQ` 멤버도 KR 커버리지에 센다 — `.KS` 만 세면 KOSDAQ 몫이 영구 결손이 된다."""
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        self._seed_signals(db_path, today_kst(), self._KR)  # .KS 150 + .KQ 50 전부
+
+        assert check_freshness("signals_kr", db_path=db_path)["status"] == "PASS"
+
+    def test_the_floor_tracks_the_configured_universe(self, monkeypatch, db_path):
+        """floor 는 상수가 아니라 config 도출이다 (Codex 6차).
+
+        400/150 을 박으면 universe 를 줄인 설치(us_core 만 쓰는 환경, KR 슬리브 없는 레포)
+        에서 잡이 멀쩡해도 영구 FAIL 이다. universe 를 30종목으로 줄이면 그 30종목
+        커버리지가 통과해야 한다.
+        """
+        import nuri.core.coverage as cov
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        small = [f"S{i:03d}" for i in range(30)]
+        monkeypatch.setattr(cov, "_load_universe", lambda path=None: {"us": set(small), "kr": set()})
+        self._seed_signals(db_path, today_kst(), small)
+
+        assert check_freshness("signals", db_path=db_path)["status"] == "PASS"
+
+    def test_the_floor_rounds_up_not_down(self, monkeypatch, db_path):
+        """floor 는 올림이다 (Codex 7차) — 내림이면 3종목 universe 에서 1행(33%)이 통과한다."""
+        import nuri.core.coverage as cov
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        tiny = ["A1", "A2", "A3"]
+        monkeypatch.setattr(cov, "_load_universe", lambda path=None: {"us": set(tiny), "kr": set()})
+        self._seed_signals(db_path, today_kst(), tiny[:1])  # 1/3 = 33% < 60%
+
+        assert check_freshness("signals", db_path=db_path)["status"] == "FAIL", (
+            "33% 커버리지가 통과했다 — floor 가 내림이다"
+        )
+
+    def test_an_unconfigured_market_is_skipped_not_red_forever(self, monkeypatch, db_path):
+        """universe 미구성 시장은 검사 생략 (Codex 6차) — KR 슬리브 없는 설치가 영구
+        빨강이면 아무도 안 본다. '신선' 이 아니라 '해당 없음' 이라 메시지로 구분한다."""
+        import nuri.core.coverage as cov
+        from nuri.core.freshness import check_freshness
+
+        monkeypatch.setattr(cov, "_load_universe", lambda path=None: {"us": {"A1"}, "kr": set()})
+
+        result = check_freshness("signals_kr", db_path=db_path)
+        assert result["status"] == "PASS"
+        assert "미구성" in result["message"]
 
     def test_full_coverage_today_passes(self, db_path):
         """정상 갱신은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다."""
         from nuri.core.freshness import check_freshness
         from nuri.core.timezone import today_kst
 
-        self._seed_signals(db_path, today_kst(), 550)
+        self._seed_signals(db_path, today_kst(), self._US)
 
         result = check_freshness("signals", db_path=db_path)
         assert result["status"] == "PASS"

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -49,9 +49,13 @@ class TestFreshnessPolicies:
 
         # `factors` 는 #1071 에서 추가 — 정책이 없어서 2026-04-14 → 08-18 넉 달간 낡은 채로도
         # 어떤 화면에도 안 떴다. BUY 점수의 가중치 0.40 짜리 최대 입력이다.
+        # `signals` 는 #1101 에서 추가 — 커버리지가 40종목(가격 753 대비)으로 넉 달을
+        # 가고 오늘 run 이 무엇을 남기든 어떤 화면에도 안 떴다. RSI 가 BUY 점수의
+        # 0.15 가중치인데 결측이라 전 종목 중립 상수 50 이었다.
         expected = {
             "prices",
             "factors",
+            "signals",
             "macro_vix",
             "macro_fear_greed",
             "consensus",
@@ -200,6 +204,30 @@ class TestCheckFreshness:
         result = check_freshness("factors", db_path=db_path)
         assert result["status"] == "FAIL"
         assert result["label"] == "멀티팩터 스코어"
+
+    def test_stale_signals_surface_instead_of_going_unnoticed(self, db_path):
+        """낡은 기술 지표가 FAIL 로 뜬다 (#1101).
+
+        프로덕션에서 `signals` 는 40종목(가격 753 대비)으로 넉 달을 갔고 정책이 없어서
+        어떤 화면에도 안 떴다. RSI 는 BUY 점수의 0.15 가중치인데 99.1% 결측이라 전 종목
+        중립 상수였다 — 틀린 값이 아니라 변별력 0 인 값이라 아무것도 이상해 보이지 않았다.
+
+        Mutation lock: `FRESHNESS_POLICIES` 에서 `signals` 를 빼면 KeyError 로 FAIL.
+        """
+        from nuri.core.db import get_db
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now
+
+        old = (kst_now() - timedelta(days=40)).strftime("%Y-%m-%d")
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO signals (ticker, date, rsi_14) VALUES (?, ?, 55.0)",
+                ("AAA", old),
+            )
+
+        result = check_freshness("signals", db_path=db_path)
+        assert result["status"] == "FAIL"
+        assert result["label"] == "기술 지표"
 
     def test_recent_factors_pass(self, db_path):
         """정상 갱신은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1410,6 +1410,23 @@ class TestTechnicalCoversTheScoringUniverse:
 
         mock_collector.run.assert_called_once_with(source="all")
 
+    def test_stock_dispatches_return_the_saved_count(self):
+        """일일 universe refresh 잡의 살아있음 증명이 `collector_runs.rows_collected` 다.
+
+        stock/stock_kr 분기가 반환을 삼키면 이 잡들이 매일 no-op 처럼 기록된다 —
+        technical 이 17건을 저장하고 0 으로 남았던 것과 같은 축 (#1105 는 나머지 분기).
+        """
+        from nuri.scheduler import _dispatch_collector
+
+        for branch, path in (
+            ("stock", "nuri.collectors.stock.StockCollector"),
+            ("stock_kr", "nuri.collectors.stock_kr.StockKRCollector"),
+        ):
+            mock_collector = MagicMock()
+            mock_collector.run.return_value = 543
+            with patch(path, return_value=mock_collector):
+                assert _dispatch_collector(branch) == 543, f"{branch} 분기가 수집량을 삼켰다"
+
     def test_daily_universe_price_jobs_are_registered(self):
         """universe 가격을 **매일** 미는 잡이 있다 (#1101 Codex P1).
 
@@ -1434,6 +1451,70 @@ class TestTechnicalCoversTheScoringUniverse:
         us_min, us_hour = by_name["stock_us_universe_daily"].split()[:2]
         tech_min, tech_hour = by_name["technical"].split()[:2]
         assert (int(us_hour), int(us_min)) < (int(tech_hour), int(tech_min))
+
+    @staticmethod
+    def _expand(field: str, lo: int, hi: int) -> set[int]:
+        """cron 필드 1개 → 값 집합. SCHEDULES 가 실제로 쓰는 문법만 지원한다."""
+        out: set[int] = set()
+        for part in field.split(","):
+            if part.startswith("*/"):
+                out |= set(range(lo, hi + 1, int(part[2:])))
+            elif part == "*":
+                out |= set(range(lo, hi + 1))
+            elif "-" in part:
+                a, b = part.split("-")
+                out |= set(range(int(a), int(b) + 1))
+            else:
+                out.add(int(part))
+        return out
+
+    def test_no_two_kr_price_jobs_share_a_firing_minute(self):
+        """KRX 는 sequential 강제다 — 같은 분에 pykrx 두 개가 뜨면 그 불변식이 깨진다.
+
+        1차 배치는 KR 일일 refresh 를 15:40 에 뒀는데 `stock_kr`(*/5, 9-15시)이 정확히
+        같은 분에 돌고 있었다 (Codex 4차). 겹침은 분 단위 전수 대조로 잠근다 — 눈으로
+        cron 표를 읽는 방식은 이미 한 번 놓쳤다.
+        """
+        from itertools import combinations
+
+        from nuri.scheduler import SCHEDULES
+
+        kr_jobs = [j for j in SCHEDULES if j.get("args") == ("stock_kr",)]
+        assert len(kr_jobs) >= 3, "stock_kr 잡이 줄었다 — 이 잠금의 전제를 확인할 것"
+
+        def firing_minutes(cron: str) -> set[tuple[int, int, int]]:
+            m, h, _dom, _mon, dow = cron.split()
+            return {
+                (d, hh, mm)
+                for d in self._expand(dow, 0, 6)
+                for hh in self._expand(h, 0, 23)
+                for mm in self._expand(m, 0, 59)
+            }
+
+        for a, b in combinations(kr_jobs, 2):
+            overlap = firing_minutes(a["cron"]) & firing_minutes(b["cron"])
+            assert not overlap, (
+                f"{a['name']} 와 {b['name']} 가 같은 분에 발화한다: {sorted(overlap)[:3]} — "
+                "pykrx 동시 2회는 KRX sequential 불변식 위반"
+            )
+
+    def test_technical_recomputes_after_the_kr_close(self):
+        """KR 종가 반영 지표가 같은 날 나온다 (#1101 Codex P2 2차).
+
+        15:40 KR 가격 refresh 는 prices 만 갱신한다 — technical 이 07:00 하루 한 번이면
+        KR 종가 RSI/SMA 는 다음날 아침까지 안 나온다. 가격은 갔는데 소비 지점(signals)에
+        안 닿는, 이 PR 이 두 번 밟을 뻔한 모양이다.
+        """
+        from nuri.scheduler import SCHEDULES
+
+        jobs = {j["name"]: j for j in SCHEDULES}
+        close_run = jobs["technical_close_kr"]
+        assert close_run["args"] == ("technical",)
+
+        # KR 가격(15:40) → technical 재계산(16:10) 순서. 뒤집히면 낡은 가격으로 계산한다.
+        kr_min, kr_hour = jobs["stock_kr_universe_daily"]["cron"].split()[:2]
+        t_min, t_hour = close_run["cron"].split()[:2]
+        assert (int(kr_hour), int(kr_min)) < (int(t_hour), int(t_min))
 
     def test_dispatch_returns_the_saved_count(self):
         """반환이 없으면 `collector_runs.rows_collected` 가 0 으로 남는다.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1410,6 +1410,31 @@ class TestTechnicalCoversTheScoringUniverse:
 
         mock_collector.run.assert_called_once_with(source="all")
 
+    def test_daily_universe_price_jobs_are_registered(self):
+        """universe 가격을 **매일** 미는 잡이 있다 (#1101 Codex P1).
+
+        주간 backfill 만으로는 universe-only 727종목의 prices 가 주중 1~6일 stale 로
+        남는다 (2026-08-18 실측: 727/732 가 금요일 날짜에 정지). 그 위에서 계산한
+        signals 는 날짜가 어긋나 RSI 스냅샷에도 못 들어간다 — technical 확장이
+        이 잡 없이는 소비 지점에서 무효다.
+        """
+        from nuri.scheduler import SCHEDULES
+
+        us = [j for j in SCHEDULES if j["name"] == "stock_us_universe_daily"]
+        kr = [j for j in SCHEDULES if j["name"] == "stock_kr_universe_daily"]
+        assert len(us) == 1 and us[0]["kwargs"] == {"period": "5d", "source": "all"}
+        assert len(kr) == 1 and kr[0]["kwargs"] == {"days": 5, "source": "all"}
+
+    def test_us_universe_prices_land_before_technical_runs(self):
+        """US 일일 universe 가격(06:20)이 technical(07:00)보다 앞이다 — 순서가 뒤면
+        아침 지표가 하루 묵은 가격으로 계산된다."""
+        from nuri.scheduler import SCHEDULES
+
+        by_name = {j["name"]: j["cron"] for j in SCHEDULES}
+        us_min, us_hour = by_name["stock_us_universe_daily"].split()[:2]
+        tech_min, tech_hour = by_name["technical"].split()[:2]
+        assert (int(us_hour), int(us_min)) < (int(tech_hour), int(tech_min))
+
     def test_dispatch_returns_the_saved_count(self):
         """반환이 없으면 `collector_runs.rows_collected` 가 0 으로 남는다.
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1389,3 +1389,38 @@ class TestFactorCompositeWired:
             f"factors({crons['factors']}) 가 fear_greed({crons['fear_greed']}) 보다 이르다"
         )
         assert crons["factors"].split()[2:] == ["*", "*", "*"], "매일 돌아야 한다 (소비자는 매 거래일 발행)"
+
+
+class TestTechnicalCoversTheScoringUniverse:
+    """technical 잡이 채점 유니버스를 덮고, 수집량을 정직하게 기록한다 (#1101).
+
+    universe 모드는 #272 부터 있었는데 스케줄러가 인자 없이 불러(기본 portfolio) 도달
+    불가였다 — `signals` 가 보유 18종목에 갇혀 BUY 점수의 0.15 가중치(RSI)가 736 채점
+    대상의 99.1% 에서 중립 상수 50 이었다. "배선은 됐는데 아무도 도달 못 하는" 클래스
+    (`held_add_shadow`, `/api/alpha` 와 동일).
+    """
+
+    def test_dispatch_expands_to_the_full_universe(self):
+        """`source="all"` (portfolio ∪ universe) 로 부른다 — 기본값이면 18종목이다."""
+        from nuri.scheduler import _dispatch_collector
+
+        mock_collector = MagicMock()
+        with patch("nuri.collectors.technical.TechnicalCollector", return_value=mock_collector):
+            _dispatch_collector("technical")
+
+        mock_collector.run.assert_called_once_with(source="all")
+
+    def test_dispatch_returns_the_saved_count(self):
+        """반환이 없으면 `collector_runs.rows_collected` 가 0 으로 남는다.
+
+        2026-08-18 실측: 17건을 저장한 run 이 `rows_collected=0 status=finished` 로
+        기록됐다 — 관측 테이블(#975)이 이 잡에 한해 장식이었다.
+        """
+        from nuri.scheduler import _dispatch_collector
+
+        mock_collector = MagicMock()
+        mock_collector.run.return_value = 751
+        with patch("nuri.collectors.technical.TechnicalCollector", return_value=mock_collector):
+            got = _dispatch_collector("technical")
+
+        assert got == 751

--- a/tests/trading/recommend/test_rsi_snapshot.py
+++ b/tests/trading/recommend/test_rsi_snapshot.py
@@ -1,0 +1,78 @@
+"""RSI 스냅샷은 티커별 최신이다 — 전역 MAX(date) 하루치가 아니라 (#1101 Codex P1).
+
+전역 `MAX(date)` 하루치만 읽으면 **시장이 섞이는 순간 한쪽이 통째로 빠진다**: KR 은 KST
+당일, US 는 전일 날짜로 signals 가 갈라지므로 최신 날짜 하나를 고르면 다른 시장 전부가
+스냅샷에서 사라진다. universe 확장 직후엔 backfill 날짜 간극 때문에 **751행을 쓰고도
+emitter 가 보유분만 읽는** 형태로 재현됐다 — 커버리지를 넓힌 수정이 소비 지점에서
+무효가 되는, 이 레포가 반복해 밟은 "배선은 됐는데 도달 못 하는" 모양이다.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.core.timezone import kst_now, today_kst
+from nuri.trading.recommend.buy_candidate_emitter import _get_rsi_snapshot
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, ticker: str, days_ago: int, rsi: float | None = 55.0):
+    d = (kst_now() - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO signals (ticker, date, rsi_14) VALUES (?, ?, ?)",
+            (ticker, d, rsi),
+        )
+
+
+class TestPerTickerLatest:
+    def test_mixed_dates_keep_both_markets(self, db_path):
+        """오늘 찍힌 티커와 3일 전 티커가 **둘 다** 스냅샷에 든다.
+
+        전역 MAX(date) 방식으로 되돌리면 3일 전 티커가 빠져 이 테스트가 FAIL 한다 —
+        그게 정확히 751행을 쓰고도 보유분만 읽히던 회귀다.
+        """
+        _seed(db_path, "HELD", 0)
+        _seed(db_path, "UNIV", 3)
+
+        got = _get_rsi_snapshot(db_path=db_path)
+
+        assert set(got) == {"HELD", "UNIV"}
+
+    def test_each_ticker_gets_its_own_latest_row(self, db_path):
+        """같은 티커의 여러 날짜 중 최신 값을 고른다."""
+        _seed(db_path, "AAAA", 3, rsi=40.0)
+        _seed(db_path, "AAAA", 1, rsi=62.0)
+
+        assert _get_rsi_snapshot(db_path=db_path)["AAAA"] == pytest.approx(62.0)
+
+    def test_stale_rows_are_dropped_not_served(self, db_path):
+        """7일 컷오프 — 상장폐지 종목의 마지막 RSI 가 영원히 남으면 안 된다.
+
+        컷오프가 없으면 낡은 값이 신선한 값과 구분 없이 점수에 들어간다. 없는 값은
+        `_score_ticker` 가 중립 50 으로 치므로, 낡은 값보다 없는 값이 낫다.
+        """
+        _seed(db_path, "DEAD", 10)
+        _seed(db_path, "LIVE", 1)
+
+        assert set(_get_rsi_snapshot(db_path=db_path)) == {"LIVE"}
+
+    def test_null_rsi_rows_do_not_shadow_older_values(self, db_path):
+        """최신 행의 rsi 가 NULL 이면 그 티커의 직전 non-null 값을 쓴다.
+
+        NULL 행이 GROUP BY 의 최신을 차지하며 값을 가리면, 데이터가 부분 결손인 날마다
+        티커가 스냅샷에서 사라진다 — WHERE 가 NULL 을 먼저 걷어내므로 그렇지 않다.
+        """
+        _seed(db_path, "AAAA", 2, rsi=48.0)
+        _seed(db_path, "AAAA", 1, rsi=None)
+
+        assert _get_rsi_snapshot(db_path=db_path)["AAAA"] == pytest.approx(48.0)

--- a/tests/trading/recommend/test_rsi_snapshot.py
+++ b/tests/trading/recommend/test_rsi_snapshot.py
@@ -66,6 +66,32 @@ class TestPerTickerLatest:
 
         assert set(_get_rsi_snapshot(db_path=db_path)) == {"LIVE"}
 
+    def test_the_cutoff_follows_kst_now_not_the_db_clock(self, db_path, monkeypatch):
+        """컷오프의 기준 시계는 `kst_now()` 다 — SQLite 의 시계가 아니라 (Codex 3차).
+
+        `date('now')` 는 UTC 라 09:00 KST 이전 — 아침 배치(07:00 technical · 07:05
+        consensus) 시간대 전부 — 에는 어제로 계산돼 8일 낡은 RSI 가 하루 더 살아남는다.
+        UTC/KST divergence 자체는 실행 시각에 따라 달라 결정론으로 잡을 수 없으므로,
+        같은 축을 다르게 잠근다: 파이썬 시계를 미래로 옮기고 컷오프가 **그 시계를**
+        따라오는지 본다. `date('now')` 로 되돌리면 SQLite 의 실제 벽시계가 쓰여 8일 낡은
+        행이 살아남아 FAIL 한다. 앵커는 `kst_now()` 상대값 — 리터럴 날짜는 이 레포에서
+        두 번 터진 시한폭탄이다 (tests/CLAUDE.md).
+        """
+        from datetime import timedelta
+
+        import nuri.core.timezone as tz
+
+        fixed = tz.kst_now() + timedelta(days=365)
+        monkeypatch.setattr(tz, "kst_now", lambda: fixed)
+
+        d8 = (fixed - timedelta(days=8)).strftime("%Y-%m-%d")
+        d6 = (fixed - timedelta(days=6)).strftime("%Y-%m-%d")
+        with get_db(db_path) as conn:
+            conn.execute("INSERT INTO signals (ticker, date, rsi_14) VALUES ('OLD8', ?, 55.0)", (d8,))
+            conn.execute("INSERT INTO signals (ticker, date, rsi_14) VALUES ('OK6', ?, 55.0)", (d6,))
+
+        assert set(_get_rsi_snapshot(db_path=db_path)) == {"OK6"}
+
     def test_null_rsi_rows_do_not_shadow_older_values(self, db_path):
         """최신 행의 rsi 가 NULL 이면 그 티커의 직전 non-null 값을 쓴다.
 


### PR DESCRIPTION
Closes #1101. #1100 결함 B·C 의 해소분.

## 무엇이 문제였나 — 실측

- `signals` 전 기간 **40종목** (가격은 753종목). 최신일 `rsi_14` non-null **7종목**
- 그래서 `_score_ticker` 의 RSI 항(가중 0.15)이 채점 대상 736종목의 **99.1% 에서 중립
  상수 50** — 틀린 값이 아니라 변별력 0 인 값이라 아무것도 이상해 보이지 않았다
- 오늘 07:00 run 은 로그상 **"완료: 17건"** 인데 `collector_runs` 에는
  `rows_collected=0 status=finished` — dispatch 분기가 반환값을 안 돌려줘서다
- `signals` 는 `FRESHNESS_POLICIES` 에 없어 이 상태가 넉 달간 어떤 화면에도 안 떴다

## 고친 것 셋

1. **`source="all"` (portfolio ∪ universe)** — universe 모드는 #272 부터 있었는데
   스케줄러가 인자 없이 불러(기본 portfolio) **도달 불가**였다. `held_add_shadow` ·
   `/api/alpha` 와 같은 "배선은 됐는데 아무도 도달 못 하는" 클래스.
   - 이 수집기는 `prices` 테이블만 읽는 **순수 계산**(네트워크 0)이라 확장 비용은 CPU 뿐
   - `MAX_FAILURE_RATE`(10%) 함정 사전 실측: prices <14일 종목은 757 중 6개 = **0.8%**
     — 저장 거부 임계에 안 걸린다
2. **`signals` freshness 정책** — 재료(`prices`)와 같은 48h/120h. 잡이 멈춰도, 가격이
   멈춰도 `MAX(date)` 가 얼어 둘 다 잡는다 (#1071 `factors` 와 같은 설계). #1091
   INPUT_STALE 카드 `_REMEDY` 에도 등재
3. **dispatch 가 수집량을 반환** — 안 하면 `collector_runs` 가 이 잡에 한해 장식이다

## 검증

- 뮤테이션 3종(`source="all"` 제거 · `return` 제거 · 정책 제거) **전부 FAIL 실측**
- 백엔드 7,229 passed / 게이트(privacy · pyright diff · doc counts) 초록

## 살아있음 증명

내일 07:00 run 후 `signals` 최신일 행 수가 17 → **~751**, `collector_runs.rows_collected`
가 0 → 실제 수집량, `check_freshness("signals")` PASS.

## 남은 형제 결함 (별도)

같은 무반환 패턴이 다른 수집기 분기 대부분에 있다 — `stock`/`macro`/`news` 등도
`rows_collected=0` 으로 기록 중. 스코프 확장 대신 후속 이슈로 분리한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)