### PR TITLE
test(scheduler): shrink known-names dispatch test to a 2-ticker universe

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -582,9 +582,29 @@ class TestSchedulerLazy:
 
 class TestSchedulerLazy_R6:
     @pytest.mark.slow
-    def test_run_collector_known_names(self):
-        """실제 collector 이름 호출 — conftest mock 덕분에 네트워크 안 탐."""
+    def test_run_collector_known_names(self, monkeypatch):
+        """실제 collector 이름 호출 — conftest mock 덕분에 네트워크 안 탐.
+
+        universe 는 US+KR 각 1개 티커로 축소한다 (#1152): 이 테스트의 목적은
+        이름 dispatch + lazy import 가 살아있는지지 757 티커 처리가 아니다.
+        축소 없이는 fundamental 의 KIS KR sub-batch 가 KOSPI200 을 순차
+        rate-limit sleep 으로 순회해 이 테스트 혼자 136s — 단일 테스트는
+        샤딩으로 못 쪼개 push CI slow lane 전체를 고정했다.
+        """
+        from nuri.collectors.base import BaseCollector
         from nuri.scheduler import _run_collector
+
+        # market 계약은 보존한다 (codex P2): stock 은 US만, stock_kr 은 KR만
+        # 기대하므로 인자를 무시하는 stub 은 혼합 universe 를 흘려 실패를 숨긴다.
+        def _tiny_universe(self, market=None, source="portfolio"):
+            tickers = ["AAPL", "005930.KS"]
+            if market == "us":
+                return [t for t in tickers if not t.endswith((".KS", ".KQ"))]
+            if market == "kr":
+                return [t for t in tickers if t.endswith((".KS", ".KQ"))]
+            return tickers
+
+        monkeypatch.setattr(BaseCollector, "_get_tickers", _tiny_universe)
 
         names = [
             "stock",


### PR DESCRIPTION
Closes #1152

## 문제

`test_run_collector_known_names` 가 slow lane 27개 중 혼자 136.29s (2위 20.6s) — 단일 테스트는 샤딩으로 못 쪼개 push CI Backend Slow 샤드 232s 를 이 테스트가 고정.

## 원인 (실측)

13개 수집기를 실제 실행하는데, conftest 가 네트워크는 mock 해도 **fundamental 의 KIS KR sub-batch 가 KOSPI200 ~200 티커를 순차 + rate-limit sleep 으로 순회** (수집기별 프로브: fundamental 106.3s / cboe 10.5s / macro 6.0s / 나머지 ≤4.2s).

## 수정

테스트 목적(이름 dispatch + lazy import 생존 확인)에 맞게 `BaseCollector._get_tickers` 를 US+KR 각 1개 티커 stub 으로 monkeypatch. **market 계약은 보존** — `market="us"`/`"kr"` 필터를 그대로 구현해 stock(US-only)/stock_kr(KR-only) 이 혼합 universe 를 받지 않게 함 (codex P2 반영).

## 검증

- 단일 테스트 136.29s → **31.5s** / slow lane 전체(27개) 144s → **39s** (로컬 -n auto)
- `make diagnostics` rc=0
- Codex 리뷰: P2 1건(market 계약) → 반영, P1 없음. xdist 오염 우려는 monkeypatch 함수 단위 복원 + 프로세스 격리로 non-issue 판정
- 기대: push CI Backend Slow 샤드 232s → ~100s. 후속 #1153 (`.test_durations` 재생성)이 PR CI fast lane 담당

🤖 Generated with [Claude Code](https://claude.com/claude-code)