### PR TITLE
fix(collectors): run the fundamentals collector over the scoring universe and watch its freshness

### DIFF
--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -72,6 +72,43 @@ FRESHNESS_POLICIES = {
         "fail_hours": 120,
         "label": "기술 지표 (KR)",
     },
+    # `fundamentals` 도 시장별 두 정책이다 — `signals` 와 같은 구성, 같은 이유 (#1109).
+    # composite 가중치 1.00 중 **0.50**(value 0.25 + quality 0.25)이 이 테이블에서 나오는데
+    # 정책이 없어서, 주간 잡이 보유 18종목만 갱신하는 동안 나머지 ~728 종목이 얼마나 낡든
+    # 어떤 화면에도 안 떴다. #1071 이 `factors` 에서, #1101 이 `signals` 에서 닫은 같은 구멍이다.
+    #
+    # 맨 `MAX(date)` 로는 부족하다: 보유 18종목만 갱신돼도 그 몇 행이 날짜를 끌어올려
+    # 초록이 된다 — 실제로 2026-04-29~05-04 에 6~9행짜리 쓰기가 그 모양이었다.
+    # 그래서 `signals` 와 같은 **universe 멤버 IN 제한 + 60% 커버리지 floor** 를 쓴다.
+    #
+    # 합치지 않는 이유도 같다: US 543 / KR 203 이라 합산 floor(60% of 746 = 448)는 US 만으로
+    # 넘는다 — KIS 가 전면 실패해 KR 이 통째로 비어도 PASS 다.
+    #
+    # 임계가 48/120 이 아닌 이유: 이 잡은 **주 1회**(일요일 00:00)다. 다음 실행 직전 정상
+    # 나이가 168h 이므로 48h WARN 은 매주 6일을 빨갛게 만든다. 192h(8일) = 한 번 걸렀다,
+    # 360h(15일) = 두 번 걸렀다.
+    "fundamentals": {
+        "query": (
+            "SELECT MAX(date) FROM (SELECT date FROM fundamentals "
+            "WHERE ticker IN ({placeholders}) "
+            "GROUP BY date HAVING COUNT(*) >= {floor})"
+        ),
+        "floor_from": "us",
+        "warn_hours": 192,
+        "fail_hours": 360,
+        "label": "펀더멘탈 (US)",
+    },
+    "fundamentals_kr": {
+        "query": (
+            "SELECT MAX(date) FROM (SELECT date FROM fundamentals "
+            "WHERE ticker IN ({placeholders}) "
+            "GROUP BY date HAVING COUNT(*) >= {floor})"
+        ),
+        "floor_from": "kr",
+        "warn_hours": 192,
+        "fail_hours": 360,
+        "label": "펀더멘탈 (KR)",
+    },
     "macro_fear_greed": {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
         "warn_hours": 24,

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -186,9 +186,21 @@ def _dispatch_collector(name: str, **kwargs):
 
         return MacroNewsCollector().run()
     elif name == "fundamental":
+        # `source="all"` (portfolio ∪ universe) — `technical` 과 같은 이유다 (#1104), 한 계층
+        # 위에서. 기본값(portfolio)이면 이 주간 잡이 보유 18종목만 갱신하고 나머지 ~728
+        # universe 종목은 **아무것도 건드리지 않는다**. 그 결과가 #1102 다: value·quality 가
+        # 채점 대상의 99% 에서 중립 상수 0.5 라 composite 가중치 1.00 중 0.50 이 순위를
+        # 만들지 못한다. universe 모드는 #272 부터 있었는데 여기서 안 불러 도달 불가였다.
+        #
+        # `universe` 가 아니라 `all` 인 이유: universe.yaml 밖 보유 종목이 11개 있다
+        # (KODEX/TIGER 계열 등). `universe` 로 좁히면 오늘 갱신되던 그 11개를 잃는다 —
+        # 확장이어야지 교체여서는 안 된다.
+        #
+        # 비용은 `technical`(순수 계산) 과 달리 실제 네트워크다: KR 203종목이 KIS 순차
+        # 0.4s ≈ 81s + US 543종목 yfinance 10-thread. 주 1회 일요일 자정이라 감당된다.
         from nuri.collectors.fundamental import FundamentalCollector
 
-        return FundamentalCollector().run()
+        return FundamentalCollector().run(source="all")
     elif name == "factors":
         # 수집이 아니라 **분석** 단계다 (`_STAGE_OF_JOB` 에서 analyze). `_run_collector` 를
         # 재사용하는 건 그쪽이 예외 격리 · 실행 기록 · 스테이지 이벤트를 이미 갖고 있어서다.

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -52,11 +52,16 @@ class TestFreshnessPolicies:
         # `signals` 는 #1101 에서 추가 — 커버리지가 40종목(가격 753 대비)으로 넉 달을
         # 가고 오늘 run 이 무엇을 남기든 어떤 화면에도 안 떴다. RSI 가 BUY 점수의
         # 0.15 가중치인데 결측이라 전 종목 중립 상수 50 이었다.
+        # `fundamentals` 는 #1109 에서 추가 — composite 가중치 1.00 중 0.50(value+quality)이
+        # 이 테이블에서 나오는데 정책이 없어서, 주간 잡이 보유 18종목만 갱신하는 동안
+        # 나머지 ~728 종목이 얼마나 낡든 어떤 화면에도 안 떴다 (#1102 의 재료 쪽 절반).
         expected = {
             "prices",
             "factors",
             "signals",
             "signals_kr",
+            "fundamentals",
+            "fundamentals_kr",
             "macro_vix",
             "macro_fear_greed",
             "consensus",
@@ -339,6 +344,75 @@ class TestCheckFreshness:
         result = check_freshness("signals_kr", db_path=db_path)
         assert result["status"] == "PASS"
         assert "미구성" in result["message"]
+
+    def _seed_fundamentals(self, db_path, date: str, tickers):
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio, roe) VALUES (?, ?, 20.0, 0.15)",
+                [(t, date) for t in tickers],
+            )
+
+    def test_stale_fundamentals_surface_instead_of_going_unnoticed(self, db_path):
+        """낡은 펀더멘탈이 FAIL 로 뜬다 (#1109).
+
+        정책이 없던 시절엔 이 테이블이 100일 넘게 낡아도 아무 화면에 안 떴다. value·quality
+        는 여기서만 나오고 둘이 합쳐 composite 가중치의 **절반**이다 — 낡은 PE/PBR 로 만든
+        점수는 없는 것보다 나쁘다. 상수 0.5 는 변별력이 없다는 게 보이기라도 하지만, 100일
+        전 숫자로 만든 순위는 진짜 신호와 구분되지 않는다.
+
+        Mutation lock: `FRESHNESS_POLICIES` 에서 `fundamentals` 를 빼면 KeyError 로 FAIL.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now
+
+        old = (kst_now() - timedelta(days=40)).strftime("%Y-%m-%d")
+        self._seed_fundamentals(db_path, old, self._US)
+
+        result = check_freshness("fundamentals", db_path=db_path)
+        assert result["status"] == "FAIL"
+        assert result["label"] == "펀더멘탈 (US)"
+
+    def test_holding_only_writes_cannot_keep_fundamentals_green(self, db_path):
+        """보유 18종목만 갱신된 날은 신선한 것으로 안 친다 (#1109).
+
+        이게 이 정책의 존재 이유다. 맨 `MAX(date)` 였다면 프로덕션에서 실제로 벌어진 일 —
+        주간 잡이 18행을 쓰고 나머지 728 종목은 손도 안 댄 상태 — 이 초록으로 보고됐다.
+        커버리지 floor 가 그 18행을 신선함으로 세지 않는다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        self._seed_fundamentals(db_path, today_kst(), self._US[:18])
+
+        result = check_freshness("fundamentals", db_path=db_path)
+        assert result["status"] == "FAIL", "보유 종목만 갱신된 날이 신선함으로 통했다"
+
+    def test_a_dead_kr_slice_cannot_hide_behind_fresh_us_fundamentals(self, db_path):
+        """KR 이 통째로 비어도 US 가 신선하면 가려진다 — 그래서 시장별로 나눈다 (#1109).
+
+        KR 은 KIS 순차 경로라 자격 증명 만료 하나로 전면 실패할 수 있다. 합산 floor(멤버
+        746 의 60% = 448)는 US 543 만으로 넘으므로, 하나로 합쳤다면 KR 전멸이 PASS 로 보인다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        self._seed_fundamentals(db_path, today_kst(), self._US)
+
+        assert check_freshness("fundamentals", db_path=db_path)["status"] == "PASS"
+        assert check_freshness("fundamentals_kr", db_path=db_path)["status"] == "FAIL"
+
+    def test_thresholds_allow_a_full_weekly_cycle(self):
+        """임계가 주간 케이던스에 맞는다 (#1109).
+
+        이 잡은 일요일 00:00 주 1회다. 다음 실행 직전 **정상** 나이가 168h 이므로 48h WARN
+        이면 매주 6일이 빨갛고, 빨간 게 정상이면 아무도 안 본다 — 정책이 있으나 마나가 된다.
+        """
+        from nuri.core.freshness import FRESHNESS_POLICIES
+
+        for key in ("fundamentals", "fundamentals_kr"):
+            assert FRESHNESS_POLICIES[key]["warn_hours"] > 168, f"{key}: 주 1회 잡인데 WARN 이 한 주기보다 짧다"
 
     def test_full_coverage_today_passes(self, db_path):
         """정상 갱신은 통과 — 가드가 상시 FAIL 이면 아무도 안 본다."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1410,6 +1410,25 @@ class TestTechnicalCoversTheScoringUniverse:
 
         mock_collector.run.assert_called_once_with(source="all")
 
+    def test_fundamental_dispatch_expands_to_the_full_universe(self):
+        """펀더멘탈도 `source="all"` 로 부른다 — 기본값이면 보유 18종목이다 (#1109).
+
+        #1104 가 `technical` 에서 고친 것과 같은 결함이 한 계층 위에 남아 있었다. 이 주간
+        잡이 18종목만 갱신하니 `fundamentals` 가 나머지 ~728 종목에 대해 영영 안 채워지고,
+        그래서 value·quality 가 채점 대상의 99% 에서 중립 상수 0.5 였다 (#1102). composite
+        가중치 1.00 중 **0.50** 이 순위를 만들지 못한 이유다.
+
+        `universe` 가 아니라 `all` 인 것도 잠근다 — universe.yaml 밖 보유 종목이 있어서
+        `universe` 로 좁히면 오늘 갱신되던 종목을 잃는다. 확장이어야지 교체여선 안 된다.
+        """
+        from nuri.scheduler import _dispatch_collector
+
+        mock_collector = MagicMock()
+        with patch("nuri.collectors.fundamental.FundamentalCollector", return_value=mock_collector):
+            _dispatch_collector("fundamental")
+
+        mock_collector.run.assert_called_once_with(source="all")
+
     def test_stock_dispatches_return_the_saved_count(self):
         """일일 universe refresh 잡의 살아있음 증명이 `collector_runs.rows_collected` 다.
 


### PR DESCRIPTION
Closes #1109. Prerequisite for #1102 — see "Why this lands first".

## The scope gap

The weekly job dispatched the collector bare (`nuri/scheduler.py:188-191`), so `collect()`
took its `source="portfolio"` default and refreshed the **18 held tickers**. Nothing ever
touched the other ~728 universe tickers. Universe mode has existed since #272
(`nuri/collectors/base.py:161-167`); the scheduler just never asked for it.

That is the same shape #1104 found for `technical`, one layer upstream. The corrected sibling
sits 24 lines above at `scheduler.py:167`; `estimates` was fixed the same way at
`scheduler.py:823-829`. `fundamental` was the one left.

Evidence the universe-wide rows came from a person, not the scheduler: on the dev snapshot the
`fundamentals` write history is three ~740-row batches on **Tuesdays** (04-14 / 04-21 / 04-28),
then single digits, then nothing. The cron is Sunday. A Sunday cron cannot produce Tuesday
rows — those were manual `--source universe` runs, and the table stopped growing when the
person stopped typing it.

`source="all"` rather than `"universe"`: 11 held tickers are not in `universe.yaml`. Narrowing
to `universe` would drop names the job refreshes today. This has to be an expansion, not a swap.

## The observability gap

`fundamentals` had no freshness policy, so a table feeding **half** the composite weight
(value 0.25 + quality 0.25) could sit arbitrarily stale and appear on no screen — the same hole
#1071 documented for `factors` and #1101 closed for `signals`.

A bare `MAX(date)` would not have caught it, and this is the load-bearing design point: the
job's own 18-row writes pull the date forward, and the check goes green over 728 untouched
tickers. On the dev snapshot the 2026-04-29→05-04 writes were 6 to 9 rows each — exactly that
shape. So the policy uses the `signals` construction: universe-member `IN (...)` plus a 60%
coverage floor, split per market so a total KIS failure on the KR leg cannot hide behind fresh
US rows (a combined floor of 60% of 746 = 448 is cleared by the 543 US members alone).

Thresholds are 192h/360h rather than the 48h/120h the daily tables use. This job runs weekly,
so 168h is a *healthy* age; a 48h WARN would be red six days out of seven, and a gate that is
red when nothing is wrong is a gate nobody reads.

## Why this lands first

#1102 is "the factor composite has no spread". Its root cause is that `value.py`/`quality.py`
fall back to `get_tickers()` = the same 18 held tickers, so `composite.py` fills 0.5 for the
rest — measured, 763/773 for value and 766/773 for quality on the latest snapshot.

Widening those readers **first** would compute 735 tickers' value and quality from numbers
nothing refreshes. Unlike today's constant 0.5, that output is indistinguishable from real
cross-sectional signal downstream. Fix the scope and the policy, then widen the readers.

## Tests

`tests/core/test_freshness.py::TestCheckFreshness` — 4 new, and
`tests/test_scheduler.py::TestTechnicalCoversTheScoringUniverse::test_fundamental_dispatch_expands_to_the_full_universe`.

Mutation-verified rather than assumed (each mutation applied to the committed tree, tests run,
then reverted):

| mutation | result |
|---|---|
| `run(source="all")` → `run()` | `test_fundamental_dispatch_expands_to_the_full_universe` FAILS |
| coverage floor → bare `MAX(date)` | `test_holding_only_writes_cannot_keep_fundamentals_green` FAILS (returns PASS) |
| 192h/360h → 48h/120h | `test_thresholds_allow_a_full_weekly_cycle` FAILS (`assert 48 > 168`) |

Baseline re-confirmed green after restore: 171 passed.

## Risk to watch on the first scheduled run

The failure-rate guard (`base.py:19`, `MAX_FAILURE_RATE = 0.10`) was activated for this
collector on 2026-05-04 (`b3ad2e2`, #590) — after the last universe write in the dev snapshot,
so the universe path has never executed under that guard there. It is fail-safe (refuses to
save rather than writing a partial cross-section), but the first Sunday run is a live-fire test
of that interaction. The last universe batch saved 743 of 746, a 0.4% miss.

Cost moves from ~18 lookups to ~757: KR 203 through KIS sequentially at 0.4s
(`fundamental.py:353`) ≈ 81s, plus 543 US on yfinance at 10 threads (`fundamental.py:243`).
Weekly, Sunday midnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
