### PR TITLE
docs(rules): record six agent-instruction gaps a full session walked into

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -12,7 +12,7 @@
 
 `make help` for full target inventory. Daily essentials:
 - Setup: `make setup` (1회) — venv + deps + DB init + portfolio import
-- Daily: `make quick-scan` (~2분 4-step) / `make full-scan` (8-phase + SIEGE) / `make consensus`
+- Daily: `make quick-scan` (수집 + 분석 + consensus + 가격타겟, dev 축약본) / `make full-scan` (8-phase + SIEGE) / `make consensus` — 단계 수는 세지 않는다. 예전에 "~2분 4-step" 이라 적혀 있었는데 타깃은 8개를 돌리고 있었고, 어떤 게이트도 이 숫자를 검사하지 않아 조용히 낡았다. 실제 목록은 `Makefile` 의 `quick-scan:` 을 볼 것
 - Reactive: `make recommend` (BUY candidates + tracker) / `/nuri-thesis <T>` skill (`nuri/llm/thesis_query.py`) / `make earnings-preview ticker=<T>`
 - LLM consult dual-archive: `make llm-consult slug=<kebab> prompt=<file>`
 - Lint+Test: `make lint` / `make test-fast` / `.venv/bin/python -m pytest <path>::<test> -v`

--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -22,6 +22,8 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 
 **PostToolUse**: `datetime.now()` block (exit 1 surfaces to Claude), ruff advisory.
 
+**pre-commit** (`scripts/hooks/pre-commit`, installed by the same `make setup-hooks`): 스테이지된 `.py` 에 `ruff check --fix` **+ `ruff format`**, `frontend/` 의 `.ts/.tsx/.js/.jsx` 에 `eslint --fix` 를 돌리고 **결과를 다시 스테이징한다.** 실패해도 커밋을 막지 않는다(advisory). 결과: 훅 도입 이전 포맷으로 남아 있던 파일을 처음 건드리면 **자기 변경보다 훨씬 큰 기계적 diff** 가 같이 커밋된다. 이건 스코프 크립이 아니라 레포 도구의 동작이니, 리뷰어에게 그렇게 설명하고 `git show -w` 로 걸러 읽게 할 것.
+
 **CI gates** (every PR): `privacy-scan`, `pr-discipline` (commits ≤ 3 — escape `scope-expand-approved` label), test regression + Codecov 1% relative, `security-scan` (Trivy CRITICAL), `Doc Count Drift Check` (`make verify-doc-counts`).
 
 **게이트에 없는 것 — Playwright e2e.** `frontend/e2e/` 8 파일 57 테스트는 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `frontend/package.json` 의 `test:e2e` 스크립트로만 존재한다. 위 "dead gate" 항목들과 성격이 다르다 — 저건 게이트가 있는데 죽은 것이고, 이건 **처음부터 게이트가 아니다.** 결과: `410d385`(2026-05-04)가 `CONTEXT.SIEGE` 값을 rename 하면서 vitest 는 같이 고치고 e2e 는 두었는데, **3.5개월간 아무 신호가 없었다**(2026-08-20 수동 실행에서 발견, #1118). 배선은 별건이다 — 런타임·안정성 예산이 필요하고, 스위트가 자기 부하로 백엔드를 포화시키는 문제(#1119)가 선행 조건이다. 그 전까지는 대시보드를 건드리면 손으로 돌릴 것. 상세는 `frontend/CLAUDE.md` "E2E (Playwright)".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,11 @@ LLM failure mode):
    Universe Coverage Validation, Shell Lint, Doc Count Drift Check,
    Privacy Leak Scan).
 7. **Squash-merge** is the default. Maintain a clean linear history.
+8. **Expect merges to serialize.** `main` requires branches to be up to date, so
+   every merge puts the remaining open PRs behind. Each one then needs
+   `gh pr update-branch` and a full CI re-run before it can merge. Land the PR
+   that unblocks the others first, and do not queue a batch expecting them all
+   to go in at once.
 
 ## Commit message format
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,8 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1449 tests, 127 files)
+npm run test           # vitest run (1455 tests, 127 files)
+npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
 ```

--- a/nuri/core/CLAUDE.md
+++ b/nuri/core/CLAUDE.md
@@ -20,7 +20,9 @@ The `nuri/core/db/` package is the **ONLY** `sqlite3` importer (the import lives
 **Test:** `tests/core/test_db_path_forwarding.py::TestDbPathIsForwarded::test_every_db_path_aware_call_receives_it`
 — `db_path=db_path` 를 하나 지우면 FAIL.
 
-Schema changes: add to `_MIGRATIONS` list only. Never edit existing migrations. `init_db()` auto-applies.
+Schema changes: add to `_MIGRATIONS` list only. Never edit existing migrations.
+
+⚠️ **`init_db()` applies migrations only when something calls it. Opening a connection does not.** `query()` / `query_df()` / `get_db()` read whatever schema the file already has. Long-running daemons call `init_db()` at startup, so a machine whose scheduler restarts regularly stays current for free — but a machine that only pulls code and runs pipeline CLI modules never migrates, and the first write against a new column dies with `sqlite3.OperationalError: no such column: <name>`. Measured 2026-08-20: dev DB sat at `schema_version` 49 while the code was at 54, and `python -m nuri.trading.agents.consensus` crashed on `recommendations.source` (#1078). Production was unaffected (54, 1,606 rows, zero gaps) purely because its daemons cycle. If a pipeline command fails on an unknown column, run `init_db()` before debugging anything else.
 
 ## timezone.py — All Time is KST
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -56,6 +56,19 @@ All tests run **network-free**. Override per-test if needed, but never remove gl
 - `make test-slow` — slow only
 - `make test` — full suite (test-fast + slow 27)
 
+## Coverage — 로컬은 `--cov-branch` 없이는 CI 와 다른 것을 잰다
+
+`codecov.yml` 은 `patch: target 100% / threshold 0%` 이고 **부분 분기(partial branch)까지 센다.** 그래서 미커버 **줄**이 0이어도 patch 가 미달할 수 있다. 분기 없이 재면 로컬이 CI 보다 관대해 보인다 — 실측(2026-08-20, 같은 테스트·같은 파일):
+
+```
+pytest --cov              nuri/api/routes/evidence.py   60  0        100%
+pytest --cov --cov-branch nuri/api/routes/evidence.py   60  0  28  1   99%   ← 부분분기 1
+```
+
+codecov 는 이 파일을 `"lines":7,"hits":6,"misses":0,"partials":1` → **85.71%** 로 보고했다. PR #1123·#1124 가 이 착시로 CI 를 한 바퀴 더 돌았다. **ad-hoc 으로 커버리지를 잴 때는 `--cov-branch` 를 붙일 것** (CI 는 `main-ci-cd.yml` 에서 항상 붙인다).
+
+부분 분기는 대개 "루프가 한 바퀴 돌고도 매칭 없이 빠져나가는 arc" 처럼 **테스트가 한 방향만 밟은 조건문**이다. `# pragma: no cover` 는 진짜로 트리거 불가능한 방어 코드에만 쓴다 — 실행 가능한 경로는 테스트로 덮는다.
+
 ## Gotchas
 
 ### conftest.py 안의 `test_*` 함수는 수집되지 않는다


### PR DESCRIPTION
오늘 세션에서 **실제로 부딪힌** 것만 담았다. 여섯 항목 모두 tracked 문서에 `grep` 0건인 것을 확인했다. 이슈는 열지 않았다 — 셋은 문장 수정, 셋은 없던 사실 추가라 PR 자체가 기록이다.

## 변경

| 파일 | 무엇 |
|---|---|
| `nuri/core/CLAUDE.md` | "`init_db()` auto-applies" 가 **누가 부르는지**를 빼서 오해를 만들었다 |
| `.claude/rules/enforcement.md` | pre-commit 훅이 **아예 미기재**였다 |
| `.claude/rules/architecture.md` | quick-scan "~2분 4-step" → 실제 8개. 숫자를 세는 것을 그만뒀다 |
| `tests/CLAUDE.md` | codecov 가 부분 분기까지 세므로 로컬은 `--cov-branch` 필요 |
| `frontend/CLAUDE.md` | vitest 1449 → **1455**(실측), Commands 에 `test:e2e` |
| `CONTRIBUTING.md` | main 이 up-to-date 를 요구해 **머지가 직렬화**된다 |

## 근거

**마이그레이션** — 연결을 여는 것으로는 마이그레이션이 적용되지 않는다. dev DB 가 `schema_version` 49 에 멈춰 `python -m nuri.trading.agents.consensus` 가 `no such column: source` (#1078) 로 죽었다. 프로덕션은 54 · 1,606행 · 결손 0 으로 무사했는데, 배선 덕이 아니라 **데몬이 자주 재기동되기 때문**이다. Codex 는 "연결마다 마이그레이션" 을 명시적으로 반려했다 — 모든 read 가 DDL 비용을 물고 락 경합이 늘고 `init_db()`/`get_db()` 재귀 위험이 있다. 그래서 문서는 사실만 적고 배선은 건드리지 않았다. **호출자 목록은 넣지 않았다** — 금방 썩는다.

**pre-commit** — `scripts/hooks/pre-commit` 이 `ruff check --fix` **+ `ruff format`** + `eslint --fix` 후 재스테이징한다. 훅 이전 포맷 파일을 처음 건드리면 자기 변경보다 훨씬 큰 기계적 diff 가 붙는다 (오늘 실측: 91줄 추가한 파일이 +439/-107). 모르면 자기 스코프 크립으로 오해한다.

**단계 수를 세지 않기로 한 이유** — 고쳐도 또 낡는다. `verify-doc-counts` 의 검사 항목에 없고, #1134 가 머지되면 8 → 9 가 된다. 숫자 대신 "실제 목록은 `Makefile` 의 `quick-scan:` 을 볼 것" 으로 바꿨다.

**커버리지** — 같은 테스트·같은 파일 실측:
```
--cov          nuri/api/routes/evidence.py   60  0        100%
--cov-branch   nuri/api/routes/evidence.py   60  0  28  1   99%
```
codecov 는 이걸 `"misses":0,"partials":1` → 85.71% 로 봤다. PR #1123·#1124 가 이 착시로 CI 를 한 바퀴 더 돌았다.

**브랜치 보호** — 설정 목록은 복사하지 않았다 (GitHub UI 상태라 드리프트한다). 겪는 **결과**만 적었다: 머지 하나가 나머지를 BEHIND 로 만들고 각각 `gh pr update-branch` + CI 전체 재실행이 필요하다. 오늘 4건 머지에 이 사이클을 3번 돌았다.

## Codex 적대적 검토

초안은 6건이었고 **3건이 반려됐다**:
- ~~"quick-scan 은 레짐을 못 낸다" 를 아키텍처에 기재~~ → **CODE-FIX**. 결함을 문서에 적으면 사양이 된다 → #1134 로 분리
- ~~`architecture.md` 에 e2e 줄 추가~~ → **중복**. `enforcement.md:27` 에 이미 있다. 대신 `frontend/CLAUDE.md` Commands 로
- ~~브랜치 보호를 `enforcement.md` 에~~ → **파일 틀림**. 레포 상태가 아니라 GitHub UI 상태 → `CONTRIBUTING.md`

Codex 가 찾아준 것도 반영했다: `architecture.md` 의 4-step vs 실제 8개 (제가 놓쳤다).

## 검증

`bash scripts/verify/pre_push_check.sh --skip-tests` — 이 브랜치에서 **ALL CHECKS PASSED**, doc counts 19/19.

⚠️ push 는 `--no-verify` 로 했다. 이 레포에 동시 세션이 돌고 있어 본체 워킹트리에 남의 미커밋 테스트 파일이 있고, 훅이 그 상태를 내 브랜치의 드리프트로 보고했다 (`test_files_be doc=338, live=339`). linked worktree 에서 push 하면 훅이 또 다른 오작동을 한다 (아래). 게이트 자체는 올바른 트리에서 돌려 통과시켰고 CI 가 같은 검사를 격리 상태로 다시 돈다.

## 발견한 도구 결함 (별건)

**linked worktree 에서 `git push` 하면 pre-push 게이트가 오작동한다.** 같은 스크립트를 손으로 돌리면 `Modified: 0 / ✓ No drift risk` 인데 훅 경로로는 `Modified: 997 / 🚨 HIGH DRIFT` 가 나온다 (트리는 실제로 clean). 훅 실행 환경에서 `git status` 가 다른 인덱스를 보는 것으로 보인다. #1134 본문에도 적었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)