### PR TITLE
chore(thesis): point the write example at a gitignored path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,8 @@ data/backups/
 data/replicas/
 data/exports/
 data/reports/
+# 논지 원장 파일 — 보유 종목 논지는 포지션 신호라 public 커밋 금지 (#577 W5 전까지)
+docs/theses/
 data/.bfg-reports/
 # scheduler.err/.log, auto-deploy log 등
 data/logs/

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ earnings-preview:
 # 투자 논지 원장 (#1083) — 상승/하락 논리를 근거와 함께 기록하고, 결정 상세 화면에
 # point-in-time 으로 붙인다. 기본 status 는 draft — active 승격은 파일에 명시할 때만.
 # Usage:
-#   make thesis-write file=docs/theses/nvda.yaml
+#   make thesis-write file=data/reports/theses/drafts/nvda.yaml  # gitignored — 논지는 public repo 에 커밋 금지
 #   make thesis-show ticker=NVDA
 thesis-write:
 	@test -n "$(file)" || (echo "usage: make thesis-write file=<thesis.yaml>"; exit 1)


### PR DESCRIPTION
Refs #577. Makefile 의 thesis-write 예시가 public 커밋 경로(docs/theses/)를 가리켰다 — 보유 종목 논지는 포지션 신호라 유출 함정. 예시를 gitignored `data/reports/theses/` 로 교체하고 `docs/theses/` 자체를 ignore (W5 공개 포맷 확정 전까지 방어선).

🤖 Generated with [Claude Code](https://claude.com/claude-code)