### PR TITLE
docs(swing): the scanner reads the DB now — say so where it is read

### DIFF
--- a/nuri/trading/swing/CLAUDE.md
+++ b/nuri/trading/swing/CLAUDE.md
@@ -8,7 +8,7 @@ Short-term (≤ 7 trading days) swing-trade scanner + rule engine. Distinct from
 
 | File | Purpose |
 |---|---|
-| `scanner.py` | Universe-wide volume-spike + momentum + breakout scan via yfinance batch download. Universe loaded from `config/universe.yaml` (fallback: hardcoded list). |
+| `scanner.py` | Universe-wide volume-spike + momentum + breakout scan **read from the `prices` table** — no network call. Universe loaded from `config/universe.yaml` (fallback: hardcoded list). |
 | `rules.py` | Entry / exit decision engine. Uses scanner score + agent consensus to gate entries; `--check` flag scans existing swing positions for exit triggers. |
 
 ## Swing rules (constants in `rules.py`, sourced from `config/rules.yaml`)
@@ -27,17 +27,18 @@ The user-level rule for swing is `-5% stop / +5% TP1 (sell 50%) / +10% TP2 (sell
 ## Invariants
 
 - **Universe is YAML-driven**: `scanner.py` reads `config/universe.yaml`. The hardcoded fallback exists for cold-start dev; production runs always load YAML.
-- **Scan latency**: us-core (~85 tickers) target < 5s. Extended (~543) < 30s. The scanner needs no threading — it is a single `yf.download(tickers, ...)` batch call (the concurrency-asymmetry rule in `.claude/rules/gotchas.md` allows yfinance 10-thread; it is **KRX/pykrx** that must stay sequential + `time.sleep(0.1)`).
+- **The scanner reads the DB, never the network** (#1119). `_fetch_prices` is a single `prices` query pivoted into the `(ticker, field)` MultiIndex frame `_analyze_ticker` expects — the shape yfinance used to return, so downstream code did not change. It used to be `yf.download(tickers, period=...)`, which put an external network round trip inside `/api/scan`'s request handler (1.7s per request, no cache) and held an AnyIO threadpool slot for the duration. Coverage measured 2026-08-21: **US 85/85, KR 202/203** tickers hold ≥ 60 trading days; a ticker short of that drops out of the frame and `_analyze_ticker` returns None for it. Values are **last collected close**, not live — acceptable for a ≤ 7-day horizon and consistent with the rest of the dashboard. If the scan returns nothing, the collectors have not run (`make collect`), not the network.
+- **Scan latency** (measured 2026-08-21, M5 Max, warm DB): us-core 85 → **0.17s**, kr-kospi200 203 → **0.21s**, extended 543 → **0.74s**. No threading needed. (The concurrency-asymmetry rule in `.claude/rules/gotchas.md` still governs the *collectors* that fill `prices`: yfinance 10-thread OK, **KRX/pykrx** sequential + `time.sleep(0.1)`.)
 - **Entry requires both gates**: scanner score AND agent consensus BUY. A high score alone never triggers an entry — the consensus pipeline (`nuri/trading/agents/`) is the second filter.
 - **Position storage**: swing positions go into the `swing_trades` table (`_MIGRATIONS` in `nuri/core/db_migrations.py`). Do not use the main `portfolio` table — swing has its own lifecycle.
-- **Korean ticker `.KS` suffix** (root CLAUDE.md "Gotchas"): scanner handles `.KS` natively via yfinance, but `trailingPE` is missing for KR individuals — use `forward_pe` if scanning by valuation.
+- **Korean ticker `.KS` suffix** (root CLAUDE.md "Gotchas"): `.KS` rows live in `prices` like any other ticker, so the scanner needs no special handling. The quirk still bites the **collectors** that fill it — `trailingPE` is missing for KR individuals, use `forward_pe` if screening by valuation.
 
 ## Distinction from `recommend/buy_candidate_emitter.py`
 
 | | swing | buy_candidate_emitter |
 |---|---|---|
 | Holding horizon | ≤ 7 days | weeks to months |
-| Universe | yfinance batch (hundreds) | factor-screened (top decile) |
+| Universe | `prices` table (hundreds) | factor-screened (top decile) |
 | Exit | scanner-driven (TP/SL/time) | trailing-stop + thesis change |
 | Position table | `swing_trades` | `portfolio` |
 | Trigger frequency | continuous (intraday capable) | daily morning |

--- a/nuri/trading/swing/scanner.py
+++ b/nuri/trading/swing/scanner.py
@@ -2,16 +2,16 @@
 """
 시장 스캐너 — 전체 유니버스에서 스윙 트레이드 후보 탐색.
 
-yfinance batch download로 수백 종목을 빠르게 스캔.
+`prices` 테이블에서 수백 종목을 읽어 스캔 — 네트워크를 타지 않는다 (#1119).
 거래량 급증, 모멘텀, 기술적 브레이크아웃 3중 필터.
 
 Universe는 config/universe.yaml에서 로드 (외부화).
 폴백: hardcoded list.
 
 사용법:
-    python -m nuri.trading.swing.scanner                     # us core (85종목, ~5초)
-    python -m nuri.trading.swing.scanner --market kr         # kr kospi200 (203종목)
-    python -m nuri.trading.swing.scanner --extended          # us core + sp500 ext (543종목)
+    python -m nuri.trading.swing.scanner                     # us core (85종목, 0.17초)
+    python -m nuri.trading.swing.scanner --market kr         # kr kospi200 (203종목, 0.21초)
+    python -m nuri.trading.swing.scanner --extended          # us core + sp500 ext (543종목, 0.74초)
 """
 
 import argparse


### PR DESCRIPTION
#1141 후속. 그 PR 이 `_fetch_prices` 를 yfinance 에서 `prices` 조회로 바꾸면서 **두 문서를 낡게 만들었다.** 제가 만든 드리프트라 바로 닫는다.

가장 나쁜 자리는 `nuri/trading/swing/CLAUDE.md` 다 — `load-triggers.md` 가 `swing/` 을 건드리기 전에 읽으라고 지정한 파일인데, Invariants 에 이렇게 적혀 있었다:

> The scanner needs no threading — it is a single `yf.download(tickers, ...)` batch call

**지금 코드에 없는 호출이다.** 이걸 읽고 들어온 사람은 존재하지 않는 네트워크 경로를 전제하고 작업한다.

## 변경

| 자리 | 전 | 후 |
|---|---|---|
| `scanner.py` docstring | "yfinance batch download로 수백 종목" | `prices` 조회, 네트워크 없음 |
| `scanner.py` 사용법 | `~5초` | 실측 us **0.17s** · kr **0.21s** · ext **0.74s** |
| CLAUDE.md Files 표 | "via yfinance batch download" | "read from the `prices` table — no network call" |
| CLAUDE.md Invariants | `yf.download` 단일 배치 호출 | 데이터 출처 · 커버리지 · **마지막 종가지 라이브 아님** · 실패 시 진단 |
| CLAUDE.md Scan latency | "target < 5s / < 30s" (목표치) | 실측값 3개 |
| CLAUDE.md `.KS` 항목 | "scanner handles `.KS` natively via yfinance" | 그 quirk 는 **수집기** 쪽 |
| CLAUDE.md Distinction 표 | "yfinance batch (hundreds)" | "`prices` table (hundreds)" |

## 새로 적은 것

Invariants 에 다음을 넣었다 — 실측 기반이고, 몰라서 헤맬 자리다:

- 커버리지 **US 85/85 · KR 202/203** 종목이 ≥60 거래일. 미달 종목은 프레임에서 빠지고 `_analyze_ticker` 가 None 을 돌려준다
- 값은 **마지막 수집 종가**지 라이브가 아니다 (≤7일 보유 전제에서 수용 가능, 대시보드 나머지와 일관)
- **스캔 결과가 비면 네트워크가 아니라 수집이 안 돈 것** (`make collect`)
- 동시성 비대칭 규칙(yfinance 10-thread / pykrx 순차)은 이제 스캐너가 아니라 `prices` 를 채우는 **수집기**에 적용된다

## 남긴 yfinance 언급

3곳 남았고 전부 "예전엔 이랬다" 맥락이다 — 왜 프레임 모양이 `(ticker, field)` MultiIndex 인지 설명하는 데 필요하다.

## 검증

`bash scripts/verify/pre_push_check.sh --skip-tests` — ALL CHECKS PASSED (doc counts 19/19, spellcheck clean). 코드 변경은 docstring 뿐이라 동작에 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)