### PR TITLE
fix(tests): patch 창을 넘어 사는 mock 제거 — 빈 격리 DB 로 교체

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,455 collected across 340 files | |
+| **Backend tests** | 7,460 collected across 340 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,455 backend tests across 340 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,460 backend tests across 340 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,455 tests, 340 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,460 tests, 340 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -82,6 +82,46 @@ import 될 뿐 테스트 모듈이 아니다.** 그런데 파일을 인자로 �
 (`tests/` 는 패키지가 아니라 import 경로가 실행 방식에 따라 달라진다).
 **Test:** `tests/test_production_db_guard.py` — 파일 자체가 이 규칙의 산물이다.
 
+### `patch("nuri.core.db.query")` 금지 — mock 이 patch 창을 넘어 산다 (#1149)
+
+patch 가 활성인 동안 **처음 import 되는** 모듈이 `from nuri.core.db import query` 를 하면
+mock 을 자기 전역에 **복사**한다. patch 는 원본 속성만 되돌리므로 그 복사본은 mock 인 채
+남고, 이후 모든 테스트에서 그 모듈의 DB 조회가 조용히 `[]` 를 낸다.
+
+실측(2026-08-21): `empty_db_ctx` 하나가 3개 모듈을 오염시켰다 — `nuri.core.coverage` ·
+`nuri.core.freshness` · `nuri.trading.recommend.tracker`. **`freshness` 가 특히 나쁘다**:
+이후 모든 정책이 "데이터 없음" 을 답하므로 *낡음을 감시하는 장치가 죽은 채로 그 장치의
+테스트가 돈다.* 피해는 `tracker` 가 보유 조회에 `[]` 를 받아 SELL 을 전부 걸러내는 형태로
+`tests/api/test_axis_native_read_path.py` 에서 IndexError 로 터졌다.
+
+**빈 결과가 목적이면 빈 격리 DB 를 준다.** `_resolve_db_path()` 가 호출 시점에 파사드의
+`DB_PATH` 를 읽으므로, 어딘가 남은 `query` 복사본도 실전 함수라 그 경로를 그대로 탄다 —
+오염 축이 성립조차 안 한다.
+
+```python
+empty = tmp_path / "empty.db"
+init_db(empty)
+monkeypatch.setattr(nuri.core.db, "DB_PATH", empty)   # patch("...query") 대신
+```
+
+손으로 나열해 복원하는 방식(`finally: mod.query = _orig`)은 쓰지 않는다 — 그게 원래 방어였고,
+새 소비자가 생길 때마다 조용히 샜다.
+
+⚠️ **이 계열은 직렬 실행에서만 보인다.** `make test-fast`(`-n auto --dist worksteal`)는
+오염원과 피해자를 다른 워커로 보내 초록이다. 격리 의심 시 `pytest tests/ --ignore=tests/quant -x`
+로 직렬 확인.
+
+**Test:** `tests/alerts/test_premarket_brief.py::TestFixtureLeavesNoMockBehind` — 4개가
+구조와 동작을 나눠 잠근다. fixture 를 query mock 방식으로 되돌리면 **넷 다 FAIL**.
+- `test_known_leak_modules_still_hold_the_real_query` — 누출 이력 3종을 **이름으로** 확인.
+  스윕만으로는 부족하다: 그 시점 로드된 모듈만 보므로 감시 대상이 아직 로드 전이면 조용히
+  통과한다. 여기서는 직접 import 하므로 항상 검사된다.
+- `test_no_other_module_holds_a_rebound_query` — 전역 스윕. 타입 이름이 아니라 **동일성**으로
+  본다 (새는 값이 `MagicMock` 이 아니라 평범한 callable 이어도 잡아야 한다).
+- `test_freshness_still_sees_real_data` · `test_coverage_still_sees_real_data` ·
+  `test_tracker_still_sees_a_seeded_portfolio` — 세 모듈 각각의 **동작** 잠금. 구조 스윕만
+  두면 tracker 만 초록인 채 낡음 감시가 다시 죽는 회귀가 통과한다.
+
 ### runpy + mock
 `runpy.run_module()` re-executes module source, **invalidating all mocks**. Use `patch("source.module.function")` for source-level patching, not `patch("target.module.function")`.
 

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -17,47 +17,50 @@ import pytest
 
 
 @pytest.fixture
-def empty_db_ctx():
-    """모든 subsystem helper 를 빈 결과로 mock.
+def empty_db_ctx(tmp_path, monkeypatch):
+    """모든 subsystem helper 를 빈 결과로 mock. DB 는 **빈 격리 DB** 를 준다.
 
-    Pre-import lazy-imported modules BEFORE applying patches — `_collect_context`
-    가 함수 안에서 `from nuri.quant.validation.market_signals import detect_all`
-    하면, patch 활성 상태에서 market_signals 모듈이 처음 로드되며 그 안의
-    `from nuri.core.db import query` 가 MOCK query 를 캡처. patch 종료 후 db.query
-    는 복원되지만 market_signals.query 는 mock 으로 stuck → 후속 테스트의
-    market_signals 호출이 모두 빈 결과 반환 (#test isolation bug).
+    예전에는 `patch("nuri.core.db.query", return_value=[])` 로 빈 결과를 만들었다.
+    그게 #1149 의 원인이다: patch 창 안에서 **처음 import 되는** 모듈이
+    `from nuri.core.db import query` 를 하면 mock 을 자기 전역에 복사하고, patch 가
+    끝나도 **그 복사본은 mock 인 채로 남는다.** `finally` 에서 손으로 나열한 2개만
+    복원하고 있었는데 실제로는 3개가 새고 있었다 —
+    `nuri.core.coverage` · `nuri.core.freshness` · `nuri.trading.recommend.tracker`.
+    freshness 가 새는 게 특히 나빴다: 이후 모든 정책이 "데이터 없음" 을 답하므로
+    **낡음을 감시하는 장치가 조용히 죽은 채로 그 장치의 테스트가 돌 수 있다.**
+    증상은 직렬 실행에서만 났다 (`-n auto` 는 오염원과 피해자를 다른 워커로 보낸다).
+
+    빈 DB 로 바꾸면 그 축이 **성립조차 안 한다.** `_resolve_db_path()` 가 호출 시점에
+    파사드의 `DB_PATH` 를 읽으므로, 어딘가에 남은 `query` 복사본도 실전 함수라 이 경로를
+    그대로 탄다. 이 레포의 격리 관용구도 원래 `db_path=` / `DB_PATH` 다
+    (`.claude/rules/invariants.md` "DB sole importer").
+
+    나머지 patch(`classify_regime` 등)는 여전히 이름 복사에 노출되므로, 그 대상들을
+    **미리 import** 해 patch 창 안에서 처음 로드되는 일이 없게 한다.
     """
-    # 강제 사전 import — 모든 lazy-loaded module 의 query 바인딩을 real 로 고정
     import nuri.api.routes.actions  # noqa: F401
-
-    # query rebound 방어 — patch 후 모듈 query 가 mock 으로 stuck 되는 케이스 복원
     import nuri.core.db as _db_mod
     import nuri.quant.regime.classifier  # noqa: F401
     import nuri.quant.regime.macro_score  # noqa: F401
     import nuri.quant.validation.market_signals  # noqa: F401
     import nuri.trading.engine.certification  # noqa: F401
+    from nuri.core.db import init_db
 
-    _real_query = _db_mod.query
-    _ms_orig_query = nuri.quant.validation.market_signals.query
+    empty = tmp_path / "empty.db"
+    init_db(empty)
+    monkeypatch.setattr(_db_mod, "DB_PATH", empty)
 
-    try:
-        with (
-            patch("nuri.quant.regime.classifier.classify_regime", return_value=None),
-            patch("nuri.quant.regime.macro_score.compute_macro_score", side_effect=RuntimeError("no macro")),
-            patch("nuri.trading.engine.certification.certify", side_effect=RuntimeError("no certify")),
-            patch(
-                "nuri.api.routes.actions._build_actions",
-                return_value={"urgent": [], "portfolio": [], "check": [], "hold": []},
-            ),
-            patch("nuri.api.routes.actions._build_opportunities", return_value=[]),
-            patch("nuri.core.db.query", return_value=[]),
-        ):
-            yield
-    finally:
-        # market_signals.query 가 patch 동안 mock 으로 rebound 되었을 수 있음 — 강제 복원
-        nuri.quant.validation.market_signals.query = _ms_orig_query
-        # db_mod.query 는 patch 가 자체 복원하지만, 방어적 lock
-        _db_mod.query = _real_query
+    with (
+        patch("nuri.quant.regime.classifier.classify_regime", return_value=None),
+        patch("nuri.quant.regime.macro_score.compute_macro_score", side_effect=RuntimeError("no macro")),
+        patch("nuri.trading.engine.certification.certify", side_effect=RuntimeError("no certify")),
+        patch(
+            "nuri.api.routes.actions._build_actions",
+            return_value={"urgent": [], "portfolio": [], "check": [], "hold": []},
+        ),
+        patch("nuri.api.routes.actions._build_opportunities", return_value=[]),
+    ):
+        yield
 
 
 class TestContextCollection:
@@ -1107,3 +1110,161 @@ class TestBuyCandidatesArePersisted:
 
         ctx = pb._collect_context(db_path=db)
         assert ctx["buy_candidates"] is emitted, "기록 실패가 후보 표출까지 날렸다"
+
+
+# 과거 실제로 새어 나간 모듈 (#1149). 스윕은 **그 시점 로드된 것만** 보므로 이 셋은
+# 이름으로 못 박고 직접 import 해서 확인한다 — 아직 로드 전이면 스윕이 조용히 통과한다.
+_KNOWN_LEAK_MODULES = (
+    "nuri.core.coverage",
+    "nuri.core.freshness",
+    "nuri.trading.recommend.tracker",
+)
+
+
+def _rebound_query_modules() -> list[str]:
+    """`nuri.*` 중 `query` 가 실전 함수가 **아닌** 모듈.
+
+    타입 이름으로 mock 을 찾지 않고 **동일성**으로 본다 — 새는 값이 `MagicMock` 이 아니라
+    평범한 callable(예: `lambda *_: []`)이어도 잡아야 한다.
+    """
+    import sys
+
+    import nuri.core.db as db_mod
+
+    real = db_mod.query
+    return sorted(
+        name
+        for name, mod in list(sys.modules.items())
+        if name.startswith("nuri.")
+        and mod is not None
+        and getattr(mod, "query", None) is not None
+        and getattr(mod, "query") is not real
+    )
+
+
+class TestFixtureLeavesNoMockBehind:
+    """#1149 회귀 잠금 — patch 창을 넘겨 살아남는 mock 이 없어야 한다.
+
+    `patch("nuri.core.db.query", ...)` 가 활성인 동안 **처음 import 되는** 모듈이
+    `from nuri.core.db import query` 를 하면 mock 을 자기 전역에 복사한다. patch 는 원본
+    속성만 되돌리므로 복사본은 mock 인 채 남고, 이후 그 모듈의 DB 조회가 조용히 빈 결과를
+    낸다. 실제로 3개가 샜다 — `nuri.core.coverage` · `nuri.core.freshness` ·
+    `nuri.trading.recommend.tracker`.
+
+    ⚠️ **이 계열은 직렬 실행에서만 보인다.** `make test-fast`(`-n auto --dist worksteal`)는
+    오염원과 피해자를 다른 워커로 보내 초록이다 — 그래서 CI 가 못 잡았다.
+    """
+
+    def test_known_leak_modules_still_hold_the_real_query(self, empty_db_ctx):
+        """과거 새어 나간 3개를 **이름으로** 확인한다.
+
+        스윕만으로는 부족하다 — 그 시점 로드된 모듈만 보므로, 감시 대상이 아직 로드 전이면
+        조용히 통과한다. 여기서는 직접 import 하므로 항상 검사된다.
+        """
+        import importlib
+
+        import nuri.core.db as db_mod
+
+        for name in _KNOWN_LEAK_MODULES:
+            mod = importlib.import_module(name)
+            assert mod.query is db_mod.query, f"{name}.query 가 rebound 됨 (#1149)"
+
+    def test_no_other_module_holds_a_rebound_query(self, empty_db_ctx):
+        """위 3개 밖에서 새로 새는 것이 없는지 — 전역 스윕."""
+        assert _rebound_query_modules() == []
+
+    def test_tracker_still_sees_a_seeded_portfolio(self, empty_db_ctx, tmp_path):
+        """#1149 최소 재현을 동작으로 박는다.
+
+        오염된 `tracker.query` 는 보유 조회에 `[]` 를 돌려주고, 그러면 SELL 이
+        `skip SELL on non-held` 로 걸러져 행이 아예 안 생겼다. 구조가 아니라 **결과**로
+        잠근다 — 다음에 다른 이름이 새도 이 단정은 여전히 유효하다.
+        """
+        from dataclasses import dataclass
+
+        from nuri.core.db import init_db, query, upsert_portfolio
+        from nuri.trading.recommend.candidates import TIER_ACTIONABLE
+        from nuri.trading.recommend.tracker import save_recommendations
+
+        db = tmp_path / "repro.db"
+        init_db(db)
+
+        @dataclass
+        class _Candidate:
+            ticker: str
+            direction: str
+            confidence: float
+            signal_id: str
+            price: float
+            regime_fit: bool = True
+            tier: str = TIER_ACTIONABLE
+            scoring_detail: dict | None = None
+
+        upsert_portfolio(
+            [
+                {
+                    "account": "test",
+                    "ticker": "ZZZ",
+                    "quantity": 5,
+                    "avg_price": 100,
+                    "currency": "USD",
+                    "sector": "Tech",
+                }
+            ],
+            db,
+        )
+        save_recommendations(
+            candidates=[
+                _Candidate(
+                    ticker="ZZZ",
+                    direction="SELL",
+                    confidence=65.0,
+                    signal_id="bb_reversal",
+                    price=100.0,
+                )
+            ],
+            db_path=db,
+        )
+        rows = query("SELECT action FROM recommendations WHERE ticker='ZZZ'", db_path=db)
+        assert rows, "SELL 이 걸러졌다 — tracker 의 보유 조회가 mock 을 물고 있다 (#1149)"
+        assert rows[0]["action"] == "SELL"
+
+    def test_freshness_still_sees_real_data(self, empty_db_ctx, tmp_path):
+        """`nuri.core.freshness` 에 대한 **동작** 잠금 (#1149 codex P2).
+
+        구조 스윕만으로는 부족하다 — tracker 만 초록인 채 낡음 감시가 다시 죽는 회귀가
+        가능하다. 그리고 이 모듈이 새는 게 제일 나쁘다: 고착된 `query` 아래에서는 모든
+        정책이 "데이터 없음" 을 답하므로, **감시 장치가 죽었는데 그 장치의 테스트가 돈다.**
+        """
+        from nuri.core.db import get_db, init_db
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        db = tmp_path / "fresh.db"
+        init_db(db)
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES ('SPY', ?, 1, 1, 1, 1, 1)",
+                (today_kst(),),
+            )
+
+        result = check_freshness("prices", db_path=db)
+        assert result["status"] == "PASS", f"낡음 감시가 데이터를 못 본다 (#1149): {result}"
+        assert result["last_updated"] is not None
+
+    def test_coverage_still_sees_real_data(self, empty_db_ctx, tmp_path):
+        """`nuri.core.coverage` 에 대한 동작 잠금 — 같은 이유."""
+        from nuri.core.coverage import _table_tickers
+        from nuri.core.db import get_db, init_db
+        from nuri.core.timezone import today_kst
+
+        db = tmp_path / "cov.db"
+        init_db(db)
+        with get_db(db) as conn:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume) VALUES ('SPY', ?, 1, 1, 1, 1, 1)",
+                (today_kst(),),
+            )
+
+        found = _table_tickers("prices", db_path=db)
+        assert found == {"SPY"}, f"커버리지 검사가 데이터를 못 본다 (#1149): {found}"


### PR DESCRIPTION
Closes #1149

## 무엇이 잘못돼 있었나

`patch("nuri.core.db.query", return_value=[])` 는 **자기가 바꾼 속성만** 되돌린다.
patch 창 안에서 **처음 import 되는** 모듈은 이미 `from nuri.core.db import query` 로 mock 을
자기 전역에 복사한 뒤였고, patch 가 끝나도 그 복사본은 mock 인 채 남는다.

fixture 는 이 실패 유형을 **알고 있었다** — docstring 이 그대로 설명한다. 그리고 `finally` 에서
**손으로 나열한 2개**만 복원했다. 실제로는 **3개**가 새고 있었다:

```
nuri.core.coverage
nuri.core.freshness          ← 
nuri.trading.recommend.tracker
```

`freshness` 가 핵심이다. 고착된 mock 아래에서는 **모든 정책이 "데이터 없음" 을 답한다** —
낡음을 감시하는 장치가 죽은 채로 그 장치의 테스트가 돈다. 방금 #1145/#1147 로 ARK 정책을
붙인 자리다.

겉으로 드러난 증상은 엉뚱한 곳이었다: `tracker` 가 보유 조회에 `[]` 를 받아 SELL 을 전부
`skip SELL on non-held` 로 걸러냈고, 뒤따르는 조회가 빈 결과를 인덱싱해 터졌다.

```
FAILED tests/api/test_axis_native_read_path.py::TestTrackerAxisPersist::test_e1_candidate_sell_persists_alpha_flat
  IndexError: list index out of range
```

## CI 가 왜 못 잡았나

**직렬 실행에서만 보인다.** `make test-fast`(`-n auto --dist worksteal`)는 오염원과 피해자를
다른 워커로 보내므로 초록이다. 단독 · 클래스 · 파일 · `tests/api` 전체(591) 어디서도
재현되지 않고, 오직 `pytest tests/ --ignore=tests/quant` 직렬에서만 결정적으로 실패했다
(2회 재현). 플레이크가 아니었다.

## 최소 재현 (2 테스트)

```bash
pytest "tests/alerts/test_premarket_brief.py::TestContextCollection::test_all_subsystems_fail_returns_none_values" \
       "tests/api/test_axis_native_read_path.py::TestTrackerAxisPersist::test_e1_candidate_sell_persists_alpha_flat" -q
```

수정 전 `1 failed, 1 passed` → 수정 후 `2 passed`.

## 무엇을 고쳤나

**mock 을 없애고 빈 격리 DB 를 준다.** `_resolve_db_path()` 가 호출 시점에 파사드의 `DB_PATH`
를 읽으므로, 어딘가 남은 `query` 복사본도 **실전 함수**라 그 경로를 그대로 탄다 —
오염 축이 성립조차 안 한다. 이 레포의 격리 관용구이기도 하다
(`.claude/rules/invariants.md` "DB sole importer").

```python
empty = tmp_path / "empty.db"
init_db(empty)
monkeypatch.setattr(_db_mod, "DB_PATH", empty)     # patch("...query") 삭제
```

손으로 나열해 복원하던 `finally` 블록도 같이 걷었다 — 그게 원래 방어였고, 새 소비자가 생길
때마다 조용히 샜다. 나머지 patch(`classify_regime` 등)는 여전히 이름 복사에 노출되므로
**사전 import 블록은 유지**한다 (그 목적에는 맞는 방어다).

## 검증

**폭발 반경**: 고착 모듈 **3 → 0** (`sys.modules` 스윕 실측).

**직렬 전체** — 원래 1883번째에서 죽던 명령:

```
$ pytest tests/ --ignore=tests/quant -q
6619 passed, 5 skipped, 9 deselected in 392.64s
```

**뮤테이션** — fixture 를 query mock 방식으로 되돌리면:

| 검사 | 결과 |
|---|---|
| `test_no_module_holds_a_mock_query` (구조 — `sys.modules` 스윕) | FAIL |
| `test_tracker_still_sees_a_seeded_portfolio` (동작 — 원 재현) | FAIL |
| 최소 재현 2-테스트 | 다시 FAIL |

구조와 동작을 **둘 다** 잠갔다 — 다음에 다른 이름이 새도 동작 쪽 단정은 여전히 유효하다.
잠금은 fixture 가 사는 파일에 뒀다(fixture 가 모듈 로컬이라 다른 곳에서 안 보인다).

**게이트**: `make test-fast` **7,424 passed** (커버리지 99%) · ruff clean ·
`make diagnostics` EXIT=0 (pyright 165 < 래칫 172) · `make verify-doc-counts` 19/19 ·
pre-push ALL CHECKS PASSED.

`tests/CLAUDE.md` 에 금지 패턴과 대안을 Gotcha-Test Pair 로 적었다.

## 남는 것 (이 PR 밖)

**직렬 실행이 게이트에 없다.** `-n auto` 만 돌리는 한 이 계열은 계속 안 보인다. 세션 전체를
관찰하는 카나리아를 두는 방법도 있으나, 루트 테스트 파일의 수집 순서가 디렉터리 사이에
끼어 위치가 불안정해 이번엔 넣지 않았다. #1149 에 별개 논점으로 적어 뒀다.
