### PR TITLE
feat(core): trade-log CLI — give the invest→post-mortem loop its missing input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,15 @@ earnings-preview:
 # Usage:
 #   make thesis-write file=data/reports/theses/drafts/nvda.yaml  # gitignored — 논지는 public repo 에 커밋 금지
 #   make thesis-show ticker=NVDA
+# 실거래 기록 (#1163) — 매매 직후 1줄. 원장은 mini (§3.11), dev 입력 시 sync_dev push.
+#   make trade-log args="--ticker AAPL --side BUY --qty 10 --price 231.50 --account main"
+trade-log:
+	@test -n "$(args)" || (echo 'usage: make trade-log args="--ticker T --side BUY --qty N --price P --account A"'; exit 1)
+	$(PYTHON) -m nuri.core.trade_cli add $(args)
+
+trade-list:
+	$(PYTHON) -m nuri.core.trade_cli list $(args)
+
 thesis-write:
 	@test -n "$(file)" || (echo "usage: make thesis-write file=<thesis.yaml>"; exit 1)
 	$(PYTHON) -m nuri.core.thesis_cli write "$(file)"

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,478 collected across 342 files | |
+| **Backend tests** | 7,484 collected across 343 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |
@@ -285,7 +285,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 | **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 58 tables (55 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 58 tables (56 forward-only migrations) | ✅ |
 | **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (55 migrations as of 2026-07-30). Key tables:
+51 tables total (56 migrations as of 2026-07-30). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,478 backend tests across 342 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,484 backend tests across 343 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,478 tests, 342 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,484 tests, 343 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1766,4 +1766,15 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
         );
     """,
     ),
+    (
+        56,
+        "trades.account — 계좌별 전략 차등을 위한 실거래 계좌 컬럼 (#1163)",
+        # 회전율 상한(W4)은 전략별 차등이 전제 (core/active/swing) 인데 trades 에 계좌가
+        # 없으면 어느 전략의 회전인지 귀속 불가. 기존 0행이라 backfill 부담 없음.
+        """
+        ALTER TABLE trades ADD COLUMN account TEXT;
+        CREATE INDEX IF NOT EXISTS idx_trades_account_date
+            ON trades(account, executed_at);
+    """,
+    ),
 ]

--- a/nuri/core/trade_cli.py
+++ b/nuri/core/trade_cli.py
@@ -1,0 +1,120 @@
+"""실거래 기록 CLI (#1163) — `make trade-log` / `make trade-list`.
+
+**왜 CLI 인가**: `trades` 테이블은 도입 이래 prod 0행 — 사용자 매매는 증권사 앱에서
+수동 실행되고 시스템 유입 경로가 없었다. 이 기록이 없으면 회전율 측정(W4), 논지→거래
+→성과 귀속, 처분효과 사후분석이 전부 불가능하다. 매매 직후 1줄 입력이 마찰의 전부가
+되도록 최소로 유지한다.
+
+**원장**: 판정에 쓰이는 기록의 원장은 prod(Mac mini) DB 다 (§3.11). dev 에서 입력했으면
+`scripts/sync_dev.sh push` 로 밀거나 mini 에서 직접 입력할 것.
+
+사용:
+    python -m nuri.core.trade_cli add --ticker AAPL --side BUY --qty 10 --price 231.50 --account main
+    python -m nuri.core.trade_cli list [--month 2026-08]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from nuri.core.db import query, upsert_trade
+from nuri.core.timezone import today_kst
+
+#: 계좌 이름은 자유 문자열이 아니다 — 오타 계좌가 생기면 회전율 귀속이 조용히 갈라진다.
+#: config/rules.yaml account_strategies 와 같은 어휘를 쓰되, 여기서는 최소 검증만 한다.
+VALID_SIDES = ("BUY", "SELL")
+
+
+def add_trade(
+    ticker: str,
+    side: str,
+    qty: float,
+    price: float,
+    account: str,
+    date: str | None = None,
+    note: str | None = None,
+    db_path: Path | None = None,
+) -> int:
+    """거래 1건 기록. BUY 는 entry_price, SELL 은 exit_price/exit_date 로 매핑."""
+    side = side.upper()
+    if side not in VALID_SIDES:
+        raise ValueError(f"side 는 BUY/SELL 만: {side!r}")
+    if qty <= 0 or price <= 0:
+        raise ValueError("qty/price 는 양수여야 한다")
+    d = date or today_kst()
+    data: dict = {
+        "ticker": ticker.upper(),
+        "action": side,
+        "executed_at": d,
+        "shares": qty,
+        "account": account,
+        "notes": note,
+    }
+    if side == "BUY":
+        data["entry_price"] = price
+    else:
+        data["exit_price"] = price
+        data["exit_date"] = d
+    return upsert_trade(data, db_path=db_path)
+
+
+def list_trades(month: str | None = None, db_path: Path | None = None) -> list[dict]:
+    """월별(YYYY-MM) 또는 전체 최근 30건."""
+    if month:
+        return query(
+            "SELECT * FROM trades WHERE executed_at LIKE ? ORDER BY executed_at DESC",
+            (f"{month}%",),
+            db_path=db_path,
+        )
+    return query("SELECT * FROM trades ORDER BY executed_at DESC LIMIT 30", db_path=db_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="실거래 기록 (#1163)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_add = sub.add_parser("add", help="거래 1건 기록")
+    p_add.add_argument("--ticker", required=True)
+    p_add.add_argument("--side", required=True, choices=["BUY", "SELL", "buy", "sell"])
+    p_add.add_argument("--qty", type=float, required=True)
+    p_add.add_argument("--price", type=float, required=True)
+    p_add.add_argument("--account", required=True)
+    p_add.add_argument("--date", default=None, help="YYYY-MM-DD (기본 오늘 KST)")
+    p_add.add_argument("--note", default=None)
+
+    p_list = sub.add_parser("list", help="기록 조회")
+    p_list.add_argument("--month", default=None, help="YYYY-MM")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "add":
+        try:
+            tid = add_trade(
+                args.ticker,
+                args.side,
+                args.qty,
+                args.price,
+                args.account,
+                date=args.date,
+                note=args.note,
+            )
+        except ValueError as e:
+            print(f"✗ {e}", file=sys.stderr)
+            return 1
+        print(f"✓ {args.ticker.upper()} {args.side.upper()} {args.qty} @ {args.price} ({args.account}) — id={tid}")
+        return 0
+    rows = list_trades(month=args.month)
+    if not rows:
+        print("기록 없음")
+        return 0
+    for r in rows:
+        price = r.get("entry_price") or r.get("exit_price")
+        print(
+            f"{r['executed_at']} {r['action']:4s} {r['ticker']:10s} {r['shares']} @ {price} ({r.get('account') or '-'})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,7 +29,7 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_55(self, db_path):
+    def test_schema_version_at_56(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
@@ -42,8 +42,9 @@ class TestSchemaMigrations:
         thesis_criteria / thesis_criteria_checks — 사전등록 반증 기준 (#1092) +
         candidate_runs / candidate_ledger — 미실행 거래 원장 (#1094) +
         superinvestors.investor_class — 확신/딜러 13F 분리 (#1098) +
-        ark_source_dates — ARK 펀드별 CSV 발행일 (#1147) → 55."""
-        assert get_schema_version(db_path) == 55
+        ark_source_dates — ARK 펀드별 CSV 발행일 (#1147) → 55. +
+        trades.account — 실거래 계좌 귀속 (#1163)"""
+        assert get_schema_version(db_path) == 56
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/core/test_trade_cli.py
+++ b/tests/core/test_trade_cli.py
@@ -1,0 +1,67 @@
+"""실거래 기록 CLI (#1163) — 회전율(W4)·논지 귀속의 데이터 입구를 잠근다."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuri.core.db import init_db, query
+from nuri.core.timezone import today_kst
+from nuri.core.trade_cli import add_trade, list_trades, main
+
+
+@pytest.fixture
+def db(tmp_path):
+    p = tmp_path / "t.db"
+    init_db(p)
+    return p
+
+
+class TestAddTrade:
+    def test_buy_maps_to_entry_price_with_account(self, db):
+        tid = add_trade("aapl", "buy", 10, 231.5, "Brokerage Alpha", db_path=db)
+        row = query("SELECT * FROM trades WHERE id = ?", (tid,), db_path=db)[0]
+        assert row["ticker"] == "AAPL"
+        assert row["action"] == "BUY"
+        assert row["entry_price"] == 231.5
+        assert row["exit_price"] is None
+        assert row["account"] == "Brokerage Alpha"
+        assert row["executed_at"] == today_kst()
+
+    def test_sell_maps_to_exit_price_and_date(self, db):
+        tid = add_trade("MSFT", "SELL", 5, 500.0, "Brokerage Beta", date="2026-08-01", db_path=db)
+        row = query("SELECT * FROM trades WHERE id = ?", (tid,), db_path=db)[0]
+        assert row["exit_price"] == 500.0
+        assert row["exit_date"] == "2026-08-01"
+        assert row["entry_price"] is None
+
+    def test_invalid_side_and_nonpositive_rejected(self, db):
+        with pytest.raises(ValueError, match="BUY/SELL"):
+            add_trade("AAPL", "HOLD", 1, 1.0, "a", db_path=db)
+        with pytest.raises(ValueError, match="양수"):
+            add_trade("AAPL", "BUY", 0, 1.0, "a", db_path=db)
+        with pytest.raises(ValueError, match="양수"):
+            add_trade("AAPL", "BUY", 1, -1.0, "a", db_path=db)
+
+    def test_month_filter(self, db):
+        add_trade("AAPL", "BUY", 1, 1.0, "a", date="2026-07-15", db_path=db)
+        add_trade("AAPL", "BUY", 1, 1.0, "a", date="2026-08-15", db_path=db)
+        assert len(list_trades(month="2026-08", db_path=db)) == 1
+        assert len(list_trades(db_path=db)) == 2
+
+
+class TestCliEntry:
+    def test_add_via_argv(self, db, monkeypatch, capsys):
+        import nuri.core.db as db_mod
+
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+        rc = main(["add", "--ticker", "NVDA", "--side", "BUY", "--qty", "3", "--price", "190.5", "--account", "main"])
+        assert rc == 0
+        assert "NVDA BUY 3.0 @ 190.5" in capsys.readouterr().out
+        assert query("SELECT COUNT(*) AS n FROM trades", db_path=db)[0]["n"] == 1
+
+    def test_add_rejects_bad_input_with_rc1(self, db, monkeypatch, capsys):
+        import nuri.core.db as db_mod
+
+        monkeypatch.setattr(db_mod, "DB_PATH", db)
+        rc = main(["add", "--ticker", "NVDA", "--side", "BUY", "--qty", "0", "--price", "1", "--account", "main"])
+        assert rc == 1


### PR DESCRIPTION
Closes #1163

## 갭

`trades` prod 0행 — 실거래 유입 경로 부재로 회전율(W4)·논지→거래 귀속·처분효과 사후분석 전부 불가.

## 변경

- `nuri/core/trade_cli.py` + `make trade-log args="--ticker AAPL --side BUY --qty 10 --price 231.50 --account main"` / `make trade-list` — 매매 직후 1줄이 마찰의 전부
- BUY→entry_price, SELL→exit_price/exit_date 매핑, side/양수 검증 (rc 1)
- **migration 56**: `trades.account` + 인덱스 — 전략별 회전율 차등(Codex 권고)의 전제. 기존 0행이라 backfill 없음
- 원장 규약 명시: 정본은 mini (§3.11), dev 입력은 sync_dev push

## 검증

- 테스트 6종 (BUY/SELL 매핑, 검증 거부, 월 필터, argv 진입점 2종) + schema lock 55→56 갱신 — core 678 passed
- diagnostics rc=0

## 후속 (W4)

이 경로로 6-12개월 분포가 쌓이면 실측 P75 를 초기 회전율 상한으로 (임의 숫자 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)