### PR TITLE
fix(scheduler): return every dispatch branch's row count

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,274 collected across 333 files | |
+| **Backend tests** | 7,320 collected across 334 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,274 backend tests across 333 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,320 backend tests across 334 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,274 tests, 333 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,320 tests, 334 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -151,7 +151,7 @@ def _dispatch_collector(name: str, **kwargs):
     elif name == "macro":
         from nuri.collectors.macro import MacroCollector
 
-        MacroCollector().run()
+        return MacroCollector().run()
     elif name == "technical":
         # `source="all"` (portfolio ∪ universe) — 기본값(portfolio)이면 signals 가 보유
         # 18종목에 갇혀 BUY 점수의 0.15 가중치(RSI)가 736 채점 대상 중 99.1% 에서 중립
@@ -168,27 +168,27 @@ def _dispatch_collector(name: str, **kwargs):
     elif name == "fear_greed":
         from nuri.collectors.fear_greed import FearGreedCollector
 
-        FearGreedCollector().run()
+        return FearGreedCollector().run()
     elif name == "ark":
         from nuri.collectors.ark import ARKCollector
 
-        ARKCollector().run()
+        return ARKCollector().run()
     elif name == "events":
         from nuri.collectors.events import EventsCollector
 
-        EventsCollector().run()
+        return EventsCollector().run()
     elif name == "news":
         from nuri.collectors.news import NewsCollector
 
-        NewsCollector().run()
+        return NewsCollector().run()
     elif name == "macro_news":
         from nuri.collectors.macro_news import MacroNewsCollector
 
-        MacroNewsCollector().run()
+        return MacroNewsCollector().run()
     elif name == "fundamental":
         from nuri.collectors.fundamental import FundamentalCollector
 
-        FundamentalCollector().run()
+        return FundamentalCollector().run()
     elif name == "factors":
         # 수집이 아니라 **분석** 단계다 (`_STAGE_OF_JOB` 에서 analyze). `_run_collector` 를
         # 재사용하는 건 그쪽이 예외 격리 · 실행 기록 · 스테이지 이벤트를 이미 갖고 있어서다.
@@ -213,59 +213,60 @@ def _dispatch_collector(name: str, **kwargs):
     elif name == "cboe":
         from nuri.collectors.cboe import CBOECollector
 
-        CBOECollector().run()
+        return CBOECollector().run()
     elif name == "coingecko":
         from nuri.collectors.coingecko import CoinGeckoCollector
 
-        CoinGeckoCollector().run()
+        return CoinGeckoCollector().run()
     elif name == "reddit":
         from nuri.collectors.reddit import RedditCollector
 
-        RedditCollector().run()
+        return RedditCollector().run()
     elif name == "fred_calendar":
         from nuri.collectors.fred_calendar import FREDCalendarCollector
 
-        FREDCalendarCollector().run()
+        return FREDCalendarCollector().run()
     elif name == "institutional":
         from nuri.collectors.institutional import InstitutionalCollector
 
-        InstitutionalCollector().run()
+        return InstitutionalCollector().run()
     elif name == "finviz":
         from nuri.collectors.finviz import FINVIZCollector
 
-        FINVIZCollector().run()
+        return FINVIZCollector().run()
     elif name == "kis_analyst_opinion":
         from nuri.collectors.kis_analyst_opinion import KISAnalystOpinionCollector
 
-        KISAnalystOpinionCollector().run()
+        return KISAnalystOpinionCollector().run()
     elif name == "superinvestors":
         from nuri.collectors.superinvestors import SuperinvestorCollector
 
-        SuperinvestorCollector().run()
+        return SuperinvestorCollector().run()
     elif name == "bank_13f":
         # 대형 은행 4곳 13F (#1098). 확신 투자자와 **같은 테이블 다른 class** 라
         # 잡을 나눠 둔다 — 은행 쪽 EDGAR 실패가 확신 13F 수집을 같이 죽이면 안 된다.
         # 분기 공시라 주 1회면 충분하고, 확신 수집(01:00) 뒤에 둬 EDGAR 부하를 겹치지 않는다.
         from nuri.collectors.superinvestors import Bank13FCollector
 
-        Bank13FCollector().run(quarters=4)
+        return Bank13FCollector().run(quarters=4)
     elif name == "estimates":
         from nuri.collectors.estimates import EstimatesCollector
 
-        EstimatesCollector().run(**kwargs)
+        return EstimatesCollector().run(**kwargs)
     elif name == "etf_flows":
         from nuri.collectors.etf_flows import EtfFlowsCollector
 
-        EtfFlowsCollector().run()
+        return EtfFlowsCollector().run()
     elif name == "wallstreet":
         from nuri.collectors.wallstreet import WallStreetCollector
 
-        WallStreetCollector().run()
+        return WallStreetCollector().run()
     elif name == "memory_snapshot":
         from nuri.trading.engine.memory import save_snapshot
 
         n = save_snapshot()
         logger.info(f"[memory_snapshot] {n}건 저장")
+        return n
     elif name == "decision_pnl":
         # decisions 테이블의 7/30/60/90d raw P&L 갱신.
         # NOTE: decision_outcomes(alpha) 테이블이 아님 — alpha 는 아래 alpha_tracking job.
@@ -273,6 +274,7 @@ def _dispatch_collector(name: str, **kwargs):
 
         n = track_decision_outcomes()
         logger.info(f"[decision_pnl] {n}건 업데이트")
+        return n
     elif name == "recommendation_outcomes":
         # recommendations 테이블의 7/14/21/30/60/90d forward return 갱신.
         # NOTE: decisions 테이블이 아님 — 그쪽은 바로 위 decision_pnl.
@@ -287,6 +289,7 @@ def _dispatch_collector(name: str, **kwargs):
 
         n = track_outcomes()
         logger.info(f"[recommendation_outcomes] {n}건 업데이트")
+        return n
     elif name == "alpha_tracking":
         # ForwardOutcomeTracker: emit 된 추천 vs SPY benchmark → realized alpha 를
         # decision_outcomes 테이블에 기록 (recommendations → agent_decisions 백필 포함).
@@ -299,11 +302,17 @@ def _dispatch_collector(name: str, **kwargs):
             f"[alpha_tracking] synced={out.get('synced_from_recommendations', 0)} "
             f"measured={out.get('n_measurements', 0)}"
         )
+        # 이 잡은 **두 가지 일**을 한다: 추천을 `agent_decisions` 로 미러(sync)한 뒤,
+        # 창이 닫힌 것만 측정(measure). 부트스트랩·백필 구간에서는 sync 가 수백 건이어도
+        # 아직 30일이 안 지나 measure 가 0 이다 — 측정만 세면 그 구간 전체가
+        # `rows_collected=0` 인 no-op 으로 기록돼, 이 PR 이 없애려는 상태 그대로다.
+        return int(out.get("synced_from_recommendations", 0)) + int(out.get("n_measurements", 0))
     elif name == "agent_accuracy":
         from nuri.trading.engine.decisions import save_agent_accuracy_snapshot
 
         n = save_agent_accuracy_snapshot()
         logger.info(f"[agent_accuracy] {n}건 저장")
+        return n
     elif name == "consensus":
         # 10-agent 합의 결과를 recommendations 에 저장 → Learning Memory 자동 학습 input.
         # decision_outcomes 가 30 일 후 outcome_30d 채우면 _compute_weights 가 가중치 조정.
@@ -318,6 +327,9 @@ def _dispatch_collector(name: str, **kwargs):
         # 했는데 헬스 지표는 전부 초록이었다 (#897).
         recorded = record_decisions(results)
         logger.info(f"[consensus] {len(results)}건 분석, recommendations {saved}건, decisions {recorded}건")
+        # `saved` 를 돌려준다 — 이 잡의 1차 산출물이 recommendations 행이다.
+        # `saved + recorded` 는 두 테이블 수를 더한 값이라 어느 쪽이 비었는지 못 읽는다.
+        return saved
     elif name == "holdings_monitor":
         # Holdings post-entry technical-divergence monitor (07:10 KST, after consensus 07:05).
         # JKHY-class entry-stage defenses (PR #303) cover before-buy; this covers after-buy
@@ -327,6 +339,11 @@ def _dispatch_collector(name: str, **kwargs):
         summary = run_monitor()
         sent = send_alerts(summary)
         logger.info(f"[holdings_monitor] {summary.n_holdings}건 분석, {summary.n_alerted}건 alert, {sent}건 surface")
+        # `sent` 가 아니라 `n_alerted` 를 돌려준다. `send_alerts` 는 best-effort 라
+        # Discord 가 죽으면 alert 를 찾아 놓고도 0 을 반환한다 — 그러면 이 잡의 산출량이
+        # **선택적 표면 채널의 가용성**에 묶여, 감시가 정상 동작한 날이 no-op 으로 기록된다.
+        # 하필 Discord outage 때 그렇게 되므로 정확히 관측이 가장 필요한 순간에 눈이 먼다.
+        return summary.n_alerted
 
 
 def _run_collector(name: str, **kwargs):

--- a/tests/core/test_dispatch_returns_counts.py
+++ b/tests/core/test_dispatch_returns_counts.py
@@ -1,0 +1,180 @@
+"""`_dispatch_collector` 의 모든 분기는 수집량을 반환한다 (#1105).
+
+## 왜 구조 스윕인가
+
+`collector_runs`(#975)는 "collector health 관측이 통째로 없어 데이터 구멍 셋(#1025/#1020)을
+손으로 DB 를 뒤져 찾았다" 는 이유로 만든 테이블이다. 그런데 분기가 `return` 을 빠뜨리면
+`_record_collector_run` 에 `None` 이 넘어가 `rows_collected=0` 으로 기록된다 —
+**실패가 아니라 성공으로, 다만 수집량 0 으로.**
+
+프로덕션 실측(2026-08-18): `technical` 이 17건을 저장하고 로그에 "완료: 17건" 을 남겼는데
+`collector_runs` 에는 `rows_collected=0 status=finished` 였다. 그 상태에서
+`CollectorOrchestrator.scan_health` 의 under-fetch 검출(`rows < expected*0.9`)은 장식이고,
+"0행 수집" 이라는 진짜 고장(#1043 클래스)과 구분이 불가능하다.
+
+한 줄 빠뜨림이라 리뷰로는 반복해서 놓친다 — #1074 에서 봉투(`len(dict)==4`)를 고쳤을 때도
+무반환 분기는 그대로 남았다. 그래서 **분기마다 잠그지 않고 구조로** 잠근다.
+
+## 한계 (알고 쓴다)
+
+이 스윕은 `return` 문의 **존재**만 본다. 반환값이 의미 있는 수인지는 못 본다 —
+그건 동작 테스트의 몫이고, 대표 분기 몇 개는 `tests/test_scheduler.py` 가 실제 호출로 덮는다.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+import nuri.scheduler as sch
+
+#: 반환할 수집량이 **없는** 분기. 사유 필수. 양방향 검사라 해소된 항목도 FAIL.
+ALLOWED_NO_RETURN: dict[str, str] = {}
+
+
+def _dispatch_branches() -> list[tuple[str, list[ast.stmt]]]:
+    """`_dispatch_collector` 의 `if/elif` 체인 → [(잡 이름, 본문 statements)]."""
+    src = inspect.getsource(sch._dispatch_collector)
+    fn = ast.parse(ast.unparse(ast.parse(src))).body[0]
+    assert isinstance(fn, ast.FunctionDef)
+
+    branches: list[tuple[str, list[ast.stmt]]] = []
+    node: ast.stmt | None = next((n for n in fn.body if isinstance(n, ast.If)), None)
+    while isinstance(node, ast.If):
+        # `name == "<job>"` 에서 잡 이름을 뽑는다.
+        job = None
+        test = node.test
+        if isinstance(test, ast.Compare) and test.comparators and isinstance(test.comparators[0], ast.Constant):
+            job = test.comparators[0].value
+        branches.append((job or "<unknown>", node.body))
+        node = node.orelse[0] if len(node.orelse) == 1 else None
+    return branches
+
+
+class TestEveryBranchReturnsItsCount:
+    def test_the_sweep_actually_finds_branches(self):
+        """스윕이 0건을 찾고도 통과하면 이 파일 전체가 장식이다."""
+        branches = _dispatch_branches()
+
+        assert len(branches) >= 20, f"분기를 {len(branches)}개만 찾았다 — 파서가 눈이 멀었다"
+        assert any(job == "stock" for job, _ in branches)
+
+    @pytest.mark.parametrize("job,body", _dispatch_branches(), ids=lambda x: x if isinstance(x, str) else "")
+    def test_branch_returns(self, job: str, body: list[ast.stmt]):
+        has_return = any(isinstance(n, ast.Return) and n.value is not None for n in ast.walk(ast.Module(body, [])))
+        if job in ALLOWED_NO_RETURN:
+            assert not has_return, f"{job}: ALLOWED_NO_RETURN 에 있는데 return 이 생겼다 — 항목을 지울 것"
+            return
+        assert has_return, (
+            f"{job} 분기가 수집량을 반환하지 않는다 — collector_runs 에 rows_collected=0 으로 "
+            f"기록되어 이 잡이 매일 no-op 처럼 보인다. 돌려줄 수가 정말 없으면 "
+            f"ALLOWED_NO_RETURN 에 사유와 함께 등재할 것."
+        )
+
+    def test_allowlist_has_no_stale_entries(self):
+        """해소된 항목이 남아 있으면 다음 위반을 조용히 통과시킨다."""
+        jobs = {job for job, _ in _dispatch_branches()}
+        stale = sorted(set(ALLOWED_NO_RETURN) - jobs)
+
+        assert not stale, f"ALLOWED_NO_RETURN 에 더 이상 존재하지 않는 분기: {stale}"
+
+
+class TestTheRecorderUnderstandsAnInt:
+    """분기가 int 를 돌려줘도 `rows_collected` 에 그대로 앉는지 — 반환이 헛되지 않게."""
+
+    def test_an_int_result_lands_as_rows_collected(self, tmp_path, monkeypatch):
+        from nuri.core.db import init_db, query
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        monkeypatch.setattr("nuri.core.db.DB_PATH", db)
+
+        sch._record_collector_run("probe", "finished", 0.0, result=751)
+
+        rows = query("SELECT collector_name, rows_collected FROM collector_runs", db_path=db)
+        assert [(r["collector_name"], r["rows_collected"]) for r in rows] == [("probe", 751)]
+
+    def test_none_result_is_recorded_as_zero(self, tmp_path, monkeypatch):
+        """무반환이 0 으로 남는다는 사실 자체를 문서화 — 이게 이 파일의 존재 이유다."""
+        from nuri.core.db import init_db, query
+
+        db = tmp_path / "t.db"
+        init_db(db)
+        monkeypatch.setattr("nuri.core.db.DB_PATH", db)
+
+        sch._record_collector_run("probe", "finished", 0.0, result=None)
+
+        assert query("SELECT rows_collected FROM collector_runs", db_path=db)[0]["rows_collected"] == 0
+
+
+class TestSourceHasNoBareCollectorRun:
+    """`XCollector().run(...)` 이 `return` 없이 서 있으면 잡는다 — AST 분기 검사의 짝.
+
+    분기 검사는 "본문 어딘가에 return 이 있는가" 만 보므로, 한 분기가 두 수집기를 부르고
+    하나만 반환하면 통과한다. 이건 그 구멍을 문장 수준에서 막는다.
+    """
+
+    def test_no_collector_call_is_a_bare_statement(self):
+        src = Path(sch.__file__).read_text(encoding="utf-8")
+        fn = next(n for n in ast.parse(src).body if isinstance(n, ast.FunctionDef) and n.name == "_dispatch_collector")
+
+        offenders = []
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+                continue
+            call = node.value
+            # `XCollector().run(...)` 형태만 — logger.info 등은 통과.
+            if (
+                isinstance(call.func, ast.Attribute)
+                and call.func.attr == "run"
+                and isinstance(call.func.value, ast.Call)
+                and isinstance(call.func.value.func, ast.Name)
+                and call.func.value.func.id.endswith("Collector")
+            ):
+                offenders.append(f"line {node.lineno}: {call.func.value.func.id}().run(...)")
+
+        assert not offenders, "return 없이 서 있는 수집기 호출:\n  " + "\n  ".join(offenders)
+
+
+class TestBranchesReportPrimaryWorkNotSideChannels:
+    """반환값은 그 잡이 **한 일**이어야 한다 — 부수 채널의 성공률이 아니라 (Codex 리뷰).
+
+    `return` 존재만 잠그면 "값은 있는데 엉뚱한 걸 센다" 가 통과한다. 두 분기가 실제로 그랬고,
+    둘 다 **관측이 가장 필요한 순간에** 0 을 기록하는 형태였다.
+    """
+
+    def test_holdings_monitor_reports_alerts_even_when_discord_is_down(self, monkeypatch):
+        """`send_alerts` 는 best-effort 라 Discord 가 죽으면 0 을 반환한다.
+
+        그 값을 기록하면 감시가 정상 동작한 날이 no-op 으로 남는다 — 하필 outage 때.
+        """
+        summary = type("S", (), {"n_holdings": 18, "n_alerted": 3, "alerts": [{}, {}, {}]})()
+        monkeypatch.setattr("nuri.trading.recommend.holdings_monitor.run_monitor", lambda: summary)
+        monkeypatch.setattr("nuri.trading.recommend.holdings_monitor.send_alerts", lambda s: 0)
+
+        assert sch._dispatch_collector("holdings_monitor") == 3
+
+    def test_alpha_tracking_counts_backfill_not_only_matured_windows(self, monkeypatch):
+        """부트스트랩 구간: sync 수백 건 + measure 0 은 no-op 이 아니다.
+
+        측정만 세면 백필 기간 전체가 `rows_collected=0` 으로 기록돼, 이 파일이 없애려는
+        상태 그대로가 된다.
+        """
+        result = type("R", (), {"output": {"synced_from_recommendations": 262, "n_measurements": 0}})()
+        monkeypatch.setattr(
+            "nuri.agents.actors.forward_outcome_tracker.ForwardOutcomeTracker.run",
+            lambda self, payload: result,
+        )
+
+        assert sch._dispatch_collector("alpha_tracking") == 262
+
+    def test_consensus_reports_recommendations_not_a_sum_of_two_tables(self, monkeypatch):
+        """두 테이블 수를 더하면 어느 쪽이 비었는지 못 읽는다."""
+        monkeypatch.setattr("nuri.trading.agents.consensus.analyze_portfolio", lambda: [1, 2, 3])
+        monkeypatch.setattr("nuri.trading.agents.consensus.save_to_recommendations", lambda r: 18)
+        monkeypatch.setattr("nuri.trading.engine.decisions.record_decisions", lambda r: 18)
+
+        assert sch._dispatch_collector("consensus") == 18


### PR DESCRIPTION
Closes #1105. #1104 에서 분리한 형제 결함.

## 문제

`collector_runs`(#975)는 "collector health 관측이 통째로 없어 데이터 구멍 셋(#1025 FRED 8지표
0행 · #1020 kospi/yield 0행)을 손으로 DB 를 뒤져 찾았다" 는 이유로 만든 테이블이다.

그런데 분기가 `run()` 반환을 삼키면 `_record_collector_run` 에 `None` 이 넘어가
**`rows_collected=0` 으로 기록된다 — 실패가 아니라 성공으로, 다만 수집량 0 으로.**

프로덕션 실측(2026-08-18): `technical` 이 17건을 저장하고 로그에 `완료: 17건` 을 남겼는데
`collector_runs` 에는 `rows_collected=0 status=finished` 였다.

그 상태에서
- `CollectorOrchestrator.scan_health` 의 under-fetch 검출(`rows < expected*0.9`)이 **장식**
- "0행 수집" 이라는 진짜 고장(#1043 클래스)과 **구분 불가**

## 고친 것

**분기 26개**가 수집량을 반환한다. 그중 7개(`memory_snapshot` · `decision_pnl` ·
`recommendation_outcomes` · `alpha_tracking` · `agent_accuracy` · `consensus` ·
`holdings_monitor`)는 **이미 카운트를 계산해 로그로 찍고 버리고 있었다**.

`consensus` 는 `saved`(recommendations 행)를 돌려준다 — `saved + recorded` 는 두 테이블
수를 더한 값이라 어느 쪽이 비었는지 못 읽는다.

## 왜 구조 스윕인가

한 줄 빠뜨림이라 리뷰로는 반복해 놓친다 — **#1074 가 바로 이 함수의 봉투 버그
(`len(dict)==4`)를 고치면서 무반환 분기는 전부 그대로 뒀다.** 그래서 분기마다 잠그지 않고
구조로 잠근다:

1. **AST 분기 스윕** — `if/elif` 체인의 각 분기가 `return <값>` 을 포함하는지. 양방향
   allowlist(신규 누락도, 낡은 항목도 FAIL)
2. **문장 수준 검사** — `XCollector().run(...)` 이 bare expression 으로 서 있으면 FAIL.
   분기 하나가 수집기 둘을 부르고 하나만 반환하는 구멍을 막는다
3. **카나리아** — 스윕이 분기를 20개 미만 찾으면 FAIL (0건 찾고 통과하는 장식 방지)
4. **기록 경로 왕복** — `result=751` 이 `rows_collected=751` 로 앉는지, `None` 이 0 으로
   남는지 둘 다 (후자는 이 PR 의 존재 이유를 문서화)

한계도 테스트에 적어뒀다: 스윕은 `return` **존재**만 본다. 값의 의미는 동작 테스트 몫이고
대표 분기는 `tests/test_scheduler.py` 가 실제 호출로 덮는다.

## 검증

- 뮤테이션 5종 전부 FAIL 실측 (단순 분기 2 · 카운트 분기 2 · 기록 경로 1)
- 백엔드 7,284 passed / 게이트(privacy · pyright diff · doc counts) 초록

## 살아있음 증명

프로덕션 `collector_runs` 에서 `rows_collected > 0` 인 collector 종류가 3 → 대부분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)