### PR TITLE
fix(api): stop doing live network I/O and uncached 20s work in read handlers

### DIFF
--- a/nuri/api/routes/regime.py
+++ b/nuri/api/routes/regime.py
@@ -1,12 +1,27 @@
 """레짐 + 매크로 + LLM 리포트 API."""
 
 import logging
+import threading
+import time
 from dataclasses import asdict
 
 from fastapi import APIRouter, HTTPException
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["regime"])
+
+# `/report/context` 는 캐시가 없어 **매 요청** 전액을 물었다 — 실측 28.4초, warm 도
+# 28.9초 (#1119). 분해하면 `gather_context()` 안의 `consensus.analyze_portfolio`
+# 하나가 약 20초로, 바로 옆 `/api/consensus` 가 5분 캐시로 이미 갖고 있는 계산이다.
+# 나머지는 screen_candidates 3.58s + detect_conflicts 3.52s + 그 외 0.76s.
+#
+# 여기서는 다른 라우트와 같은 TTL + single-flight 만 붙인다. 구조적 해법
+# (gather_context 가 `recommendations` 에 저장된 합의를 읽게 하는 것 —
+# `ticker.py::_read_consensus_from_db` 에 선례가 있다) 은 LLM 리포트가 보는
+# 내용을 바꾸므로 별건이다.
+_context_cache: dict = {"data": None, "ts": 0.0}
+CONTEXT_CACHE_TTL = 300  # 5분
+_context_lock = threading.Lock()
 
 
 @router.get("/regime")
@@ -44,15 +59,27 @@ def get_report():
 
 @router.get("/report/context")
 def get_report_context():
-    """LLM 리포트 컨텍스트 (프롬프트 입력 데이터)."""
+    """LLM 리포트 컨텍스트 (프롬프트 입력 데이터). 5분 캐시 + single-flight."""
     from nuri.llm.report import format_prompt, gather_context
 
-    ctx = gather_context()
-    return {
-        "prompt": format_prompt(ctx),
-        "gate_score": ctx.gate_score,
-        "known_tickers": list(ctx.known_tickers),
-    }
+    now = time.time()
+    if _context_cache["data"] and (now - _context_cache["ts"]) < CONTEXT_CACHE_TTL:
+        return _context_cache["data"]
+
+    with _context_lock:
+        # double-check — 락을 기다리는 동안 다른 요청이 채웠을 수 있다
+        now = time.time()
+        if _context_cache["data"] and (now - _context_cache["ts"]) < CONTEXT_CACHE_TTL:
+            return _context_cache["data"]
+        ctx = gather_context()
+        result = {
+            "prompt": format_prompt(ctx),
+            "gate_score": ctx.gate_score,
+            "known_tickers": list(ctx.known_tickers),
+        }
+        _context_cache["data"] = result
+        _context_cache["ts"] = now
+        return result
 
 
 @router.get("/strategy")

--- a/nuri/trading/swing/scanner.py
+++ b/nuri/trading/swing/scanner.py
@@ -187,18 +187,44 @@ class ScanResult:
     score: float  # 종합 점수 (높을수록 후보)
 
 
-def _fetch_prices(tickers: list[str], days: int = 60) -> pd.DataFrame | None:
-    """yfinance batch download."""
-    import yfinance as yf
+def _fetch_prices(tickers: list[str], days: int = 60, db_path=None) -> pd.DataFrame | None:
+    """`prices` 테이블에서 최근 `days` 거래일을 읽어 yfinance batch 와 같은 모양으로 만든다.
 
-    try:
-        df = yf.download(tickers, period=f"{days}d", group_by="ticker", progress=False)
-        if df.empty:
-            return None
-        return df
-    except Exception as e:
-        logger.error(f"yfinance download 실패: {e}")
+    예전에는 `yf.download(tickers, period=...)` 였다. 그건 **요청 핸들러 안에서 도는
+    외부 네트워크 호출**이라 `/api/scan` 이 매 요청 야후를 쳤고(실측 1.7초, 캐시 없음),
+    동기 핸들러가 AnyIO 40-스레드 풀을 그만큼 오래 점유했다 (#1119). `nuri/api/CLAUDE.md`
+    가 스스로 적어둔 계약 — *this layer queries and renders, it never computes strategy* —
+    에도 어긋났다.
+
+    수집기가 이미 같은 데이터를 `prices` 에 넣는다. 실측(2026-08-21): 스캔 유니버스
+    US 85/85 · KR 202/203 종목이 60거래일 이상 보유(중앙값 1,298행), OHLCV 완비.
+    미달 종목은 프레임에서 빠지고 `_analyze_ticker` 가 None 으로 흘린다.
+
+    반환 모양은 바뀌지 않는다 — `_analyze_ticker` 가 `data[ticker]["Close"]` 로 읽으므로
+    (ticker, field) MultiIndex 컬럼을 유지한다. 값은 이제 **마지막 수집 종가**다.
+    """
+    from nuri.core.db import query_df
+
+    if not tickers:
         return None
+    placeholders = ",".join("?" * len(tickers))
+    df = query_df(
+        f"SELECT ticker, date, close, volume FROM prices WHERE ticker IN ({placeholders}) ORDER BY date",  # noqa: S608 — placeholders 는 ? 만
+        tuple(tickers),
+        db_path=db_path,
+    )
+    if df is None or df.empty:
+        logger.error("prices 조회 결과 없음 — 수집이 돌았는지 확인 (make collect)")
+        return None
+
+    df["date"] = pd.to_datetime(df["date"])
+    wide = df.pivot(index="date", columns="ticker", values=["close", "volume"])
+    # (field, ticker) → (ticker, field) 로 뒤집고 yfinance 컬럼명에 맞춘다
+    wide.columns = pd.MultiIndex.from_tuples(
+        [(tkr, {"close": "Close", "volume": "Volume"}[field]) for field, tkr in wide.columns]
+    )
+    wide = wide.sort_index().tail(days)
+    return wide if not wide.empty else None
 
 
 def _analyze_ticker(ticker: str, data: pd.DataFrame) -> ScanResult | None:

--- a/tests/api/test_regime.py
+++ b/tests/api/test_regime.py
@@ -138,3 +138,75 @@ class TestRegimeAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["gate_score"] == 80
+
+
+class TestReportContextCache:
+    """`/report/context` 가 매 요청 전액을 다시 물지 않는지 잠근다 (#1119).
+
+    회귀 전에는 캐시가 없어 cold 28.4초 · warm 28.9초였다. 그 중 약 20초가
+    `gather_context()` 안의 `consensus.analyze_portfolio` 인데, 바로 옆
+    `/api/consensus` 가 5분 캐시로 이미 갖고 있는 계산이다.
+    """
+
+    def _reset(self):
+        import nuri.api.routes.regime as m
+
+        m._context_cache["data"] = None
+        m._context_cache["ts"] = 0.0
+
+    def test_second_request_does_not_recompute(self, client, monkeypatch):
+        class FakeContext:
+            gate_score = 80
+            known_tickers = {"AAPL"}
+
+        calls = []
+
+        def counted():
+            calls.append(1)
+            return FakeContext()
+
+        self._reset()
+        monkeypatch.setattr("nuri.llm.report.gather_context", counted)
+        monkeypatch.setattr("nuri.llm.report.format_prompt", lambda ctx: "p")
+        try:
+            assert client.get("/api/report/context").status_code == 200
+            assert client.get("/api/report/context").status_code == 200
+            assert len(calls) == 1, f"gather_context 가 {len(calls)}회 실행됐다"
+        finally:
+            self._reset()
+
+    def test_concurrent_requests_compute_once(self, client, monkeypatch):
+        """락 안쪽 double-check 경로 — 경합 없이는 실행되지 않는다."""
+        import threading
+
+        class FakeContext:
+            gate_score = 1
+            known_tickers = set()
+
+        calls = []
+        barrier = threading.Barrier(4)
+
+        def slow():
+            calls.append(1)
+            _time.sleep(0.25)
+            return FakeContext()
+
+        self._reset()
+        monkeypatch.setattr("nuri.llm.report.gather_context", slow)
+        monkeypatch.setattr("nuri.llm.report.format_prompt", lambda ctx: "p")
+
+        import nuri.api.routes.regime as m
+
+        def worker():
+            barrier.wait(timeout=5)
+            m.get_report_context()
+
+        try:
+            threads = [threading.Thread(target=worker) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=15)
+            assert len(calls) == 1, f"동시 4요청이 {len(calls)}회 계산했다 — single-flight 없음"
+        finally:
+            self._reset()

--- a/tests/trading/swing/test_scanner.py
+++ b/tests/trading/swing/test_scanner.py
@@ -3,6 +3,7 @@
 Extracted from the former tests/test_trading_strategy_all.py.
 Shared fixtures live in conftest.py for this directory.
 """
+
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,12 +16,17 @@ class TestScanResult:
 
     def test_analyze_ticker(self):
         from nuri.trading.swing.scanner import ScanResult, _analyze_ticker
+
         dates = pd.bdate_range("2025-01-01", periods=30)
         close = np.linspace(100, 120, 30)
         volume = [1000000] * 20 + [3000000] * 10
-        data = pd.DataFrame({
-            "Close": close, "Volume": volume,
-        }, index=dates)
+        data = pd.DataFrame(
+            {
+                "Close": close,
+                "Volume": volume,
+            },
+            index=dates,
+        )
         result = _analyze_ticker("TEST", data)
         if result:
             assert isinstance(result, ScanResult)
@@ -36,22 +42,28 @@ class TestAnalyzeTickerScanner:
         if volumes is None:
             volumes = [50_000_000] * n
         dates = pd.bdate_range("2024-01-01", periods=n)
-        df = pd.DataFrame({
-            "Close": prices, "Volume": volumes,
-            "Open": [p - 1 for p in prices],
-            "High": [p + 2 for p in prices],
-            "Low": [p - 2 for p in prices],
-        }, index=dates)
+        df = pd.DataFrame(
+            {
+                "Close": prices,
+                "Volume": volumes,
+                "Open": [p - 1 for p in prices],
+                "High": [p + 2 for p in prices],
+                "Low": [p - 2 for p in prices],
+            },
+            index=dates,
+        )
         return df
 
     def test_too_short_returns_none(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         df = self._make_data([100.0] * 10)
         result = _analyze_ticker("AAPL", df)
         assert result is None
 
     def test_volume_spike_detected(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         volumes = [10_000_000] * 29 + [30_000_000]
         prices = [100.0 + i * 0.5 for i in range(30)]
         df = self._make_data(prices, volumes)
@@ -61,6 +73,7 @@ class TestAnalyzeTickerScanner:
 
     def test_zero_price_returns_none(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         prices = [0.0] * 30
         df = self._make_data(prices)
         result = _analyze_ticker("AAPL", df)
@@ -68,6 +81,7 @@ class TestAnalyzeTickerScanner:
 
     def test_no_signal_returns_none(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         prices = [100.0] * 30
         volumes = [10_000_000] * 30
         df = self._make_data(prices, volumes)
@@ -80,18 +94,22 @@ class TestScanMarket:
 
     def test_scan_returns_empty_on_no_data(self):
         from nuri.trading.swing.scanner import scan_market
+
         with patch("nuri.trading.swing.scanner._fetch_prices", return_value=None):
             results = scan_market()
         assert results == []
 
     def test_scan_filters_and_sorts(self):
         from nuri.trading.swing.scanner import ScanResult, scan_market
+
         fake_results = {
             "AAPL": ScanResult("AAPL", 180.0, 2.0, 8.0, 3.0, 55.0, 0.6, "volume_spike", 40.0),
             "NVDA": ScanResult("NVDA", 900.0, 5.0, 15.0, 2.5, 65.0, 0.8, "momentum", 60.0),
         }
+
         def mock_analyze(ticker, data):
             return fake_results.get(ticker)
+
         with patch("nuri.trading.swing.scanner._fetch_prices", return_value=pd.DataFrame({"x": [1]})):
             with patch("nuri.trading.swing.scanner._analyze_ticker", side_effect=mock_analyze):
                 results = scan_market(top_n=5)
@@ -100,6 +118,7 @@ class TestScanMarket:
 
     def test_scan_kr_market(self):
         from nuri.trading.swing.scanner import scan_market
+
         with patch("nuri.trading.swing.scanner._fetch_prices", return_value=None):
             results = scan_market(market="kr")
         assert results == []
@@ -110,6 +129,7 @@ class TestPrintScan:
 
     def test_print_scan_results(self, capsys):
         from nuri.trading.swing.scanner import ScanResult, print_scan
+
         results = [
             ScanResult("AAPL", 180.0, 2.0, 8.0, 3.0, 55.0, 0.6, "volume_spike", 40.0),
         ]
@@ -119,6 +139,7 @@ class TestPrintScan:
 
     def test_print_scan_empty(self, capsys):
         from nuri.trading.swing.scanner import print_scan
+
         print_scan([])
         out = capsys.readouterr().out
         assert "스캔 결과 없음" in out
@@ -132,15 +153,20 @@ class TestScannerMomentumBreakout:
         if volumes is None:
             volumes = [50_000_000] * n
         dates = pd.bdate_range("2024-01-01", periods=n)
-        return pd.DataFrame({
-            "Close": prices, "Volume": volumes,
-            "Open": [p - 1 for p in prices],
-            "High": [p + 2 for p in prices],
-            "Low": [p - 2 for p in prices],
-        }, index=dates)
+        return pd.DataFrame(
+            {
+                "Close": prices,
+                "Volume": volumes,
+                "Open": [p - 1 for p in prices],
+                "High": [p + 2 for p in prices],
+                "Low": [p - 2 for p in prices],
+            },
+            index=dates,
+        )
 
     def test_momentum_signal(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         prices = [100.0 + i * 1.5 for i in range(30)]
         df = self._make_data(prices)
         result = _analyze_ticker("AAPL", df)
@@ -149,6 +175,7 @@ class TestScannerMomentumBreakout:
 
     def test_breakout_signal(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         prices = [100.0] * 25 + [100.0, 101.0, 103.0, 108.0, 115.0]
         volumes = [10_000_000] * 25 + [10_000_000, 15_000_000, 20_000_000, 25_000_000, 35_000_000]
         df = self._make_data(prices, volumes)
@@ -162,11 +189,13 @@ class TestScanner_Push:
 
     def test_scan_market_empty(self, db_path):
         from nuri.trading.swing.scanner import scan_market
+
         results = scan_market(market="us")
         assert isinstance(results, list)
 
     def test_scan_result_fields(self):
         from nuri.trading.swing.scanner import ScanResult
+
         r = ScanResult("AAPL", 150.0, 2.5, 5.0, 1.5, 35.0, 0.1, "bounce", 30.0)
         assert r.ticker == "AAPL"
         assert r.score == 30.0
@@ -177,6 +206,7 @@ class TestSwingScannerInternals:
 
     def test_scan_with_signals(self, rich_db):
         from nuri.trading.swing.scanner import scan_market
+
         results = scan_market()
         if results:
             r = results[0]
@@ -188,17 +218,25 @@ class TestScanner_R26:
 
     def test_analyze_ticker_flat(self):
         from nuri.trading.swing.scanner import _analyze_ticker
+
         n = 30
         dates = pd.bdate_range("2024-01-01", periods=n)
-        df = pd.DataFrame({
-            "Close": [100.0] * n, "Volume": [1_000_000] * n,
-            "Open": [99.0] * n, "High": [101.0] * n, "Low": [99.0] * n,
-        }, index=dates)
+        df = pd.DataFrame(
+            {
+                "Close": [100.0] * n,
+                "Volume": [1_000_000] * n,
+                "Open": [99.0] * n,
+                "High": [101.0] * n,
+                "Low": [99.0] * n,
+            },
+            index=dates,
+        )
         result = _analyze_ticker("TEST", df)
         assert result is None
 
     def test_scan_market_empty(self, db_path):
         from nuri.trading.swing.scanner import scan_market
+
         with patch("nuri.trading.swing.scanner._fetch_prices", return_value=None):
             results = scan_market()
         assert results == []
@@ -210,6 +248,7 @@ class TestUniverseLoading:
     def test_get_us_universe_core(self):
         """us_core (extended=False)는 정상 로드."""
         from nuri.trading.swing.scanner import get_us_universe
+
         universe = get_us_universe(extended=False)
         assert len(universe) > 0
         assert "AAPL" in universe
@@ -220,6 +259,7 @@ class TestUniverseLoading:
     def test_get_us_universe_extended(self):
         """extended=True는 us_core보다 더 많은 종목."""
         from nuri.trading.swing.scanner import get_us_universe
+
         core = get_us_universe(extended=False)
         extended = get_us_universe(extended=True)
         assert len(extended) > len(core)
@@ -230,6 +270,7 @@ class TestUniverseLoading:
     def test_get_kr_universe(self):
         """KR universe는 .KS 종목들."""
         from nuri.trading.swing.scanner import get_kr_universe
+
         universe = get_kr_universe()
         assert len(universe) > 0
         assert all(t.endswith(".KS") for t in universe)
@@ -240,6 +281,7 @@ class TestUniverseLoading:
         import builtins
 
         from nuri.trading.swing import scanner
+
         real_open = builtins.open
 
         def bad_open(*args, **kwargs):
@@ -254,12 +296,14 @@ class TestUniverseLoading:
     def test_load_universe_missing_group(self):
         """존재하지 않는 group key는 무시."""
         from nuri.trading.swing.scanner import _load_universe
+
         result = _load_universe(["nonexistent_group"])
         assert result == []
 
     def test_get_us_universe_uses_fallback_when_yaml_missing(self, monkeypatch):
         """YAML 누락 시 fallback hardcoded list 사용."""
         from nuri.trading.swing import scanner
+
         monkeypatch.setattr(scanner, "_load_universe", lambda keys: [])
         universe = scanner.get_us_universe()
         assert len(universe) > 0
@@ -268,9 +312,70 @@ class TestUniverseLoading:
     def test_scan_market_with_extended_flag(self, db_path):
         """scan_market(extended=True)이 더 큰 universe 사용."""
         from nuri.trading.swing.scanner import scan_market
+
         with patch("nuri.trading.swing.scanner._fetch_prices", return_value=None):
             results_core = scan_market(market="us", extended=False)
             results_ext = scan_market(market="us", extended=True)
         # 둘 다 빈 결과 (mock이라) — 호출 자체가 에러 없이 동작하면 OK
         assert results_core == []
         assert results_ext == []
+
+
+class TestFetchPricesReadsDbNotNetwork:
+    """스캐너가 `prices` 테이블에서 읽고 요청 경로에서 네트워크를 타지 않는지 잠근다 (#1119).
+
+    회귀 전에는 `_fetch_prices` 가 `yf.download(tickers, period=...)` 였다. `/api/scan`
+    이 매 요청 야후를 쳤고(실측 1.7초), 동기 핸들러가 AnyIO 40-스레드 풀을 그만큼
+    점유했다. 수집기가 이미 같은 데이터를 `prices` 에 넣는다.
+    """
+
+    def _seed(self, db_path, ticker="TST_S", n=80):
+        from nuri.core.db import upsert_prices
+        from nuri.core.timezone import today_kst
+
+        dates = pd.bdate_range(end=today_kst(), periods=n)
+        rows = [
+            {
+                "ticker": ticker,
+                "date": d.strftime("%Y-%m-%d"),
+                "open": 100.0 + i,
+                "high": 101.0 + i,
+                "low": 99.0 + i,
+                "close": 100.0 + i,
+                "volume": 1_000_000 + i,
+                "adj_close": 100.0 + i,
+            }
+            for i, d in enumerate(dates)
+        ]
+        upsert_prices(pd.DataFrame(rows), db_path=db_path)
+
+    def test_returns_yfinance_shaped_frame_from_db(self, db_path):
+        from nuri.trading.swing.scanner import _fetch_prices
+
+        self._seed(db_path)
+        df = _fetch_prices(["TST_S"], days=60, db_path=db_path)
+
+        assert df is not None
+        # `_analyze_ticker` 는 `data[ticker]["Close"]` 로 읽는다 — 모양이 바뀌면 깨진다
+        assert df.columns.nlevels == 2
+        assert ("TST_S", "Close") in df.columns
+        assert ("TST_S", "Volume") in df.columns
+        assert len(df) == 60  # days 로 잘린다
+        assert df["TST_S"]["Close"].notna().all()
+
+    def test_does_not_import_yfinance(self, db_path):
+        """네트워크 경로가 남아 있으면 yfinance 가 sys.modules 에 들어온다."""
+        import sys
+
+        from nuri.trading.swing.scanner import _fetch_prices
+
+        self._seed(db_path)
+        sys.modules.pop("yfinance", None)
+        _fetch_prices(["TST_S"], days=60, db_path=db_path)
+        assert "yfinance" not in sys.modules
+
+    def test_empty_and_unknown_tickers_return_none(self, db_path):
+        from nuri.trading.swing.scanner import _fetch_prices
+
+        assert _fetch_prices([], days=60, db_path=db_path) is None
+        assert _fetch_prices(["TST_NOPE"], days=60, db_path=db_path) is None

--- a/tests/trading/swing/test_swing_branches_full.py
+++ b/tests/trading/swing/test_swing_branches_full.py
@@ -36,23 +36,39 @@ def basic_db(tmp_path, monkeypatch):
 
 
 class TestScannerExtraBranches:
-    def test_fetch_prices_returns_data_on_success(self, monkeypatch):
-        """Line 130-132: non-empty yfinance result → return df.
+    def test_fetch_prices_returns_data_on_success(self, db_path):
+        """success path: `prices` 에 행이 있으면 (ticker, field) 프레임을 돌려준다.
 
-        Lock the success path: scanner._fetch_prices returns the same DataFrame
-        yfinance gave it (not a transformed copy).
+        예전에는 `yf.download` 를 monkeypatch 하고 "yfinance 가 준 DataFrame 을
+        그대로 돌려주는지" 를 잠갔다. #1119 에서 요청 경로의 네트워크 호출을
+        걷어내면서 그 구현이 사라졌으므로 같은 자리에서 새 계약을 잠근다.
         """
-        import yfinance as yf
-
+        from nuri.core.db import upsert_prices
         from nuri.trading.swing import scanner as scanner_mod
 
         idx = pd.bdate_range("2025-03-01", periods=20)
-        fake = pd.DataFrame({"Close": list(range(100, 120))}, index=idx)
-        monkeypatch.setattr(yf, "download", lambda *a, **kw: fake)
-        result = scanner_mod._fetch_prices(["AAA"], days=20)
+        upsert_prices(
+            pd.DataFrame(
+                [
+                    {
+                        "ticker": "AAA",
+                        "date": d.strftime("%Y-%m-%d"),
+                        "open": 100.0 + i,
+                        "high": 100.0 + i,
+                        "low": 100.0 + i,
+                        "close": 100.0 + i,
+                        "volume": 1_000,
+                        "adj_close": 100.0 + i,
+                    }
+                    for i, d in enumerate(idx)
+                ]
+            ),
+            db_path=db_path,
+        )
+        result = scanner_mod._fetch_prices(["AAA"], days=20, db_path=db_path)
         assert result is not None
         assert len(result) == 20
-        assert result["Close"].iloc[-1] == 119
+        assert result["AAA"]["Close"].iloc[-1] == 119
 
     def test_analyze_ticker_multiindex_unknown_ticker_returns_none(self):
         """Line 142-143: ticker not in MultiIndex level 0 → None.


### PR DESCRIPTION
#1119 의 남은 층 중 **고칠 수 있는 것**을 고친다. single-flight 락(#1126)은 중복 계산만 없앴고, 요청 하나가 무엇을 하는지는 그대로였다.

## ① `/api/scan` 이 요청마다 야후를 쳤다

`scanner._fetch_prices` 가 `yf.download(85종목, 60일)` 이었다 — 캐시 없이 매 요청. 요청 핸들러 안의 외부 네트워크 호출이라 동기 핸들러가 AnyIO 40-스레드 풀을 그만큼 점유했고, `nuri/api/CLAUDE.md` 가 스스로 적어둔 계약(*this layer queries and renders, it never computes strategy*)에도 어긋났다.

수집기가 **이미 같은 데이터를 `prices` 에 넣는다.** 실측 (2026-08-21):

| | 커버리지 |
|---|---|
| US 유니버스 | **85 / 85** 종목이 60거래일 이상 |
| KR 유니버스 | **202 / 203** (미달 1종목은 `_analyze_ticker` 가 None 으로 흘림) |
| 컬럼 | OHLCV 완비, 종목당 중앙값 1,298행 |

`prices` 조회로 교체한 결과:

```
_fetch_prices    1.7s → 0.11s
scan_market(us)  1.7s → 0.12s
scan_market(kr)        0.27s
yfinance         sys.modules 에 들어오지도 않는다
```

**반환 모양은 바뀌지 않는다** — `_analyze_ticker` 가 `data[ticker]["Close"]` 로 읽으므로 (ticker, field) MultiIndex 를 유지한다.

⚠️ **동작 변경**: 스캔 값이 라이브에서 **마지막 수집 종가**로 바뀐다. 사용자 승인 후 진행했다. 스윙은 ≤7일 보유라 종가 기준이 무리 없고, 대시보드의 다른 화면이 전부 DB 기반이라 오히려 일관된다.

## ② `/report/context` 가 매 요청 28초를 물었다

cold 28.4s / **warm 28.9s** — 캐시가 없었다. 분해:

| 단계 | 실측 |
|---|---|
| `check_all_gates` | 0.12s |
| `classify_regime` | 0.01s |
| `compute_macro_score` | 0.01s |
| `analyze_risk` | 0.62s |
| `screen_candidates(5d)` | 3.58s |
| `detect_conflicts` | 3.52s |
| **`consensus.analyze_portfolio`** | **~20s** |

**바로 옆 `/api/consensus` 가 5분 캐시로 이미 갖고 있는 계산을 다시 돈다.** 다른 라우트와 같은 TTL + single-flight 를 붙였다.

`/api/report` 는 **일부러 캐시하지 않았다** — 사용자가 "Generate Report" 로 시작하는 생성 액션이라 재클릭이 캐시된 결과를 돌려주면 안 된다.

> 구조적 해법(= `gather_context` 가 `recommendations` 에 저장된 합의를 읽게 하는 것. `ticker.py::_read_consensus_from_db` 에 선례가 있다)은 LLM 리포트가 보는 내용을 바꾸므로 별건으로 남긴다.

## ③ 취소 부재 — 고치지 않았다

클라이언트가 끊어도 동기 핸들러는 끝까지 돈다. starlette 는 이걸 스레드풀에서 돌리고 **실행 중인 스레드를 죽일 방법이 없다.** async 재작성 없이는 불가능하다. 정직한 대응은 일을 줄여 백로그가 안 쌓이게 하는 것이고, ①②가 그 일이다. #1119 는 이 항목 때문에 **열어 둔다.**

## 회귀 테스트

- `tests/trading/swing/test_scanner.py::TestFetchPricesReadsDbNotNetwork` — 프레임 모양 / **yfinance 미로드** / 빈 입력·미지 티커
- `tests/api/test_regime.py::TestReportContextCache` — 2회 요청 1회 계산 / 4스레드 동시 진입 1회 계산

**뮤테이션 실측**: 스캐너를 `yf.download` 로 되돌리면 2건 FAIL, `_context_lock` 을 `nullcontext` + 캐시 저장 제거하면 2건 FAIL.

## 기존 테스트 1건 갱신 (의도적)

`test_swing_branches_full.py::test_fetch_prices_returns_data_on_success` 는 *"yfinance 가 준 DataFrame 을 그대로 돌려주는지"* 를 잠그고 있었다 — 제거된 구현이라 유지 불가능하다. 같은 자리에서 새 계약(`prices` 시드 → (ticker, field) 프레임)을 잠그도록 다시 썼다.

## 검증

- 변경 모듈 patch coverage: 미커버 **0줄 / 부분분기 0개** (`regime.py` 100%, `scanner.py` 의 부분분기 1개는 기존 코드 147→142)
- `tests/trading/swing/` + `tests/api/test_regime.py` + `tests/api/test_swing.py` — **116 passed**
- `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)