### PR TITLE
fix(e2e): assert the certification label from strings.ts, not a renamed literal

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -24,6 +24,8 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 
 **CI gates** (every PR): `privacy-scan`, `pr-discipline` (commits ≤ 3 — escape `scope-expand-approved` label), test regression + Codecov 1% relative, `security-scan` (Trivy CRITICAL), `Doc Count Drift Check` (`make verify-doc-counts`).
 
+**게이트에 없는 것 — Playwright e2e.** `frontend/e2e/` 8 파일 57 테스트는 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `frontend/package.json` 의 `test:e2e` 스크립트로만 존재한다. 위 "dead gate" 항목들과 성격이 다르다 — 저건 게이트가 있는데 죽은 것이고, 이건 **처음부터 게이트가 아니다.** 결과: `410d385`(2026-05-04)가 `CONTEXT.SIEGE` 값을 rename 하면서 vitest 는 같이 고치고 e2e 는 두었는데, **3.5개월간 아무 신호가 없었다**(2026-08-20 수동 실행에서 발견, #1118). 배선은 별건이다 — 런타임·안정성 예산이 필요하고, 스위트가 자기 부하로 백엔드를 포화시키는 문제(#1119)가 선행 조건이다. 그 전까지는 대시보드를 건드리면 손으로 돌릴 것. 상세는 `frontend/CLAUDE.md` "E2E (Playwright)".
+
 ## .claude/ 4-Layer Architecture (STRATEGY §5.10)
 
 L1 CLAUDE.md (13 scoped + global) → L2 Skills (`.claude/skills/nuri-*/`, 6) → L3 Hooks (`.claude/settings.json` PreToolUse + PostToolUse) → L4 Agents (`.claude/agents/nuri-*.md`, 2). Slash commands: `.claude/commands/nuri-*.md` (8). Path-scoped + always-on rules: `.claude/rules/*.md`. `nuri-` prefix 만 git tracked — 머신별 개인 설치는 `.gitignore` 로 자동 ignored.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -80,6 +80,18 @@ Symptom if someone drops it: eslint prints `Oops! Something went wrong!` with a
 confirm by file count rather than by absence of output — `npx eslint --format json | jq length`
 should be **212**.
 
+## E2E (Playwright) — runs against the real backend, gated by nothing
+
+`npm run test:e2e` (`npx playwright test`). 8 spec files under `e2e/`, 57 tests. `playwright.config.ts` starts both servers itself (`uvicorn` :8001, `npm run dev` :3000) with `reuseExistingServer: true`.
+
+- **No CI job, no Makefile target, no `scripts/verify/` step runs it.** It is the one suite in this repo that has never gated a merge, which is exactly how `410d385` (2026-05-04) renamed `CONTEXT.SIEGE` to `"Certification"`, updated the matching vitest files, and left three e2e assertions searching for `text=SIEGE` for 3.5 months. Wiring it into a gate is a separate decision (needs a runtime/stability budget); until then, run it by hand before touching the dashboard.
+- **Never inline a user-facing string literal in a spec — import it from `src/lib/strings.ts`.** That file is the single source of truth and specs can import across the directory boundary (`import { ACTION, CONTEXT } from "../src/lib/strings"`). The contrast is on record: `dashboard.spec.ts:19` survived the same rename only because it OR'd several candidate strings, while the three brittle single-literal assertions all broke.
+- **Scope assertions to `main`.** The sidebar carries a "Certification Engine" link, so a `body`-wide `includes("Certification")` passes even when the health card is gone. A spec that can pass with the feature deleted is worse than no spec.
+- **Don't assert live portfolio values.** `action-first.spec.ts:28` hardcoded `TSLA` at `15.4%` in the `urgent` bucket, captured 2026-04-13; by 2026-08-20 the same holding was 14.3% and in `check`. Read what the API actually returned and assert the UI matches it.
+- **`workers` is capped at 2 on purpose.** The default (cores/2 = 8 here) fires 8 spec files at one `next dev` and one uvicorn; every page is a `force-dynamic` Server Component issuing several API calls, so the backend saturates and unrelated specs time out. The cap is mitigation, not a fix — the real constraint is API concurrency (#1119). Do not raise a timeout to turn a red spec green without checking which side is actually slow.
+- **Per-assertion `{ timeout: N }` overrides `expect.timeout` from the config.** Two explore-search specs stayed red after the config budget was raised to 15 s because they carried an inline `5000`. Keep the waiting budget in one place.
+- **The `request` fixture goes through `baseURL`, i.e. the Next proxy** — which aborts at 30 s. A cold heavy endpoint makes the fixture see a non-ok response while the API logs `200 OK`. Warm the endpoint with a `page.goto` before asserting on it.
+
 ## Testing Gotchas
 
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control.

--- a/frontend/e2e/action-first.spec.ts
+++ b/frontend/e2e/action-first.spec.ts
@@ -1,17 +1,25 @@
 import { test, expect } from "@playwright/test";
+import { ACTION, CONTEXT } from "../src/lib/strings";
+
+// 라벨 리터럴을 여기 박지 않는다 — strings.ts 가 단일 출처다. 410d385 가
+// CONTEXT.SIEGE 값을 "SIEGE" → "Certification" 으로 바꿨을 때 vitest 는 같이
+// 갱신됐지만 이 파일은 안 됐고, playwright 가 어떤 게이트에도 없어서 3.5개월간
+// 아무도 몰랐다. import 로 묶어두면 다음 rename 은 단언이 따라온다.
+//
+// 시스템 건강 4-card 중 Certification 카드는 main 안의 /engine 링크다.
+// 사이드바에도 /engine 링크("Certification Engine")가 있어 main 스코프가 필요하다 —
+// body 전체를 훑으면 카드가 사라져도 사이드바 때문에 초록으로 통과한다.
+const healthCard = (page: import("@playwright/test").Page) =>
+  page.locator('main a[href="/engine"]');
 
 test.describe("Action-First Dashboard", () => {
-  test("renders system health cards (SIEGE, regime, macro, freshness)", async ({ page }) => {
+  test("renders system health cards (certification, regime, macro, freshness)", async ({ page }) => {
     await page.goto("/", { timeout: 20000 });
-    await page.waitForTimeout(5000);
-    // System health section should have SIEGE label
-    await expect(page.locator("text=SIEGE").first()).toBeVisible({ timeout: 10000 });
-    // Should show regime info
-    const body = await page.textContent("body");
-    expect(body).toBeTruthy();
-    // At least one health card should show a percentage or status
-    const hasHealth = body!.includes("SIEGE") || body!.includes("인증") || body!.includes("미인증");
-    expect(hasHealth).toBe(true);
+    await expect(healthCard(page)).toContainText(CONTEXT.SIEGE, { timeout: 15000 });
+    // 카드 본문은 인증/미인증 상태를 함께 낸다
+    await expect(healthCard(page)).toContainText(
+      new RegExp(`${CONTEXT.CERTIFIED}|${CONTEXT.REJECTED}`),
+    );
   });
 
   test("renders action items with priority sections", async ({ page }) => {
@@ -25,15 +33,45 @@ test.describe("Action-First Dashboard", () => {
     expect(hasActions).toBe(true);
   });
 
-  test("TSLA shows as urgent action (SIEGE violation)", async ({ page }) => {
-    await page.goto("/", { timeout: 20000 });
-    await page.waitForTimeout(5000);
-    const body = await page.textContent("body");
-    // TSLA should appear in the action items section
-    expect(body).toContain("TSLA");
-    // SIEGE violation should be mentioned
-    const hasSiegeWarning = body!.includes("SIEGE") || body!.includes("한도") || body!.includes("15.4%");
-    expect(hasSiegeWarning).toBe(true);
+  // 이 테스트는 원래 "TSLA 가 15.4% 비중으로 urgent 에 뜬다" 를 박아뒀다. 셋 다
+  // 2026-04-13 당시의 라이브 포트폴리오 값이라 매일 드리프트한다(오늘 TSLA 는
+  // 14.3% · check 버킷 · Certification 위반 없음). 티커도 수치도 API 가 실제로
+  // 낸 것에서 가져온다.
+  test("action items surface the API's urgent/check tickers with their reasons", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(90_000);
+
+    // 페이지를 **먼저** 연다. `/api/actions` 는 콜드 실측 3.8초인데, 이 fixture 의
+    // 요청은 Next rewrite 프록시를 타고 그 프록시는 30초에 소켓을 끊는다
+    // (`proxyTimeout || 30000`). 콜드 스위트에서 API 를 먼저 부르면 스위트가
+    // 동시에 깨우는 무거운 엔드포인트들 뒤에 줄을 서다 프록시 타임아웃에 걸린다
+    // — API 로그는 전부 200 인데 fixture 만 not-ok 를 받는다 (#1119).
+    // 대시보드 렌더가 서버사이드에서 같은 엔드포인트를 깨우므로, 그 다음 호출은
+    // 5분 TTL 캐시에 맞는다.
+    await page.goto("/", { timeout: 30000 });
+    const main = page.locator("main");
+    await expect(main).toContainText(ACTION.TITLE, { timeout: 15000 });
+
+    const res = await request.get("/api/actions");
+    expect(res.ok()).toBe(true);
+    const data = await res.json();
+    const items: { ticker: string; reasons?: string[] }[] = [
+      ...(data.urgent ?? []),
+      ...(data.check ?? []),
+    ];
+    test.skip(items.length === 0, "urgent/check 액션 0건 — 검증 대상 없음");
+
+    for (const item of items) {
+      await expect(main.locator(`a[href="/ticker/${item.ticker}"]`).first()).toBeVisible();
+    }
+
+    // reason 문자열은 액션 카드에서만 렌더된다(action-items.tsx:69) — 보유
+    // 테이블이 대신 통과시켜주지 않는 유일한 스코프다.
+    const reason = items.flatMap((i) => i.reasons ?? [])[0];
+    expect(reason, "액션 아이템에 reason 이 하나도 없다").toBeTruthy();
+    await expect(main).toContainText(reason);
   });
 
   test("action items have expand/collapse detail button", async ({ page }) => {
@@ -114,6 +152,6 @@ test.describe("Action-First Dashboard", () => {
     await page.waitForTimeout(5000);
     await expect(page.locator("text=오늘의 액션").first()).toBeVisible({ timeout: 10000 });
     // Health cards should wrap on mobile
-    await expect(page.locator("text=SIEGE").first()).toBeVisible();
+    await expect(healthCard(page)).toContainText(CONTEXT.SIEGE, { timeout: 15000 });
   });
 });

--- a/frontend/e2e/server-pages.spec.ts
+++ b/frontend/e2e/server-pages.spec.ts
@@ -91,8 +91,11 @@ test.describe("Server Component Pages (real backend)", () => {
     await expect(page.locator('[data-testid="explore-search-input"]')).toBeVisible({ timeout: 10000 });
     // Type "TSLA" and wait for results
     await page.fill('[data-testid="explore-search-input"]', "TSLA");
-    await expect(page.locator('[data-testid="explore-search-dropdown"]')).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('[data-testid="search-result-TSLA"]')).toBeVisible({ timeout: 5000 });
+    // 인라인 timeout 을 두지 않는다 — 여기 박힌 5000ms 가 config 의 expect.timeout 을
+    // 덮어써서, 서버가 붐빌 때 fetch(0.03s 짜리 쿼리)가 프록시 큐에서 4초 넘게
+    // 기다리는 구간을 실패로 바꿨다. 대기 예산은 config 한 곳에서 관리한다.
+    await expect(page.locator('[data-testid="explore-search-dropdown"]')).toBeVisible();
+    await expect(page.locator('[data-testid="search-result-TSLA"]')).toBeVisible();
   });
 
   test("explore search returns results for Korean name", async ({ page }) => {
@@ -100,7 +103,7 @@ test.describe("Server Component Pages (real backend)", () => {
     await expect(page.locator('[data-testid="explore-search-input"]')).toBeVisible({ timeout: 10000 });
     // Type "삼성" and wait for Korean stock results
     await page.fill('[data-testid="explore-search-input"]', "삼성");
-    await expect(page.locator('[data-testid="explore-search-dropdown"]')).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('[data-testid="search-result-005930.KS"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="explore-search-dropdown"]')).toBeVisible();
+    await expect(page.locator('[data-testid="search-result-005930.KS"]')).toBeVisible();
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,6 +5,18 @@ export default defineConfig({
   testMatch: "**/*.spec.ts",
   timeout: 30000,
   retries: 0,
+  // 기본값(코어/2 = M5 Max 에서 8)은 spec 파일 8개를 단일 Next 프로세스와 단일
+  // uvicorn 에 동시 투입한다. 모든 페이지가 force-dynamic Server Component 라
+  // 페이지 하나가 여러 API 호출을 낸다.
+  // ⚠️ 이 캡은 완화지 해결이 아니다. 실측(2026-08-20): workers=2 로 줄이고
+  //    expect 예산을 15s 로 올려도 explore 검색 2건은 여전히 깨진다. 진짜 병목은
+  //    Playwright 가 아니라 API 다 — 무거운 sync 핸들러(/api/scan 은 요청마다
+  //    yfinance 85종목, /api/report/context 161s)가 AnyIO 40-스레드 풀을 채우고,
+  //    클라이언트가 끊어도 계속 돌아 백로그가 남는다. 포화 시 /api/health 조차
+  //    46.7s 대기(50×/api/scan 부하 실측). 그 이슈가 닫히기 전에는 이 스위트가
+  //    전부 초록이 되지 않는다. 여기 숫자를 더 키워 초록으로 만들지 말 것.
+  workers: 2,
+  expect: { timeout: 15000 },
   use: {
     baseURL: "http://localhost:3000",
     headless: true,
@@ -13,7 +25,7 @@ export default defineConfig({
   projects: [
     { name: "chromium", use: { browserName: "chromium" } },
   ],
-  // Start both backend API and frontend dev server
+  // Start both backend API and frontend server
   webServer: [
     {
       command: "cd .. && .venv/bin/python -m uvicorn nuri.api.main:app --host 0.0.0.0 --port 8001",
@@ -22,6 +34,13 @@ export default defineConfig({
       reuseExistingServer: true,
     },
     {
+      // ⚠️ `npm run build && npm run start` 로 바꾸지 말 것 — 실측으로 더 나빠진다
+      //    (2026-08-20: dev 3 fail → prod 16 fail, workers=1 에서도 6 fail).
+      //    프로덕션 빌드는 페이지를 즉시 서빙해 API 를 더 세게 때리는데, 병목은
+      //    Next 가 아니라 API 쪽이다(사이드 이슈: 무거운 sync 핸들러가 40-스레드
+      //    풀을 점유하고 클라이언트가 끊어도 계속 돈다). 게다가 `next start` 의
+      //    서버사이드 fetch 는 undici 30s headers timeout 이라 "느림" 이 500 으로
+      //    바뀐다(UND_ERR_HEADERS_TIMEOUT). API 동시성이 해결된 뒤 재시도할 것.
       command: "npm run dev",
       port: 3000,
       timeout: 30000,


### PR DESCRIPTION
Closes #1118

## 무엇이 틀렸나

`action-first.spec.ts` 3건이 `text=SIEGE` 를 못 찾아 실패했다. **UI 는 정상이었다.**

`410d385` (2026-05-04) "chore(rename): SIEGE → Certification — user-surface strings only" 이 `strings.ts` 의 `CONTEXT.SIEGE` **값**을 바꿨다. `market-context.tsx:143` 이 `label={CONTEXT.SIEGE}` 로 렌더하므로 화면에는 "Certification" 이 나온다. 그 커밋은 vitest 4개를 같이 갱신했지만 e2e 는 손대지 않았고, `frontend/e2e/` 의 마지막 커밋은 그보다 앞선 `623fab6` (2026-04-13) 이다.

**3.5개월간 신호가 없었던 이유**: playwright 가 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `package.json` 의 `test:e2e` 스크립트로만 존재한다.

대조군이 같은 파일에 있다 — `dashboard.spec.ts:19` 는 `인증/미인증/CERTIFIED` 를 OR 로 걸어둬 같은 rename 을 맞고도 살아남았다.

## 수정

1. **라벨을 import 한다** — `import { ACTION, CONTEXT } from "../src/lib/strings"`. 다음 rename 은 단언이 자동으로 따라온다.
2. **스코프를 `main a[href="/engine"]` 으로 좁힌다** — 사이드바에도 `/engine` 링크("Certification Engine")가 있어 `body` 전체 검색은 **카드가 삭제돼도 초록으로 통과**한다. 단순 문자열 치환으로 고쳤다면 false green 이 됐을 자리다.
3. **`:28` 은 하드코딩을 걷었다** — `TSLA` · `15.4%` · `urgent` 셋 다 2026-04-13 당시의 라이브 포트폴리오 값이다. 오늘 그 종목은 `position_pct` 14.3% · `check` 버킷 · Certification 위반 없음이라 테스트 이름과 실제가 어긋나 있었다. 이제 `/api/actions` 가 실제로 낸 티커와 reason 으로 검증한다 (reason 문자열은 액션 카드에서만 렌더돼 보유 테이블이 대신 통과시켜주지 않는다).

## 동시성 — 왜 config 도 같이 건드렸나

수정 후에도 explore 검색 2건이 계속 red 였다. 실패 스냅샷이 `textbox: TSLA` + `text: 검색 중...` 이라 입력·이벤트는 정상이고 **fetch 가 5초 안에 안 끝난** 것이었다. 하이드레이션 가설은 CPU 20x 스로틀에도 2.3초로 반증, 콜드 컴파일 가설은 `/explore` 최초 요청 190ms 로 반증됐다.

- `workers` 무설정 → 기본 8. spec 8개가 단일 `next dev` + 단일 uvicorn 을 동시 타격
- spec 의 인라인 `{ timeout: 5000 }` 이 config 의 `expect.timeout` 을 덮고 있었다 → 예산을 config 한 곳으로

진짜 병목은 API 쪽이라 #1119 에서 별도로 고쳤다. 이 PR 의 캡은 완화다 — config 주석에 그렇게 적어뒀다.

## 프로덕션 빌드는 채택하지 않았다 (실측 근거)

`webServer` 를 `npm run build && npm run start` 로 바꿔봤더니 **더 나빠졌다**: dev 3 fail → **prod 16 fail**, `workers=1` 에서도 6 fail. 프로덕션은 페이지를 즉시 서빙해 API 를 더 세게 때리고, `next start` 의 서버사이드 fetch 는 undici 30초 headers timeout 이라 "느림"이 **500** 으로 바뀐다 (`UND_ERR_HEADERS_TIMEOUT`). 재시도 조건과 함께 config 주석에 남겼다.

## 검증

`#1119` 와 합쳐 콜드 API 에서 2회 연속 **56 passed / 0 failed / 1 skipped**. (이 PR 단독으로는 explore 2건이 여전히 red 다 — API 쪽이 원인이라 #1119 가 선행 조건이다.)

## 문서

- `frontend/CLAUDE.md` — E2E 섹션 신설 (없었다). 위 함정 6가지 + workers 캡 근거
- `.claude/rules/enforcement.md` — CI 게이트 목록에 "playwright 는 여기 없다" 를 명시. 기존 "dead gate" 항목들과 성격이 다르다 (저건 게이트가 죽은 것, 이건 처음부터 게이트가 아닌 것)

🤖 Generated with [Claude Code](https://claude.com/claude-code)