### PR TITLE
fix(collectors): ARK 죽은 소스 교체 + 폴백이 만들던 거짓 매도 신호 차단

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,421 collected across 339 files | |
+| **Backend tests** | 7,437 collected across 339 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 601 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 610 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 187 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -508,6 +508,15 @@ symmetric_amplifier:
 #   - 매일 07:10 KST (consensus 07:05 직후) APScheduler job 실행
 #   - portfolio DB table 의 holdings × TechnicalAgent → trigger 평가
 #   - Alert 발동 시 pipeline_events 에 기록 + Discord/Telegram surface
+# ─── ARK 매매 파생 (#1143) ───
+# ARK 는 매매 내역이 아니라 일별 보유 스냅샷을 낸다. Buy/Sell 은 직전 수집분 대비
+# shares 증감으로 파생하는데, ARK 는 리밸런싱으로 매일 소수점 수준을 움직이므로
+# 0 이 아닌 모든 변화를 매매라 부르면 전 종목이 매일 신호를 낸다.
+# 이 값이 smart_money 에이전트의 ARK 항목이 발화하는지를 직접 결정한다 — 코드 상수가
+# 아니라 여기 있어야 하는 이유 (Config over code).
+ark:
+  min_trade_pct: 1.0                     # |shares 변화율| 이 이 값 미만이면 Hold
+
 holdings_monitor:
   enabled: true
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,421 backend tests across 339 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,437 backend tests across 339 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,421 tests, 339 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,437 tests, 339 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -127,8 +127,19 @@ API 가 죽은 뒤 스크래핑이 **예외 없이 점수를 못 찾은** 경우
 
 ARK 는 **일별 보유 CSV** 를 낸다. 매매 내역 파일(`ARK_TRADE.csv`)은 없어졌다.
 그래서 `direction` 은 받아 적는 값이 아니라 **직전 수집분 대비 `shares` 증감으로
-파생**한다. `MIN_TRADE_PCT`(1.0%) 미만은 Hold — ARK 는 리밸런싱으로 매일 소수점
-수준을 움직여서, 0 이 아닌 모든 변화를 매매라 부르면 전 종목이 매일 신호를 낸다.
+파생**한다. `config/rules.yaml ark.min_trade_pct`(1.0%) 미만은 Hold — ARK 는
+리밸런싱으로 매일 소수점 수준을 움직여서, 0 이 아닌 모든 변화를 매매라 부르면 전 종목이
+매일 신호를 낸다. 이 값이 smart_money 의 ARK 항목 발화 여부를 직접 결정하므로 코드 상수가
+아니라 config 에 있다 (Config over code).
+
+⚠️ **부재는 CSV 에 행으로 나타나지 않는다.** ARK 가 한 종목을 완전히 털면 그냥 사라지므로,
+오늘 행만 훑는 파생은 가장 강한 신호인 **전량 청산을 통째로 놓친다** (펀드 간 이동도 같은
+구멍 — 떠난 펀드엔 아무 일도 없고 새 펀드엔 첫 관측이라 Hold). `_exit_records()` 가 직전
+수집분에 있었는데 오늘 없는 종목을 `Sell` / `shares=0.0` 으로 적는다. 그 0 행은 다시
+"여기서 0 이 됐다" 는 기록이 되어, 재진입 때 기준선 조회가 첫 관측으로 되돌린다 — pre-exit
+규모와 비교하면 **더 작게 재진입한 것이 Sell 로 뒤집힌다.** 같은 이유로 `shares` 파싱 실패는
+0.0 이 아니라 **행 폐기**다: 0 으로 눕히면 소스 포맷 드리프트가 전량 청산으로 읽힌다.
+CSV 에서 한 건도 못 건지면 청산 판정 자체를 하지 않는다 (그건 소스 문제지 ARK 의 매도가 아니다).
 
 소스는 펀드별 `assets.ark-funds.com/fund-documents/funds-etf-csv/...` 5개다.
 컬럼이 소문자이고 `weight (%)` 이며 `Direction` 이 없다 — 예전 통합 CSV 의
@@ -145,7 +156,7 @@ ticker 가 비어 있는데, 둘 다 ticker 빈 값으로 자연히 걸러진다
 폴백은 제거했다 (`shares=0.0` 이 델타 기준선까지 오염시킨다 — 기준선 쿼리가
 `shares > 0` 을 거는 이유).
 
-**Test:** `tests/collectors/test_ark.py` (파싱 · 방향 파생 5종 · #1043 실패 구분 ·
+**Test:** `tests/collectors/test_ark.py` (파싱 · 방향 파생 · 청산/재진입 5종 · #1043 실패 구분 ·
 폴백 부활 감시 — AST 로 본다, 소스의 'yfinance' 는 왜 뺐는지 적은 주석이라 grep 은
 영영 빨갛다) + `tests/trading/agents/test_smart_money_branches.py::TestSmartMoneyBranches`
 의 `test_ark_hold_rows_are_not_counted_as_sells` ·

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -39,7 +39,7 @@ CLI: `--source` flag is the standard way to switch (stock, stock_kr, fundamental
 |-----------|--------|-------------|-----|
 | stock, fundamental, wallstreet, estimates | yfinance | **10 threads** | API tolerates concurrency |
 | stock_kr | pykrx (KRX) | **sequential + 0.1s sleep** | First ~60 fast then server hangs |
-| ark, finviz | yfinance/finviz | small loop | <20 items, no benefit |
+| ark, finviz | ark-funds.com CSV / finviz | small loop | <20 items, no benefit |
 
 Standard parallel pattern (consistent across yfinance collectors):
 ```python
@@ -122,6 +122,38 @@ API 가 죽은 뒤 스크래핑이 **예외 없이 점수를 못 찾은** 경우
 (2026-06-22→2026-08-03)이 무발화로 지나갔다. 별건이며 #1042 밖이다.
 **Test:** `tests/collectors/test_cboe.py::TestCBOEFailedVsNoData::test_db_stale_still_counts_as_success`
 — 이 한계를 명시적으로 잠근다(조용히 바꾸면 라이브 소스가 흔들릴 때마다 수집기가 죽는다).
+
+## ARK: 보유 스냅샷이지 매매 내역이 아니다 (`ark.py`, #1143)
+
+ARK 는 **일별 보유 CSV** 를 낸다. 매매 내역 파일(`ARK_TRADE.csv`)은 없어졌다.
+그래서 `direction` 은 받아 적는 값이 아니라 **직전 수집분 대비 `shares` 증감으로
+파생**한다. `MIN_TRADE_PCT`(1.0%) 미만은 Hold — ARK 는 리밸런싱으로 매일 소수점
+수준을 움직여서, 0 이 아닌 모든 변화를 매매라 부르면 전 종목이 매일 신호를 낸다.
+
+소스는 펀드별 `assets.ark-funds.com/fund-documents/funds-etf-csv/...` 5개다.
+컬럼이 소문자이고 `weight (%)` 이며 `Direction` 이 없다 — 예전 통합 CSV 의
+`Ticker` / `% of ETF` 표기와 다르다. 마지막 행은 면책 문구 한 줄이고 비상장 보유분은
+ticker 가 비어 있는데, 둘 다 ticker 빈 값으로 자연히 걸러진다.
+
+⚠️ **폴백이 신호 아닌 것을 신호 자리에 쓰면, 소비자는 그걸 신호로 읽는다.**
+죽은 CSV 를 메우던 yfinance 폴백은 `top_holdings`(상위 10개)를 `direction="Hold"` /
+`shares=0.0` 으로 적었다. 그 자체로는 조용한 결손처럼 보였지만, `smart_money.py` 가
+`sells = len(rows) - buys` 로 세고 있어서 **Hold 가 전부 매도로 집계**됐다 — ark
+테이블에 있는 티커는 예외 없이 `score -1` 과 "ARK 최근 매도 N건" 이라는 거짓 근거를
+받았고, `config/agents.yaml` 의 `score_sell = -1` 이라 그 하나로 verdict 가 SELL 로
+넘어갈 수 있었다. 결손이 아니라 **틀린 신호**였고, 헬스체크는 내내 초록이었다.
+폴백은 제거했다 (`shares=0.0` 이 델타 기준선까지 오염시킨다 — 기준선 쿼리가
+`shares > 0` 을 거는 이유).
+
+**Test:** `tests/collectors/test_ark.py` (파싱 · 방향 파생 5종 · #1043 실패 구분 ·
+폴백 부활 감시 — AST 로 본다, 소스의 'yfinance' 는 왜 뺐는지 적은 주석이라 grep 은
+영영 빨갛다) + `tests/trading/agents/test_smart_money_branches.py::TestSmartMoneyBranches`
+의 `test_ark_hold_rows_are_not_counted_as_sells` ·
+`test_ark_counting_is_safe_even_if_the_query_stops_filtering` ·
+`test_ark_hold_does_not_crowd_out_real_trades`. 소비자 쪽 방어선은 **둘**이고 막는 게
+서로 다르다 — SQL 의 `direction IN ('Buy','Sell')` 이 없으면 최신 Hold 가 `LIMIT 5`
+창을 잡아먹어 진짜 매매가 안 보이고(침묵), 집계식이 틀리면 거짓 매도가 나온다.
+그래서 집계 쪽 잠금은 `_safe_query` 를 가로채 Hold 행을 집계 코드에 직접 흘린다.
 
 ## 13F: 확신 보유 vs 딜러 보유 (`superinvestors.py`, #1098)
 

--- a/nuri/collectors/ark.py
+++ b/nuri/collectors/ark.py
@@ -1,10 +1,16 @@
 """
 ARK Invest 매매 추적 수집기.
 
-소스 우선순위 (모두 무료, fallback chain):
-    1. cathiesark.com 통합 CSV (CSV)
-    2. ark-funds.com 공식 ARK_TRADE.csv (CSV)
-    3. yfinance ETF holdings (ARKK/ARKW/ARKG/ARKQ/ARKF) — REST 차단 시 폴백
+소스: ark-funds.com 공식 ETF 별 보유 CSV (`assets.ark-funds.com`).
+
+이전 소스 2개는 둘 다 죽어 있었다 (#1143) — `cathiesark.com` 은 500/503, 통합
+`ARK_TRADE.csv` 는 301 후 404. 그 자리를 메우던 yfinance 폴백은 `top_holdings`
+(상위 10개) 스냅샷을 `direction="Hold"` / `shares=0.0` 으로 적었는데, 이건 매매가
+아니어서 신호가 없을 뿐 아니라 아래 델타 계산의 기준선을 오염시킨다. 그래서 제거했다.
+
+ARK 는 **매매 내역이 아니라 일별 보유 스냅샷**을 공개한다. 따라서 Buy/Sell 은 직전
+수집분 대비 `shares` 증감으로 파생한다 — 저장 단위가 `(date, ticker, fund)` 라
+파생에 필요한 과거분은 이미 테이블에 있다.
 
 사용법:
     python -m nuri.collectors.ark
@@ -16,152 +22,201 @@ import logging
 
 import requests
 
-from nuri.collectors.base import DEFAULT_HEADERS, BaseCollector, parse_date, today_str
-from nuri.core.db import get_tickers, upsert_ark
+from nuri.collectors.base import DEFAULT_HEADERS, BaseCollector, parse_date
+from nuri.core.db import get_tickers, query, upsert_ark
+from nuri.core.rules import ARK_MIN_TRADE_PCT
 
-# ARK 매매 내역 URL (우선순위 순)
-ARK_TRADE_URLS = [
-    "https://cathiesark.com/ark-combined-holdings-of-etf.csv",
-    "https://ark-funds.com/wp-content/uploads/funds-etf-csv/ARK_TRADE.csv",
-]
-
-# 폴백: yfinance로 직접 조회할 ARK ETF 목록
-ARK_ETFS = ["ARKK", "ARKW", "ARKG", "ARKQ", "ARKF"]
+# ETF 별 보유 CSV. 통합 파일이 없어졌으므로 펀드마다 따로 받는다.
+# 한 펀드가 실패해도 나머지는 수집된다 (부분 성공 허용).
+ARK_HOLDINGS_BASE = "https://assets.ark-funds.com/fund-documents/funds-etf-csv"
+ARK_HOLDINGS_FILES = {
+    "ARKK": "ARK_INNOVATION_ETF_ARKK_HOLDINGS.csv",
+    "ARKW": "ARK_NEXT_GENERATION_INTERNET_ETF_ARKW_HOLDINGS.csv",
+    "ARKG": "ARK_GENOMIC_REVOLUTION_ETF_ARKG_HOLDINGS.csv",
+    "ARKQ": "ARK_AUTONOMOUS_TECH._&_ROBOTICS_ETF_ARKQ_HOLDINGS.csv",
+    "ARKF": "ARK_FINTECH_INNOVATION_ETF_ARKF_HOLDINGS.csv",
+}
 
 
 class ARKCollector(BaseCollector):
-    """ARK Invest 일일 매매 추적."""
+    """ARK Invest 일일 보유 추적 + 전일 대비 매매 파생."""
 
     def __init__(self):
         super().__init__("ark")
 
     def collect(self, **kwargs) -> list[dict]:
-        """ARK 매매 CSV 다운로드 및 파싱. CSV 실패 시 yfinance fallback."""
-        held_tickers = set(get_tickers())
+        """ETF 5종의 보유 CSV 를 받아 보유 종목만 남기고, 직전 보유분과 비교한다."""
+        db_path = kwargs.get("db_path")
+        held_tickers = set(get_tickers(db_path=db_path))
 
-        for url in ARK_TRADE_URLS:
-            try:
-                records = self._collect_csv(url, held_tickers)
-                if records:
-                    return records
-            except Exception as e:
-                self.logger.warning("ARK CSV 다운로드 실패 (%s): %s", url.split("/")[2], e)
-
-        # yfinance 폴백 — ETF holdings 조회
-        try:
-            records = self._collect_yfinance(held_tickers)
-            if records:
-                self.logger.info("ARK 데이터 yfinance fallback 사용 (%d건)", len(records))
-                return records
-        except Exception as e:
-            self.logger.warning("yfinance ARK fallback 실패: %s", e)
-
-        self.logger.warning("모든 ARK 소스 실패 (CSV + yfinance)")
-        return []
-
-    def _collect_yfinance(self, held_tickers: set) -> list[dict]:
-        """yfinance Ticker.funds_data 또는 holdings로 ARK ETF의 보유 종목 조회.
-
-        yfinance API는 ETF의 일별 매매 내역은 제공하지 않으므로,
-        '오늘 날짜의 보유 비중' (held=hold) 스냅샷만 기록한다.
-        """
-        import yfinance as yf
-        from tqdm import tqdm
-
-        records = []
-        succeeded: list[str] = []
+        records: list[dict] = []
+        errors: list[Exception] = []
         failed: list[str] = []
-        today = today_str()
-
-        self.logger.info(f"ARK ETF holdings 수집: {len(ARK_ETFS)}개 ETF")
-        iterator = tqdm(ARK_ETFS, desc="  ARK ETFs", unit="etf", disable=len(ARK_ETFS) < 5)
-        for etf in iterator:
+        for fund, filename in ARK_HOLDINGS_FILES.items():
+            url = f"{ARK_HOLDINGS_BASE}/{filename}"
             try:
-                t = yf.Ticker(etf)
-                # yfinance 0.2.x: funds_data.top_holdings → DataFrame
-                fd = getattr(t, "funds_data", None)
-                holdings_df = None
-                if fd is not None:
-                    holdings_df = getattr(fd, "top_holdings", None)
-                if holdings_df is None or len(holdings_df) == 0:
-                    continue
-                # 컬럼 정규화
-                cols = {c.lower(): c for c in holdings_df.columns}
-                weight_col = cols.get("holding percent") or cols.get("weight")
-                for symbol, row in holdings_df.iterrows():
-                    sym = str(symbol).strip().upper()
-                    if sym not in held_tickers:
-                        continue
-                    weight = float(row[weight_col]) * 100 if weight_col else 0.0
-                    records.append(
-                        {
-                            "date": today,
-                            "ticker": sym,
-                            "direction": "Hold",  # 매매 내역 X, 보유 스냅샷
-                            "shares": 0.0,
-                            "weight": weight,
-                            "fund": etf,
-                        }
-                    )
-                succeeded.append(etf)
+                records.extend(self._collect_fund(url, fund, held_tickers, db_path))
             except Exception as e:
-                failed.append(etf)
-                self.logger.debug("ARK yfinance %s 실패: %s", etf, e)
-                continue
+                errors.append(e)
+                failed.append(fund)
+                self.logger.warning("ARK %s 보유 CSV 실패 (%s): %s", fund, url.split("/")[2], e)
 
-        self.logger.info(
-            "📊 ARK ETF holdings: ✅ %d 성공 / ❌ %d 실패 — total %d holdings recorded",
-            len(succeeded),
-            len(failed),
-            len(records),
-        )
+        if failed:
+            self.logger.warning("ARK 펀드 %d/%d 실패: %s", len(failed), len(ARK_HOLDINGS_FILES), ", ".join(failed))
+
+        # 전면 실패는 빈 수집과 다르다 (#1043, collectors/CLAUDE.md). 조건이 `len(errors) == 5`
+        # 가 아니라 `errors and not records` 인 이유: 일부가 예외이고 나머지는 우리 보유 종목과
+        # 겹치는 항목이 없어 빈 경우도 실패다. 반대로 5개 다 200 인데 겹치는 종목이 하나도
+        # 없으면 예외가 없어 `[]` 가 그대로 나간다 — 그게 NO_DATA 다.
+        # `errors[-1]` 이 아니라 `errors[0]`: 마지막 것만 올리면 첫 펀드의 원인이 알림에서 사라진다.
+        if errors and not records:
+            raise errors[0]
+        if not records:
+            self.logger.warning("ARK 보유 종목과 겹치는 항목 없음 (NO_DATA — 수집 자체는 성공)")
+            return []
+
+        directions = {d: sum(1 for r in records if r["direction"] == d) for d in ("Buy", "Sell", "Hold")}
+        self.logger.info("ARK 보유 %d건 (보유 종목 필터) — %s", len(records), directions)
         return records
 
-    def _collect_csv(self, url: str, held_tickers: set) -> list[dict]:
-        """ARK CSV에서 매매/보유 내역 파싱."""
+    def _collect_fund(self, url: str, fund: str, held_tickers: set, db_path=None) -> list[dict]:
+        """한 ETF 의 보유 CSV 를 파싱하고 직전 보유분 대비 방향을 파생한다."""
         resp = requests.get(url, headers=DEFAULT_HEADERS, timeout=30)
         resp.raise_for_status()
 
         reader = csv.DictReader(io.StringIO(resp.text))
         records = []
+        seen: set[str] = set()
+        csv_date = None
 
         for row in reader:
-            # ARK CSV 컬럼: Date, Fund, Direction, Ticker, CUSIP, Name, Shares, % of ETF
-            ticker = row.get("Ticker", row.get("ticker", "")).strip()
-            if not ticker:
+            # 현재 컬럼: date, fund, company, ticker, cusip, shares, market value ($), weight (%)
+            # 마지막 행은 면책 문구 한 줄이라 ticker 가 비어 자연히 걸러진다. 비상장 보유분도 마찬가지.
+            ticker = _clean(row.get("ticker") or row.get("Ticker"))
+            if not ticker or ticker not in held_tickers:
                 continue
 
-            # 보유 종목만 필터링
-            if ticker not in held_tickers:
+            date = parse_date(_clean(row.get("date") or row.get("Date")))
+            if not date:
                 continue
 
-            # 날짜 파싱 (MM/DD/YYYY 또는 YYYY-MM-DD)
-            date_raw = row.get("Date", row.get("date", "")).strip()
-            date = parse_date(date_raw) or date_raw
+            # shares 를 못 읽으면 행을 버린다 — 0.0 으로 눕히면 방향 파생이 그걸
+            # **전량 청산**으로 읽는다. 소스 포맷이 흔들린 것을 매도 신호로 바꾸지 않는다.
+            shares = _to_float_or_none(row.get("shares") or row.get("Shares"))
+            if shares is None:
+                self.logger.warning("ARK %s %s: shares 파싱 실패 — 행 건너뜀", fund, ticker)
+                continue
 
-            shares_raw = row.get("Shares", row.get("shares", "0"))
-            shares = float(str(shares_raw).replace(",", "")) if shares_raw else 0.0
+            # 'weight (%)' 가 현재 컬럼명. 예전 통합 CSV 의 '% of ETF' 도 받아 둔다.
+            # weight 는 방향 파생에 안 쓰이므로 못 읽으면 0.0 이어도 신호를 왜곡하지 않는다.
+            weight = _to_float_or_none(row.get("weight (%)") or row.get("% of ETF") or row.get("weight"))
 
-            weight_raw = row.get("% of ETF", row.get("weight", "0"))
-            weight = float(str(weight_raw).replace("%", "").replace(",", "")) if weight_raw else 0.0
-
+            csv_date = date
+            seen.add(ticker)
             records.append(
                 {
                     "date": date,
                     "ticker": ticker,
-                    "direction": row.get("Direction", row.get("direction", "")).strip(),
+                    "direction": self._derive_direction(ticker, fund, date, shares, db_path),
                     "shares": shares,
-                    "weight": weight,
-                    "fund": row.get("Fund", row.get("fund", "")).strip(),
+                    "weight": weight if weight is not None else 0.0,
+                    "fund": _clean(row.get("fund") or row.get("Fund")) or fund,
                 }
             )
 
-        self.logger.info(f"ARK 매매 {len(records)}건 (보유 종목 필터)")
+        if csv_date:
+            records.extend(self._exit_records(fund, csv_date, seen, held_tickers, db_path))
         return records
 
+    def _exit_records(self, fund: str, date: str, seen: set[str], held_tickers: set, db_path=None) -> list[dict]:
+        """어제 있었는데 오늘 CSV 에 없는 종목 → 전량 청산 (#1143 codex P1).
+
+        **부재는 CSV 에 행으로 나타나지 않는다.** ARK 가 한 종목을 완전히 털면 그 종목은
+        그냥 사라지므로, 오늘 행만 훑는 파생은 `_derive_direction` 을 호출조차 못 하고
+        가장 강한 신호인 전량 청산이 통째로 유실된다. 펀드 간 이동도 같은 구멍이다 —
+        떠난 펀드에서는 아무 일도 안 일어나고 새 펀드에서는 첫 관측이라 Hold 다.
+
+        `shares=0.0` 으로 적어 두면 이 행 자체가 "여기서 0 이 됐다" 는 기록이 되고,
+        재진입 때 기준선 조회가 이걸 보고 첫 관측으로 되돌린다 (pre-exit 규모와 비교해
+        엉뚱한 Sell 을 내지 않는다).
+        """
+        prev = query(
+            "SELECT ticker, shares FROM ark a WHERE a.fund = ? AND a.date < ? AND a.date = ("
+            "  SELECT MAX(b.date) FROM ark b "
+            "  WHERE b.fund = a.fund AND b.ticker = a.ticker AND b.date < ?"
+            ")",
+            (fund, date, date),
+            db_path=db_path,
+        )
+        return [
+            {
+                "date": date,
+                "ticker": r["ticker"],
+                "direction": "Sell",
+                "shares": 0.0,
+                "weight": 0.0,
+                "fund": fund,
+            }
+            for r in prev
+            # shares > 0 조건이 청산 반복을 막는다 — 어제 이미 0 으로 적힌 종목은
+            # '보유 중이었다' 에 해당하지 않으므로 매일 Sell 을 다시 내지 않는다.
+            if r["shares"] > 0 and r["ticker"] not in seen and r["ticker"] in held_tickers
+        ]
+
+    def _derive_direction(self, ticker: str, fund: str, date: str, shares: float, db_path=None) -> str:
+        """직전 보유분 대비 shares 증감 → Buy / Sell / Hold.
+
+        기준선 후보는 `shares > 0` 인 행 **또는 우리가 적은 청산 표식**(`Sell` + 0)이다.
+        과거 yfinance 폴백이 남긴 `shares=0.0` / `Hold` 행은 실제 0 이 아니라 값을 몰라서
+        0 인 것이라 기준선에서 빼야 한다 — 그걸 기준선으로 잡으면 다음 수집분이 통째로
+        Buy 로 보인다 (#1143).
+
+        기준선이 청산 표식이면 오늘은 **재진입**이므로 첫 관측으로 되돌린다 (Hold).
+        pre-exit 규모와 비교하면, 더 작게 재진입한 경우가 Sell 로 뒤집힌다.
+        비교 대상이 아예 없어도 (첫 관측) 방향을 주장하지 않는다.
+        """
+        prev = query(
+            "SELECT shares FROM ark WHERE ticker = ? AND fund = ? AND date < ? "
+            "AND (shares > 0 OR direction = 'Sell') ORDER BY date DESC LIMIT 1",
+            (ticker, fund, date),
+            db_path=db_path,
+        )
+        if not prev:
+            return "Hold"
+
+        before = prev[0]["shares"]
+        if before <= 0:
+            return "Hold"  # 청산 표식 → 재진입은 새 포지션이다
+
+        change_pct = (shares - before) / before * 100
+        if change_pct >= ARK_MIN_TRADE_PCT:
+            return "Buy"
+        if change_pct <= -ARK_MIN_TRADE_PCT:
+            return "Sell"
+        return "Hold"
+
     def save(self, data: list[dict]) -> int:
-        """ARK 매매 내역을 DB에 저장."""
+        """ARK 보유/매매 내역을 DB에 저장."""
         return upsert_ark(data)
+
+
+def _clean(value) -> str:
+    return str(value).strip() if value else ""
+
+
+def _to_float_or_none(raw) -> float | None:
+    """'1,713,664' / '9.36%' / '$601,701,703.70' → float. 파싱 불가 시 **None**.
+
+    0.0 을 돌려주면 안 된다 — 방향 파생이 shares 0 을 전량 청산으로 읽으므로,
+    소스 포맷이 흔들린 것이 매도 신호로 둔갑한다 (#1143 codex P2).
+    """
+    s = _clean(raw).replace(",", "").replace("%", "").replace("$", "")
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
 
 
 if __name__ == "__main__":

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -55,6 +55,10 @@ SWING_MIN_AGENT_CONFIDENCE = TAKE_PROFIT_SWING.get("min_agent_confidence", 50)
 # (승자 run). value/swing 은 위 ladder 유지. config/rules.yaml take_profit.leader.
 TAKE_PROFIT_LEADER = _tp.get("leader", {"enabled": False, "trail_ma": 50})
 
+# ─── ARK 매매 파생 (#1143) ───
+# 보유 스냅샷 → Buy/Sell 파생 임계. smart_money 의 ARK 항목 발화 여부를 결정한다.
+ARK_MIN_TRADE_PCT = RULES.get("ark", {}).get("min_trade_pct", 1.0)
+
 # ─── 트레일링 스톱 ───
 _ts = RULES.get("trailing_stop", {})
 TRAILING_STOP_GROWTH = _ts.get("growth", -15)

--- a/nuri/trading/agents/CLAUDE.md
+++ b/nuri/trading/agents/CLAUDE.md
@@ -23,6 +23,13 @@ Live probe (2026-04-17):
 - `005930.KS` → korean_market activates (20-day momentum + institutional flows), retail/crypto dormant by design. Consensus HOLD @ 62 conf, 90% agreement.
 - `GOOGL` → korean_market neutral for US (conf 50, "US ticker — Korean market agent neutral"), retail active (WSB coverage present, conf 48). Consensus HOLD @ 62, 80%.
 
+## ARK 항목은 Buy/Sell 만 센다 (`smart_money.py`, #1143)
+
+`ark.direction` 은 Buy / Sell / **Hold** 세 값이다. `sells` 를 `len(rows) - buys` 로
+구하면 Hold 가 전부 매도가 된다 — ark 테이블이 Hold 만 담고 있던 기간(수집 소스 사망 +
+보유 스냅샷 폴백) 동안 거기 있는 티커는 전부 상시 `score -1` 을 받았다. 수집기 쪽 사정과
+무관하게 이 집계는 방어적으로 옳아야 한다. 배경은 `nuri/collectors/CLAUDE.md` "ARK".
+
 ## Veto + Divergence
 
 - **Risk agent** (19% weight) has **veto power**: SELL + confidence ≥ 80 overrides all others.

--- a/nuri/trading/agents/smart_money.py
+++ b/nuri/trading/agents/smart_money.py
@@ -82,14 +82,21 @@ class SmartMoneyAgent(BaseAgent):
                     reasons.append(f"목표가 하회 {upside:.0f}%")
 
         # 4. ARK 최근 매매
+        # `direction` 은 Buy / Sell / Hold 세 값을 갖는다. 예전에는 sells 를
+        # `len(rows) - buys` 로 구해서 **Hold 가 전부 매도로 집계**됐다 (#1143). ark
+        # 테이블이 한동안 Hold 만 담고 있었으므로 (죽은 CSV 소스 → 보유 스냅샷 폴백)
+        # 거기 있는 티커는 예외 없이 score -1 과 "ARK 최근 매도 N건" 이라는 거짓 근거를
+        # 받았다. 데이터 결손이 아니라 틀린 신호였다. Buy/Sell 을 각각 세고, 쿼리에서도
+        # 걸러 LIMIT 5 창을 Hold 가 잡아먹지 않게 한다.
         ark_rows = self._safe_query(
-            "SELECT direction, shares FROM ark WHERE ticker = ? ORDER BY date DESC LIMIT 5",
+            "SELECT direction, shares FROM ark WHERE ticker = ? "
+            "AND direction IN ('Buy', 'Sell') ORDER BY date DESC LIMIT 5",
             (ticker,),
             db_path,
         )
         if ark_rows:
             buys = sum(1 for r in ark_rows if r["direction"] == "Buy")
-            sells = len(ark_rows) - buys
+            sells = sum(1 for r in ark_rows if r["direction"] == "Sell")
             if buys > sells:
                 score += 1
                 reasons.append(f"ARK 최근 매수 {buys}건")

--- a/tests/collectors/test_ark.py
+++ b/tests/collectors/test_ark.py
@@ -1,66 +1,326 @@
-"""Per-collector tests for ark.
+"""ARK 수집기 테스트 (#1143).
 
-Split from tests/test_collectors_all.py for module-level isolation.
+이 수집기에는 테스트가 없었다. 그래서 CSV 소스 2개가 죽고 폴백이 매매 아닌
+보유 스냅샷을 `direction="Hold"` 로 쓰는 상태가 몇 달간 아무 신호 없이 지나갔다.
 """
-from unittest.mock import MagicMock
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nuri.core.db import get_db, query
+
+# 실제 CSV 형태 — 소문자 컬럼, 콤마 섞인 숫자, `weight (%)`, 마지막 면책 문구 행,
+# 그리고 비상장 보유분(ticker 빈 칸)까지 그대로 재현한다.
+ARKK_CSV = (
+    "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+    '08/20/2026,ARKK,TESLA INC,TSLA,88160R101,"1,713,664","$601,701,703.70",9.36%\n'
+    '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"434,775","$202,777,545.00",3.15%\n'
+    '08/20/2026,ARKK,NOT HELD BY US,ZZZZ,111111111,"1,000","$1,000.00",0.01%\n'
+    '08/20/2026,ARKK,BRERA HOLDINGS PLC-CL B,,G13311132,"268,782","$1,135,603.95",0.02%\n'
+    '"Investors should carefully consider the investment objectives and risks."\n'
+)
 
 
-class TestARKCollector:
-    def test_instantiate(self):
+def _resp(text: str) -> MagicMock:
+    r = MagicMock()
+    r.text = text
+    r.raise_for_status.return_value = None
+    return r
+
+
+@pytest.fixture
+def held(db_path):
+    """보유 종목 2개를 심는다 (공개 레포 — 임의 값)."""
+    with get_db(db_path) as c:
+        for t in ("TSLA", "AMD"):
+            c.execute(
+                "INSERT INTO portfolio (ticker, quantity, avg_price, account) VALUES (?,?,?,?)",
+                (t, 10, 100.0, "Brokerage Alpha"),
+            )
+    return db_path
+
+
+class TestArkCsvParsing:
+    def test_parses_current_lowercase_columns(self, held):
+        """`ticker` / `shares` / `weight (%)` — 예전 파서는 `% of ETF` 만 봤다."""
         from nuri.collectors.ark import ARKCollector
 
-        c = ARKCollector()
-        assert c.name == "ark"
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(ARKK_CSV)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
-    def test_save_empty(self, db_path):
+        by_ticker = {r["ticker"]: r for r in rows}
+        assert set(by_ticker) == {"TSLA", "AMD"}
+        assert by_ticker["TSLA"]["shares"] == 1713664.0  # 콤마 제거
+        assert by_ticker["TSLA"]["weight"] == 9.36  # '%' 제거
+        assert by_ticker["TSLA"]["date"] == "2026-08-20"  # MM/DD/YYYY → ISO
+        assert by_ticker["TSLA"]["fund"] == "ARKK"
+
+    def test_skips_disclaimer_row_and_unlisted_holdings(self, held):
+        """면책 문구 행과 ticker 없는 비상장 보유분은 ticker 가 비어 걸러진다."""
         from nuri.collectors.ark import ARKCollector
 
-        c = ARKCollector()
-        assert c.save([]) == 0
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(ARKK_CSV)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
-    def test_save_records(self, db_path):
+        assert all(r["ticker"] for r in rows)
+        assert "ZZZZ" not in {r["ticker"] for r in rows}  # 보유 종목 필터
+
+
+class TestArkDirectionDerivation:
+    """ARK 는 매매가 아니라 보유 스냅샷을 낸다 — 방향은 직전 보유분 대비 증감이다."""
+
+    def _derive(self, db_path, prev_shares, now_shares, prev_date="2026-08-19"):
         from nuri.collectors.ark import ARKCollector
 
-        c = ARKCollector()
-        records = [{"date": "2026-03-30", "ticker": "TSLA", "direction": "Buy",
-                     "shares": 50000.0, "weight": 8.5, "fund": "ARKK"}]
-        count = c.save(records)
-        assert count == 1
+        if prev_shares is not None:
+            with get_db(db_path) as c:
+                c.execute(
+                    "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                    (prev_date, "TSLA", "Hold", prev_shares, 1.0, "ARKK"),
+                )
+        return ARKCollector()._derive_direction("TSLA", "ARKK", "2026-08-20", now_shares, db_path)
+
+    def test_increase_is_a_buy(self, db_path):
+        assert self._derive(db_path, 1000.0, 1100.0) == "Buy"
+
+    def test_decrease_is_a_sell(self, db_path):
+        assert self._derive(db_path, 1000.0, 900.0) == "Sell"
+
+    def test_noise_below_threshold_is_hold(self, db_path):
+        """ARK 는 매일 소수점 수준으로 리밸런싱한다 — 0 이 아닌 모든 변화를 매매라 부르면
+        전 종목이 매일 신호를 낸다."""
+        assert self._derive(db_path, 1000.0, 1005.0) == "Hold"
+
+    def test_first_observation_claims_no_direction(self, db_path):
+        """비교 대상이 없으면 방향을 주장하지 않는다 — 첫 관측은 Hold."""
+        assert self._derive(db_path, None, 1000.0) == "Hold"
+
+    def test_zero_share_snapshot_is_not_a_baseline(self, db_path):
+        """폴백이 남긴 `shares=0.0` 행을 기준선으로 잡으면 다음 수집분이 통째로 Buy 가 된다.
+
+        기준선 쿼리에서 `shares > 0` 을 빼면 이 테스트가 Buy 를 보고 실패한다.
+        """
+        assert self._derive(db_path, 0.0, 1000.0) == "Hold"
+
+    def test_a_real_prior_wins_over_a_newer_zero_snapshot(self, db_path):
+        """0 스냅샷이 더 최신이어도 진짜 보유분을 기준선으로 삼아야 한다."""
+        with get_db(db_path) as c:
+            c.execute(
+                "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                ("2026-08-10", "TSLA", "Hold", 1000.0, 1.0, "ARKK"),
+            )
+        assert self._derive(db_path, 0.0, 900.0) == "Sell"
 
 
+class TestArkFailureIsNotEmptyCollection:
+    """#1043 규약 — 전면 실패는 raise, 겹치는 종목 없음은 NO_DATA."""
 
-class TestARKCollectorCollectAndSave:
-    def test_collect_csv_success(self, monkeypatch, db_with_portfolio):
+    def test_total_failure_raises_instead_of_returning_empty(self, held):
         from nuri.collectors.ark import ARKCollector
 
-        csv_text = "Date,Fund,Direction,Ticker,CUSIP,Name,Shares,% of ETF\n"
-        csv_text += "01/15/2025,ARKK,Buy,AAPL,123456,Apple Inc,1000,2.5\n"
-        csv_text += "01/15/2025,ARKK,Sell,NVDA,654321,NVIDIA,500,1.3\n"
-        mock_resp = MagicMock()
-        mock_resp.text = csv_text
-        mock_resp.raise_for_status = MagicMock()
-        monkeypatch.setattr("nuri.collectors.ark.requests.get", MagicMock(return_value=mock_resp))
-        results = ARKCollector().collect()
-        assert "AAPL" in [r["ticker"] for r in results]
+        with patch("nuri.collectors.ark.requests.get", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                ARKCollector().collect(db_path=held)
 
-    def test_collect_csv_empty_ticker(self, monkeypatch, db_with_portfolio):
+    def test_first_error_is_raised_not_the_last(self, held):
+        """마지막 것만 올리면 첫 펀드의 원인이 알림 문구에서 사라진다."""
         from nuri.collectors.ark import ARKCollector
 
-        csv_text = "Date,Fund,Direction,Ticker,CUSIP,Name,Shares,% of ETF\n01/15/2025,ARKK,Buy,,123456,Unknown,1000,2.5\n"
-        mock_resp = MagicMock()
-        mock_resp.text = csv_text
-        mock_resp.raise_for_status = MagicMock()
-        monkeypatch.setattr("nuri.collectors.ark.requests.get", MagicMock(return_value=mock_resp))
-        assert ARKCollector().collect() == []
+        errs = [RuntimeError(f"err{i}") for i in range(5)]
+        with patch("nuri.collectors.ark.requests.get", side_effect=errs):
+            with pytest.raises(RuntimeError, match="err0"):
+                ARKCollector().collect(db_path=held)
 
-    def test_collect_all_urls_fail(self, monkeypatch, db_with_portfolio):
+    def test_partial_failure_still_returns_what_worked(self, held):
+        """한 펀드가 죽어도 나머지는 수집된다 — raise 조건이 `errors` 뿐이면 여기서 터진다."""
         from nuri.collectors.ark import ARKCollector
 
-        monkeypatch.setattr("nuri.collectors.ark.requests.get", MagicMock(side_effect=Exception("fail")))
-        assert ARKCollector().collect() == []
+        seq = [RuntimeError("one fund down")] + [_resp(ARKK_CSV)] * 4
+        with patch("nuri.collectors.ark.requests.get", side_effect=seq):
+            rows = ARKCollector().collect(db_path=held)
 
-    def test_save(self, db_with_portfolio):
+        assert rows
+        assert {r["ticker"] for r in rows} == {"TSLA", "AMD"}
+
+    def test_no_overlap_is_no_data_not_failure(self, held):
+        """200 인데 우리 보유 종목과 겹치는 게 없으면 예외가 아니라 빈 수집이다."""
         from nuri.collectors.ark import ARKCollector
 
-        assert ARKCollector().save([{"date": "2025-01-15", "ticker": "AAPL", "direction": "Buy",
-                                     "shares": 1000, "weight": 2.5, "fund": "ARKK"}]) == 1
+        csv_no_overlap = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '08/20/2026,ARKK,SOMETHING ELSE,QQQQ,111,"1,000","$1,000.00",0.01%\n'
+        )
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(csv_no_overlap)):
+            assert ARKCollector().collect(db_path=held) == []
+
+
+class TestArkNoNetworkFallback:
+    def test_yfinance_is_not_imported(self):
+        """폴백은 top-10 보유 스냅샷을 `shares=0.0` 으로 써서 델타 기준선을 오염시켰다.
+        지금은 소스가 살아 있으므로 제거했다 — 되살아나면 이 테스트가 잡는다.
+
+        문자열 grep 이 아니라 AST 로 본다. 소스에 'yfinance' 가 등장하는 곳은 왜 뺐는지
+        적어둔 주석·docstring 이라, grep 은 그 설명 자체에 걸려 영영 빨갛다.
+        """
+        import ast
+        import inspect
+
+        import nuri.collectors.ark as ark_mod
+
+        tree = ast.parse(inspect.getsource(ark_mod))
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+
+        assert "yfinance" not in imported
+        assert not hasattr(ark_mod.ARKCollector, "_collect_yfinance")
+
+
+class TestArkSave:
+    def test_save_persists_direction(self, held):
+        from nuri.collectors.ark import ARKCollector
+
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(ARKK_CSV)):
+            rows = ARKCollector().collect(db_path=held)
+        assert ARKCollector().save(rows) == len(rows)
+        stored = query("SELECT ticker, direction, shares FROM ark ORDER BY ticker", db_path=held)
+        assert {r["ticker"] for r in stored} == {"AMD", "TSLA"}
+
+
+class TestArkMalformedInput:
+    def test_unparseable_date_row_is_skipped(self, held):
+        """날짜를 못 읽으면 그 행만 버린다 — parse_date 가 None 을 주는 경우."""
+        from nuri.collectors.ark import ARKCollector
+
+        bad = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '조만간,ARKK,TESLA INC,TSLA,88160R101,"1,000","$1,000.00",1.00%\n'
+            '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
+        )
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(bad)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+
+        assert {r["ticker"] for r in rows} == {"AMD"}
+
+    def test_amount_parsing(self):
+        from nuri.collectors.ark import _to_float_or_none
+
+        assert _to_float_or_none("1,713,664") == 1713664.0
+        assert _to_float_or_none("$601,701,703.70") == 601701703.70
+        assert _to_float_or_none("9.36%") == 9.36
+
+    def test_unparseable_shares_is_none_not_zero(self):
+        """0.0 으로 눕히면 방향 파생이 그걸 전량 청산으로 읽는다 — 포맷 드리프트가
+        매도 신호로 둔갑한다 (#1143 codex P2)."""
+        from nuri.collectors.ark import _to_float_or_none
+
+        assert _to_float_or_none("N/A") is None
+        assert _to_float_or_none(None) is None
+        assert _to_float_or_none("") is None
+
+    def test_row_with_unparseable_shares_is_dropped_not_zeroed(self, held):
+        """shares 를 못 읽은 행은 버린다. 남겨서 0 으로 적으면 매도가 된다."""
+        from nuri.collectors.ark import ARKCollector
+
+        bad = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '08/20/2026,ARKK,TESLA INC,TSLA,88160R101,N/A,"$1,000.00",1.00%\n'
+            '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
+        )
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(bad)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+
+        assert {r["ticker"] for r in rows} == {"AMD"}
+        assert all(r["direction"] != "Sell" for r in rows)
+
+
+class TestArkExits:
+    """전량 청산과 펀드 간 이동 — 부재는 CSV 에 행으로 나타나지 않는다 (#1143 codex P1)."""
+
+    def _seed_prior(self, db_path, fund="ARKK", ticker="TSLA", shares=1000.0, date="2026-08-19"):
+        with get_db(db_path) as c:
+            c.execute(
+                "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                (date, ticker, "Hold", shares, 1.0, fund),
+            )
+
+    def test_disappearing_ticker_becomes_a_sell(self, held):
+        """어제 ARKK 가 TSLA 를 들고 있었는데 오늘 CSV 에 없다 → 전량 청산."""
+        from nuri.collectors.ark import ARKCollector
+
+        self._seed_prior(held)
+        only_amd = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
+        )
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(only_amd)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+
+        exits = [r for r in rows if r["ticker"] == "TSLA"]
+        assert len(exits) == 1
+        assert exits[0]["direction"] == "Sell"
+        assert exits[0]["shares"] == 0.0
+        assert exits[0]["date"] == "2026-08-20"
+
+    def test_exit_is_emitted_once_not_every_day(self, held):
+        """어제 이미 0 으로 적힌 종목은 '보유 중이었다' 가 아니다 — 매일 Sell 을 다시 내면
+        smart_money 의 LIMIT 5 창이 같은 청산으로 영원히 채워진다."""
+        from nuri.collectors.ark import ARKCollector
+
+        with get_db(held) as c:
+            c.execute(
+                "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                ("2026-08-19", "TSLA", "Sell", 0.0, 0.0, "ARKK"),
+            )
+        only_amd = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
+        )
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(only_amd)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+
+        assert not [r for r in rows if r["ticker"] == "TSLA"]
+
+    def test_reentry_after_exit_is_a_fresh_position_not_a_sell(self, held):
+        """청산 뒤 더 작게 재진입한 것을 pre-exit 규모와 비교하면 Sell 로 뒤집힌다."""
+        from nuri.collectors.ark import ARKCollector
+
+        with get_db(held) as c:
+            c.execute(
+                "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                ("2026-08-10", "TSLA", "Hold", 5000.0, 5.0, "ARKK"),
+            )
+            c.execute(
+                "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                ("2026-08-19", "TSLA", "Sell", 0.0, 0.0, "ARKK"),
+            )
+        assert ARKCollector()._derive_direction("TSLA", "ARKK", "2026-08-20", 100.0, held) == "Hold"
+
+    def test_exit_only_covers_the_fund_that_lost_it(self, held):
+        """ARKK 에서 빠져도 ARKW 는 별개 — 펀드별로 판단한다."""
+        from nuri.collectors.ark import ARKCollector
+
+        self._seed_prior(held, fund="ARKW")
+        only_amd = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
+        )
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(only_amd)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+
+        assert not [r for r in rows if r["ticker"] == "TSLA"]
+
+    def test_no_exit_rows_when_the_fetch_yielded_nothing(self, held):
+        """CSV 가 비었거나 전부 걸러졌으면 청산이라 단정하지 않는다 — 그건 소스 문제다."""
+        from nuri.collectors.ark import ARKCollector
+
+        self._seed_prior(held)
+        empty = "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+        with patch("nuri.collectors.ark.requests.get", return_value=_resp(empty)):
+            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+
+        assert rows == []

--- a/tests/collectors/test_e4_branch_coverage.py
+++ b/tests/collectors/test_e4_branch_coverage.py
@@ -522,60 +522,9 @@ class TestCboeExtractPcrZeroDivision:
 # ─────────────────────────────────────────────────────────────────
 
 
-class TestArkExceptionPaths:
-    """L56-57 yfinance fallback raises, L107-110 per-etf failure, L136 ticker filter."""
-
-    def test_yfinance_fallback_raises(self, db_with_portfolio, monkeypatch):
-        from nuri.collectors.ark import ARKCollector
-
-        c = ARKCollector()
-        # ARK collect() calls module-level get_tickers(), not a method.
-        with (
-            patch("nuri.collectors.ark.get_tickers", return_value=["TSLA"]),
-            patch.object(c, "_collect_csv", side_effect=RuntimeError("csv")),
-            patch.object(c, "_collect_yfinance", side_effect=RuntimeError("yf")),
-        ):
-            result = c.collect()
-        assert result == []
-
-    def test_yfinance_per_etf_failure(self, db_path):
-        """L107-110: per-ETF yfinance ticker.funds_data raises → continue."""
-        from nuri.collectors import ark as ark_mod
-        from nuri.collectors.ark import ARKCollector
-
-        mock_yf = MagicMock()
-        # Each Ticker call raises
-        mock_yf.Ticker.side_effect = RuntimeError("yfinance broken")
-
-        with patch.dict(sys.modules, {"yfinance": mock_yf}):
-            with patch.object(ark_mod, "ARK_ETFS", ["ARKK"]):
-                result = ARKCollector()._collect_yfinance({"TSLA"})
-        # All failed → empty records
-        assert result == []
-
-
-class TestArkCsvNonHeldTicker:
-    """L136 (135-136): ticker not in held_tickers → continue (skipped)."""
-
-    def test_csv_filters_non_held(self, db_path):
-        from nuri.collectors.ark import ARKCollector
-
-        csv_text = (
-            "Date,Fund,Direction,Ticker,Shares,% of ETF\n"
-            "2026-01-15,ARKK,Buy,UNHELD,1000,0.5\n"
-            "2026-01-15,ARKK,Buy,HELD,500,0.3\n"
-        )
-        mock_resp = MagicMock()
-        mock_resp.text = csv_text
-        mock_resp.raise_for_status = MagicMock()
-
-        with patch("nuri.collectors.ark.requests.get", return_value=mock_resp):
-            result = ARKCollector()._collect_csv("http://fake", {"HELD"})
-        # Only HELD parsed, UNHELD skipped (L136 continue)
-        tickers = {r["ticker"] for r in result}
-        assert "UNHELD" not in tickers
-        assert "HELD" in tickers
-
+# ARK 분기 테스트 2종 (TestArkExceptionPaths / TestArkCsvNonHeldTicker) 이 여기 있었다.
+# 검증 대상이던 `_collect_yfinance` · `_collect_csv` 가 #1143 에서 사라져 같이 나갔고,
+# 대응 동작(전면 실패 · 부분 실패 · 미보유 종목 필터)은 tests/collectors/test_ark.py 로 옮겼다.
 
 # ─────────────────────────────────────────────────────────────────
 # universe_sync.py — kr apply path + run() exception

--- a/tests/collectors/test_fallbacks.py
+++ b/tests/collectors/test_fallbacks.py
@@ -1,12 +1,14 @@
-"""ARK / CBOE 외부 소스 fallback 단위 테스트.
+"""CBOE 외부 소스 fallback 단위 테스트.
 
 검증 범위:
-    - ARK CSV 실패 → yfinance ETF holdings fallback
-    - ARK weight 단위 변환 (yfinance 0.10 → 10%)
     - CBOE 모든 소스 실패 → yfinance SPY 옵션 PCR
     - CBOE PCR DB stale fallback
     - consensus print verbose 모드
+
+ARK 폴백 테스트는 여기 있었는데, 그 폴백이 제거되면서 같이 나갔다 (#1143 — top-10
+보유 스냅샷을 매매 자리에 쓰던 코드다). ARK 는 `tests/collectors/test_ark.py` 로.
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -14,97 +16,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from nuri.collectors.ark import ARK_ETFS, ARKCollector
 from nuri.collectors.cboe import CBOECollector
-
-# ═══════════════════════════════════════════════════════
-# ARK yfinance fallback
-# ═══════════════════════════════════════════════════════
-
-
-class TestARKYFinanceFallback:
-    def test_yfinance_fallback_collects_holdings(self):
-        """CSV 실패 → yfinance fallback 호출 → holdings 정상 변환."""
-        # 모의 yfinance Ticker.funds_data.top_holdings
-        mock_holdings = pd.DataFrame({
-            "Name": ["Tesla Inc", "NVIDIA Corp"],
-            "Holding Percent": [0.1040, 0.0850],  # 10.4%, 8.5%
-        }, index=pd.Index(["TSLA", "NVDA"], name="Symbol"))
-        mock_fd = MagicMock()
-        mock_fd.top_holdings = mock_holdings
-        mock_ticker = MagicMock()
-        mock_ticker.funds_data = mock_fd
-
-        held = {"TSLA", "NVDA", "AMD"}  # AMD는 없는 종목
-        collector = ARKCollector()
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            records = collector._collect_yfinance(held)
-
-        assert len(records) > 0
-        # ARK ETF 5개 × 2개 종목 = 10건
-        assert len(records) == len(ARK_ETFS) * 2
-        # 단위 변환 확인: 0.1040 → 10.40
-        tsla_records = [r for r in records if r["ticker"] == "TSLA"]
-        assert all(abs(r["weight"] - 10.40) < 0.01 for r in tsla_records)
-        nvda_records = [r for r in records if r["ticker"] == "NVDA"]
-        assert all(abs(r["weight"] - 8.50) < 0.01 for r in nvda_records)
-        # direction은 "Hold" (매매 내역 X)
-        assert all(r["direction"] == "Hold" for r in records)
-        # held 필터링: AMD는 없어야 함
-        assert not any(r["ticker"] == "AMD" for r in records)
-
-    def test_yfinance_fallback_skips_non_held(self):
-        mock_holdings = pd.DataFrame({
-            "Name": ["Tesla Inc"],
-            "Holding Percent": [0.1040],
-        }, index=pd.Index(["TSLA"], name="Symbol"))
-        mock_fd = MagicMock()
-        mock_fd.top_holdings = mock_holdings
-        mock_ticker = MagicMock()
-        mock_ticker.funds_data = mock_fd
-
-        # 보유 종목에 TSLA 없음
-        held = {"AMD"}
-        collector = ARKCollector()
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            records = collector._collect_yfinance(held)
-        assert records == []
-
-    def test_yfinance_fallback_empty_holdings(self):
-        mock_fd = MagicMock()
-        mock_fd.top_holdings = pd.DataFrame()
-        mock_ticker = MagicMock()
-        mock_ticker.funds_data = mock_fd
-
-        collector = ARKCollector()
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            records = collector._collect_yfinance({"TSLA"})
-        assert records == []
-
-    def test_yfinance_fallback_no_funds_data(self):
-        """funds_data가 None인 ETF."""
-        mock_ticker = MagicMock()
-        mock_ticker.funds_data = None
-
-        collector = ARKCollector()
-        with patch("yfinance.Ticker", return_value=mock_ticker):
-            records = collector._collect_yfinance({"TSLA"})
-        assert records == []
-
-    def test_collect_falls_through_to_yfinance(self):
-        """CSV 2개 모두 실패 시 yfinance fallback 호출 확인."""
-        collector = ARKCollector()
-        with patch.object(collector, "_collect_csv",
-                          side_effect=Exception("CSV 다운 실패")):
-            with patch.object(collector, "_collect_yfinance",
-                              return_value=[{"ticker": "TSLA", "weight": 10.4,
-                                              "shares": 0.0, "direction": "Hold",
-                                              "fund": "ARKK", "date": "2026-04-08"}]):
-                with patch("nuri.collectors.ark.get_tickers", return_value=["TSLA"]):
-                    result = collector.collect()
-        assert len(result) == 1
-        assert result[0]["ticker"] == "TSLA"
-
 
 # ═══════════════════════════════════════════════════════
 # CBOE yfinance SPY PCR fallback

--- a/tests/trading/agents/test_agents_branch_coverage.py
+++ b/tests/trading/agents/test_agents_branch_coverage.py
@@ -510,7 +510,13 @@ class TestRetailAgentBuyBranch:
 
 class TestSmartMoneyArkSells:
     def test_ark_sells_dominant(self, db_path):
-        """ARK 최근 매도 우세 → score -=1, reason 추가."""
+        """ARK 최근 매도 우세 → score -=1, reason 추가.
+
+        예전에는 direction 을 소문자 'sell'/'buy' 로 심었다. 그건 `== "Buy"` 에 한 번도
+        안 걸리므로 **버그 덕에 통과하던 테스트**였다 — sells 가 'Buy 가 아닌 나머지'로
+        집계되던 시절엔 소문자 6행이 전부 매도로 세어졌다 (#1143). 수집기가 실제로 쓰는
+        표기는 'Buy'/'Sell' 이므로 그대로 맞춘다.
+        """
         from nuri.trading.agents.smart_money import SmartMoneyAgent
 
         with get_db(db_path) as conn:
@@ -526,17 +532,17 @@ class TestSmartMoneyArkSells:
                 conn.execute(
                     """INSERT INTO ark (date, ticker, direction, shares, weight, fund)
                        VALUES (?, ?, ?, ?, ?, ?)""",
-                    (date, "TSLA", "sell", 1000, 1.0, fund),
+                    (date, "TSLA", "Sell", 1000, 1.0, fund),
                 )
             conn.execute(
                 """INSERT INTO ark (date, ticker, direction, shares, weight, fund)
                    VALUES (?, ?, ?, ?, ?, ?)""",
-                ("2026-04-26", "TSLA", "buy", 500, 0.5, "ARKK"),
+                ("2026-04-26", "TSLA", "Buy", 500, 0.5, "ARKK"),
             )
 
         v = SmartMoneyAgent().analyze("TSLA", db_path=db_path)
-        # ARK 매도 reason 포함
-        assert "ARK" in v.reasoning
+        # 날짜 DESC LIMIT 5 → Buy 1 + Sell 4 → 매도 우세
+        assert "ARK 최근 매도 4건" in v.reasoning
 
 
 # ─── technical: yfinance fallback / chart 예외 / FINVIZ 예외 ───────────

--- a/tests/trading/agents/test_smart_money_branches.py
+++ b/tests/trading/agents/test_smart_money_branches.py
@@ -92,3 +92,78 @@ class TestSmartMoneyBranches:
                 )
         v = SmartMoneyAgent().analyze("EQAR", db_path=db_path)
         assert "ARK 최근" not in v.reasoning
+
+    def test_ark_hold_rows_are_not_counted_as_sells(self, db_path):
+        """#1143 회귀 잠금: direction='Hold' 는 매도가 아니다.
+
+        예전 코드는 `sells = len(rows) - buys` 로 세서 Hold 를 전부 매도로 집계했다.
+        죽은 CSV 소스 때문에 ark 테이블이 Hold 만 담고 있던 기간 동안, 거기 있는
+        티커는 예외 없이 score -1 과 "ARK 최근 매도 N건" 이라는 거짓 근거를 받았다.
+
+        Hold 만 있을 때 ARK 는 아무 방향도 주장하지 않아야 한다. estimates 로 다른
+        근거를 하나 깔아 no-data 경로를 우회하고, ARK 항목만 관찰한다.
+        """
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO estimates "
+                "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("HOLDONLY", "2026-01-01", "buy", 130.0, 100.0, 5),
+            )
+            for i in range(5):
+                conn.execute(
+                    "INSERT INTO ark (ticker, date, direction, shares, fund) VALUES (?, ?, ?, ?, ?)",
+                    ("HOLDONLY", f"2026-03-{20 + i:02d}", "Hold", 0.0, f"ARK{i}"),
+                )
+        v = SmartMoneyAgent().analyze("HOLDONLY", db_path=db_path)
+        assert "ARK 최근 매도" not in v.reasoning
+        assert "ARK 최근 매수" not in v.reasoning
+
+    def test_ark_counting_is_safe_even_if_the_query_stops_filtering(self, db_path):
+        """#1143 회귀 잠금 — 집계 그 자체.
+
+        위 테스트는 SQL 의 `direction IN ('Buy','Sell')` 만으로도 통과한다. 즉 필터를
+        지우면 잡히지만 **집계식을 되돌리면 안 잡힌다.** 두 방어선은 막는 게 서로 다르다:
+        필터가 없으면 침묵(진짜 매매가 창 밖으로 밀림), 집계가 틀리면 거짓 매도다.
+        후자를 잠그려고 `_safe_query` 를 가로채 Hold 행을 집계 코드에 직접 흘린다 —
+        나중에 필터가 느슨해지거나 다른 호출자가 생겨도 집계는 안전해야 한다.
+        """
+        from nuri.trading.agents.smart_money import SmartMoneyAgent
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO estimates "
+                "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("RAWHOLD", "2026-01-01", "buy", 130.0, 100.0, 5),
+            )
+
+        agent = SmartMoneyAgent()
+        real_safe_query = agent._safe_query
+
+        def _leak_hold_rows(sql, params=(), db_path=None):
+            if "FROM ark" in sql:
+                return [{"direction": "Hold", "shares": 0.0} for _ in range(5)]
+            return real_safe_query(sql, params, db_path)
+
+        agent._safe_query = _leak_hold_rows
+        v = agent.analyze("RAWHOLD", db_path=db_path)
+        assert "ARK 최근 매도" not in v.reasoning
+        assert "ARK 최근 매수" not in v.reasoning
+
+    def test_ark_hold_does_not_crowd_out_real_trades(self, db_path):
+        """#1143: 쿼리가 Hold 를 거르지 않으면 최신 Hold 5건이 LIMIT 5 창을 잡아먹어
+        그 아래 실제 Buy 가 영영 안 보인다 — 결손이 아니라 침묵이라 신호가 없다."""
+        with get_db(db_path) as conn:
+            for i in range(3):  # 오래된 진짜 매수
+                conn.execute(
+                    "INSERT INTO ark (ticker, date, direction, shares, fund) VALUES (?, ?, ?, ?, ?)",
+                    ("CROWD", f"2026-03-0{1 + i}", "Buy", 1000.0, f"ARK{i}"),
+                )
+            for i in range(5):  # 그 위를 덮는 최신 Hold 스냅샷
+                conn.execute(
+                    "INSERT INTO ark (ticker, date, direction, shares, fund) VALUES (?, ?, ?, ?, ?)",
+                    ("CROWD", f"2026-03-{20 + i:02d}", "Hold", 0.0, f"ARK{i}"),
+                )
+        v = SmartMoneyAgent().analyze("CROWD", db_path=db_path)
+        assert "ARK 최근 매수 3건" in v.reasoning


### PR DESCRIPTION
Closes #1143

## 무엇이 잘못돼 있었나

Mac mini 로그에 매일 남던 ARK 수집 경고를 따라가 보니 3층이었고, 마지막 층이 실제 피해였다.

**1. CSV 소스 2개가 전부 죽었다.** `cathiesark.com` 500/503, 통합 `ARK_TRADE.csv` 는 301 후 404.

**2. 폴백이 매매 아닌 것을 매매 자리에 썼다.** yfinance `top_holdings`(상위 10개) 스냅샷을
`direction="Hold"` / `shares=0.0` 으로 저장했다. production 실측 — `ark` 319행, **전부 Hold**,
Buy/Sell 은 한 건도 없음.

**3. 소비자가 Hold 를 매도로 셌다.** `smart_money.py` 의 `sells = len(rows) - buys` 는
"Sell 을 센" 게 아니라 "Buy 가 아닌 나머지"였다. 모든 행이 Hold 이므로:

```
buys = 0  sells = 5
-> score -1  "ARK 최근 매도 5건"   ← 테이블에 있는 9개 티커 전부, 매일
```

`config/agents.yaml` 의 `score_sell = -1` 이라 다른 근거가 없으면 이 -1 하나로 verdict 가
SELL 로 넘어간다. **데이터 결손이 아니라 틀린 신호였고, 그동안 헬스체크는 전부 초록이었다.**

## 무엇을 고쳤나

**소비자 (commit 1).** Buy 와 Sell 을 각각 센다. 쿼리에서도 `direction IN ('Buy','Sell')` 로
걸러 최신 Hold 가 `LIMIT 5` 창을 잡아먹지 않게 했다. 방어선이 둘인 이유는 막는 게 서로 달라서다 —
필터가 없으면 침묵(진짜 매매가 창 밖으로 밀림), 집계가 틀리면 거짓 매도.

**소스 (commit 2).** `assets.ark-funds.com` 의 펀드별 보유 CSV 5종으로 교체. top-10 이 아니라
전체 보유다. 컬럼이 소문자이고 `weight (%)` 이며 `Direction` 이 없다.

**방향 파생 (commit 2).** ARK 는 매매 내역이 아니라 보유 스냅샷을 낸다. 그래서 Buy/Sell 을
직전 수집분 대비 `shares` 증감으로 파생한다. `MIN_TRADE_PCT`(1.0%) 미만은 Hold — ARK 는
리밸런싱으로 매일 소수점 수준을 움직여서, 0 이 아닌 모든 변화를 매매라 부르면 전 종목이 매일
신호를 낸다. 기준선 쿼리는 `shares > 0` 을 거는데, 폴백이 남긴 `shares=0.0` 행을 기준선으로
잡으면 다음 수집분이 통째로 Buy 로 보이기 때문이다.

**yfinance 폴백 제거.** 고친 뒤에는 어차피 신호가 0 이고(전부 Hold), 델타 기준선을 오염시킨다.
전면 실패는 `[]` 대신 raise 한다 (#1043 규약) — 겹치는 종목이 없는 경우는 NO_DATA 로 구분.

**문서 (commit 3).** `load-triggers.md` 가 이 디렉터리들을 건드리기 전에 읽으라고 지정한
두 파일이 존재하지 않는 ARK 를 설명하고 있었다.

## 검증

**live 실행** (격리 DB, 임의 시드):

```
수집: 12건  방향: Counter({'Hold': 12})       # 첫 관측 — 기준선 없음, 방향 주장 안 함
어제자 보유(-10%) 심고 재실행 → TSLA/AMD/PACB/RBLX 전부 Buy   # 델타 파생 동작
```

**뮤테이션** — 고친 줄을 되돌리면 실제로 FAIL 하는지 실측:

| 되돌린 것 | 결과 |
|---|---|
| `sells` 를 `len(rows) - buys` 로 | 1 FAIL |
| 쿼리의 `direction IN ('Buy','Sell')` 제거 | 1 FAIL |

첫 시도에서 집계 축이 **PASS** 했다 — SQL 필터가 대신 막고 있어서 집계 자체는 잠기지 않았다.
`_safe_query` 를 가로채 Hold 행을 집계 코드에 직접 흘리는 테스트를 추가해 두 축을 따로 잠갔다.

**버그에 의존하던 기존 테스트 1건 수정.** `test_ark_sells_dominant` 는 소문자 `"sell"` 을
심었는데, 그건 `== "Buy"` 에 한 번도 안 걸리므로 "Buy 가 아닌 나머지" 집계 덕에만 통과하고
있었다. 수집기가 실제로 쓰는 `Buy`/`Sell` 표기로 맞추고 단정도 구체화했다.

**제거된 코드를 검증하던 테스트 정리.** `test_fallbacks.py` 의 `TestARKYFinanceFallback`,
`test_e4_branch_coverage.py` 의 ARK 클래스 2종. 대응 동작(전면 실패 · 부분 실패 · 미보유 필터)은
새 `tests/collectors/test_ark.py` 가 덮는다. 이 수집기에는 원래 전용 테스트가 없었다 — 그래서
몇 달간 아무 신호가 없었다.

**게이트**: `tests/collectors/` + `tests/trading/agents/` 1,211 passed · ruff clean ·
privacy scan clean · `make diagnostics` EXIT=0 (pyright 165 < 래칫 172, 변경 파일 진단 0) ·
`make verify-doc-counts` 19/19 · pre-push ALL CHECKS PASSED.

커버리지: `smart_money.py` 100% / `ark.py` 96% (미커버는 변경되지 않은 `__main__` 블록뿐 —
diff 에 안 잡히므로 patch 대상 아님).

## 남는 것

기존 319 Hold 행은 지우지 않았다. 고친 집계에서 무해하고(Buy/Sell 어느 쪽도 아님),
`shares=0` 이라 델타 기준선에서도 자연히 빠진다.
