### PR TITLE
fix(tests): purge the last facade query patch and ban the class by AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,492 collected across 344 files | |
+| **Backend tests** | 7,494 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,492 backend tests across 344 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,494 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,492 tests, 344 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,494 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -107,6 +107,13 @@ monkeypatch.setattr(nuri.core.db, "DB_PATH", empty)   # patch("...query") 대신
 손으로 나열해 복원하는 방식(`finally: mod.query = _orig`)은 쓰지 않는다 — 그게 원래 방어였고,
 새 소비자가 생길 때마다 조용히 샜다.
 
+**금지는 사람 눈이 아니라 기계가 지킨다**: #1150 이 fixture 를 고친 뒤에도 같은 파일의
+resilience 테스트에 1곳이 남아 3주 잠복하다 CI 샤드 재구성(#1157) 후 워커 순서에서 발화했다
+(PR #1172 red — `market_signals` 가 창 안에서 first-import). **Test:**
+`tests/test_no_facade_query_patch.py::TestNoFacadeQueryPatch` — AST 로 실호출만 세고
+(독스트링/주석 언급은 오탐이라 텍스트 sweep 기각), allowlist 는 "patch 창의 import 표면이
+함수-로컬 lazy import 뿐" 인 파일만 사유와 함께 양방향 등재.
+
 ⚠️ **이 계열은 직렬 실행에서만 보인다.** `make test-fast`(`-n auto --dist worksteal`)는
 오염원과 피해자를 다른 워커로 보내 초록이다. 격리 의심 시 `pytest tests/ --ignore=tests/quant -x`
 로 직렬 확인.

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -417,7 +417,15 @@ class TestGenerateBrief:
     def test_subsystem_exceptions_are_caught_not_raised(self, tmp_path, monkeypatch):
         """_collect_context 는 각 subsystem raise 해도 graceful degrade — logger.warning
         만 기록하고 브리프 생성 계속. except 블록 coverage lock (82-193 missing)."""
+        import nuri.core.db as db_mod
         from nuri.alerts import premarket_brief as pb
+
+        # DB 실패 축은 facade patch 가 아니라 **존재하지 않는 DB 경로**로 만든다.
+        # `patch("nuri.core.db.query")` 는 #1149 클래스다: 이 함수의 lazy import 표면이
+        # 넓어 (market_signals 등) patch 창에서 first-import 되는 모듈이 mock 을 영구
+        # 보유했다 — CI 샤드 재구성(#1157) 후 워커 순서에서 실제 발화 (PR #1172 red).
+        # 경로가 없으면 진짜 OperationalError 가 나므로 except 블록 coverage 는 동일하다.
+        monkeypatch.setattr(db_mod, "DB_PATH", tmp_path / "nonexistent" / "no.db")
 
         # 모든 subsystem 에 실제 exception raise 주입 → except 블록이 전부 실행
         with (
@@ -426,7 +434,6 @@ class TestGenerateBrief:
             patch("nuri.trading.engine.certification.certify", side_effect=RuntimeError("siege fail")),
             patch("nuri.api.routes.actions._build_actions", side_effect=RuntimeError("actions fail")),
             patch("nuri.api.routes.actions._build_opportunities", side_effect=RuntimeError("ops fail")),
-            patch("nuri.core.db.query", side_effect=RuntimeError("db fail")),
         ):
             ctx = pb._collect_context()
         # 모든 subsystem 실패했지만 ctx dict 자체는 반환 — 값은 None/빈 리스트

--- a/tests/test_no_facade_query_patch.py
+++ b/tests/test_no_facade_query_patch.py
@@ -1,0 +1,80 @@
+"""`patch("nuri.core.db.query")` 금지를 기계로 잠근다 (#1149 클래스킬러).
+
+facade patch 창 안에서 first-import 되는 모듈이 `from nuri.core.db import query` 를
+하면 mock 을 전역에 복사해 patch 종료 후에도 남는다. #1150 이 fixture 를 고쳤지만
+같은 파일의 resilience 테스트에 1곳이 잔존해 3주 잠복하다 CI 샤드 재구성(#1157) 후
+발화했다 (PR #1172 red) — 사람 눈은 반복해서 놓치므로 텍스트 sweep 으로 잠근다.
+
+allowlist: patch 창의 import 표면이 함수-로컬 lazy import 뿐이라 모듈 전역 오염이
+구조적으로 불가능한 파일만, 사유와 함께. 양방향 — 새 위반도, 낡은 allowlist 도 FAIL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+PATTERN = 'patch("nuri.core.db.query"'
+
+#: 파일 → 허용 사유. 대상 함수가 query 를 **함수 안에서** lazy import 하면 patch 는
+#: 로컬 바인딩만 잡고 모듈 전역이 오염되지 않는다.
+ALLOWED = {
+    "collectors/test_fallbacks.py": "cboe._collect_db_stale 은 함수-로컬 lazy import — 전역 오염 불가",
+    "core/test_ticker_names.py": "ticker_names.get_ticker_name 은 함수-로컬 lazy import — 전역 오염 불가",
+    "api/test_stream.py": "stream._get_snapshot 은 함수-로컬 lazy import — 전역 오염 불가",
+}
+
+
+def _live_occurrences(path: Path) -> int:
+    """실제 `patch("nuri.core.db.query", ...)` **호출 노드**만 센다 (AST).
+
+    텍스트 sweep 은 주석/독스트링 경계에서 오탐·눈멂 둘 다 낸다 — 실측: 이 파일의
+    v1 텍스트 판이 #1149 교훈을 적어둔 독스트링을 위반으로 오인했다.
+    """
+    import ast
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    n = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.id if isinstance(fn, ast.Name) else fn.attr if isinstance(fn, ast.Attribute) else ""
+        if name != "patch" or not node.args:
+            continue
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and arg.value == "nuri.core.db.query":
+            n += 1
+    return n
+
+
+class TestNoFacadeQueryPatch:
+    def test_canary_detects_a_real_call(self, tmp_path):
+        """sweep 이 실제 호출을 못 집으면 아래가 공허 통과 — 카나리아.
+        독스트링/주석 속 언급은 세지 않아야 한다 (v1 텍스트 판의 오탐 축)."""
+        f = tmp_path / "test_canary.py"
+        f.write_text(
+            '"""독스트링 언급: patch("nuri.core.db.query") 는 금지다."""\n'
+            "from unittest.mock import patch\n"
+            "def test_x():\n"
+            '    with patch("nuri.core.db.query", return_value=[]):\n'
+            "        pass\n",
+            encoding="utf-8",
+        )
+        assert _live_occurrences(f) == 1
+
+    def test_only_allowlisted_files_use_the_facade_patch(self):
+        offenders: dict[str, int] = {}
+        for f in TESTS.rglob("test_*.py"):
+            if f.name == Path(__file__).name:
+                continue
+            n = _live_occurrences(f)
+            if n:
+                offenders[str(f.relative_to(TESTS))] = n
+        unexpected = set(offenders) - set(ALLOWED)
+        stale = set(ALLOWED) - set(offenders)
+        assert not unexpected, (
+            f"금지 패턴 신규 사용: {sorted(unexpected)} — 빈 격리 DB(init_db + DB_PATH "
+            "monkeypatch) 또는 use-site patch 로 바꿀 것 (tests/CLAUDE.md #1149)"
+        )
+        assert not stale, f"allowlist 낡음 (더는 안 쓰는 파일): {sorted(stale)} — 목록에서 제거"


### PR DESCRIPTION
Refs #1149 · Unblocks #1172 (CI red 원인)

## 경위

#1150 이 fixture 는 고쳤지만 **같은 파일 resilience 테스트에 금지 패턴 1곳 잔존** → 3주 잠복 → CI 샤드 재구성(#1157) 후 워커 순서에서 `market_signals` 가 patch 창 내 first-import 되며 발화 (#1172 red, mock-leak sweep 적중 — 그 sweep 자체는 정상 작동).

## 수정

- resilience 테스트의 DB 실패 축을 facade patch → **존재하지 않는 DB 경로** 로 (진짜 OperationalError 로 같은 except 커버리지)
- **AST ban 테스트** (`tests/test_no_facade_query_patch.py`): 실호출 노드만 계수 — v1 텍스트 판은 gotcha 독스트링을 오탐해 기각 (카나리아가 그 축을 잠금). allowlist 3파일은 "patch 창 import 표면이 함수-로컬 lazy import 뿐" 사유로 양방향 등재
- tests/CLAUDE.md gotcha 에 잠복→발화 경위 + Test 인용 추가

## 검증

- 뮤테이션: allowlist 밖 실호출 추가 → FAIL 실측 · alerts 스위트 green · diagnostics rc=0
- 참고: `test_postmarket_brief.py::test_ollama_host_local_guard` 로컬 실패는 본 변경과 무관한 기존 환경 의존 (baseline 재현, CI 전체 스위트는 green) — 별도 확인 필요 시 이슈화

🤖 Generated with [Claude Code](https://claude.com/claude-code)