### PR TITLE
fix(quant): stop treating a four-month-old RSI as the current value

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,348 collected across 336 files | |
+| **Backend tests** | 7,353 collected across 336 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,348 backend tests across 336 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,353 backend tests across 336 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,348 tests, 336 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,353 tests, 336 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/factors/momentum.py
+++ b/nuri/quant/factors/momentum.py
@@ -4,12 +4,58 @@ import pandas as pd
 
 from nuri.core.db import query_df
 
+#: RSI 를 "현재값" 으로 인정하는 최대 나이 (일). `buy_candidate_emitter._get_rsi_snapshot`
+#: 과 같은 값이다 (#1104) — 같은 테이블의 같은 컬럼을 읽는 두 소비자가 서로 다른 나이를
+#: 현재로 치면, 같은 종목이 팩터에서는 신선하고 emitter 에서는 낡은 상태가 된다.
+#: 낡은 RSI 를 쓰는 것과 없는 값을 중립 50 으로 치는 것 사이의 절충이고, 컷오프가 없으면
+#: 상장폐지·수집중단 종목의 마지막 RSI 가 영원히 현재값 행세를 한다.
+RSI_MAX_AGE_DAYS = 7
+
+
+def _rsi_snapshot() -> dict[str, float]:
+    """티커별 최신 RSI(14) — `RSI_MAX_AGE_DAYS` 보다 낡은 값은 버린다 (#1073).
+
+    이전엔 루프 안에서 티커마다
+    `SELECT rsi_14 FROM signals WHERE ticker = ? ORDER BY date DESC LIMIT 1` 을 돌렸다.
+    **나이 제한이 없어서** `technical` 이 멈춘 종목의 마지막 RSI 가 무기한 현재값
+    행세를 했다 — dev 스냅샷 실측(2026-08-14 기준): signals 를 가진 46종목 중 **29종목**이
+    7일보다 낡았고, 가장 낡은 값은 **128일** 전이었다. 이 값은 모멘텀의 0.3 성분이고
+    모멘텀은 다시 composite 의 0.30 이므로 BUY 점수의 9% 를 낡은 값이 만든다.
+
+    전역 `MAX(date)` 하루치로 좁히지 않는 이유는 emitter 쪽과 같다: KR 은 KST 당일,
+    US 는 전일로 signals 날짜가 갈라져 최신 하루만 고르면 한 시장이 통째로 빠진다.
+
+    `rsi_14 IS NOT NULL` 이 여기서 새로 필요하다. 행이 하나면 pandas 가 NULL 을 객체
+    `None` 으로 주지만(그래서 이전 코드는 우연히 안전했다), 여러 행을 한 번에 읽으면
+    컬럼이 float64 가 되어 NULL 이 **NaN** 이 된다. `bool(nan) is True` 라 결측 검사를
+    통과하고 NaN 이 momentum_score → composite_score 로 전파돼 NULL 로 저장된다.
+
+    컷오프는 KST 로 계산해 파라미터로 넘긴다 — SQLite 의 `date('now')` 는 UTC 라 아침
+    배치 시간대(09:00 KST 이전)에 하루 느슨해진다.
+    """
+    from datetime import timedelta
+
+    from nuri.core.timezone import kst_now
+
+    cutoff = (kst_now() - timedelta(days=RSI_MAX_AGE_DAYS)).strftime("%Y-%m-%d")
+    df = query_df(
+        """SELECT ticker, rsi_14, MAX(date) AS date FROM signals
+           WHERE date >= ? AND rsi_14 IS NOT NULL
+           GROUP BY ticker""",
+        (cutoff,),
+    )
+    if df.empty:
+        return {}
+    return {str(row["ticker"]): float(row["rsi_14"]) for _, row in df.iterrows()}
+
 
 def compute_momentum(tickers: list[str] | None = None) -> pd.DataFrame:
     """종목별 모멘텀 스코어 계산 (0~1 정규화)."""
     prices = query_df("SELECT ticker, date, close FROM prices ORDER BY date")
     if prices.empty:
         return pd.DataFrame()
+
+    rsi_map = _rsi_snapshot()
 
     pivot = prices.pivot_table(index="date", columns="ticker", values="close")
     if tickers:
@@ -24,12 +70,12 @@ def compute_momentum(tickers: list[str] | None = None) -> pd.DataFrame:
         # 기간 수익률 (데이터 전체)
         period_return = (s.iloc[-1] / s.iloc[0]) - 1
 
-        # RSI 기반 모멘텀 (signals 테이블에서)
-        rsi_rows = query_df(
-            "SELECT rsi_14 FROM signals WHERE ticker = ? ORDER BY date DESC LIMIT 1",
-            (ticker,),
-        )
-        rsi = rsi_rows.iloc[0]["rsi_14"] if not rsi_rows.empty and rsi_rows.iloc[0]["rsi_14"] else 50
+        # RSI 기반 모멘텀 (signals 테이블에서). 없거나 낡았으면 중립 50.
+        # `or 50` 이 아니라 `is None` 인 이유: RSI 0.0 은 falsy 라서 `or` 로 쓰면 실제
+        # 관측값이 조용히 50 으로 덮인다 (이전 코드가 그랬다).
+        rsi = rsi_map.get(ticker)
+        if rsi is None:
+            rsi = 50
 
         # 52주(또는 가용 데이터) 고점 대비 %
         high_52w = s.max()

--- a/tests/quant/test_factors_momentum.py
+++ b/tests/quant/test_factors_momentum.py
@@ -1,4 +1,5 @@
 """Tests for factors_momentum — split from test_quant_all.py."""
+
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -23,6 +24,7 @@ class TestMomentum:
 
     def test_compute_with_data(self, factor_data):
         from nuri.quant.factors.momentum import compute_momentum
+
         result = compute_momentum()
         assert not result.empty
         assert "momentum_score" in result.columns
@@ -31,21 +33,141 @@ class TestMomentum:
 
     def test_empty_db(self, db_path_mp):
         from nuri.quant.factors.momentum import compute_momentum
+
         result = compute_momentum()
         assert result.empty
 
     def test_with_tickers_filter(self, factor_data):
         from nuri.quant.factors.momentum import compute_momentum
+
         result = compute_momentum(tickers=["AAPL"])
         assert len(result) <= 1
 
+    def _seed_signals(self, db_path, rows):
+        """rows: list of (ticker, date, rsi_14)."""
+        with get_db(db_path) as conn:
+            conn.executemany("INSERT INTO signals (ticker, date, rsi_14) VALUES (?,?,?)", rows)
+
+    def _seed_bars(self, db_path, ticker, days=30):
+        dates = pd.bdate_range(end=kst_now().date(), periods=days)
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES (?,?,?,?,?,?,?)",
+                [(ticker, d.strftime("%Y-%m-%d"), 100, 101, 99, 100 + i * 0.5, 1000) for i, d in enumerate(dates)],
+            )
+
+    def test_a_stale_rsi_is_not_treated_as_the_current_value(self, db_path_mp):
+        """`RSI_MAX_AGE_DAYS` 보다 낡은 RSI 는 중립 50 으로 떨어진다 (#1073).
+
+        이전 쿼리는 `ORDER BY date DESC LIMIT 1` 로 **나이 제한 없이** 마지막 행을 집었다.
+        `technical` 이 멈춘 종목의 마지막 RSI 가 무기한 현재값 행세를 했고, dev 스냅샷
+        실측에서 signals 를 가진 46종목 중 29종목이 7일보다 낡았으며 가장 낡은 값은
+        128일 전이었다. RSI 는 모멘텀의 0.3, 모멘텀은 composite 의 0.30 이므로 BUY 점수의
+        9% 를 그 값이 만든다.
+        """
+        from nuri.quant.factors.momentum import compute_momentum
+
+        self._seed_bars(db_path_mp, "STALE")
+        old = (kst_now() - timedelta(days=90)).strftime("%Y-%m-%d")
+        self._seed_signals(db_path_mp, [("STALE", old, 95.0)])
+
+        df = compute_momentum()
+
+        assert float(df.loc["STALE", "rsi_14"]) == 50, "90일 낡은 RSI 가 현재값으로 쓰였다"
+
+    def test_a_fresh_rsi_is_used(self, db_path_mp):
+        """컷오프 안쪽 값은 그대로 쓴다 — 위 테스트가 전부를 50 으로 만드는 걸로 통과하면 안 된다."""
+        from nuri.quant.factors.momentum import compute_momentum
+
+        self._seed_bars(db_path_mp, "FRESH")
+        recent = (kst_now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        self._seed_signals(db_path_mp, [("FRESH", recent, 95.0)])
+
+        df = compute_momentum()
+
+        assert float(df.loc["FRESH", "rsi_14"]) == 95.0
+
+    def test_an_rsi_of_zero_is_an_observation_not_a_missing_value(self, db_path_mp):
+        """RSI 0.0 이 중립 50 으로 덮이지 않는다 (#1073).
+
+        이전 코드는 `... if not rows.empty and rows.iloc[0]["rsi_14"] else 50` 였다.
+        `bool(0.0) is False` 라 실제 관측값 0 이 조용히 50 으로 바뀐다 — 방향이 정반대인
+        값이라, 최악의 과매도 종목이 중립으로 보고된다.
+        """
+        from nuri.quant.factors.momentum import compute_momentum
+
+        self._seed_bars(db_path_mp, "ZERO")
+        recent = (kst_now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        self._seed_signals(db_path_mp, [("ZERO", recent, 0.0)])
+
+        df = compute_momentum()
+
+        assert float(df.loc["ZERO", "rsi_14"]) == 0.0, "관측된 RSI 0 이 50 으로 덮였다"
+
+    def test_a_null_rsi_does_not_poison_the_score_with_nan(self, db_path_mp):
+        """NULL rsi_14 가 NaN 으로 점수에 전파되지 않는다 (#1073).
+
+        배치 조회로 바꾸면 컬럼이 float64 가 되어 NULL 이 NaN 이 된다. `bool(nan) is True`
+        라 결측 검사를 통과하고, NaN 은 정규화를 거쳐 momentum_score 로, 다시
+        composite_score 로 전파돼 NULL 로 저장된다. 단일 행이던 이전 코드는 pandas 가
+        객체 `None` 을 주는 덕에 **우연히** 안전했다 — 그 우연에 기대지 않는다.
+        """
+        from nuri.quant.factors.momentum import compute_momentum
+
+        recent = (kst_now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        for t in ("NULLRSI", "OTHER"):
+            self._seed_bars(db_path_mp, t)
+        self._seed_signals(db_path_mp, [("NULLRSI", recent, None), ("OTHER", recent, 60.0)])
+
+        df = compute_momentum()
+
+        assert float(df.loc["NULLRSI", "rsi_14"]) == 50
+        assert not bool(df["momentum_score"].isna().any()), "NaN 이 momentum_score 로 전파됐다"
+
+    def test_rsi_is_read_in_one_query_not_one_per_ticker(self, db_path_mp):
+        """N+1 방지 — 티커 수와 무관하게 signals 조회는 1회다 (#1073).
+
+        이전엔 루프 안에서 티커마다 조회했다. 유니버스가 18종목이던 시절엔 안 보였지만
+        #1104 이후 채점 대상이 750종목대라 매 실행 750 왕복이 된다.
+        """
+        import nuri.quant.factors.momentum as mom
+
+        for t in ("A", "B", "C"):
+            self._seed_bars(db_path_mp, t)
+        recent = (kst_now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        self._seed_signals(db_path_mp, [(t, recent, 55.0) for t in ("A", "B", "C")])
+
+        calls = []
+        original = mom.query_df
+
+        def counting(sql, *args, **kwargs):
+            calls.append(sql)
+            return original(sql, *args, **kwargs)
+
+        with patch.object(mom, "query_df", counting):
+            mom.compute_momentum()
+
+        signal_queries = [c for c in calls if "signals" in c]
+        assert len(signal_queries) == 1, f"signals 를 {len(signal_queries)}회 조회했다"
+
     def test_insufficient_data(self, db_path_mp):
-        prices = pd.DataFrame([{
-            "ticker": "SHORT", "date": f"2024-01-{i+1:02d}",
-            "open": 100, "high": 101, "low": 99, "close": 100,
-            "volume": 1000, "adj_close": 100,
-        } for i in range(5)])
+        prices = pd.DataFrame(
+            [
+                {
+                    "ticker": "SHORT",
+                    "date": f"2024-01-{i + 1:02d}",
+                    "open": 100,
+                    "high": 101,
+                    "low": 99,
+                    "close": 100,
+                    "volume": 1000,
+                    "adj_close": 100,
+                }
+                for i in range(5)
+            ]
+        )
         upsert_prices(prices, db_path_mp)
         from nuri.quant.factors.momentum import compute_momentum
+
         result = compute_momentum()
         assert "SHORT" not in result.index if not result.empty else True


### PR DESCRIPTION
Closes #1073.

## What was left

#1073 asked for two things. The **policy** half landed in #1101/#1104 — `signals` and
`signals_kr` are registered in `FRESHNESS_POLICIES` with a universe-member coverage floor. The
**consumer** half, which is the part the issue actually names (`momentum.py:28`), did not.

`momentum.py` still read:

```sql
SELECT rsi_14 FROM signals WHERE ticker = ? ORDER BY date DESC LIMIT 1
```

No age limit at all. When `technical` stops for a ticker, its last RSI impersonates the current
value indefinitely — which is precisely the case the issue said the policy alone would not
cover, because a stalled `technical` leaves the price date advancing while RSI freezes.

Measured on the dev snapshot at 2026-08-14: of the 46 tickers with signals rows, **29 were
older than 7 days**, and the oldest value momentum would have picked up was **128 days** old.

| latest signals date | tickers |
|---|---|
| 2026-08-14 | 17 |
| 2026-08-03 | 1 |
| 2026-07-31 | 4 |
| 2026-05-27 | 2 |
| 2026-05-26 | 2 |
| 2026-04-30 → 04-16 | 9 |

RSI is 0.3 of the momentum factor and momentum is 0.30 of the composite, so stale values were
producing 9% of the BUY score.

## The dating precondition the issue asked about

The issue said to confirm `signals.date` is a market date before writing any policy against it,
since a write-date would launder staleness the way #1071 described. **It is a market date** —
`nuri/collectors/technical.py:93` stamps `prices.iloc[last_idx]["date"]`, the ticker's last
price bar. So no dating fix was needed first.

## Two adjacent bugs in the same four lines

**An observed RSI of 0.0 was rewritten to 50.** The guard was
`rsi_rows.iloc[0]["rsi_14"] if ... and rsi_rows.iloc[0]["rsi_14"] else 50`, and `bool(0.0)` is
False. That is not a rounding error: 0 and 50 sit at opposite ends of the scale, so the most
oversold name in the market would report as neutral. No row currently has RSI 0.0, so this is a
latent bug rather than an active one, but it costs nothing to close.

**A NULL RSI would have poisoned the score with NaN — but only after this change.** Worth being
precise, because the audit that surfaced it stated it more strongly than the code supports. With
the old single-row query, pandas returns an object-dtype `None`, which is falsy and fell through
to 50 correctly. The old code was *accidentally* safe. Batching the read makes the column
float64, where NULL becomes NaN, and `bool(nan)` is True — it would pass the guard and propagate
into `momentum_score` and on into `composite_score`, saved as NULL. So `rsi_14 IS NOT NULL` is
not fixing an existing bug; it is refusing to introduce one.

## The fix

One grouped query with a 7-day cutoff, `rsi_14 IS NOT NULL`, and `is None` rather than falsy
semantics for the neutral fallback.

The cutoff is 7 days to match `buy_candidate_emitter._get_rsi_snapshot` (#1104). Two consumers
of the same column disagreeing about what counts as current is its own defect — the same ticker
would be fresh in the factor and stale in the emitter.

The N+1 also goes: one query instead of one per ticker. Invisible at 18 tickers; after #1104 the
scoring universe is in the 750s.

## Tests

`tests/quant/test_factors_momentum.py` — 5 new, each mutation-verified against the committed
tree:

| mutation | test that fails |
|---|---|
| `RSI_MAX_AGE_DAYS` 7 → 100000 | `test_a_stale_rsi_is_not_treated_as_the_current_value` |
| drop `AND rsi_14 IS NOT NULL` | `test_a_null_rsi_does_not_poison_the_score_with_nan` |
| `is None` → `or 50` | `test_an_rsi_of_zero_is_an_observation_not_a_missing_value` |
| restore the per-ticker query in the loop | `test_rsi_is_read_in_one_query_not_one_per_ticker` |

`test_a_fresh_rsi_is_used` is the paired positive — without it the staleness test would pass
under an implementation that returns 50 for everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
