### PR TITLE
fix(quant): make the factor composite produce a ranking instead of a constant

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -746,6 +746,7 @@
     "signalperiod",
     "signum",
     "sizeup",
+    "skipna",
     "slowapi",
     "slowperiod",
     "sma",

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,330 collected across 335 files | |
+| **Backend tests** | 7,348 collected across 336 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,330 backend tests across 335 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,348 backend tests across 336 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,330 tests, 335 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,348 tests, 336 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,5 +1,9 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 <!-- END:nextjs-agent-rules -->

--- a/nuri/quant/factors/composite.py
+++ b/nuri/quant/factors/composite.py
@@ -72,14 +72,37 @@ def _effective_weights(fg_score: float | None) -> dict[str, float]:
 
 
 def compute_composite() -> pd.DataFrame:
-    """멀티팩터 합성 스코어 계산."""
+    """멀티팩터 합성 스코어 계산.
+
+    ## value/quality 도 **채점 대상 전체**에 대해 계산한다 (#1102)
+
+    이전엔 `compute_value()` / `compute_quality()` 를 인자 없이 불렀다. 그 둘은 티커가
+    없으면 `get_tickers()` = `SELECT DISTINCT ticker FROM portfolio` 로 떨어지므로
+    **보유 18종목**만 계산됐고, 나머지는 아래 0.5 대입을 받았다. 실측(2026-07-08, 773종목):
+    `value_score` 가 정확히 0.5 인 종목 **763**, `quality_score` 는 **766**. 센티먼트는
+    시장 지수라 설계상 전 종목 동일하므로, 가중치 1.00 중 **0.70 이 종목 간 상수**였고
+    순위를 만드는 건 momentum 0.30 하나였다. 항등식으로 확인된다 —
+    `composite == 0.30 * momentum + 0.33692` 가 763/773 종목에서 오차 5e-5 이내로 성립한다.
+    0.40 가중치짜리 "멀티팩터" 채널이 실은 두 번째 모멘텀 항이었다.
+
+    유니버스는 momentum 의 인덱스를 그대로 쓴다. `config/universe.yaml` 을 따로 읽으면
+    두 집합이 어긋나 (실측 23종목이 momentum 에만, 7종목이 yaml 에만) 그 차집합이 다시
+    0.5 대입을 받는다. momentum 인덱스 = 실제로 채점될 종목이므로 **구성상 불일치가 0** 이다.
+    """
     from nuri.quant.factors.momentum import compute_momentum
     from nuri.quant.factors.quality import compute_quality
     from nuri.quant.factors.value import compute_value
 
     momentum = compute_momentum()
-    value = compute_value()
-    quality = compute_quality()
+    if momentum.empty:
+        # 가격이 한 행도 없으면 채점할 대상이 없다. 여기서 끊지 않으면 아래 두 호출이
+        # 빈 리스트를 받고, 그 둘은 falsy 인자를 "미지정" 으로 보아 **보유 종목으로
+        # 되돌아간다** — 고치려던 바로 그 경로다.
+        return pd.DataFrame()
+
+    universe = list(momentum.index)
+    value = compute_value(tickers=universe)
+    quality = compute_quality(tickers=universe)
 
     # 센티먼트: Fear & Greed 기반 (전체 시장). 없으면 **지어내지 않고 뺀다** — 아래 참조.
     fg_score = _market_sentiment()
@@ -93,6 +116,9 @@ def compute_composite() -> pd.DataFrame:
 
     results = []
     for ticker in sorted(all_tickers):
+        # 0.5 대입은 **백분위 정규화 이후에야** 중립이다 (#1102). min-max 시절 확장된
+        # value 분포의 중앙값은 0.0923 이라 0.5 는 92 백분위였다 — fundamentals 가 없다는
+        # 이유만으로 상위 8% 에 앉았다. 백분위 척도에서는 0.5 가 정의상 중앙값이다.
         m = momentum.loc[ticker, "momentum_score"] if ticker in momentum.index else 0.5
         v = value.loc[ticker, "value_score"] if ticker in value.index else 0.5
         q = quality.loc[ticker, "quality_score"] if ticker in quality.index else 0.5

--- a/nuri/quant/factors/quality.py
+++ b/nuri/quant/factors/quality.py
@@ -14,16 +14,37 @@ logger = logging.getLogger(__name__)
 
 
 def _normalize_quality_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """단일 시장 내 ROE/영업이익률 min-max 정규화 (높을수록 높은 퀄리티)."""
+    """단일 시장 내 ROE/영업이익률 **백분위** 정규화 (높을수록 높은 퀄리티).
+
+    ## min-max 가 아닌 이유 (#1102) — `value.py` 와 같은 병, 다른 증상
+
+    극단값이 척도를 정한다. 실측(유니버스 확장 시뮬레이션): US `roe` 최댓값 84.57(MAS,
+    자본잠식 종목의 산술 부산물) 대 최솟값 −1.19 로 범위가 85.76 이라, 정상적인 ROE
+    0.153 이 **0.0156** 으로 정규화됐다 — US `roe_norm` 의 99.4% 가 [0, 0.1] 에 몰렸다.
+    반대편에서 `operating_margin_norm` 은 MSTR 의 −44.0 이 최솟값이라 p50 이 0.977 이었다.
+    거의-0 상수와 거의-1 상수의 평균은 **거의-0.5 상수** — #1102 의 증상이 유니버스를
+    넓혀도 그대로 살아남는 경로다.
+
+    ## 이전 구현의 두 번째 결함: `dropna()` 서브셋으로 대입
+
+    `valid = df[col].dropna()` 로 만든 시리즈를 `df[col + "_norm"]` 에 대입하면 인덱스
+    정렬 때문에 **결측 행에는 값이 아예 안 들어가고 NaN 이 남는다**. 그다음
+    `df[norm_cols].mean(axis=1)` 이 기본 `skipna=True` 라, 그 종목은 살아남은 컬럼
+    하나만으로 채점된다. 관측 1개의 평균은 관측 2개보다 분산이 2배라 꼬리를 독점한다:
+    MO 는 ROE 가 없다는 이유만으로 영업이익률 단독 채점을 받아 `quality_score = 1.0000`
+    이었고, ROE 가 실제로 있는 VICI 는 0.5035 였다. **결측이 곧 보너스**였고, 자본잠식
+    종목 31개 중 27개가 ROE 결측이라 `value.py` 의 클립 보너스와 같은 종목에 겹쳐 쌓였다.
+
+    그래서 여기서는 `where` 로 행 정렬을 유지하고, 중립값 대입은 평균 직전에 한 번만
+    한다(`compute_quality`). 미관측은 그 척도의 중앙값 0.5 로 — 백분위라 그게 실제 중립이다.
+    """
     for col in ["roe", "operating_margin"]:
         if col in df.columns:
-            valid = df[col].dropna()
-            if len(valid) > 1:
-                col_min, col_max = valid.min(), valid.max()
-                if col_max > col_min:
-                    df[col + "_norm"] = (valid - col_min) / (col_max - col_min)
-                else:
-                    df[col + "_norm"] = 0.5
+            valid = df[col].astype(float)
+            if valid.dropna().nunique() > 1:
+                df[col + "_norm"] = valid.rank(pct=True, na_option="keep")
+            else:
+                df[col + "_norm"] = 0.5
     return df
 
 
@@ -76,14 +97,16 @@ def compute_quality(tickers: list[str] | None = None, db_path=None) -> pd.DataFr
     df = pd.DataFrame(scores).T
 
     # 시장별(.KS=KR vs US) 정규화 — ROE/영업이익률 baseline 이 시장마다 달라 cross-market
-    # min-max 가 KR 종목을 왜곡한다. 각 시장 안에서만 정규화 (#757).
+    # 순위가 KR 종목을 왜곡한다. 각 시장 안에서만 정규화 (#757, 백분위로 바꾼 #1102 이후도 동일).
     is_kr = df.index.to_series().str.endswith(".KS")
     parts = [_normalize_quality_columns(sub.copy()) for sub in (df[is_kr], df[~is_kr]) if not sub.empty]
     df = pd.concat(parts)
 
     norm_cols = [c for c in df.columns if c.endswith("_norm")]
     if norm_cols:
-        df["quality_score"] = df[norm_cols].mean(axis=1)
+        # 미관측 측정치 → 그 척도의 중립값 0.5. `skipna` 로 관측된 것만 평균 내면
+        # 결측이 보너스가 된다 (`_normalize_quality_columns` 참조).
+        df["quality_score"] = df[norm_cols].fillna(0.5).mean(axis=1)
     else:
         df["quality_score"] = 0.5
 

--- a/nuri/quant/factors/value.py
+++ b/nuri/quant/factors/value.py
@@ -14,18 +14,37 @@ logger = logging.getLogger(__name__)
 
 
 def _normalize_value_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """단일 시장 내 PE/PB 역수 min-max 정규화 (낮은 PE/PB = 높은 가치 스코어)."""
+    """단일 시장 내 PE/PB **백분위** 정규화 (낮은 PE/PB = 높은 가치 스코어).
+
+    ## 왜 min-max 가 아니라 백분위인가 (#1102)
+
+    min-max 는 **양 끝값 2개에 앵커링**된다. PE/PBR 처럼 꼬리가 두꺼운 재무 비율에서는
+    한 종목이 전체 척도를 정하고 나머지가 뭉개진다. 실측(2026-07-08 스냅샷, 유니버스
+    확장 시뮬레이션): KR `pe_ratio_norm` 은 25종목이 1.0 에 고정되고 **나머지 194종목의
+    중앙값이 0.00045** 였다. 변별력이 0 인 컬럼이다.
+
+    앵커를 만든 건 이전 구현의 `1 / valid.clip(lower=0.01)` 이다. **음수 PE 는 0.01 로
+    클립돼 역수 100** 이 되므로 그 시장의 최댓값이 되고, 적자기업이 정의상 `_norm == 1.0`
+    = **가장 싼 종목**이 된다. 동시에 분모가 100 으로 벌어져 흑자기업 전부가 0 근처로
+    압축된다. 두 시장이 서로의 실패를 가렸다 — US 는 음수 PE 가 0, KR 은 음수 PB 가 0
+    이라 각자 다른 컬럼 하나씩만 죽어 있었다.
+
+    백분위는 극단값이 순위 하나만 차지하므로 이 앵커링이 원천적으로 없고, 분포가 [0,1]
+    에 균등해 **0.5 가 정의상 중앙값**이 된다 — `composite.py` 의 결측 중립값 대입이
+    비로소 실제로 중립이다 (min-max 시절 0.5 는 92 백분위였다).
+
+    비양수 PE/PB 는 **관측 불가**로 둔다(`NaN`). 적자기업은 "싼" 게 아니라 이 척도로
+    잴 수 없는 것이고, 음수를 최저가로 취급하면 위 반전이 그대로 돌아온다.
+    """
     for col in ["pe_ratio", "pb_ratio"]:
         if col in df.columns:
-            valid = df[col].dropna()
-            if len(valid) > 1:
-                inverted = 1 / valid.clip(lower=0.01)
-                col_min, col_max = inverted.min(), inverted.max()
-                if col_max > col_min:
-                    df[col + "_norm"] = (inverted - col_min) / (col_max - col_min)
-                else:
-                    df[col + "_norm"] = 0.5
+            # 비양수는 관측 불가 — dropna 가 아니라 where 로 걸러 **행 정렬을 유지**한다.
+            valid = df[col].where(df[col] > 0)
+            if valid.dropna().nunique() > 1:
+                # 부호 반전으로 방향만 뒤집는다 (낮은 PE = 높은 점수). 미관측은 NaN 유지.
+                df[col + "_norm"] = (-valid).rank(pct=True, na_option="keep")
             else:
+                # 관측이 0~1개거나 전부 동값 — 순위를 매길 수 없다. 중립.
                 df[col + "_norm"] = 0.5
     return df
 
@@ -77,15 +96,21 @@ def compute_value(tickers: list[str] | None = None, db_path=None) -> pd.DataFram
 
     df = pd.DataFrame(scores).T
 
-    # 시장별(.KS=KR vs US) 정규화 — PE/PB baseline 이 시장마다 달라 cross-market min-max 는
+    # 시장별(.KS=KR vs US) 정규화 — PE/PB baseline 이 시장마다 달라 cross-market 순위는
     # 저PE 시장(KR)을 구조적 고가치로 왜곡한다. 각 시장 안에서만 정규화 (#757).
+    # 백분위로 바꿔도(#1102) 이 분리는 그대로 필요하다: 합쳐서 순위를 매기면 KR 이
+    # 상위를 독식한다 — 척도만 바뀌었지 baseline 차이는 그대로다.
     is_kr = df.index.to_series().str.endswith(".KS")
     parts = [_normalize_value_columns(sub.copy()) for sub in (df[is_kr], df[~is_kr]) if not sub.empty]
     df = pd.concat(parts)
 
     norm_cols = [c for c in df.columns if c.endswith("_norm")]
     if norm_cols:
-        df["value_score"] = df[norm_cols].mean(axis=1)
+        # 미관측 측정치는 **그 척도의 중립값**으로 채운다 — 백분위 척도에서 중립값은
+        # 정의상 0.5(중앙값)다. `skipna` 로 관측된 컬럼만 평균 내면 관측 1개짜리 종목의
+        # 분산이 2개짜리의 2배가 되어 꼬리를 독점한다: 실측에서 ROE 결측 종목이 그
+        # 이유만으로 quality 1.0 을 받아 확장 후 1위였다 (같은 원리, quality.py 참조).
+        df["value_score"] = df[norm_cols].fillna(0.5).mean(axis=1)
     else:  # pragma: no cover — pe/pb 둘 다 None 인 row 는 위에서 skip 됨, dict 키 항상 양쪽 존재
         df["value_score"] = 0.5
 

--- a/scripts/verify/verify.py
+++ b/scripts/verify/verify.py
@@ -207,7 +207,29 @@ def verify_factors(report_dir: Path, summary: list[str]) -> None:
 
     top = df.index[0]
     top_score = df.iloc[0]["composite_score"]
-    summary.append(f"[OK] 팩터: {len(df)}종목, Top {top} ({top_score:.3f})")
+
+    # 변별력 검사 (#1102). 이 단계는 원래 종목 수와 1위 점수만 찍었고, 그 둘은 붕괴해도
+    # 멀쩡해 보인다 — value/quality 가 채점 대상의 99% 에서 상수 0.5 이던 넉 달 내내
+    # 여기는 초록이었다. 합성 스코어가 **순위를 만들지 못하면 그건 신호가 아니라 상수**이므로,
+    # 값의 정상 범위가 아니라 **퍼짐**을 본다.
+    #
+    # 임계 0.05: 붕괴 상태의 실측 p10~p90 은 0.0585 였고 그중 대부분이 momentum 단독
+    # 기여였다. 성분 하나만 살아 있어도 그 정도는 나온다는 뜻이라 그 위에 둔다.
+    # 부분 상수도 같이 본다 — 전체 폭은 momentum 이 떠받치고 성분 하나만 죽는 형태가
+    # 실제로 벌어진 일이라, 폭만 보면 그 절반을 놓친다.
+    spread = float(df["composite_score"].quantile(0.9) - df["composite_score"].quantile(0.1))
+    flat = [
+        col
+        for col in ("value_score", "quality_score", "momentum_score")
+        if len(df) > 1 and float(df[col].nunique()) / len(df) < 0.10
+    ]
+    if spread < 0.05 or flat:
+        why = f"p10~p90 폭 {spread:.4f}"
+        if flat:
+            why += f", 사실상 상수인 성분 {flat}"
+        summary.append(f"[FAIL] 팩터: {len(df)}종목이지만 변별력이 없다 ({why})")
+    else:
+        summary.append(f"[OK] 팩터: {len(df)}종목, Top {top} ({top_score:.3f}), p10~p90 폭 {spread:.4f}")
 
 
 def verify_backtest(report_dir: Path, summary: list[str]) -> None:

--- a/tests/quant/test_factors_composite.py
+++ b/tests/quant/test_factors_composite.py
@@ -42,6 +42,58 @@ class TestComposite:
             for score in result["composite_score"]:
                 assert 0 <= score <= 1
 
+    def test_unheld_tickers_are_scored_on_value_and_quality(self, db_path_mp):
+        """보유하지 않은 종목도 value/quality 를 실제로 받는다 (#1102).
+
+        이전엔 `compute_value()` / `compute_quality()` 를 인자 없이 불렀고, 그 둘은 티커가
+        없으면 `get_tickers()` = `SELECT DISTINCT ticker FROM portfolio` 로 떨어졌다.
+        그래서 **보유 종목만** 계산되고 나머지는 중립 0.5 대입을 받았다 — 실측 773종목 중
+        value 763 / quality 766 이 정확히 0.5 였다. 센티먼트는 시장 지수라 종목 간 상수이므로,
+        가중치 1.00 중 0.70 이 상수였고 순위를 만드는 건 momentum 0.30 하나였다.
+
+        이 테스트는 **채점 대상이 보유 종목보다 넓을 때** 그 차집합이 실제 점수를 받는지를
+        본다. 되돌리면 HELD 만 계산되고 나머지 둘이 0.5 로 떨어져 FAIL 한다.
+        """
+        from nuri.quant.factors.composite import compute_composite
+
+        tickers = ["HELD", "UNHELD1", "UNHELD2"]
+        for i, t in enumerate(tickers):
+            _seed_prices(db_path_mp, ticker=t, days=40, start_price=100.0 + i * 20)
+        _seed_portfolio(db_path_mp, [("HELD", 100.0, 10)])  # 셋 중 하나만 보유
+        with get_db(db_path_mp) as conn:
+            for i, t in enumerate(tickers):
+                conn.execute(
+                    "INSERT INTO fundamentals (ticker, date, pe_ratio, price_to_book, roe, operating_margin) "
+                    "VALUES (?,?,?,?,?,?)",
+                    (t, "2026-04-15", 10.0 + i * 15, 1.0 + i, 0.05 + i * 0.08, 0.10 + i * 0.15),
+                )
+
+        df = compute_composite()
+
+        assert set(tickers) <= set(df.index), f"채점 대상이 누락됐다: {set(df.index)}"
+        for t in ("UNHELD1", "UNHELD2"):
+            assert float(df.loc[t, "value_score"]) != 0.5, f"{t} 가 중립 대입으로 떨어졌다 (보유 종목만 계산됨)"
+            assert float(df.loc[t, "quality_score"]) != 0.5, f"{t} 가 중립 대입으로 떨어졌다"
+        assert df["composite_score"].nunique() > 1
+
+    def test_an_empty_price_table_does_not_fall_back_to_holdings(self, db_path_mp):
+        """가격이 없으면 빈 결과다 — 보유 종목으로 되돌아가지 않는다 (#1102).
+
+        `compute_value` / `compute_quality` 는 falsy 인자를 "미지정" 으로 보고 `get_tickers()`
+        로 떨어진다. momentum 이 비었을 때 그대로 빈 리스트를 넘기면 고치려던 그 경로가
+        되살아나, 가격이 하나도 없는데 보유 종목 점수만 담긴 스냅샷이 저장된다.
+        """
+        from nuri.quant.factors.composite import compute_composite
+
+        _seed_portfolio(db_path_mp, [("HELD", 100.0, 10)])
+        with get_db(db_path_mp) as conn:
+            conn.execute(
+                "INSERT INTO fundamentals (ticker, date, pe_ratio, roe) VALUES (?,?,?,?)",
+                ("HELD", "2026-04-15", 12.0, 0.2),
+            )
+
+        assert compute_composite().empty
+
     def test_compute_manual(self, factor_data):
         from nuri.quant.factors.composite import WEIGHTS
 

--- a/tests/quant/test_factors_quality.py
+++ b/tests/quant/test_factors_quality.py
@@ -86,6 +86,53 @@ class TestQualityDbRead:
         assert float(df.loc["NVDA", "quality_score"]) > float(df.loc["AAPL", "quality_score"])
         assert float(df.loc["AAPL", "quality_score"]) > float(df.loc["MSFT", "quality_score"])
 
+    def test_a_missing_roe_is_not_a_quality_bonus(self, db_path_mp):
+        """ROE 가 없다는 이유만으로 최고 퀄리티가 되지 않는다 (#1102).
+
+        이전 구현은 `valid = df[col].dropna()` 로 만든 시리즈를 `df[col + "_norm"]` 에
+        대입해서, 결측 행에는 값이 **안 들어가고 NaN 이 남았다**. 그다음
+        `mean(axis=1)` 이 기본 `skipna=True` 라 그 종목은 살아남은 컬럼 하나로만 채점됐다.
+        관측 1개의 평균은 2개보다 분산이 2배라 꼬리를 독점한다 — 실측에서 MO 는 ROE 결측
+        + 최고 영업이익률만으로 `quality_score = 1.0000` 이었고, ROE 가 실제로 있는
+        VICI 는 0.5035 였다. 자본잠식 종목 31개 중 27개가 ROE 결측이라 `value.py` 의
+        클립 보너스와 **같은 종목에 겹쳐** 쌓였고, 유니버스 확장 시뮬레이션에서 상위 25개가
+        전부 그 조합이었다.
+        """
+        from nuri.quant.factors.quality import compute_quality
+
+        rows = [(f"T{i:02d}", "2026-04-15", 0.05 + i * 0.02, 0.05 + i * 0.03) for i in range(10)]
+        rows.append(("NOROE", "2026-04-15", None, 0.99))  # 최고 마진, ROE 결측
+        self._seed_fundamentals(db_path_mp, rows)
+
+        df = compute_quality(tickers=[r[0] for r in rows])
+
+        assert float(df.loc["NOROE", "quality_score"]) < 1.0, "결측이 만점을 만들었다"
+        best_observed = df.drop(index="NOROE")["quality_score"].max()
+        assert float(df.loc["NOROE", "quality_score"]) <= best_observed + 0.13, (
+            "두 축을 다 관측한 최상위 종목보다 결측 종목이 크게 앞섰다"
+        )
+
+    def test_one_extreme_roe_does_not_flatten_everyone_else(self, db_path_mp):
+        """극단 ROE 하나가 나머지의 변별력을 지우지 않는다 (#1102).
+
+        실측: US `roe` 최댓값 84.57 (자본잠식 종목의 산술 부산물) 대 최솟값 −1.19 라
+        범위가 85.76 이 되어, 정상적인 ROE 0.153 이 0.0156 으로 정규화됐다 —
+        `roe_norm` 의 99.4% 가 [0, 0.1] 에 몰렸다. 거의-0 상수와 거의-1 상수의 평균은
+        거의-0.5 상수이므로, #1102 의 증상이 유니버스를 넓혀도 그대로 살아남는 경로였다.
+        """
+        from nuri.quant.factors.quality import compute_quality
+
+        rows = [(f"T{i:02d}", "2026-04-15", 0.05 + i * 0.02, 0.10 + i * 0.02) for i in range(10)]
+        rows.append(("BLOWUP", "2026-04-15", 84.57, 0.30))  # 자본잠식 부산물
+        self._seed_fundamentals(db_path_mp, rows)
+
+        df = compute_quality(tickers=[r[0] for r in rows])
+        normal = df.drop(index="BLOWUP")["roe_norm"]
+
+        assert normal.max() - normal.min() > 0.5, (
+            f"극단 ROE 하나가 나머지를 압축했다 (spread={normal.max() - normal.min():.4f})"
+        )
+
     def test_quality_reads_latest_date_per_ticker(self, db_path_mp):
         """동일 ticker 여러 날짜 → 가장 최신 row 만 사용."""
         from nuri.quant.factors.quality import compute_quality

--- a/tests/quant/test_factors_value.py
+++ b/tests/quant/test_factors_value.py
@@ -85,6 +85,76 @@ class TestValueDbRead:
         assert float(df.loc["AAPL", "value_score"]) > float(df.loc["MSFT", "value_score"])
         assert float(df.loc["MSFT", "value_score"]) > float(df.loc["NVDA", "value_score"])
 
+    def test_a_loss_maker_is_not_the_cheapest_stock(self, db_path_mp):
+        """음수 PE 가 최고 가치 점수를 받지 않는다 (#1102).
+
+        이전 구현은 `1 / valid.clip(lower=0.01)` 이라 **음수 PE 가 0.01 로 클립돼 역수 100**
+        = 그 시장의 최댓값이 됐다. 적자기업이 정의상 `pe_ratio_norm == 1.0`, 즉 가장 싼
+        종목이 됐고, 실측에서 비양수 PE 25종목이 예외 없이 1.0 이었다.
+        적자는 싼 게 아니라 이 척도로 **잴 수 없는 것**이다.
+        """
+        from nuri.quant.factors.value import compute_value
+
+        self._seed_fundamentals(
+            db_path_mp,
+            [
+                ("CHEAP", "2026-04-15", 8.0, 1.0),
+                ("MID", "2026-04-15", 25.0, 3.0),
+                ("RICH", "2026-04-15", 60.0, 8.0),
+                ("LOSS", "2026-04-15", -30.0, 4.0),  # 적자
+            ],
+        )
+        df = compute_value(tickers=["CHEAP", "MID", "RICH", "LOSS"])
+
+        assert float(df.loc["LOSS", "value_score"]) < float(df.loc["CHEAP", "value_score"]), (
+            "적자기업이 실제 저PE 종목보다 싸다고 채점됐다"
+        )
+        # 비양수 PE 는 컬럼 수준에서 **관측 불가(NaN)** 로 남고, 중립값 0.5 는 평균 직전에
+        # 한 번만 대입된다. 그래서 LOSS 의 value_score 는 (중립 + 실제 PB 순위)/2 다.
+        assert pd.isna(df.loc["LOSS", "pe_ratio_norm"]), "비양수 PE 가 관측값 행세를 했다"
+        assert float(df.loc["LOSS", "value_score"]) == pytest.approx(
+            (0.5 + float(df.loc["LOSS", "pb_ratio_norm"])) / 2, abs=1e-4
+        )
+
+    def test_one_extreme_outlier_does_not_flatten_everyone_else(self, db_path_mp):
+        """극단값 하나가 나머지의 변별력을 지우지 않는다 (#1102).
+
+        min-max 는 양 끝값 2개에 앵커링돼서, 한 종목이 척도를 정하면 나머지가 뭉개진다.
+        실측에서 KR `pe_ratio_norm` 은 그렇게 **중앙값 0.00045** 가 됐다 — 값이 틀린 게
+        아니라 순위를 만들지 못하는 값이라 화면 어디도 이상해 보이지 않았다.
+        백분위는 극단값이 순위 하나만 차지하므로 이 앵커링이 원천적으로 없다.
+        """
+        from nuri.quant.factors.value import compute_value
+
+        rows = [(f"T{i:02d}", "2026-04-15", 10.0 + i, 1.0 + i * 0.1) for i in range(10)]
+        rows.append(("MOON", "2026-04-15", 5000.0, 900.0))  # 극단값
+        self._seed_fundamentals(db_path_mp, rows)
+
+        df = compute_value(tickers=[r[0] for r in rows])
+        normal = df.drop(index="MOON")["value_score"]
+
+        assert normal.max() - normal.min() > 0.5, (
+            f"극단값 하나가 나머지를 압축했다 (spread={normal.max() - normal.min():.4f})"
+        )
+
+    def test_the_neutral_fill_sits_at_the_median(self, db_path_mp):
+        """미관측에 쓰는 0.5 가 실제로 중앙값이다 (#1102).
+
+        `composite.py` 는 value/quality 가 없는 티커에 0.5 를 채운다. min-max 시절 그 0.5
+        는 **92 백분위**여서, 데이터가 없다는 이유만으로 상위 8% 에 앉았다. 백분위 척도에서는
+        0.5 가 정의상 중앙값이라 그 대입이 비로소 중립이다.
+        """
+        from nuri.quant.factors.value import compute_value
+
+        rows = [(f"T{i:02d}", "2026-04-15", 5.0 + i * 3, 0.5 + i * 0.4) for i in range(21)]
+        self._seed_fundamentals(db_path_mp, rows)
+
+        df = compute_value(tickers=[r[0] for r in rows])
+
+        assert float(df["value_score"].median()) == pytest.approx(0.5, abs=0.05), (
+            f"중앙값이 0.5 가 아니다 ({df['value_score'].median():.4f}) — 0.5 대입이 중립이 아니게 된다"
+        )
+
     def test_kr_included_and_normalized_per_market(self, db_path_mp):
         """#757: KR(.KS) 도 value_score 를 받되 정규화는 시장별로 분리.
 

--- a/tests/scripts/test_verify_factor_dispersion.py
+++ b/tests/scripts/test_verify_factor_dispersion.py
@@ -1,0 +1,88 @@
+"""`verify_factors` 는 값의 범위가 아니라 **변별력**을 본다 (#1102).
+
+이 단계는 원래 종목 수와 1위 점수만 요약에 찍었다. 둘 다 붕괴 상태에서 멀쩡해 보인다 —
+`value_score` 가 채점 대상 773종목 중 763에서, `quality_score` 가 766에서 정확히 0.5 이던
+넉 달 내내 `[OK] 팩터: 773종목, Top 105560.KS (0.728)` 이 찍혔다. 틀린 숫자가 아니라
+**순위를 만들지 못하는 숫자**라 화면 어디도 이상해 보이지 않았다.
+
+합성 스코어의 존재 이유가 순위이므로, 게이트는 퍼짐을 봐야 한다.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _frame(composite, value=None, quality=None, momentum=None):
+    n = len(composite)
+    return pd.DataFrame(
+        {
+            "composite_score": composite,
+            "value_score": value if value is not None else np.linspace(0.05, 0.95, n),
+            "quality_score": quality if quality is not None else np.linspace(0.10, 0.90, n),
+            "momentum_score": momentum if momentum is not None else np.linspace(0.15, 0.85, n),
+        },
+        index=[f"T{i:03d}" for i in range(n)],
+    ).sort_values("composite_score", ascending=False)
+
+
+@pytest.fixture
+def run(tmp_path, monkeypatch):
+    def _run(df):
+        import nuri.quant.factors.composite as comp_mod
+        from scripts.verify import verify as vmod
+
+        # `verify_factors` 는 함수 **본문 안에서** import 하므로 매 호출마다 원본 모듈에서
+        # 다시 바인딩한다 — vmod 에 패치하면 아무 효과가 없다 (실제로 밟았다).
+        monkeypatch.setattr(comp_mod, "compute_composite", lambda: df)
+        monkeypatch.setattr(comp_mod, "print_composite", lambda _df: None)
+        summary: list[str] = []
+        vmod.verify_factors(tmp_path, summary)
+        return summary[0]
+
+    return _run
+
+
+class TestItMeasuresDiscriminationNotRange:
+    def test_a_collapsed_composite_fails(self, run):
+        """실측 붕괴 분포(p10~p90 = 0.0585)는 통과하면 안 된다.
+
+        되돌리면 이 프레임에서도 `[OK]` 가 나온다 — 그게 넉 달 동안 있었던 일이다.
+        """
+        line = run(_frame(np.linspace(0.4011, 0.4596, 200)))
+
+        assert line.startswith("[FAIL]"), line
+        assert "변별력" in line
+
+    def test_a_real_distribution_passes(self, run):
+        """수정 후 시뮬레이션 분포(p10~p90 = 0.2127)는 통과한다."""
+        line = run(_frame(np.linspace(0.3264, 0.5391, 200)))
+
+        assert line.startswith("[OK]"), line
+
+    def test_a_constant_component_fails_even_when_the_total_spread_looks_fine(self, run):
+        """폭만 보면 절반을 놓친다 — momentum 이 떠받치고 성분 하나만 죽는 형태 (#1102).
+
+        정확히 이 모양이었다: composite 는 momentum 덕에 퍼져 보였지만 value/quality 는
+        상수였다. 폭 단독 검사였다면 유니버스만 넓히고 정규화를 안 고친 중간 상태가
+        조용히 통과한다.
+        """
+        n = 200
+        line = run(_frame(np.linspace(0.30, 0.60, n), value=np.full(n, 0.5), quality=np.full(n, 0.5)))
+
+        assert line.startswith("[FAIL]"), line
+        assert "value_score" in line and "quality_score" in line
+
+    def test_an_empty_frame_is_skipped_not_failed(self, run):
+        """데이터가 없는 것과 변별력이 없는 것은 다르다."""
+        line = run(pd.DataFrame())
+
+        assert line.startswith("[SKIP]"), line
+
+    def test_a_single_ticker_does_not_trip_the_constant_check(self, run):
+        """종목이 1개면 어떤 성분이든 nunique 는 1 이다 — 그건 상수화가 아니라 표본 부족이다."""
+        line = run(_frame(np.array([0.42])))
+
+        assert "사실상 상수" not in line, line


### PR DESCRIPTION
Closes #1102. Rebased on top of #1110 (merged) — see "Ordering".

## What was actually wrong

Three defects, stacked. Each one alone would have been survivable; together they made the
0.40-weight factor channel a constant.

**1. Only held tickers were scored.** `compute_composite()` called `compute_value()` and
`compute_quality()` with no arguments, and both fall back to `get_tickers()` =
`SELECT DISTINCT ticker FROM portfolio` when given none. So 18 names were computed and the
rest took the neutral 0.5 fill. Measured on the 2026-07-08 snapshot of 773 scored tickers:
`value_score` was exactly 0.5 for **763**, `quality_score` for **766**.

Sentiment is a market index, identical for every ticker by design. So **0.70 of the weight was
a cross-sectional constant** and only momentum's 0.30 produced any ordering. The identity holds
to 5e-5 on 763 of 773 rows:

```
composite == 0.30 * momentum + 0.33692
```

The "multi-factor" channel was a second momentum term stacked on the emitter's 0.25
`momentum_5d` channel — two of four live channels, 65% of the BUY weight, carrying one signal.

**2. Min-max normalization inverted the value factor.** `1 / valid.clip(lower=0.01)` raises a
**negative** `pe_ratio` to 0.01, inverting it to 100 — by construction the market maximum. Every
loss-making company scored `pe_ratio_norm == 1.0`, the cheapest stock in its market, and the
denominator it created crushed everyone else. Measured: all 25 non-positive-PE tickers pinned at
exactly 1.0, and the remaining 194 KR names had a median `pe_ratio_norm` of **0.00045**. The two
markets hid each other — US has no negative PE, KR no negative PB, so each lost a different one
of its two value inputs and neither looked broken.

**3. Missing data was a bonus.** `quality.py` assigned norms from a `.dropna()` subset, so
missing rows stayed NaN and `mean(axis=1)` skipped them — scoring those tickers on one column.
One observation has twice the variance of two, so they monopolized the tail: **MO scored 1.0000
on a missing ROE while VICI, which reports one, scored 0.5035.** 27 of the 31 negative-equity
names collect this bonus *and* defect 2's at once.

Which is why **fixing only #1 makes the ranking worse.** Simulated: widening the universe with
the normalization untouched puts **25 of the top 25** on clip-and-fill artifacts (HPQ, MO, DELL,
MAS, CAH, PM, …) — every one of them a negative-book-equity name with no ROE.

## The fix

Percentile ranking within each market instead of min-max. An outlier occupies one rank, so it
cannot set the scale; and the distribution is uniform on [0,1], which makes **0.5 the median by
construction**. That is what finally justifies the neutral fill in `composite.py` — under min-max
the expanded value distribution had a median of 0.0923, so 0.5 was the **92nd percentile** and a
ticker with no fundamentals was placed in the top 8% for having no data.

Non-positive PE/PB is treated as unobserved rather than cheapest: a loss-maker is not
inexpensive, it is unmeasurable on that axis. Unobserved measurements are filled with the
neutral value of their own scale once, just before averaging, so a ticker with one observed
column no longer inherits double variance.

The universe is momentum's own index rather than a second read of `config/universe.yaml`. The
two sets do not match (23 tickers are in `prices` but not the yaml, 7 the other way) and every
ticker in the difference would land right back on the fill. Momentum's index is by definition
what gets scored, so the mismatch is zero by construction.

## Measured effect

Simulation against the 2026-07-08 snapshot, running the real functions:

| | p10 | p50 | p90 | **p10-p90** | std | top-25 artifacts |
|---|---|---|---|---|---|---|
| today | 0.4011 | 0.4407 | 0.4596 | **0.0585** | 0.0295 | — (nothing to rank) |
| naive universe widening only | — | — | — | — | 0.0618 | **25 / 25** |
| this PR | 0.3264 | 0.4442 | 0.5391 | **0.2127** | 0.0811 | **0 / 25** |

`value_score` and `quality_score` medians land at exactly 0.5000, so the neutral fill sits at
the 48th percentile instead of the 92nd. MO falls from #1 to #62; VICI, which reports the data,
rises to #7. The new top of the book is a coherent value tilt — insurers, utilities, banks, KR
financials — rather than a list of companies with negative book equity.

## What this PR does not do

The issue forbids two things and both are respected: no post-hoc rescaling of the distribution
(that redraws the same ordering wider without creating discrimination), and no weight tuning,
which is STRATEGY PR territory and needs a backtest. `WEIGHTS` is untouched.

The second half of the issue's liveness criterion — that top-ranked names actually separate from
the bottom in forward returns — is **not** established here and cannot be established by a unit
test. That needs walk-forward, and it is a separate question from "does this produce a ranking at
all", which is what #1102 was filed about.

One landmine found during this work is filed separately as **#1111**: `held_add`'s
`composite_score_min` gates are 75/75/80 against a score that has never exceeded 0.7279 in any
row `factors` has ever held, so they have never been reachable. This PR does not fix that and
slightly lowers the top of the distribution, so those gates stay shut either way.

## Ordering

#1110 (fundamentals collector scope + freshness policy) landed first, and this branch is rebased
on it. That order was not cosmetic: this PR widens the *readers*, and without #1110 the weekly
collector still refreshed only 18 tickers, so the newly computed scores for the other ~735 would
have come from numbers nothing updates. Unlike today's constant 0.5, that output is
indistinguishable from real signal downstream.

Note that the values only become genuinely current after the first Sunday run of the widened
collector. Until then the scores are real cross-sectional rankings computed on whatever vintage
`fundamentals` currently holds, and #1110's new freshness policy is what makes that vintage
visible rather than silent.

## Tests

Every lock was mutation-verified — mutation applied to the committed tree, tests run, reverted:

| mutation | test that fails |
|---|---|
| restore `1 / clip(lower=0.01)` | `test_a_loss_maker_is_not_the_cheapest_stock`, `test_one_extreme_outlier_does_not_flatten_everyone_else`, `test_the_neutral_fill_sits_at_the_median` |
| quality back to `.dropna()` assign + skipna mean | `test_a_missing_roe_is_not_a_quality_bonus` |
| quality back to min-max | `test_one_extreme_roe_does_not_flatten_everyone_else` |
| `compute_value()` / `compute_quality()` called bare again | `test_unheld_tickers_are_scored_on_value_and_quality` |
| drop the empty-momentum early return | `test_an_empty_price_table_does_not_fall_back_to_holdings` |
| remove the dispersion gate | `test_a_collapsed_composite_fails`, `test_a_constant_component_fails_even_when_the_total_spread_looks_fine` |
| dispersion gate checks spread only | `test_a_constant_component_fails_even_when_the_total_spread_looks_fine` |

The last one matters most. `verify_factors` previously reported `len(df)` and the top score, and
both look healthy during a total collapse — it printed `[OK] 팩터: 773종목, Top 105560.KS (0.728)`
every run for four months. It now measures p10-p90 spread **and** per-component distinctness,
because the real failure had momentum holding the total width up while value and quality were
constants underneath. Spread alone would let a half-landed fix through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
