### PR TITLE
docs(core): freshness 정책 계약 2건 기록 — allowlist 의도, 소스≠교집합

### DIFF
--- a/nuri/core/CLAUDE.md
+++ b/nuri/core/CLAUDE.md
@@ -49,6 +49,17 @@ Two guarantees hold here, and both are load-bearing for readers elsewhere:
 
 `FRESHNESS_POLICIES` per data source (prices 48h/120h, VIX 24h/72h, etc.). `check_freshness(key)` returns PASS/WARN/FAIL.
 
+정책을 추가/삭제하면 `tests/core/test_freshness.py::test_expected_policy_keys` 가 **일부러**
+깨진다 — 양방향 allowlist 라 등재할 때 "왜 이 정책이 생겼는지" 한 줄을 그 테스트에 같이
+적는다 (#1071 `factors` / #1101 `signals` / #1145 `ark` 가 전례).
+
+⚠️ **정책 쿼리는 소스를 재야지, 우리와 소스의 교집합을 재면 안 된다** (#1147). 보유 종목으로
+필터된 테이블(`ark` 가 그랬다)의 `MAX(date)` 는 "소스가 마지막으로 발행한 날"이 아니라
+"우리가 마지막으로 겹친 날"이다 — 포트폴리오 구성이 바뀌면 멀쩡한 소스가 낡음으로 오판된다.
+수집기가 필터 **이전** 사실을 따로 기록하게 하고(`ark_source_dates`) 정책은 그걸 읽는다.
+축이 여러 개인 소스(펀드·시장)는 합산 `MAX` 금지 — 멀쩡한 축이 죽은 축을 가린다
+(`signals` 의 KR/US 분리, `ark` 의 `COUNT(*)=5` + 펀드별 MIN 이 같은 원칙).
+
 ## pipeline.py — Orchestration
 
 `STEP_DEPENDENCIES` defines the 5-stage DAG (`collect → analyze → consensus → certify → track`). `run_step()` enforces dependency completion.


### PR DESCRIPTION
#1147 후속 문서화. `/init` 정합 점검에서 발견한 유일한 갭.

`nuri/core/CLAUDE.md` 의 freshness 섹션이 2줄뿐이라, 오늘 ARK 작업(#1145→#1147)에서 실제로
두 번 밟은 비자명한 사실이 어디에도 없었다:

1. **정책 추가는 allowlist 테스트에 일부러 걸린다** — `test_expected_policy_keys` 는 양방향이라
   등재 시 사유를 같이 적는 것이 규약이다 (#1071/#1101/#1145 전례).
2. **정책 쿼리는 소스를 재야지, 우리와 소스의 교집합을 재면 안 된다** — 보유 종목으로 필터된
   테이블의 `MAX(date)` 는 "소스 발행일"이 아니라 "우리가 마지막으로 겹친 날"이다. #1147 에서
   멀쩡한 ARKG 를 4개월 낡음으로 오판한 근본 원인의 일반화. 다축 소스의 합산 `MAX` 금지도 함께.

문서 1파일, 코드 변경 0. `verify-doc-counts` 19/19 · pre-push ALL CHECKS PASSED.

`/init` 나머지 판정: 4-Layer 수치(scoped 13+global / skills 6 / agents 2 / commands 8) 전부
실측 일치, 오늘 12+2 PR 의 scoped 문서 동반 갱신 확인 — 이 갭 외 드리프트 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)