### PR TITLE
fix(analysis): build the firewall's portfolio state from the table that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,320 collected across 334 files | |
+| **Backend tests** | 7,330 collected across 335 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,320 backend tests across 334 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,330 backend tests across 335 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,320 tests, 334 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,330 tests, 335 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -100,9 +100,19 @@ def portfolio_state(db_path=None, config_path: Path | None = None) -> dict:
 
     ## cash 는 DB 가 아니라 `config/portfolio.yaml` 이 원본이다
 
-    잔고는 브로커에서 손으로 옮겨 적는 값이라 DB 에 없다. `cash_reserve` /
-    `leverage_cap` 게이트가 이 값을 쓰므로, 없으면 **0 으로 두고 게이트가 보수적으로
-    발화하게** 한다 — 모르는 현금을 넉넉하다고 가정하면 그 게이트는 있으나 마나다.
+    잔고는 브로커에서 손으로 옮겨 적는 값이라 DB 에 없다. 없으면 **0** 이다 — 모르는
+    현금을 넉넉하다고 가정하면 `cash_reserve` 가 있으나 마나가 된다.
+
+    다만 0 이 모든 게이트를 조이는 건 아니다. 정확히는 이렇다:
+
+    - `cash_reserve` — post-trade 현금 비중이 음수가 되므로 **반드시 막는다** (fail-closed).
+    - `leverage_cap` — firewall 이 `cash > 0` 일 때만 검사하므로 **건너뛴다**. 0 으로
+      나눌 수 없으니 그쪽 설계가 맞다. 즉 cash=0 은 그 한 게이트에 대해서는 조이는
+      방향이 아니다 — 지금 룰에서 BUY 는 `cash_reserve` 가 먼저 잡아서 결과가 같지만,
+      "0 이면 무조건 보수적" 이라고 읽지 말 것.
+
+    **Test:** `tests/analysis/test_portfolio_state.py::TestTheFirewallActuallyBlocksNow::
+    test_unreadable_cash_cannot_turn_a_block_into_a_pass`
     """
     import yaml
 

--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -12,7 +12,10 @@
     python -m nuri.analysis.portfolio
 """
 
+from __future__ import annotations
+
 import logging
+from pathlib import Path
 
 import pandas as pd
 
@@ -21,6 +24,11 @@ from nuri.core.rules import LEVERAGE_ETFS, MAX_SINGLE_POSITION
 from nuri.core.ticker_names import is_kr_ticker
 
 logger = logging.getLogger(__name__)
+
+#: 현금 잔고 원본. 모듈 상수로 두는 이유는 두 가지다 — 매 호출 경로 계산을 피하고,
+#: `test_db_path_forwarding` 스윕이 `Path.resolve()` 를 (이름이 같은) DB 리더로 오탐하는
+#: 것을 막는다. 그 스윕은 함수명으로 매칭하므로 `resolve` 가 함수 본문에 있으면 걸린다.
+_DEFAULT_PORTFOLIO_YAML = Path(__file__).resolve().parents[2] / "config" / "portfolio.yaml"
 
 
 class StaleExchangeRateError(Exception):
@@ -67,6 +75,74 @@ def get_exchange_rate(db_path=None) -> float:
     raise StaleExchangeRateError(
         "USD/KRW 환율을 찾을 수 없습니다. 'python -m nuri.collectors.macro'로 환율 데이터를 수집하세요."
     )
+
+
+def portfolio_state(db_path=None, config_path: Path | None = None) -> dict:
+    """`ExecutionFirewall` 이 받는 포트폴리오 스냅샷 (#1107).
+
+    반환 형태는 `execution_firewall.ExecutionFirewall._check` 의 계약 그대로:
+    `{total_value, cash, positions: {ticker: {value, sector}}, vix}` — 전부 USD 정규화.
+
+    ## 왜 이 함수가 새로 필요한가
+
+    유일한 빌더가 `scripts/ops/run_phase2_chain.py:97` 의
+    `SELECT ticker, qty, current_price FROM holdings` 였는데 **`holdings` 테이블은 존재하지
+    않는다** (실제 테이블은 `portfolio`, 컬럼도 `quantity`/`avg_price` 이고 `current_price`
+    는 없다). 예외가 `except Exception` 에 삼켜져 `total_value=100_000, positions={}` 라는
+    **허구**로 계산됐고, 그래서 `execution_blocks` 는 도입 이래 프로덕션 **0행**이다 —
+    firewall 이 "안 불린" 게 아니라 **산술적으로 아무것도 못 막는** 상태였다.
+
+    ## 왜 `analyze_portfolio()` 를 재사용하나
+
+    그쪽이 이미 KRW→USD 환산(`.KS`/`.KQ` 는 계좌 통화와 무관하게 KRW 처리, #764) ·
+    다계좌 합산 · 섹터를 처리한다. 여기서 다시 짜면 두 경로가 갈라지고, 갈라진 쪽이
+    조용히 낡는다.
+
+    ## cash 는 DB 가 아니라 `config/portfolio.yaml` 이 원본이다
+
+    잔고는 브로커에서 손으로 옮겨 적는 값이라 DB 에 없다. `cash_reserve` /
+    `leverage_cap` 게이트가 이 값을 쓰므로, 없으면 **0 으로 두고 게이트가 보수적으로
+    발화하게** 한다 — 모르는 현금을 넉넉하다고 가정하면 그 게이트는 있으나 마나다.
+    """
+    import yaml
+
+    from nuri.core.db import query
+
+    df = analyze_portfolio(db_path=db_path)
+
+    positions: dict[str, dict] = {}
+    total_value = 0.0
+    if not df.empty:
+        # 다계좌 동일 종목은 합산한다 — firewall 의 position_limit 은 **종목** 단위다.
+        for ticker, grp in df.groupby("ticker"):
+            value = float(grp["current_value_usd"].sum())
+            sector = next((s for s in grp["sector"] if s), None)
+            positions[str(ticker)] = {"value": value, "sector": sector}
+            total_value += value
+
+    rate = get_exchange_rate(db_path=db_path) or 1400.0
+    cash = 0.0
+    path = config_path or _DEFAULT_PORTFOLIO_YAML
+    try:
+        accounts = (yaml.safe_load(path.read_text(encoding="utf-8")) or {}).get("accounts") or {}
+        for info in accounts.values():
+            if isinstance(info, dict):
+                cash += float(info.get("cash_usd") or 0) + float(info.get("cash_krw") or 0) / rate
+    except (OSError, yaml.YAMLError, TypeError, ValueError) as e:
+        # 현금을 못 읽으면 0 — 넉넉하다고 가정하는 쪽이 위험하다.
+        logger.warning("portfolio.yaml cash 읽기 실패, cash=0 으로 진행: %s", e)
+
+    vix_row = query(
+        "SELECT value FROM macro WHERE indicator = 'vix' ORDER BY date DESC LIMIT 1",
+        db_path=db_path,
+    )
+
+    return {
+        "total_value": round(total_value, 2),
+        "cash": round(cash, 2),
+        "positions": positions,
+        "vix": float(vix_row[0]["value"]) if vix_row else None,
+    }
 
 
 def analyze_portfolio(db_path=None) -> pd.DataFrame:

--- a/scripts/ops/run_phase2_chain.py
+++ b/scripts/ops/run_phase2_chain.py
@@ -88,34 +88,19 @@ def fetch_ticker_returns(ticker: str, start_date: str = "2025-01-01") -> pd.Data
     return df.dropna()
 
 
-def fetch_portfolio_state(default_cash: float = 50_000.0) -> dict[str, Any]:
-    """Best-effort portfolio snapshot (없으면 default placeholder).
+def fetch_portfolio_state() -> dict[str, Any]:
+    """실 포트폴리오 스냅샷 — `nuri.analysis.portfolio.portfolio_state()` 위임 (#1107).
 
-    실 holdings 가 있으면 그걸 쓰고, 없으면 빈 portfolio + cash 만 사용.
+    이 함수는 원래 `SELECT ticker, qty, current_price FROM holdings` 를 조회했다.
+    그런 테이블은 **존재하지 않는다** (실제는 `portfolio`, 컬럼도 다르다). 예외가
+    `except Exception` 에 삼켜져 `total_value=100_000, positions={}` 라는 허구가 흘렀고,
+    firewall 은 빈 포트폴리오를 상대로 게이트를 계산했다 — `execution_blocks` 가 도입 이래
+    프로덕션 0행인 이유가 이것이다. 재구현하지 않고 위임한다: 환율·다계좌·섹터 처리가
+    한 곳에만 있어야 갈라지지 않는다.
     """
-    try:
-        rows = query_df("SELECT ticker, qty, current_price FROM holdings WHERE qty > 0")
-        positions: dict[str, dict[str, Any]] = {}
-        total_value = 0.0
-        for _, r in rows.iterrows():
-            value = float(r["qty"]) * float(r["current_price"] or 0)
-            if value > 0:
-                positions[r["ticker"]] = {"value": value, "sector": "unknown"}
-                total_value += value
-    except Exception:
-        positions = {}
-        total_value = 0.0
+    from nuri.analysis.portfolio import portfolio_state
 
-    # VIX 최신값 — ExecutionFirewall vix_too_high gate
-    vix_row = query_df("SELECT value FROM macro WHERE indicator='vix' ORDER BY date DESC LIMIT 1")
-    vix = float(vix_row["value"].iloc[0]) if not vix_row.empty else None
-
-    return {
-        "total_value": total_value if total_value > 0 else 100_000.0,
-        "cash": default_cash,
-        "positions": positions,
-        "vix": vix,
-    }
+    return portfolio_state()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/analysis/test_portfolio_state.py
+++ b/tests/analysis/test_portfolio_state.py
@@ -1,0 +1,301 @@
+"""ExecutionFirewall 이 받는 포트폴리오 스냅샷 (#1107).
+
+## 왜 이 파일이 있나
+
+`execution_blocks` 는 도입 이래 프로덕션 **0행**이다. firewall 이 안 불려서가 아니라
+**산술적으로 아무것도 못 막는 상태**였기 때문이다: 유일한 빌더가
+
+    SELECT ticker, qty, current_price FROM holdings WHERE qty > 0
+
+를 조회했는데 **`holdings` 테이블은 존재하지 않는다** (실제는 `portfolio`, 컬럼도
+`quantity`/`avg_price` 이고 `current_price` 는 없다). 예외가 `except Exception` 에 삼켜져
+`total_value=100_000, positions={}` 라는 허구가 흘렀고, 빈 포트폴리오를 상대로는
+집중도·섹터·현금 게이트가 전부 통과한다.
+
+**틀린 숫자가 아니라 그럴듯한 숫자라 화면 어디도 이상해 보이지 않았다.**
+그래서 이 파일은 형태가 아니라 **판정 결과**를 잠근다 — 허구였다면 통과했을 매수가
+실제 상태에서는 막히는지.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+import yaml
+
+from nuri.analysis.portfolio import portfolio_state
+from nuri.core.db import get_db, init_db, upsert_prices
+from nuri.core.timezone import today_kst
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, rows, prices, rate: float = 1400.0):
+    with get_db(db_path) as conn:
+        # 환율이 없으면 `get_exchange_rate` 가 StaleExchangeRateError 를 던진다 — 의도된
+        # 가드다(낡은 환율로 KR 종목을 환산하느니 크게 실패한다). 픽스처가 그걸 채운다.
+        conn.execute(
+            "INSERT INTO macro (indicator, date, value) VALUES ('usd_krw', ?, ?)",
+            (today_kst(), rate),
+        )
+        conn.executemany(
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+            "VALUES (:account, :ticker, :quantity, :avg_price, :currency, :sector)",
+            rows,
+        )
+    d = today_kst()
+    upsert_prices(
+        pd.DataFrame(
+            [
+                {
+                    "ticker": t,
+                    "date": d,
+                    "open": c,
+                    "high": c,
+                    "low": c,
+                    "close": c,
+                    "volume": 1000,
+                    "adj_close": c,
+                }
+                for t, c in prices.items()
+            ]
+        ),
+        db_path=db_path,
+    )
+
+
+def _decision_id(db_path=None) -> str:
+    """`execution_blocks.decision_id` 는 `agent_decisions` 를 참조하는 FK 다 —
+    없는 id 로 부르면 게이트 판정이 아니라 IntegrityError 가 난다 (실제로 밟았다)."""
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO agent_decisions "
+            "(decision_id, ticker, as_of_date, action, conviction, inputs_json, rationale_json, status) "
+            "VALUES ('probe-decision', 'ZZZZ', ?, 'BUY', 50.0, '{}', '{}', 'emitted')",
+            (today_kst(),),
+        )
+    return "probe-decision"
+
+
+def _cash_yaml(tmp_path, accounts):
+    p = tmp_path / "portfolio.yaml"
+    p.write_text(yaml.safe_dump({"accounts": accounts}), encoding="utf-8")
+    return p
+
+
+class TestItReadsTheTableThatExists:
+    def test_positions_come_from_the_portfolio_table(self, db_path, tmp_path):
+        """`holdings` 가 아니라 `portfolio` 를 읽는다 — 그 오타 하나가 게이트를 넉 달 무력화했다."""
+        _seed(
+            db_path,
+            [
+                {
+                    "account": "A",
+                    "ticker": "AAAA",
+                    "quantity": 10,
+                    "avg_price": 90.0,
+                    "currency": "USD",
+                    "sector": "Tech",
+                }
+            ],
+            {"AAAA": 100.0},
+        )
+
+        st = portfolio_state(db_path=db_path, config_path=_cash_yaml(tmp_path, {}))
+
+        assert st["positions"] == {"AAAA": {"value": 1000.0, "sector": "Tech"}}
+        assert st["total_value"] == 1000.0
+
+    def test_an_empty_portfolio_is_not_papered_over_with_a_default(self, db_path, tmp_path):
+        """빈 포트폴리오는 `total_value=0` 이지 `100_000` 이 아니다.
+
+        옛 빌더는 조회가 실패하면 10만 달러를 지어냈다. 그 값에 비하면 어떤 매수도
+        작아 보여 집중도 게이트가 영원히 통과한다.
+        """
+        _seed(db_path, [], {})
+
+        st = portfolio_state(db_path=db_path, config_path=_cash_yaml(tmp_path, {}))
+
+        assert st["total_value"] == 0.0
+        assert st["positions"] == {}
+
+
+class TestNormalization:
+    def test_multi_account_same_ticker_is_summed(self, db_path, tmp_path):
+        """firewall 의 position_limit 은 **종목** 단위다 — 계좌별로 쪼개 보면 캡이 헐거워진다."""
+        _seed(
+            db_path,
+            [
+                {
+                    "account": "A",
+                    "ticker": "AAAA",
+                    "quantity": 10,
+                    "avg_price": 1.0,
+                    "currency": "USD",
+                    "sector": "Tech",
+                },
+                {
+                    "account": "B",
+                    "ticker": "AAAA",
+                    "quantity": 5,
+                    "avg_price": 1.0,
+                    "currency": "USD",
+                    "sector": "Tech",
+                },
+            ],
+            {"AAAA": 100.0},
+        )
+
+        st = portfolio_state(db_path=db_path, config_path=_cash_yaml(tmp_path, {}))
+
+        assert st["positions"]["AAAA"]["value"] == 1500.0
+
+    def test_korean_tickers_are_converted_to_usd(self, db_path, tmp_path):
+        """`.KS` 는 계좌 통화와 무관하게 KRW 다 (#764). 환산 없이 더하면 KR 종목이
+        포트폴리오를 통째로 지배해 모든 게이트가 무의미해진다."""
+        _seed(
+            db_path,
+            [
+                {
+                    "account": "A",
+                    "ticker": "005930.KS",
+                    "quantity": 10,
+                    "avg_price": 50000.0,
+                    "currency": "KRW",
+                    "sector": "Tech",
+                }
+            ],
+            {"005930.KS": 70000.0},
+        )
+
+        st = portfolio_state(db_path=db_path, config_path=_cash_yaml(tmp_path, {}))
+
+        # 700,000 KRW → USD. 정확한 환율은 DB 에 따라 다르므로 자릿수만 본다.
+        assert 100.0 < st["positions"]["005930.KS"]["value"] < 10_000.0
+
+
+class TestCash:
+    def test_cash_sums_usd_and_krw_across_accounts(self, db_path, tmp_path):
+        _seed(db_path, [], {})
+        cfg = _cash_yaml(tmp_path, {"A": {"cash_usd": 1000.0}, "B": {"cash_usd": 500.0, "cash_krw": 1_400_000.0}})
+
+        st = portfolio_state(db_path=db_path, config_path=cfg)
+
+        assert st["cash"] > 1500.0, "KRW 현금이 누락됐다"
+
+    def test_unreadable_cash_becomes_zero_not_generous(self, db_path, tmp_path):
+        """현금을 못 읽으면 0 이다.
+
+        `cash_reserve` / `leverage_cap` 게이트가 이 값을 쓴다 — 모르는 현금을 넉넉하다고
+        가정하면 두 게이트가 있으나 마나가 된다. 보수적으로 발화하는 쪽이 맞다.
+        """
+        _seed(db_path, [], {})
+
+        st = portfolio_state(db_path=db_path, config_path=tmp_path / "does-not-exist.yaml")
+
+        assert st["cash"] == 0.0
+
+    def test_a_missing_exchange_rate_raises_instead_of_guessing(self, db_path, tmp_path):
+        """환율이 없으면 예외 — 조용히 잘못된 통화로 합산하느니 크게 실패한다.
+
+        옛 빌더는 `except Exception` 으로 전부 삼켜 허구를 흘렸다. 이 경로가 다시
+        삼키게 되면 KR 종목이 원화 액면으로 더해져 포트폴리오를 통째로 지배한다.
+        """
+        from nuri.analysis.portfolio import StaleExchangeRateError
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
+                "VALUES ('A', 'AAAA', 1, 1.0, 'USD', 'Tech')"
+            )
+
+        with pytest.raises(StaleExchangeRateError):
+            portfolio_state(db_path=db_path, config_path=_cash_yaml(tmp_path, {}))
+
+
+class TestTheFirewallActuallyBlocksNow:
+    """이 클래스가 이 PR 의 이유다 — 형태가 아니라 **판정**을 잠근다.
+
+    ⚠️ `ExecutionFirewall.run()` 은 `db_path` 를 안 받고 **전역 DB** 에 쓴다. conftest 의
+    autouse 픽스처가 그걸 이미 per-test 복사본으로 격리하므로 이 클래스는 db_path 를
+    넘기지 않는다. 둘을 섞으면 결정은 픽스처 DB 에, 차단 기록은 전역 DB 에 앉아
+    `execution_blocks.decision_id` FK 가 깨진다 (실제로 밟았다).
+    """
+
+    def _state(self, tmp_path):
+        _seed(
+            None,
+            [
+                {
+                    "account": "A",
+                    "ticker": "AAAA",
+                    "quantity": 100,
+                    "avg_price": 90.0,
+                    "currency": "USD",
+                    "sector": "Tech",
+                }
+            ],
+            {"AAAA": 100.0},
+        )
+        return portfolio_state(config_path=_cash_yaml(tmp_path, {"A": {"cash_usd": 5000.0}}))
+
+    #: 판정이 갈리는 규모 (실측). 허구 상태는 **$10,000 까지 전부 통과**시키고 $20,000 에서야
+    #: `position_cap` 하나로 막는다 — 총액 10만을 지어냈으니 당연하다. 실 상태(총 1만)는
+    #: $500 부터 막는다. 3,000 은 그 사이 어디든 되지만, 실 상태에서 게이트 4개가 모두
+    #: 발화하는 지점이라 대비가 가장 선명하다.
+    PROPOSED = 3_000.0
+
+    def _check(self, state):
+        from nuri.agents.actors.execution_firewall import ExecutionFirewall
+
+        return ExecutionFirewall().run(
+            {
+                "action": "check",
+                "decision_id": _decision_id(),
+                "ticker": "ZZZZ",
+                "trade_action": "BUY",
+                "proposed_position_value": self.PROPOSED,
+                "sector": "Tech",
+                "portfolio_state": state,
+            }
+        )
+
+    def test_an_oversized_buy_is_blocked_on_the_real_state(self, tmp_path):
+        """총 1만 달러 포트폴리오에 3천 달러 매수 → 게이트 4개 발화."""
+        st = self._state(tmp_path)
+        assert st["total_value"] == 10_000.0
+
+        result = self._check(st)
+
+        assert result.outcome.value == "block", f"실 상태에서 과대 매수가 통과했다: {result.output}"
+        fired = {b.get("type") for b in (result.output.get("blocks") or [])}
+        # 이 둘은 **실 포지션이 있어야** 발화한다 — 허구의 `positions={}` 에서는 계산 자체가 안 된다.
+        assert {"position_cap", "sector_concentration"} <= fired, fired
+
+    def test_the_old_fiction_would_have_let_it_through(self, tmp_path):
+        """카나리아 — 허구 상태(`total_value=100_000, positions={}`)에서는 같은 매수가 통과한다.
+
+        이 대비가 없으면 위 테스트가 "firewall 이 원래 잘 막는다" 를 재확인할 뿐이고,
+        빌더 수정이 무엇을 바꿨는지 증명하지 못한다.
+        """
+        self._state(tmp_path)  # 결정 FK 와 환율만 필요 — 상태는 허구를 쓴다
+        fiction = {"total_value": 100_000.0, "cash": 50_000.0, "positions": {}, "vix": 15.0}
+
+        result = self._check(fiction)
+
+        assert result.outcome.value != "block", (
+            "허구 상태에서도 막혔다 — 이 카나리아의 전제가 깨졌으니 위 테스트의 의미를 재확인할 것"
+        )
+
+    def test_a_block_leaves_a_row_in_the_ledger(self, tmp_path):
+        """`execution_blocks` 는 도입 이래 프로덕션 0행이었다 — 행이 생기는지가 살아있음 증명이다."""
+        from nuri.core.db import query
+
+        self._check(self._state(tmp_path))
+
+        assert query("SELECT COUNT(*) AS c FROM execution_blocks")[0]["c"] > 0

--- a/tests/analysis/test_portfolio_state.py
+++ b/tests/analysis/test_portfolio_state.py
@@ -74,7 +74,9 @@ def _decision_id(db_path=None) -> str:
     없는 id 로 부르면 게이트 판정이 아니라 IntegrityError 가 난다 (실제로 밟았다)."""
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO agent_decisions "
+            # OR IGNORE — 한 테스트가 두 번 검사할 수 있다 (아는 현금 vs 못 읽는 현금).
+            # 같은 결정을 재사용하는 게 맞고, 두 번째 INSERT 가 UNIQUE 로 죽으면 안 된다.
+            "INSERT OR IGNORE INTO agent_decisions "
             "(decision_id, ticker, as_of_date, action, conviction, inputs_json, rationale_json, status) "
             "VALUES ('probe-decision', 'ZZZZ', ?, 'BUY', 50.0, '{}', '{}', 'emitted')",
             (today_kst(),),
@@ -175,8 +177,9 @@ class TestNormalization:
 
         st = portfolio_state(db_path=db_path, config_path=_cash_yaml(tmp_path, {}))
 
-        # 700,000 KRW → USD. 정확한 환율은 DB 에 따라 다르므로 자릿수만 본다.
-        assert 100.0 < st["positions"]["005930.KS"]["value"] < 10_000.0
+        # 700,000 KRW / 1400 = 500.00 USD. 픽스처가 환율을 고정하므로 정확값을 잠근다 —
+        # 범위로 두면 환율이 틀려도(예: 1300 으로 읽어도) 통과해 환산 자체를 증명하지 못한다.
+        assert st["positions"]["005930.KS"]["value"] == 500.0
 
 
 class TestCash:
@@ -186,7 +189,9 @@ class TestCash:
 
         st = portfolio_state(db_path=db_path, config_path=cfg)
 
-        assert st["cash"] > 1500.0, "KRW 현금이 누락됐다"
+        # 1000 + 500 + 1,400,000/1400 = 2500.00. 부등식으로 두면 KRW 를 빠뜨려도,
+        # USD 를 두 번 더해도 통과한다.
+        assert st["cash"] == 2500.0
 
     def test_unreadable_cash_becomes_zero_not_generous(self, db_path, tmp_path):
         """현금을 못 읽으면 0 이다.
@@ -291,6 +296,26 @@ class TestTheFirewallActuallyBlocksNow:
         assert result.outcome.value != "block", (
             "허구 상태에서도 막혔다 — 이 카나리아의 전제가 깨졌으니 위 테스트의 의미를 재확인할 것"
         )
+
+    def test_unreadable_cash_cannot_turn_a_block_into_a_pass(self, tmp_path):
+        """현금을 못 읽어 0 이 됐을 때, 막혔어야 할 매수가 통과로 뒤집히지 않는다.
+
+        cash=0 은 게이트별로 방향이 다르다 — `cash_reserve` 는 반드시 발화하지만
+        `leverage_cap` 은 firewall 이 `cash > 0` 일 때만 검사하므로 건너뛴다. 그래서
+        "0 이면 보수적" 이라는 서술은 검증 없이는 과장이다. 이 테스트가 실제 결과를
+        잠근다: 현금을 아는 상태에서 막히는 매수는 못 읽는 상태에서도 막힌다.
+        """
+        known = self._state(tmp_path)
+        assert known["cash"] == 5000.0
+        assert self._check(known).outcome.value == "block"
+
+        blind = portfolio_state(config_path=tmp_path / "does-not-exist.yaml")
+        assert blind["cash"] == 0.0
+
+        result = self._check(blind)
+
+        assert result.outcome.value == "block", f"현금을 못 읽자 차단이 통과로 뒤집혔다: {result.output}"
+        assert "cash_reserve" in {b.get("type") for b in (result.output.get("blocks") or [])}
 
     def test_a_block_leaves_a_row_in_the_ledger(self, tmp_path):
         """`execution_blocks` 는 도입 이래 프로덕션 0행이었다 — 행이 생기는지가 살아있음 증명이다."""


### PR DESCRIPTION
Closes #1107

## What was broken

`fetch_portfolio_state()` in `scripts/ops/run_phase2_chain.py` — the sole builder of the
`portfolio_state` dict handed to `ExecutionFirewall` — queried a table that does not exist:

```sql
SELECT ticker, qty, current_price FROM holdings WHERE qty > 0
```

The real table is `portfolio`, with `quantity` / `avg_price` and no `current_price` column.
A bare `except Exception` swallowed the failure and substituted a fabricated snapshot:
`total_value=100_000` (a literal), `cash=50_000` (a default argument), `positions={}`.

Every value-relative gate — `position_cap`, `sector_concentration`, `cash_reserve`,
`leverage_cap` — was therefore computed against an empty portfolio worth an invented $100k.
They could not fire. That is the arithmetic reason `execution_blocks` has zero rows in
production since the actor shipped: not "never called", but structurally unable to block.

Same class as #1042 / #1043 — a total failure wearing the clothes of a measurement.

## What changed

- `nuri/analysis/portfolio.py::portfolio_state()` (new) builds the snapshot from
  `analyze_portfolio()`, which already owns KRW→USD conversion (`.KS`/`.KQ` treated as KRW
  regardless of account currency, #764), multi-account aggregation, and sector. Positions are
  summed **per ticker across accounts** because the firewall's `position_cap` is a per-ticker cap.
- Cash comes from `config/portfolio.yaml` (it is hand-transcribed from the broker and has no DB
  source). When unreadable, it is **0**, not a default — assuming cash you cannot see makes
  `cash_reserve` and `leverage_cap` worse than absent.
- A missing exchange rate still raises `StaleExchangeRateError` rather than being swallowed.
  Summing KR tickers at face KRW would let one position dominate and neuter every gate.
- `fetch_portfolio_state()` now delegates instead of reimplementing. Two conversion paths would
  diverge, and the divergent one goes stale unseen.

## Tests

`tests/analysis/test_portfolio_state.py` (10 tests) locks the **verdict**, not the shape:

- `test_an_oversized_buy_is_blocked_on_the_real_state` — $3,000 buy against a real $10,000
  portfolio fires `position_cap` + `sector_concentration`.
- `test_the_old_fiction_would_have_let_it_through` — canary: the same buy **passes** under
  `total_value=100_000, positions={}`. Without this pair, the first test would only re-confirm
  "the firewall blocks things" and prove nothing about the builder fix.
- `test_a_block_leaves_a_row_in_the_ledger` — `execution_blocks` gets a row.

Also covered: reads `portfolio` not `holdings`, empty portfolio is `0` not `100_000`,
multi-account summing, KRW→USD, cash summation, cash-unreadable→0, stale-rate raises.

## Not in this PR

`daily_pnl_pct` is still not supplied, so the `max_daily_loss` gate remains inert. Tracked in
#1107's "out of scope" note; separate issue when picked up.

## Review

Codex (gpt-5.4): **PASS**, no P1. Two P2s, both addressed in commit 2 — the `cash=0`
claim was overstated (`leverage_cap` is skipped when `cash == 0`, so it is not uniformly
conservative; reworded and locked with a verdict test), and two assertions were
inequalities that would have passed under a wrong exchange rate (now exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
