### PR TITLE
test(frontend): stub AUTH_SECRET explicitly instead of assuming its absence

### DIFF
--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -15,6 +15,7 @@ describe("middleware", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("passes through when no DASHBOARD_PASSWORD set", async () => {
@@ -75,14 +76,35 @@ describe("middleware", () => {
 
   it("passes through with valid auth cookie", async () => {
     vi.stubEnv("DASHBOARD_PASSWORD", "secret123");
+    // #1136: 앰비언트 환경에 기대지 않는다 — AUTH_SECRET 을 명시 stub 해야
+    // 러너 환경에 AUTH_SECRET 이 있어도(래퍼 프로세스 등) 결과가 갈리지 않는다.
+    vi.stubEnv("AUTH_SECRET", "test-auth-secret");
     const { middleware } = await import("@/middleware");
 
     // Generate the expected token using the same HMAC scheme as the
-    // production auth-token helper. AUTH_SECRET is unset so the helper
-    // falls back to DASHBOARD_PASSWORD as the HMAC key. The body of the
-    // hash is the static label "nuri-auth-token:v1" — password content
-    // is intentionally NOT mixed in (CodeQL would flag that as an
-    // insecure password hash regardless of the HMAC key).
+    // production auth-token helper. The body of the hash is the static
+    // label "nuri-auth-token:v1" — password content is intentionally NOT
+    // mixed in (CodeQL would flag that as an insecure password hash
+    // regardless of the HMAC key).
+    const expectedToken = createHmac("sha256", "test-auth-secret")
+      .update("nuri-auth-token:v1")
+      .digest("hex");
+
+    const request = {
+      nextUrl: { pathname: "/dashboard" },
+      cookies: { get: (name: string) => name === "nuri-auth" ? { value: expectedToken } : undefined },
+      url: "http://localhost:3000/dashboard",
+    };
+
+    const result = await middleware(request as unknown as NextRequest);
+    expect(result).toEqual({ type: "next" });
+  });
+
+  it("falls back to DASHBOARD_PASSWORD as HMAC key when AUTH_SECRET is empty", async () => {
+    vi.stubEnv("DASHBOARD_PASSWORD", "secret123");
+    vi.stubEnv("AUTH_SECRET", "");
+    const { middleware } = await import("@/middleware");
+
     const expectedToken = createHmac("sha256", "secret123")
       .update("nuri-auth-token:v1")
       .digest("hex");


### PR DESCRIPTION
Closes #1136

## 원인

valid-cookie 테스트가 기대 HMAC 토큰을 **폴백 키**(DASHBOARD_PASSWORD)로 계산 — 러너 환경에 `AUTH_SECRET` 이 없을 때만 일치. npm 직접 실행은 초록, `AUTH_SECRET` 을 export 하는 래퍼 프로세스 경유는 적색이었다 (이슈 실측: 직접 5/5 통과 vs 래퍼 3/3 실패).

## 수정

- `vi.stubEnv("AUTH_SECRET", "test-auth-secret")` 명시 stub + 기대 토큰도 그 키로 계산 — stub 을 지우면 폴백 키와 어긋나 **어느 환경에서든** 실패하므로 자체 잠금
- `beforeEach` 에 `vi.unstubAllEnvs()` 추가 (기존엔 globals 만 해제해 env stub 이 테스트 간 누수)
- 폴백 경로(`AUTH_SECRET` 빈 값 → DASHBOARD_PASSWORD 키) 전용 테스트 추가

## 검증

- 청정 환경 8/8 + **오염 환경 재현조건**(`AUTH_SECRET=ambient-poison`) 8/8 통과
- 전체 frontend 스위트 1,456 passed, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)