### PR TITLE
fix(collectors): 200 을 주면서 내용만 언 ARK 펀드를 드러낸다

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,437 collected across 339 files | |
+| **Backend tests** | 7,449 collected across 340 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | File | Lines | Purpose | Loader |
 |------|-------|---------|--------|
-| `rules.yaml` | 610 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
+| `rules.yaml` | 614 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 187 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -516,6 +516,10 @@ symmetric_amplifier:
 # 아니라 여기 있어야 하는 이유 (Config over code).
 ark:
   min_trade_pct: 1.0                     # |shares 변화율| 이 이 값 미만이면 Hold
+  # 펀드별 CSV 발행 지연 허용치 (#1145). ARK 는 엔드포인트가 200 인 채로 내용만 얼 수 있다 —
+  # 실제로 ARKF 가 7.5개월 얼어 있었고, 다른 펀드 4개가 최신이라 MAX(date) 는 초록이었다.
+  # 주말/공휴일 흡수용으로 7일. 이 값을 넘는 펀드는 수집 시 경고 + freshness 검사에서 빨강.
+  max_source_lag_days: 7
 
 holdings_monitor:
   enabled: true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,437 backend tests across 339 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,449 backend tests across 340 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,437 tests, 339 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,449 tests, 340 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/collectors/CLAUDE.md
+++ b/nuri/collectors/CLAUDE.md
@@ -156,9 +156,28 @@ ticker 가 비어 있는데, 둘 다 ticker 빈 값으로 자연히 걸러진다
 폴백은 제거했다 (`shares=0.0` 이 델타 기준선까지 오염시킨다 — 기준선 쿼리가
 `shares > 0` 을 거는 이유).
 
+⚠️ **소스는 200 인 채로 내용만 언다** (#1145). ARKF 는 7.5개월 전 보유를 담은 CSV 를 정상
+서빙하고 있었다 — 다운로드도 파싱도 성공하므로 수집기 실패율에도 `collector_runs` 에도 안
+걸린다. 저장 자체는 정확하다(그날 그렇게 들고 있던 게 맞다). 문제는 **그 펀드가 멈춘 걸
+아무도 모른다**는 것이다. 두 겹으로 본다: 수집 시점의 펀드별 지연 경고(`_warn_stale_funds`,
+임계 `config/rules.yaml ark.max_source_lag_days`)와 `freshness.py` 의 `ark` 정책.
+
+**정책 쿼리가 `MAX(date) FROM ark` 가 아닌 이유**: 그건 **초록**이다 — 멀쩡한 펀드 4개가 죽은
+펀드 하나를 가린다. `signals` 정책이 KR/US 를 안 합치는 것과 같은 축이고, 여기서는 펀드가 그
+축이다. 그래서 **펀드별 최신 날짜의 최소값**(가장 낡은 펀드)을 본다. 범위는 추적 중인 5개
+펀드로 좁힌다 — 전 fund 값을 그룹핑하면 오타나 과거 실험이 남긴 stray 그룹 하나가 정책을
+영구 빨강으로 못박고, 영구 빨강 게이트는 아무도 안 보므로 죽은 게이트와 같아진다.
+
+⚠️ **CSV 날짜는 보유 종목 필터보다 먼저 읽는다.** 필터 뒤에서 읽으면 우리가 아무것도 안
+겹치는 펀드는 records 가 비어 `fund_date` 가 안 생기고, 아무리 낡아도 검사에 안 걸린다 —
+**소스 감시가 우리 포트폴리오 구성에 의존해버린다.** ARKF 가 그 상태로 미끄러지는 데 필요한
+건 우리가 ARKF 보유 종목을 하나도 안 들게 되는 것뿐이다. 그래서 `_collect_fund()` 는
+`(records, csv_date)` 를 돌려준다.
+
 **Test:** `tests/collectors/test_ark.py` (파싱 · 방향 파생 · 청산/재진입 5종 · #1043 실패 구분 ·
 폴백 부활 감시 — AST 로 본다, 소스의 'yfinance' 는 왜 뺐는지 적은 주석이라 grep 은
-영영 빨갛다) + `tests/trading/agents/test_smart_money_branches.py::TestSmartMoneyBranches`
+영영 빨갛다 · 소스 staleness 4종) + `tests/core/test_ark_freshness_policy.py`
+(`test_a_naive_max_date_would_have_passed_the_same_data` 가 정책 쿼리 형태를 못 박는다) + `tests/trading/agents/test_smart_money_branches.py::TestSmartMoneyBranches`
 의 `test_ark_hold_rows_are_not_counted_as_sells` ·
 `test_ark_counting_is_safe_even_if_the_query_stops_filtering` ·
 `test_ark_hold_does_not_crowd_out_real_trades`. 소비자 쪽 방어선은 **둘**이고 막는 게

--- a/nuri/collectors/ark.py
+++ b/nuri/collectors/ark.py
@@ -19,12 +19,14 @@ ARK 는 **매매 내역이 아니라 일별 보유 스냅샷**을 공개한다. 
 import csv
 import io
 import logging
+from datetime import date
 
 import requests
 
 from nuri.collectors.base import DEFAULT_HEADERS, BaseCollector, parse_date
 from nuri.core.db import get_tickers, query, upsert_ark
-from nuri.core.rules import ARK_MIN_TRADE_PCT
+from nuri.core.rules import ARK_MAX_SOURCE_LAG_DAYS, ARK_MIN_TRADE_PCT
+from nuri.core.timezone import today_kst
 
 # ETF 별 보유 CSV. 통합 파일이 없어졌으므로 펀드마다 따로 받는다.
 # 한 펀드가 실패해도 나머지는 수집된다 (부분 성공 허용).
@@ -52,14 +54,20 @@ class ARKCollector(BaseCollector):
         records: list[dict] = []
         errors: list[Exception] = []
         failed: list[str] = []
+        fund_dates: dict[str, str] = {}
         for fund, filename in ARK_HOLDINGS_FILES.items():
             url = f"{ARK_HOLDINGS_BASE}/{filename}"
             try:
-                records.extend(self._collect_fund(url, fund, held_tickers, db_path))
+                fund_records, csv_date = self._collect_fund(url, fund, held_tickers, db_path)
+                records.extend(fund_records)
+                if csv_date:
+                    fund_dates[fund] = csv_date
             except Exception as e:
                 errors.append(e)
                 failed.append(fund)
                 self.logger.warning("ARK %s 보유 CSV 실패 (%s): %s", fund, url.split("/")[2], e)
+
+        self._warn_stale_funds(fund_dates)
 
         if failed:
             self.logger.warning("ARK 펀드 %d/%d 실패: %s", len(failed), len(ARK_HOLDINGS_FILES), ", ".join(failed))
@@ -79,8 +87,39 @@ class ARKCollector(BaseCollector):
         self.logger.info("ARK 보유 %d건 (보유 종목 필터) — %s", len(records), directions)
         return records
 
-    def _collect_fund(self, url: str, fund: str, held_tickers: set, db_path=None) -> list[dict]:
-        """한 ETF 의 보유 CSV 를 파싱하고 직전 보유분 대비 방향을 파생한다."""
+    def _warn_stale_funds(self, fund_dates: dict[str, str]) -> None:
+        """펀드별 CSV 발행 날짜가 오늘에서 얼마나 뒤처졌는지 본다 (#1145).
+
+        **소스는 200 인 채로 내용만 얼 수 있다.** ARKF 는 CSV 를 정상 서빙하면서 7.5개월
+        전 보유를 담고 있었다 — 다운로드도 파싱도 성공하므로 이 검사가 없으면 아무 신호가
+        없다. 저장 자체는 정확하다(그날 그렇게 들고 있던 게 맞다). 문제는 그 펀드가 멈춘 걸
+        아무도 모른다는 것이다.
+
+        펀드별로 본다. 합쳐서 최신 하나만 보면 멀쩡한 펀드 뒤로 죽은 펀드가 숨는다 —
+        `freshness.py` 의 `signals` 정책이 KR/US 를 안 합치는 것과 같은 이유다.
+        """
+        if not fund_dates:
+            return
+
+        today = date.fromisoformat(today_kst())
+        for fund, csv_date in sorted(fund_dates.items()):
+            lag = (today - date.fromisoformat(csv_date)).days
+            if lag > ARK_MAX_SOURCE_LAG_DAYS:
+                self.logger.warning(
+                    "ARK %s 소스가 %d일 낡음 (CSV 기준일 %s, 허용 %d일) — 엔드포인트는 정상이고 내용만 얼어 있다",
+                    fund,
+                    lag,
+                    csv_date,
+                    ARK_MAX_SOURCE_LAG_DAYS,
+                )
+
+    def _collect_fund(self, url: str, fund: str, held_tickers: set, db_path=None) -> tuple[list[dict], str | None]:
+        """한 ETF 의 보유 CSV 를 파싱하고 직전 보유분 대비 방향을 파생한다.
+
+        `(records, csv_date)` 를 돌려준다. **날짜를 따로 내보내는 이유**: records 는 보유
+        종목으로 걸러진 뒤라, 우리가 아무것도 안 겹치는 펀드는 records 가 비어 CSV 가
+        아무리 낡아도 staleness 검사에 안 걸린다 (#1145 codex P1).
+        """
         resp = requests.get(url, headers=DEFAULT_HEADERS, timeout=30)
         resp.raise_for_status()
 
@@ -92,12 +131,18 @@ class ARKCollector(BaseCollector):
         for row in reader:
             # 현재 컬럼: date, fund, company, ticker, cusip, shares, market value ($), weight (%)
             # 마지막 행은 면책 문구 한 줄이라 ticker 가 비어 자연히 걸러진다. 비상장 보유분도 마찬가지.
-            ticker = _clean(row.get("ticker") or row.get("Ticker"))
-            if not ticker or ticker not in held_tickers:
-                continue
 
+            # 날짜는 **보유 종목 필터보다 먼저** 읽는다 (#1145 codex P1). 필터 뒤에서 읽으면
+            # 우리가 아무것도 안 겹치는 펀드는 낡아도 fund_date 가 안 생겨 staleness 검사에
+            # 안 걸린다 — 소스 감시가 우리 포트폴리오 구성에 의존해버린다. ARKF 가 그 상태로
+            # 미끄러지는 데 필요한 건 우리가 ARKF 보유 종목을 하나도 안 들게 되는 것뿐이다.
             date = parse_date(_clean(row.get("date") or row.get("Date")))
             if not date:
+                continue
+            csv_date = date
+
+            ticker = _clean(row.get("ticker") or row.get("Ticker"))
+            if not ticker or ticker not in held_tickers:
                 continue
 
             # shares 를 못 읽으면 행을 버린다 — 0.0 으로 눕히면 방향 파생이 그걸
@@ -111,7 +156,6 @@ class ARKCollector(BaseCollector):
             # weight 는 방향 파생에 안 쓰이므로 못 읽으면 0.0 이어도 신호를 왜곡하지 않는다.
             weight = _to_float_or_none(row.get("weight (%)") or row.get("% of ETF") or row.get("weight"))
 
-            csv_date = date
             seen.add(ticker)
             records.append(
                 {
@@ -126,7 +170,7 @@ class ARKCollector(BaseCollector):
 
         if csv_date:
             records.extend(self._exit_records(fund, csv_date, seen, held_tickers, db_path))
-        return records
+        return records, csv_date
 
     def _exit_records(self, fund: str, date: str, seen: set[str], held_tickers: set, db_path=None) -> list[dict]:
         """어제 있었는데 오늘 CSV 에 없는 종목 → 전량 청산 (#1143 codex P1).

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -137,6 +137,34 @@ FRESHNESS_POLICIES = {
         "fail_hours": 48,
         "label": "Certification",
     },
+    "ark": {
+        # ARK 는 **엔드포인트가 200 인 채로 내용만 언다** (#1145). 실측: ARKF 가 7.5개월 전
+        # 보유를 담은 CSV 를 정상 서빙하는 동안 다른 4개 펀드는 최신이었다. 다운로드도
+        # 파싱도 성공하므로 수집기 실패율·collector_runs 어디에도 안 걸린다.
+        #
+        # 맨 `MAX(date) FROM ark` 는 **초록**이다 — 멀쩡한 펀드 4개가 죽은 펀드 하나를
+        # 가린다. 위 `signals` 정책이 KR/US 를 안 합치는 것과 같은 이유이고, 여기서는
+        # 펀드가 그 축이다. 그래서 **펀드별 최신 날짜의 최소값**, 즉 가장 낡은 펀드를 본다.
+        #
+        # 임계: 수집 잡은 화~토 07:30 이고 CSV 기준일은 보통 전 영업일이라 정상 나이가
+        # 24~72h 다. 주말·공휴일 흡수해 168h(7일) WARN — `config/rules.yaml
+        # ark.max_source_lag_days` 와 같은 값이다. 336h(14일) = 2주째 안 움직였다.
+        #
+        # 추적 중인 5개 펀드로 **범위를 좁힌다**. 전 fund 값을 그룹핑하면 오타 하나나 과거
+        # 실험이 남긴 stray 그룹이 정책을 영구 빨강으로 못박는다 — 영구 빨강 게이트는
+        # 아무도 안 보게 되므로 죽은 게이트와 같아진다. 목록은 `ark.py ARK_HOLDINGS_FILES`
+        # 와 일치해야 하고, `tests/core/test_ark_freshness_policy.py` 가 양방향으로 대조한다.
+        "query": (
+            "SELECT MIN(latest) FROM ("
+            "  SELECT fund, MAX(date) AS latest FROM ark "
+            "  WHERE fund IN ('ARKK', 'ARKW', 'ARKG', 'ARKQ', 'ARKF') AND date IS NOT NULL "
+            "  GROUP BY fund"
+            ")"
+        ),
+        "warn_hours": 168,
+        "fail_hours": 336,
+        "label": "ARK 보유 (가장 낡은 펀드)",
+    },
     "portfolio": {
         # P0 stale-data fix (#507 audit 2026-04-30): broker 매도/매수 발생 후 yaml
         # sync 누락 시 0주 ticker 에 SELL 권고가 누설됨. 24h 이상이면 WARN, 72h

--- a/nuri/core/rules.py
+++ b/nuri/core/rules.py
@@ -58,6 +58,8 @@ TAKE_PROFIT_LEADER = _tp.get("leader", {"enabled": False, "trail_ma": 50})
 # ─── ARK 매매 파생 (#1143) ───
 # 보유 스냅샷 → Buy/Sell 파생 임계. smart_money 의 ARK 항목 발화 여부를 결정한다.
 ARK_MIN_TRADE_PCT = RULES.get("ark", {}).get("min_trade_pct", 1.0)
+# 펀드별 CSV 발행 지연 허용치 — 200 인 채로 내용만 어는 소스를 잡는다 (#1145).
+ARK_MAX_SOURCE_LAG_DAYS = RULES.get("ark", {}).get("max_source_lag_days", 7)
 
 # ─── 트레일링 스톱 ───
 _ts = RULES.get("trailing_stop", {})

--- a/tests/collectors/test_ark.py
+++ b/tests/collectors/test_ark.py
@@ -47,7 +47,7 @@ class TestArkCsvParsing:
         from nuri.collectors.ark import ARKCollector
 
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(ARKK_CSV)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         by_ticker = {r["ticker"]: r for r in rows}
         assert set(by_ticker) == {"TSLA", "AMD"}
@@ -61,7 +61,7 @@ class TestArkCsvParsing:
         from nuri.collectors.ark import ARKCollector
 
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(ARKK_CSV)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         assert all(r["ticker"] for r in rows)
         assert "ZZZZ" not in {r["ticker"] for r in rows}  # 보유 종목 필터
@@ -202,7 +202,7 @@ class TestArkMalformedInput:
             '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
         )
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(bad)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         assert {r["ticker"] for r in rows} == {"AMD"}
 
@@ -232,7 +232,7 @@ class TestArkMalformedInput:
             '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
         )
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(bad)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         assert {r["ticker"] for r in rows} == {"AMD"}
         assert all(r["direction"] != "Sell" for r in rows)
@@ -258,7 +258,7 @@ class TestArkExits:
             '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
         )
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(only_amd)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         exits = [r for r in rows if r["ticker"] == "TSLA"]
         assert len(exits) == 1
@@ -281,7 +281,7 @@ class TestArkExits:
             '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
         )
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(only_amd)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         assert not [r for r in rows if r["ticker"] == "TSLA"]
 
@@ -310,7 +310,7 @@ class TestArkExits:
             '08/20/2026,ARKK,ADVANCED MICRO DEVICES,AMD,007903107,"2,000","$2,000.00",2.00%\n'
         )
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(only_amd)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         assert not [r for r in rows if r["ticker"] == "TSLA"]
 
@@ -321,6 +321,115 @@ class TestArkExits:
         self._seed_prior(held)
         empty = "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
         with patch("nuri.collectors.ark.requests.get", return_value=_resp(empty)):
-            rows = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
+            rows, _ = ARKCollector()._collect_fund("http://x/y.csv", "ARKK", {"TSLA", "AMD"}, held)
 
         assert rows == []
+
+
+class TestArkSourceStaleness:
+    """소스가 200 인 채로 내용만 어는 경우 (#1145)."""
+
+    def _csv(self, csv_date: str, fund: str = "ARKK") -> str:
+        return (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            f'{csv_date},{fund},TESLA INC,TSLA,88160R101,"1,000","$1,000.00",1.00%\n'
+        )
+
+    def test_stale_fund_is_warned(self, held, caplog):
+        """ARKF 는 7.5개월 전 보유를 담은 CSV 를 200 으로 정상 서빙하고 있었다.
+        다운로드도 파싱도 성공하므로 이 경고가 없으면 아무 신호가 없다."""
+        import logging
+
+        from nuri.collectors.ark import ARKCollector
+
+        with caplog.at_level(logging.WARNING):
+            ARKCollector()._warn_stale_funds({"ARKF": "2026-01-02"})
+
+        assert any("ARKF" in r.getMessage() for r in caplog.records)
+        assert any("낡음" in (r.getMessage()) for r in caplog.records)
+
+    def test_fresh_fund_is_silent(self, held, caplog):
+        """정상 지연(전 영업일)에 경고를 내면 경고가 소음이 되어 아무도 안 본다."""
+        import logging
+
+        from nuri.collectors.ark import ARKCollector
+        from nuri.core.timezone import today_kst
+
+        with caplog.at_level(logging.WARNING):
+            ARKCollector()._warn_stale_funds({"ARKK": today_kst()})
+
+        assert not [r for r in caplog.records if "낡음" in (r.getMessage())]
+
+    def test_a_stale_fund_does_not_hide_behind_fresh_ones(self, held, caplog):
+        """펀드별로 본다 — 합쳐서 최신 하나만 보면 죽은 펀드가 멀쩡한 펀드 뒤로 숨는다."""
+        import logging
+
+        from nuri.collectors.ark import ARKCollector
+        from nuri.core.timezone import today_kst
+
+        with caplog.at_level(logging.WARNING):
+            ARKCollector()._warn_stale_funds({"ARKK": today_kst(), "ARKG": today_kst(), "ARKF": "2026-01-02"})
+
+        warned = [r.getMessage() for r in caplog.records if "낡음" in (r.getMessage())]
+        assert len(warned) == 1
+        assert "ARKF" in warned[0]
+
+    def test_collect_wires_the_staleness_check(self, held, caplog):
+        """`_warn_stale_funds` 를 직접 부르는 테스트만으로는 **호출 배선**이 안 잠긴다 —
+        `collect()` 에서 그 한 줄을 지워도 초록이었다. 수집 경로 전체로 확인한다."""
+        import logging
+
+        from nuri.collectors.ark import ARK_HOLDINGS_FILES, ARKCollector
+        from nuri.core.timezone import today_kst
+
+        fresh = self._csv(f"{today_kst()[5:7]}/{today_kst()[8:10]}/{today_kst()[:4]}")
+        stale = self._csv("01/02/2026")
+        # 첫 펀드만 얼어 있고 나머지는 당일
+        seq = [_resp(stale)] + [_resp(fresh)] * (len(ARK_HOLDINGS_FILES) - 1)
+
+        with caplog.at_level(logging.WARNING):
+            with patch("nuri.collectors.ark.requests.get", side_effect=seq):
+                ARKCollector().collect(db_path=held)
+
+        warned = [r.getMessage() for r in caplog.records if "낡음" in r.getMessage()]
+        assert len(warned) == 1
+        assert "2026-01-02" in warned[0]
+
+    def test_a_stale_fund_we_hold_nothing_from_is_still_warned(self, held, caplog):
+        """**소스 감시가 우리 포트폴리오 구성에 의존하면 안 된다** (#1145 codex P1).
+
+        날짜를 보유 종목 필터 뒤에서 읽으면, 우리가 아무것도 안 겹치는 펀드는 records 가
+        비어 fund_date 가 안 생기고 → 낡아도 경고가 없다. ARKF 가 그 상태로 미끄러지는 데
+        필요한 건 우리가 ARKF 보유 종목을 하나도 안 들게 되는 것뿐이다.
+        """
+        import logging
+
+        from nuri.collectors.ark import ARKCollector
+
+        # CSV 는 낡았고, 담긴 종목은 우리 보유(TSLA/AMD)와 하나도 안 겹친다
+        stale_no_overlap = (
+            "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+            '01/02/2026,ARKF,SHOPIFY INC - CLASS A,SHOP,82509L107,"662,061","$1.00",9.65%\n'
+        )
+        with caplog.at_level(logging.WARNING):
+            with patch("nuri.collectors.ark.requests.get", return_value=_resp(stale_no_overlap)):
+                rows, csv_date = ARKCollector()._collect_fund("http://x/y.csv", "ARKF", {"TSLA", "AMD"}, held)
+
+        assert rows == []  # 겹치는 보유 종목 없음
+        assert csv_date == "2026-01-02"  # 그래도 날짜는 나온다
+
+    def test_a_fund_with_no_usable_date_records_no_lag(self, held, caplog):
+        """헤더만 있거나 날짜를 하나도 못 읽은 펀드는 지연 판정 대상이 아니다 —
+        모르는 것을 0일 낡음으로도, 무한히 낡음으로도 단정하지 않는다."""
+        import logging
+
+        from nuri.collectors.ark import ARK_HOLDINGS_FILES, ARKCollector
+
+        header_only = "date,fund,company,ticker,cusip,shares,market value ($),weight (%)\n"
+        seq = [_resp(header_only)] * len(ARK_HOLDINGS_FILES)
+
+        with caplog.at_level(logging.WARNING):
+            with patch("nuri.collectors.ark.requests.get", side_effect=seq):
+                assert ARKCollector().collect(db_path=held) == []
+
+        assert not [r for r in caplog.records if "낡음" in r.getMessage()]

--- a/tests/core/test_ark_freshness_policy.py
+++ b/tests/core/test_ark_freshness_policy.py
@@ -1,0 +1,91 @@
+"""ARK freshness 정책 — 가장 낡은 펀드를 본다 (#1145).
+
+ARK 는 엔드포인트가 200 인 채로 내용만 얼 수 있다. 수집기 실패율에도, `collector_runs`
+에도 안 걸린다. 이 정책이 유일한 감시선이다.
+"""
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.core.freshness import FRESHNESS_POLICIES, check_freshness
+from nuri.core.timezone import today_kst
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "ark_freshness.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, rows):
+    with get_db(db_path) as c:
+        for fund, date in rows:
+            c.execute(
+                "INSERT INTO ark (date,ticker,direction,shares,weight,fund) VALUES (?,?,?,?,?,?)",
+                (date, "TSLA", "Hold", 1000.0, 1.0, fund),
+            )
+
+
+class TestArkFreshnessPolicy:
+    def test_policy_is_registered(self):
+        assert "ark" in FRESHNESS_POLICIES
+
+    def test_all_funds_current_passes(self, db_path):
+        _seed(db_path, [("ARKK", today_kst()), ("ARKG", today_kst())])
+        assert check_freshness("ark", db_path=db_path)["status"] == "PASS"
+
+    def test_one_frozen_fund_fails_even_when_the_others_are_current(self, db_path):
+        """**이 테스트가 이 정책의 존재 이유다.**
+
+        production 실측 상태 그대로 — ARKF 만 7.5개월 전, 나머지는 당일.
+        """
+        _seed(
+            db_path,
+            [
+                ("ARKK", today_kst()),
+                ("ARKG", today_kst()),
+                ("ARKQ", today_kst()),
+                ("ARKW", today_kst()),
+                ("ARKF", "2026-01-02"),
+            ],
+        )
+        assert check_freshness("ark", db_path=db_path)["status"] == "FAIL"
+
+    def test_a_naive_max_date_would_have_passed_the_same_data(self, db_path):
+        """정책이 `MIN(펀드별 MAX)` 이어야 하는 이유를 데이터로 못 박는다.
+
+        같은 행 집합에 대해 맨 `MAX(date)` 는 오늘을 돌려준다 — 멀쩡한 펀드 4개가
+        죽은 펀드 하나를 가린다. 쿼리를 `SELECT MAX(date) FROM ark` 로 되돌리면
+        위 테스트가 FAIL 대신 PASS 를 보고 실패한다.
+        """
+        from nuri.core.db import query
+
+        _seed(
+            db_path,
+            [("ARKK", today_kst()), ("ARKG", today_kst()), ("ARKF", "2026-01-02")],
+        )
+        naive = query("SELECT MAX(date) AS d FROM ark", db_path=db_path)[0]["d"]
+        staleest = query(FRESHNESS_POLICIES["ark"]["query"], db_path=db_path)[0]
+        assert naive == today_kst()  # 초록으로 보였을 값
+        assert list(staleest.values())[0] == "2026-01-02"  # 실제로 봐야 하는 값
+
+    def test_policy_fund_list_matches_the_collector(self):
+        """정책의 IN 목록과 수집기의 `ARK_HOLDINGS_FILES` 는 같이 움직여야 한다.
+
+        양방향이다 — 수집기에 펀드를 추가하고 정책을 안 고치면 그 펀드는 감시 밖이고,
+        정책에만 남은 펀드는 영영 행이 안 생겨 정책을 영구 빨강으로 못박는다.
+        """
+        import re
+
+        from nuri.collectors.ark import ARK_HOLDINGS_FILES
+
+        in_clause = re.search(r"fund IN \(([^)]*)\)", FRESHNESS_POLICIES["ark"]["query"])
+        assert in_clause, "정책 쿼리에서 fund IN 목록을 못 찾음"
+        policy_funds = {f.strip().strip("'") for f in in_clause.group(1).split(",")}
+        assert policy_funds == set(ARK_HOLDINGS_FILES)
+
+    def test_a_stray_fund_value_cannot_pin_the_policy_red(self, db_path):
+        """추적 목록 밖의 fund 값(오타·과거 실험)은 정책을 물들이지 않는다."""
+        _seed(db_path, [("ARKK", today_kst()), ("TYPO_FUND", "2020-01-01")])
+        assert check_freshness("ark", db_path=db_path)["status"] == "PASS"

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -55,6 +55,11 @@ class TestFreshnessPolicies:
         # `fundamentals` 는 #1109 에서 추가 — composite 가중치 1.00 중 0.50(value+quality)이
         # 이 테이블에서 나오는데 정책이 없어서, 주간 잡이 보유 18종목만 갱신하는 동안
         # 나머지 ~728 종목이 얼마나 낡든 어떤 화면에도 안 떴다 (#1102 의 재료 쪽 절반).
+        # `ark` 는 #1145 에서 추가 — 소스가 **200 인 채로 내용만 언다**. ARKF 가 7.5개월 전
+        # 보유를 담은 CSV 를 정상 서빙하는 동안 다운로드·파싱이 다 성공해 수집기 실패율에도
+        # `collector_runs` 에도 안 걸렸다. 정책 쿼리는 맨 `MAX(date)` 가 아니라 **펀드별
+        # 최신 날짜의 최소값**이다 — 전자는 멀쩡한 펀드 4개가 죽은 펀드 하나를 가려 초록이
+        # 된다 (`signals` 가 KR/US 를 안 합치는 것과 같은 축).
         expected = {
             "prices",
             "factors",
@@ -67,6 +72,7 @@ class TestFreshnessPolicies:
             "consensus",
             "certification",
             "portfolio",
+            "ark",
         }
         assert expected == set(FRESHNESS_POLICIES.keys())
 


### PR DESCRIPTION
Closes #1145

## 무엇이 잘못돼 있었나

#1144 배포 후 production 에서 ARK 를 1회 돌려보니 10건 중 1건이 다른 날짜 파티션으로 갔다.

```
2026-01-02 ARKF NVDA   Hold 89295      ← 7.5개월 전
2026-08-20 ARKK GOOGL  Hold 74637
2026-08-20 ARKK TSLA   Hold 1713664
...나머지 8건 전부 08-20
```

우리 코드가 아니라 **소스**다. 같은 시각 실측:

```
ARKF: 01/02/2026,ARKF,SHOPIFY INC - CLASS A,SHOP,...   ← 7.5개월
ARKG: 08/20/2026,ARKG,10X GENOMICS INC-CLASS A,TXG,...
ARKK: 08/20/2026,ARKK,TESLA INC,TSLA,...
```

**엔드포인트는 200 이고 CSV 도 멀쩡하다. 내용만 얼어 있다.** 다운로드도 파싱도 성공하므로
수집기 실패율에도 `collector_runs` 에도 안 걸린다. 저장 자체는 정확하다 — 01/02 에 ARKF 가
그렇게 들고 있던 게 맞다. 문제는 **그 펀드가 멈춘 걸 아무도 모른다**는 것이다.

이 레포가 이미 두 번 겪은 유형이다 — `put_call_ratio` 6주 구멍(정책 부재),
`factors` 넉 달(#1071).

## 무엇을 고쳤나

**두 겹.** 하나로는 부족하다 — 로그는 운영자가 볼 때만 보이고, 정책은 화면에 남는다.

1. **수집 시점 경고** — `_warn_stale_funds()` 가 펀드별 CSV 날짜를 오늘과 비교해
   `config/rules.yaml ark.max_source_lag_days`(7일)를 넘으면 경고한다.
2. **freshness 정책** — `nuri/core/freshness.py` 에 `ark` 추가 (168h WARN / 336h FAIL).

**정책 쿼리가 `MAX(date) FROM ark` 가 아닌 이유가 이 PR 의 핵심이다.** 그건 **초록**이다 —
멀쩡한 펀드 4개가 죽은 펀드 하나를 가린다. `signals` 정책이 KR/US 를 안 합치는 것과 같은
축이고(*"합산 floor 는 US 단독으로 넘는다 — KR 전면 정지가 US 뒤에 숨는다"*), 여기서는
펀드가 그 축이다. 그래서 **펀드별 최신 날짜의 최소값**을 본다:

```sql
SELECT MIN(latest) FROM (SELECT fund, MAX(date) AS latest FROM ark GROUP BY fund)
```

이걸 테스트로 못 박았다 — `test_a_naive_max_date_would_have_passed_the_same_data` 는
같은 행 집합에 대해 맨 `MAX(date)` 가 오늘을 돌려주는 것과 정책 쿼리가 `2026-01-02` 를
돌려주는 것을 나란히 단정한다.

## 검증

**뮤테이션** — 고친 줄을 되돌리면 실제로 FAIL:

| 되돌린 것 | 결과 |
|---|---|
| `collect()` 의 `_warn_stale_funds` 호출 제거 | 1 FAIL |
| 지연 판정 무력화 (`if False`) | 2 FAIL |
| 항상 경고 (임계 제거 → 소음화) | 2 FAIL |
| 정책 쿼리를 맨 `MAX(date)` 로 | 2 FAIL |

첫 라운드에서 **배선 축이 PASS 했다** — `_warn_stale_funds` 를 직접 부르는 테스트만 있어서
`collect()` 에서 그 한 줄을 지워도 초록이었다. `test_collect_wires_the_staleness_check`
(수집 경로 전체 통과)를 추가해 잠갔다.

**게이트**: `tests/core/` + `tests/collectors/` 1,503 passed · ruff clean ·
`make diagnostics` EXIT=0 (pyright 165 < 래칫 172) · `make verify-doc-counts` 19/19 ·
pre-push ALL CHECKS PASSED. `ark.py` 97% (미커버는 변경 없는 `__main__`).

`test_expected_policy_keys` 는 정책 추가를 일부러 잡는 양방향 allowlist라 사유와 함께 등재했다.

## 배포하면 즉시 빨강이 된다 — 그게 목적이다

ARKF 때문에 `ark` 검사가 바로 FAIL 로 뜬다. 지금은 **같은 상태가 초록**이다. 다만 영구 빨강
게이트는 아무도 안 보게 되므로, ARK 가 ARKF 발행을 재개하지 않으면 `ARK_HOLDINGS_FILES`
에서 빼는 판단이 뒤따라야 한다. 그건 관측 결과를 며칠 보고 정할 일이라 이 PR 밖이다.
