### PR TITLE
fix(build): make quick-scan and the local test targets do what they claim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,14 @@ setup-hooks: ## Install repo-tracked git hooks (pre-commit auto-fix). Idempotent
 # ═══════════════════════════════════════════════════════════════
 # TEST / LINT / VERIFY
 # ═══════════════════════════════════════════════════════════════
+# --cov-branch 는 CI 와 의미를 맞추기 위한 것이다 (#1133). codecov 는 patch
+# target 100% / threshold 0% 로 **부분 분기**까지 세므로, 분기 없이 재면 로컬은
+# 100% 를 보고하고 codecov 는 미달을 낸다 (실측 PR #1124: 로컬 100% ↔ codecov 85.71%).
 test:
-	$(PYTHON) -m pytest tests/ -v --cov=nuri -n auto --dist worksteal
+	$(PYTHON) -m pytest tests/ -v --cov=nuri --cov-branch -n auto --dist worksteal
 
 test-fast:
-	$(PYTHON) -m pytest tests/ -v --cov=nuri -n auto --dist worksteal -m "not slow"
+	$(PYTHON) -m pytest tests/ -v --cov=nuri --cov-branch -n auto --dist worksteal -m "not slow"
 
 # ─── CI artifact ground-truth coverage (Issue #616 verification protocol) ───
 # 직전 main CI run 의 6 shards (.coverage artifacts) 다운로드 + combine →
@@ -521,6 +524,7 @@ full-scan:
 
 quick-scan:
 	$(PYTHON) -m nuri.collectors.stock
+	$(PYTHON) -m nuri.collectors.stock --source freshness   # SPY/TLT/GC=F — 없으면 classify_regime() 이 계속 None (#1133)
 	$(PYTHON) -m nuri.collectors.stock_kr
 	$(PYTHON) -m nuri.collectors.macro
 	$(PYTHON) -m nuri.collectors.fear_greed


### PR DESCRIPTION
Closes #1133

두 로컬 `make` 타깃이 문서가 주장하는 것과 다르게 동작했다. 같은 결함 계열이라 묶었다 — **로컬에서 초록인데 실제로는 다른 것을 했다.**

## ① `quick-scan` 이 레짐 게이트가 필요로 하는 티커를 안 받았다

`classify_regime()` 은 SPY 가 120h 를 넘으면 `None` 을 돌려 분류를 차단한다. SPY/TLT/GC=F 를 받는 유일한 경로는 `stock --source freshness` 인데 그 줄이 `collect` 에만 있고 `quick-scan` 에는 없었다.

실측 (2026-08-20, dev): SPY **144h** → `classify_regime()` 전 호출 `None` → consensus 가 레짐 없이 18행 기록. 그 줄을 수동 실행하자 즉시 `bull_low_vol` (conf 0.75) 복구.

원장에 남은 흔적은 **dev 한정**이다:

| DB | `recommendations` 중 `regime IS NULL` |
|---|---|
| dev | 2026-08-10 **17/17** · 2026-07-08 **23/23** (quick-scan 을 수동으로 돌린 날) |
| 프로덕션 | **0 / 1,606 (전 기간)** |

프로덕션이 멀쩡한 이유는 스케줄러가 `collect` 경로를 쓰기 때문이다. **프로덕션 결함이 아니라 dev 명령의 결함**이고, 고치면 dev 가 프로덕션처럼 동작한다.

> 이걸 "quick-scan 은 레짐을 못 낸다" 로 문서화하려다 접었다 — 결함을 아키텍처 문서에 적으면 사양이 된다. (Codex consult 판정: `CODE-FIX`, not `DOC-ONLY`.)

## ② `test` / `test-fast` 가 CI 와 다른 커버리지 의미로 돌았다

| | 커맨드 |
|---|---|
| `Makefile:85,88` | `pytest ... --cov=nuri` |
| `main-ci-cd.yml:450,498` | `pytest ... --cov=nuri --cov-branch` |

`codecov.yml` 은 `patch: target 100% / threshold 0%` 이고 **부분 분기까지 센다.** 분기 없이 재면 로컬이 CI 보다 관대해 보인다.

같은 테스트·같은 파일 실측:

```
--cov          nuri/api/routes/evidence.py   60  0        100%
--cov-branch   nuri/api/routes/evidence.py   60  0  28  1  99%   ← 부분분기 1
```

PR #1123 · #1124 가 정확히 이것 때문에 CI 를 한 바퀴 더 돌았다 (로컬 100% ↔ codecov 85.71%, `"misses":0,"partials":1`).

## 검증

- `make -n quick-scan` — 새 줄이 `stock` 다음, `stock_kr` 앞. 주석 스타일은 기존 `collect` 타깃과 동일 (레시피의 `#` 는 셸 주석)
- `make -n test-fast` — `--cov-branch` 반영 확인
- 위 커버리지 비교는 이 브랜치에서 실측
- `bash scripts/verify/pre_push_check.sh --skip-tests` 통과

## 발견한 도구 결함 (이 PR 범위 아님)

**linked worktree 에서 `git push` 하면 pre-push 게이트가 오작동한다.** 같은 스크립트를 손으로 돌리면 `Modified: 0 / ✓ No drift risk` 인데, 훅 경로로는 `Modified: 997 / 🚨 HIGH DRIFT` 가 나온다 (작업 트리는 실제로 clean). 훅 실행 환경에서 `git status` 가 다른 인덱스를 보는 것으로 보인다. 이번엔 본체 트리에서 브랜치명으로 push 해 우회했다. 별건으로 분리한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)