### PR TITLE
fix(verify): let the doc-count fixture actually run the test-count rules

### DIFF
--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -64,10 +64,18 @@ live_migrations()     { grep -cE '^        [0-9]+,$' nuri/core/db_migrations.py 
 live_scheduler_jobs() { grep -cE '"cron":' nuri/scheduler.py || true; }
 live_rules_lines()    { wc -l < config/rules.yaml | tr -d ' '; }
 
+# pytest 는 수집 요약을 두 형식으로 낸다:
+#   "7371/7380 tests collected (9 deselected)"  ← **deselect 가 있을 때만**
+#   "7380 tests collected"                       ← deselect 가 0 이면 이 형식
+# 예전엔 앞 형식만 봤다. 그래서 deselect 가 0 이 되는 순간 이 함수가 빈 값을 돌려주고,
+# 호출부의 `if [ -n "$TESTS_BE" ]` 가 테스트-수 동기화 3건을 **통째로 건너뛴다**.
+# `verify_doc_counts.sh` 는 파일 수만 검사하고 테스트 수는 안 보므로 그 침묵을 잡을
+# 게이트도 없다 — fixer 가 아무것도 안 하면서 성공으로 끝나는 형태다 (#1084).
+# `[0-9]+ tests collected` 하나로 두 형식을 다 집는다 (앞 형식에서는 총계 쪽에 매치).
 live_tests_be() {
     $PYTHON -m pytest tests/ --collect-only -q 2>/dev/null \
-        | grep -oE '[0-9]+/[0-9]+ tests collected' \
-        | head -1 | awk -F'/' '{print $2}' | awk '{print $1}'
+        | grep -oE '[0-9]+ tests collected' \
+        | head -1 | awk '{print $1}'
 }
 
 CHANGED=0

--- a/tests/verify/test_doc_claim_parity.py
+++ b/tests/verify/test_doc_claim_parity.py
@@ -141,6 +141,11 @@ class TestClaimListParity:
         assert not stale, "sync 대상이 이사갔거나 사라짐:\n" + "\n".join(f"  {f}  {pat}" for f, pat in stale)
 
 
+#: `repo_copy` 가 심는 테스트 개수. 라이브 수치와 안 겹치는 작은 값이어야
+#: "fixer 가 정말 다시 썼는가" 를 값으로 구분할 수 있다.
+_SEEDED_TESTS = 3
+
+
 @pytest.fixture
 def repo_copy(tmp_path):
     """검사 대상 문서만 복사한 얕은 사본 + `.venv` 심볼릭 링크.
@@ -172,6 +177,15 @@ def repo_copy(tmp_path):
             shutil.copy2(f, dst / pkg / f.name)
     for sub in ("tests", "frontend/src", "frontend/e2e"):
         (dst / sub).mkdir(parents=True, exist_ok=True)
+    # `tests/` 를 빈 채로 두면 `live_tests_be` 가 0 을 세고, 그러면
+    # `sync_doc_counts.sh` 의 `if [ -n "$TESTS_BE" ]` 블록이 통째로 건너뛰어져
+    # **테스트-수 규칙 3건이 이 fixture 에서 한 줄도 실행되지 않는다** — 그 규칙을
+    # 겨눈 뮤테이션이 전부 무력했던 이유다 (#1084). 실제 파일을 심어 블록을 살린다.
+    # 개수(_SEEDED_TESTS)는 아래 테스트가 복구된 값을 확인하는 데 쓴다.
+    (dst / "tests" / "test_seeded.py").write_text(
+        "".join(f"def test_seed_{i}():\n    pass\n\n" for i in range(_SEEDED_TESTS)),
+        encoding="utf-8",
+    )
     (dst / "pyproject.toml").write_text("")  # _common.sh 의 레포 루트 마커
     (dst / ".venv").symlink_to(REPO_ROOT / ".venv")
     return dst
@@ -220,6 +234,35 @@ class TestRoundTrip:
         after = _run(VERIFY, repo_copy)
         assert "DRIFT" not in after.stdout, f"sync 후에도 drift 잔존:\n{after.stdout}"
         assert marker in readme.read_text()
+
+    def test_the_test_count_rules_run_when_nothing_is_deselected(self, repo_copy):
+        """수집 요약에 deselect 가 없어도 테스트-수 동기화가 돈다 (#1084).
+
+        `live_tests_be` 는 pytest 요약을 긁는데, pytest 는 **deselect 가 있을 때만**
+        `N/M tests collected` 를 찍는다. 0 건이면 `N tests collected` 다. 옛 정규식은
+        앞 형식만 봐서 그 순간 빈 값을 돌려줬고, 호출부의 `if [ -n "$TESTS_BE" ]` 가
+        테스트-수 claim 3건을 **통째로 건너뛰었다** — 종료코드 0 으로, 조용히.
+
+        `verify_doc_counts.sh` 는 파일 수만 검사하고 테스트 수는 안 본다. 즉 fixer 가
+        일을 멈춰도 그걸 잡을 게이트가 없다. 이 사본은 deselect 가 0 이므로 바로 그
+        조건이고, 여기서 복구가 일어나야 정규식이 두 형식을 다 받는다는 증명이 된다.
+        """
+        strategy = repo_copy / "docs" / "STRATEGY.md"
+        before = strategy.read_text()
+        marker = _live_marker(before, r"[0-9,]+ tests, [0-9]+ files \(statement")
+
+        corrupted = before.replace(marker, marker.replace(marker.split(" tests,")[0], "9,999", 1), 1)
+        strategy.write_text(corrupted)
+        assert "9,999 tests," in strategy.read_text(), "손상이 안 걸렸다 — 아래가 공짜로 통과한다"
+
+        sync = _run(SYNC, repo_copy)
+        assert sync.returncode == 0, sync.stdout + sync.stderr
+
+        after = strategy.read_text()
+        assert "9,999 tests," not in after, (
+            "테스트 수가 복구되지 않았다 — deselect 0 인 수집 요약에서 블록이 건너뛰어졌다\n" + sync.stdout
+        )
+        assert f"{_SEEDED_TESTS} tests," in after, f"fixer 가 심은 개수({_SEEDED_TESTS})로 다시 쓰지 않았다"
 
     def test_sync_leaves_neighbouring_numbers_alone(self, repo_copy):
         """Backend **파일 수** 동기화가 같은 표의 다른 숫자를 건드리지 않는다.


### PR DESCRIPTION
Closes #1084.

Two defects, and the second is why the first went unnoticed.

## The fixer skipped its own test-count block whenever nothing was deselected

`live_tests_be` scraped pytest's collection summary with `[0-9]+/[0-9]+ tests collected`.
pytest only prints the `N/M` form when tests are **deselected**; with zero deselections it
prints `N tests collected`. The regex missed, the function returned empty, and the enclosing
`if [ -n "$TESTS_BE" ]` skipped all three test-count claims — silently, exit code 0.

```
$ pytest tests/ --collect-only -q        # no deselection
2 tests collected in 0.00s
$ ... | grep -oE '[0-9]+/[0-9]+ tests collected'
                                          # ← empty
```

`verify_doc_counts.sh` checks only *file* counts, never the test count, so there is no gate
that would notice a fixer that stopped fixing. `[0-9]+ tests collected` matches both forms —
in the `N/M` case it lands on the total, which is the number these claims carry.

## The parity fixture could not exercise those rules at all

`repo_copy` created `tests/` as an empty directory. `live_tests_be` counted zero in the copy,
so the same block was skipped there too, and every mutation aimed at those rules was inert.

That is exactly what #1084 reported: the docstring of
`test_sync_leaves_neighbouring_numbers_alone` promised a Gotcha-Test Pair on the STRATEGY
pattern, and both promised mutations passed. The fixture now seeds real test files, so the
block runs and the rules are live.

## Verification

Mutation-verified against the **committed** tree:

| mutation | test that fails |
|---|---|
| widen the STRATEGY pattern to `Backend tests.*[0-9,]+ tests` (puts "Codecov 1%" in the first digit run) | `test_sync_leaves_neighbouring_numbers_alone` |
| revert `live_tests_be` to the `N/M`-only regex | `test_the_test_count_rules_run_when_nothing_is_deselected` |
| remove the seeded test files from `repo_copy` | `test_the_test_count_rules_run_when_nothing_is_deselected` |

The first of those passed before this change — that is the inertness #1084 filed.

Full suite: 7381 passed, 6 skipped. Doc counts 19/19.

## A process note, because it changes how to read an earlier result

During an initial mutation pass I ran `git checkout scripts/doc/sync_doc_counts.sh` between
mutations while the fix was **still uncommitted**. That reverted the fix mid-experiment, so
the second mutation ran against unfixed code and "passed" for the wrong reason. Every
mutation result above was re-run after committing. Same trap as
`.claude/rules/` records for #1022 — reverting before committing deletes your own work and
looks like success.

## Not fixed here

The test **count** claims are written by sync and verified by nothing —
`verify_doc_counts.sh` covers file counts only. That asymmetry is what let the silent skip
survive, and closing it means adding a claim to the verify side. Out of scope for this PR;
worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
