### PR TITLE
chore: doctor follow-up — skill frontmatter repair, derivable trim, cspell term

### DIFF
--- a/.claude/skills/nuri-harness-debug/SKILL.md
+++ b/.claude/skills/nuri-harness-debug/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: nuri-harness-debug
-description: LLM 에이전트 실패 패턴 디버깅 — 코드/툴 레벨 (§5.1-5.6: hallucination, phantom fix, test illusion, scope creep, context bias, stale number drift) + 대화/추론 레벨 (§5.14.1-2: data→recommendation slide, cross-context inconsistency). Use when user reports "test passes but doesn't cover the code", "fix applied but bug persists", "why does this keep failing the same way", "Claude is hallucinating API", "갑자기 추천한 이유가 뭔가요", "왜 KR/US 다르게 적용했나요", or when a regression test needs a Gotcha-Test Pair citation. Case study narrative: git log of PR #272, #300-#307, session 2026-05-27.
+# ⚠️ 무인용 콜론(`§5.1-5.6: ...`)이 YAML 스캐너를 깨뜨려 frontmatter 전체가 드롭되던 것을
+# block scalar 로 수리 (2026-08-25 /doctor). 내용 무변경.
+description: >-
+  LLM 에이전트 실패 패턴 디버깅 — 코드/툴 레벨 (§5.1-5.6: hallucination, phantom fix,
+  test illusion, scope creep, context bias, stale number drift) + 대화/추론 레벨
+  (§5.14.1-2: data→recommendation slide, cross-context inconsistency). Use when user
+  reports "test passes but doesn't cover the code", "fix applied but bug persists",
+  "why does this keep failing the same way", "Claude is hallucinating API",
+  "갑자기 추천한 이유가 뭔가요", "왜 KR/US 다르게 적용했나요", or when a regression test
+  needs a Gotcha-Test Pair citation. Case study narrative: git log of PR #272,
+  #300-#307, session 2026-05-27.
 ---
 
 # Harness Debug — 실패 패턴 + Gotcha-Test Pair

--- a/.cspell.json
+++ b/.cspell.json
@@ -390,6 +390,7 @@
     "bordercolor",
     "borderpad",
     "borderwidth",
+    "branchcov",
     "bsop",
     "busday",
     "calmar",

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,10 +27,6 @@ Client Components: `/report` (LLM generation), `/pipeline` (ReactFlow DAG), `/po
 
 **RSC boundary — never import a server util through a `"use client"` module.** next 16.2.9+ throws at *request time* (not build/vitest) when a Server Component calls a function re-exported from a `"use client"` module. `composition-section-lazy.tsx` is `"use client"` and re-exports the pure `parseCompositionTab`; importing it there from `page.tsx` made the whole dashboard render the error boundary. Import pure utils from their **source server module** (`composition-section`), take only the lazy wrapper component from the `-lazy` file. **Test:** `src/__tests__/pages/page-rsc-import-guard.test.tsx::page.tsx RSC import boundary` (asserts the import source — the runtime error is invisible to `next build` and jsdom render). (#731)
 
-## 18 Routes
-
-`/` (dashboard), `/signals`, `/consensus`, `/scan`, `/strategy`, `/rebalance`, `/engine`, `/pipeline`, `/report`, `/evidence`, `/portfolio`, `/targets`, `/advisor`, `/decisions`, `/decisions/[id]`, `/explore`, `/login`, `/ticker/[symbol]`.
-
 ## Design System (3 shared components)
 
 - `DataTable` — Universal table with column config, renderers, `rowClassName`, compact mode


### PR DESCRIPTION
From the 2026-08-25 /doctor pass (user-approved): YAML frontmatter repair for nuri-harness-debug (unquoted colons dropped every field — name/description/matching silently degraded), removal of the derivable routes list from frontend/CLAUDE.md, and registering "branchcov" so the IDE cSpell stops flagging it. cspell ASCII-order lock test green; frontend/CLAUDE.md now cspell-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)