### PR TITLE
test(verify): make the doc-count gate read the test-count claims sync writes

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -1,6 +1,6 @@
 # Mechanical Enforcement
 
-Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-cd.yml`. Pre-push: `scripts/hooks/pre-push` (installed by `make setup-hooks`) → `scripts/verify/pre_push_check.sh --skip-tests` (0.9s; 테스트는 CI 4-shard 가 미러하고 full 로컬 실행은 320.8s 라 훅에서는 뺀다 — 느린 훅은 우회당한 훅이다). 이 문장은 #1070 까지 **거짓**이었다: 게이트 스크립트는 있었지만 `scripts/hooks/` 에 `pre-push` 소스가 없어 `make setup-hooks` 가 정상 동작하면서 아무것도 설치하지 않았다. **Test:** `tests/test_pre_push_hook.py` — 훅을 grep 하지 않고 임시 레포에서 **실행**해 exit code 를 본다(게이트 rc 0/1 양방향 + 게이트 부재 + 인터프리터 부재).
+Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-cd.yml`. Pre-push: `scripts/hooks/pre-push` (installed by `make setup-hooks`) → `scripts/verify/pre_push_check.sh --skip-tests` (6.6s, 2026-08-21 M5 Max — #1132 가 pytest collect ~2.5s 를 더함; 테스트는 CI shard 매트릭스가 미러하고 full 로컬 실행은 320.8s 라 훅에서는 뺀다 — 느린 훅은 우회당한 훅이다). 이 문장은 #1070 까지 **거짓**이었다: 게이트 스크립트는 있었지만 `scripts/hooks/` 에 `pre-push` 소스가 없어 `make setup-hooks` 가 정상 동작하면서 아무것도 설치하지 않았다. **Test:** `tests/test_pre_push_hook.py` — 훅을 grep 하지 않고 임시 레포에서 **실행**해 exit code 를 본다(게이트 rc 0/1 양방향 + 게이트 부재 + 인터프리터 부재).
 
 **PreToolUse hook** blocks: `import sqlite3` outside `nuri/core/db/connection.py`, `git push --force` / `reset --hard` / `clean -f`, privacy ticker+PnL inline writes (`scripts/verify/check_privacy_leak.py --message --quiet`).
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,460 collected across 340 files | |
+| **Backend tests** | 7,465 collected across 341 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,460 backend tests across 340 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,465 backend tests across 341 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,460 tests, 340 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,465 tests, 341 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -58,6 +58,16 @@ print(sqlite3.connect(_p).execute(\"SELECT COUNT(*) FROM sqlite_master WHERE typ
 # based (no Python) so they HARD-GATE in CI, unlike regimes/db_tables above.
 live_migrations()     { grep -cE '^        [0-9]+,$' nuri/core/db_migrations.py || true; }
 live_scheduler_jobs() { grep -cE '"cron":' nuri/scheduler.py || true; }
+
+# #1132: 테스트 **수** claim 3곳은 sync 가 쓰는데 verify 가 안 읽어 17개 드리프트가
+# 초록으로 통과했다. collect-only 는 venv 가 필요하므로 regimes/db_tables 와 같은
+# 계약: CI(venv 부재)에서는 skip, 로컬 make verify-doc-counts / pre-push 가 잡는다.
+# 실측 ~2.5s (7,460 tests) — pre-push 총합에 반영, enforcement.md 수치 갱신됨.
+live_tests_be() {
+    [ -x .venv/bin/python ] || { echo ""; return; }
+    .venv/bin/python -m pytest tests/ --collect-only -q 2>/dev/null \
+        | grep -oE '[0-9]+ tests collected' | head -1 | awk '{print $1}' || echo ""
+}
 live_rules_lines()    { wc -l < config/rules.yaml | tr -d ' '; }
 
 # Extract the target integer from EVERY occurrence of a claim in a file.
@@ -99,6 +109,32 @@ check_claim() {
         return 0
     else
         fail "$label ($file): doc=$bad, live=$expected — DRIFT (${count} sites checked)"
+        return 1
+    fi
+}
+
+# 앞머리 comma-number([0-9,]+)가 대상인 claim 전용 (테스트 수). extract_nums 는
+# 마지막 숫자런을 집으므로 "7,446" 이 446 으로 쪼개진다 — 콤마 제거 후 비교한다.
+# 패턴은 sync_doc_counts.sh 의 update_comma_number 3곳과 문자 그대로 동일해야 하며
+# tests/scripts/test_doc_count_gate_parity.py 가 양방향으로 잠근다.
+check_comma_claim() {
+    local label="$1" expected="$2" file="$3" pattern="$4"
+    local nums count bad
+    [ ! -f "$file" ] && { warn "$label: $file missing"; return 1; }
+    nums=$(grep -oE "$pattern" "$file" | while IFS= read -r m; do
+        echo "$m" | grep -oE '[0-9,]+' | head -1 | tr -d ','
+    done)
+    if [ -z "$nums" ]; then
+        warn "$label: pattern not found in $file — $pattern"
+        return 1
+    fi
+    count=$(echo "$nums" | wc -l | tr -d ' ')
+    bad=$(echo "$nums" | grep -vxF "$expected" | sort -u | paste -sd, - || true)
+    if [ -z "$bad" ]; then
+        pass "$label ($file): $expected (${count} site(s))"
+        return 0
+    else
+        fail "$label ($file): doc=$bad, live=$expected — DRIFT"
         return 1
     fi
 }
@@ -157,11 +193,19 @@ check_claim "scheduler_jobs"   "$JOBS"  "docs/ARCHITECTURE.md" '[0-9]+ cron jobs
 check_claim "scheduler_jobs"   "$JOBS"  "README.md" \
     '[0-9]+ (cron jobs · in-process|independent APScheduler jobs|cron entries)' || true
 check_claim "rules_yaml_lines" "$RULES" "config/CLAUDE.md"     '\| [0-9]+ \| Investment rules' || true
+TESTS_BE=$(live_tests_be)
+if [ -n "$TESTS_BE" ]; then
+    check_comma_claim "tests_be" "$TESTS_BE" "docs/ARCHITECTURE.md" '[0-9,]+ backend tests across' || true
+    check_comma_claim "tests_be" "$TESTS_BE" "docs/STRATEGY.md"     '[0-9,]+ tests, [0-9]+ files \(statement' || true
+    check_comma_claim "tests_be" "$TESTS_BE" "README.md"            '[0-9,]+ collected across' || true
+else
+    info "tests_be: skipped (no .venv/bin/python — CI contract; local make verify-doc-counts covers)"
+fi
 
-# Note: agent count + pytest collect count intentionally excluded from hard
-# verify. Agent count has no single stable grep pattern across docs (multiple
-# phrasings "10-agent", "10 agents", "10개"), and pytest collect takes 30+s
-# which would slow PR CI. Those are covered by sync_doc_counts.sh best-effort.
+# Note: agent count intentionally excluded from hard verify — no single stable
+# grep pattern across docs (multiple phrasings "10-agent", "10 agents", "10개").
+# pytest collect count was excluded on a stale "30+s" estimate; measured 2026-08-21
+# at ~2.5s, now venv-gated above (#1132).
 
 # 2026-07-08: doc integrity guard. Merge conflict markers were committed into
 # docs/ARCHITECTURE.md and sat undetected — the count greps above still matched

--- a/tests/scripts/test_doc_count_gate_parity.py
+++ b/tests/scripts/test_doc_count_gate_parity.py
@@ -1,0 +1,87 @@
+"""sync 가 쓰는 테스트-수 사이트 = verify 가 읽는 사이트 를 잠근다 (#1132).
+
+`sync_doc_counts.sh` 는 테스트 수를 3곳에 썼지만 `verify_doc_counts.sh` 는
+그 3곳을 읽지 않았다 — 17개 드리프트가 게이트 초록인 채 통과했다. 두 스크립트의
+실측 함수 집합이 조용히 갈리는 것이 재발 형태이므로, 패턴을 **문자 그대로**
+양방향 대조한다 (한쪽에만 있는 사이트는 즉시 FAIL).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC = REPO_ROOT / "scripts" / "doc" / "sync_doc_counts.sh"
+VERIFY = REPO_ROOT / "scripts" / "verify" / "verify_doc_counts.sh"
+
+
+def _live_lines(path: Path) -> str:
+    """주석 줄 제거 — 정규식 sweep 은 따옴표/주석 경계에서 조용히 눈이 먼다.
+
+    주석 처리로 사이트를 죽여도 grep 은 그대로 집는다 — 실측: 이 필터 없이는
+    README 사이트를 주석 처리한 mutant 가 파리티 검사를 통과했다.
+    """
+    return "\n".join(ln for ln in path.read_text(encoding="utf-8").splitlines() if not ln.lstrip().startswith("#"))
+
+
+def _sync_sites() -> set[tuple[str, str]]:
+    return {(m.group(1), m.group(2)) for m in re.finditer(r"update_comma_number (\S+)\s+'([^']+)'", _live_lines(SYNC))}
+
+
+def _verify_sites() -> set[tuple[str, str]]:
+    return {
+        (m.group(1).strip('"'), m.group(2))
+        for m in re.finditer(r'check_comma_claim "tests_be" "\$TESTS_BE" (\S+)\s+\'([^\']+)\'', _live_lines(VERIFY))
+    }
+
+
+class TestDocCountGateParity:
+    def test_sites_found(self):
+        """정규식이 0건을 집으면 아래 동등성 검사가 공허하게 통과한다 — 먼저 잠근다."""
+        assert len(_sync_sites()) >= 3, "sync 의 update_comma_number 사이트를 못 찾았다"
+        assert len(_verify_sites()) >= 3, "verify 의 check_comma_claim 사이트를 못 찾았다"
+
+    def test_sync_and_verify_read_the_same_sites(self):
+        sync, verify = _sync_sites(), _verify_sites()
+        assert sync == verify, (
+            f"sync 에만: {sorted(sync - verify)}\nverify 에만: {sorted(verify - sync)}\n"
+            "→ 한쪽만 고치면 드리프트가 다시 게이트를 지나간다"
+        )
+
+
+class TestCommaClaimBehavior:
+    """check_comma_claim 이 comma-number 를 실제로 잡는지 — grep 이 아니라 실행으로.
+
+    기존 extract_nums 는 마지막 숫자런을 집어 "7,446" 을 446 으로 읽는다.
+    그 축이 회귀하면 게이트는 초록인 채 눈이 먼다 (green dead gate).
+    """
+
+    def _run(self, doc_line: str, expected: str) -> int:
+        text = VERIFY.read_text(encoding="utf-8")
+        m = re.search(r"check_comma_claim\(\) \{.*?\n\}", text, re.DOTALL)
+        assert m, "check_comma_claim 함수를 verify 스크립트에서 못 찾았다"
+        script = (
+            "pass() { :; }; fail() { :; }; warn() { :; }\n"
+            + m.group(0)
+            + f'\nprintf \'%s\\n\' "{doc_line}" > "$TMPF"\n'
+            + f"check_comma_claim tests_be '{expected}' \"$TMPF\" '[0-9,]+ backend tests across'\n"
+        )
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            tmpf = f.name
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            env={"TMPF": tmpf, "PATH": "/usr/bin:/bin"},
+            capture_output=True,
+            text=True,
+        )
+        return proc.returncode
+
+    def test_matching_comma_number_passes(self):
+        assert self._run("7,446 backend tests across 493 files", "7446") == 0
+
+    def test_drifted_comma_number_fails(self):
+        assert self._run("7,446 backend tests across 493 files", "7461") != 0


### PR DESCRIPTION
Closes #1132

## 원인

`sync_doc_counts.sh` 는 테스트 수를 3곳(README/ARCHITECTURE/STRATEGY)에 쓰는데 `verify_doc_counts.sh` 는 그 3곳을 안 읽었다 — 17개 드리프트가 게이트 초록으로 통과. 제외 사유였던 "pytest collect 30+s" 는 낡은 추정 (실측 ~2.5s).

## 수정

- `live_tests_be` 추가 — regimes/db_tables 와 같은 venv-gate 계약 (CI 는 venv 부재로 skip, 로컬/pre-push 가 잡음)
- `check_comma_claim` 신설 — 기존 `extract_nums` 는 마지막 숫자런을 집어 `7,446` 을 `446` 으로 읽으므로 comma-number 전용 비교
- 패턴 3곳은 sync 와 **문자 그대로 동일**, `tests/scripts/test_doc_count_gate_parity.py` 가 양방향 잠금

## 검증 (게이트가 진짜인 증거)

- **첫 실행에서 실제 드리프트 적발**: docs 7,460 vs live 7,461 (#1157 이 추가한 테스트가 미동기) — 본 PR 에서 정식 경로(`sync_doc_counts.sh`)로 동기화, 이 테스트 파일 자체의 +4 포함 최종 7,465
- 뮤테이션 2축: ① verify 사이트 주석 처리 → 파리티 FAIL (naive 정규식은 주석도 집어 **통과했었음** — 주석-제외 필터로 잠금), ② comma 파싱은 bash 함수를 추출-실행하는 행동 테스트로 잠금 (일치 rc 0 / 드리프트 rc 1)
- pre-push 실측 6.6s (+2.5s) — enforcement.md 의 낡은 0.9s 갱신
- `make diagnostics` rc=0, scripts 테스트 502 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)