### PR TITLE
fix(analysis): size position and sector trims in USD, not the ticker's native price

### DIFF
--- a/nuri/analysis/rebalance_advisor.py
+++ b/nuri/analysis/rebalance_advisor.py
@@ -187,12 +187,20 @@ def detect_violations(db_path: Optional[Path] = None) -> list[dict]:
 
         target_value = account_total * max_pos
         excess_value = row["ticker_value"] - target_value
-        current_price = row["current_price"]
-        if current_price > 0:
-            sell_shares = math.ceil(excess_value / current_price)
-        else:
-            sell_shares = int(row["quantity"])
-        sell_value = sell_shares * current_price
+        # `ticker_value` 는 USD 환산액인데 `current_price` 는 .KS 종목이면 KRW 다.
+        # 둘을 그대로 나누면 원화 종목의 매도 수량이 환율배(약 1,400)만큼 축소되고
+        # `sell_value_usd` 에는 KRW 금액이 그대로 들어간다 — 우선순위 정렬이
+        # 회수금액 기준이라 순서까지 틀어진다. 이미 환산된 값에서 주당 USD 단가를
+        # 되뽑아 쓴다: 별도 환율 조회가 없고 analyze_portfolio 가 쓴 환율과
+        # 자동으로 일치한다(`current_value_usd = current_price * qty / usd_krw`).
+        qty_held = int(row["quantity"])
+        if qty_held <= 0:
+            continue
+        # 여기 도달했다는 건 account_weight > max_pos ≥ 0 이므로 ticker_value > 0 이다
+        # — price_usd 는 0 이 될 수 없고, 가격이 stale(0) 이어도 나눗셈이 안전하다.
+        price_usd = row["ticker_value"] / qty_held
+        sell_shares = math.ceil(excess_value / price_usd)
+        sell_value = sell_shares * price_usd
         weight_pct = account_weight * 100
 
         violations.append(
@@ -240,21 +248,25 @@ def detect_violations(db_path: Optional[Path] = None) -> list[dict]:
                         break
                     continue
 
-                current_price = row["current_price"]
-                if current_price <= 0:
+                # position_limit 분기와 같은 이유로 주당 USD 단가를 되뽑는다.
+                # 여기서는 `remaining_excess` 가 루프를 돌며 누적 차감되기 때문에
+                # 단위가 섞이면 수량뿐 아니라 남은 초과분 회계 자체가 무너진다.
+                qty_held = int(row["quantity"])
+                price_usd = row["current_value_usd"] / qty_held if qty_held > 0 else 0.0
+                if price_usd <= 0:
                     continue
 
                 if remaining_excess >= row["current_value_usd"]:
                     # 전량 매도
-                    sell_shares = int(row["quantity"])
+                    sell_shares = qty_held
                     sell_value = row["current_value_usd"]
                     action = "SELL_ALL"
                     remaining_excess -= sell_value
                 else:
                     # 일부 매도
-                    sell_shares = math.ceil(remaining_excess / current_price)
-                    sell_shares = min(sell_shares, int(row["quantity"]))
-                    sell_value = sell_shares * current_price
+                    sell_shares = math.ceil(remaining_excess / price_usd)
+                    sell_shares = min(sell_shares, qty_held)
+                    sell_value = sell_shares * price_usd
                     action = "REDUCE"
                     remaining_excess -= sell_value
 

--- a/tests/analysis/test_rebalance_advisor.py
+++ b/tests/analysis/test_rebalance_advisor.py
@@ -1,24 +1,39 @@
 """Tests for nuri.analysis.rebalance_advisor — split from tests/test_analysis_all.py (#157)."""
+
+import math
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 
 from nuri.core.db import get_db
 
 
 class TestRebalanceDeep:
     """From test_coverage_round7.py."""
+
     def test_detect_violations_leveraged(self, rich_db):
         # Uses TQQQ from the leverage_ban list (config/rules.yaml banned_etfs)
         # to test detection. Generic quantity/price — no user-specific data.
         from nuri.analysis.rebalance_advisor import detect_violations
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio") as mock_ap:
-            mock_df = pd.DataFrame([
-                {"ticker": "TQQQ", "account": "test", "quantity": 10,
-                 "avg_price": 100.0, "current_price": 90.0,
-                 "current_value_usd": 900, "pnl_pct": -10.0,
-                 "weight_pct": 5.0, "sector": "ETF", "currency": "USD"},
-            ])
+            mock_df = pd.DataFrame(
+                [
+                    {
+                        "ticker": "TQQQ",
+                        "account": "test",
+                        "quantity": 10,
+                        "avg_price": 100.0,
+                        "current_price": 90.0,
+                        "current_value_usd": 900,
+                        "pnl_pct": -10.0,
+                        "weight_pct": 5.0,
+                        "sector": "ETF",
+                        "currency": "USD",
+                    },
+                ]
+            )
             mock_df.attrs["total_value_usd"] = 18000
             mock_ap.return_value = mock_df
             violations = detect_violations()
@@ -28,20 +43,46 @@ class TestRebalanceDeep:
 
 class TestDetectViolations:
     """From test_new_modules.py."""
+
     def test_leverage_etf_detected(self, db_path):
         # Uses TQQQ from leverage_ban list. Generic quantity/price.
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "TQQQ", "sector": "ETF", "quantity": 10,
-             "avg_price": 100.0, "current_price": 90.0, "currency": "USD",
-             "current_value_usd": 900.0, "cost_basis_usd": 1000.0,
-             "pnl_usd": -100.0, "pnl_pct": -10.0, "weight_pct": 5.0, "price_date": "2026-03-27"},
-            {"account": "test", "ticker": "AAA", "sector": "Tech", "quantity": 10,
-             "avg_price": 100.0, "current_price": 110.0, "currency": "USD",
-             "current_value_usd": 1100.0, "cost_basis_usd": 1000.0,
-             "pnl_usd": 100.0, "pnl_pct": 10.0, "weight_pct": 10.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "TQQQ",
+                    "sector": "ETF",
+                    "quantity": 10,
+                    "avg_price": 100.0,
+                    "current_price": 90.0,
+                    "currency": "USD",
+                    "current_value_usd": 900.0,
+                    "cost_basis_usd": 1000.0,
+                    "pnl_usd": -100.0,
+                    "pnl_pct": -10.0,
+                    "weight_pct": 5.0,
+                    "price_date": "2026-03-27",
+                },
+                {
+                    "account": "test",
+                    "ticker": "AAA",
+                    "sector": "Tech",
+                    "quantity": 10,
+                    "avg_price": 100.0,
+                    "current_price": 110.0,
+                    "currency": "USD",
+                    "current_value_usd": 1100.0,
+                    "cost_basis_usd": 1000.0,
+                    "pnl_usd": 100.0,
+                    "pnl_pct": 10.0,
+                    "weight_pct": 10.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 2000.0
         from nuri.analysis.rebalance_advisor import detect_violations
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             violations = detect_violations(db_path=db_path)
         leverage_violations = [v for v in violations if v["violation_type"] == "leverage_etf"]
@@ -49,32 +90,71 @@ class TestDetectViolations:
         assert leverage_violations[0]["ticker"] == "TQQQ"
 
     def test_stop_loss_exceeded(self, db_path):
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "BADSTOCK", "sector": "Test", "quantity": 10,
-             "avg_price": 100.0, "current_price": 80.0, "currency": "USD",
-             "current_value_usd": 800.0, "cost_basis_usd": 1000.0,
-             "pnl_usd": -200.0, "pnl_pct": -20.0, "weight_pct": 100.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "BADSTOCK",
+                    "sector": "Test",
+                    "quantity": 10,
+                    "avg_price": 100.0,
+                    "current_price": 80.0,
+                    "currency": "USD",
+                    "current_value_usd": 800.0,
+                    "cost_basis_usd": 1000.0,
+                    "pnl_usd": -200.0,
+                    "pnl_pct": -20.0,
+                    "weight_pct": 100.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 800.0
         from nuri.analysis.rebalance_advisor import detect_violations
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             violations = detect_violations(db_path=db_path)
         stop_violations = [v for v in violations if v["violation_type"] == "stop_loss_exceeded"]
         assert len(stop_violations) >= 1
 
     def test_position_limit_exceeded(self, db_path):
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "TSLA", "sector": "SectorA", "quantity": 100,
-             "avg_price": 350.0, "current_price": 360.0, "currency": "USD",
-             "current_value_usd": 36000.0, "cost_basis_usd": 35000.0,
-             "pnl_usd": 1000.0, "pnl_pct": 2.9, "weight_pct": 95.0, "price_date": "2026-03-27"},
-            {"account": "test", "ticker": "NVDA", "sector": "Semiconductor", "quantity": 1,
-             "avg_price": 160.0, "current_price": 168.0, "currency": "USD",
-             "current_value_usd": 168.0, "cost_basis_usd": 160.0,
-             "pnl_usd": 8.0, "pnl_pct": 5.0, "weight_pct": 5.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "TSLA",
+                    "sector": "SectorA",
+                    "quantity": 100,
+                    "avg_price": 350.0,
+                    "current_price": 360.0,
+                    "currency": "USD",
+                    "current_value_usd": 36000.0,
+                    "cost_basis_usd": 35000.0,
+                    "pnl_usd": 1000.0,
+                    "pnl_pct": 2.9,
+                    "weight_pct": 95.0,
+                    "price_date": "2026-03-27",
+                },
+                {
+                    "account": "test",
+                    "ticker": "NVDA",
+                    "sector": "Semiconductor",
+                    "quantity": 1,
+                    "avg_price": 160.0,
+                    "current_price": 168.0,
+                    "currency": "USD",
+                    "current_value_usd": 168.0,
+                    "cost_basis_usd": 160.0,
+                    "pnl_usd": 8.0,
+                    "pnl_pct": 5.0,
+                    "weight_pct": 5.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 36168.0
         from nuri.analysis.rebalance_advisor import detect_violations
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             violations = detect_violations(db_path=db_path)
         pos_violations = [v for v in violations if v["violation_type"] == "position_limit_exceeded"]
@@ -83,15 +163,29 @@ class TestDetectViolations:
     def test_no_violations(self, db_path):
         # 8 positions × $1000 each, 4 sectors → 각 종목 12.5% < core 15%, 각 섹터 25% < 35%
         sectors = ["Tech", "Health", "Energy", "Consumer"]
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": f"T{i:02d}", "sector": sectors[i % 4], "quantity": 10,
-             "avg_price": 100.0, "current_price": 100.0, "currency": "USD",
-             "current_value_usd": 1000.0, "cost_basis_usd": 1000.0,
-             "pnl_usd": 0.0, "pnl_pct": 5.0, "weight_pct": 12.5, "price_date": "2026-03-27"}
-            for i in range(8)
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": f"T{i:02d}",
+                    "sector": sectors[i % 4],
+                    "quantity": 10,
+                    "avg_price": 100.0,
+                    "current_price": 100.0,
+                    "currency": "USD",
+                    "current_value_usd": 1000.0,
+                    "cost_basis_usd": 1000.0,
+                    "pnl_usd": 0.0,
+                    "pnl_pct": 5.0,
+                    "weight_pct": 12.5,
+                    "price_date": "2026-03-27",
+                }
+                for i in range(8)
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 8000.0
         from nuri.analysis.rebalance_advisor import detect_violations
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             violations = detect_violations(db_path=db_path)
         assert len(violations) == 0
@@ -109,27 +203,44 @@ def _two_account_df(main_tsla_qty: int, sub_tsla_qty: int):
     total_portfolio = 20000.0
     for account, tsla_qty in (("Main", main_tsla_qty), ("Sub", sub_tsla_qty)):
         tsla_value = float(tsla_qty * 100)
-        rows.append({
-            "account": account, "ticker": "TSLA", "sector": "Auto", "quantity": tsla_qty,
-            "avg_price": 100.0, "current_price": 100.0, "currency": "USD",
-            "current_value_usd": tsla_value, "cost_basis_usd": tsla_value,
-            "pnl_usd": 0.0, "pnl_pct": 0.0,
-            "weight_pct": tsla_value / total_portfolio * 100,
-            "price_date": "2026-04-10",
-        })
+        rows.append(
+            {
+                "account": account,
+                "ticker": "TSLA",
+                "sector": "Auto",
+                "quantity": tsla_qty,
+                "avg_price": 100.0,
+                "current_price": 100.0,
+                "currency": "USD",
+                "current_value_usd": tsla_value,
+                "cost_basis_usd": tsla_value,
+                "pnl_usd": 0.0,
+                "pnl_pct": 0.0,
+                "weight_pct": tsla_value / total_portfolio * 100,
+                "price_date": "2026-04-10",
+            }
+        )
         remaining = 10000.0 - tsla_value
         per_filler_value = remaining / 8
         per_filler_qty = per_filler_value / 100
         for i in range(8):
-            rows.append({
-                "account": account, "ticker": f"F{account[0]}{i}", "sector": sectors[i % 4],
-                "quantity": per_filler_qty, "avg_price": 100.0, "current_price": 100.0,
-                "currency": "USD",
-                "current_value_usd": per_filler_value, "cost_basis_usd": per_filler_value,
-                "pnl_usd": 0.0, "pnl_pct": 0.0,
-                "weight_pct": per_filler_value / total_portfolio * 100,
-                "price_date": "2026-04-10",
-            })
+            rows.append(
+                {
+                    "account": account,
+                    "ticker": f"F{account[0]}{i}",
+                    "sector": sectors[i % 4],
+                    "quantity": per_filler_qty,
+                    "avg_price": 100.0,
+                    "current_price": 100.0,
+                    "currency": "USD",
+                    "current_value_usd": per_filler_value,
+                    "cost_basis_usd": per_filler_value,
+                    "pnl_usd": 0.0,
+                    "pnl_pct": 0.0,
+                    "weight_pct": per_filler_value / total_portfolio * 100,
+                    "price_date": "2026-04-10",
+                }
+            )
     df = pd.DataFrame(rows)
     df.attrs["total_value_usd"] = total_portfolio
     return df
@@ -153,8 +264,11 @@ class TestPositionLimitPerAccount:
         # Main TSLA 14% (core 15% 이내), Sub TSLA 12% (active 25% 이내)
         mock_df = _two_account_df(main_tsla_qty=14, sub_tsla_qty=12)
         from nuri.analysis.rebalance_advisor import detect_violations
-        with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df), \
-             patch("nuri.core.rules.get_account_strategy", side_effect=_fake_account_strategy):
+
+        with (
+            patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df),
+            patch("nuri.core.rules.get_account_strategy", side_effect=_fake_account_strategy),
+        ):
             violations = detect_violations(db_path=db_path)
         pos = [v for v in violations if v["violation_type"] == "position_limit_exceeded"]
         assert pos == [], f"Expected no position violations, got: {pos}"
@@ -164,8 +278,11 @@ class TestPositionLimitPerAccount:
         # 이전 버그에서는 max(0.15,0.25)=0.25 → 종합 26% > 25% 1건만 검출 (limit_value 잘못)
         mock_df = _two_account_df(main_tsla_qty=16, sub_tsla_qty=10)
         from nuri.analysis.rebalance_advisor import detect_violations
-        with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df), \
-             patch("nuri.core.rules.get_account_strategy", side_effect=_fake_account_strategy):
+
+        with (
+            patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df),
+            patch("nuri.core.rules.get_account_strategy", side_effect=_fake_account_strategy),
+        ):
             violations = detect_violations(db_path=db_path)
         pos = [v for v in violations if v["violation_type"] == "position_limit_exceeded"]
         assert len(pos) == 1
@@ -177,15 +294,15 @@ class TestPositionLimitPerAccount:
         # Main TSLA 20% (core 15% 위반), Sub TSLA 30% (active 25% 위반)
         mock_df = _two_account_df(main_tsla_qty=20, sub_tsla_qty=30)
         from nuri.analysis.rebalance_advisor import detect_violations
-        with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df), \
-             patch("nuri.core.rules.get_account_strategy", side_effect=_fake_account_strategy):
+
+        with (
+            patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df),
+            patch("nuri.core.rules.get_account_strategy", side_effect=_fake_account_strategy),
+        ):
             violations = detect_violations(db_path=db_path)
         pos = [v for v in violations if v["violation_type"] == "position_limit_exceeded"]
         assert len(pos) == 2
-        by_account = {
-            ("Main" if "Main" in v["reason"] else "Sub"): v
-            for v in pos
-        }
+        by_account = {("Main" if "Main" in v["reason"] else "Sub"): v for v in pos}
         assert set(by_account) == {"Main", "Sub"}
         assert by_account["Main"]["limit_value"] == 0.15
         assert by_account["Main"]["current_value"] == 20.0
@@ -195,19 +312,45 @@ class TestPositionLimitPerAccount:
 
 class TestCalculateRebalanceActions:
     """From test_new_modules.py."""
+
     def test_sorted_by_priority(self, db_path):
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "BBB", "sector": "SectorB", "quantity": 96,
-             "avg_price": 20.0, "current_price": 11.44, "currency": "USD",
-             "current_value_usd": 1098.24, "cost_basis_usd": 1625.28,
-             "pnl_usd": -527.04, "pnl_pct": -32.4, "weight_pct": 5.0, "price_date": "2026-03-27"},
-            {"account": "test", "ticker": "BADSTOCK", "sector": "Test", "quantity": 10,
-             "avg_price": 100.0, "current_price": 80.0, "currency": "USD",
-             "current_value_usd": 800.0, "cost_basis_usd": 1000.0,
-             "pnl_usd": -200.0, "pnl_pct": -20.0, "weight_pct": 5.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "BBB",
+                    "sector": "SectorB",
+                    "quantity": 96,
+                    "avg_price": 20.0,
+                    "current_price": 11.44,
+                    "currency": "USD",
+                    "current_value_usd": 1098.24,
+                    "cost_basis_usd": 1625.28,
+                    "pnl_usd": -527.04,
+                    "pnl_pct": -32.4,
+                    "weight_pct": 5.0,
+                    "price_date": "2026-03-27",
+                },
+                {
+                    "account": "test",
+                    "ticker": "BADSTOCK",
+                    "sector": "Test",
+                    "quantity": 10,
+                    "avg_price": 100.0,
+                    "current_price": 80.0,
+                    "currency": "USD",
+                    "current_value_usd": 800.0,
+                    "cost_basis_usd": 1000.0,
+                    "pnl_usd": -200.0,
+                    "pnl_pct": -20.0,
+                    "weight_pct": 5.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 1898.24
         from nuri.analysis.rebalance_advisor import calculate_rebalance_actions
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             actions = calculate_rebalance_actions(db_path=db_path)
         if len(actions) >= 2:
@@ -215,14 +358,28 @@ class TestCalculateRebalanceActions:
             assert priorities == sorted(priorities)
 
     def test_total_recovery_calculated(self, db_path):
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "BBB", "sector": "SectorB", "quantity": 96,
-             "avg_price": 20.0, "current_price": 11.44, "currency": "USD",
-             "current_value_usd": 1098.24, "cost_basis_usd": 1625.28,
-             "pnl_usd": -527.04, "pnl_pct": -32.4, "weight_pct": 100.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "BBB",
+                    "sector": "SectorB",
+                    "quantity": 96,
+                    "avg_price": 20.0,
+                    "current_price": 11.44,
+                    "currency": "USD",
+                    "current_value_usd": 1098.24,
+                    "cost_basis_usd": 1625.28,
+                    "pnl_usd": -527.04,
+                    "pnl_pct": -32.4,
+                    "weight_pct": 100.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 1098.24
         from nuri.analysis.rebalance_advisor import calculate_rebalance_actions
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             actions = calculate_rebalance_actions(db_path=db_path)
         assert len(actions) > 0
@@ -232,15 +389,30 @@ class TestCalculateRebalanceActions:
 
 class TestGenerateAdvisorReport:
     """From test_new_modules.py."""
+
     def test_report_structure(self, db_path):
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "BBB", "sector": "SectorB", "quantity": 96,
-             "avg_price": 20.0, "current_price": 11.44, "currency": "USD",
-             "current_value_usd": 1098.24, "cost_basis_usd": 1625.28,
-             "pnl_usd": -527.04, "pnl_pct": -32.4, "weight_pct": 5.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "BBB",
+                    "sector": "SectorB",
+                    "quantity": 96,
+                    "avg_price": 20.0,
+                    "current_price": 11.44,
+                    "currency": "USD",
+                    "current_value_usd": 1098.24,
+                    "cost_basis_usd": 1625.28,
+                    "pnl_usd": -527.04,
+                    "pnl_pct": -32.4,
+                    "weight_pct": 5.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 1098.24
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             report = generate_advisor_report(db_path=db_path)
         assert "actions" in report
@@ -253,6 +425,7 @@ class TestGenerateAdvisorReport:
     def test_empty_portfolio_report(self, db_path):
         mock_df = pd.DataFrame()
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             report = generate_advisor_report(db_path=db_path)
         assert report["total_violations"] == 0
@@ -261,54 +434,80 @@ class TestGenerateAdvisorReport:
 
 class TestRebalanceSeverity:
     """From test_coverage_round16.py."""
+
     def test_leverage_etf(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("leverage_etf", 0, 0) == "critical"
 
     def test_stop_loss_critical(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("stop_loss_exceeded", -15, -7) == "critical"
 
     def test_stop_loss_high(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("stop_loss_exceeded", -8, -7) == "high"
 
     def test_position_limit_high(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("position_limit_exceeded", 30, 0.15) == "high"
 
     def test_position_limit_medium(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("position_limit_exceeded", 18, 0.15) == "medium"
 
     def test_sector_limit_high(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("sector_limit_exceeded", 50, 0.35) == "high"
 
     def test_sector_limit_medium(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("sector_limit_exceeded", 40, 0.35) == "medium"
 
     def test_unknown_type(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("some_new_type", 0, 0) == "medium"
 
 
 class TestRebalancePrint:
     """From test_coverage_round16.py."""
+
     def test_no_actions(self, capsys):
         from nuri.analysis.rebalance_advisor import print_rebalance_advisor
+
         print_rebalance_advisor([])
         out = capsys.readouterr().out
         assert "위반 사항 없음" in out
 
     def test_with_actions(self, capsys):
         from nuri.analysis.rebalance_advisor import print_rebalance_advisor
+
         actions = [
-            {"ticker": "TQQQ", "sell_shares": 100, "sell_value_usd": 5000, "reason": "레버리지 ETF",
-             "action": "SELL_ALL", "severity": "critical", "cumulative_recovery_usd": 5000},
-            {"ticker": "AAPL", "sell_shares": 5, "sell_value_usd": 1000, "reason": "비중 초과",
-             "action": "REDUCE", "severity": "high", "cumulative_recovery_usd": 6000},
+            {
+                "ticker": "TQQQ",
+                "sell_shares": 100,
+                "sell_value_usd": 5000,
+                "reason": "레버리지 ETF",
+                "action": "SELL_ALL",
+                "severity": "critical",
+                "cumulative_recovery_usd": 5000,
+            },
+            {
+                "ticker": "AAPL",
+                "sell_shares": 5,
+                "sell_value_usd": 1000,
+                "reason": "비중 초과",
+                "action": "REDUCE",
+                "severity": "high",
+                "cumulative_recovery_usd": 6000,
+            },
         ]
         print_rebalance_advisor(actions)
         out = capsys.readouterr().out
@@ -319,25 +518,30 @@ class TestRebalancePrint:
 
 class TestRebalanceGetFactorScores:
     """From test_coverage_round16.py."""
+
     def test_empty(self, rich_db):
         from nuri.analysis.rebalance_advisor import _get_factor_scores
+
         scores = _get_factor_scores(db_path=rich_db)
         assert scores == {}
 
     def test_with_data(self, rich_db):
         from nuri.analysis.rebalance_advisor import _get_factor_scores
+
         with get_db(rich_db) as conn:
             conn.execute(
-                "INSERT INTO factors (ticker, date, composite_score) VALUES (?, ?, ?)",
-                ("AAPL", "2025-03-20", 0.85))
+                "INSERT INTO factors (ticker, date, composite_score) VALUES (?, ?, ?)", ("AAPL", "2025-03-20", 0.85)
+            )
         scores = _get_factor_scores(db_path=rich_db)
         assert scores["AAPL"] == 0.85
 
 
 class TestRebalanceGenerateReport:
     """From test_coverage_round16.py."""
+
     def test_no_violations(self, rich_db):
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=[]):
             report = generate_advisor_report(db_path=rich_db)
         assert report["total_violations"] == 0
@@ -345,10 +549,20 @@ class TestRebalanceGenerateReport:
 
     def test_with_violations(self, rich_db):
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         fake_violations = [
-            {"ticker": "TQQQ", "violation_type": "leverage_etf", "priority": 1,
-             "current_value": -5, "limit_value": 0, "severity": "critical",
-             "action": "SELL_ALL", "sell_shares": 50, "sell_value_usd": 3000, "reason": "test"},
+            {
+                "ticker": "TQQQ",
+                "violation_type": "leverage_etf",
+                "priority": 1,
+                "current_value": -5,
+                "limit_value": 0,
+                "severity": "critical",
+                "action": "SELL_ALL",
+                "sell_shares": 50,
+                "sell_value_usd": 3000,
+                "reason": "test",
+            },
         ]
         with patch("nuri.analysis.rebalance_advisor.detect_violations", return_value=fake_violations):
             report = generate_advisor_report(db_path=rich_db)
@@ -359,51 +573,67 @@ class TestRebalanceGenerateReport:
 
 class TestRebalanceAdvisor_R27:
     """From test_coverage_round27.py."""
+
     def test_severity_leverage(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("leverage_etf", 0, 0) == "critical"
 
     def test_severity_stop_loss_critical(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("stop_loss_exceeded", -14, -7) == "critical"
 
     def test_severity_stop_loss_high(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("stop_loss_exceeded", -8, -7) == "high"
 
     def test_severity_position_limit(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("position_limit_exceeded", 20, 0.15) == "medium"
         assert _severity("position_limit_exceeded", 30, 0.15) == "high"
 
     def test_severity_sector_limit(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("sector_limit_exceeded", 40, 0.35) == "medium"
         assert _severity("sector_limit_exceeded", 55, 0.35) == "high"
 
     def test_severity_default(self):
         from nuri.analysis.rebalance_advisor import _severity
+
         assert _severity("unknown_type", 0, 0) == "medium"
 
     def test_print_rebalance_advisor_empty(self, capsys):
         from nuri.analysis.rebalance_advisor import print_rebalance_advisor
+
         print_rebalance_advisor([])
         captured = capsys.readouterr()
         assert "위반 사항 없음" in captured.out
 
     def test_print_rebalance_advisor_with_actions(self, capsys):
         from nuri.analysis.rebalance_advisor import print_rebalance_advisor
-        actions = [{
-            "ticker": "TQQQ", "action": "SELL_ALL", "sell_shares": 10,
-            "sell_value_usd": 500, "reason": "레버리지 ETF 금지",
-            "severity": "critical", "cumulative_recovery_usd": 500,
-        }]
+
+        actions = [
+            {
+                "ticker": "TQQQ",
+                "action": "SELL_ALL",
+                "sell_shares": 10,
+                "sell_value_usd": 500,
+                "reason": "레버리지 ETF 금지",
+                "severity": "critical",
+                "cumulative_recovery_usd": 500,
+            }
+        ]
         print_rebalance_advisor(actions)
         captured = capsys.readouterr()
         assert "TQQQ" in captured.out
 
     def test_generate_advisor_report_empty(self, monkeypatch):
         from nuri.analysis.rebalance_advisor import generate_advisor_report
+
         monkeypatch.setattr("nuri.analysis.rebalance_advisor.calculate_rebalance_actions", lambda db_path=None: [])
         report = generate_advisor_report()
         assert report["total_violations"] == 0
@@ -412,14 +642,116 @@ class TestRebalanceAdvisor_R27:
 
 class TestRebalanceModule_R3:
     """From test_coverage_round3.py (detect_violations with rate)."""
+
     def test_detect_violations_with_rate(self, db_path):
         from nuri.analysis.rebalance_advisor import detect_violations
-        mock_df = pd.DataFrame([
-            {"ticker": "AAPL", "account": "test", "quantity": 10,
-             "avg_price": 190, "current_price": 200, "current_value_usd": 2000,
-             "pnl_pct": 5.2, "weight_pct": 60.0, "sector": "Tech", "currency": "USD"},
-        ])
+
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "ticker": "AAPL",
+                    "account": "test",
+                    "quantity": 10,
+                    "avg_price": 190,
+                    "current_price": 200,
+                    "current_value_usd": 2000,
+                    "pnl_pct": 5.2,
+                    "weight_pct": 60.0,
+                    "sector": "Tech",
+                    "currency": "USD",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 2000
         with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
             violations = detect_violations()
         assert isinstance(violations, list)
+
+
+class TestKrwTickerSellValuesAreUsd:
+    """`.KS` 종목의 비중/섹터 초과 매도 수량·회수금액이 USD 단위인지 잠근다.
+
+    회귀 전에는 `current_value_usd`(USD 환산액)를 `current_price`(원화 종목이면
+    KRW)로 나눠 매도 수량이 환율배만큼 축소되고 `sell_value_usd` 에는 KRW 금액이
+    그대로 들어갔다. 우선순위 정렬이 회수금액 기준이라 순서까지 틀어졌다.
+    실측(2026-08-20): 448290.KS 15주/$189 가 1주/$17,875 로 나왔고
+    `total_recovery_usd` 는 $10,511 대신 $1,834,172 였다.
+
+    환율 1,400 을 가정한 합성 데이터 — 실제 보유와 무관한 더미 티커다.
+    """
+
+    def _krw_row(self, ticker, qty, krw_price, sector, weight_pct, rate=1400.0):
+        # analyze_portfolio 와 같은 방식: current_value_usd = price * qty / rate
+        return {
+            "ticker": ticker,
+            "account": "test",
+            "quantity": qty,
+            "avg_price": krw_price,
+            "current_price": krw_price,
+            "current_value_usd": krw_price * qty / rate,
+            "pnl_pct": 0.0,
+            "weight_pct": weight_pct,
+            "sector": sector,
+            "currency": "KRW",
+        }
+
+    def test_position_limit_sell_shares_and_value_are_usd(self, db_path):
+        from nuri.analysis.rebalance_advisor import detect_violations
+        from nuri.core.rules import MAX_SINGLE_POSITION, get_account_strategy
+
+        # 100주 × ₩14,000 / 1,400 = $1,000 (주당 $10)
+        mock_df = pd.DataFrame(
+            [
+                self._krw_row("999999.KS", 100, 14000.0, "Dummy", 83.3),
+                {
+                    "ticker": "AAA",
+                    "account": "test",
+                    "quantity": 2,
+                    "avg_price": 100.0,
+                    "current_price": 100.0,
+                    "current_value_usd": 200.0,
+                    "pnl_pct": 0.0,
+                    "weight_pct": 16.7,
+                    "sector": "Other",
+                    "currency": "USD",
+                },
+            ]
+        )
+        mock_df.attrs["total_value_usd"] = 1200.0
+        with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
+            violations = detect_violations()
+
+        v = next(
+            v for v in violations if v["ticker"] == "999999.KS" and v["violation_type"] == "position_limit_exceeded"
+        )
+
+        max_pos = get_account_strategy("test").get("max_single_position", MAX_SINGLE_POSITION)
+        excess_usd = 1000.0 - 1200.0 * max_pos
+        expected_shares = math.ceil(excess_usd / 10.0)  # 주당 USD 단가
+
+        assert v["sell_shares"] == expected_shares
+        # 회귀 코드는 ceil(excess / 14000) = 1 주였다
+        assert v["sell_shares"] > 1
+        assert v["sell_value_usd"] == pytest.approx(expected_shares * 10.0, rel=1e-6)
+        # 회수금액은 보유 USD 평가액을 넘을 수 없다 — KRW 가 새면 즉시 깨진다
+        assert v["sell_value_usd"] <= 1000.0
+
+    def test_sector_limit_sell_value_is_usd(self, db_path):
+        from nuri.analysis.rebalance_advisor import detect_violations
+
+        # 같은 섹터 원화 종목 2개로 섹터 한도(35%) 초과를 만든다
+        mock_df = pd.DataFrame(
+            [
+                self._krw_row("999998.KS", 100, 14000.0, "DummySector", 50.0),
+                self._krw_row("999997.KS", 100, 14000.0, "DummySector", 50.0),
+            ]
+        )
+        mock_df.attrs["total_value_usd"] = 2000.0
+        with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=mock_df):
+            violations = detect_violations()
+
+        sector_v = [v for v in violations if v["violation_type"] == "sector_limit_exceeded"]
+        assert sector_v, "섹터 한도 위반이 감지되지 않았다"
+        for v in sector_v:
+            # 한 종목 전체가 $1,000 이다. KRW 가 새면 14,000 단위 숫자가 나온다.
+            assert v["sell_value_usd"] <= 1000.0

--- a/tests/analysis/test_rebalance_advisor_branches.py
+++ b/tests/analysis/test_rebalance_advisor_branches.py
@@ -2,7 +2,8 @@
 
 Targets residual branches uncovered by test_rebalance_advisor.py:
 - L167 (account_total <= 0): account_totals 가 0 이면 division skip.
-- L180 (current_price <= 0 in position-limit branch): qty fallback path.
+- position-limit 분기의 stale 가격(current_price=0): 주당 단가를 USD 평가액에서
+  되뽑으므로 전량 매도 fallback 없이 초과분만 정확히 계산된다.
 - L203 (Unknown sector skip): 'Unknown' 라벨된 sector 는 위반 검사 X.
 - L219 (sector ticker is leverage ETF): leverage 항목은 sector 위반에서도 skip
   (priority 1 leverage_etf 룰이 더 강력 — 두 번 카운트 방지).
@@ -17,6 +18,7 @@ Privacy: synthetic ticker TST_*. No broker name.
 
 from __future__ import annotations
 
+import math
 from unittest.mock import patch
 
 import pandas as pd
@@ -24,6 +26,7 @@ import pytest
 
 from nuri.analysis.rebalance_advisor import detect_violations
 from nuri.core.db import init_db
+from nuri.core.rules import MAX_SINGLE_POSITION, get_account_strategy
 
 
 @pytest.fixture
@@ -135,9 +138,16 @@ class TestPositionLimitZeroPrice:
             violations = detect_violations(db_path=db_path)
         pos = [v for v in violations if v["violation_type"] == "position_limit_exceeded" and v["ticker"] == "TST_X"]
         assert len(pos) == 1
-        # current_price=0 → sell_shares=quantity=100 fallback (L180).
-        assert pos[0]["sell_shares"] == 100
-        assert pos[0]["sell_value_usd"] == 0.0  # 100 * 0
+        # 예전에는 current_price=0 을 만나면 `sell_shares=quantity` 로 전량 매도로
+        # 떨어지면서 `sell_value_usd` 는 100*0 = $0 를 보고했다 — 100주를 팔라면서
+        # 회수액 0 이라 그 자체로 말이 안 됐다. 이제 주당 단가를 USD 평가액에서
+        # 되뽑으므로($2,000/100주 = $20) stale 가격에도 초과분만 정확히 덜어낸다.
+        strategy = get_account_strategy("acct")
+        max_pos = strategy.get("max_single_position", MAX_SINGLE_POSITION)
+        expected_shares = math.ceil((2000.0 - 2500.0 * max_pos) / 20.0)
+        assert pos[0]["sell_shares"] == expected_shares
+        assert pos[0]["sell_shares"] < 100  # 전량 매도로 떨어지지 않는다
+        assert pos[0]["sell_value_usd"] == pytest.approx(expected_shares * 20.0)
 
 
 # ════════════════════════════════════════════════════════════

--- a/tests/analysis/test_rebalance_advisor_branches.py
+++ b/tests/analysis/test_rebalance_advisor_branches.py
@@ -150,6 +150,56 @@ class TestPositionLimitZeroPrice:
         assert pos[0]["sell_value_usd"] == pytest.approx(expected_shares * 20.0)
 
 
+class TestPositionLimitZeroQuantity:
+    def test_zero_quantity_is_skipped_not_divided_by(self, db_path):
+        """수량 0 인데 평가액이 남아 있으면 그 종목은 건너뛴다 (0-나눗셈 방지).
+
+        주당 단가를 `ticker_value / quantity` 로 되뽑기 때문에 수량 0 이 그대로
+        들어오면 ZeroDivisionError 다. 실데이터에서는 수량 0 이면 평가액도 0 이라
+        비중 위반 자체가 안 나지만, DB 가 어긋나면 도달할 수 있는 자리다 —
+        위 TestPositionLimitZeroPrice 와 같은 성격의 모순 데이터로 가드를 잠근다.
+        """
+        rows = [
+            {
+                "account": "acct",
+                "ticker": "TST_Z",
+                "sector": "Tech",
+                "quantity": 0,
+                "avg_price": 20.0,
+                "current_price": 20.0,
+                "currency": "USD",
+                "current_value_usd": 2000.0,
+                "cost_basis_usd": 2000.0,
+                "pnl_usd": 0.0,
+                "pnl_pct": 0.0,
+                "weight_pct": 80.0,
+                "price_date": "2026-04-10",
+            },
+            {
+                "account": "acct",
+                "ticker": "TST_W",
+                "sector": "Health",
+                "quantity": 5,
+                "avg_price": 100.0,
+                "current_price": 100.0,
+                "currency": "USD",
+                "current_value_usd": 500.0,
+                "cost_basis_usd": 500.0,
+                "pnl_usd": 0.0,
+                "pnl_pct": 0.0,
+                "weight_pct": 20.0,
+                "price_date": "2026-04-10",
+            },
+        ]
+        df = pd.DataFrame(rows)
+        df.attrs["total_value_usd"] = 2500.0
+        with patch("nuri.analysis.rebalance_advisor.analyze_portfolio", return_value=df):
+            violations = detect_violations(db_path=db_path)  # 예외 없이 끝나야 한다
+        assert not [
+            v for v in violations if v["ticker"] == "TST_Z" and v["violation_type"] == "position_limit_exceeded"
+        ]
+
+
 # ════════════════════════════════════════════════════════════
 # L203 — Unknown sector skip
 # ════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #1116

## 무엇이 틀렸나

`rebalance_advisor` 의 **비중 초과 · 섹터 초과 두 분기**가 USD 예산을 네이티브 가격으로 나눴다.

```python
excess_value = row["ticker_value"] - target_value   # USD
sell_shares  = math.ceil(excess_value / current_price)   # .KS 면 KRW
sell_value   = sell_shares * current_price               # KRW 를 sell_value_usd 로 저장
```

손절 · 레버리지 분기는 `current_value_usd` 를 쓴다. 그래서 USD 종목만 보면 증상이 없고 원화 종목에서만 터졌다. 섹터 분기는 `remaining_excess` 를 루프에서 누적 차감하므로 수량뿐 아니라 **남은 초과분 회계**까지 무너졌다.

## 수정

이미 환산된 값에서 주당 USD 단가를 되뽑는다.

```python
price_usd = row["ticker_value"] / qty_held
```

별도 환율 조회가 없고 `analyze_portfolio` 가 실제로 쓴 환율(`current_value_usd = current_price * qty / usd_krw`)과 자동으로 일치한다.

## 실측 (dev DB, 2026-08-20)

| 종목 | 전 | 후 |
|---|---|---|
| 448290.KS | 1주 / $17,875 | **15주 / $189.17** |
| 402340.KS | 1주 / $1,120,000 | 1주 / **$790.18** |
| 005380.KS | 1주 / $417,250 | 1주 / **$294.38** |
| 005930.KS | 1주 / $270,000 | 1주 / **$190.49** |
| TSLA / QTUM / NVDA | 변화 없음 | 변화 없음 |
| **총 회수** | $1,834,172 | **$10,511.42** |

US 종목이 그대로인 것이 이 수정이 환산 경로에만 닿는다는 증거다. `SELL_PRIORITY` 정렬이 회수금액 기준이라 순위도 함께 정정된다.

## 회귀 테스트

`tests/analysis/test_rebalance_advisor.py::TestKrwTickerSellValuesAreUsd` — 비중 · 섹터 두 분기 각각.
**뮤테이션 실측**: `price_usd` 를 `row["current_price"]` 로 되돌리면 2건 모두 FAIL (`assert 14000.0 <= 1000.0`).

## 기존 테스트 1건 갱신 (의도적)

`test_zero_price_falls_back_to_quantity` 는 `current_price=0` + `current_value_usd=2000` 이라는 모순 데이터로 0-나눗셈 가드를 검증했고, 예전 코드는 **100주 전량 매도 + 회수액 $0** 를 냈다 (그 자체로 말이 안 되는 출력). 이제 $2,000/100주 = $20 를 되뽑아 초과분만 정확히 계산한다. 단언을 그 동작으로 갱신하고 "전량 매도로 떨어지지 않는다"를 추가로 잠갔다. 0-나눗셈 위험은 `qty_held <= 0` 가드로 남아 있다.

## ⚠️ diff 크기에 대해

`tests/analysis/test_rebalance_advisor.py` 가 +439/-107 로 보이는데 **실제 추가는 91줄**이다. 나머지는 레포 자신의 `.git/hooks/pre-commit` 이 스테이지된 `.py` 에 `ruff format` 을 돌리고 재스테이징하기 때문 — 이 파일이 훅 도입 이전 포맷이라 첫 접촉에서 한 번에 정리된다. 로직 변경은 `nuri/analysis/rebalance_advisor.py` 36줄이 전부다.

## 검증

- `make lint` clean · `make test-fast` 7350 passed · `make diagnostics` pyright 162 (래칫 172 이하) · cspell clean · doc counts 19/19 · privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)