### PR TITLE
fix(agents): suppress stale sources per-source in smart_money with explicit exclusion notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,504 collected across 345 files | |
+| **Backend tests** | 7,510 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,510 collected across 345 files | |
+| **Backend tests** | 7,513 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,513 collected across 345 files | |
+| **Backend tests** | 7,514 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
 | **E2E tests** | 57 across 8 Playwright specs | |

--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -102,6 +102,12 @@ smart_money:
   downside_threshold: -10   # -1점
   score_buy: 2
   score_sell: -1
+  # source 별 최대 나이 (#1187) — 이보다 낡은 행은 점수에서 제외 + "낡음 — 제외" 명시.
+  # ARK 235일 stale 행이 "ARK 최근 매수 ±1" 로 표면화된 사고가 기원.
+  freshness:
+    superinvestors_max_age_days: 200 # 13F: 분기 + 45일 제출 지연 → 정상 나이 ~135d, 여유 200d
+    estimates_max_age_days: 45 # 애널리스트 등급/목표가 — 45일 넘은 컨센서스는 컨센서스가 아님
+    ark_max_age_days: 14 # config/freshness.yaml ark fail(336h=14d) 과 정렬
   confidence:
     buy_cap: 80
     buy_base: 40

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,504 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,510 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,510 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,513 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,513 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,514 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,510 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,513 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,504 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,510 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,513 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,514 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
 | E2E | 핵심 flow | 57 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/agents/CLAUDE.md
+++ b/nuri/trading/agents/CLAUDE.md
@@ -33,12 +33,14 @@ Live probe (2026-04-17):
 ## smart_money 는 source 별 신선도 억제를 한다 (#1187)
 
 세 소스(13F superinvestors · estimates · ark) 각각 `config/agents.yaml
-smart_money.freshness` 의 max-age 를 넘는 행은 점수에서 제외하고, "행이 있었는데 전부
-낡아 제외" 는 reasoning 에 `"<라벨> 낡음(최신 날짜) — 제외"` 로 명시한다 (조용한 결손
-금지). `data_points["stale_sources"]` 가 제외 목록을 노출한다. 235일 낡은 ARK Buy 가
-"ARK 최근 매수 ±1" 로 표면화된 사고가 기원. **Test:**
-`tests/trading/agents/test_smart_money_branches.py::TestSourceFreshnessSuppression` —
-축별 전용 테스트 (한 소스의 컷오프를 지우면 그 축 테스트만 FAIL).
+smart_money.freshness` 의 max-age 를 넘는 행은 점수에서 제외한다. **"낡음 — 제외" 노트는
+소스-레벨 프로브가 소스 자체의 staleness 를 확인했을 때만** 낸다 — 티커 행만 늙은 것
+(13F 에서 팔린 종목, ARK 가 보유만 유지한 종목)은 정상 부재라 조용히 제외한다 (Codex P2).
+ARK 의 소스 프로브는 `ark` 테이블이 아니라 `ark_source_dates` 다 (#1147 — ark 는 보유
+교집합이라 소스 신선도의 정본이 아님). `data_points["stale_sources"]` 가 제외 목록을
+노출한다. 235일 낡은 ARK Buy 가 "ARK 최근 매수 ±1" 로 표면화된 사고가 기원. **Test:**
+`tests/trading/agents/test_smart_money_branches.py::TestSourceFreshnessSuppression` (축별
+억제) + `::TestStaleRowsVsFreshSource` (정상 부재 vs 소스 staleness 구분).
 
 ## Veto + Divergence
 

--- a/nuri/trading/agents/CLAUDE.md
+++ b/nuri/trading/agents/CLAUDE.md
@@ -30,6 +30,16 @@ Live probe (2026-04-17):
 보유 스냅샷 폴백) 동안 거기 있는 티커는 전부 상시 `score -1` 을 받았다. 수집기 쪽 사정과
 무관하게 이 집계는 방어적으로 옳아야 한다. 배경은 `nuri/collectors/CLAUDE.md` "ARK".
 
+## smart_money 는 source 별 신선도 억제를 한다 (#1187)
+
+세 소스(13F superinvestors · estimates · ark) 각각 `config/agents.yaml
+smart_money.freshness` 의 max-age 를 넘는 행은 점수에서 제외하고, "행이 있었는데 전부
+낡아 제외" 는 reasoning 에 `"<라벨> 낡음(최신 날짜) — 제외"` 로 명시한다 (조용한 결손
+금지). `data_points["stale_sources"]` 가 제외 목록을 노출한다. 235일 낡은 ARK Buy 가
+"ARK 최근 매수 ±1" 로 표면화된 사고가 기원. **Test:**
+`tests/trading/agents/test_smart_money_branches.py::TestSourceFreshnessSuppression` —
+축별 전용 테스트 (한 소스의 컷오프를 지우면 그 축 테스트만 FAIL).
+
 ## Veto + Divergence
 
 - **Risk agent** (19% weight) has **veto power**: SELL + confidence ≥ 80 overrides all others.

--- a/nuri/trading/agents/smart_money.py
+++ b/nuri/trading/agents/smart_money.py
@@ -1,10 +1,19 @@
 """스마트머니 에이전트 — 슈퍼투자자 + ARK + 애널리스트 컨센서스 기반 판정."""
 
+from datetime import timedelta
+
 from nuri.core.agent_config import AGENT_CONFIG
+from nuri.core.timezone import kst_now
 from nuri.trading.agents.base import AgentVerdict, BaseAgent
 
 _CFG = AGENT_CONFIG.get("smart_money", {})
 _CONF = _CFG.get("confidence", {})
+_FRESH = _CFG.get("freshness", {})
+
+
+def _cutoff(days: int) -> str:
+    """max-age 일수 → 'YYYY-MM-DD' 컷오프 (문자열 비교용, DB 날짜 포맷과 동일)."""
+    return (kst_now() - timedelta(days=days)).strftime("%Y-%m-%d")
 
 
 class SmartMoneyAgent(BaseAgent):
@@ -14,18 +23,30 @@ class SmartMoneyAgent(BaseAgent):
     def analyze(self, ticker: str, db_path=None) -> AgentVerdict:
         score = 0
         reasons = []
+        # source 별 신선도 억제 (#1187): 낡은 소스는 점수에서 빼되 **조용히 빼지 않는다**
+        # — "행이 있었는데 전부 낡아 제외" 는 reasons 에 명시한다 (Surface rung).
+        # 임계는 config/agents.yaml smart_money.freshness (config-over-code).
+        stale_sources: list[str] = []
 
         pct_high = _CFG.get("portfolio_pct_high", 5)
         upside_th = _CFG.get("upside_threshold", 20)
         downside_th = _CFG.get("downside_threshold", -10)
+        si_cutoff = _cutoff(_FRESH.get("superinvestors_max_age_days", 200))
+        est_cutoff = _cutoff(_FRESH.get("estimates_max_age_days", 45))
+        ark_cutoff = _cutoff(_FRESH.get("ark_max_age_days", 14))
 
         # 1. 슈퍼투자자 보유 여부
-        si_rows = self._safe_query(
-            "SELECT investor, portfolio_pct FROM superinvestors "
+        si_all = self._safe_query(
+            "SELECT investor, portfolio_pct, filing_date FROM superinvestors "
             "WHERE ticker = ? AND investor_class = 'conviction' ORDER BY portfolio_pct DESC",
             (ticker,),
             db_path,
         )
+        si_rows = [r for r in si_all if (r.get("filing_date") or "") >= si_cutoff]
+        if si_all and not si_rows:
+            latest = max(r.get("filing_date") or "?" for r in si_all)
+            stale_sources.append("superinvestors")
+            reasons.append(f"슈퍼투자자 13F 낡음(최신 {latest}) — 제외")
         if si_rows:
             investors = [r["investor"] for r in si_rows[:3]]
             max_pct = si_rows[0]["portfolio_pct"]
@@ -35,30 +56,36 @@ class SmartMoneyAgent(BaseAgent):
                 score += 1
                 reasons.append(f"최대 비중 {max_pct:.1f}%")
 
-        # 2. 슈퍼투자자 포지션 변화 (NEW/INCREASED)
+        # 2. 슈퍼투자자 포지션 변화 (NEW/INCREASED) — 같은 13F 컷오프 적용 (#1187):
+        # "최근 신규 매수" 가 두 분기 전 제출분이면 최근이 아니다
         change_rows = self._safe_query(
             "SELECT DISTINCT investor FROM superinvestors s1 "
-            "WHERE ticker = ? AND investor_class = 'conviction' AND filing_date = ("
+            "WHERE ticker = ? AND investor_class = 'conviction' AND filing_date >= ? AND filing_date = ("
             "  SELECT MAX(filing_date) FROM superinvestors WHERE investor = s1.investor"
             ") AND NOT EXISTS ("
             "  SELECT 1 FROM superinvestors s2 "
             "  WHERE s2.investor = s1.investor AND s2.ticker = s1.ticker "
             "  AND s2.filing_date < s1.filing_date"
             ")",
-            (ticker,),
+            (ticker, si_cutoff),
             db_path,
         )
         if change_rows:
             score += 1
             reasons.append(f"최근 신규 매수: {', '.join(r['investor'] for r in change_rows)}")
 
-        # 3. 애널리스트 컨센서스
+        # 3. 애널리스트 컨센서스 — 최신 1행이라도 컷오프보다 낡으면 제외 (#1187):
+        # LIMIT 1 은 나이를 안 본다. 낡은 목표가/등급이 점수에 들어가면 안 된다.
         est_rows = self._safe_query(
-            "SELECT recommendation, target_mean, current_price, num_analysts "
+            "SELECT recommendation, target_mean, current_price, num_analysts, date "
             "FROM estimates WHERE ticker = ? ORDER BY date DESC LIMIT 1",
             (ticker,),
             db_path,
         )
+        if est_rows and (est_rows[0].get("date") or "") < est_cutoff:
+            stale_sources.append("estimates")
+            reasons.append(f"애널리스트 컨센서스 낡음(최신 {est_rows[0].get('date') or '?'}) — 제외")
+            est_rows = []
         if est_rows:
             est = est_rows[0]
             rec = est.get("recommendation", "")
@@ -88,12 +115,20 @@ class SmartMoneyAgent(BaseAgent):
         # 거기 있는 티커는 예외 없이 score -1 과 "ARK 최근 매도 N건" 이라는 거짓 근거를
         # 받았다. 데이터 결손이 아니라 틀린 신호였다. Buy/Sell 을 각각 세고, 쿼리에서도
         # 걸러 LIMIT 5 창을 Hold 가 잡아먹지 않게 한다.
-        ark_rows = self._safe_query(
-            "SELECT direction, shares FROM ark WHERE ticker = ? "
+        # 컷오프 (#1187): ARK "최근 매매" 는 진짜로 최근이어야 한다 — 235일 전 Buy 가
+        # "ARK 최근 매수" 로 표면화된 게 이 조항의 기원. 임계는 config/freshness.yaml
+        # ark fail(336h=14d) 과 정렬. 창(LIMIT 5) 안에 낡은 행이 섞이지 않게 SQL 에서 거른다.
+        ark_all = self._safe_query(
+            "SELECT direction, shares, date FROM ark WHERE ticker = ? "
             "AND direction IN ('Buy', 'Sell') ORDER BY date DESC LIMIT 5",
             (ticker,),
             db_path,
         )
+        ark_rows = [r for r in ark_all if (r.get("date") or "") >= ark_cutoff]
+        if ark_all and not ark_rows:
+            latest = max(r.get("date") or "?" for r in ark_all)
+            stale_sources.append("ark")
+            reasons.append(f"ARK 매매 낡음(최신 {latest}) — 제외")
         if ark_rows:
             buys = sum(1 for r in ark_rows if r["direction"] == "Buy")
             sells = sum(1 for r in ark_rows if r["direction"] == "Sell")
@@ -135,5 +170,5 @@ class SmartMoneyAgent(BaseAgent):
             action,
             round(self.normalize_confidence(confidence), 1),
             "; ".join(reasons),
-            {"score": score, "n_superinvestors": len(si_rows)},
+            {"score": score, "n_superinvestors": len(si_rows), "stale_sources": stale_sources},
         )

--- a/nuri/trading/agents/smart_money.py
+++ b/nuri/trading/agents/smart_money.py
@@ -20,11 +20,26 @@ class SmartMoneyAgent(BaseAgent):
     def __init__(self):
         super().__init__("smart_money")
 
+    def _source_is_fresh(self, probe_sql: str, cutoff: str, db_path) -> bool:
+        """소스 **전체**의 최신 날짜가 컷오프 안인지 — 티커 행 나이와 구분한다 (#1187 Codex P2).
+
+        티커의 행만 낡은 것은 소스 staleness 가 아니다: 13F 에서 팔린 종목, ARK 가
+        보유만 유지한 종목은 소스가 멀쩡해도 그 티커의 매매/보유 행이 늙는다. 그건
+        정상 부재라 조용히 제외하고, 소스 자체가 낡았을 때만 "낡음 — 제외" 를 낸다.
+        프로브 실패/빈 결과는 미상 = 신선 아님 (ark COUNT(*)=5 원칙과 같은 방향).
+        """
+        rows = self._safe_query(probe_sql, (), db_path)
+        if not rows:
+            return False
+        latest = list(rows[0].values())[0]
+        return bool(latest) and str(latest) >= cutoff
+
     def analyze(self, ticker: str, db_path=None) -> AgentVerdict:
         score = 0
         reasons = []
-        # source 별 신선도 억제 (#1187): 낡은 소스는 점수에서 빼되 **조용히 빼지 않는다**
-        # — "행이 있었는데 전부 낡아 제외" 는 reasons 에 명시한다 (Surface rung).
+        # source 별 신선도 억제 (#1187): 낡은 행은 점수에서 빼되, "소스가 낡아 제외" 는
+        # 소스-레벨 프로브가 낡음을 확인했을 때만 명시한다 (Surface rung). 소스가
+        # 신선한데 티커 행만 늙었으면 정상 부재로 조용히 제외한다 (Codex P2 ×2).
         # 임계는 config/agents.yaml smart_money.freshness (config-over-code).
         stale_sources: list[str] = []
 
@@ -43,7 +58,17 @@ class SmartMoneyAgent(BaseAgent):
             db_path,
         )
         si_rows = [r for r in si_all if (r.get("filing_date") or "") >= si_cutoff]
-        if si_all and not si_rows:
+        if (
+            si_all
+            and not si_rows
+            and not self._source_is_fresh(
+                # investor_class 필터는 잠금 테스트 의무이자 의미상 정확 — 이 에이전트의
+                # universe 는 conviction 이므로 소스 신선도도 conviction 제출분으로 잰다
+                "SELECT MAX(filing_date) FROM superinvestors WHERE investor_class = 'conviction'",
+                si_cutoff,
+                db_path,
+            )
+        ):
             latest = max(r.get("filing_date") or "?" for r in si_all)
             stale_sources.append("superinvestors")
             reasons.append(f"슈퍼투자자 13F 낡음(최신 {latest}) — 제외")
@@ -83,8 +108,9 @@ class SmartMoneyAgent(BaseAgent):
             db_path,
         )
         if est_rows and (est_rows[0].get("date") or "") < est_cutoff:
-            stale_sources.append("estimates")
-            reasons.append(f"애널리스트 컨센서스 낡음(최신 {est_rows[0].get('date') or '?'}) — 제외")
+            if not self._source_is_fresh("SELECT MAX(date) FROM estimates", est_cutoff, db_path):
+                stale_sources.append("estimates")
+                reasons.append(f"애널리스트 컨센서스 낡음(최신 {est_rows[0].get('date') or '?'}) — 제외")
             est_rows = []
         if est_rows:
             est = est_rows[0]
@@ -126,9 +152,13 @@ class SmartMoneyAgent(BaseAgent):
         )
         ark_rows = [r for r in ark_all if (r.get("date") or "") >= ark_cutoff]
         if ark_all and not ark_rows:
-            latest = max(r.get("date") or "?" for r in ark_all)
-            stale_sources.append("ark")
-            reasons.append(f"ARK 매매 낡음(최신 {latest}) — 제외")
+            # 소스 프로브는 `ark` 테이블이 아니라 `ark_source_dates` 다 (#1147): ark 는
+            # 보유 교집합 + Hold 스냅샷이라 "보유만 유지한 종목" 도 매매 행이 늙는다.
+            # 수집기가 필터 이전 사실을 기록하는 곳이 소스 신선도의 정본이다.
+            if not self._source_is_fresh("SELECT MAX(csv_date) FROM ark_source_dates", ark_cutoff, db_path):
+                latest = max(r.get("date") or "?" for r in ark_all)
+                stale_sources.append("ark")
+                reasons.append(f"ARK 매매 낡음(최신 {latest}) — 제외")
         if ark_rows:
             buys = sum(1 for r in ark_rows if r["direction"] == "Buy")
             sells = sum(1 for r in ark_rows if r["direction"] == "Sell")

--- a/tests/trading/agents/test_agents_branch_coverage.py
+++ b/tests/trading/agents/test_agents_branch_coverage.py
@@ -10,11 +10,17 @@ Privacy: AAA/BBB synthetic tickers, no real holdings.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import timedelta
 
 import pandas as pd
 import pytest
 
 from nuri.core.db import get_db
+from nuri.core.timezone import kst_now
+
+# 오늘 앵커 날짜 — 고정 리터럴은 시한폭탄 (tests/CLAUDE.md Time-bomb seed dates, #1187)
+_ARK_FRESH_DATE = (kst_now() - timedelta(days=3)).strftime("%Y-%m-%d")
+_ARK_FRESHER_DATE = (kst_now() - timedelta(days=2)).strftime("%Y-%m-%d")
 
 # ─── crypto_agent.py: lines 65-66 (BTC -7% mid-crash branch) ────────────
 
@@ -522,11 +528,11 @@ class TestSmartMoneyArkSells:
         with get_db(db_path) as conn:
             # 다른 fund / date — UNIQUE constraint (date,ticker,fund) 회피
             funds_dates = [
-                ("ARKK", "2026-04-25"),
-                ("ARKW", "2026-04-25"),
-                ("ARKG", "2026-04-25"),
-                ("ARKQ", "2026-04-25"),
-                ("ARKF", "2026-04-25"),
+                ("ARKK", _ARK_FRESH_DATE),
+                ("ARKW", _ARK_FRESH_DATE),
+                ("ARKG", _ARK_FRESH_DATE),
+                ("ARKQ", _ARK_FRESH_DATE),
+                ("ARKF", _ARK_FRESH_DATE),
             ]
             for fund, date in funds_dates:
                 conn.execute(
@@ -537,7 +543,7 @@ class TestSmartMoneyArkSells:
             conn.execute(
                 """INSERT INTO ark (date, ticker, direction, shares, weight, fund)
                    VALUES (?, ?, ?, ?, ?, ?)""",
-                ("2026-04-26", "TSLA", "Buy", 500, 0.5, "ARKK"),
+                (_ARK_FRESHER_DATE, "TSLA", "Buy", 500, 0.5, "ARKK"),
             )
 
         v = SmartMoneyAgent().analyze("TSLA", db_path=db_path)

--- a/tests/trading/agents/test_smart_money.py
+++ b/tests/trading/agents/test_smart_money.py
@@ -1,4 +1,5 @@
 """Tests for smart_money agent — split from test_trading_agents_all.py."""
+
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -9,7 +10,13 @@ import pandas as pd
 import pytest
 
 from nuri.core.db import get_db, init_db, upsert_macro, upsert_portfolio, upsert_prices
+from nuri.core.timezone import kst_now
 from tests.trading.agents._helpers import _seed_macro, _seed_portfolio, _seed_prices, _seed_ticker  # noqa: F401
+
+
+def _d(days_ago: int) -> str:
+    """오늘 앵커 날짜 — 고정 리터럴은 시한폭탄 (tests/CLAUDE.md Time-bomb seed dates, #1187)."""
+    return (kst_now() - timedelta(days=days_ago)).strftime("%Y-%m-%d")
 
 
 class TestSmartMoneyBranches:
@@ -17,21 +24,20 @@ class TestSmartMoneyBranches:
 
     def test_superinvestor_buy(self, db_path):
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         with get_db(db_path) as conn:
             conn.execute(
-                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date) "
-                "VALUES (?, ?, ?, ?)",
-                ("Buffett", "GOOD", 8.0, "2025-03-01"),
+                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date) VALUES (?, ?, ?, ?)",
+                ("Buffett", "GOOD", 8.0, _d(30)),
             )
             conn.execute(
-                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date) "
-                "VALUES (?, ?, ?, ?)",
-                ("Dalio", "GOOD", 3.0, "2025-03-01"),
+                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date) VALUES (?, ?, ?, ?)",
+                ("Dalio", "GOOD", 3.0, _d(30)),
             )
             conn.execute(
                 "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("GOOD", "2025-03-25", "buy", 200.0, 100.0, 10),
+                ("GOOD", _d(5), "buy", 200.0, 100.0, 10),
             )
         v = SmartMoneyAgent().analyze("GOOD", db_path=db_path)
         assert v.action == "BUY"
@@ -39,22 +45,24 @@ class TestSmartMoneyBranches:
 
     def test_analyst_sell(self, db_path):
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         with get_db(db_path) as conn:
             conn.execute(
                 "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("BAD", "2025-03-25", "sell", 50.0, 100.0, 5),
+                ("BAD", _d(5), "sell", 50.0, 100.0, 5),
             )
         v = SmartMoneyAgent().analyze("BAD", db_path=db_path)
         assert v.action == "SELL"
 
     def test_ark_buy(self, db_path):
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         with get_db(db_path) as conn:
             for i in range(3):
                 conn.execute(
                     "INSERT INTO ark (ticker, date, direction, shares) VALUES (?, ?, ?, ?)",
-                    ("ARKY", f"2025-03-{20+i:02d}", "Buy", 1000),
+                    ("ARKY", _d(4 - i), "Buy", 1000),
                 )
         v = SmartMoneyAgent().analyze("ARKY", db_path=db_path)
         assert "ARK" in v.reasoning
@@ -63,6 +71,7 @@ class TestSmartMoneyBranches:
 class TestSmartMoneyAgent_R26:
     def test_no_data(self, db_path):
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         result = SmartMoneyAgent().analyze("AAPL", db_path=db_path)
         assert result.action == "HOLD"
         assert "없음" in result.reasoning
@@ -72,19 +81,20 @@ class TestSmartMoneyAgent_R26:
             conn.execute(
                 "INSERT INTO superinvestors (investor, ticker, shares, portfolio_pct, filing_date) "
                 "VALUES (?, ?, ?, ?, ?)",
-                ("Buffett", "AAPL", 1000, 8.0, "2025-03-01"),
+                ("Buffett", "AAPL", 1000, 8.0, _d(30)),
             )
             conn.execute(
                 "INSERT INTO superinvestors (investor, ticker, shares, portfolio_pct, filing_date) "
                 "VALUES (?, ?, ?, ?, ?)",
-                ("Gates", "AAPL", 500, 3.0, "2025-03-01"),
+                ("Gates", "AAPL", 500, 3.0, _d(30)),
             )
             conn.execute(
                 "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("AAPL", "2025-03-01", "buy", 200, 150, 20),
+                ("AAPL", _d(30), "buy", 200, 150, 20),
             )
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         result = SmartMoneyAgent().analyze("AAPL", db_path=db_path)
         assert result.action == "BUY"
 
@@ -94,9 +104,10 @@ class TestSmartMoneyAgent_R26:
             conn.execute(
                 "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("AAPL", "2025-03-01", "sell", 100, 150, 10),
+                ("AAPL", _d(30), "sell", 100, 150, 10),
             )
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         result = SmartMoneyAgent().analyze("AAPL", db_path=db_path)
         assert any("하회" in r for r in result.reasoning.split("; "))
 
@@ -104,6 +115,7 @@ class TestSmartMoneyAgent_R26:
 class TestSmartMoneyAgent_Source_Final:
     def test_no_data(self, db_path):
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         agent = SmartMoneyAgent()
         v = agent.analyze("NEWCO", db_path=db_path)
         assert v.action in ("BUY", "SELL", "HOLD")
@@ -115,9 +127,10 @@ class TestSmartMoneyAgent_Source_Final:
                 conn.execute(
                     "INSERT INTO superinvestors (investor, filing_date, ticker, shares, market_value, portfolio_pct) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    (inv, "2026-03-01", "AAPL", 1000000, 150000000, 3.5),
+                    (inv, _d(30), "AAPL", 1000000, 150000000, 3.5),
                 )
         from nuri.trading.agents.smart_money import SmartMoneyAgent
+
         agent = SmartMoneyAgent()
         v = agent.analyze("AAPL", db_path=db_path)
         assert v.action in ("BUY", "SELL", "HOLD")

--- a/tests/trading/agents/test_smart_money_branches.py
+++ b/tests/trading/agents/test_smart_money_branches.py
@@ -11,8 +11,16 @@ Branches:
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from nuri.core.db import get_db
+from nuri.core.timezone import kst_now
 from nuri.trading.agents.smart_money import SmartMoneyAgent
+
+
+def _d(days_ago: int) -> str:
+    """오늘 앵커 날짜 — 고정 리터럴은 시한폭탄 (tests/CLAUDE.md Time-bomb seed dates, #1187)."""
+    return (kst_now() - timedelta(days=days_ago)).strftime("%Y-%m-%d")
 
 
 class TestSmartMoneyBranches:
@@ -26,7 +34,7 @@ class TestSmartMoneyBranches:
                 "INSERT INTO estimates "
                 "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("TESTHO", "2026-01-01", "hold", 105.0, 100.0, 8),  # upside +5% < 20%
+                ("TESTHO", _d(5), "hold", 105.0, 100.0, 8),  # upside +5% < 20%
             )
         v = SmartMoneyAgent().analyze("TESTHO", db_path=db_path)
         # rec=hold 이라 buy/sell 분기 미진입; upside=5% (>0 but <20) → 76→81
@@ -43,7 +51,7 @@ class TestSmartMoneyBranches:
                 "INSERT INTO estimates "
                 "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("NOPX", "2026-01-01", "buy", None, 100.0, 5),
+                ("NOPX", _d(5), "buy", None, 100.0, 5),
             )
         v = SmartMoneyAgent().analyze("NOPX", db_path=db_path)
         # rec=buy → score+=1, 그러나 target=None → 71→81 False → 목표가 reasons 미추가
@@ -56,7 +64,7 @@ class TestSmartMoneyBranches:
                 "INSERT INTO estimates "
                 "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("MIDUP", "2026-01-01", "buy", 110.0, 100.0, 5),  # upside +10% (between -10/+20)
+                ("MIDUP", _d(5), "buy", 110.0, 100.0, 5),  # upside +10% (between -10/+20)
             )
         v = SmartMoneyAgent().analyze("MIDUP", db_path=db_path)
         # upside=10% → 73(>20) False, 76(<-10) False → score 추가/감소 미발생
@@ -69,7 +77,7 @@ class TestSmartMoneyBranches:
             for i, direction in enumerate(["Sell", "Sell", "Sell", "Buy"]):
                 conn.execute(
                     "INSERT INTO ark (ticker, date, direction, shares) VALUES (?, ?, ?, ?)",
-                    ("ARKSL", f"2026-03-{20 + i:02d}", direction, 1000),
+                    ("ARKSL", _d(4 - i), direction, 1000),
                 )
         v = SmartMoneyAgent().analyze("ARKSL", db_path=db_path)
         assert "ARK 최근 매도" in v.reasoning
@@ -83,12 +91,12 @@ class TestSmartMoneyBranches:
                 "INSERT INTO estimates "
                 "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("EQAR", "2026-01-01", "buy", 130.0, 100.0, 5),
+                ("EQAR", _d(5), "buy", 130.0, 100.0, 5),
             )
             for i, direction in enumerate(["Buy", "Sell"]):  # 1:1
                 conn.execute(
                     "INSERT INTO ark (ticker, date, direction, shares) VALUES (?, ?, ?, ?)",
-                    ("EQAR", f"2026-03-{20 + i:02d}", direction, 1000),
+                    ("EQAR", _d(4 - i), direction, 1000),
                 )
         v = SmartMoneyAgent().analyze("EQAR", db_path=db_path)
         assert "ARK 최근" not in v.reasoning
@@ -108,12 +116,12 @@ class TestSmartMoneyBranches:
                 "INSERT INTO estimates "
                 "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("HOLDONLY", "2026-01-01", "buy", 130.0, 100.0, 5),
+                ("HOLDONLY", _d(5), "buy", 130.0, 100.0, 5),
             )
             for i in range(5):
                 conn.execute(
                     "INSERT INTO ark (ticker, date, direction, shares, fund) VALUES (?, ?, ?, ?, ?)",
-                    ("HOLDONLY", f"2026-03-{20 + i:02d}", "Hold", 0.0, f"ARK{i}"),
+                    ("HOLDONLY", _d(4 - i), "Hold", 0.0, f"ARK{i}"),
                 )
         v = SmartMoneyAgent().analyze("HOLDONLY", db_path=db_path)
         assert "ARK 최근 매도" not in v.reasoning
@@ -135,7 +143,7 @@ class TestSmartMoneyBranches:
                 "INSERT INTO estimates "
                 "(ticker, date, recommendation, target_mean, current_price, num_analysts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                ("RAWHOLD", "2026-01-01", "buy", 130.0, 100.0, 5),
+                ("RAWHOLD", _d(5), "buy", 130.0, 100.0, 5),
             )
 
         agent = SmartMoneyAgent()
@@ -158,12 +166,117 @@ class TestSmartMoneyBranches:
             for i in range(3):  # 오래된 진짜 매수
                 conn.execute(
                     "INSERT INTO ark (ticker, date, direction, shares, fund) VALUES (?, ?, ?, ?, ?)",
-                    ("CROWD", f"2026-03-0{1 + i}", "Buy", 1000.0, f"ARK{i}"),
+                    ("CROWD", _d(10 - i), "Buy", 1000.0, f"ARK{i}"),
                 )
             for i in range(5):  # 그 위를 덮는 최신 Hold 스냅샷
                 conn.execute(
                     "INSERT INTO ark (ticker, date, direction, shares, fund) VALUES (?, ?, ?, ?, ?)",
-                    ("CROWD", f"2026-03-{20 + i:02d}", "Hold", 0.0, f"ARK{i}"),
+                    ("CROWD", _d(4 - i), "Hold", 0.0, f"ARK{i}"),
                 )
         v = SmartMoneyAgent().analyze("CROWD", db_path=db_path)
         assert "ARK 최근 매수 3건" in v.reasoning
+
+
+class TestSourceFreshnessSuppression:
+    """#1187: source 별 신선도 억제 — 낡은 소스는 점수 0 + '낡음 — 제외' 명시.
+
+    축별로 따로 잠근다 (mutation-axes 규칙): 한 소스의 컷오프를 지워도
+    다른 소스 테스트는 초록이므로 축마다 전용 테스트가 있어야 한다.
+    """
+
+    def test_stale_superinvestors_are_excluded_with_note(self, db_path):
+        """13F 가 컷오프(200d)보다 낡으면 보유·신규매수 점수 모두 0 + 명시."""
+        with get_db(db_path) as conn:
+            for inv in ("Buffett", "Dalio", "Gates"):
+                conn.execute(
+                    "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date, investor_class) "
+                    "VALUES (?, ?, ?, ?, 'conviction')",
+                    (inv, "STALE13F", 8.0, _d(300)),
+                )
+        v = SmartMoneyAgent().analyze("STALE13F", db_path=db_path)
+        assert "슈퍼투자자 13F 낡음" in v.reasoning
+        assert "슈퍼투자자 3명 보유" not in v.reasoning
+        assert "최근 신규 매수" not in v.reasoning
+        assert v.data_points["score"] == 0
+        assert "superinvestors" in v.data_points["stale_sources"]
+
+    def test_fresh_superinvestors_still_score(self, db_path):
+        with get_db(db_path) as conn:
+            for inv in ("Buffett", "Dalio"):
+                conn.execute(
+                    "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date, investor_class) "
+                    "VALUES (?, ?, ?, ?, 'conviction')",
+                    (inv, "FRESH13F", 8.0, _d(30)),
+                )
+        v = SmartMoneyAgent().analyze("FRESH13F", db_path=db_path)
+        assert "슈퍼투자자 2명 보유" in v.reasoning
+        assert v.data_points["stale_sources"] == []
+
+    def test_stale_estimates_are_excluded_with_note(self, db_path):
+        """estimates 최신 행이 45d 컷오프보다 낡으면 등급/목표가 점수 제외 + 명시."""
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("STALEEST", _d(90), "strong_buy", 200.0, 100.0, 10),
+            )
+        v = SmartMoneyAgent().analyze("STALEEST", db_path=db_path)
+        assert "애널리스트 컨센서스 낡음" in v.reasoning
+        assert "애널리스트: strong_buy" not in v.reasoning
+        assert "목표가" not in v.reasoning
+        assert v.data_points["score"] == 0
+        assert "estimates" in v.data_points["stale_sources"]
+
+    def test_stale_ark_trades_are_excluded_with_note(self, db_path):
+        """ARK 매매가 14d 컷오프보다 낡으면 ± 점수 제외 + 명시 — 235d stale ±1 사고의 재발 방지."""
+        with get_db(db_path) as conn:
+            for i in range(3):
+                conn.execute(
+                    "INSERT INTO ark (ticker, date, direction, shares) VALUES (?, ?, ?, ?)",
+                    ("STALEARK", _d(235 + i), "Buy", 1000),
+                )
+        v = SmartMoneyAgent().analyze("STALEARK", db_path=db_path)
+        assert "ARK 매매 낡음" in v.reasoning
+        assert "ARK 최근 매수" not in v.reasoning
+        assert v.data_points["score"] == 0
+        assert "ark" in v.data_points["stale_sources"]
+
+    def test_mixed_ark_counts_only_fresh_rows(self, db_path):
+        """창 안에 낡은 Sell + 신선한 Buy 가 섞이면 신선한 것만 센다."""
+        with get_db(db_path) as conn:
+            for i in range(2):  # 낡은 Sell
+                conn.execute(
+                    "INSERT INTO ark (ticker, date, direction, shares) VALUES (?, ?, ?, ?)",
+                    ("MIXARK", _d(60 + i), "Sell", 1000),
+                )
+            for i in range(2):  # 신선한 Buy
+                conn.execute(
+                    "INSERT INTO ark (ticker, date, direction, shares) VALUES (?, ?, ?, ?)",
+                    ("MIXARK", _d(1 + i), "Buy", 1000),
+                )
+        v = SmartMoneyAgent().analyze("MIXARK", db_path=db_path)
+        assert "ARK 최근 매수 2건" in v.reasoning
+        assert "ARK 매매 낡음" not in v.reasoning
+
+    def test_all_sources_stale_returns_hold_with_exclusion_notes(self, db_path):
+        """전 소스 낡음 → '데이터 없음' 이 아니라 제외 사유가 나열된 HOLD."""
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date, investor_class) "
+                "VALUES ('Buffett', 'ALLSTALE', 8.0, ?, 'conviction')",
+                (_d(300),),
+            )
+            conn.execute(
+                "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
+                "VALUES ('ALLSTALE', ?, 'buy', 200.0, 100.0, 10)",
+                (_d(90),),
+            )
+            conn.execute(
+                "INSERT INTO ark (ticker, date, direction, shares) VALUES ('ALLSTALE', ?, 'Buy', 1000)",
+                (_d(235),),
+            )
+        v = SmartMoneyAgent().analyze("ALLSTALE", db_path=db_path)
+        assert v.action == "HOLD"
+        assert "스마트머니 데이터 없음" not in v.reasoning
+        assert "낡음" in v.reasoning
+        assert set(v.data_points["stale_sources"]) == {"superinvestors", "estimates", "ark"}

--- a/tests/trading/agents/test_smart_money_branches.py
+++ b/tests/trading/agents/test_smart_money_branches.py
@@ -341,3 +341,24 @@ class TestStaleRowsVsFreshSource:
         assert "ARK 매매 낡음" not in v.reasoning
         assert "ARK 최근 매수" not in v.reasoning  # 낡은 매매는 점수에도 안 들어감
         assert "ark" not in v.data_points.get("stale_sources", [])
+
+    def test_probe_empty_result_counts_as_not_fresh(self, db_path, monkeypatch):
+        """프로브가 빈 결과(테이블 부재 등 _safe_query 예외 흡수)면 미상 = 신선 아님 →
+        낡은 행만 있으면 노트가 난다. 부재를 신선으로 치면 '진짜 낡았는데 침묵' 이 된다."""
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO ark (ticker, date, direction, shares) VALUES ('NOPROBE', ?, 'Buy', 1000)",
+                (_d(60),),
+            )
+        agent = SmartMoneyAgent()
+        real = agent._safe_query
+
+        def _probe_blind(sql, params, dbp):
+            if "ark_source_dates" in sql:
+                return []  # 테이블 부재 → _safe_query 가 예외를 먹고 빈 리스트
+            return real(sql, params, dbp)
+
+        monkeypatch.setattr(agent, "_safe_query", _probe_blind)
+        v = agent.analyze("NOPROBE", db_path=db_path)
+        assert "ARK 매매 낡음" in v.reasoning
+        assert "ark" in v.data_points["stale_sources"]

--- a/tests/trading/agents/test_smart_money_branches.py
+++ b/tests/trading/agents/test_smart_money_branches.py
@@ -280,3 +280,64 @@ class TestSourceFreshnessSuppression:
         assert "스마트머니 데이터 없음" not in v.reasoning
         assert "낡음" in v.reasoning
         assert set(v.data_points["stale_sources"]) == {"superinvestors", "estimates", "ark"}
+
+
+class TestStaleRowsVsFreshSource:
+    """#1187 Codex P2 ×2: 티커 행만 낡은 것(정상 부재)과 소스 staleness 를 구분한다.
+
+    - 13F 에서 팔린 종목: 소스는 매 분기 갱신 중인데 그 티커의 마지막 보유 행만 늙는다
+    - ARK 보유 유지 종목: Hold 스냅샷은 매일 오는데 마지막 Buy/Sell 행만 늙는다
+    둘 다 "낡음 — 제외" 노트 없이 조용히 제외돼야 한다. 소스 프로브는 ark 의 경우
+    `ark_source_dates` (#1147 — ark 테이블은 보유 교집합이라 소스 신선도의 정본이 아님).
+    """
+
+    def test_sold_out_13f_name_is_silent_absence_not_stale_note(self, db_path):
+        with get_db(db_path) as conn:
+            # 이 티커의 마지막 보유는 300일 전 (매도 종결)
+            conn.execute(
+                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date, investor_class) "
+                "VALUES ('Buffett', 'SOLDOUT', 8.0, ?, 'conviction')",
+                (_d(300),),
+            )
+            # 소스는 살아 있다 — 다른 티커에 신선한 제출분
+            conn.execute(
+                "INSERT INTO superinvestors (investor, ticker, portfolio_pct, filing_date, investor_class) "
+                "VALUES ('Buffett', 'OTHER', 5.0, ?, 'conviction')",
+                (_d(30),),
+            )
+        v = SmartMoneyAgent().analyze("SOLDOUT", db_path=db_path)
+        assert "낡음" not in v.reasoning
+        assert "슈퍼투자자" not in v.reasoning  # 점수 기여도 없음 (조용한 부재)
+        assert "superinvestors" not in v.data_points.get("stale_sources", [])
+
+    def test_stale_estimates_with_fresh_source_is_silent(self, db_path):
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
+                "VALUES ('DROPPED', ?, 'buy', 200.0, 100.0, 10)",
+                (_d(90),),
+            )
+            conn.execute(
+                "INSERT INTO estimates (ticker, date, recommendation, target_mean, current_price, num_analysts) "
+                "VALUES ('COVERED', ?, 'buy', 300.0, 200.0, 12)",
+                (_d(3),),
+            )
+        v = SmartMoneyAgent().analyze("DROPPED", db_path=db_path)
+        assert "낡음" not in v.reasoning
+        assert "애널리스트" not in v.reasoning
+
+    def test_ark_held_steady_with_fresh_snapshots_is_silent(self, db_path):
+        with get_db(db_path) as conn:
+            # 마지막 매매는 60일 전이지만, 소스(ark_source_dates)는 매일 갱신 중
+            conn.execute(
+                "INSERT INTO ark (ticker, date, direction, shares) VALUES ('HELD', ?, 'Buy', 1000)",
+                (_d(60),),
+            )
+            conn.execute(
+                "INSERT INTO ark_source_dates (fund, csv_date, observed_at) VALUES ('ARKK', ?, ?)",
+                (_d(1), _d(1)),
+            )
+        v = SmartMoneyAgent().analyze("HELD", db_path=db_path)
+        assert "ARK 매매 낡음" not in v.reasoning
+        assert "ARK 최근 매수" not in v.reasoning  # 낡은 매매는 점수에도 안 들어감
+        assert "ark" not in v.data_points.get("stale_sources", [])


### PR DESCRIPTION
Closes #1187

## What
PR 4 (final) of the dashboard-honesty sequence (#1180 → #1182 → #1185). smart_money's three sources (13F superinvestors, analyst estimates, ARK trades) fed the ±score with no age check — a 235d-stale ARK Buy surfaced as "ARK 최근 매수 ±1".

- **Config-driven max-age per source** (`config/agents.yaml smart_money.freshness`): 13F 200d (quarterly + 45d filing lag), estimates 45d, ARK 14d (aligned with `config/freshness.yaml` ark fail 336h). Rows past cutoff are excluded from scoring.
- **Source staleness vs normal absence** (Codex P2 ×2): the "낡음(최신 날짜) — 제외" note fires only when a source-level probe confirms the *source* is stale. A sold-out 13F name or an ARK position held steady is normal absence and is excluded silently. ARK's source probe is `ark_source_dates` (#1147 — the `ark` table is a holdings intersection, not source truth). `data_points.stale_sources` exposes the excluded list.
- The 13F position-change ("최근 신규 매수") query shares the 13F cutoff.
- Fixed-date fixtures in three test files re-anchored to `kst_now()` per the time-bomb rule; per-axis suppression tests + absence-vs-staleness distinction tests added.

## Codex review (Flow phase 4)
GATE: PASS (no P1). Both P2s (sold-out 13F / ARK hold mislabeled as stale) resolved with the source-level probes above.

## Verification
- 7480 passed / lint clean / pyright 165 ≤ ratchet
- Live dev-DB run: TSLA now reads "슈퍼투자자 1명 보유; 애널리스트 컨센서스 낡음(최신 2026-04-28) — 제외; ARK 매매 낡음(최신 2026-03-30) — 제외" with `stale_sources: ['estimates','ark']` — previously both stale sources contributed silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)