### PR TITLE
fix(exits): key REGIME_MULTIPLIER on the classifier's actual vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,465 collected across 341 files | |
+| **Backend tests** | 7,468 collected across 341 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,465 backend tests across 341 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,468 backend tests across 341 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,465 tests, 341 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,468 tests, 341 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/quant/exits/atr.py
+++ b/nuri/quant/exits/atr.py
@@ -19,7 +19,7 @@ bucket / certification / risk_agent semantic 변경 없음.
 
 - ATR 계산: talib.ATR(14-day) 사용. prices OHLC 충분.
 - Grid: `k ∈ {1.5, 2.0, 2.5, 3.0}` × regime multiplier {bull_low_vol 0.8,
-  neutral 1.0, bear_high_vol 1.3} = **12 조합**. E3-3c regime_override 와 동일
+  기본 1.0, bear_high_vol/stagflation 1.3} = **12 조합**. E3-3c regime_override 와 동일
   structure, walk-forward statistical power 확보.
 - Stop = `entry_price - (k × regime_mult × ATR_at_entry)`. **entry_atr_fixed**
   (static anchor, trailing dynamic 은 PR F2).
@@ -55,12 +55,16 @@ K_GRID = (1.5, 2.0, 2.5, 3.0)
 
 # Regime multiplier — E3-3c `regime_overrides` 와 동일 패턴 (codex Plan Q1)
 # 높은 multiplier = 더 넓은 stop (bear 에서 overshoot 방지).
+# 키는 `classify_regime()` 의 ALL_REGIMES 10개와 정확히 일치해야 한다 (#1137):
+# 예전의 "neutral" 은 classifier 가 절대 내지 않는 값이라 도달 불가였고, canonical
+# "sector_rotation" 은 빠져 있어 .get 기본값으로 새고 있었다. 값(정책)은 불변 —
+# 도달 가능한 레짐의 배수는 하나도 안 바뀌었다 (neutral/sector_rotation 둘 다 1.0).
 REGIME_MULTIPLIER = {
     "bull_low_vol": 0.8,
     "bull_high_vol": 1.0,
-    "neutral": 1.0,
     "sideways_low_vol": 1.0,
     "sideways_high_vol": 1.0,
+    "sector_rotation": 1.0,
     "recovery": 1.0,
     "bear_low_vol": 1.0,
     "bear_high_vol": 1.3,
@@ -94,13 +98,30 @@ class AtrStopResult:
     atr: float | None
     atr_pct_of_price: float | None
     k: float
-    regime: str
+    regime: str | None
     regime_multiplier: float
     stop_price: float | None
     stop_pct: float | None
     breached: bool
     basis: str = "entry_atr_fixed"
     detail: str = ""
+
+
+def _regime_multiplier(regime: str | None) -> float:
+    """regime → stop 배수. None/UNKNOWN 은 명시적 1.0, 모르는 문자열은 즉시 실패.
+
+    `.get(regime, 1.0)` 은 오타·비-canonical 값(#1130 클래스)을 정상 동작으로
+    읽는다 — 예전 기본 인자 "neutral" 이 정확히 그 경로로 새고 있었다 (#1137).
+    """
+    if regime is None:
+        return 1.0
+    from nuri.quant.regime.classifier import UNKNOWN_REGIME
+
+    if regime == UNKNOWN_REGIME:
+        return 1.0
+    if regime not in REGIME_MULTIPLIER:
+        raise ValueError(f"unknown regime {regime!r} — canonical: {sorted(REGIME_MULTIPLIER)}")
+    return REGIME_MULTIPLIER[regime]
 
 
 def compute_atr(df: pd.DataFrame, period: int = DEFAULT_PERIOD) -> Optional[pd.Series]:
@@ -134,7 +155,7 @@ def compute_atr_stop(
     entry_price: float,
     current_price: float,
     account: str | None = None,
-    regime: str = "neutral",
+    regime: str | None = None,
     k: float = DEFAULT_K,
     period: int = DEFAULT_PERIOD,
     db_path=None,
@@ -147,6 +168,8 @@ def compute_atr_stop(
 
     Returns AtrStopResult with stop_price None if insufficient history.
     """
+    regime_mult = _regime_multiplier(regime)
+
     from nuri.core.db import query_df
 
     df = query_df(
@@ -166,7 +189,7 @@ def compute_atr_stop(
             atr_pct_of_price=None,
             k=k,
             regime=regime,
-            regime_multiplier=REGIME_MULTIPLIER.get(regime, 1.0),
+            regime_multiplier=regime_mult,
             stop_price=None,
             stop_pct=None,
             breached=False,
@@ -185,7 +208,7 @@ def compute_atr_stop(
             atr_pct_of_price=None,
             k=k,
             regime=regime,
-            regime_multiplier=REGIME_MULTIPLIER.get(regime, 1.0),
+            regime_multiplier=regime_mult,
             stop_price=None,
             stop_pct=None,
             breached=False,
@@ -203,7 +226,7 @@ def compute_atr_stop(
             atr_pct_of_price=None,
             k=k,
             regime=regime,
-            regime_multiplier=REGIME_MULTIPLIER.get(regime, 1.0),
+            regime_multiplier=regime_mult,
             stop_price=None,
             stop_pct=None,
             breached=False,
@@ -211,7 +234,6 @@ def compute_atr_stop(
         )
 
     atr_val = float(atr_latest)
-    regime_mult = REGIME_MULTIPLIER.get(regime, 1.0)
     effective_k = k * regime_mult
     stop_distance = effective_k * atr_val
     stop_price = entry_price - stop_distance

--- a/tests/quant/exits/test_atr.py
+++ b/tests/quant/exits/test_atr.py
@@ -4,7 +4,7 @@ Anchor contract + fallback regression lock (codex Plan Biggest Risk):
 - OHLC 부족 (< 14 rows) → `stop_price=None` + detail "OHLC 부족" (never raise).
 - NaN/0 ATR → None + detail "ATR NaN/0" graceful.
 - Normal path: entry - k × regime_mult × ATR, breached check.
-- Regime multiplier: bull_low_vol=0.8, neutral=1.0, bear_high_vol=1.3 (E3-3c parity).
+- Regime multiplier: bull_low_vol=0.8, 기본 1.0, bear_high_vol=1.3 (E3-3c parity).
 - Grid frozen: K_GRID = (1.5, 2.0, 2.5, 3.0).
 
 Revert detection: anchor contract 변경 (entry_price 재해석) or grid drift 시 fail.
@@ -76,7 +76,36 @@ class TestGridAndRegimeConstants:
 
         assert REGIME_MULTIPLIER["bull_low_vol"] == 0.8
         assert REGIME_MULTIPLIER["bear_high_vol"] == 1.3
-        assert REGIME_MULTIPLIER.get("neutral", None) == 1.0
+        # #1137: 예전 "neutral" 은 classifier 가 절대 내지 않는 도달 불가 키였다 —
+        # canonical 어휘로 정합. 도달 가능한 레짐의 배수는 불변 (정책 변경 아님).
+        assert "neutral" not in REGIME_MULTIPLIER
+        assert REGIME_MULTIPLIER["sector_rotation"] == 1.0
+
+    def test_keys_match_classifier_vocabulary_exactly(self):
+        """키 = ALL_REGIMES 양방향 (#1137). 한쪽만 어긋나도 .get 류 침묵 누수가 부활한다."""
+        from nuri.quant.exits.atr import REGIME_MULTIPLIER
+        from nuri.quant.regime.classifier import ALL_REGIMES
+
+        assert set(REGIME_MULTIPLIER) == set(ALL_REGIMES), (
+            f"multiplier 에만: {set(REGIME_MULTIPLIER) - set(ALL_REGIMES)}, "
+            f"classifier 에만: {set(ALL_REGIMES) - set(REGIME_MULTIPLIER)}"
+        )
+
+    def test_unknown_regime_string_fails_loud(self):
+        """오타/비-canonical 문자열은 1.0 으로 새지 않고 즉시 터진다 (#1130 클래스)."""
+        import pytest
+
+        from nuri.quant.exits.atr import _regime_multiplier
+
+        with pytest.raises(ValueError, match="unknown regime"):
+            _regime_multiplier("neutral")
+
+    def test_none_and_unknown_label_mean_explicit_one(self):
+        from nuri.quant.exits.atr import _regime_multiplier
+        from nuri.quant.regime.classifier import UNKNOWN_REGIME
+
+        assert _regime_multiplier(None) == 1.0
+        assert _regime_multiplier(UNKNOWN_REGIME) == 1.0
 
     def test_default_k_within_grid(self):
         from nuri.quant.exits.atr import DEFAULT_K, K_GRID
@@ -137,7 +166,9 @@ class TestComputeAtrStopNormalPath:
         from nuri.quant.exits.atr import compute_atr_stop
 
         self._seed(db_path, "NORM", rows=20, base=100, noise=2)
-        r = compute_atr_stop("NORM", entry_price=100, current_price=98, regime="neutral", k=2.0, db_path=db_path)
+        r = compute_atr_stop(
+            "NORM", entry_price=100, current_price=98, regime="sideways_low_vol", k=2.0, db_path=db_path
+        )
         assert r.atr is not None
         assert r.stop_price is not None
         # ATR ≈ 4 (high-low=4 constant) → k=2 × 1.0 × 4 = 8 → stop ≈ 92
@@ -152,34 +183,40 @@ class TestComputeAtrStopNormalPath:
 
         self._seed(db_path, "BRCH", rows=20, base=100, noise=2)
         # stop ≈ 92, current 80 → breached
-        r = compute_atr_stop("BRCH", entry_price=100, current_price=80, regime="neutral", k=2.0, db_path=db_path)
+        r = compute_atr_stop(
+            "BRCH", entry_price=100, current_price=80, regime="sideways_low_vol", k=2.0, db_path=db_path
+        )
         assert r.stop_price is not None
         assert r.breached is True
         assert "BREACHED" in r.detail
 
     def test_regime_multiplier_widens_stop_in_bear(self, db_path):
-        """bear_high_vol (mult 1.3) stop 이 neutral (1.0) 보다 entry 에서 더 멀어짐
+        """bear_high_vol (mult 1.3) stop 이 기본 1.0 레짐보다 entry 에서 더 멀어짐
         (더 넓은 stop = whipsaw 방지)."""
         from nuri.quant.exits.atr import compute_atr_stop
 
         self._seed(db_path, "REGI", rows=20, base=100, noise=2)
-        r_neu = compute_atr_stop("REGI", entry_price=100, current_price=100, regime="neutral", k=2.0, db_path=db_path)
+        r_neu = compute_atr_stop(
+            "REGI", entry_price=100, current_price=100, regime="sideways_low_vol", k=2.0, db_path=db_path
+        )
         r_bear = compute_atr_stop(
             "REGI", entry_price=100, current_price=100, regime="bear_high_vol", k=2.0, db_path=db_path
         )
         assert r_neu.stop_price is not None and r_bear.stop_price is not None
-        # bear 의 stop 은 neutral 보다 entry 에서 더 멀어짐 (더 낮은 stop_price)
+        # bear 의 stop 은 1.0 레짐보다 entry 에서 더 멀어짐 (더 낮은 stop_price)
         assert r_bear.stop_price < r_neu.stop_price
         assert r_bear.regime_multiplier == 1.3
         assert r_neu.regime_multiplier == 1.0
 
     def test_regime_multiplier_tightens_stop_in_bull_low_vol(self, db_path):
-        """bull_low_vol (mult 0.8) stop 이 neutral 보다 entry 에 더 가까움 —
+        """bull_low_vol (mult 0.8) stop 이 기본 1.0 레짐보다 entry 에 더 가까움 —
         quick exit on any deterioration."""
         from nuri.quant.exits.atr import compute_atr_stop
 
         self._seed(db_path, "BULL", rows=20, base=100, noise=2)
-        r_neu = compute_atr_stop("BULL", entry_price=100, current_price=100, regime="neutral", k=2.0, db_path=db_path)
+        r_neu = compute_atr_stop(
+            "BULL", entry_price=100, current_price=100, regime="sideways_low_vol", k=2.0, db_path=db_path
+        )
         r_bull = compute_atr_stop(
             "BULL", entry_price=100, current_price=100, regime="bull_low_vol", k=2.0, db_path=db_path
         )

--- a/tests/test_scheduler_branches.py
+++ b/tests/test_scheduler_branches.py
@@ -735,7 +735,8 @@ class TestHeldAddShadowSkipReasons:
             patch("nuri.trading.recommend.buy_candidate_emitter._get_factor_scores", return_value={}),
             patch("nuri.trading.recommend.buy_candidate_emitter._get_rsi_snapshot", return_value={}),
             patch("nuri.trading.recommend.buy_candidate_emitter._get_price_signals", return_value={}),
-            patch("nuri.trading.recommend.buy_candidate_emitter._get_regime", return_value=("BULL", 18.5)),
+            # canonical 레짐만 스텁한다 (#1137) — "BULL" 은 classifier 가 절대 내지 않는 값
+            patch("nuri.trading.recommend.buy_candidate_emitter._get_regime", return_value=("bull_low_vol", 18.5)),
             patch("nuri.trading.recommend.held_add.emit_held_add_shadow", side_effect=fake_emit),
             caplog.at_level(logging.INFO, logger="nuri.scheduler"),
         ):
@@ -762,7 +763,8 @@ class TestHeldAddShadowSkipReasons:
             patch("nuri.trading.recommend.buy_candidate_emitter._get_factor_scores", return_value={}),
             patch("nuri.trading.recommend.buy_candidate_emitter._get_rsi_snapshot", return_value={}),
             patch("nuri.trading.recommend.buy_candidate_emitter._get_price_signals", return_value={}),
-            patch("nuri.trading.recommend.buy_candidate_emitter._get_regime", return_value=("BULL", 18.5)),
+            # canonical 레짐만 스텁한다 (#1137) — "BULL" 은 classifier 가 절대 내지 않는 값
+            patch("nuri.trading.recommend.buy_candidate_emitter._get_regime", return_value=("bull_low_vol", 18.5)),
             patch("nuri.trading.recommend.held_add.emit_held_add_shadow", side_effect=fake_emit),
             caplog.at_level(logging.INFO, logger="nuri.scheduler"),
         ):


### PR DESCRIPTION
Closes #1137

## 실측 요약

- `compute_atr_stop` 의 **런타임 호출자는 0** (episode 검증 스크립트 + 테스트뿐) — 라이브 피해 없음, 잠복 결함
- `REGIME_MULTIPLIER` 에 classifier 가 절대 내지 않는 `neutral` 이 있고, canonical `sector_rotation` 은 빠져 `.get` 기본값 1.0 으로 새고 있었음 (#1130 과 동일 클래스)

## 변경

1. 키를 `ALL_REGIMES` 10개와 정확히 일치시킴 — **freeze lock 관점 주의**: 도달 가능한 레짐의 배수는 하나도 안 바뀜 (`neutral`/`sector_rotation` 둘 다 1.0) → 정책 변경이 아니라 어휘 정합, STRATEGY 개정 대상 아님
2. 기본 인자 `regime="neutral"` 제거 → `None` (명시적 1.0). `UNKNOWN_REGIME` 도 1.0, **그 외 모르는 문자열은 ValueError** — 오타가 1.0 으로 침묵 통과하는 경로 자체를 제거 (`_regime_multiplier` 단일 해석점, `.get` 4곳 제거)
3. `tests/test_scheduler_branches.py` 의 비-canonical `("BULL", 18.5)` 스텁 → `("bull_low_vol", 18.5)`

## 잠금 + 뮤테이션

- `test_keys_match_classifier_vocabulary_exactly` (양방향) — 뮤테이션 실측: `sector_rotation`→`neutral` 되돌리면 **3 FAIL**
- `test_unknown_regime_string_fails_loud` / `test_none_and_unknown_label_mean_explicit_one`
- quant+scheduler+scripts 1,353 passed, `make diagnostics` rc=0, doc counts 재동기 (+3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)