### PR TITLE
feat(recommend): surface active-thesis presence on buy candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,475 collected across 342 files | |
+| **Backend tests** | 7,478 collected across 342 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,475 backend tests across 342 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,478 backend tests across 342 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,475 tests, 342 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,478 tests, 342 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/recommend/buy_candidate_emitter.py
+++ b/nuri/trading/recommend/buy_candidate_emitter.py
@@ -62,6 +62,9 @@ class BuyCandidate:
     why_now: str  # single-sentence catalyst
     sources: dict[str, float]  # {factor: 0.78, momentum: 0.65, ...}
     sector: str | None = None
+    # 논지 원장 Surface (#1165): active thesis 가 있으면 "v{n} {stance}", 없으면 None.
+    # Surface 등급만 — 논지 없는 후보를 막지 않는다 (hard 승격은 STRATEGY PR, §2.6).
+    thesis: str | None = None
 
 
 @dataclass
@@ -422,6 +425,20 @@ def _build_why_now(sources: dict[str, float], price: dict[str, float], rsi: floa
     return f"30d 고가 -{abs(bo):.1f}% 근접 (pullback)"
 
 
+def _thesis_label(ticker: str, db_path: Path | None = None) -> str | None:
+    """active 논지 라벨 (#1165). draft 는 없음 취급 — get_active_thesis 가 active 만 반환.
+
+    조회 실패는 None (표면화 실패가 emit 을 막으면 안 된다 — #894 관측 비게이트).
+    """
+    try:
+        from nuri.core.db.thesis_ops import get_active_thesis
+
+        t = get_active_thesis(ticker, db_path=db_path)
+        return f"v{t['version']} {t['stance']}" if t else None
+    except Exception:
+        return None
+
+
 def emit_buy_candidates(
     config_path: Path | None = None,
     limit: int | None = None,
@@ -569,6 +586,7 @@ def emit_buy_candidates(
                 tp2=round(entry * (1 + risk.get("tp2_pct", 40.0) / 100.0), 2),
                 why_now=_build_why_now(sources, price, _rsi),
                 sources=sources,
+                thesis=_thesis_label(ticker, db_path=db_path),
             )
         )
 
@@ -600,6 +618,11 @@ def render_markdown(result: EmitResult) -> str:
         )
         src = " · ".join(f"{k}={v:.0f}" for k, v in c.sources.items())
         lines.append(f"   - Sources: {src}")
+        # 논지 Surface (#1165) — 정보 노출만, 매수를 막지 않는다
+        if c.thesis:
+            lines.append(f"   - Thesis: ✓ {c.thesis}")
+        else:
+            lines.append("   - Thesis: 없음 — 매수 전 논지 작성 권장 (make thesis-write)")
 
     if result.skipped:
         skipped_top = list(result.skipped.items())[:5]

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -781,3 +781,62 @@ def test_buy_emitter_tp_ladder_matches_canonical_growth():
         f"buy_signals tp2_pct={risk.get('tp2_pct')} != canonical "
         f"{TAKE_PROFIT_GROWTH['target_2']} (rules.yaml take_profit.growth)"
     )
+
+
+# --- Thesis Surface (#1165) --------------------------------------------------
+
+
+def _register_thesis(db, ticker, status="active"):
+    from nuri.core.db.thesis_ops import add_criteria, upsert_thesis
+
+    tid = upsert_thesis(
+        ticker=ticker,
+        author="user",
+        stance="bullish",
+        bull_case="테스트 상승 논지",
+        bear_case="테스트 하락 논지",
+        evidence=[{"side": "bull", "claim": "테스트", "source_type": "measurement"}],
+        status=status,
+        db_path=db,
+    )
+    add_criteria(
+        tid,
+        [{"kind": "machine", "statement": "테스트 기준", "metric": "close", "op": "<", "threshold": 1}],
+        db_path=db,
+    )
+    return tid
+
+
+def test_candidate_surfaces_active_thesis(db, cfg_path):
+    """active 논지가 있으면 후보에 라벨이 붙는다 — emit 진입점 통과 잠금 (wiring axis)."""
+    _seed_calm_setup(db)
+    _register_thesis(db, "AAPL", status="active")
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.candidates, f"blocked_reason={res.blocked_reason}"
+    assert res.candidates[0].thesis == "v1 bullish"
+
+    md = render_markdown(res)
+    assert "Thesis: ✓ v1 bullish" in md
+
+
+def test_candidate_without_thesis_surfaces_absence_not_block(db, cfg_path):
+    """논지 없음은 Surface 만 — 후보를 막지 않는다 (Escalation §2.6 Surface 등급)."""
+    _seed_calm_setup(db)
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.candidates, "논지 부재가 emit 을 막으면 Surface 가 아니라 gate 다"
+    assert res.candidates[0].thesis is None
+
+    md = render_markdown(res)
+    assert "Thesis: 없음" in md
+
+
+def test_draft_thesis_counts_as_absent(db, cfg_path):
+    """draft 는 결정 화면에 붙지 않는다 — 원장 규약과 동일하게 없음 취급."""
+    _seed_calm_setup(db)
+    _register_thesis(db, "AAPL", status="draft")
+
+    res = emit_buy_candidates(config_path=cfg_path)
+    assert res.candidates
+    assert res.candidates[0].thesis is None


### PR DESCRIPTION
Closes #1165 · Refs #577 (W2)

## 변경

- `BuyCandidate.thesis` — active 논지 라벨 (`v{n} {stance}`), draft/부재는 None (원장 규약과 동일)
- brief 렌더: `Thesis: ✓ v1 bullish` / `Thesis: 없음 — 매수 전 논지 작성 권장`
- **Surface 등급만** — 논지 부재가 후보를 막지 않음 (hard 승격은 운용 후 STRATEGY PR, §2.6)
- 조회 실패는 None soft-fail — 표면화가 emit 을 못 죽임 (#894)

## 검증

- 테스트 3종 (active 표면화 / 부재 비차단 / draft=부재) — **emit 진입점 통과** 잠금, 뮤테이션 실측: 배선 한 줄 제거 → 1 FAIL
- `db_path` forward 준수 (forwarding 잠금 테스트 포함 46 passed) · diagnostics rc=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)