### PR TITLE
feat(thesis): add close_over_sma200_pct so criteria can be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,471 collected across 342 files | |
+| **Backend tests** | 7,475 collected across 342 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,471 backend tests across 342 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,475 backend tests across 342 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,471 tests, 342 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,475 tests, 342 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/engine/thesis_criteria.py
+++ b/nuri/trading/engine/thesis_criteria.py
@@ -73,8 +73,24 @@ def _resolver(table: str, column: str) -> Callable[[str, Optional[Path]], tuple[
 #: metric 이름 → (값, 날짜, 소스테이블) 해소기.
 #: **여기 없는 metric 은 writer 가 거부한다.** 추가할 때는 그 컬럼이 실제로 채워지는지
 #: 프로덕션에서 세어 보고 넣을 것 — 비어 있는 컬럼을 넣으면 그 기준은 영원히 unevaluable 이다.
+def _close_over_sma200(ticker: str, db_path: Optional[Path]) -> tuple[Optional[float], Optional[str], str]:
+    """종가의 200일선 대비 괴리율(%). 절대가격 threshold 의 함정을 피하는 상대 지표.
+
+    절대가격 기준(예: "등록 시점 200일선 값 아래로")은 몇 달 뒤 그 숫자가 200일선도
+    레짐도 아닌 그냥 과거 가격이 된다 — 반증 불가 (#1137 계열 threshold trap,
+    2026-08-21 논지 원장 첫 운용에서 codex 가 지적). 괴리율은 시점 무관하게 같은
+    의미를 유지한다: 0 미만 = 200일선 하회.
+    """
+    close, date_c = _latest("prices", "close", ticker, db_path)
+    sma, date_s = _latest("signals", "sma_200", ticker, db_path)
+    if close is None or sma is None or sma == 0:
+        return None, None, "prices+signals"
+    return (close / sma - 1.0) * 100.0, max(d for d in (date_c, date_s) if d), "prices+signals"
+
+
 METRIC_RESOLVERS: dict[str, Callable[[str, Optional[Path]], tuple[Optional[float], Optional[str], str]]] = {
     "close": _resolver("prices", "close"),
+    "close_over_sma200_pct": _close_over_sma200,
     "volume": _resolver("prices", "volume"),
     "rsi_14": _resolver("signals", "rsi_14"),
     "sma_50": _resolver("signals", "sma_50"),

--- a/tests/trading/engine/test_thesis_criteria.py
+++ b/tests/trading/engine/test_thesis_criteria.py
@@ -273,3 +273,56 @@ class TestReadPath:
         assert sch._STAGE_OF_JOB["thesis_criteria"] == "track"
         scheduled = {j["args"][0] for j in sch.SCHEDULES if j.get("func") is sch._run_collector and j.get("args")}
         assert "thesis_criteria" in scheduled
+
+
+class TestCloseOverSma200Pct:
+    """파생 metric `close_over_sma200_pct` — 절대가격 threshold trap 의 대체 (#thesis-W1).
+
+    절대가격 기준은 등록 몇 달 뒤 200일선도 레짐도 아닌 과거 숫자가 된다 (codex 지적,
+    2026-08-21 논지 원장 첫 운용). 괴리율(%)은 시점 무관하게 같은 의미를 유지한다.
+    """
+
+    def _seed_sma(self, db_path, sma: float):
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO signals (ticker, date, sma_200) VALUES ('ZZZZ', ?, ?)",
+                (today_kst(), sma),
+            )
+
+    def test_resolves_as_pct_deviation(self, db_path):
+        _seed_close(db_path, 110.0)
+        self._seed_sma(db_path, 100.0)
+        value, date, table = tc.METRIC_RESOLVERS["close_over_sma200_pct"]("ZZZZ", db_path)
+        assert value == pytest.approx(10.0)
+        assert date == today_kst()
+        assert table == "prices+signals"
+
+    def test_below_sma_is_negative(self, db_path):
+        _seed_close(db_path, 95.0)
+        self._seed_sma(db_path, 100.0)
+        value, _, _ = tc.METRIC_RESOLVERS["close_over_sma200_pct"]("ZZZZ", db_path)
+        assert value == pytest.approx(-5.0)
+
+    def test_missing_either_leg_is_none_not_zero(self, db_path):
+        """한쪽 부재는 unevaluable(None)이어야 한다 — 0 이면 '200일선 정확히 위' 로 읽힌다."""
+        _seed_close(db_path, 110.0)  # signals 없음
+        value, date, _ = tc.METRIC_RESOLVERS["close_over_sma200_pct"]("ZZZZ", db_path)
+        assert value is None and date is None
+
+    def test_writer_accepts_the_new_metric(self, db_path, thesis):
+        n = add_criteria(
+            thesis,
+            [
+                {
+                    "kind": "machine",
+                    "statement": "200일선 하회면 추세 전제 기각",
+                    "metric": "close_over_sma200_pct",
+                    "op": "<",
+                    "threshold": 0,
+                }
+            ],
+            db_path=db_path,
+        )
+        assert n == 1


### PR DESCRIPTION
Refs #577 (HITL 논지 워크플로)

## 왜 지금

논지 원장 첫 실운용(보유 상위 2종목)에서 codex 적대 검토가 **절대가격 threshold trap** 을 P1 으로 지적: "등록 시점 200일선 값(16,458) 아래로" 는 몇 달 뒤 200일선도 레짐도 아닌 과거 숫자가 되어 아무것도 반증하지 못한다.

## 변경

- `close_over_sma200_pct` 파생 해소기: `close/sma_200 − 1` (%) — 시점 무관 동일 의미. 한쪽 부재는 **None(unevaluable)**, 0 금지 (0 은 "정확히 선 위"로 읽힘)
- 실해소 확인: 보유 2종목 + AAPL 에서 당일자 값 해소

## 잠금

- 정상 해소(+10%/−5%) · 부재→None · writer 수용 4종 추가, 기존 계약 테스트(빈 DB 전 metric 무예외) 자동 포함 — 21 passed
- diagnostics rc=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)