### PR TITLE
feat(frontend): label hero metrics as portfolio snapshot, separate from adjudication ledger

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { HERO } from "../src/lib/strings";
 
 test.describe("Dashboard (with real backend)", () => {
   test("renders main dashboard with verdict", async ({ page }) => {
@@ -38,5 +39,23 @@ test.describe("Dashboard (with real backend)", () => {
       const body = await page.textContent("body");
       expect(body!.length).toBeGreaterThan(50);
     }
+  });
+});
+
+// #1185: 출처 분리 — 히어로 지표는 스냅샷임을 항상 명시하고 판정 원장으로 링크
+test.describe("Hero provenance (#1185)", () => {
+  test("hero always shows the snapshot provenance strip with a ledger link", async ({ page }) => {
+    await page.goto("/", { timeout: 15000 });
+    const strip = page.getByTestId("hero-provenance");
+    await expect(strip).toBeVisible({ timeout: 15000 });
+    await expect(strip).toContainText(HERO.PROVENANCE_SNAPSHOT);
+    await expect(strip.locator("a")).toHaveAttribute("href", "/decisions");
+  });
+
+  test("win-rate stat carries the not-system-performance scope note", async ({ page }) => {
+    await page.goto("/", { timeout: 15000 });
+    const winrate = page.getByTestId("hero-winrate");
+    await expect(winrate).toBeVisible({ timeout: 15000 });
+    await expect(winrate).toContainText(HERO.WIN_RATE_SCOPE);
   });
 });

--- a/frontend/src/__tests__/components/hero-stats.test.tsx
+++ b/frontend/src/__tests__/components/hero-stats.test.tsx
@@ -211,6 +211,7 @@ describe("HeroStats provenance (#1185)", () => {
     );
     const strip = screen.getByTestId("hero-provenance");
     expect(strip.textContent).toContain(HERO.PROVENANCE_SNAPSHOT);
+    expect(strip.textContent).toContain(HERO.PROVENANCE_SCOPE);
     expect(strip.textContent).toContain(HERO.PROVENANCE_LEDGER_LINK);
     const link = strip.querySelector("a");
     expect(link?.getAttribute("href")).toBe("/decisions");

--- a/frontend/src/__tests__/components/hero-stats.test.tsx
+++ b/frontend/src/__tests__/components/hero-stats.test.tsx
@@ -10,6 +10,7 @@ vi.mock("next/link", () => ({
 
 import { HeroStats } from "@/components/ui/hero-stats";
 import type { HoldingsSummary } from "@/lib/holdings-summary";
+import { HERO } from "@/lib/strings";
 
 function summary(over: Partial<HoldingsSummary> = {}): HoldingsSummary {
   return {
@@ -193,5 +194,54 @@ describe("HeroStats", () => {
     );
     const total = screen.getByTestId("hero-total");
     expect(total.textContent).not.toContain("보유 $");
+  });
+});
+
+// #1185: 출처 분리 — 히어로 지표는 스냅샷, 판정 성과는 원장(/decisions)
+describe("HeroStats provenance (#1185)", () => {
+  it("always renders the snapshot provenance strip with a ledger link", () => {
+    render(
+      <HeroStats
+        totalUsd={10000}
+        cashTotalUsd={2000}
+        holdingsValueUsd={8000}
+        summary={summary()}
+        verdictLabel="관망"
+      />,
+    );
+    const strip = screen.getByTestId("hero-provenance");
+    expect(strip.textContent).toContain(HERO.PROVENANCE_SNAPSHOT);
+    expect(strip.textContent).toContain(HERO.PROVENANCE_LEDGER_LINK);
+    const link = strip.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("/decisions");
+  });
+
+  it("marks the win-rate stat as unrealized-snapshot, not system performance", () => {
+    render(
+      <HeroStats
+        totalUsd={10000}
+        cashTotalUsd={2000}
+        holdingsValueUsd={8000}
+        summary={summary({ winRate: { winners: 3, losers: 7, flat: 0, winRatePct: 30 } })}
+        verdictLabel="관망"
+      />,
+    );
+    const winrate = screen.getByTestId("hero-winrate");
+    expect(winrate.textContent).toContain(HERO.WIN_RATE_SCOPE);
+  });
+
+  it("keeps the flat count alongside the win-rate scope note", () => {
+    render(
+      <HeroStats
+        totalUsd={10000}
+        cashTotalUsd={2000}
+        holdingsValueUsd={8000}
+        summary={summary({ winRate: { winners: 2, losers: 2, flat: 3, winRatePct: 50 } })}
+        verdictLabel="관망"
+      />,
+    );
+    const winrate = screen.getByTestId("hero-winrate");
+    expect(winrate.textContent).toContain(`${HERO.FLAT} 3`);
+    expect(winrate.textContent).toContain(HERO.WIN_RATE_SCOPE);
   });
 });

--- a/frontend/src/components/ui/hero-stats.tsx
+++ b/frontend/src/components/ui/hero-stats.tsx
@@ -18,6 +18,8 @@
  * Server Component. Pure presentational; consumes pre-computed numbers.
  */
 
+import Link from "next/link";
+
 import { StatusBadge } from "@/components/ui/status-badge";
 import type { HoldingsSummary } from "@/lib/holdings-summary";
 import { HERO } from "@/lib/strings";
@@ -136,13 +138,24 @@ export function HeroStats({
                   {movers > 0 ? `${wr.winners}W / ${wr.losers}L` : ""}
                 </span>
               </div>
+              {/* #1185: 승률은 보유 종목의 미실현 스냅샷 — 시스템 판정 성과(원장)로 오독 금지 */}
               <p className="text-xs text-zinc-400 mt-1">
-                {wr.flat > 0 ? `${HERO.FLAT} ${wr.flat}` : HERO.HOLDINGS_BASIS}
+                {wr.flat > 0 ? `${HERO.FLAT} ${wr.flat} · ` : ""}{HERO.WIN_RATE_SCOPE}
               </p>
             </div>
           );
         })()}
       </div>
+
+      {/* #1185: 출처 분리 (§3.11) — 위 4지표는 전부 스냅샷. 판정 성과는 원장(/decisions)에서만 */}
+      <p className="text-[10px] text-zinc-500" data-testid="hero-provenance">
+        {HERO.PROVENANCE_SNAPSHOT}
+        {" · "}
+        {HERO.PROVENANCE_LEDGER_LINK}{" "}
+        <Link href="/decisions" className="underline decoration-zinc-700 hover:text-zinc-300 transition-colors">
+          /decisions →
+        </Link>
+      </p>
     </section>
   );
 }

--- a/frontend/src/components/ui/hero-stats.tsx
+++ b/frontend/src/components/ui/hero-stats.tsx
@@ -150,6 +150,8 @@ export function HeroStats({
       {/* #1185: 출처 분리 (§3.11) — 위 4지표는 전부 스냅샷. 판정 성과는 원장(/decisions)에서만 */}
       <p className="text-[10px] text-zinc-500" data-testid="hero-provenance">
         {HERO.PROVENANCE_SNAPSHOT}
+        {" — "}
+        {HERO.PROVENANCE_SCOPE}
         {" · "}
         {HERO.PROVENANCE_LEDGER_LINK}{" "}
         <Link href="/decisions" className="underline decoration-zinc-700 hover:text-zinc-300 transition-colors">

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -15,8 +15,11 @@ export const HERO = {
   FLAT: "보합",
   HOLDINGS_PREFIX: "보유",
   CASH_PREFIX: "현금",
-  // #1185: 출처 분리 — 히어로 4지표는 전부 포트폴리오 스냅샷이지 판정 원장이 아니다 (§3.11)
-  PROVENANCE_SNAPSHOT: "지표 출처: 포트폴리오 스냅샷 (portfolio.yaml + 최신 종가, 미실현 포함)",
+  // #1185: 출처 분리 — 히어로 4지표는 전부 포트폴리오 스냅샷이지 판정 원장이 아니다 (§3.11).
+  // 출처는 보유 DB(portfolio 테이블)+최신 종가다 — yaml 은 sync 지연/실패 시 어긋난다 (Codex P2).
+  // 범위도 갈린다: 총 자산=전 계좌+현금, 오늘·누적·승률=연금 제외 보유분 (page.tsx 필터).
+  PROVENANCE_SNAPSHOT: "지표 출처: 포트폴리오 스냅샷 (보유 DB + 최신 종가, 미실현 포함)",
+  PROVENANCE_SCOPE: "총 자산=전 계좌+현금 · 오늘·누적·승률=연금 제외 보유분",
   PROVENANCE_LEDGER_LINK: "시스템 판정 성과는 판정 원장",
   WIN_RATE_SCOPE: "보유 미실현 기준 — 시스템 판정 성과 아님",
 } as const;

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -13,9 +13,12 @@ export const HERO = {
   CUMULATIVE_SUB: "실현 미실현 합계",
   WIN_RATE: "승률",
   FLAT: "보합",
-  HOLDINGS_BASIS: "보유 종목 기준",
   HOLDINGS_PREFIX: "보유",
   CASH_PREFIX: "현금",
+  // #1185: 출처 분리 — 히어로 4지표는 전부 포트폴리오 스냅샷이지 판정 원장이 아니다 (§3.11)
+  PROVENANCE_SNAPSHOT: "지표 출처: 포트폴리오 스냅샷 (portfolio.yaml + 최신 종가, 미실현 포함)",
+  PROVENANCE_LEDGER_LINK: "시스템 판정 성과는 판정 원장",
+  WIN_RATE_SCOPE: "보유 미실현 기준 — 시스템 판정 성과 아님",
 } as const;
 
 /* ── Composition Section ────────────────────────────────────── */


### PR DESCRIPTION
Closes #1185

## What
PR 3 of the dashboard-honesty sequence (#1180 → #1182 →). The four hero stats are an **unrealized portfolio snapshot** computed in the frontend, but nothing said so — 승률 30% (3W/7L) was trivially misread as *system* performance, which §3.11 only allows from the adjudication ledger.

- Provenance strip under the hero grid (`data-testid="hero-provenance"`, always rendered): source = **보유 DB + 최신 종가** (unrealized included), per-metric scope = 총 자산 spans all accounts+cash while 오늘/누적/승률 exclude pension, and a link to the ledger view `/decisions`.
- 승률 sublabel: "보유 미실현 기준 — 시스템 판정 성과 아님".
- Strings centralized in `src/lib/strings.ts`; orphaned `HOLDINGS_BASIS` removed.
- vitest (3 new, 13 total in file) + Playwright e2e specs (provenance strip + win-rate scope note, scoped per frontend/CLAUDE.md rules).

## Codex review (Flow phase 4)
GATE: PASS (no P1). Both P2 wording corrections applied: (a) source misattributed to portfolio.yaml — the API reads the `portfolio` DB table and `_try_sync_yaml()` keeps DB changes even when yaml sync fails; (b) the strip implied one scope for all four metrics while `page.tsx` filters pension out of 오늘/누적/승률.

## Verification
- Frontend 1461 passed / build clean; e2e specs added (full e2e run scheduled after PR 4 lands, reported separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)