### PR TITLE
fix(recommend): record the regime that governed the decision, not a fresh one

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,417 collected across 339 files | |
+| **Backend tests** | 7,421 collected across 339 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,417 backend tests across 339 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,421 backend tests across 339 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,417 tests, 339 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,421 tests, 339 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/recommend/tracker.py
+++ b/nuri/trading/recommend/tracker.py
@@ -15,6 +15,7 @@ import logging
 from datetime import datetime, timedelta
 
 from nuri.core.db import get_db, query
+from nuri.quant.regime.classifier import canonical_regime_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -72,15 +73,39 @@ def save_buy_candidates(result, db_path=None) -> int:
         return 0
 
     today = today_kst()
-    batch_regime: str | None = None
-    try:
-        from nuri.quant.regime.classifier import canonical_regime_or_none, classify_regime
 
-        rr = classify_regime(db_path=db_path)
-        if rr is not None:
-            batch_regime = canonical_regime_or_none(rr.regime)
-    except Exception:
-        logger.debug("save_buy_candidates: regime classify 실패, NULL 유지", exc_info=True)
+    # 원장에는 **그 결정을 실제로 지배한** 레짐을 적는다 (#1082). 여기서 다시 분류하면
+    # 게이트가 본 값과 다른 값이 행에 박힌다 — 프로덕션 실측(2026-08-18)에서
+    # emit 은 `recovery`, 저장된 행은 `bull_low_vol` 이었다. 둘 다 canonical 이라
+    # `canonical_regime_or_none` 도 못 걸렀고, 원장을 되짚으면 틀린 근거가 나왔다.
+    #
+    # #1138 로 emitter 도 `classify_regime()` 을 쓰게 되어 두 writer 가 같은 **척도**를
+    # 공유한다. 다만 같아진 건 척도지 **시점**이 아니다 — 그래서 재측정이 아니라 소비여야
+    # 한다. 두 계열이 한 컬럼에서 실제로 관측되는 자리는 `llm/thesis_query.py` 하나뿐이다
+    # (`source` 필터 없이 티커 히스토리를 렌더). 나머지 분석 경로는 전부 `source IS NULL`
+    # 로 합의 행만 본다. 덤으로 호출당 14-18ms 를 아낀다.
+    #
+    # `getattr(result, "regime", None)` 이 아니다: `.candidates` 만 있고 `.regime` 이 없는
+    # 객체(예: `held_add.HeldAddResult`)를 넘기면 **결측이 조용히 NULL 로 강등**돼,
+    # 이 PR 이 구분하려고 만든 "기록 안 됨" 칸으로 들어간다. 그건 데이터 부재가 아니라
+    # 배선 오류이므로 AttributeError 로 터지는 게 맞다 (#894 는 관측이 본 작업을
+    # 게이트하지 말라는 규칙이지, 호출 계약 위반을 삼키라는 규칙이 아니다).
+    emitted_regime = result.regime
+    batch_regime = canonical_regime_or_none(emitted_regime)
+
+    # 컬럼은 canonical 10개 아니면 NULL 이다 (#832). 그래서 "분류 불가"(`unknown`)와
+    # "아예 기록 안 됨"이 컬럼에서는 똑같이 NULL 로 보인다. 컬럼의 도메인을 넓히는
+    # 대신 사실을 `scoring_detail` 에 남겨 둘을 구분한다.
+    #
+    # `EmitResult.regime` 의 기본값 `""` 도 그대로 흘려보낸다 — 빈 문자열은 falsy 라
+    # 아래 부착 조건에서 걸러진다. 여기서 `or None` 으로 한 번 더 정규화하던 코드는
+    # 동작이 같은 중복이었고(뮤테이션으로 확인: 지워도 12/12 초록), 커버리지가 세지
+    # 않는 삼항 갈래만 하나 늘렸다.
+    #
+    # ⚠️ 마커는 **내구적이지 않다**: 합의 경로가 나중에 같은 `(date, ticker)` 를 쓰면
+    # `ON CONFLICT DO UPDATE` 가 `scoring_detail` 을 통째로 덮고 `source` 를 NULL 로
+    # 되돌린다 (`agents/consensus/persistence.py`, 의도된 동작이고 그쪽 테스트가 잠근다).
+    unresolved = None if batch_regime else emitted_regime
 
     records = []
     for c in candidates:
@@ -107,6 +132,9 @@ def save_buy_candidates(result, db_path=None) -> int:
                         "tp1": c.tp1,
                         "tp2": c.tp2,
                         "why_now": c.why_now,
+                        # canonical 이 아니어서 regime 컬럼이 NULL 이 된 경우에만 존재.
+                        # 값은 emitter 가 실제로 쓴 라벨(보통 `unknown`)이다.
+                        **({"regime_unresolved": unresolved} if unresolved else {}),
                     },
                     ensure_ascii=False,
                 ),

--- a/tests/trading/recommend/test_tracker.py
+++ b/tests/trading/recommend/test_tracker.py
@@ -1386,7 +1386,7 @@ class TestSaveBuyCandidates:
     """
 
     @staticmethod
-    def _result(*tickers):
+    def _result(*tickers, regime="bull_low_vol"):
         from nuri.trading.recommend.buy_candidate_emitter import BuyCandidate, EmitResult
 
         return EmitResult(
@@ -1404,7 +1404,7 @@ class TestSaveBuyCandidates:
                 )
                 for t in tickers
             ],
-            regime="bull_low_vol",
+            regime=regime,
         )
 
     def test_writes_rows_tagged_with_the_emit_source(self, db_path):
@@ -1457,47 +1457,95 @@ class TestSaveBuyCandidates:
         assert save_buy_candidates(EmitResult(blocked_reason="VIX 35 > 30"), db_path=db_path) == 0
         assert query("SELECT COUNT(*) c FROM recommendations", db_path=db_path)[0]["c"] == 0
 
-    def test_regime_classify_failure_does_not_block_persistence(self, db_path, monkeypatch):
-        """레짐 분류가 터져도 후보는 저장된다 — regime 만 NULL 로 남는다.
+    def test_the_ledger_records_the_regime_that_governed_the_decision(self, db_path, monkeypatch):
+        """#1082 — 행의 레짐은 **게이트가 본 값**이지 저장 시점에 다시 잰 값이 아니다.
 
-        관측(레짐 라벨)이 본 작업(원장 기록)을 게이트하면 안 된다 (#894). 이 emitter 의
-        기록이 없어서 체인 전체가 비어 있었던 게 #1078 의 출발점인데, 라벨 하나 때문에
-        다시 비면 같은 자리로 돌아간다.
+        프로덕션 실측(2026-08-18): emit 은 `recovery` 였는데 저장된 행은 `bull_low_vol`
+        이었다. 둘 다 canonical 이라 `canonical_regime_or_none` 도 못 걸렀고, 원장을
+        되짚으면 그 후보를 통과시키지 않은 레짐이 나왔다.
+
+        분류기를 **다른 canonical 값**으로 패치해 둔다. 저장 경로가 다시 분류하면 행에
+        `sideways_high_vol` 이 박혀 이 테스트가 실패한다 — 두 값이 모두 canonical 이라야
+        `canonical_regime_or_none` 뒤에 숨지 않고 차이가 드러난다.
         """
         import nuri.quant.regime.classifier as clf
 
-        def boom(*a, **k):
-            raise RuntimeError("regime down")
-
-        monkeypatch.setattr(clf, "classify_regime", boom)
+        monkeypatch.setattr(clf, "classify_regime", lambda **k: SimpleNamespace(regime="sideways_high_vol"))
 
         from nuri.trading.recommend.tracker import save_buy_candidates
 
-        assert save_buy_candidates(self._result("AAA"), db_path=db_path) == 1
-        row = query("SELECT ticker, regime FROM recommendations", db_path=db_path)[0]
-        assert row["ticker"] == "AAA"
+        assert save_buy_candidates(self._result("AAA", regime="recovery"), db_path=db_path) == 1
+        row = query("SELECT regime FROM recommendations", db_path=db_path)[0]
+        assert row["regime"] == "recovery"
+
+    def test_an_unresolved_regime_is_null_but_says_so_in_scoring_detail(self, db_path):
+        """분류 불가는 NULL 이되, "아예 기록 안 됨" 과 구분된다.
+
+        컬럼 도메인은 canonical 10종 또는 NULL 이다 (#832) — `unknown` 을 컬럼에 넣지
+        않는다. 대신 emitter 가 실제로 쓴 라벨을 `scoring_detail` 에 남긴다. 이게 없으면
+        "분류가 실패했다" 와 "이 경로가 레짐을 아예 안 적는다" 가 사후에 구분되지 않는다.
+        """
+        from nuri.quant.regime.classifier import UNKNOWN_REGIME
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        assert save_buy_candidates(self._result("AAA", regime=UNKNOWN_REGIME), db_path=db_path) == 1
+        row = query("SELECT regime, scoring_detail FROM recommendations", db_path=db_path)[0]
         assert row["regime"] is None
+        assert json.loads(row["scoring_detail"])["regime_unresolved"] == UNKNOWN_REGIME
+
+    def test_an_empty_regime_is_null_without_a_marker(self, db_path):
+        """`EmitResult.regime` 기본값 `""` 는 "분류 실패" 가 아니라 "아무도 안 넣음" 이다.
+
+        마커를 붙이면 거짓말이 된다 — `regime_unresolved: ""` 는 시도했다는 뜻이 되니까.
+        `unresolved = ... (emitted_regime or None)` 의 `or None` 갈래가 이걸 담당하는데,
+        삼항 단축은 coverage 가 분기로 세지 않으므로 **테스트가 유일한 잠금**이다.
+        """
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        assert save_buy_candidates(self._result("AAA", regime=""), db_path=db_path) == 1
+        row = query("SELECT regime, scoring_detail FROM recommendations", db_path=db_path)[0]
+        assert row["regime"] is None
+        assert "regime_unresolved" not in json.loads(row["scoring_detail"])
+
+    def test_a_result_without_a_regime_attribute_is_a_wiring_error(self, db_path):
+        """`.candidates` 만 있고 `.regime` 이 없는 객체는 조용히 NULL 이 되면 안 된다.
+
+        `held_add.HeldAddResult` 가 정확히 그 모양이다 — `candidates` / `skipped` 는 있고
+        `regime` 은 없다. `getattr(result, "regime", None)` 로 받으면 그런 객체가
+        **이 PR 이 구분하려고 만든 "기록 안 됨" 칸**으로 조용히 들어간다. 데이터 부재가
+        아니라 호출 계약 위반이므로 터져야 한다.
+        """
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        wrong = SimpleNamespace(candidates=self._result("AAA").candidates, skipped={})
+        with pytest.raises(AttributeError, match="regime"):
+            save_buy_candidates(wrong, db_path=db_path)
+        assert query("SELECT COUNT(*) c FROM recommendations", db_path=db_path)[0]["c"] == 0
+
+    def test_a_resolved_regime_leaves_no_unresolved_marker(self, db_path):
+        """마커는 미해결일 때만 — 항상 붙으면 존재 자체가 신호가 아니게 된다."""
+        from nuri.trading.recommend.tracker import save_buy_candidates
+
+        save_buy_candidates(self._result("AAA", regime="bull_low_vol"), db_path=db_path)
+        row = query("SELECT scoring_detail FROM recommendations", db_path=db_path)[0]
+        assert "regime_unresolved" not in json.loads(row["scoring_detail"])
 
     @pytest.mark.parametrize(
-        ("classified", "expected"),
+        ("emitted", "expected"),
         [
             ("bull_low_vol", "bull_low_vol"),  # canonical → 그대로 행에 박힌다
             ("[recovery] 비중 축소", None),  # free-text → NULL (#832)
         ],
     )
-    def test_regime_label_is_canonical_or_null(self, db_path, monkeypatch, classified, expected):
-        """분류가 성공하면 라벨이 행에 남되, canonical 10종이 아니면 NULL 이다.
+    def test_regime_label_is_canonical_or_null(self, db_path, emitted, expected):
+        """emitter 가 준 라벨이 행에 남되, canonical 10종이 아니면 NULL 이다.
 
-        실패 경로만 잠그면 `canonical_regime_or_none` 을 벗겨도(=`rr.regime` 을 그대로
-        대입해도) 초록이다. free-text 유입이 라벨 커버리지를 3% 로 만든 게 #832 였다.
+        미해결 경로만 잠그면 `canonical_regime_or_none` 을 벗겨도(=`result.regime` 을
+        그대로 대입해도) 초록이다. free-text 유입이 라벨 커버리지를 3% 로 만든 게 #832 다.
         """
-        import nuri.quant.regime.classifier as clf
-
-        monkeypatch.setattr(clf, "classify_regime", lambda **k: SimpleNamespace(regime=classified))
-
         from nuri.trading.recommend.tracker import save_buy_candidates
 
-        assert save_buy_candidates(self._result("AAA"), db_path=db_path) == 1
+        assert save_buy_candidates(self._result("AAA", regime=emitted), db_path=db_path) == 1
         row = query("SELECT regime FROM recommendations", db_path=db_path)[0]
         assert row["regime"] == expected
 


### PR DESCRIPTION
Closes #1082.

## Summary

`save_buy_candidates` ignored `EmitResult.regime` and re-ran `classify_regime()`, so the ledger row recorded a regime that did not gate the candidate. Production 2026-08-18: the emitter decided under `recovery`, the row stored `bull_low_vol`. Both are canonical, so `canonical_regime_or_none` had nothing to catch. Anyone filtering the ledger by regime got candidates that passed a *different* gate — and because the column is a diagnostic label rather than an adjudication axis (§3.11), nothing downstream ever complained.

The row now consumes the emitted regime.

**Why it was written as a re-classification.** Column consistency: `save_recommendations` classifies too, and nobody wanted two scales in one column. #1138 settled the scale by moving the emitter onto `classify_regime()`. What it did not settle is the *vintage* — and that is the whole reason to consume rather than re-measure. The one place both writers are read as a single history is `llm/thesis_query.py:179`, which selects by ticker with no `source` filter; every analytic path (`decision_alpha`, `/actions`, `/dashboard`, `ticker`, `freshness`) filters `source IS NULL`. Consuming also drops a 14-18ms call per save.

`save_recommendations` keeps its own classify call — the E-1/E-2 path has no `EmitResult` to be faithful to.

**Unresolvable regimes.** The column domain is the canonical ten or NULL (#832), and `UNKNOWN_REGIME` is deliberately outside it. But NULL then reads identically to "this path never recorded a regime", so the emitted label goes into `scoring_detail.regime_unresolved`, present only when the column is NULL. The marker is **not durable**: consensus `ON CONFLICT DO UPDATE` overwrites `scoring_detail` wholesale if it later writes the same `(date, ticker)` — existing, intended, and locked by its own test.

### Live verification

Dev DB read-only; writes went to a throwaway DB.

```
게이트가 본 레짐: bull_low_vol (VIX 14.89)

emit='bull_low_vol'  → row regime='bull_low_vol'   unresolved=None
emit='recovery'      → row regime='recovery'       unresolved=None      ← the #1082 scenario
emit='unknown'       → row regime=None             unresolved='unknown'
```

## Test Coverage

`nuri/trading/recommend/tracker.py`: 205 stmts, 0 miss, 80 branch, 1 partial — 99%. The partial is `__main__` argparse, outside this diff. Backend suite 7,404 → **7,406** passed, 6 skipped.

### Mutation verification

Run against the committed tree; working tree verified clean after each.

| mutation | pair test | result |
|---|---|---|
| re-classify at save time (the original defect) | `test_the_ledger_records_the_regime_that_governed_the_decision` | FAIL |
| drop `canonical_regime_or_none` (#832 regression) | `test_regime_label_is_canonical_or_null` | FAIL |
| drop the `regime_unresolved` marker | `test_an_unresolved_regime_is_null_but_says_so_in_scoring_detail` | FAIL |
| always attach the marker | `test_a_resolved_regime_leaves_no_unresolved_marker` | FAIL |
| restore `getattr(result, "regime", None)` | `test_a_result_without_a_regime_attribute_is_a_wiring_error` | FAIL |

The re-classify mutation is locked in both regression shapes — deferred import and hoisted module-level import.

## Pre-Landing Review

`/codex review` on the diff (gpt-5.4): **NEEDS_REWORK**, and it stated **P1: none** explicitly rather than omitting the level. Four P2s, all addressed.

```codex-review
P2  tracker.py — getattr(result, "regime", None) accepts any duck-typed object.
    held_add.HeldAddResult has .candidates/.skipped but no .regime, so a future
    wiring would land silently in the "never recorded" bucket this PR just built.
P2  tracker.py comment + llm/thesis_query.py:179 — claiming #1138 "resolved" the
    two-writer concern is too strong: it settled the scale, not the vintage, and
    thesis_query reads both writers as one history with no source filter.
P2  the deleted test_regime_classify_failure_does_not_block_persistence removed a
    #894 lock while the classifier import sits unguarded inside the function.
P2  `unresolved = ... (emitted_regime or None)` — the `or None` sub-branch has zero
    tests and coverage.py cannot flag it (ternary short-circuits aren't branches).
```

- **Duck typing** → reads `result.regime` directly, so a wrong caller raises `AttributeError`. #894 forbids letting *observation* gate the primary work; it does not require swallowing a caller-contract violation. Locked by a new test that also asserts no row is written.
- **Overclaiming comment** → rewritten to say scale-not-vintage, and to name `thesis_query.py` as the single reader where both writers appear together.
- **Unguarded import** → hoisted to module level, so an ImportError surfaces at load time rather than at save time. `tests/core/test_cross_stage_imports.py` still passes (`nuri/quant` is a shared library, not a stage). The retired lock is called out in the commit message rather than left silent.
- **The `or None` branch** → mutation-tested and found to be **dead**: the downstream `if unresolved` guard already filters the empty string, so removing `or None` left 12/12 green. Deleted rather than tested, per Simplicity First. A test pins the `regime=""` behaviour either way.

Codex also confirmed the attack lines I asked it to check are empty: exactly two call sites, both passing a real `EmitResult`; no falsy-but-valid canonical regime exists; every `scoring_detail` reader is a pass-through `json.loads` with no fixed key set, and the API routes filter `source IS NULL`, so `regime_unresolved` can never reach the frontend.

## Design Review

No frontend files changed — skipped.

## Eval Results

No prompt-related files changed — skipped.

## Plan Completion

No plan file detected.

## Scope

Two commits. Split out rather than absorbed:

- **#1139** — the suite is green only under xdist. Surfaced when Step 16 ran `pytest tests/ -q` without `-n auto`: 31 failures, all tracker-family, from cross-file pollution. Measured **31 on `main` at `484bd62` as well**, so it predates this branch. The tracker file alone passes 79/79 here and 75/75 on main.

## Test plan

- [x] Backend suite green under the repo's standard invocation — 7,406 passed / 6 skipped (`-n auto --dist worksteal`)
- [x] Branch coverage 99% on `tracker.py`, the only partial outside this diff
- [x] 5 mutations verified, each pair test fails on revert; tree clean after each
- [x] Live three-case run of the emit → save path
- [x] `make lint`, `make verify-doc-counts` (19/19), privacy scan, cross-stage import test
- [ ] Serial full-suite run — 31 failures, pre-existing on `main`, filed as #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
