### PR TITLE
fix(api): externalize freshness thresholds to config and gate dashboard verdict on stale inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,494 collected across 345 files | |
+| **Backend tests** | 7,502 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -11,6 +11,7 @@
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
 | `buy_signals.yaml` | 187 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |
 | `alerts.yaml` | 24 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
+| `freshness.yaml` | 27 | Data freshness SLA (per-source `warn_hours`/`fail_hours`) + `verdict_gate` (dashboard verdict 가 확인하는 입력 목록, #1180). Queries/labels stay in `nuri/core/freshness.py` | `nuri/core/freshness.py` (`_load_config`) |
 | `stock_types.yaml` | 49 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |
 | `universe.yaml` | 755 | 746 tickers: `us_core` (85) + `us_sp500_extended` (458) + `kr_kospi200` (203). Auto-maintained by `make universe-sync`; manual entries preserved | `nuri/collectors/universe_sync.py` |
 | `portfolio.example.yaml` | 39 | Example template showing account + holdings shape | `scripts/ops/import_portfolio.py` (via `cp` to `portfolio.yaml`) |

--- a/config/freshness.yaml
+++ b/config/freshness.yaml
@@ -1,0 +1,27 @@
+# 데이터 신선도 SLA — warn/fail 임계 (시간 단위)
+# 쿼리·라벨은 구현이므로 nuri/core/freshness.py 에 있고, **정책 숫자**만 여기 둔다.
+# 키 목록은 freshness.py 의 FRESHNESS_POLICIES 와 1:1 — 어긋나면 로더가 기동 시 ValueError.
+# 각 임계의 근거(주말/공휴일 여유, 잡 주기)는 freshness.py 해당 정책 주석 참조.
+
+thresholds:
+  prices: { warn_hours: 48, fail_hours: 120 } # 주말/공휴일 감안 (금→화 = 96h)
+  macro_vix: { warn_hours: 24, fail_hours: 72 }
+  factors: { warn_hours: 48, fail_hours: 120 } # 재료가 prices 라 임계 동일 (#1071)
+  signals: { warn_hours: 48, fail_hours: 120 }
+  signals_kr: { warn_hours: 48, fail_hours: 120 } # 설날·추석엔 정직하게 WARN/FAIL
+  fundamentals: { warn_hours: 192, fail_hours: 360 } # 주 1회 잡 — 정상 나이 168h (#1109)
+  fundamentals_kr: { warn_hours: 192, fail_hours: 360 }
+  macro_fear_greed: { warn_hours: 24, fail_hours: 48 }
+  consensus: { warn_hours: 24, fail_hours: 48 }
+  certification: { warn_hours: 24, fail_hours: 48 }
+  ark: { warn_hours: 168, fail_hours: 336 } # rules.yaml ark.max_source_lag_days 와 동일 (#1145)
+  portfolio: { warn_hours: 24, fail_hours: 72 } # import_portfolio.py 매일 수동 실행 가정 (#507)
+
+# /api/dashboard 한 줄 판단(verdict)이 신선도를 확인하는 입력 목록.
+# 이 중 하나라도 FAIL 이면 "공격 가능" 류 판단 대신 stale 안내를 낸다 (#1180, Surface rung).
+# 판단의 실제 입력만 나열: 레짐=prices, 매크로=macro_vix+fear_greed, 액션=consensus.
+verdict_gate:
+  - prices
+  - macro_vix
+  - macro_fear_greed
+  - consensus

--- a/config/freshness.yaml
+++ b/config/freshness.yaml
@@ -12,6 +12,8 @@ thresholds:
   fundamentals: { warn_hours: 192, fail_hours: 360 } # 주 1회 잡 — 정상 나이 168h (#1109)
   fundamentals_kr: { warn_hours: 192, fail_hours: 360 }
   macro_fear_greed: { warn_hours: 24, fail_hours: 48 }
+  macro_market: { warn_hours: 48, fail_hours: 120 } # 금리 3종 + put/call — prices 와 동일 임계
+  macro_monthly: { warn_hours: 1080, fail_hours: 1800 } # 월간 릴리즈: 45d 한 사이클 / 75d 두 사이클
   consensus: { warn_hours: 24, fail_hours: 48 }
   certification: { warn_hours: 24, fail_hours: 48 }
   ark: { warn_hours: 168, fail_hours: 336 } # rules.yaml ark.max_source_lag_days 와 동일 (#1145)
@@ -24,4 +26,6 @@ verdict_gate:
   - prices
   - macro_vix
   - macro_fear_greed
+  - macro_market
+  - macro_monthly
   - consensus

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,494 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,502 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,494 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,502 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -107,12 +107,14 @@ interface MarketContextData {
 
 const verdictLabels: Record<string, string> = {
   aggressive: VERDICT.AGGRESSIVE, neutral: VERDICT.NEUTRAL, cautious: VERDICT.CAUTIOUS, defensive: VERDICT.DEFENSIVE,
+  stale: VERDICT.STALE,
 };
 const levelStyles: Record<string, { text: string }> = {
   aggressive: { text: "text-emerald-400" },
   neutral:    { text: "text-zinc-400" },
   cautious:   { text: "text-amber-400" },
   defensive:  { text: "text-red-400" },
+  stale:      { text: "text-amber-400" }, // 판단 보류 — 경고색 (#1180)
 };
 const pipelineStatusColors: Record<string, string> = {
   idle: "bg-zinc-500", running: "bg-blue-500 animate-pulse", done: "bg-emerald-500", error: "bg-red-500",

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -36,6 +36,7 @@ export const VERDICT = {
   NEUTRAL: "관망",
   CAUTIOUS: "주의",
   DEFENSIVE: "방어",
+  STALE: "데이터 낡음", // 판단 입력 stale — verdict 보류 (#1180)
 } as const;
 
 export const TREND = {

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -57,12 +57,23 @@ def _build_dashboard() -> dict:
     alerts = _get_active_alerts()
 
     # ── 4. 한 줄 판단 (verdict) ──
+    # stale gate (#1180, Surface rung): 판단 입력(config/freshness.yaml verdict_gate)이
+    # FAIL 이면 "공격 가능" 류 판단을 내지 않는다 — 4일 낡은 가격 위의 판단은 판단이 아니다.
+    # 데이터(actions/alerts/...)는 그대로 내려보내고 한 줄 판단만 stale 안내로 바꾼다.
+    verdict_stale_inputs = _get_stale_verdict_inputs()
     trend = regime_data.get("trend", "unknown")
     macro_score = macro_data["score"]
     n_buys = len([a for a in actions if a["action"] == "BUY"])
     n_sells = len([a for a in actions if a["action"] == "SELL"])
 
-    if trend == "bear" or macro_score < 35:
+    if verdict_stale_inputs:
+        labels = ", ".join(
+            f"{s['label']} {s['age_hours']:.0f}h" if s["age_hours"] is not None else s["label"]
+            for s in verdict_stale_inputs
+        )
+        verdict = f"판단 보류. 입력 데이터 낡음 ({labels}) — 재수집 후 판단하세요."
+        verdict_level = "stale"
+    elif trend == "bear" or macro_score < 35:
         verdict = "방어 모드. 현금 비중 유지하고 숏 헤지를 검토하세요."
         verdict_level = "defensive"
     elif trend == "bull" and macro_score >= 60:
@@ -107,6 +118,8 @@ def _build_dashboard() -> dict:
     return {
         "verdict": verdict,
         "verdict_level": verdict_level,
+        # stale gate 근거 — 어떤 입력이 얼마나 낡아 판단이 보류됐는지 (빈 리스트 = 게이트 통과)
+        "verdict_stale_inputs": verdict_stale_inputs,
         "regime": regime_data,
         "macro": macro_data,
         "allocation": allocation,  # target (regime 권장) — legacy 이름, backward compat
@@ -537,15 +550,34 @@ def _get_upcoming_events() -> list[dict]:
 
 
 def _get_freshness() -> dict:
-    """데이터 신선도 요약."""
+    """데이터 신선도 요약.
+
+    키는 `d["key"]` 다 — `d["table"]` 로 읽던 시절엔 KeyError 가 except 에 먹혀
+    이 함수가 **항상 빈 dict** 를 조용히 반환했다 (#1180). 회귀 잠금:
+    tests/api/test_dashboard.py::TestDashboardFreshness.
+    """
     try:
         from nuri.core.freshness import check_all_freshness
 
         details = check_all_freshness()
-        return {d["table"]: {"age_hours": d["age_hours"], "status": d["status"]} for d in details}
+        return {d["key"]: {"age_hours": d["age_hours"], "status": d["status"]} for d in details}
     except Exception as e:
         logger.debug(f"Freshness: {e}")
         return {}
+
+
+def _get_stale_verdict_inputs() -> list[dict]:
+    """verdict gate 입력 중 FAIL 만 — 실패 시 빈 리스트 (관측이 판단을 죽이면 안 됨, #894)."""
+    try:
+        from nuri.core.freshness import stale_verdict_inputs
+
+        return [
+            {"key": s["key"], "label": s["label"], "age_hours": s["age_hours"], "last_updated": s["last_updated"]}
+            for s in stale_verdict_inputs()
+        ]
+    except Exception as e:
+        logger.debug(f"Verdict stale gate: {e}")
+        return []
 
 
 def _get_pipeline_status() -> dict:

--- a/nuri/core/CLAUDE.md
+++ b/nuri/core/CLAUDE.md
@@ -47,7 +47,7 @@ Two guarantees hold here, and both are load-bearing for readers elsewhere:
 
 ## freshness.py — Data Freshness SLA
 
-`FRESHNESS_POLICIES` per data source (prices 48h/120h, VIX 24h/72h, etc.). `check_freshness(key)` returns PASS/WARN/FAIL.
+`FRESHNESS_POLICIES` per data source. `check_freshness(key)` returns PASS/WARN/FAIL. 임계(`warn_hours`/`fail_hours`)는 `config/freshness.yaml` 이 정본이고 `_load_config()` 가 기동 시 주입한다 — 키 목록은 양방향 대조라 config 누락/잉여 둘 다 ValueError (#1180). 쿼리·라벨은 구현이라 코드에 남는다. `VERDICT_GATE_KEYS`/`stale_verdict_inputs()` 는 dashboard verdict 의 stale gate 입력 (FAIL 만 센다 — WARN 은 주말/공휴일 정상 나이).
 
 정책을 추가/삭제하면 `tests/core/test_freshness.py::test_expected_policy_keys` 가 **일부러**
 깨진다 — 양방향 allowlist 라 등재할 때 "왜 이 정책이 생겼는지" 한 줄을 그 테스트에 같이

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -109,6 +109,35 @@ FRESHNESS_POLICIES: dict[str, dict] = {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
         "label": "Fear & Greed",
     },
+    # macro_score 의 나머지 입력 두 그룹 (#1180 Codex P1) — vix/fear_greed 만 gate 하면
+    # 수익률곡선·put/call·고용·CPI·금리가 낡은 채로 점수에 들어가 verdict 가 선다.
+    #
+    # **present-only per-indicator MIN** 이 핵심이다: macro_score 는 **결측** 지표를
+    # coverage 재정규화로 점수에서 제외하므로(#1026) 없는 지표를 gate 하면 점수에
+    # 안 들어가는 입력으로 판단을 막는 셈이다. 반면 **낡은**(행은 있는데 오래된) 지표는
+    # `_get_latest_macro` 가 나이 불문 반환해 점수에 그대로 들어간다 — 그게 여기서 잡는
+    # 대상이다. GROUP BY 는 존재하는 지표만 만들고, 그중 가장 낡은 것(MIN)을 본다.
+    # 그룹 전체 부재 → NULL → FAIL: 구성된 프로덕션에서 그룹째 사라진 건 수집 장애다.
+    # 합산 MAX 금지(멀쩡한 지표가 죽은 지표를 가린다)는 signals/ark 와 같은 원칙.
+    "macro_market": {
+        # 시장성 일간 지표 — 국채 3종 + put/call. 임계는 prices 와 같은 48/120 (주말/공휴일).
+        "query": (
+            "SELECT MIN(d) FROM (SELECT MAX(date) AS d FROM macro "
+            "WHERE indicator IN ('us_10y_yield', 'us_2y_yield', 'us_3m_yield', 'put_call_ratio') "
+            "GROUP BY indicator)"
+        ),
+        "label": "매크로 시장지표 (금리·PCR)",
+    },
+    "macro_monthly": {
+        # 월간 릴리즈 지표 — 고용·CPI·기준금리. 관측월 기준 날짜라 정상 나이가 수 주다:
+        # 45일(1080h) = 한 사이클 지연, 75일(1800h) = 두 사이클째 안 들어왔다.
+        "query": (
+            "SELECT MIN(d) FROM (SELECT MAX(date) AS d FROM macro "
+            "WHERE indicator IN ('unemployment', 'cpi_yoy', 'fed_funds_rate') "
+            "GROUP BY indicator)"
+        ),
+        "label": "매크로 월간지표 (고용·CPI·금리)",
+    },
     "consensus": {
         # FIX (Session 10): `diagnose` step_completed event 가 실제로 emit 되지 않아 항상 FAIL.
         # `recommendations.date` (consensus 결과 persist) 를 source of truth 로 변경.

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -1,23 +1,29 @@
-"""데이터 신선도 체크 — Dagster PASS/WARN/FAIL + Palantir TSLU 패턴."""
+"""데이터 신선도 체크 — Dagster PASS/WARN/FAIL + Palantir TSLU 패턴.
+
+임계(warn/fail 시간)는 **정책**이라 `config/freshness.yaml` 에 있고(#1180,
+config-over-code), 쿼리·라벨은 구현이라 여기 남는다. 아래 각 정책의 긴 주석은
+쿼리 형태의 근거이므로 임계가 config 로 나가도 유지한다.
+"""
 
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 from nuri.core.db import query
 from nuri.core.timezone import KST, kst_now
 
-FRESHNESS_POLICIES = {
+_CONFIG_PATH = Path(__file__).parent.parent.parent / "config" / "freshness.yaml"
+
+# 임계 없는 정책 골격 — warn_hours/fail_hours 는 _load_config() 가 config 에서 주입한다.
+FRESHNESS_POLICIES: dict[str, dict] = {
     "prices": {
         "query": "SELECT MAX(date) FROM prices WHERE ticker = 'SPY'",
-        "warn_hours": 48,
-        "fail_hours": 120,  # 주말/공휴일 감안 (금→화 = 96h, classifier.py와 동일)
         "label": "주가 데이터",
     },
     "macro_vix": {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'vix'",
-        "warn_hours": 24,
-        "fail_hours": 72,
         "label": "VIX",
     },
     "factors": {
@@ -29,8 +35,6 @@ FRESHNESS_POLICIES = {
         # 당일 행이 생겨 이 정책이 낡음을 잡는 게 아니라 세탁했다 (#1071 Codex P1).
         # 그래서 임계도 `prices` 와 같다 — 재료가 같으니 주말/공휴일 여유도 같아야 한다.
         "query": "SELECT MAX(date) FROM factors",
-        "warn_hours": 48,
-        "fail_hours": 120,
         "label": "멀티팩터 스코어",
     },
     # `signals` 는 시장별 두 정책이다 (#1101). BUY 점수의 0.15 가중치(RSI)와 SIEGE 게이트
@@ -55,8 +59,6 @@ FRESHNESS_POLICIES = {
             "GROUP BY date HAVING COUNT(*) >= {floor})"
         ),
         "floor_from": "us",
-        "warn_hours": 48,
-        "fail_hours": 120,
         "label": "기술 지표 (US)",
     },
     "signals_kr": {
@@ -68,8 +70,6 @@ FRESHNESS_POLICIES = {
             "GROUP BY date HAVING COUNT(*) >= {floor})"
         ),
         "floor_from": "kr",
-        "warn_hours": 48,
-        "fail_hours": 120,
         "label": "기술 지표 (KR)",
     },
     # `fundamentals` 도 시장별 두 정책이다 — `signals` 와 같은 구성, 같은 이유 (#1109).
@@ -94,8 +94,6 @@ FRESHNESS_POLICIES = {
             "GROUP BY date HAVING COUNT(*) >= {floor})"
         ),
         "floor_from": "us",
-        "warn_hours": 192,
-        "fail_hours": 360,
         "label": "펀더멘탈 (US)",
     },
     "fundamentals_kr": {
@@ -105,14 +103,10 @@ FRESHNESS_POLICIES = {
             "GROUP BY date HAVING COUNT(*) >= {floor})"
         ),
         "floor_from": "kr",
-        "warn_hours": 192,
-        "fail_hours": 360,
         "label": "펀더멘탈 (KR)",
     },
     "macro_fear_greed": {
         "query": "SELECT MAX(date) FROM macro WHERE indicator = 'fear_greed'",
-        "warn_hours": 24,
-        "fail_hours": 48,
         "label": "Fear & Greed",
     },
     "consensus": {
@@ -124,8 +118,6 @@ FRESHNESS_POLICIES = {
         # 테이블에 쓰므로, 필터가 없으면 합의 job 이 죽은 날에도 브리핑이 낸 후보 행
         # 하나가 "합의 신선함" 으로 읽힌다 — 관측이 거짓말하는 형태다.
         "query": "SELECT datetime(MAX(date)) FROM recommendations WHERE source IS NULL",
-        "warn_hours": 24,
-        "fail_hours": 48,
         "label": "에이전트 합의",
     },
     "certification": {
@@ -133,8 +125,6 @@ FRESHNESS_POLICIES = {
         # 이전 policy 는 pipeline_events 'certification_result' 이벤트를 기대했으나 emitter 부재
         # → 항상 FAIL. certifications.timestamp 는 ISO datetime (kst_now().isoformat()).
         "query": "SELECT MAX(timestamp) FROM certifications",
-        "warn_hours": 24,
-        "fail_hours": 48,
         "label": "Certification",
     },
     "ark": {
@@ -169,8 +159,6 @@ FRESHNESS_POLICIES = {
             "SELECT CASE WHEN COUNT(*) = 5 THEN MIN(csv_date) END FROM ark_source_dates "
             "WHERE fund IN ('ARKK', 'ARKW', 'ARKG', 'ARKQ', 'ARKF') AND csv_date IS NOT NULL"
         ),
-        "warn_hours": 168,
-        "fail_hours": 336,
         "label": "ARK 보유 (가장 낡은 펀드)",
     },
     "portfolio": {
@@ -178,11 +166,55 @@ FRESHNESS_POLICIES = {
         # sync 누락 시 0주 ticker 에 SELL 권고가 누설됨. 24h 이상이면 WARN, 72h
         # FAIL — `import_portfolio.py` 매일 수동 실행 가정. updated_at 은 KST naive.
         "query": "SELECT MAX(updated_at) FROM portfolio",
-        "warn_hours": 24,
-        "fail_hours": 72,
         "label": "포트폴리오 sync",
     },
 }
+
+
+def _load_config() -> dict:
+    """config/freshness.yaml 로드 + 정책 골격에 임계 주입 (#1180).
+
+    키 목록은 양방향 대조한다 — config 에만 있는 키(낡은 항목)와 코드에만 있는 키
+    (임계 없는 정책) 둘 다 기동 시 ValueError. 조용히 기본값으로 넘어가면
+    config-over-code 가 다시 무너진다.
+    """
+    with open(_CONFIG_PATH, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    thresholds = cfg.get("thresholds") or {}
+    code_keys = set(FRESHNESS_POLICIES)
+    cfg_keys = set(thresholds)
+    if code_keys != cfg_keys:
+        missing = code_keys - cfg_keys
+        stale = cfg_keys - code_keys
+        raise ValueError(
+            f"freshness.yaml 임계와 FRESHNESS_POLICIES 불일치 — config 누락: {sorted(missing)}, config 잉여: {sorted(stale)}"
+        )
+
+    for key, hours in thresholds.items():
+        FRESHNESS_POLICIES[key]["warn_hours"] = hours["warn_hours"]
+        FRESHNESS_POLICIES[key]["fail_hours"] = hours["fail_hours"]
+
+    gate = cfg.get("verdict_gate") or []
+    unknown = [k for k in gate if k not in code_keys]
+    if unknown:
+        raise ValueError(f"freshness.yaml verdict_gate 에 미등록 정책 키: {unknown}")
+    return cfg
+
+
+_CONFIG = _load_config()
+
+# /api/dashboard verdict 가 신선도를 확인하는 입력 키 목록 (config 정의, #1180)
+VERDICT_GATE_KEYS: tuple[str, ...] = tuple(_CONFIG.get("verdict_gate") or ())
+
+
+def stale_verdict_inputs(db_path: Optional[Path] = None) -> list[dict]:
+    """verdict gate 입력 중 FAIL 인 정책만 반환 (#1180, Surface rung).
+
+    WARN 은 통과 — 주말/공휴일의 정상 나이를 WARN 으로 두는 정책이 많아
+    WARN 까지 막으면 매주 판단이 죽는다. FAIL = 임계 초과 확정만 센다.
+    """
+    return [r for r in (check_freshness(k, db_path) for k in VERDICT_GATE_KEYS) if r["status"] == "FAIL"]
 
 
 def _parse_timestamp(value: str) -> datetime:

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -264,14 +264,23 @@ class TestDashboardBuildExtended:
             ],
             db_path,
         )
+
+        # consensus freshness (#1180 stale gate) — verdict gate 입력이라 fresh 하게 seed.
+        # source IS NULL = 합의 산출물 (freshness.py consensus 정책 참조).
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO recommendations (date, ticker, action, confidence) VALUES (?, ?, ?, ?)",
+                (today, "AAPL", "BUY", 70),
+            )
         return db_path
 
     def test_verdict_levels(self, rich_db):
-        """rich_db로 dashboard 빌드 — verdict_level 확인."""
+        """rich_db로 dashboard 빌드 — verdict_level 확인 (입력이 fresh 하므로 stale 아님)."""
         from nuri.api.routes.dashboard import _build_dashboard
 
         result = _build_dashboard()
         assert result["verdict_level"] in ("aggressive", "neutral", "cautious", "defensive")
+        assert result["verdict_stale_inputs"] == []
         assert isinstance(result["alerts"], list)
         assert isinstance(result["actions"], list)
 
@@ -424,6 +433,8 @@ class TestDashboardAPI_R22:
         monkeypatch.setattr(dash_mod, "_get_gate_score", lambda: 80)
         monkeypatch.setattr(dash_mod, "_get_freshness", lambda: {})
         monkeypatch.setattr(dash_mod, "_get_pipeline_status", lambda: {})
+        # stale gate (#1180) 는 전용 테스트에서 잠금 — 여기선 하위 분기만 본다
+        monkeypatch.setattr(dash_mod, "_get_stale_verdict_inputs", lambda: [])
 
         resp = _client.get("/api/dashboard")
         assert resp.status_code == 200
@@ -451,6 +462,8 @@ class TestDashboardAPI_R22:
         monkeypatch.setattr(dash_mod, "_get_gate_score", lambda: 50)
         monkeypatch.setattr(dash_mod, "_get_freshness", lambda: {})
         monkeypatch.setattr(dash_mod, "_get_pipeline_status", lambda: {})
+        # stale gate (#1180) 는 전용 테스트에서 잠금 — 여기선 하위 분기만 본다
+        monkeypatch.setattr(dash_mod, "_get_stale_verdict_inputs", lambda: [])
 
         resp1 = _client.get("/api/dashboard")
         resp2 = _client.get("/api/dashboard")
@@ -475,6 +488,8 @@ class TestDashboardAPI_R22:
         monkeypatch.setattr(dash_mod, "_get_gate_score", lambda: 30)
         monkeypatch.setattr(dash_mod, "_get_freshness", lambda: {})
         monkeypatch.setattr(dash_mod, "_get_pipeline_status", lambda: {})
+        # stale gate (#1180) 는 전용 테스트에서 잠금 — 여기선 하위 분기만 본다
+        monkeypatch.setattr(dash_mod, "_get_stale_verdict_inputs", lambda: [])
 
         dash_mod._cache["data"] = None
         dash_mod._cache["timestamp"] = 0
@@ -512,6 +527,8 @@ class TestDashboardAPI_R22:
         monkeypatch.setattr(dash_mod, "_get_gate_score", lambda: 50)
         monkeypatch.setattr(dash_mod, "_get_freshness", lambda: {})
         monkeypatch.setattr(dash_mod, "_get_pipeline_status", lambda: {})
+        # stale gate (#1180) 는 전용 테스트에서 잠금 — 여기선 하위 분기만 본다
+        monkeypatch.setattr(dash_mod, "_get_stale_verdict_inputs", lambda: [])
 
         dash_mod._cache["data"] = None
         dash_mod._cache["timestamp"] = 0
@@ -666,10 +683,15 @@ class TestDashboard_R27:
         assert result["regime"] == "unknown"
 
     def test_get_freshness(self, monkeypatch):
-        """_get_freshness returns dict."""
+        """_get_freshness returns dict.
+
+        mock 의 키는 `"key"` — 실제 check_all_freshness 반환 형태다. 예전 mock 이
+        `"table"` 로 돼 있어서 프로덕션의 d["table"] 버그(항상 {} 반환)를 오히려
+        잠그고 있었다 (#1180). 실 데이터 형태 잠금은 TestDashboardFreshness.
+        """
         monkeypatch.setattr(
             "nuri.core.freshness.check_all_freshness",
-            MagicMock(return_value=[{"table": "prices", "age_hours": 5, "status": "PASS"}]),
+            MagicMock(return_value=[{"key": "prices", "age_hours": 5, "status": "PASS"}]),
         )
         import nuri.api.routes.dashboard as dash_mod
 
@@ -1458,3 +1480,47 @@ class TestGetCashBalancesAppend:
         # main + toss 모두 append (cash > 0), empty 는 제외
         assert len(result["accounts"]) == 2
         assert result["total_cash_usd"] > 1000
+
+
+class TestVerdictStaleGate:
+    """#1180: verdict 는 stale 입력 위에서 "공격 가능" 을 내면 안 된다 (Surface rung)."""
+
+    def test_stale_inputs_hold_the_verdict(self, db_path):
+        """빈 DB(모든 gate 입력 FAIL) → verdict_level=stale + 근거 노출."""
+        from nuri.api.routes.dashboard import _build_dashboard
+
+        result = _build_dashboard()
+        assert result["verdict_level"] == "stale"
+        assert "판단 보류" in result["verdict"]
+        keys = {s["key"] for s in result["verdict_stale_inputs"]}
+        from nuri.core.freshness import VERDICT_GATE_KEYS
+
+        assert keys == set(VERDICT_GATE_KEYS)
+        # 데이터 자체는 게이트되지 않는다 — Surface rung (액션/알림은 그대로 내려간다)
+        assert "actions" in result and "alerts" in result
+
+    def test_gate_failure_does_not_kill_the_dashboard(self, db_path, monkeypatch):
+        """신선도 체크 자체가 죽어도 대시보드는 산다 (#894 관측이 본 작업을 게이트 금지)."""
+        import nuri.api.routes.dashboard as dash_mod
+
+        def _boom():
+            raise RuntimeError("freshness check exploded")
+
+        monkeypatch.setattr("nuri.core.freshness.stale_verdict_inputs", _boom)
+        result = dash_mod._build_dashboard()
+        assert result["verdict_stale_inputs"] == []
+        assert result["verdict_level"] != "stale"
+
+
+class TestDashboardFreshness:
+    """#1180 회귀 잠금: _get_freshness 가 d["table"] 을 읽어 항상 {} 를 반환하던 버그."""
+
+    def test_get_freshness_returns_every_policy(self, db_path):
+        from nuri.api.routes.dashboard import _get_freshness
+        from nuri.core.freshness import FRESHNESS_POLICIES
+
+        result = _get_freshness()
+        # 빈 DB 여도 정책마다 FAIL 항목이 나온다 — 빈 dict 는 키 이름 회귀다
+        assert set(result) == set(FRESHNESS_POLICIES)
+        for v in result.values():
+            assert set(v) == {"age_hours", "status"}

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -261,6 +261,11 @@ class TestDashboardBuildExtended:
                 {"indicator": "sp500_yoy", "date": today, "value": 15.0, "source": "test"},
                 {"indicator": "gdp_growth", "date": today, "value": 2.5, "source": "test"},
                 {"indicator": "unemployment", "date": today, "value": 3.8, "source": "test"},
+                # macro_market gate 입력 (#1180) — 그룹 전체 부재는 FAIL 이라 fresh 하게 seed
+                {"indicator": "us_10y_yield", "date": today, "value": 4.2, "source": "test"},
+                {"indicator": "us_2y_yield", "date": today, "value": 3.9, "source": "test"},
+                {"indicator": "us_3m_yield", "date": today, "value": 4.0, "source": "test"},
+                {"indicator": "put_call_ratio", "date": today, "value": 0.9, "source": "test"},
             ],
             db_path,
         )

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -1,4 +1,5 @@
 """Tests for routes — split from test_api_all.py."""
+
 import asyncio
 import json
 import time as _time
@@ -20,11 +21,13 @@ from tests.api._helpers import _csv_file  # noqa: F401
 class TestAPIRoutes:
     def test_targets_route_exists(self):
         from nuri.api.routes.targets import router
+
         routes = [getattr(r, "path", "") for r in router.routes]
         assert any("targets" in r for r in routes)
 
     def test_agents_route_exists(self):
         from nuri.api.routes.agents import router
+
         routes = [getattr(r, "path", "") for r in router.routes]
         assert any("consensus" in r for r in routes)
 
@@ -32,20 +35,24 @@ class TestAPIRoutes:
 class TestAPIRoutesExtended:
     def test_stream_route_exists(self):
         from nuri.api.routes.stream import router
+
         assert router is not None
 
     def test_signals_route(self):
         from nuri.api.routes.signals import router
+
         routes = [getattr(r, "path", "") for r in router.routes]
         assert len(routes) > 0
 
     def test_regime_route(self):
         from nuri.api.routes.regime import router
+
         routes = [getattr(r, "path", "") for r in router.routes]
         assert len(routes) > 0
 
     def test_portfolio_route(self):
         from nuri.api.routes.portfolio import router
+
         routes = [getattr(r, "path", "") for r in router.routes]
         assert len(routes) > 0
 
@@ -55,11 +62,13 @@ class TestAPIRoutes_R9:
     def _client(self, tmp_path, monkeypatch):
         import nuri.core.db as db_mod
         import nuri.core.portfolio_sync as sync_mod
+
         db = tmp_path / "t.db"
         init_db(db)
         monkeypatch.setattr(db_mod, "DB_PATH", db)
         monkeypatch.setattr(sync_mod, "CONFIG_PATH", tmp_path / "p.yaml")
         from nuri.api.main import app
+
         return TestClient(app)
 
     def test_consensus_endpoint(self, _client):
@@ -93,33 +102,47 @@ class TestAPIDeep:
         fp_db = tmp_path / "test.db"
         init_db(fp_db)
         import nuri.core.db as db_mod
+
         monkeypatch.setattr(db_mod, "DB_PATH", fp_db)
 
         with get_db(fp_db) as conn:
             conn.execute(
                 "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) "
-                "VALUES (?, ?, ?, ?, ?, ?)", ("test", "AAPL", 10, 150, "USD", "Technology"))
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("test", "AAPL", 10, 150, "USD", "Technology"),
+            )
 
         dates = pd.bdate_range("2023-06-01", periods=250)
         for t, base in [("SPY", 430), ("AAPL", 150)]:
             close = np.linspace(base, base * 1.1, 250)
-            df = pd.DataFrame({
-                "ticker": t, "date": [d.strftime("%Y-%m-%d") for d in dates],
-                "open": close * 0.99, "high": close * 1.01,
-                "low": close * 0.98, "close": close,
-                "volume": [1000000] * 250, "adj_close": close,
-            })
+            df = pd.DataFrame(
+                {
+                    "ticker": t,
+                    "date": [d.strftime("%Y-%m-%d") for d in dates],
+                    "open": close * 0.99,
+                    "high": close * 1.01,
+                    "low": close * 0.98,
+                    "close": close,
+                    "volume": [1000000] * 250,
+                    "adj_close": close,
+                }
+            )
             upsert_prices(df, fp_db)
 
-        upsert_macro([
-            {"indicator": "vix", "date": dates[-1].strftime("%Y-%m-%d"), "value": 18.0, "source": "test"},
-            {"indicator": "fear_greed", "date": dates[-1].strftime("%Y-%m-%d"), "value": 55.0, "source": "test"},
-        ], fp_db)
+        upsert_macro(
+            [
+                {"indicator": "vix", "date": dates[-1].strftime("%Y-%m-%d"), "value": 18.0, "source": "test"},
+                {"indicator": "fear_greed", "date": dates[-1].strftime("%Y-%m-%d"), "value": 55.0, "source": "test"},
+            ],
+            fp_db,
+        )
 
         import nuri.core.portfolio_sync as sync_mod
+
         monkeypatch.setattr(sync_mod, "CONFIG_PATH", tmp_path / "p.yaml")
 
         from nuri.api.main import app
+
         return TestClient(app)
 
     @pytest.mark.slow
@@ -128,7 +151,8 @@ class TestAPIDeep:
         assert r.status_code == 200
         data = r.json()
         assert "verdict" in data
-        assert data["verdict_level"] in ("aggressive", "neutral", "cautious", "defensive")
+        # "stale" 은 #1180 stale gate — 판단 입력이 낡으면 판단을 보류한다
+        assert data["verdict_level"] in ("aggressive", "neutral", "cautious", "defensive", "stale")
 
     def test_regime_with_data(self, _client):
         r = _client.get("/api/regime")

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -695,3 +695,59 @@ class TestCertificationFreshnessE4_0a:
         dt = _parse_timestamp("2026-4-1")
         assert dt.year == 2026 and dt.month == 4 and dt.day == 1
         assert dt.tzinfo is not None  # KST 부착됨
+
+
+class TestFreshnessConfig:
+    """임계는 config/freshness.yaml 이 정본 (#1180, config-over-code)."""
+
+    def test_thresholds_come_from_config(self):
+        """로드된 정책 임계 == yaml 값 — 코드 하드코딩이 되살아나면 여기서 어긋난다."""
+        import yaml as _yaml
+
+        from nuri.core.freshness import _CONFIG_PATH, FRESHNESS_POLICIES
+
+        with open(_CONFIG_PATH, encoding="utf-8") as f:
+            cfg = _yaml.safe_load(f)
+
+        assert set(cfg["thresholds"]) == set(FRESHNESS_POLICIES)
+        for key, hours in cfg["thresholds"].items():
+            assert FRESHNESS_POLICIES[key]["warn_hours"] == hours["warn_hours"], key
+            assert FRESHNESS_POLICIES[key]["fail_hours"] == hours["fail_hours"], key
+
+    def test_config_key_mismatch_raises(self, tmp_path, monkeypatch):
+        """config 누락/잉여 키는 기동 시 ValueError — 조용한 기본값 폴백 금지."""
+        import nuri.core.freshness as fresh_mod
+
+        bad = tmp_path / "freshness.yaml"
+        bad.write_text("thresholds:\n  prices: { warn_hours: 1, fail_hours: 2 }\n", encoding="utf-8")
+        monkeypatch.setattr(fresh_mod, "_CONFIG_PATH", bad)
+        with pytest.raises(ValueError, match="불일치"):
+            fresh_mod._load_config()
+
+    def test_verdict_gate_unknown_key_raises(self, tmp_path, monkeypatch):
+        import yaml as _yaml
+
+        import nuri.core.freshness as fresh_mod
+
+        with open(fresh_mod._CONFIG_PATH, encoding="utf-8") as f:
+            cfg = _yaml.safe_load(f)
+        cfg["verdict_gate"] = ["nonexistent_policy"]
+        bad = tmp_path / "freshness.yaml"
+        bad.write_text(_yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+        monkeypatch.setattr(fresh_mod, "_CONFIG_PATH", bad)
+        with pytest.raises(ValueError, match="verdict_gate"):
+            fresh_mod._load_config()
+
+    def test_verdict_gate_keys_are_registered_policies(self):
+        from nuri.core.freshness import FRESHNESS_POLICIES, VERDICT_GATE_KEYS
+
+        assert VERDICT_GATE_KEYS, "verdict_gate 가 비어 있으면 stale gate 가 무력하다"
+        assert set(VERDICT_GATE_KEYS) <= set(FRESHNESS_POLICIES)
+
+    def test_stale_verdict_inputs_flags_fail_only(self, db_path):
+        """빈 DB → gate 입력 전부 FAIL 로 표면화. 반환 항목은 FAIL 만."""
+        from nuri.core.freshness import VERDICT_GATE_KEYS, stale_verdict_inputs
+
+        stale = stale_verdict_inputs(db_path)
+        assert {s["key"] for s in stale} == set(VERDICT_GATE_KEYS)
+        assert all(s["status"] == "FAIL" for s in stale)

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -69,6 +69,12 @@ class TestFreshnessPolicies:
             "fundamentals_kr",
             "macro_vix",
             "macro_fear_greed",
+            # `macro_market`/`macro_monthly` 는 #1180 에서 추가 — verdict stale gate 가
+            # vix/fear_greed 만 보면 금리·put/call·고용·CPI 가 낡은 채로 macro 점수에
+            # 들어가 "공격 가능" 이 선다 (Codex P1). 결측 지표는 macro_score 가 coverage
+            # 재정규화로 이미 제외하므로(#1026) present-only MIN — 낡음만 잡는다.
+            "macro_market",
+            "macro_monthly",
             "consensus",
             "certification",
             "portfolio",


### PR DESCRIPTION
Closes #1180

## What
1. **Freshness thresholds → config** (`config/freshness.yaml`): `warn_hours`/`fail_hours` per policy move out of `nuri/core/freshness.py` hardcoding. Loader validates key parity both ways at import (config 누락/잉여 모두 ValueError). Queries/labels stay in code — implementation, not policy.
2. **Stale-aware verdict** (`/api/dashboard`): a config-listed `verdict_gate` input set (prices, vix, fear_greed, macro_market, macro_monthly, consensus) is checked before the one-line verdict; any FAIL replaces "공격 가능" with `판단 보류. 입력 데이터 낡음 (...)` + `verdict_level: "stale"` + `verdict_stale_inputs` evidence. Data (actions/alerts) is NOT gated — Escalation Ladder **Surface** rung.
3. **Bug fix**: `dashboard.py _get_freshness()` read `d["table"]` but `check_all_freshness()` returns `"key"` — the helper silently returned `{}` forever; the legacy test had mocked the wrong shape and was locking the bug in. Fixed + regression-locked.
4. **Frontend**: `stale` verdict label ("데이터 낡음") + amber style; unknown levels still fall back to neutral.

## Codex review (Flow phase 4)
- **P1 resolved**: verdict_gate initially covered only vix/fear_greed; yield curves, put/call, unemployment, CPI, fed funds also feed `macro.score`. Added `macro_market` (daily cadence, 48/120h) + `macro_monthly` (release cadence, 1080/1800h) policies using **present-only per-indicator MIN** — absent indicators are already excluded from the score by coverage renormalization (#1026), so only staleness is gated.
- **P2 resolved**: in-repo `verdict_level` enum consumers updated for `"stale"`.

## Verification
- `make test-fast` 7469 passed; changed-file branch coverage: new/changed lines 100%
- Live run on dev DB (weekend-stale VIX 148h): verdict correctly renders `판단 보류. 입력 데이터 낡음 (VIX 148h, Fear & Greed 100h, 매크로 시장지표 148h, 에이전트 합의 100h)` instead of `공격 가능`
- `make lint` clean, `make diagnostics` pyright 165 ≤ ratchet 172, doc counts synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)