### PR TITLE
fix(recommend): give the BUY gate a regime it can actually act on

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,382 collected across 338 files | |
+| **Backend tests** | 7,417 collected across 339 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -9,7 +9,7 @@
 | `rules.yaml` | 601 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
-| `buy_signals.yaml` | 152 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |
+| `buy_signals.yaml` | 187 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |
 | `alerts.yaml` | 24 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
 | `stock_types.yaml` | 49 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |
 | `universe.yaml` | 755 | 746 tickers: `us_core` (85) + `us_sp500_extended` (458) + `kr_kospi200` (203). Auto-maintained by `make universe-sync`; manual entries preserved | `nuri/collectors/universe_sync.py` |

--- a/config/buy_signals.yaml
+++ b/config/buy_signals.yaml
@@ -25,11 +25,20 @@ leadership:
 # ─── Quality bar (final score 0-100, when to emit) ──────────────────
 quality_bar:
   base_threshold: 70          # 기본 임계 — 이 이상만 emit
+  # ⚠️ 키는 반드시 `nuri.quant.regime.classifier.ALL_REGIMES` 의 원소여야 한다.
+  # 그 밖의 문자열은 `classify_regime()` 이 절대 내지 않으므로 `.get(regime, 0)` 이
+  # 조용히 0 을 돌려주고 **조정이 통째로 무시된다** — 예외도 로그도 없다 (#1130).
+  # 잠금: tests/quant/regime/test_config_regime_vocabulary.py
   per_regime:
     sideways_high_vol: +5     # 변동성 큰 regime — 더 엄격
-    momentum_uptrend: -5      # 강한 상승 trend — 완화
-    extreme_fear: 999         # F&G < 20 — 사실상 emit 차단
-    extreme_greed: +10        # F&G > 80 — 과열 — 더 엄격
+    # 2026-08-21 제거 (#1130) — 셋 다 ALL_REGIMES 밖이라 도입 이래 한 번도 발화 못 했다:
+    #   momentum_uptrend: -5   임계를 70→65 로 **여는** 방향. 도입 커밋에 백테스트 인용이
+    #                          없어 근거 없이 되살리지 않는다.
+    #   extreme_fear: 999      주석부터 `F&G < 20` — Fear&Greed 어휘지 레짐이 아니다.
+    #                          별도 F&G 게이트로 옮길 사안.
+    #   extreme_greed: +10     `euphoria` 로 개명하려면 의미가 같아야 하는데 다르다:
+    #                          euphoria = `VIX < 12 AND F&G > 80` (classifier.py:241) 로
+    #                          더 좁다. 개명이 아니라 정책 변경이라 백테스트 대상.
   max_candidates: 5           # 상위 N개만 emit
   min_candidates: 0           # 0이면 명시적으로 "no candidate" 출력
 
@@ -37,6 +46,14 @@ quality_bar:
 gates:
   # VIX 게이트 임계(block 30 / caution 25)는 rules.yaml entry_rules.vix_gate 가 SSoT.
   # emitter 는 nuri.core.rules 의 VIX_BLOCK_ABOVE / VIX_CAUTION_ABOVE 를 직접 읽는다 (#760).
+
+  # 레짐 하드 차단 — **의도적으로 비어 있다**. 레짐 축은 soft penalty(배분 축소)로만
+  # 운용하고, hard veto 승격은 STRATEGY PR + 백테스트를 요구한다 (Escalation Ladder,
+  # STRATEGY §2.6). risk-of-ruin 방어는 VIX > 30 하드 차단이 이미 담당한다.
+  # 이전엔 코드에 `{bear, crash, extreme_fear}` 가 하드코딩돼 있었는데 셋 다
+  # ALL_REGIMES 밖이라 발화 불가능했다 (#1130) — 코드에서 config 로 옮겨 승격이
+  # 코드 변경이 아니라 값 변경이 되게 한다.
+  blocking_regimes: []
 
   # #517 Phase 2b — Cooldown SELL-type split (codex+Qwen consult B3 REFINE: hard_sell 14→21d).
   # event taxonomy unified: payload.action_type ∈ {hard_sell, trim_action, position_reduce, divergence_alert}.
@@ -54,16 +71,28 @@ gates:
 # 사용자 cash * total_pct = 이번 세션 deploy 추천 금액
 # Phase 2: 계좌별 cash gating + 전략별 차등
 allocation:
+  # 레짐 미상(SPY 데이터 120h 초과 · 히스토리 부족 · 분류 실패) 시 배분. 아래 레짐별
+  # 표와 **분리해 둔다** — `unknown` 은 정식 레짐이 아니라 표에 넣으면 안 된다.
+  # 이 키가 생기기 전에는 미상 라벨이 `neutral` 이었고 표에 `neutral: 0.40` 이 있어서
+  # 레짐을 모를 때 표에서 가장 공격적인 배분이 나갔다 (#1131).
+  unknown_regime_pct: 0.10
+  # ⚠️ per_regime 과 같은 제약 — 키는 ALL_REGIMES 의 원소만. 미등재 레짐은 아래
+  # `default_pct` 로 떨어지고 그 사실이 WARNING 으로 남는다 (조용한 기본값 금지).
   total_pct_by_regime:
-    sideways_high_vol: 0.30   # 보수적 (현재 default)
+    bear_low_vol: 0.10        # soft penalty — 약세장 신규 배분 축소 (2026-08-21 #1130)
+    bear_high_vol: 0.10       # soft penalty
+    sideways_high_vol: 0.30
     sideways_low_vol: 0.40
-    neutral: 0.40
-    momentum_uptrend: 0.60
-    momentum_downtrend: 0.10
-    extreme_fear: 0.00
-    extreme_greed: 0.20
-    bear: 0.00
-    crash: 0.00
+    # 2026-08-21 제거 (#1130) — 전부 ALL_REGIMES 밖이라 도달 불가였다. 진짜 약세
+    # 레짐은 `bear_low_vol` / `bear_high_vol` 이고 위에서 soft penalty 로 다룬다:
+    #   neutral: 0.40             미상 폴백 라벨이었다 → `unknown_regime_pct` 로 이관.
+    #   momentum_uptrend: 0.60    여는 방향. 근거 없어 되살리지 않음.
+    #   momentum_downtrend: 0.10
+    #   extreme_fear: 0.00 / extreme_greed: 0.20   F&G 어휘.
+    #   bear: 0.00 / crash: 0.00  hard veto 였다 → 사용자 판정(2026-08-21)으로
+    #                             soft penalty 0.10 로 대체. 0.00 복원은 백테스트 후.
+  default_pct: 0.30           # 표에 없는 레짐 (bull_* · euphoria · stagflation ·
+                              # recovery · sector_rotation) — 값을 지어내지 않는다
   per_candidate_method: score_weighted    # score 비중에 따라 분할 (vs equal_split)
 
 # ─── Risk per candidate (entry/stop/TP from rules.yaml) ─────────────
@@ -145,7 +174,13 @@ held_add_mode:
         composite_score_min: 80           # 가장 높은 bar
         rsi_max: 35
         days_held_min: 14
-        macro_veto: true                  # F2: regime ∉ {bear,crash} AND VIX < 28
+        macro_veto: true                  # F2: 레짐 veto + 레짐 미상 veto + VIX < 28
+        # 물타기를 막을 레짐. 키는 ALL_REGIMES 원소만 — 그 밖의 문자열은 조용히 무시된다.
+        # **의도적으로 비어 있다**: 이전엔 코드에 `{bear, crash}` 로 하드코딩돼 있었는데
+        # 둘 다 ALL_REGIMES 밖이라 발화 불가능했고(#1130), 되살리는 건 hard veto 승격이라
+        # 백테스트가 선결이다 (Escalation Ladder). 레짐 **미상**은 이 목록과 무관하게
+        # 항상 veto 한다 — 측정 실패는 평온의 확인이 아니다.
+        macro_veto_regimes: []
       cap_max_source: "account_strategies.<account>.max_single_position"
       max_add_pct_of_account_cash: 3
       cooldown_days: 21

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,382 backend tests across 338 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,417 backend tests across 339 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,382 tests, 338 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,417 tests, 339 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/regime/classifier.py
+++ b/nuri/quant/regime/classifier.py
@@ -226,6 +226,19 @@ BASE_REGIMES: tuple[str, ...] = (
 SPECIAL_REGIMES: tuple[str, ...] = tuple(SPECIAL_REGIME_SIZING.keys())
 ALL_REGIMES: tuple[str, ...] = BASE_REGIMES + SPECIAL_REGIMES  # 6 + 4 = 10
 
+#: 레짐을 알 수 없을 때의 라벨 — `classify_regime()` 이 `None` 을 돌려준 경우
+#: (SPY 데이터 120시간 초과 · 히스토리 200일 미만 · 분류 실패).
+#:
+#: **의도적으로 `ALL_REGIMES` 의 원소가 아니다.** config 의 레짐별 조정 표
+#: (`buy_signals.yaml` 의 `quality_bar.per_regime` / `allocation.total_pct_by_regime`)
+#: 에 절대 매치되지 않아야 하기 때문이다 — 미상은 완화도 강화도 받으면 안 된다.
+#:
+#: 이 상수가 생기기 전에는 소비자가 미상을 `"neutral"` 로 표기했고, 그 문자열이
+#: `total_pct_by_regime` 에 `0.40` 으로 **존재해서** 레짐 미상이 표에서 가장 공격적인
+#: 배분을 받았다 (#1131). VIX 미상을 `20.0` 으로 메우지 않는 것과 같은 이유다 (#753):
+#: 모르는 것을 아는 값으로 둔갑시키지 않는다.
+UNKNOWN_REGIME = "unknown"
+
 
 def canonical_regime_or_none(value: str | None) -> str | None:
     """ALL_REGIMES 원소만 통과, 그 외(빈문자열·free-text)는 None (#832).

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -621,7 +621,7 @@ def _run_held_add_shadow():
     안 함). 14d 누적 후 #519 2c calibration sample.
 
     Providers wire-up: buy_candidate_emitter helpers 재사용 — score (factor
-    composite × 100), rsi (RSI snapshot), regime (regime_transitions + VIX),
+    composite × 100), rsi (RSI snapshot), regime (classify_regime 라이브 + VIX),
     sector_mom (price 5d momentum proxy), breakout_above_trim (False default
     — strict, false-positive 회피).
     """

--- a/nuri/trading/recommend/CLAUDE.md
+++ b/nuri/trading/recommend/CLAUDE.md
@@ -23,6 +23,7 @@ The user-facing output layer: BUY candidates, SELL alerts on holdings, price tar
 - **rules.yaml is source of truth** for stop / TP / trailing %. Hardcoding any threshold in this directory is a config-discipline violation (CLAUDE.md root §"Always-on Invariants").
 - **Outcome tracking writes to `recommendations`, not `agent_decisions`**. The two tables exist by design — see `nuri/trading/CLAUDE.md` "decisions vs agent_decisions" if/when added, or root README for the cross-validation rationale.
 - **Dedup window** for re-emission: 7 calendar days per `(ticker, trigger_type)` is the convention (`holdings_monitor.py` baseline). New emitters should match unless they justify otherwise.
+- **레짐은 `classify_regime()` 에서만 오고, 그 어휘는 `ALL_REGIMES` 10개뿐이다.** `regime_transitions` 는 히스토리지 게이팅 출처가 아니다 — 예약 writer 가 없어 임의로 낡는다(실측 121일). 그리고 config·코드가 `bear` / `crash` / `neutral` / `extreme_fear` 같은 **표에 없는 문자열**을 조회하면 `.get(key, default)` 가 조용히 기본값을 주므로 방어 게이트가 초록인 채 죽는다 — 실제로 3건이 2026-04-30~08-21 동안 한 번도 발화하지 못했다. 레짐 목록은 config 에 두고 코드에 박지 않는다. 분류 불가(`None`)는 레짐이 아니라 `UNKNOWN_REGIME` 이며, 어떤 조정 표에도 매치되지 않고 별도의 보수 배분을 받는다. **Test:** `tests/quant/regime/test_config_regime_vocabulary.py::TestConfigSpeaksTheClassifiersLanguage::test_every_regime_key_is_canonical` (config 4개 사이트) + `::TestGateCodeDoesNotHardcodeRegimes::test_no_literal_regime_set_is_compared_against` (AST) + `tests/trading/recommend/test_buy_candidate_emitter.py::test_stale_regime_transitions_row_no_longer_governs_the_gate`.
 
 ## Asset-class scope
 

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -36,6 +36,7 @@ from nuri.core.db import DatabaseError, OperationalError, query_df
 from nuri.core.rules import VIX_BLOCK_ABOVE, VIX_CAUTION_ABOVE
 from nuri.core.timezone import kst_now
 from nuri.quant.factors.relative_strength import leadership_snapshot
+from nuri.quant.regime.classifier import UNKNOWN_REGIME
 from nuri.trading.recommend.vix_gate import latest_vix
 
 logger = logging.getLogger(__name__)
@@ -279,27 +280,43 @@ def _get_rsi_snapshot(db_path=None) -> dict[str, float]:
 
 
 def _get_regime(db_path=None) -> tuple[str, float | None]:
-    """Current regime + VIX. VIX 가 없거나 노후하면 **None** — 지어내지 않는다.
+    """Current regime + VIX. 둘 다 모르면 지어내지 않고 미상으로 표면화한다.
 
-    과거엔 부재·조회실패·노후를 전부 `20.0` 으로 메웠다. 20.0 은 차단(>30)과
-    caution(>=25) 임계 **아래**라, 측정 불가가 조용히 '평온'으로 둔갑해 게이트를 열었고
-    브리핑에는 `VIX=20.0` 이 측정값처럼 찍혔다. #753 이 같은 계열(수집 안 되는
-    `prices.VIX` 를 읽어 항상 폴백)로 이미 한 번 게이트를 무력화한 기록이다.
+    **레짐은 매번 새로 분류한다** (#1131). 이전엔 `regime_transitions` 의 최신 행을
+    읽었다. 그 테이블의 유일한 writer 는 `strategy/monitor.py:78` 의
+    `detect_regime_transition()` 이고, 그걸 부르는 예약 job 이 없다 — 진입점은
+    `Makefile` 의 `strategy:` 수동 타깃뿐이다. 게다가 그 함수는 레짐이 **바뀔 때만**
+    행을 넣으므로 "마지막 전환 = 현재 레짐" 이 성립하려면 감지기가 주기적으로 돌아야
+    하는데 돌지 않는다. dev 스냅샷 실측(2026-08-20): 2행, 최신 2026-04-21 — **121일**.
+    그 값이 하드 차단(`:438`) · 임계 조정(`:444`) · 배분(`:508`) 셋을 지배했다.
 
-    이제 `None` 을 돌려주고 부르는 쪽이 caution 과 동일하게(절반 포지션) 처리한다 —
-    STRATEGY §2.6 Soft penalty. 노후 임계는 `entry_rules.vix_gate.max_age_days`.
+    `classify_regime()` 로 옮기면 신선도 강제가 따라온다: SPY 데이터가 120시간을 넘으면
+    그쪽이 `None` 을 돌려준다 (`classifier.py:366`). 낡은 레짐이 현재값 행세를 하는
+    경로 자체가 사라진다는 뜻이고, `regime_transitions` 는 히스토리 전용으로 남는다.
+
+    `None` 은 `UNKNOWN_REGIME` 으로 표면화한다. 그 라벨은 `ALL_REGIMES` 밖이라 config 의
+    레짐별 조정 표에 매치되지 않는다 — 미상은 완화도 강화도 받지 않는다.
+
+    VIX 쪽은 종전과 같다: 부재·조회실패·노후를 `20.0` 으로 메우면 측정 불가가 조용히
+    '평온'으로 둔갑해 게이트를 연다 (#753). `None` 을 돌려주고 부르는 쪽이 caution 과
+    동일하게(절반 포지션) 처리한다 — STRATEGY §2.6 Soft penalty.
     """
+    from nuri.quant.regime.classifier import classify_regime
+
     try:
-        df = query_df(
-            """SELECT to_regime FROM regime_transitions
-               ORDER BY date DESC LIMIT 1""",
-            db_path=db_path,
-        )
-        regime = df["to_regime"].iloc[0] if not df.empty else "neutral"
+        state = classify_regime(db_path=db_path)
     except (OperationalError, DatabaseError):
-        logger.warning("regime 조회 실패 — neutral 처리", exc_info=True)
-        regime = "neutral"
-    return regime, latest_vix(db_path=db_path)
+        # DB 오류만 삼킨다. 넓게 잡으면 `classify_regime` 안의 **코딩 오류**까지 미상으로
+        # 위장돼 게이트가 조용히 보수 경로로 빠진다 — 이 모듈이 VIX 쪽에서 이미 명시적으로
+        # 거부한 형태다 (`test_a_coding_error_is_not_disguised_as_unknown_vix`).
+        # 데이터 부족·노후라는 **예상된** 열화는 예외가 아니라 `None` 으로 온다.
+        logger.warning("regime 분류 실패 — 미상 처리", exc_info=True)
+        state = None
+
+    if state is None:
+        logger.warning("[emitter] 레짐 미상 — 레짐별 조정 없이 보수 배분 적용")
+        return UNKNOWN_REGIME, latest_vix(db_path=db_path)
+    return state.regime, latest_vix(db_path=db_path)
 
 
 def _score_ticker(
@@ -434,8 +451,15 @@ def emit_buy_candidates(
         result.blocked_reason = f"VIX {vix:.1f} > {VIX_BLOCK_ABOVE} (신규 매수 차단)"
         return result
 
-    # Hard gate: regime
-    if regime in {"bear", "crash", "extreme_fear"}:
+    # Hard gate: regime — 차단 집합은 config SSoT 다 (#1130).
+    # 코드에 `{bear, crash, extreme_fear}` 로 하드코딩돼 있었는데 셋 다 `ALL_REGIMES`
+    # 밖이라 `classify_regime()` 이 내는 어떤 값과도 겹치지 않았고, 도입(2026-04-30,
+    # #508) 이래 **한 번도 발화하지 못했다**. 현재 config 기본값은 빈 집합 — 레짐 축은
+    # soft penalty(배분 축소)로만 운용하고 hard veto 승격은 STRATEGY PR + 백테스트를
+    # 요구한다 (Escalation Ladder). 코드가 아니라 config 에 두는 이유는 그 승격이
+    # 값 변경이어야지 코드 변경이어서는 안 되기 때문이다.
+    blocking = set(gates.get("blocking_regimes") or [])
+    if regime in blocking:
         result.blocked_reason = f"regime={regime} (방어 모드, 신규 매수 차단)"
         return result
 
@@ -505,7 +529,25 @@ def emit_buy_candidates(
         return result
 
     # Allocation
-    total_pct = alloc.get("total_pct_by_regime", {}).get(regime, 0.30)
+    by_regime = alloc.get("total_pct_by_regime", {})
+    if regime == UNKNOWN_REGIME:
+        # 미상은 레짐 표의 기본값이 아니라 **별도 키**로 내린다. 이전엔 미상의 라벨이
+        # `"neutral"` 이었고 표에 `neutral: 0.40` 이 있어서, 레짐을 모를 때 표에서 가장
+        # 공격적인 배분이 나갔다 (#1131). 표에 `unknown` 을 넣지 않는 이유는 그게 정식
+        # 레짐이 아니기 때문이다 — 넣으면 #1130 이 걷어내는 비정식 키가 다시 생긴다.
+        total_pct = float(alloc.get("unknown_regime_pct", 0.10))
+    elif regime in by_regime:
+        total_pct = float(by_regime[regime])
+    else:
+        # 표에 없는 정식 레짐은 선언된 기본값으로 떨어지되 **그 사실을 남긴다**.
+        # 이 경로가 조용하던 동안 `.get(regime, 0.30)` 이 어휘 불일치(#1130)를 정상
+        # 동작처럼 삼켰다 — 예외도 경고도 없이 "그 레짐은 조정 없음" 으로 읽혔다.
+        total_pct = float(alloc.get("default_pct", 0.30))
+        logger.info(
+            "[emitter] regime=%s 는 total_pct_by_regime 미등재 — 기본 배분 %.2f 적용",
+            regime,
+            total_pct,
+        )
     # VIX 미상(None)도 caution 과 동일 취급 — 절반 포지션. STRATEGY §2.6 Soft penalty.
     # 측정 불가를 '평온'으로 읽지 않는다는 뜻이고, 차단(hard veto)까지는 가지 않는다.
     if vix is None or vix >= VIX_CAUTION_ABOVE:

--- a/nuri/trading/recommend/held_add.py
+++ b/nuri/trading/recommend/held_add.py
@@ -31,6 +31,7 @@ from nuri.core.account_cap import derive_position_cap
 from nuri.core.db import get_db, query_df
 from nuri.core.rules import TAKE_PROFIT_GROWTH
 from nuri.core.timezone import kst_now, today_kst
+from nuri.quant.regime.classifier import UNKNOWN_REGIME
 
 logger = logging.getLogger(__name__)
 
@@ -305,9 +306,20 @@ def _evaluate_average_down(
     if pos["days_held"] < int(trig.get("days_held_min", 14)):
         return None
 
-    # macro veto: regime ∉ {bear, crash} AND VIX < 28
+    # macro veto: 레짐 목록 + 미상 + VIX < 28
     if trig.get("macro_veto", True):
-        if regime in {"bear", "crash"}:
+        # 목록은 config SSoT (#1130). 코드에 `{bear, crash}` 로 박혀 있었는데 둘 다
+        # `ALL_REGIMES` 밖이라 `classify_regime()` 이 내는 어떤 값과도 겹치지 않았다 —
+        # macro veto 의 레짐 절반이 도입 이래 한 번도 발화하지 못했다는 뜻이다.
+        # (VIX 절반은 #1076 에서 고쳐져 정상 동작해 왔다.)
+        if regime in set(trig.get("macro_veto_regimes") or []):
+            return None
+        # 레짐 미상도 veto 다 — 바로 아래 VIX 미측정과 같은 논리다 (#1131). 이 경로의
+        # regime 은 `scheduler.py` 가 `buy_candidate_emitter._get_regime()` 결과를
+        # 그대로 넘긴 값이고, 그쪽이 분류 실패·데이터 노후를 `UNKNOWN_REGIME` 으로
+        # 표면화한다. "거시가 무서우면 물타기 금지" 에서 미상은 **거시가 평온하다는
+        # 확인이 안 된** 상태이므로 통과시키면 안 된다.
+        if regime == UNKNOWN_REGIME:
             return None
         # VIX 미측정(None)은 **veto** 다. `_get_regime()` 이 부재·조회실패·노후를
         # 20.0 으로 메우지 않고 None 을 돌려주기 때문에(#753) 여기로 들어온다.
@@ -424,7 +436,13 @@ def emit_held_add_shadow(
     # neutral 값 반환 (해당 mode trigger 가 작동 안 함).
     score_fn = score_provider or (lambda t: 0.0)
     rsi_fn = rsi_provider or (lambda t: None)
-    regime_fn = regime_provider or (lambda: ("neutral", 20.0))
+    # provider 부재 시 **미상**이다. 이전 기본값 `("neutral", 20.0)` 은 둘 다 조작된
+    # 평온값이었다 — `"neutral"` 은 `ALL_REGIMES` 밖이라 어떤 veto 목록에도 걸리지 않고
+    # `20.0 < 28` 이라 VIX veto 도 통과한다. macro veto 의 **두 절반이 동시에 fail-open**
+    # 이었고, 이 함수 docstring 이 regime 은 `buy_candidate_emitter._get_regime()` 에서
+    # 온다고 적은 계약과도 모순이었다. 프로덕션은 항상 provider 를 주입하지만
+    # (`scheduler.py`) 기본값이 지뢰로 남을 이유가 없다.
+    regime_fn = regime_provider or (lambda: (UNKNOWN_REGIME, None))
     sector_mom_fn = sector_mom_provider or (lambda t: 0.0)
     breakout_fn = breakout_above_trim_provider or (lambda t: False)
 

--- a/tests/quant/regime/test_config_regime_vocabulary.py
+++ b/tests/quant/regime/test_config_regime_vocabulary.py
@@ -1,0 +1,182 @@
+"""레짐 어휘 잠금 — config 키와 게이트 코드가 분류기가 내는 값과 같은 우주에 있을 것.
+
+`classify_regime()` 이 낼 수 있는 값은 `ALL_REGIMES` 10개뿐인데, BUY 게이트는 오랫동안
+다른 어휘(`bear` · `crash` · `extreme_fear` · `neutral` · `momentum_*` · `extreme_greed`)를
+조회했다. 파이썬 딕셔너리의 `.get(key, default)` 는 키가 안 맞아도 예외를 던지지 않으므로
+불일치가 **정상 동작으로 읽혔다** — 로그도 경고도 실패도 없이 방어 게이트 3건이
+도입(2026-04-30) 이래 한 번도 발화하지 못했다 (#1130).
+
+`.claude/rules/enforcement.md` 가 부르는 "green dead gate" 계열이고, 이 파일이 그 계열의
+재발을 막는 짝이다 (STRATEGY §5.3.1 Gotcha-Test Pair).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nuri.quant.regime.classifier import ALL_REGIMES, UNKNOWN_REGIME
+
+REPO = Path(__file__).resolve().parents[3]
+BUY_SIGNALS = REPO / "config" / "buy_signals.yaml"
+RULES = REPO / "config" / "rules.yaml"
+
+
+def _avg_down_trigger(c: dict) -> dict:
+    modes = (c.get("held_add_mode") or {}).get("modes") or {}
+    return (modes.get("average_down") or {}).get("trigger") or {}
+
+
+#: 출하 config 에서 레짐 문자열을 담는 자리. (설명, 값 추출) 쌍.
+#: 새 자리를 추가하면 여기에도 등재한다 — 등재를 잊으면 그 자리는 검사되지 않는다.
+_REGIME_SITES = [
+    ("quality_bar.per_regime", lambda c: (c.get("quality_bar") or {}).get("per_regime") or {}),
+    ("gates.blocking_regimes", lambda c: (c.get("gates") or {}).get("blocking_regimes") or []),
+    (
+        "allocation.total_pct_by_regime",
+        lambda c: (c.get("allocation") or {}).get("total_pct_by_regime") or {},
+    ),
+    (
+        "held_add_mode.modes.average_down.trigger.macro_veto_regimes",
+        lambda c: _avg_down_trigger(c).get("macro_veto_regimes") or [],
+    ),
+    # rules.yaml 쪽 — 현재는 canonical 이지만 잠겨 있지 않았다. 같은 결함이 재발할
+    # 자리이므로 함께 본다 (#1131 Codex P2).
+    (
+        "rules.yaml siege_gates.regime_overrides",
+        lambda c: ((c.get("_rules") or {}).get("siege_gates") or {}).get("regime_overrides") or {},
+    ),
+]
+
+#: 값이 **비어 있어도 키는 존재해야 하는** 자리. 키를 통째로 지우면 소비 코드의
+#: `.get(...) or []` 가 빈 목록으로 폴백해 게이트가 조용히 사라진다 — 값이 비어 있는
+#: 것(의도된 soft-penalty 운용)과 키가 없는 것(사고)은 구분돼야 한다.
+_REQUIRED_KEYS = [
+    ("gates.blocking_regimes", lambda c: c.get("gates") or {}, "blocking_regimes"),
+    ("held_add_mode...macro_veto_regimes", _avg_down_trigger, "macro_veto_regimes"),
+]
+
+#: 비면 어휘 검사가 공허해지는 자리 — 채점 표는 항상 값을 갖는다.
+_SCORING_SITES = {
+    "quality_bar.per_regime",
+    "allocation.total_pct_by_regime",
+    "rules.yaml siege_gates.regime_overrides",
+}
+
+
+def _is_regime_expr(node: ast.expr) -> bool:
+    """`regime` · `state.regime` · `_get_regime()[0]` 처럼 레짐을 담는 표현인가.
+
+    이름만 보던 이전 판은 `state.regime in {...}` 과 `_get_regime()[0] in {...}` 를
+    통째로 놓쳤다 (#1131 Codex P2).
+    """
+    if isinstance(node, ast.Name):
+        return "regime" in node.id
+    if isinstance(node, ast.Attribute):
+        return "regime" in node.attr
+    if isinstance(node, ast.Subscript):
+        return _is_regime_expr(node.value)
+    if isinstance(node, ast.Call):
+        return _is_regime_expr(node.func)
+    return False
+
+
+def _string_literals(node: ast.expr) -> list[str]:
+    """비교 대상이 담은 문자열 리터럴 — 단일 상수와 리터럴 컬렉션 둘 다."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.Set, ast.List, ast.Tuple)):
+        return [e.value for e in node.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+    return []
+
+
+#: 레짐을 게이팅에 쓰는 모듈. 여기서 레짐 문자열을 **코드에** 박으면 config 가 SSoT 가
+#: 아니게 되고, 오타/어휘 불일치가 다시 조용해진다.
+_GATE_MODULES = [
+    REPO / "nuri" / "trading" / "recommend" / "buy_candidate_emitter.py",
+    REPO / "nuri" / "trading" / "recommend" / "held_add.py",
+]
+
+
+@pytest.fixture(scope="module")
+def shipped() -> dict:
+    """두 config 를 한 매핑으로 — 사이트 추출기가 최상위 키로 갈라 본다."""
+    return {
+        **yaml.safe_load(BUY_SIGNALS.read_text()),
+        "_rules": yaml.safe_load(RULES.read_text()),
+    }
+
+
+class TestConfigSpeaksTheClassifiersLanguage:
+    @pytest.mark.parametrize("label,extract", _REGIME_SITES, ids=[s[0] for s in _REGIME_SITES])
+    def test_every_regime_key_is_canonical(self, shipped, label, extract):
+        """비정식 키는 `.get()` 이 조용히 삼키므로, 존재 자체가 결함이다."""
+        keys = set(extract(shipped))
+        unreachable = sorted(keys - set(ALL_REGIMES))
+        assert not unreachable, (
+            f"{label} 에 `classify_regime()` 이 절대 내지 않는 키가 있다: {unreachable}. "
+            f"허용 어휘는 ALL_REGIMES 10개뿐이다 — 이 키들은 조용히 무시된다 (#1130)."
+        )
+
+    @pytest.mark.parametrize("label", sorted(_SCORING_SITES))
+    def test_the_scoring_sites_are_populated(self, shipped, label):
+        """전 사이트가 비면 위 검사는 공허하게 통과한다 — 카나리아.
+
+        `any()` 로는 판별이 안 된다: veto 사이트 둘이 비어 있어도 채점 사이트만으로
+        통과해 버린다 (#1131 Codex P2). 채점 사이트는 **비면 안 되는** 쪽이므로 각각을
+        직접 본다. veto 사이트가 비어 있는 것은 의도된 운용이라 여기서 요구하지 않고,
+        대신 `test_veto_keys_exist_even_when_empty` 가 키의 존재를 잠근다.
+        """
+        extract = next(e for lbl, e in _REGIME_SITES if lbl == label)
+        assert extract(shipped), f"{label} 이 비었다 — 어휘 검사가 공허해진다"
+
+    @pytest.mark.parametrize("label,parent,key", _REQUIRED_KEYS, ids=[r[0] for r in _REQUIRED_KEYS])
+    def test_veto_keys_exist_even_when_empty(self, shipped, label, parent, key):
+        """빈 목록과 없는 키는 다르다 — 소비 코드가 둘을 구분 못 하므로 여기서 잠근다."""
+        assert key in parent(shipped), (
+            f"{label} 키가 사라졌다. 소비 코드는 `.get(...) or []` 로 빈 목록에 폴백하므로 "
+            f"게이트가 조용히 없어진다 — 비활성이면 빈 목록을 **명시**할 것."
+        )
+
+    def test_unknown_label_can_never_match_a_regime_table(self):
+        """미상이 `ALL_REGIMES` 에 들어오면 조정 표에 매치될 수 있게 된다.
+
+        그러면 "모른다" 가 완화나 강화를 받는다 — 미상을 별도 키로 분리한 이유가 사라진다.
+        """
+        assert UNKNOWN_REGIME not in ALL_REGIMES
+
+    def test_the_allocation_table_declares_its_own_default(self, shipped):
+        """표에 없는 정식 레짐이 **선언되지 않은** 상수로 떨어지면 안 된다."""
+        alloc = shipped.get("allocation") or {}
+        assert "default_pct" in alloc
+        assert "unknown_regime_pct" in alloc
+
+
+class TestGateCodeDoesNotHardcodeRegimes:
+    @pytest.mark.parametrize("path", _GATE_MODULES, ids=lambda p: p.name)
+    def test_no_literal_regime_set_is_compared_against(self, path):
+        """`if regime in {"bear", "crash"}` 와 `regime == "bear"` 의 재발을 막는다.
+
+        문자열 grep 이 아니라 AST 로 본다 — 주석과 docstring 이 그 문자열을 **설명하기
+        위해** 담고 있어서(이 커밋이 그렇다) grep 은 오탐만 낸다. 여기서 보는 것은
+        레짐 표현을 문자열 리터럴과 비교하는 노드뿐이고, 상수 이름(`UNKNOWN_REGIME`)
+        과의 비교는 리터럴이 아니므로 통과한다.
+        """
+        tree = ast.parse(path.read_text())
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare) or not _is_regime_expr(node.left):
+                continue
+            for op, comparator in zip(node.ops, node.comparators):
+                if not isinstance(op, (ast.In, ast.NotIn, ast.Eq, ast.NotEq)):
+                    continue
+                literals = _string_literals(comparator)
+                if literals:
+                    offenders.append((node.lineno, literals))
+        assert not offenders, (
+            f"{path.name} 이 레짐을 문자열 리터럴과 비교한다: {offenders}. "
+            f"config 로 옮길 것 — 코드에 박으면 어휘 불일치가 다시 조용해진다 (#1130)."
+        )

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -15,6 +15,7 @@ import yaml
 from nuri.core.db import get_db, init_db, upsert_portfolio, upsert_prices
 from nuri.core.rules import VIX_MAX_AGE_BUSINESS_DAYS
 from nuri.core.timezone import today_kst
+from nuri.quant.regime.classifier import UNKNOWN_REGIME, RegimeState
 from nuri.trading.recommend.buy_candidate_emitter import (
     BuyCandidate,
     EmitResult,
@@ -53,12 +54,25 @@ def cfg_path(tmp_path):
         "quality_bar": {
             "base_threshold": 70,
             "max_candidates": 5,
-            "per_regime": {"neutral": 0, "bull": -5, "sideways_high_vol": 999},
+            # 값은 출하 config 와 일부러 다르게 두되(= config 를 읽는다는 증명),
+            # **키는 반드시 canonical** 이다. 이전 fixture 는 `neutral` / `bull` 을 썼는데
+            # 둘 다 `ALL_REGIMES` 밖이라, 출하 config 의 같은 결함(#1130)을 이 스위트가
+            # 재현조차 못 했다 — 테스트가 프로덕션이 도달 못 하는 우주를 잠그고 있었다.
+            "per_regime": {"sideways_low_vol": 0, "bull_low_vol": -5, "sideways_high_vol": 999},
         },
-        "gates": {"vix_block_above": 30, "vix_caution_above": 25, "cooldown_days": 5},
+        "gates": {
+            "vix_block_above": 30,
+            "vix_caution_above": 25,
+            "cooldown_days": 5,
+            # 출하 config 는 빈 집합(soft penalty 전용)이지만, 차단 **기구**가 살아 있음을
+            # 확인하려면 fixture 에는 값이 있어야 한다.
+            "blocking_regimes": ["bear_high_vol"],
+        },
         "exclude_etfs": ["SOXL", "SQQQ", "TQQQ", "TSLL", "LABU"],
         "allocation": {
-            "total_pct_by_regime": {"neutral": 0.30, "bull": 0.50},
+            "total_pct_by_regime": {"sideways_low_vol": 0.30, "bull_low_vol": 0.50},
+            "unknown_regime_pct": 0.10,
+            "default_pct": 0.25,
         },
         # 의도적 non-canonical (21/42): emitter 가 config 를 읽음(하드코딩 아님)을 증명.
         # 실제 출하 config 의 canonical(20/40) 정합은
@@ -135,13 +149,45 @@ def _seed_vix(db_path, value: float, *, days_old: int = 0):
         )
 
 
-def _seed_regime(db_path, regime: str):
-    with get_db(db_path) as conn:
-        conn.execute(
-            "INSERT INTO regime_transitions (date, from_regime, to_regime, action_taken) "
-            "VALUES ('2026-04-30', 'unknown', ?, 'test')",
-            (regime,),
+#: 이번 테스트가 `classify_regime()` 에게 내게 할 레짐. `None` = 미상(분류 차단).
+_REGIME: dict[str, str | None] = {"regime": None}
+
+
+@pytest.fixture(autouse=True)
+def _stub_classifier(monkeypatch):
+    """`classify_regime()` 을 테스트가 지정한 레짐으로 고정한다.
+
+    이전엔 `regime_transitions` 에 문자열을 직접 INSERT 했다(`_seed_regime`). 그 테이블은
+    더 이상 게이트 출처가 아니고(#1131), 더 중요하게는 그 방식이 **프로덕션이 도달할 수
+    없는 상태**를 만들었다 — `classify_regime()` 은 `ALL_REGIMES` 밖의 값을 내지 않는데
+    스위트는 `"bear"` / `"neutral"` 을 넣고 초록이었다 (#1130). 이제 진짜 출처를 가로채
+    canonical 값만 흘린다.
+
+    기본값이 `None`(미상)인 것은 의도적이다: 레짐을 명시하지 않은 테스트는 미상 경로를
+    지나가야 하고, 미상이 조용히 공격적인 배분을 받으면 그 테스트들이 깨진다.
+    """
+    _REGIME["regime"] = None
+
+    def _fake(date=None, db_path=None):
+        regime = _REGIME["regime"]
+        if regime is None:
+            return None
+        trend, _, vol = regime.rpartition("_")
+        return RegimeState(
+            date="2026-04-30",
+            trend=trend.split("_")[0] or "sideways",
+            volatility="high" if "high" in regime else "low",
+            regime=regime,
+            confidence=0.8,
+            details={},
         )
+
+    monkeypatch.setattr("nuri.quant.regime.classifier.classify_regime", _fake)
+
+
+def _use_regime(regime: str | None):
+    """이번 테스트가 볼 레짐 고정. `None` 이면 미상."""
+    _REGIME["regime"] = regime
 
 
 # --- Score / why-now ------------------------------------------------------
@@ -193,7 +239,7 @@ def test_vix_block_above_30(db, cfg_path):
     _seed_factor(db, "AAPL", 0.9)
     _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
     _seed_vix(db, 35.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates == []
@@ -210,7 +256,7 @@ def test_vix_gate_reads_macro_not_prices(db, cfg_path):
     """
     _seed_factor(db, "AAPL", 0.9)
     _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
     with get_db(db) as conn:
         conn.execute(
             "INSERT INTO macro (indicator, date, value, source) VALUES ('vix', ?, 35.0, 'test')",
@@ -231,7 +277,7 @@ def test_vix_caution_halves_allocation(db, cfg_path):
     _seed_prices(db, "AAPL", [100.0] * 25 + [120.0, 121.0, 122.0, 123.0, 124.0, 125.0])
     _seed_rsi(db, "AAPL", 55)
     _seed_vix(db, 27.0)  # between caution(25) and block(30)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates, f"expected candidate, blocked_reason={res.blocked_reason}"
@@ -247,7 +293,7 @@ def _seed_calm_setup(db):
     _seed_factor(db, "AAPL", 0.95)
     _seed_prices(db, "AAPL", [100.0] * 25 + [120.0, 121.0, 122.0, 123.0, 124.0, 125.0])
     _seed_rsi(db, "AAPL", 55)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
 
 def test_fresh_calm_vix_gets_full_allocation(db, cfg_path):
@@ -338,16 +384,97 @@ def test_unknown_vix_is_not_printed_as_a_number(db, cfg_path):
 # --- Gate: regime ----------------------------------------------------------
 
 
-@pytest.mark.parametrize("regime", ["bear", "crash", "extreme_fear"])
-def test_regime_blocks_new_buy(db, cfg_path, regime):
+def test_regime_in_the_configured_blocking_set_blocks_new_buy(db, cfg_path):
+    """차단 **기구** 자체는 살아 있다 — fixture config 가 `bear_high_vol` 을 차단한다.
+
+    이 테스트가 파라미터를 `["bear", "crash", "extreme_fear"]` 로 돌던 시절엔,
+    프로덕션이 만들 수 없는 문자열을 DB 에 직접 넣고 초록이었다. `classify_regime()` 이
+    낼 수 있는 값은 `ALL_REGIMES` 10개뿐이라 그 셋과 교집합이 없었기 때문이다 (#1130).
+    """
     _seed_factor(db, "AAPL", 0.9)
     _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
     _seed_vix(db, 20.0)
-    _seed_regime(db, regime)
+    _use_regime("bear_high_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates == []
-    assert regime in (res.blocked_reason or "")
+    assert "bear_high_vol" in (res.blocked_reason or "")
+
+
+def test_shipped_config_softens_bear_instead_of_blocking_it(db):
+    """출하 config 기준 약세 레짐의 실제 처분 — 차단이 아니라 배분 축소 (2026-08-21).
+
+    사용자 판정: 레짐 축은 soft penalty 로만, hard veto 승격은 백테스트 후. 이 테스트가
+    잠그는 것은 그 판정의 **두 절반**이다 — 차단되지 않을 것(`blocking_regimes` 가 비어
+    있음)과, 그렇다고 강세장과 같은 배분을 받지도 않을 것(0.10).
+
+    `default_pct`(0.30) 와 다른 값이어야 의미가 있다: 같으면 표에서 지워도 통과한다.
+    """
+    _seed_factor(db, "AAPL", 0.95)
+    _seed_prices(db, "AAPL", [100.0] * 30 + [130.0])
+    _seed_vix(db, 20.0)
+    _use_regime("bear_high_vol")
+
+    res = emit_buy_candidates()  # 출하 config
+    assert res.blocked_reason is None or "방어 모드" not in res.blocked_reason
+    assert res.total_deploy_pct == pytest.approx(10.0, abs=0.5)
+
+
+def test_stale_regime_transitions_row_no_longer_governs_the_gate(db, cfg_path, monkeypatch):
+    """#1131 잠금 — 게이트는 `regime_transitions` 를 더 이상 읽지 않는다.
+
+    그 테이블의 유일한 writer 를 부르는 예약 job 이 없어 값이 임의로 낡는다(실측 121일).
+    여기서는 차단 레짐을 **테이블에** 심고, 분류기는 양성 레짐을 내게 둔다. 게이트가
+    테이블로 되돌아가면 후보가 0 이 되어 이 테스트가 실패한다.
+    """
+    from nuri.core.db import get_db as _get_db
+
+    with _get_db(db) as conn:
+        conn.execute(
+            "INSERT INTO regime_transitions (date, from_regime, to_regime, action_taken) "
+            "VALUES ('2026-04-21', 'recovery', 'bear_high_vol', 'stale')",
+        )
+    _seed_factor(db, "AAPL", 0.9)
+    _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
+    _seed_vix(db, 20.0)
+    _use_regime("sideways_low_vol")
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.regime == "sideways_low_vol"
+    assert res.candidates != []
+
+
+def test_unclassifiable_market_is_unknown_and_gets_the_conservative_slice(db, cfg_path):
+    """미상은 레짐이 아니다 — 조정 표에 매치되지 않고 별도 보수 배분을 받는다.
+
+    이전엔 미상 라벨이 `"neutral"` 이었고 `total_pct_by_regime` 에 `neutral: 0.40` 이
+    있어서 **레짐을 모를 때 표에서 가장 공격적인 배분**이 나갔다 (#1131).
+    fixture 는 미상 0.10 / 최대 0.50 이라 두 값이 갈린다.
+    """
+    _seed_factor(db, "AAPL", 0.9)
+    _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
+    _seed_vix(db, 20.0)
+    _use_regime(None)  # classify_regime() → None
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.regime == UNKNOWN_REGIME
+    assert res.candidates != []
+    assert res.total_deploy_pct == pytest.approx(10.0, abs=0.5)
+
+
+def test_a_canonical_regime_absent_from_the_table_uses_the_declared_default(db, cfg_path):
+    """표에 없는 정식 레짐은 `default_pct` 로 — 지어낸 값이 아니라 **선언된** 기본값.
+
+    fixture 의 default 는 0.25 이고 미상(0.10) · 등재 레짐(0.30/0.50) 어느 것과도 다르다.
+    """
+    _seed_factor(db, "AAPL", 0.9)
+    _seed_prices(db, "AAPL", [100.0] * 30 + [120.0])
+    _seed_vix(db, 20.0)
+    _use_regime("recovery")  # canonical 이지만 fixture 표에 없음
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.regime == "recovery"
+    assert res.total_deploy_pct == pytest.approx(25.0, abs=0.5)
 
 
 def test_regime_threshold_999_blocked(db, cfg_path):
@@ -355,7 +482,7 @@ def test_regime_threshold_999_blocked(db, cfg_path):
     _seed_factor(db, "AAPL", 0.99)
     _seed_prices(db, "AAPL", [100.0] * 30 + [200.0])
     _seed_vix(db, 20.0)
-    _seed_regime(db, "sideways_high_vol")
+    _use_regime("sideways_high_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates == []
@@ -383,7 +510,7 @@ def test_held_ticker_skipped(db, cfg_path):
     _seed_prices(db, "AAPL", [100.0] * 30 + [200.0])
     _seed_rsi(db, "AAPL", 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert "AAPL" in res.skipped
@@ -395,7 +522,7 @@ def test_cooldown_ticker_skipped(db, cfg_path):
     _seed_prices(db, "MSFT", [100.0] * 30 + [200.0])
     _seed_rsi(db, "MSFT", 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
     with get_db(db) as conn:
         conn.execute(
             "INSERT INTO pipeline_events (timestamp, event_type, payload) "
@@ -425,7 +552,7 @@ def test_leverage_etf_skipped(db, cfg_path, etf):
     _seed_prices(db, etf, [100.0] * 30 + [200.0])
     _seed_rsi(db, etf, 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert etf in res.skipped
@@ -437,7 +564,7 @@ def test_leverage_etf_skipped(db, cfg_path, etf):
 
 def test_empty_factors_blocked(db, cfg_path):
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates == []
@@ -449,7 +576,7 @@ def test_below_threshold_blocked(db, cfg_path):
     _seed_prices(db, "WEAK", [100.0] * 30 + [99.0])  # flat
     _seed_rsi(db, "WEAK", 50)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates == []
@@ -471,7 +598,7 @@ def test_emit_reports_the_denominator(db, cfg_path):
     _seed_prices(db, "STRONG", [100.0] * 25 + [110.0, 115.0, 120.0, 125.0, 130.0, 135.0])
     _seed_rsi(db, "STRONG", 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.n_scored >= 1, "채점 규모가 결과에 안 실렸다"
@@ -484,7 +611,7 @@ def test_emit_above_threshold(db, cfg_path):
     _seed_prices(db, "STRONG", [100.0] * 25 + [110.0, 115.0, 120.0, 125.0, 130.0, 135.0])
     _seed_rsi(db, "STRONG", 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert len(res.candidates) == 1
@@ -504,7 +631,7 @@ def test_allocation_split_by_score(db, cfg_path):
         _seed_prices(db, t, [100.0] * 25 + [110, 115, 120, 125, 130, 135])
         _seed_rsi(db, t, 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     res = emit_buy_candidates(config_path=cfg_path)
     assert len(res.candidates) == 2
@@ -618,7 +745,7 @@ def test_brief_surfaces_buy_candidates(db, cfg_path):
     _seed_prices(db, "STRONG", [100.0] * 25 + [110, 115, 120, 125, 130, 135])
     _seed_rsi(db, "STRONG", 55)
     _seed_vix(db, 20.0)
-    _seed_regime(db, "neutral")
+    _use_regime("sideways_low_vol")
 
     # emitter reads CONFIG_PATH, not config_path arg in _collect_context.
     # Patch CONFIG_PATH so the brief picks up our test config.

--- a/tests/trading/recommend/test_buy_candidate_emitter_branches.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter_branches.py
@@ -104,7 +104,9 @@ class TestRegimeAndVixDegradation:
         regime, vix = bce._get_regime()
 
         assert vix is None, "조회 실패인데 숫자를 지어냈다"
-        assert regime == "neutral"
+        from nuri.quant.regime.classifier import UNKNOWN_REGIME
+
+        assert regime == UNKNOWN_REGIME
         assert any("macro" in s for s in calls), "VIX 조회 자체가 일어나지 않았다"
 
     def test_a_coding_error_is_not_disguised_as_unknown_vix(self, monkeypatch):

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -23,6 +23,7 @@ import pytest
 import yaml
 
 from nuri.core.db import init_db, query
+from nuri.quant.regime.classifier import UNKNOWN_REGIME
 from nuri.trading.recommend import held_add as ha
 
 # ─── Fixtures ──────────────────────────────────────────────────────
@@ -95,6 +96,11 @@ def cfg_held_add(tmp_path: Path) -> dict:
                         "rsi_max": 35,
                         "days_held_min": 14,
                         "macro_veto": True,
+                        # 출하 config 는 빈 목록(hard veto 승격 미결, #1130)이지만
+                        # veto **기구**를 확인하려면 fixture 에는 값이 있어야 한다.
+                        # 키는 canonical — 이전엔 코드가 `{bear, crash}` 를 봤고 둘 다
+                        # `ALL_REGIMES` 밖이라 이 분기가 발화한 적이 없다.
+                        "macro_veto_regimes": ["bear_high_vol"],
                     },
                     "precedence": 3,
                 },
@@ -289,7 +295,11 @@ class TestModeEvaluation:
         assert mode == "tp1_residual_add"  # precedence=1
 
     def test_average_down_macro_veto_in_bear(self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict) -> None:
-        """regime=bear → average_down macro veto."""
+        """config 의 `macro_veto_regimes` 에 든 레짐 → average_down veto.
+
+        이전엔 `regime="bear"` 를 먹였다. `classify_regime()` 은 그 문자열을 내지 않으므로
+        프로덕션에서 이 분기는 한 번도 실행되지 않았는데 테스트는 초록이었다 (#1130).
+        """
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
             lambda ticker, max_days=60: None,
@@ -309,7 +319,43 @@ class TestModeEvaluation:
             cfg_held_add["held_add_mode"],
             score=85,
             rsi=30,
-            regime="bear",
+            regime="bear_high_vol",
+            vix=18,
+            breakout_above_trim=False,
+            sector_mom=0,
+        )
+        assert mode is None
+
+    def test_average_down_vetoes_when_the_regime_is_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, cfg_held_add: dict
+    ) -> None:
+        """레짐 미상 → veto. 목록에 없어도 막는다 (#1131).
+
+        이 경로의 regime 은 `scheduler.py` 가 `buy_candidate_emitter._get_regime()` 결과를
+        그대로 넘긴 값이고, 그쪽이 분류 실패·SPY 데이터 노후를 `UNKNOWN_REGIME` 으로
+        표면화한다. 바로 아래 VIX 미측정 veto 와 같은 논리다 — "거시가 무서우면 물타기
+        금지" 에서 미상은 **거시가 평온하다는 확인이 안 된** 상태다.
+
+        `macro_veto_regimes` 에 의존하지 않는다는 점이 핵심이다: 출하 config 의 목록은
+        비어 있으므로, 미상 veto 가 목록 검사에만 얹혀 있으면 프로덕션에서 통과해 버린다.
+        """
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_last_trim_age_days",
+            lambda ticker, max_days=60: None,
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_account_strategy_profile",
+            lambda account: {"stop_loss": -10, "tp1_pct": 21.0},
+        )
+        cfg = cfg_held_add["held_add_mode"]
+        cfg["modes"]["average_down"]["trigger"]["macro_veto_regimes"] = []
+        pos = {"ticker": "MSFT", "account": "acct_alpha", "pnl_pct": -5.0, "days_held": 20}
+        mode = ha.select_held_mode(
+            pos,
+            cfg,
+            score=85,
+            rsi=30,
+            regime=UNKNOWN_REGIME,
             vix=18,
             breakout_above_trim=False,
             sector_mom=0,
@@ -592,6 +638,41 @@ class TestEmitHeldAddShadow:
         assert len(result.candidates) == 0
         assert "MSFT@acct_alpha" in result.skipped
         assert "earnings blackout" in result.skipped["MSFT@acct_alpha"]
+
+    def test_the_default_regime_provider_reports_unknown_not_a_calm_market(
+        self, tmp_path: Path, cfg_held_add: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """provider 를 안 주면 **미상**이 내려와야 한다 — 조작된 평온값이 아니라.
+
+        기본값은 `("neutral", 20.0)` 이었다. 둘 다 게이트를 여는 값이다:
+        `"neutral"` 은 `ALL_REGIMES` 밖이라 어떤 veto 목록에도 안 걸리고
+        `20.0 < 28` 이라 VIX veto 도 통과한다 — macro veto 의 **두 절반이 동시에
+        fail-open**. 프로덕션은 항상 provider 를 주입하므로(`scheduler.py`) 이건
+        잠재 지뢰였고, 그래서 어떤 테스트도 되돌림을 잡지 못했다 (#1131 Codex P1).
+
+        모드 평가에 실제로 무엇이 전달되는지를 본다 — 기본값의 *모양*이 아니라
+        *하류에 미치는 값*이 잠금 대상이다.
+        """
+        seen: dict[str, object] = {}
+
+        def _spy(pos, cfg, score, rsi, regime, vix, **_kw):
+            seen["regime"] = regime
+            seen["vix"] = vix
+            return None
+
+        monkeypatch.setattr(ha, "select_held_mode", _spy)
+        monkeypatch.setattr(
+            ha,
+            "_get_held_positions",
+            lambda: [{"ticker": "MSFT", "account": "acct_alpha", "pnl_pct": -5.0, "days_held": 20}],
+        )
+        cfg_path = tmp_path / "buy_signals.yaml"
+        cfg_path.write_text(yaml.safe_dump(cfg_held_add))
+
+        ha.emit_held_add_shadow(config_path=cfg_path, db_path=tmp_path / "x.db")
+
+        assert seen.get("regime") == UNKNOWN_REGIME, "provider 부재 시 레짐을 지어냈다 — 미상이어야 한다"
+        assert seen.get("vix") is None, "VIX 미측정을 숫자로 메웠다 (#753)"
 
     def test_disabled_returns_empty(self, tmp_path: Path) -> None:
         """held_add_mode.enabled=False → no-op."""

--- a/tests/trading/recommend/test_recommend_branch_coverage_v2.py
+++ b/tests/trading/recommend/test_recommend_branch_coverage_v2.py
@@ -106,33 +106,32 @@ class TestBuyCandidateEmitterShortSeries:
 
 
 class TestBuyCandidateEmitterRegimeFallbacks:
-    """Lines 256-257, 264-265: regime/VIX query exceptions → defaults 'neutral'/20.0."""
+    """regime/VIX 조회 예외 → 미상. 지어낸 기본값(`neutral` / 20.0)으로 메우지 않는다."""
 
-    def test_regime_query_exception_falls_back_to_neutral(self, monkeypatch):
-        """Line 256-257: query_df for regime_transitions raises → 'neutral'."""
+    def test_regime_classification_db_error_yields_unknown(self, monkeypatch):
+        """분류가 DB 오류로 죽으면 `UNKNOWN_REGIME` — 레짐을 지어내지 않는다.
+
+        이 테스트는 `regime == "neutral"` 을 잠그고 있었다. `neutral` 은 `ALL_REGIMES`
+        밖이면서 `total_pct_by_regime` 에는 `0.40` 으로 존재해, **분류 실패가 표에서 가장
+        공격적인 배분**을 받는 경로였다 (#1131). 이제 미상은 별도의 보수 배분을 받는다.
+        """
+        from nuri.quant.regime import classifier as clf
+        from nuri.quant.regime.classifier import UNKNOWN_REGIME
         from nuri.trading.recommend import buy_candidate_emitter as bce
         from nuri.trading.recommend import vix_gate as vg
 
-        # First query (regime) raises, second query (VIX) returns empty df
-        call_count = {"n": 0}
+        def boom(*a, **kw):
+            # DB 오류만 삼킨다 — RuntimeError 로 두면 코딩 오류까지 위장되므로
+            # `except (OperationalError, DatabaseError)` 로 좁혀 두었다.
+            from nuri.core.db import OperationalError
 
-        def fake_query_df(sql, *a, **kw):
-            call_count["n"] += 1
-            if "regime_transitions" in sql:
-                # DB 오류만 삼킨다 — RuntimeError 로 두면 코딩 오류까지 위장되므로
-                # `except (OperationalError, DatabaseError)` 로 좁혔다.
-                from nuri.core.db import OperationalError
+            raise OperationalError("synthetic regime fail")
 
-                raise OperationalError("synthetic regime fail")
-            return pd.DataFrame()  # empty VIX
-
-        monkeypatch.setattr(bce, "query_df", fake_query_df)
-        monkeypatch.setattr(vg, "query_df", fake_query_df)
+        monkeypatch.setattr(clf, "classify_regime", boom)
+        monkeypatch.setattr(vg, "query_df", lambda *a, **kw: pd.DataFrame())
         regime, vix = bce._get_regime()
 
-        # Behavioral lock: exception path must fall back to literal "neutral"
-        # (not "" or None) so downstream gate logic (regime in {"bear", ...}) is safe.
-        assert regime == "neutral"
+        assert regime == UNKNOWN_REGIME
         # 빈 VIX df → 지어내지 않고 None (2026-08-10 이전엔 20.0 이었다)
         assert vix is None
 
@@ -142,8 +141,6 @@ class TestBuyCandidateEmitterRegimeFallbacks:
         from nuri.trading.recommend import vix_gate as vg
 
         def fake_query_df(sql, *a, **kw):
-            if "regime_transitions" in sql:
-                return pd.DataFrame()  # empty → "neutral"
             if "vix" in sql:
                 from nuri.core.db import OperationalError
 
@@ -154,7 +151,10 @@ class TestBuyCandidateEmitterRegimeFallbacks:
         monkeypatch.setattr(vg, "query_df", fake_query_df)
         regime, vix = bce._get_regime()
 
-        assert regime == "neutral"
+        # 데이터가 없는 테스트 DB 라 분류는 신선도 미충족으로 차단된다 → 미상
+        from nuri.quant.regime.classifier import UNKNOWN_REGIME
+
+        assert regime == UNKNOWN_REGIME
         assert vix is None
 
 
@@ -289,7 +289,7 @@ class TestBuyCandidateEmitterCooldownBranches:
                         "vix_caution_above": 25,
                         "cooldown": {"hard_sell_days": 21, "fallback_days": 5},  # dict → type-aware
                     },
-                    "allocation": {"total_pct_by_regime": {"neutral": 0.30}},
+                    "allocation": {"total_pct_by_regime": {"sideways_low_vol": 0.30}},
                     "risk": {"stop_pct": -7.0, "tp1_pct": 21.0, "tp2_pct": 42.0},
                 }
             )
@@ -308,7 +308,7 @@ class TestBuyCandidateEmitterCooldownBranches:
         monkeypatch.setattr(bce, "_get_price_signals", lambda **_kw: {})
         monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda **_kw: {})
         monkeypatch.setattr(bce, "leadership_snapshot", lambda *a, **k: {})  # P2 shadow (prices 미시드)
-        monkeypatch.setattr(bce, "_get_regime", lambda **_kw: ("neutral", 18.0))
+        monkeypatch.setattr(bce, "_get_regime", lambda **_kw: ("sideways_low_vol", 18.0))
 
         result = bce.emit_buy_candidates(config_path=cfg_path)
         # Lock-in: the type-aware path was taken exactly once
@@ -338,7 +338,7 @@ class TestBuyCandidateEmitterCooldownBranches:
                     "weights": {"factor_composite": 1.0},
                     "quality_bar": {"base_threshold": 0, "max_candidates": 5, "per_regime": {}},
                     "gates": {"vix_block_above": 30, "vix_caution_above": 25, "cooldown_days": 0},
-                    "allocation": {"total_pct_by_regime": {"neutral": 0.30}},
+                    "allocation": {"total_pct_by_regime": {"sideways_low_vol": 0.30}},
                     "risk": {"stop_pct": -7.0, "tp1_pct": 21.0, "tp2_pct": 42.0},
                 }
             )
@@ -349,7 +349,7 @@ class TestBuyCandidateEmitterCooldownBranches:
         monkeypatch.setattr(bce, "_get_price_signals", lambda **_kw: {})  # NOPRICE missing
         monkeypatch.setattr(bce, "_get_rsi_snapshot", lambda **_kw: {})
         monkeypatch.setattr(bce, "leadership_snapshot", lambda *a, **k: {})  # P2 shadow (prices 미시드)
-        monkeypatch.setattr(bce, "_get_regime", lambda **_kw: ("neutral", 18.0))
+        monkeypatch.setattr(bce, "_get_regime", lambda **_kw: ("sideways_low_vol", 18.0))
 
         result = bce.emit_buy_candidates(config_path=cfg_path)
 
@@ -384,7 +384,7 @@ class TestBuyCandidateEmitterRenderMarkdownSkipped:
                 )
             ],
             skipped={"BBB": "held", "CCC": "cooldown"},  # 2 entries, < 5
-            regime="neutral",
+            regime="sideways_low_vol",
             vix=18.0,
             total_deploy_pct=10.0,
             timestamp_kst="2026-05-04 12:00:00 KST",
@@ -403,7 +403,7 @@ class TestBuyCandidateEmitterRenderMarkdownSkipped:
         result = EmitResult(
             candidates=[],
             skipped=skipped,
-            regime="neutral",
+            regime="sideways_low_vol",
             vix=18.0,
             total_deploy_pct=0.0,
             blocked_reason="no qualified",
@@ -514,7 +514,7 @@ class TestBuyCandidateEmitterMain:
         fake = EmitResult(
             candidates=[],
             skipped={},
-            regime="neutral",
+            regime="sideways_low_vol",
             vix=18.0,
             blocked_reason="stub",
             timestamp_kst="2026-05-04",
@@ -883,7 +883,7 @@ class TestHeldAddAverageDownNoneBranches:
 
         cfg = {"modes": {"average_down": {}}}
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": -5.0, "days_held": 30}
-        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=30, regime="neutral", vix=18) is None
+        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=30, regime="sideways_low_vol", vix=18) is None
 
     def test_pnl_outside_window_returns_none(self, monkeypatch):
         """Line 307-308: pnl outside [pnl_max, pnl_min] window → None."""
@@ -902,7 +902,7 @@ class TestHeldAddAverageDownNoneBranches:
         }
         # stop -10 × 0.3 = -3, × 0.7 = -7. Window: [-7, -3]. pnl=-1 outside.
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": -1.0, "days_held": 30}
-        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=30, regime="neutral", vix=18) is None
+        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=30, regime="sideways_low_vol", vix=18) is None
 
     def test_score_below_min_returns_none(self, monkeypatch):
         """Line 310-311: score < min → None."""
@@ -921,7 +921,7 @@ class TestHeldAddAverageDownNoneBranches:
             }
         }
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": -5.0, "days_held": 30}
-        assert ha._evaluate_average_down(pos, cfg, score=70, rsi=30, regime="neutral", vix=18) is None
+        assert ha._evaluate_average_down(pos, cfg, score=70, rsi=30, regime="sideways_low_vol", vix=18) is None
 
     def test_rsi_above_max_returns_none(self, monkeypatch):
         """Line 313-314: rsi > rsi_max → None."""
@@ -942,7 +942,7 @@ class TestHeldAddAverageDownNoneBranches:
         }
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": -5.0, "days_held": 30}
         # rsi 50 > 35 → None
-        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=50, regime="neutral", vix=18) is None
+        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=50, regime="sideways_low_vol", vix=18) is None
 
     def test_rsi_none_returns_none(self, monkeypatch):
         """Line 313-314: rsi is None → None (require RSI signal)."""
@@ -962,7 +962,7 @@ class TestHeldAddAverageDownNoneBranches:
             }
         }
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": -5.0, "days_held": 30}
-        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=None, regime="neutral", vix=18) is None
+        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=None, regime="sideways_low_vol", vix=18) is None
 
     def test_days_held_below_min_returns_none(self, monkeypatch):
         """Line 316-317: days_held < min → None."""
@@ -983,7 +983,7 @@ class TestHeldAddAverageDownNoneBranches:
             }
         }
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": -5.0, "days_held": 5}
-        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=30, regime="neutral", vix=18) is None
+        assert ha._evaluate_average_down(pos, cfg, score=85, rsi=30, regime="sideways_low_vol", vix=18) is None
 
 
 class TestHeldAddEmitFlowSkipped:
@@ -1051,7 +1051,7 @@ class TestHeldAddEmitFlowSkipped:
             today=date(2026, 5, 4),
             score_provider=lambda t: 50.0,  # below all 999 thresholds
             rsi_provider=lambda t: 50.0,
-            regime_provider=lambda: ("neutral", 18.0),
+            regime_provider=lambda: ("sideways_low_vol", 18.0),
             db_path=fresh_db,
         )
 
@@ -1903,7 +1903,7 @@ class TestHeldAddSelectModeUnknownMode:
 
         cfg = {"modes": {}}
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": 0, "days_held": 0}
-        result = ha.select_held_mode(pos, cfg, score=50, rsi=None, regime="neutral", vix=18)
+        result = ha.select_held_mode(pos, cfg, score=50, rsi=None, regime="sideways_low_vol", vix=18)
         # Lock: None — unknown mode → else r=None (351), known modes → None, final → None.
         assert result is None
 


### PR DESCRIPTION
Closes #1130. Closes #1131.

## Summary

The BUY emitter's regime axis could not act. Two defects held it shut, and each one hid the other.

**The source** (#1131) — `_get_regime()` read `regime_transitions.to_regime`. That table's only writer is `detect_regime_transition()` in `strategy/monitor.py`, no scheduler job calls it, and its only entrypoint is the manual `make strategy` target. It also inserts only on a *change*, so "latest row = current regime" needs a detector that actually runs. Dev snapshot 2026-08-20: 2 rows, newest 2026-04-21 — **121 days** — while live `classify_regime()` returned `bull_low_vol`. That stale string governed the hard block, the quality threshold and the deploy allocation.

**The vocabulary** (#1130) — `classify_regime()` emits only the 10 strings in `ALL_REGIMES`, but the gate looked up a different vocabulary, and `.get(key, default)` reports a miss as a normal lookup. Measured across all 10 regimes on shipped config:

| regime | hard-gate | threshold | deploy |
|---|---|---|---|
| `bull_low_vol` | — | 70 | 0.30 |
| `bear_low_vol` | — | 70 | 0.30 |
| `bear_high_vol` | — | 70 | 0.30 |
| `sideways_high_vol` | — | 75 | 0.30 |
| (6 others) | — | 70 | 0.30 |

A real bear regime drew the same threshold and the same 30% deployment as a bull one. Three defences were unreachable: the hard block `{bear, crash, extreme_fear}` (empty intersection with `ALL_REGIMES`), `extreme_fear: 999`, and `bear: 0.00` / `crash: 0.00`. `held_add`'s macro veto had the same empty intersection — its VIX half worked, its regime half never fired. All three had been inert since `abb354c` (2026-04-30).

### What changed

- `_get_regime()` classifies live. That also buys freshness enforcement for free: `classify_regime()` returns `None` past 120h of SPY staleness, so a stale regime can no longer pose as current. `regime_transitions` stays as history.
- Config keys are canonical; non-regime keys are removed with the reason recorded inline. A missing regime falls to a declared `default_pct` that logs itself.
- Bear regimes get a **soft penalty (0.10)**, not the 0.00 the old config declared. Restoring an unreachable hard veto without a backtest would re-promote a ladder rung, and `abb354c`'s own message records what a 6-month all-SELL asymmetry already cost. Risk-of-ruin defence stays with the VIX > 30 block, which works.
- Both blocking sets move from code to config (`gates.blocking_regimes`, `macro_veto_regimes`, both empty) so promotion is a value change, not a code change.
- `momentum_uptrend: -5` is deliberately **not** remapped — it opens the gate and its introducing commit cites no backtest. `extreme_greed` is **not** renamed to `euphoria`, which is strictly narrower (`VIX < 12 AND F&G > 80`), so the rename would be a policy change wearing a rename's clothes.
- An unclassifiable market surfaces as `UNKNOWN_REGIME`, outside `ALL_REGIMES` by design so it matches no adjustment table. The old fallback label was `"neutral"`, which `total_pct_by_regime` defined at 0.40 — the most aggressive reachable value — so "regime unknown" produced the largest deployment.
- `emit_held_add_shadow`'s provider default was `("neutral", 20.0)`: a fabricated calm on both axes, failing the regime veto open (not in `ALL_REGIMES`) and the VIX veto open (20 < 28) at once, while the function's own docstring claimed the regime came from `_get_regime()`.

### Live execution (dev DB)

```
before   regime=sideways_high_vol (2026-04-21, 121d)   threshold=75
after    regime=bull_low_vol      (live, conf 0.75)    threshold=70
         candidates=0 — "top scorer 56/100 < threshold 70 (scored=7, qualified=0)"
```

Zero candidates is the scorer, not a gate block.

## Test Coverage

Branch coverage on the two substantively changed modules, measured with `--cov-branch` (per `tests/CLAUDE.md`: a run without it is more lenient than CI):

```
nuri/trading/recommend/buy_candidate_emitter.py   279 stmts   0 miss   94 branch   0 partial   100%
nuri/trading/recommend/held_add.py                231 stmts   0 miss   90 branch   0 partial   100%
```

`classifier.py` gains a module-level constant and `scheduler.py` a docstring — neither adds an executable line.

Backend suite: 7,396 → **7,402** passed, 6 skipped.

### Mutation verification

Every defensive change was reverted against the committed tree to confirm its pair test actually fails. All nine:

| mutation | pair test | result |
|---|---|---|
| gate reads `regime_transitions` again | `test_stale_regime_transitions_row_no_longer_governs_the_gate` | FAIL |
| unknown takes the table default | `test_unclassifiable_market_is_unknown_and_gets_the_conservative_slice` | FAIL |
| non-canonical key back in config | `test_every_regime_key_is_canonical` | FAIL |
| `regime in {"bear","crash"}` re-hardcoded | `test_no_literal_regime_set_is_compared_against` | FAIL |
| `regime == "bear"` (single-equals form) | same | FAIL |
| bear soft penalty removed | `test_shipped_config_softens_bear_instead_of_blocking_it` | FAIL |
| unknown veto removed from `held_add` | `test_average_down_vetoes_when_the_regime_is_unknown` | FAIL |
| default provider back to `("neutral", 20.0)` | `test_the_default_regime_provider_reports_unknown_not_a_calm_market` | FAIL |
| veto key deleted from config | `test_veto_keys_exist_even_when_empty` | FAIL |

The AST lock was separately mutation-checked against four evasion forms (literal set, single-equals, attribute left side, call-subscript left side) — all caught — with a control confirming comparison against the `UNKNOWN_REGIME` constant still passes.

## Pre-Landing Review

`/codex review` on the diff (gpt-5.4) returned **NEEDS_REWORK**: 2 P1, 3 P2. All addressed in this branch.

```codex-review
P1  test_recommend_branch_coverage_v2.py — still stubbed ("neutral", 18.0) and shipped
    {"total_pct_by_regime": {"neutral": 0.30}}: the exact unreachable-vocabulary state
    this diff exists to kill, left alive in a file the diff touches. Under the new code
    "neutral" falls to default_pct, so the test passed for a new wrong reason.
P1  held_add.py — regime_fn default ("neutral", 20.0) fails both halves of the macro
    veto open, contradicting the docstring this diff added.
P2  test_config_regime_vocabulary.py — AST lock missed `regime == "bear"`,
    `state.regime in {...}`, `_get_regime()[0] in {...}`; site list omitted
    rules.yaml siege_gates.regime_overrides; the canary passed on scoring sites
    while both veto sites shipped empty.
P2  scheduler.py:624 — job docstring still pointed at the dead source.
P2  tracker.py:79 — save_buy_candidates re-classifies instead of consuming
    EmitResult.regime.
```

Fixed here: both P1s, the AST-lock widening (plus the `rules.yaml` site and a discriminating canary), and the scheduler docstring. **The tracker P2 is deferred to #1082**, which is exactly that question — which regime the ledger should record — and answering it inside this PR would decide #1082 without its own review. Worth stating precisely: `canonical_regime_or_none("unknown")` returns `None`, so while the brief says `regime=unknown` the ledger row stores `NULL`, indistinguishable from "never recorded". That divergence predates this branch (the tracker already stored `NULL` whenever classification failed); this branch makes it legible rather than creating it.

Codex also raised two P3s dated-in-the-future findings that were its own clock being a day stale, and an unreachable-`ValueError` concern already wrapped at both production call sites. Discarded with reasons.

**Specialist fan-out was not dispatched.** `.claude/rules/communication.md` caps subagent spawn ("자기 작업 검증을 서브에이전트에 맡기지 않는다", and records a 56-agent/3M-token audit as the thing not to repeat). The repo's own Flow phase 4 names `/codex review` as the external gate, which ran. Nine mutations and a live execution carry the rest.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file detected.

## Scope

**This PR closes two issues, against the usual 1-issue-1-PR rule.** They are one defect seen from two sides: shipping the vocabulary fix alone would have repaired a gate still reading a 121-day-old value, and shipping the source fix alone would have left the gate unable to fire. Codex's own recommended safe scope was the union ("canonicalization + dead-alias removal + source freshness + tests"). Three commits, within the gate.

Split out rather than absorbed:

- **#1082** — which regime the ledger records (the tracker P2 above).
- **#1136** — `middleware.test.ts` depends on `AUTH_SECRET` being absent instead of stubbing it. Surfaced when the frontend lane failed under a wrapper process and passed 5/5 when run directly. No frontend file in this diff.
- **#1137** — `REGIME_MULTIPLIER` in `nuri/quant/exits/atr.py` still keys on `"neutral"`. Same defect class, different axis (exit sizing), so moving it needs its own backtest.

## Test plan

- [x] Backend suite green — 7,402 passed / 6 skipped (`pytest -n auto --dist worksteal`)
- [x] Branch coverage 100% on both changed modules (`--cov-branch`)
- [x] 9 mutations verified, each pair test fails on revert; working tree clean after each
- [x] Live `emit_buy_candidates()` run on the dev DB
- [x] `make lint`, `make verify-doc-counts` (19/19), privacy scan
- [ ] Frontend vitest — 1 pre-existing environment-dependent failure, filed as #1136; no frontend file in this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
