### PR TITLE
fix(recommend): feed held_add the fused BUY score its gates were written for

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,353 collected across 336 files | |
+| **Backend tests** | 7,356 collected across 336 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,353 backend tests across 336 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,356 backend tests across 336 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,353 tests, 336 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,356 tests, 336 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -631,6 +631,8 @@ def _run_held_add_shadow():
             _get_price_signals,
             _get_regime,
             _get_rsi_snapshot,
+            _load_config,
+            _score_ticker,
         )
         from nuri.trading.recommend.held_add import emit_held_add_shadow
 
@@ -638,10 +640,36 @@ def _run_held_add_shadow():
         rsi_map = _get_rsi_snapshot()
         prices = _get_price_signals()
         regime, vix = _get_regime()
+        weights = _load_config().get("weights", {})
 
         def _score(t: str) -> float:
-            f = factors.get(t)
-            return float((f or {}).get("composite", 0.0)) * 100.0
+            """held_add 게이트가 받는 점수 — emitter 와 **같은 0-100 융합 점수** (#1111).
+
+            이전엔 `composite * 100` 을 넘겼다. 그런데 게이트 임계는 75/75/80 이고
+            (`buy_signals.yaml:148,161,173`) raw composite 는 대략 [0.20, 0.73] 에 산다 —
+            `factors` 가 지금까지 가진 **모든 행**을 통틀어 `composite_score >= 0.75` 인
+            행은 0건이고 역대 최댓값은 0.7279 였다. 즉 세 게이트 모두 한 번도 열린 적이
+            없고, `held_add_shadow` 가 2행인 게 그 증거다.
+
+            75/80 이라는 숫자는 애초에 emitter 의 융합 0-100 점수를 겨냥해 쓰인 값이다
+            (같은 파일의 `quality_bar.base_threshold: 70` 과 같은 척도). 그러니 고칠 것은
+            임계가 아니라 **넘기는 값**이다 — 임계를 재도출하면 백테스트 없이 숫자를
+            지어내는 셈이고, 그건 이 레포가 금지하는 쪽이다.
+
+            `_score_ticker` 는 순수 함수고 필요한 입력(factor·price·rsi·weights)이 이미
+            여기 다 있다. 결측 소스는 그쪽에서 중립 50 으로 처리하므로, 데이터가 부분적인
+            보유 종목도 점수를 받는다.
+            """
+            factor = factors.get(t)
+            if not factor:
+                # 팩터 행이 아예 없으면 **평가 불가 → 0**. `_score_ticker` 는 결측 소스를
+                # 중립 50 으로 메우지만(부분 데이터가 신규 후보를 막지 않게 하려는 규약),
+                # held_add 는 **이미 가진 포지션에 자본을 더 넣는** 결정이라 "모른다" 를
+                # 중립으로 치면 안 된다. 이전 동작도 0.0 이었고 그 의미는 유지한다.
+                return 0.0
+
+            score, _sources = _score_ticker(t, factor, prices.get(t) or {}, rsi_map.get(t), weights)
+            return float(score)
 
         def _rsi(t: str) -> float | None:
             return rsi_map.get(t)

--- a/tests/test_scheduler_branches.py
+++ b/tests/test_scheduler_branches.py
@@ -318,18 +318,23 @@ class TestRunHeldAddShadow:
         """Lines 272-312: providers built from collectors, passed into emit_held_add_shadow,
         n_emit/n_skip/shadow_mode logged.
 
-        The behavioral lock here: the score provider must multiply factor composite
-        by 100 (line 288). If a regression drops `* 100.0`, the captured score for
-        AAA differs from the expected 42.0.
+        The behavioral lock here: the score provider hands `held_add` the emitter's
+        **fused 0-100 score**, not `composite * 100` (#1111). The gates it feeds are
+        75/75/80, which are numbers on the fused scale (`quality_bar.base_threshold: 70`
+        lives on the same one). Raw composite tops out around 0.73, so on that scale the
+        gates were unreachable — zero rows in `factors` have ever had
+        `composite_score >= 0.75`.
         """
         import logging
 
         from nuri.scheduler import _run_held_add_shadow
 
         # Snapshot returned by buy_candidate_emitter helpers
-        factors = {"AAA": {"composite": 0.42}}  # 0.42 → expect score 42.0
+        factors = {"AAA": {"composite": 0.42}}
         rsi_map = {"AAA": 65.0}
-        prices = {"AAA": {"ret_5d": 0.03}}  # 3% 5d return → sector_mom proxy
+        # ret_5d 는 퍼센트 단위다 (`sector_momentum_min: 5` 가 같은 값을 읽는다).
+        # 0.03 은 3% 가 아니라 0.03% 이지만, 이 픽스처가 잠그는 건 배선이지 단위가 아니다.
+        prices = {"AAA": {"ret_5d": 0.03}}  # sector_mom proxy 로도 그대로 흐른다
 
         # Capture the providers passed into emit_held_add_shadow
         captured: dict = {}
@@ -374,10 +379,20 @@ class TestRunHeldAddShadow:
         ):
             _run_held_add_shadow()
 
-        # Behavioral assertions: providers wired correctly
-        assert captured["score"] == pytest.approx(42.0), (
-            "score provider must multiply factor composite by 100 (line 288)"
+        # Behavioral assertions: providers wired correctly.
+        #
+        # 42.0 (= composite × 100) 이 아니라 융합 점수를 기대한다. 성분별로:
+        #   factor    0.42 → 42.00 × 0.40 = 16.8000
+        #   momentum  50 + 0.03×5 = 50.15 × 0.25 = 12.5375
+        #   rsi       65 → 70 + 15×0.67 = 80.05 × 0.15 = 12.0075
+        #   breakout  없음 → 70.00 × 0.20 = 14.0000
+        #                                   ─────────
+        #                                     55.3450
+        # 합계만 잠그면 성분 하나가 틀려도 다른 하나가 상쇄해 통과할 수 있어 성분을 적어둔다.
+        assert captured["score"] == pytest.approx(55.345), (
+            "score provider 가 emitter 의 융합 0-100 점수를 넘겨야 한다 (#1111)"
         )
+        assert captured["score"] != pytest.approx(42.0), "raw composite×100 척도로 되돌아갔다"
         assert captured["rsi"] == 65.0
         assert captured["regime"] == ("BULL", 18.5)
         # sector_mom proxy = ret_5d (line 299)
@@ -389,10 +404,12 @@ class TestRunHeldAddShadow:
         assert "shadow=True" in msgs
 
     def test_score_provider_handles_missing_factor(self):
-        """Line 287-288: factors.get(t) returning None → composite default 0.0 → score 0.0.
+        """팩터 행이 없는 티커는 0.0 — 중립이 아니라 **평가 불가** 다 (#1111).
 
-        The (f or {}).get pattern guards against None. If revert to factors[t]['composite'],
-        an unknown ticker raises KeyError.
+        `_score_ticker` 는 결측 소스를 중립 50 으로 메운다. 신규 후보 채점에서는 맞는
+        규약이지만(부분 데이터가 후보를 막지 않게), held_add 는 이미 가진 포지션에
+        자본을 더 넣는 결정이라 "모른다" 를 중립으로 치면 안 된다. 그대로 통과시켰다면
+        팩터가 하나도 없는 종목이 54.0 을 받는다.
         """
         from nuri.scheduler import _run_held_add_shadow
 
@@ -426,8 +443,7 @@ class TestRunHeldAddShadow:
         ):
             _run_held_add_shadow()
 
-        # 0.0 = explicit default from `(f or {}).get("composite", 0.0)`
-        assert captured["unknown"] == 0.0
+        assert captured["unknown"] == 0.0, "팩터 없는 티커가 중립 점수를 받았다"
 
     def test_exception_swallowed(self, caplog):
         """Lines 313-314: any exception inside the closure → ERROR log, not raise."""

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -969,6 +969,75 @@ class TestGetRealAccountsHeldAdd:
         assert isinstance(result, set)
 
 
+class TestTheGatesAreReachable:
+    """`composite_score_min` 이 도달 가능한 값인지 잠근다 (#1111).
+
+    이 파일의 다른 테스트는 전부 `score_provider=lambda t: 85.0` 처럼 점수를 **주입**한다.
+    분기가 도는지는 증명하지만 그 점수가 프로덕션에서 나올 수 있는지는 묻지 않는다.
+    실제로는 나올 수 없었다: 게이트는 75/75/80 인데 넘어오던 값이 `composite * 100` 이었고,
+    `factors` 가 가진 모든 행을 통틀어 `composite_score >= 0.75` 인 행이 **0건**,
+    역대 최댓값이 0.7279 였다. 초록 테스트 · 죽은 게이트 · `held_add_shadow` 2행.
+
+    그래서 여기서는 주입하지 않고 emitter 의 실제 채점 함수를 돌려 도달 가능성을 본다.
+    """
+
+    def _weights(self):
+        from nuri.trading.recommend.buy_candidate_emitter import _load_config
+
+        return _load_config().get("weights", {})
+
+    def _fuse(self, composite, ret_5d, rsi, breakout):
+        from nuri.trading.recommend.buy_candidate_emitter import _score_ticker
+
+        score, _ = _score_ticker(
+            "T",
+            {"composite": composite},
+            {"ret_5d": ret_5d, "breakout_pct": breakout},
+            rsi,
+            self._weights(),
+        )
+        return score
+
+    #: 수정 후 실측 분포 (2026-07-08 스냅샷, 773종목): p50 0.4442 · p90 0.5391 · max 0.6279.
+    #: p90 근방을 "현실적 강세" 로 잡는다 — max 를 쓰면 도달성 증명이 단 한 종목에 기댄다.
+    REALISTIC_STRONG_COMPOSITE = 0.55
+
+    def test_a_realistic_strong_setup_clears_the_75_gates(self):
+        """p90 근방 팩터 + 강한 가격 신호면 75 를 넘는다 — 게이트가 살아 있다."""
+        score = self._fuse(self.REALISTIC_STRONG_COMPOSITE, ret_5d=12.0, rsi=63.0, breakout=3.0)
+
+        assert score >= 75.0, f"현실적 강세 셋업이 75 를 못 넘었다 ({score:.3f}) — 게이트가 여전히 죽어 있다"
+
+    def test_the_old_raw_composite_scale_could_not_reach_any_gate(self):
+        """같은 셋업이 옛 척도에서는 55.0 이다 — 세 게이트 어느 것도 못 넘는다.
+
+        이 대비가 없으면 위 테스트는 "게이트 숫자가 낮다" 를 재확인할 뿐이고, 척도 수정이
+        무엇을 바꿨는지 증명하지 못한다.
+        """
+        old_scale = self.REALISTIC_STRONG_COMPOSITE * 100.0
+
+        assert old_scale < 75.0
+        assert old_scale < 80.0
+
+    def test_the_80_gate_needs_a_top_decile_factor_and_everything_else_pegged(self):
+        """80(average_down)은 열리긴 하지만 폭이 아주 좁다 — 조용히 넘어가지 않게 적어둔다.
+
+        비-factor 채널을 전부 최대로 밀어도 57.0075 이므로, 80 에 닿으려면
+        composite >= 0.5748 이 필요하다. 수정 후 실측 p90 이 0.5391, max 가 0.6279 이니
+        상위 몇 % + 완벽한 셋업이라야 한다. 75 와 달리 이건 "가끔 열리는" 게이트가 아니다.
+        """
+        non_factor_ceiling = self._fuse(0.0, ret_5d=20.0, rsi=65.0, breakout=5.0)
+        assert non_factor_ceiling == pytest.approx(57.0075, abs=1e-3)
+
+        required = (80.0 - non_factor_ceiling) / self._weights()["factor_composite"] / 100.0
+        assert required == pytest.approx(0.5748, abs=1e-3)
+
+        # 반올림한 0.5748 을 그대로 넣으면 79.9995 로 아슬하게 미달한다 — 경계 자체를
+        # 증명하는 테스트이므로 계산된 값을 쓴다.
+        assert self._fuse(required, ret_5d=20.0, rsi=65.0, breakout=5.0) >= 80.0
+        assert self._fuse(0.5391, ret_5d=20.0, rsi=65.0, breakout=5.0) < 80.0  # p90 로는 못 넘는다
+
+
 class TestUnmeasuredVixIsAVeto:
     """VIX 미측정(`None`)은 통과가 아니라 **veto** 다 (#1076).
 


### PR DESCRIPTION
Closes #1111.

## The mismatch

`composite_score_min` is **75 / 75 / 80** (`config/buy_signals.yaml:148,161,173`), gating all
three held-add modes. The scheduler handed those gates `composite * 100`
(`nuri/scheduler.py:641-643`), and raw composite lives in roughly [0.20, 0.73].

Across every row `factors` has ever held:

```
SELECT COUNT(*) FROM factors WHERE composite_score >= 0.75   ->  0
SELECT COUNT(*) FROM factors WHERE composite_score >= 0.80   ->  0
```

All-time maximum: **0.7279**, on 2026-07-08. So none of the three modes has ever opened, and
`held_add_shadow` holding **2 rows** is the confirmation rather than a coincidence.

## Why the value moves and not the thresholds

75 and 80 are numbers on the emitter's fused 0-100 scale — the same scale as
`quality_bar.base_threshold: 70`, two sections above them in the same file. They read like
thresholds on a fused score because that is what they were written for. Raw `composite * 100`
is a different quantity on a different range.

Re-deriving the thresholds against the raw composite distribution would mean inventing a
number without a backtest, which is the thing this repo does not allow. Fixing the scale keeps
the numbers meaning what they were written to mean.

`_score_ticker` is a pure function and the scheduler call site already holds every input it
needs (`factors`, `prices`, `rsi_map`, plus `weights` from the same config). The change is the
provider, not the machinery.

## Missing data is not neutral here

A ticker with no factor row still scores **0.0** rather than the neutral fused score of 54.0.
`_score_ticker` fills missing sources with 50 so partial data cannot block a *new* candidate —
correct for the emitter. held_add decides whether to put more capital into a position already
open, and "we do not know" must not read as neutral there. The previous behavior was also 0.0;
this preserves the meaning explicitly instead of by accident.

## Reachability — measured, not asserted

This is the part #1111 asked for: a test that the gate is reachable on a realistic distribution,
not just that the branch runs when handed 85.0.

With every non-factor channel pegged (`ret_5d >= +10%`, RSI 65, `breakout >= +3%`) the
non-factor ceiling is **57.0075**. So:

| gate | required composite | vs post-#1102 distribution (p50 0.4442 / p90 0.5391 / max 0.6279) |
|---|---|---|
| 75 (`tp1_residual_add`, `ride_winner`) | **>= 0.4498** | around the median — opens on a strong setup |
| 80 (`average_down`) | **>= 0.5748** with everything else maxed | above p90; top few percent only |

A realistic strong setup — composite 0.55 (~p90), +12% in 5 days, RSI 63, breakout +3% — scores
**78.806**. It clears both 75 gates and misses the 80 one. On the old scale that same setup
scored 55.0 and cleared nothing.

The 80 gate staying tight is a direct consequence of keeping the thresholds, so it is written
into a test (`test_the_80_gate_needs_a_top_decile_factor_and_everything_else_pegged`) rather than
left to be rediscovered the next time someone asks why `average_down` never fires.

## Tests

New: `tests/trading/recommend/test_held_add_mode.py::TestTheGatesAreReachable` — 3 tests that
run the real `_score_ticker` instead of injecting a score, including the paired negative showing
the old scale cleared nothing.

Two existing tests were locking the old scale and now lock the new one:

- `test_success_routes_providers_and_logs_counts` asserted `42.0` from `composite * 100`; it now
  asserts the fused **55.345** with the per-channel arithmetic written out, so a single wrong
  channel cannot be cancelled by another.
- `test_score_provider_handles_missing_factor` keeps its `0.0` assertion but for the stated
  reason rather than as a side effect of the old expression.

Mutation-verified against the committed tree:

| mutation | test that fails |
|---|---|
| provider back to `composite * 100` | `test_success_routes_providers_and_logs_counts` |
| missing factor falls through to the neutral fused score | `test_score_provider_handles_missing_factor` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
