### PR TITLE
ci: scale fast test shards 4 -> 6 to cut PR CI critical path

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -391,9 +391,10 @@ jobs:
   #
   # Architecture (post PR #320 revert + STRATEGY §5.8 #2 "2번 실패하면 접근을
   # 바꾼다"):
-  #   1. backend-tests-shard  — fast tests only (-m "not slow"), 2-shard matrix.
-  #      Runs on both PR and push. Always excludes slow.
-  #   2. backend-tests-slow   — 23 slow tests, unsharded, single job.
+  #   1. backend-tests-shard  — fast tests only (-m "not slow"), time-balanced
+  #      shard matrix (개수는 아래 job 의 matrix 가 정본). Runs on both PR and
+  #      push. Always excludes slow.
+  #   2. backend-tests-slow   — slow tests only (-m slow), sharded matrix.
   #      Runs ONLY on push to main (PR still skips slow, matching pre-split
   #      behavior).
   #   3. backend-tests        — aggregator. Reports the "Backend Tests"
@@ -406,7 +407,7 @@ jobs:
   # containing slow). Coverage uploaded from both with distinct flags so
   # Codecov merges correctly.
   #
-  # Shard names are "Backend Tests Shard 1/2" — NOT required checks.
+  # Shard names are "Backend Tests · Fast/Slow <n>" — NOT required checks.
   # Only the aggregator name "Backend Tests" is protected.
 
   backend-tests-shard:
@@ -434,7 +435,7 @@ jobs:
 
       # pytest-split (timing-aware) — `pytest-shard` (hash-based) 가 #320 처럼
       # 테스트 런타임 분포가 치우치면 한 shard 가 전체 wall 을 결정. pytest-split
-      # 은 `.test_durations` (repo 동봉) 의 historical 시간을 읽어 4 shard 를
+      # 은 `.test_durations` (repo 동봉) 의 historical 시간을 읽어 shard 를
       # 균등 분배. 파일 부재 시 test-count balance 로 degrade 하는데, 그건
       # graceful 하지 않다 — 2026-08-10 실측: shard 1~3 은 전체 job 이 2~3분인데
       # shard 4 는 pytest 단계만 5분 timeout 을 넘겨 PR 2건이 막혔다(#1012·#1015).

--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -417,7 +417,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Skip notice (no backend changes)
         if: needs.changes.outputs.run_backend != 'true'
@@ -447,7 +447,7 @@ jobs:
         if: needs.changes.outputs.run_backend == 'true'
         # `--cov-report=` (empty) suppresses XML — backend-coverage-merge 가 모든
         # shard 의 `.coverage` 를 모아 단일 XML 을 만들고 codecov 에 한 번 업로드.
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --splits 4 --group ${{ matrix.shard }} --cov=nuri --cov-branch --cov-report= --cov-report=term
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "not slow and not integration" --splits 6 --group ${{ matrix.shard }} --cov=nuri --cov-branch --cov-report= --cov-report=term
         # 5분은 **관측된 최악값과 같았다** — 그래서 통과/실패가 동전던지기였다.
         # shard 4 실측 4회: 139s · 302s(timeout) · pass · timeout(82% 에서 절단, #1028).
         # timeout 은 예상 최악값 위에 여유를 둬야 하고, 그러면서도 진짜 hang 은

--- a/tests/scripts/test_ci_shard_balance.py
+++ b/tests/scripts/test_ci_shard_balance.py
@@ -1,4 +1,4 @@
-"""CI 의 4-shard 분할이 **시간 기반**으로 도는지 잠근다.
+"""CI 의 fast-shard 분할이 **시간 기반**으로 도는지 잠근다.
 
 pytest-split 은 `.test_durations` 가 없으면 조용히 **개수 균형**으로 degrade 한다. 그게
 graceful 하지 않다 — 2026-08-10 실측으로 shard 최대/최소가 3.75배 벌어졌고, 최악 shard 가
@@ -30,7 +30,7 @@ class TestDurationsFile:
     def test_exists_and_parses(self):
         """파일이 없으면 CI 가 count-split 으로 조용히 떨어진다."""
         assert DURATIONS.exists(), (
-            f"{DURATIONS.name} 이 없다 — CI 4-shard 가 개수 균형으로 degrade 한다.\n"
+            f"{DURATIONS.name} 이 없다 — CI fast shard 가 개수 균형으로 degrade 한다.\n"
             "`make sync-test-durations` 로 재생성할 것."
         )
         data = json.loads(DURATIONS.read_text())

--- a/tests/scripts/test_ci_shard_balance.py
+++ b/tests/scripts/test_ci_shard_balance.py
@@ -93,3 +93,29 @@ class TestFilenameIsNotMisspelled:
         assert len(mentioning) == len(self.SITES), "durations 파일을 언급하지 않는 곳: " + ", ".join(
             set(self.SITES) - set(mentioning)
         )
+
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "main-ci-cd.yml"
+
+
+class TestShardTopology:
+    """matrix.shard 와 pytest `--splits` 의 정합을 잠근다 (#1156 codex P2).
+
+    matrix 를 [1..4] 로 줄이면서 `--splits 6` 을 두면 group 5/6 의 테스트는
+    **어느 shard 에서도 안 돌지만 CI 는 초록**이다 — 실행 누락이 침묵한다.
+    """
+
+    def test_matrix_matches_splits(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        # 워크플로 구조상 각 테스트 job 은 matrix 선언 뒤에 자기 pytest 커맨드가
+        # 온다 — 등장 순서 쌍(fast, slow)으로 대조한다.
+        matrices = re.findall(r"shard: \[([0-9, ]+)\]", text)
+        splits = re.findall(r"--splits (\d+)", text)
+        assert len(matrices) == len(splits) >= 2, (
+            f"테스트 job 의 matrix/--splits 쌍을 못 찾았다 (matrix {len(matrices)} / splits {len(splits)})"
+        )
+        for m, s in zip(matrices, splits):
+            shard_list = [int(x) for x in m.split(",")]
+            assert shard_list == list(range(1, int(s) + 1)), (
+                f"matrix {shard_list} ≠ --splits {s} — 빠진 group 의 테스트는 어느 shard 에서도 안 돈다"
+            )

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -72,7 +72,7 @@ def test_hook_propagates_the_gate_exit_code(tmp_path, gate_rc):
 
     assert proc.returncode == gate_rc, f"게이트 rc={gate_rc} 인데 훅은 rc={proc.returncode}"
     assert argv_log.read_text(encoding="utf-8").split() == ["--skip-tests"], (
-        "테스트 단계는 CI 4-shard 가 미러한다 — 훅이 full 모드로 돌면 320.8s 라 우회당한다"
+        "테스트 단계는 CI shard 매트릭스가 미러한다 — 훅이 full 모드로 돌면 320.8s 라 우회당한다"
     )
 
 


### PR DESCRIPTION
Closes #1156

## 근거 (실측)

#1154/#1155 이후 PR CI critical path 는 fast lane: 직전 main push 실측 220s/178s/154s/138s (pytest 합계 ~610s). 로컬 CI 조건 재현(4 worker+cov)으로 slow 샤드 시간이 고정비가 아닌 실제 작업량임을 확인 — 증설이 맞는 레버.

## 변경

- fast matrix `[1..4]` → `[1..6]`, `--splits 4` → `6`. slow 는 2 유지 (slow 테스트는 durations 미기록 count-split 인데 136s outlier 가 #1154 로 제거되어 충분)
- **TestShardTopology 잠금 추가** (codex P2): matrix ↔ `--splits` 불일치 시 빠진 group 의 테스트가 CI 초록인 채 조용히 안 도는 것을 차단. 뮤테이션 실측: matrix `[1..4]`+`--splits 6` → FAIL
- 낡은 shard 개수 주석 4곳 개수-중립화 (codex P2): matrix 가 유일 정본이 되도록

## 사전 확인

- coverage-merge: `pattern: coverage-*` 라 샤드 수 무관 (codex 확인)
- branch protection: required check 는 집계 job "Backend Tests" 하나 — Fast 5/6 추가 무해 (gh api 실측 + codex 교차 확인)
- 이 PR CI 가 새 durations + 6-shard 의 첫 실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)