### PR TITLE
fix(api): ignore future-dated and non-date report directories

### DIFF
--- a/nuri/api/routes/evidence.py
+++ b/nuri/api/routes/evidence.py
@@ -1,11 +1,14 @@
 """증거 차트 API — Plotly HTML 차트 서빙 + 메타데이터."""
 
 import logging
+import re
 from datetime import date
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
+
+from nuri.core.timezone import today_kst
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["evidence"])
@@ -22,13 +25,25 @@ CHART_TYPES = {
 }
 
 
+_DATE_DIR_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
 def _find_latest_report_dir() -> Path | None:
-    """가장 최근 리포트 디렉토리 찾기."""
+    """가장 최근 리포트 디렉토리 찾기.
+
+    `data/reports/` 에는 날짜 디렉터리 말고도 `briefs` / `postmarket` /
+    `buy_tracking` 이 섞여 있고, 잘못된 날짜로 생성된 **미래 디렉터리**도 남는다
+    (실측 2026-08-20: `2026-11-08` · `2027-02-06` · `2027-09-14`). 이름을 그냥
+    역순 정렬하면 그런 것들이 1등을 먹어서, 오늘 `make evidence` 를 돌려도
+    화면에는 2027-09-14 자 차트가 뜬다. 이름이 ISO 날짜이고 **오늘 이하**인
+    것만 후보로 본다.
+    """
     if not REPORT_DIR.exists():
         return None
-    dirs = sorted(REPORT_DIR.iterdir(), reverse=True)
-    for d in dirs:
-        if d.is_dir() and (d / "evidence").exists():
+    today = today_kst()
+    dated = [d for d in REPORT_DIR.iterdir() if d.is_dir() and _DATE_DIR_RE.match(d.name) and d.name <= today]
+    for d in sorted(dated, key=lambda p: p.name, reverse=True):
+        if (d / "evidence").exists():
             return d / "evidence"
     return None
 

--- a/tests/api/test_evidence.py
+++ b/tests/api/test_evidence.py
@@ -222,3 +222,61 @@ class TestEvidenceReportLatest:
         monkeypatch.setattr(ev_mod, "REPORT_DIR", report_dir)
         result = ev_mod.get_evidence_report()
         assert "Today Plan" in result["content"]
+
+
+class TestReportDirIsNotFutureDated:
+    """미래 날짜 / 비-날짜 디렉터리가 최신 리포트로 뽑히지 않는지 잠근다.
+
+    `data/reports/` 에는 `briefs` · `postmarket` · `buy_tracking` 이 섞여 있고,
+    잘못된 날짜로 만들어진 미래 디렉터리도 남는다 (실측 2026-08-20 로컬:
+    `2026-11-08` · `2027-02-06` · `2027-09-14`). 이름 역순 정렬만 하면 그것들이
+    1등이라 /evidence 화면 날짜가 통째로 2027-09-14 였다.
+    """
+
+    def _seed(self, root: Path, name: str) -> None:
+        (root / name / "evidence").mkdir(parents=True)
+
+    def test_future_dated_dir_is_ignored(self, tmp_path, monkeypatch):
+        import nuri.api.routes.evidence as ev_mod
+        from nuri.api.routes.evidence import _find_latest_report_dir
+        from nuri.core.timezone import today_kst
+
+        reports = tmp_path / "reports"
+        today = today_kst()
+        year = int(today[:4])
+        self._seed(reports, today)
+        self._seed(reports, f"{year + 1}-09-14")  # 미래
+        monkeypatch.setattr(ev_mod, "REPORT_DIR", reports)
+
+        result = _find_latest_report_dir()
+        assert result is not None
+        assert result.parent.name == today
+
+    def test_non_date_dir_is_ignored(self, tmp_path, monkeypatch):
+        import nuri.api.routes.evidence as ev_mod
+        from nuri.api.routes.evidence import _find_latest_report_dir
+        from nuri.core.timezone import today_kst
+
+        reports = tmp_path / "reports"
+        today = today_kst()
+        self._seed(reports, today)
+        # 'postmarket' 은 사전순으로 어떤 '20xx-' 보다 뒤라 역순 정렬에서 1등이다
+        self._seed(reports, "postmarket")
+        monkeypatch.setattr(ev_mod, "REPORT_DIR", reports)
+
+        result = _find_latest_report_dir()
+        assert result is not None
+        assert result.parent.name == today
+
+    def test_no_valid_dir_returns_none(self, tmp_path, monkeypatch):
+        import nuri.api.routes.evidence as ev_mod
+        from nuri.api.routes.evidence import _find_latest_report_dir
+        from nuri.core.timezone import today_kst
+
+        reports = tmp_path / "reports"
+        year = int(today_kst()[:4])
+        self._seed(reports, f"{year + 1}-09-14")
+        self._seed(reports, "briefs")
+        monkeypatch.setattr(ev_mod, "REPORT_DIR", reports)
+
+        assert _find_latest_report_dir() is None

--- a/tests/api/test_evidence.py
+++ b/tests/api/test_evidence.py
@@ -268,6 +268,28 @@ class TestReportDirIsNotFutureDated:
         assert result is not None
         assert result.parent.name == today
 
+    def test_dated_dir_without_evidence_falls_through_to_older_one(self, tmp_path, monkeypatch):
+        """날짜는 유효하지만 `evidence/` 가 없는 디렉터리는 건너뛰고 더 오래된 것을 쓴다.
+
+        루프가 한 바퀴 돌고도 매칭 없이 다음 후보로 넘어가는 arc — 이게 없으면
+        codecov 가 partial branch 로 잡는다 (실측 #1124: misses 0 / partials 1).
+        """
+        import nuri.api.routes.evidence as ev_mod
+        from nuri.api.routes.evidence import _find_latest_report_dir
+        from nuri.core.timezone import today_kst
+
+        reports = tmp_path / "reports"
+        today = today_kst()
+        # 최신 날짜인데 evidence/ 가 없다 → 건너뛰어야 한다
+        (reports / today).mkdir(parents=True)
+        older = f"{int(today[:4]) - 1}-01-02"
+        self._seed(reports, older)
+        monkeypatch.setattr(ev_mod, "REPORT_DIR", reports)
+
+        result = _find_latest_report_dir()
+        assert result is not None
+        assert result.parent.name == older
+
     def test_no_valid_dir_returns_none(self, tmp_path, monkeypatch):
         import nuri.api.routes.evidence as ev_mod
         from nuri.api.routes.evidence import _find_latest_report_dir


### PR DESCRIPTION
Closes #1117

## 증상

`/api/evidence` 가 모든 차트의 `date` 를 **2027-09-14** 로 보고했다 (오늘 2026-08-20). `/evidence` 화면 전체가 그 날짜였다.

## 근본원인

`_find_latest_report_dir` 이 `data/reports/` 를 이름 역순 정렬하고 `evidence/` 가 있는 첫 디렉터리를 골랐다. **상한이 없다.**

로컬 실측으로 미래 날짜 디렉터리가 셋 남아 있다 — `2026-11-08` · `2027-02-06` · `2027-09-14`. 사전순 역순이라 항상 이것들이 1등이고, 오늘 `make evidence` 를 돌려도 화면은 2027-09-14 자 산출물을 가리켰다.

같은 이유로 비-날짜 디렉터리도 후보에 섞였다. `postmarket` 은 사전순으로 어떤 `20xx-` 보다 뒤라 역순 1등이다 (지금은 `evidence/` 하위가 없어 통과했을 뿐, 언제든 1등을 먹을 수 있는 자리였다).

## 수정

이름이 ISO 날짜이고 `today_kst()` 이하인 디렉터리만 후보로 본다.

## 검증

수정 후 `/api/evidence` → `date: 2026-08-20`. `regime` 차트가 `available: false` 로 바뀌는데 이는 **정정**이다 — 오늘 디렉터리에 그 산출물이 없는 게 사실이고, 이전에는 2027 디렉터리의 파일을 available 로 보고하고 있었다.

## 회귀 테스트

`tests/api/test_evidence.py::TestReportDirIsNotFutureDated` 3건 — 미래 날짜 무시 / 비-날짜 무시 / 유효 후보 없으면 None. 날짜를 `today_kst()` 기준 상대값으로 만들어 시한폭탄이 되지 않게 했다 (`tests/CLAUDE.md` "Time-bomb seed dates").

## 곁가지 (이 PR 범위 아님)

같은 파일 `get_evidence_report` 이 `date.today()` 를 쓴다. 레포 불변식은 `today_kst()` 인데 PreToolUse 훅이 `datetime.now()` 만 막아서 통과한 자리다. #1117 본문에 적어뒀고 별건으로 분리한다.

## 검증

- `make lint` clean · `make test-fast` 7350 passed · doc counts 19/19 · privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)