### PR TITLE
docs: sync docs with the 2026-08-25 release batch and remeasure stale counts

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -26,7 +26,7 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 
 **CI gates** (every PR): `privacy-scan`, `pr-discipline` (commits ≤ 3 — escape `scope-expand-approved` label), test regression + Codecov 1% relative, `security-scan` (Trivy CRITICAL), `Doc Count Drift Check` (`make verify-doc-counts`).
 
-**게이트에 없는 것 — Playwright e2e.** `frontend/e2e/` 8 파일 57 테스트는 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `frontend/package.json` 의 `test:e2e` 스크립트로만 존재한다. 위 "dead gate" 항목들과 성격이 다르다 — 저건 게이트가 있는데 죽은 것이고, 이건 **처음부터 게이트가 아니다.** 결과: `410d385`(2026-05-04)가 `CONTEXT.SIEGE` 값을 rename 하면서 vitest 는 같이 고치고 e2e 는 두었는데, **3.5개월간 아무 신호가 없었다**(2026-08-20 수동 실행에서 발견, #1118). 배선은 별건이다 — 런타임·안정성 예산이 필요하고, 스위트가 자기 부하로 백엔드를 포화시키는 문제(#1119)가 선행 조건이다. 그 전까지는 대시보드를 건드리면 손으로 돌릴 것. 상세는 `frontend/CLAUDE.md` "E2E (Playwright)".
+**게이트에 없는 것 — Playwright e2e.** `frontend/e2e/` 8 파일 59 테스트는 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `frontend/package.json` 의 `test:e2e` 스크립트로만 존재한다. 위 "dead gate" 항목들과 성격이 다르다 — 저건 게이트가 있는데 죽은 것이고, 이건 **처음부터 게이트가 아니다.** 결과: `410d385`(2026-05-04)가 `CONTEXT.SIEGE` 값을 rename 하면서 vitest 는 같이 고치고 e2e 는 두었는데, **3.5개월간 아무 신호가 없었다**(2026-08-20 수동 실행에서 발견, #1118). 배선은 별건이다 — 런타임·안정성 예산이 필요하고, 스위트가 자기 부하로 백엔드를 포화시키는 문제(#1119)가 선행 조건이다. 그 전까지는 대시보드를 건드리면 손으로 돌릴 것. 상세는 `frontend/CLAUDE.md` "E2E (Playwright)".
 
 ## .claude/ 4-Layer Architecture (STRATEGY §5.10)
 

--- a/.cspell.json
+++ b/.cspell.json
@@ -375,6 +375,7 @@
     "bargap",
     "bargroupgap",
     "barlist",
+    "bashism",
     "bbands",
     "bbpos",
     "bdate",

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The dashboard at `:3000/` answers **"what should I do today?"** — Action-First
 
 | Section | Purpose |
 |---------|---------|
-| **Hero** | 4-stat ribbon — 총 자산 · 오늘 P&L · 누적 수익률 · 승률, with a provenance strip labeling every number as a **portfolio snapshot** (holdings + latest close, unrealized) as distinct from the adjudication ledger |
+| **Hero** | 4-stat ribbon — 총 자산 · 오늘 P&L · 누적 수익률 · 승률, with a provenance strip labeling the numbers as a **portfolio snapshot** (총 자산 = all accounts + cash; 오늘 · 누적 · 승률 = pension-excluded holdings, unrealized) as distinct from the adjudication ledger |
 | **System Health** | Certification score · Regime · Macro score · Data freshness |
 | **Action Items** | 🔴 즉시 실행 (stop-loss, Certification veto) · 🟡 오늘 확인 (take-profit, squeeze) · 🟦 리밸런스 · ✅ 유지 — each card links its **evidence chain** (`/decisions/{id}`, dated `as_of`) when a same-date decision record exists |
 | **Macro Events** | Deduplicated high-impact headlines with 한국어 categories |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ flowchart TB
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
 | **Collect** | 26 jobs, `*/5` during market hours down to weekly | external APIs | `prices` · `fundamentals` · `macro` · `news` |
-| **Analyze** | **no job** — 22 per-ticker signals · 10 regimes (6 base + 4 special) · 4-factor composite are computed when a report or an endpoint asks | `prices` · `macro` | nothing (`news.sentiment` aside) |
+| **Analyze** | **no job** — 22 signals (20 per-ticker actionable + 2 market-wide shadow) · 10 regimes (6 base + 4 special) · 4-factor composite are computed when a report or an endpoint asks | `prices` · `macro` | nothing (`news.sentiment` aside) |
 | **Consensus** | `consensus`, `5 7 * * *` | `recommendations.outcome_30d` (for weights) · collector tables | `recommendations` with `agent_verdicts` JSON |
 | **Certify** | **no job of its own** — `record_decisions` runs inside the consensus job; the `certifications` table is written by `premarket_brief` (`0 9 * * 1-5`) | consensus result **in memory** | `decisions` · `agent_decisions` · `certifications` |
 | **Track** | 4 jobs — `decision_pnl` `0 7`, `recommendation_outcomes` `2 7`, `alpha_tracking` `0 17`, `agent_accuracy` weekly | `recommendations` · `prices` | `outcome_{30,60,90}d` · `decision_outcomes` · `strategy_memory` |
@@ -126,7 +126,7 @@ The factor composite (`nuri/quant/factors/composite.py`) blends four terms — m
 
 That composite is then one input among several to the BUY-candidate scorer (`config/buy_signals.yaml`), which also weighs 5-day momentum, RSI, and 30-day breakout. Two further channels — cross-sectional relative strength and dollar-volume surge — are wired into that same formula at **weight 0**: they are computed and surfaced as evidence but contribute nothing to the score, and they stay that way until a walk-forward test justifies promoting them.
 
-Two signal registries exist and are deliberately not merged. The 22 in `config/signals.yaml` are **per-ticker and actionable**; `nuri/quant/validation/market_signals.py` holds 2 **market-wide shadow** signals (yield-curve inversion, HY-OAS widening) that carry `actionable: false` and surface as warnings only.
+`config/signals.yaml` holds 22 entries of two deliberately unmerged kinds. 20 are **per-ticker and actionable** — the backtest detector registry. The other 2 — yield-curve inversion and HY-OAS widening — are **market-wide shadow** signals: their metadata carries `actionable: false`, their detectors live in `nuri/quant/validation/market_signals.py`, and they surface as warnings only.
 
 Detail: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Certification spec: [`docs/CERTIFICATION_SPEC.md`](docs/CERTIFICATION_SPEC.md).
 
@@ -186,13 +186,15 @@ The dashboard at `:3000/` answers **"what should I do today?"** — Action-First
 
 | Section | Purpose |
 |---------|---------|
-| **Hero** | 4-stat ribbon — 총 자산 · 오늘 P&L · 누적 수익률 · 승률 |
+| **Hero** | 4-stat ribbon — 총 자산 · 오늘 P&L · 누적 수익률 · 승률, with a provenance strip labeling every number as a **portfolio snapshot** (holdings + latest close, unrealized) as distinct from the adjudication ledger |
 | **System Health** | Certification score · Regime · Macro score · Data freshness |
-| **Action Items** | 🔴 즉시 실행 (stop-loss, Certification veto) · 🟡 오늘 확인 (take-profit, squeeze) · 🟦 리밸런스 · ✅ 유지 |
+| **Action Items** | 🔴 즉시 실행 (stop-loss, Certification veto) · 🟡 오늘 확인 (take-profit, squeeze) · 🟦 리밸런스 · ✅ 유지 — each card links its **evidence chain** (`/decisions/{id}`, dated `as_of`) when a same-date decision record exists |
 | **Macro Events** | Deduplicated high-impact headlines with 한국어 categories |
 | **Composition** | Donut chart — 자산 / 섹터 / 계좌 tabs |
 | **Holdings table** | Sorted by `positionPct` desc · top 8 + expand |
 | **Opportunity Explorer** | Top 3 non-portfolio tickers · pros / cons / verdict |
+
+The dashboard's one-line verdict is gated on data freshness: if any input it depends on (prices, VIX, Fear & Greed, market rates, monthly macro, consensus — the `verdict_gate` list in [`config/freshness.yaml`](config/freshness.yaml)) has gone FAIL-stale, the verdict declines to advise and names the stale inputs instead of rendering a judgment on old data.
 
 Korean tickers display as names (삼성전자) instead of codes (005930.KS). 18 routes total.
 
@@ -268,21 +270,21 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 
 ## Project Stats
 
-Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
+Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
 
 | Metric | Value | |
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,449 across 127 files — 100% statement coverage | |
-| **E2E tests** | 57 across 8 Playwright specs | |
+| **Frontend tests** | 1,461 across 127 files — 100% statement coverage | |
+| **E2E tests** | 59 across 8 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
 | **Scheduler jobs** | 57 cron entries (APScheduler, in-process) | |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
-| **Trading signals** | 22 per-ticker (actionable) + 2 market-wide (shadow) | |
+| **Trading signals** | 22 — 20 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 72 (FastAPI on `:8001`) | |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
 | **DB tables** | SQLite WAL · 58 tables (56 forward-only migrations) | ✅ |
@@ -294,6 +296,8 @@ Measured against `main` on 2026-07-29. Counts marked ✅ are verified on every P
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — detailed code / DB layout, schema, env vars, CI/CD
 - [`docs/CERTIFICATION_SPEC.md`](docs/CERTIFICATION_SPEC.md) — 3-D certification spec
 - [`docs/KIS_INTEGRATION.md`](docs/KIS_INTEGRATION.md) — KIS (Korea Investment & Securities) Open API
+- [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md) — session-efficiency scripts, pre-push checklist
+- [`docs/FRESH_CLONE_SETUP.md`](docs/FRESH_CLONE_SETUP.md) — fresh-clone end-to-end verification (quarterly / onboarding)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — development workflow, PR discipline
 - [`SECURITY.md`](SECURITY.md) — security policy, LLM egress rules
 - [`CLAUDE.md`](CLAUDE.md) / [`AGENTS.md`](AGENTS.md) — agent guides (Claude Code / Cursor / Copilot)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Key DB access patterns:
 - `query_df(sql, params)` → pandas DataFrame
 - `upsert_*()` functions for each table (prices, portfolio, fundamentals, etc.)
 - `replace_portfolio_account(account, records)` — DELETE+INSERT in one tx for yaml→DB sync
-## Signal System (20 signals, YAML-driven registry)
+## Signal System (22 signals: 20 actionable + 2 shadow, YAML-driven registry)
 `signal_backtest.py` uses a **detector registry** — Python detector functions separated from metadata (thresholds/classification/hold_days). Metadata externalized to `config/signals.yaml` (`nuri/core/signal_config.py` loads); the yaml holds 22 entries — the 20 actionable ones below plus 2 market-wide shadow signals (`actionable: false`, detectors in `nuri/quant/validation/market_signals.py`). 4 categories:
 - **Price-based** (10): rsi_oversold/overbought, macd_golden/dead, sma_golden/dead, bb_bounce, volume_spike, gap_up, gap_down
 - **Macro-based** (3): vix_reversal, pcr_reversal, yield_curve_recovery — `merge_macro_data()` required
@@ -62,7 +62,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 ### Action-First Dashboard APIs (PR #264-#266)
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/actions` | GET | 우선순위 분류된 오늘의 액션 (🔴urgent/🟡check/✅hold). 연금/IRP 제외, 중복 제거. 각 항목에 `decision_id` + `as_of` (same-date `decisions` LEFT JOIN, #1182) — 프론트가 `/decisions/{id}` 증거 체인으로 링크 |
+| `/api/actions` | GET | 우선순위 분류된 오늘의 액션 (🔴urgent/🟡check/🟦portfolio/✅hold). 연금/IRP 제외, 중복 제거. 각 항목에 `decision_id` + `as_of` (same-date `decisions` LEFT JOIN, #1182) — 프론트가 `/decisions/{id}` 증거 체인으로 링크 |
 | `/api/opportunities` | GET | 비보유 이슈 종목 탐색 — scan + WSB + events 기반 찬성/반대/판정 |
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Key DB access patterns:
 - `upsert_*()` functions for each table (prices, portfolio, fundamentals, etc.)
 - `replace_portfolio_account(account, records)` — DELETE+INSERT in one tx for yaml→DB sync
 ## Signal System (20 signals, YAML-driven registry)
-`signal_backtest.py` uses a **detector registry** — Python detector functions separated from metadata (thresholds/classification/hold_days). Metadata externalized to `config/signals.yaml` (`nuri/core/signal_config.py` loads). 4 categories:
+`signal_backtest.py` uses a **detector registry** — Python detector functions separated from metadata (thresholds/classification/hold_days). Metadata externalized to `config/signals.yaml` (`nuri/core/signal_config.py` loads); the yaml holds 22 entries — the 20 actionable ones below plus 2 market-wide shadow signals (`actionable: false`, detectors in `nuri/quant/validation/market_signals.py`). 4 categories:
 - **Price-based** (10): rsi_oversold/overbought, macd_golden/dead, sma_golden/dead, bb_bounce, volume_spike, gap_up, gap_down
 - **Macro-based** (3): vix_reversal, pcr_reversal, yield_curve_recovery — `merge_macro_data()` required
 - **Data-dependent** (2): insider_cluster, short_squeeze — `merge_data_signals()` required
@@ -44,7 +44,7 @@ Special regimes (priority order, override base `regime` field): euphoria, stagfl
 Full certification architecture + 3-dimensional certification specification: **[`docs/CERTIFICATION_SPEC.md`](CERTIFICATION_SPEC.md)** (canonical). Confidence scoring formula: [`docs/STRATEGY.md` §3.3](STRATEGY.md). Gate policy: [`docs/STRATEGY.md` §6](STRATEGY.md).
 ## Pipeline Observability
 `nuri/core/events.py` — Append-only event journal. `emit_event()` records state transitions and always writes **valid JSON** to `payload` (#935). `get_pipeline_status()` returns 5-stage status. `get_timeline()` returns history with `causation_id` for chain tracing.
-`nuri/core/freshness.py` — Data freshness SLA. `FRESHNESS_POLICIES` defines warn/fail thresholds. `check_freshness(key)` returns PASS/WARN/FAIL. Sources: prices (48h/120h), VIX (24h/72h), F&G (24h/48h), consensus (24h/48h), certification (24h/48h).
+`nuri/core/freshness.py` — Data freshness SLA. `check_freshness(key)` returns PASS/WARN/FAIL. Thresholds (`warn_hours`/`fail_hours` per source) live in `config/freshness.yaml` (#1181) — `_load_config()` injects them at import and the key set is cross-checked both ways against `FRESHNESS_POLICIES` (missing or extra config key → ValueError). Queries/labels stay in code. `VERDICT_GATE_KEYS` + `stale_verdict_inputs()` feed the dashboard verdict's stale gate — FAIL only; WARN passes because weekend/holiday age is normal.
 `nuri/core/pipeline.py` — Pipeline orchestration. `STEP_DEPENDENCIES` defines the 5-stage DAG (`collect → analyze → consensus → certify → track`). `run_step()` enforces dependency completion + records events.
 Pipeline control API (`nuri/api/routes/pipeline.py`):
 - `GET /api/pipeline/status` — 5-stage status + record counts
@@ -56,13 +56,13 @@ Trade execution API (`nuri/api/routes/trades.py`):
 - `GET /api/trades` — List trades (optional ticker filter)
 - `PUT /api/trades/{id}` — Update exit info
 ## Dashboard API (Projection-based, <5s)
-`/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display.
+`/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display. The one-line `verdict` is stale-gated (#1181): when any `verdict_gate` input (`config/freshness.yaml`) is FAIL-stale, the response carries `verdict_level: "stale"` + `verdict_stale_inputs` and the verdict text names the stale inputs instead of advising.
 ## API (72 endpoints)
 `nuri/api/routes/` — 72 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 21 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
 ### Action-First Dashboard APIs (PR #264-#266)
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/actions` | GET | 우선순위 분류된 오늘의 액션 (🔴urgent/🟡check/✅hold). 연금/IRP 제외, 중복 제거 |
+| `/api/actions` | GET | 우선순위 분류된 오늘의 액션 (🔴urgent/🟡check/✅hold). 연금/IRP 제외, 중복 제거. 각 항목에 `decision_id` + `as_of` (same-date `decisions` LEFT JOIN, #1182) — 프론트가 `/decisions/{id}` 증거 체인으로 링크 |
 | `/api/opportunities` | GET | 비보유 이슈 종목 탐색 — scan + WSB + events 기반 찬성/반대/판정 |
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-51 tables total (56 migrations as of 2026-07-30). Key tables:
+58 tables total (56 migrations as of 2026-08-25). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -133,8 +133,9 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
 ## Config Files (`config/`)
 - `portfolio.yaml` — accounts + holdings (gitignored; shape ref: `portfolio.example.yaml`)
 - `stock_types.yaml` — Growth/value override per ticker. Controls stop-loss/take-profit thresholds.
-- `agents.yaml` — Agent thresholds + confidence normalization scales. Loaded via `nuri/core/agent_config.py`.
+- `agents.yaml` — Agent thresholds + confidence normalization scales (incl. `smart_money.freshness` per-source max-age, #1187). Loaded via `nuri/core/agent_config.py`.
 - `alerts.yaml` — Alert thresholds, report timing
+- `freshness.yaml` — Data freshness SLA thresholds (`warn_hours`/`fail_hours` per source) + `verdict_gate` input list. Loaded via `nuri/core/freshness.py` `_load_config()`.
 - `rules.yaml` — Investment rules. Loaded via `nuri/core/rules.py`.
 - `signals.yaml` — Signal metadata (thresholds, categories, hold_days)
 ## Scripts (`scripts/`)
@@ -158,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1449 frontend vitest (127 files) + 57 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1461 frontend vitest (127 files) + 59 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,8 +276,8 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1449 tests, 127 files |
-| E2E | 핵심 flow | 57 Playwright (8 spec) |
+| Frontend tests | 목표 ≥ 90% | 1461 tests, 127 files |
+| E2E | 핵심 flow | 59 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |
 ### 4.2 코드

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1455 tests, 127 files)
+npm run test           # vitest run (1461 tests, 127 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -79,7 +79,7 @@ should be **212**.
 
 ## E2E (Playwright) — runs against the real backend, gated by nothing
 
-`npm run test:e2e` (`npx playwright test`). 8 spec files under `e2e/`, 57 tests. `playwright.config.ts` starts both servers itself (`uvicorn` :8001, `npm run dev` :3000) with `reuseExistingServer: true`.
+`npm run test:e2e` (`npx playwright test`). 8 spec files under `e2e/`, 59 tests. `playwright.config.ts` starts both servers itself (`uvicorn` :8001, `npm run dev` :3000) with `reuseExistingServer: true`.
 
 - **No CI job, no Makefile target, no `scripts/verify/` step runs it.** It is the one suite in this repo that has never gated a merge, which is exactly how `410d385` (2026-05-04) renamed `CONTEXT.SIEGE` to `"Certification"`, updated the matching vitest files, and left three e2e assertions searching for `text=SIEGE` for 3.5 months. Wiring it into a gate is a separate decision (needs a runtime/stability budget); until then, run it by hand before touching the dashboard.
 - **Never inline a user-facing string literal in a spec — import it from `src/lib/strings.ts`.** That file is the single source of truth and specs can import across the directory boundary (`import { ACTION, CONTEXT } from "../src/lib/strings"`). The contrast is on record: `dashboard.spec.ts:19` survived the same rename only because it OR'd several candidate strings, while the three brittle single-literal assertions all broke.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,8 +7,8 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1449 tests, 127 files)
-npx playwright test    # E2E (57 tests, 8 specs)
+npm run test           # vitest (1461 tests, 127 files)
+npx playwright test    # E2E (59 tests, 8 specs)
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

Post-merge doc sync for the 2026-08-25 release batch (#1181–#1193), per `/document-release`.

**Feature surfacing (what shipped, where users read about it)**
- README dashboard section: verdict stale gate (`config/freshness.yaml` `verdict_gate`), per-card evidence-chain links (`/decisions/{id}` + `as_of`), hero provenance strip (portfolio snapshot vs adjudication ledger)
- ARCHITECTURE: `freshness.yaml` added to Config Files, freshness paragraph rewritten (thresholds externalized, `VERDICT_GATE_KEYS`/`stale_verdict_inputs()`, FAIL-only gating), `/api/dashboard` stale-gate response fields, `/api/actions` `decision_id`/`as_of` join

**Remeasured drift (exact numbers, measured today)**
- Frontend vitest 1449/1455 → **1461** (127 files) — README, ARCHITECTURE, STRATEGY, frontend/CLAUDE.md, frontend/README.md
- Playwright e2e 57 → **59** (8 specs; hero provenance specs) — same files + `.claude/rules/enforcement.md`
- ARCHITECTURE DB tables 51 → **58** (live `init_db` count; README's CI-gated 58 was already correct)
- Signal-registry claim corrected: `config/signals.yaml` = 22 entries — 20 per-ticker actionable (backtest registry) + 2 market-wide shadow (`actionable: false`, detectors in `market_signals.py`). The old text claimed all 22 were actionable and the shadow pair lived in a separate registry — measured false
- Project Stats header date 2026-07-29 → 2026-08-25

**Discoverability**
- `docs/DEVELOPER_GUIDE.md` and `docs/FRESH_CLONE_SETUP.md` were tracked but unreachable from README/CLAUDE.md — linked from README Documentation

**Gates**: `make verify-doc-counts` 22/22 green · `make diagnostics` green · privacy scan clean · cspell clean (registered pre-existing "bashism")

🤖 Generated with [Claude Code](https://claude.com/claude-code)