### PR TITLE
fix(frontend): unify currency formatting — KRW tickers rendered with $

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,461 across 127 files — 100% statement coverage | |
+| **Frontend tests** | 1,471 across 128 files — 100% statement coverage | |
 | **E2E tests** | 59 across 8 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,471 across 128 files — 100% statement coverage | |
+| **Frontend tests** | 1,472 across 128 files — 100% statement coverage | |
 | **E2E tests** | 59 across 8 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1471 frontend vitest (128 files) + 59 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1472 frontend vitest (128 files) + 59 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1461 frontend vitest (127 files) + 59 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1471 frontend vitest (128 files) + 59 Playwright E2E (8 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1461 tests, 127 files |
+| Frontend tests | 목표 ≥ 90% | 1471 tests, 128 files |
 | E2E | 핵심 flow | 59 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1471 tests, 128 files |
+| Frontend tests | 목표 ≥ 90% | 1472 tests, 128 files |
 | E2E | 핵심 flow | 59 Playwright (8 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1471 tests, 128 files)
+npm run test           # vitest run (1472 tests, 128 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1461 tests, 127 files)
+npm run test           # vitest run (1471 tests, 128 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -94,4 +94,4 @@ should be **212**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control.
 - Dashboard tests mock recharts at file level to avoid jsdom suspense on `CompositionDonut`.
 - Mock `@/lib/api` + `next/navigation` in all page tests.
-- Test files: 90 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 37 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 91 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 37 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1461 tests, 127 files)
+npm run test           # vitest (1471 tests, 128 files)
 npx playwright test    # E2E (59 tests, 8 specs)
 ```
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1471 tests, 128 files)
+npm run test           # vitest (1472 tests, 128 files)
 npx playwright test    # E2E (59 tests, 8 specs)
 ```
 

--- a/frontend/src/__tests__/components/holding-row.test.tsx
+++ b/frontend/src/__tests__/components/holding-row.test.tsx
@@ -69,8 +69,9 @@ describe("formatPrice", () => {
   it("formats USD < 100 with 2 decimals", () => {
     expect(formatPrice(45.67, "USD")).toBe("$45.67");
   });
-  it("formats USD >= 100 as integer with thousands separator", () => {
-    expect(formatPrice(2345, "USD")).toBe("$2,345");
+  it("formats USD >= 100 with 2 decimals and thousands separator (#1197 unified)", () => {
+    // 이전의 정수 반올림($2,345)은 액션 카드($195.50)와 같은 화면에서 표기 이원화를 만들었다
+    expect(formatPrice(2345, "USD")).toBe("$2,345.00");
   });
 });
 
@@ -316,8 +317,8 @@ describe("HoldingRow", () => {
 
   it("renders current price and avg price in compound cell (#214 polish)", () => {
     render(<HoldingRow holding={holdingFixture({ latestPrice: 245.67, avgPrice: 180 })} />);
-    expect(screen.getByText("$246")).toBeInTheDocument();  // formatPrice rounds ≥100
-    expect(screen.getByText("$180")).toBeInTheDocument();
+    expect(screen.getByText("$245.67")).toBeInTheDocument();  // #1197: USD 소수 2자리 통일
+    expect(screen.getByText("$180.00")).toBeInTheDocument();
   });
 
   it("renders em dash when latestPrice or avgPrice is null", () => {

--- a/frontend/src/__tests__/coverage/price-chart-tooltip-coverage.test.tsx
+++ b/frontend/src/__tests__/coverage/price-chart-tooltip-coverage.test.tsx
@@ -77,6 +77,23 @@ describe("PriceChart — Tooltip formatter", () => {
     expect(sma50Name).toBe("SMA50");
   });
 
+  // #1197 잠금: KR 티커 툴팁은 ₩ — 헤더는 ₩ 인데 툴팁만 $ 였던 혼합 표기 회귀 방지
+  it("formats KRW ticker tooltip prices with ₩", async () => {
+    const { PriceChart } = await import("@/components/ui/price-chart");
+    const data = Array.from({ length: 30 }, (_, i) => ({
+      date: `2024-01-${String((i % 28) + 1).padStart(2, "0")}`,
+      open: 1_120_000, high: 1_140_000, low: 1_100_000, close: 1_128_000 + i,
+      volume: 10_000,
+    }));
+    render(<PriceChart data={data} ticker="402340.KS" />);
+
+    expect(capturedFormatter).not.toBeNull();
+    const [closeLabel] = capturedFormatter!(1_128_000, "close");
+    expect(closeLabel).toBe("₩1,128,000");
+    const [smaLabel] = capturedFormatter!(1_130_000.4, "sma20");
+    expect(smaLabel).toBe("₩1,130,000");
+  });
+
   it("formats volume in K range", async () => {
     const { PriceChart } = await import("@/components/ui/price-chart");
     const data = Array.from({ length: 30 }, (_, i) => ({

--- a/frontend/src/__tests__/lib/format.test.ts
+++ b/frontend/src/__tests__/lib/format.test.ts
@@ -1,0 +1,87 @@
+// 통화·숫자 포맷 일원화 잠금 (#1197 U1b-1).
+// 잠금 1: KRW 판정은 티커 접미사(.KS/.KQ)/currency 로만 — 가격 크기 휴리스틱(v > 10000)은
+//        ₩8,145 종목을 $ 로 표기했던 버그라 되돌아오면 안 된다.
+// 잠금 2: 퍼센트는 부호 병기 — 색만으로 방향을 전달하지 않는다.
+import { describe, it, expect } from "vitest";
+import { isKrwTicker, formatMoney, formatPct, formatNum } from "@/lib/format";
+
+describe("isKrwTicker", () => {
+  it("detects KOSPI (.KS) and KOSDAQ (.KQ) suffixes", () => {
+    expect(isKrwTicker("005930.KS")).toBe(true);
+    expect(isKrwTicker("402340.KS")).toBe(true);
+    expect(isKrwTicker("035720.KQ")).toBe(true);
+  });
+
+  it("is case/whitespace tolerant", () => {
+    expect(isKrwTicker(" 005930.ks ")).toBe(true);
+    expect(isKrwTicker("035720.kq")).toBe(true);
+  });
+
+  it("rejects US tickers, empty, null, undefined", () => {
+    expect(isKrwTicker("TSLA")).toBe(false);
+    expect(isKrwTicker("BRK.B")).toBe(false);
+    expect(isKrwTicker("")).toBe(false);
+    expect(isKrwTicker(null)).toBe(false);
+    expect(isKrwTicker(undefined)).toBe(false);
+  });
+});
+
+describe("formatMoney", () => {
+  it("renders KRW as ₩ integer with thousand separators", () => {
+    expect(formatMoney(1128000, { ticker: "402340.KS" })).toBe("₩1,128,000");
+    expect(formatMoney(8145.4, { ticker: "0167Z0.KS" })).toBe("₩8,145");
+  });
+
+  it("renders USD as $ with 2 decimals and thousand separators", () => {
+    expect(formatMoney(345.13, { ticker: "TSLA" })).toBe("$345.13");
+    expect(formatMoney(1123000, { ticker: "TSLA" })).toBe("$1,123,000.00");
+  });
+
+  it("low-priced KRW ticker stays ₩ (the v>10000 heuristic bug)", () => {
+    expect(formatMoney(8145, { ticker: "0167Z0.KS" })).toBe("₩8,145");
+  });
+
+  it("high-priced US value stays $ (the reverse heuristic bug)", () => {
+    expect(formatMoney(985.82, { ticker: "CAT" })).toBe("$985.82");
+    expect(formatMoney(12000, {})).toBe("$12,000.00");
+  });
+
+  it("currency field overrides ticker inference", () => {
+    expect(formatMoney(1000, { ticker: "TSLA", currency: "KRW" })).toBe("₩1,000");
+    expect(formatMoney(10, { ticker: "005930.KS", currency: "USD" })).toBe("$10.00");
+    expect(formatMoney(1000, { currency: "krw" })).toBe("₩1,000");
+  });
+
+  it("returns em-dash for null/undefined/NaN", () => {
+    expect(formatMoney(null)).toBe("—");
+    expect(formatMoney(undefined)).toBe("—");
+    expect(formatMoney(Number.NaN, { ticker: "TSLA" })).toBe("—");
+  });
+});
+
+describe("formatPct", () => {
+  it("always carries the sign for positives", () => {
+    expect(formatPct(7.6)).toBe("+7.6%");
+    expect(formatPct(-8.0)).toBe("-8.0%");
+    expect(formatPct(0)).toBe("0.0%");
+  });
+
+  it("respects digits and handles null/NaN", () => {
+    expect(formatPct(29.0421, 2)).toBe("+29.04%");
+    expect(formatPct(null)).toBe("—");
+    expect(formatPct(Number.NaN)).toBe("—");
+  });
+});
+
+describe("formatNum", () => {
+  it("rounds raw floats (no 52.9428571428571 leakage)", () => {
+    expect(formatNum(52.9428571428571)).toBe("52.9");
+    expect(formatNum(71.5, 0)).toBe("72");
+  });
+
+  it("handles null/undefined/NaN", () => {
+    expect(formatNum(null)).toBe("—");
+    expect(formatNum(undefined)).toBe("—");
+    expect(formatNum(Number.NaN)).toBe("—");
+  });
+});

--- a/frontend/src/__tests__/pages/ticker-detail.test.tsx
+++ b/frontend/src/__tests__/pages/ticker-detail.test.tsx
@@ -257,6 +257,7 @@ describe("TickerPage", () => {
     const element = await mod.default({ params: Promise.resolve({ symbol: "TEST" }) });
     await act(async () => { render(element); });
 
-    expect(screen.getByText("$100")).toBeInTheDocument();
+    // formatMoney (#1197): USD 는 소수 2자리 고정
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/decisions/page.tsx
+++ b/frontend/src/app/decisions/page.tsx
@@ -6,6 +6,7 @@ import { fetchAPI } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { Metric } from "@/components/ui/metric";
+import { formatMoney } from "@/lib/format";
 import { DECISIONS, COMMON } from "@/lib/strings";
 
 // === Types ===
@@ -161,7 +162,7 @@ function DecisionTable({ decisions }: { decisions: Decision[] }) {
                   {d.regime ?? "—"}
                 </td>
                 <td className="px-3 py-2 text-right hidden md:table-cell font-mono text-xs">
-                  {d.entry_price ? `$${d.entry_price.toFixed(2)}` : "—"}
+                  {d.entry_price ? formatMoney(d.entry_price, { ticker: d.ticker }) : "—"}
                 </td>
                 <td className="px-3 py-2 text-right hidden lg:table-cell"><PnlCell value={d.pnl_7d} /></td>
                 <td className="px-3 py-2 text-right"><PnlCell value={d.pnl_30d} /></td>

--- a/frontend/src/app/ticker/[symbol]/page.tsx
+++ b/frontend/src/app/ticker/[symbol]/page.tsx
@@ -8,6 +8,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { Metric } from "@/components/ui/metric";
 import { PriceChartLazy as PriceChart } from "@/components/ui/price-chart-lazy";
 import { TICKER_DETAIL as TD } from "@/lib/strings";
+import { formatMoney } from "@/lib/format";
 
 interface AgentVerdict {
   agent_name: string;
@@ -140,7 +141,7 @@ export async function TickerDetail({ symbol }: { symbol: string }) {
         <h1 className="text-3xl font-bold">{data.name || data.ticker}</h1>
         {data.name && <span className="text-lg text-muted-foreground">{data.ticker}</span>}
         {data.price?.close && (
-          <span className="text-2xl text-foreground/80">${Number(data.price.close).toLocaleString()}</span>
+          <span className="text-2xl text-foreground/80">{formatMoney(Number(data.price.close), { ticker: data.ticker })}</span>
         )}
         {consensus.final_action && (
           <StatusBadge status={consensus.final_action} size="md" />
@@ -294,12 +295,12 @@ export async function TickerDetail({ symbol }: { symbol: string }) {
             <CardContent className="pt-5">
               <p className="text-xs text-muted-foreground mb-3">Price Targets ({targets.stock_type})</p>
               <div className="space-y-1.5 text-xs">
-                <div className="flex justify-between"><span className="text-muted-foreground">{TD.STOP_LOSS}</span><span className="text-red-400">${targets.stop_loss?.toFixed(2)} ({targets.stop_loss_pct}%)</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TARGET_1}</span><span className="text-emerald-400">${targets.target_1?.toFixed(2)} (+{targets.target_1_pct}%)</span></div>
-                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TARGET_2}</span><span className="text-emerald-400">${targets.target_2?.toFixed(2)} (+{targets.target_2_pct}%)</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.STOP_LOSS}</span><span className="text-red-400">{formatMoney(targets.stop_loss, { ticker: data.ticker })} ({targets.stop_loss_pct}%)</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TARGET_1}</span><span className="text-emerald-400">{formatMoney(targets.target_1, { ticker: data.ticker })} (+{targets.target_1_pct}%)</span></div>
+                <div className="flex justify-between"><span className="text-muted-foreground">{TD.TARGET_2}</span><span className="text-emerald-400">{formatMoney(targets.target_2, { ticker: data.ticker })} (+{targets.target_2_pct}%)</span></div>
                 <div className="flex justify-between"><span className="text-muted-foreground">{TD.TRAILING}</span><span className="text-muted-foreground">{targets.trailing_stop_pct}% from high</span></div>
                 {targets.analyst_target && (
-                  <div className="flex justify-between"><span className="text-muted-foreground">{TD.ANALYST}</span><span className="text-blue-400">${targets.analyst_target?.toFixed(2)} ({(targets.analyst_upside_pct ?? 0) > 0 ? "+" : ""}{targets.analyst_upside_pct}%)</span></div>
+                  <div className="flex justify-between"><span className="text-muted-foreground">{TD.ANALYST}</span><span className="text-blue-400">{formatMoney(targets.analyst_target, { ticker: data.ticker })} ({(targets.analyst_upside_pct ?? 0) > 0 ? "+" : ""}{targets.analyst_upside_pct}%)</span></div>
                 )}
               </div>
             </CardContent>

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { ACTION } from "@/lib/strings";
+import { formatMoney } from "@/lib/format";
 
 export interface ActionItem {
   ticker: string;
@@ -44,11 +45,8 @@ const priorityStyles = {
 function ActionCard({ item }: { item: ActionItem }) {
   const [expanded, setExpanded] = useState(false);
   const style = priorityStyles[item.priority as keyof typeof priorityStyles] || priorityStyles.hold;
-  const isKr = item.ticker.endsWith(".KS");
-  const fmt = (v: number | null | undefined) => {
-    if (v == null) return "—";
-    return isKr ? `₩${v.toLocaleString()}` : `$${v.toFixed(2)}`;
-  };
+  // 통화 판정은 lib/format 한 곳 (#1197) — 이전 로컬 판정은 .KQ(코스닥)를 놓쳤다
+  const fmt = (v: number | null | undefined) => formatMoney(v, { ticker: item.ticker });
 
   return (
     <div className={`rounded-lg p-3 ${style.bg} border ${style.border}`}>

--- a/frontend/src/components/ui/client-table.tsx
+++ b/frontend/src/components/ui/client-table.tsx
@@ -12,6 +12,7 @@
  */
 import { DataTable } from "./data-table";
 import { StatusBadge } from "./status-badge";
+import { formatMoney } from "@/lib/format";
 
 interface Props {
   variant: string;
@@ -32,10 +33,11 @@ const badge = (v: string) => <StatusBadge status={v} size="sm" />;
 const badgeMd = (v: string) => <StatusBadge status={v} size="md" />;
 const dim = (v: any) => <span className="text-muted-foreground text-xs">{String(v ?? "—")}</span>;
 const money = (v: number) => <span className="text-emerald-400">${v?.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span>;
-const price = (v: number) => {
+// 통화는 티커로 판정 (#1197) — 이전의 `v > 10000` 휴리스틱은 ₩8,145 종목을 $ 로,
+// $10,000 초과 미국 종목을 ₩ 로 표기했다. row 가 없는 호출은 USD 로 남는다.
+const price = (v: number, row?: { ticker?: string }) => {
   if (!v) return <span className="text-muted-foreground/70">—</span>;
-  const isKr = v > 10000;
-  return <span>{isKr ? `₩${v.toLocaleString()}` : `$${v.toFixed(2)}`}</span>;
+  return <span>{formatMoney(v, { ticker: row?.ticker })}</span>;
 };
 
 // === 변형별 컬럼 정의 ===
@@ -49,7 +51,7 @@ const VARIANTS: Record<string, any[]> = {
   ],
   scan: [
     { key: "ticker", label: "Ticker", render: ticker },
-    { key: "price", label: "Price", align: "right", render: (v: number) => `$${v?.toFixed(2)}` },
+    { key: "price", label: "Price", align: "right", render: price },
     { key: "change_1d", label: "1D", align: "right", render: pct },
     { key: "change_5d", label: "5D", align: "right", render: pct },
     { key: "rsi", label: "RSI", align: "right", render: num },
@@ -88,10 +90,10 @@ const VARIANTS: Record<string, any[]> = {
     { key: "ticker", label: "Ticker", render: ticker },
     { key: "stock_type", label: "Type", align: "center", render: (v: string) => badge(v === "growth" ? "momentum" : "HOLD") },
     { key: "current_price", label: "현재가", align: "right", render: price },
-    { key: "stop_loss", label: "손절가", align: "right", render: (v: number) => <span className="text-red-400">{price(v)}</span> },
-    { key: "target_1", label: "1차 익절", align: "right", render: (v: number) => <span className="text-emerald-400">{price(v)}</span> },
-    { key: "target_2", label: "2차 익절", align: "right", render: (v: number) => <span className="text-emerald-400">{price(v)}</span> },
-    { key: "analyst_target", label: "목표가", align: "right", render: (v: number) => v ? <span className="text-blue-400">{price(v)}</span> : dim("—") },
+    { key: "stop_loss", label: "손절가", align: "right", render: (v: number, row: any) => <span className="text-red-400">{price(v, row)}</span> },
+    { key: "target_1", label: "1차 익절", align: "right", render: (v: number, row: any) => <span className="text-emerald-400">{price(v, row)}</span> },
+    { key: "target_2", label: "2차 익절", align: "right", render: (v: number, row: any) => <span className="text-emerald-400">{price(v, row)}</span> },
+    { key: "analyst_target", label: "목표가", align: "right", render: (v: number, row: any) => v ? <span className="text-blue-400">{price(v, row)}</span> : dim("—") },
     { key: "take_profit_triggered", label: "시그널", align: "center", render: (_v: string | null, row: any) => {
       if (row.trailing_stop_triggered) return <span className="text-red-400 text-[10px] font-medium">TRAIL STOP</span>;
       if (_v === "target_2") return <span className="text-amber-400 text-[10px] font-medium">TP2 ({row.take_profit_sell_pct}%)</span>;
@@ -101,7 +103,7 @@ const VARIANTS: Record<string, any[]> = {
   ],
   swing: [
     { key: "ticker", label: "Ticker", render: ticker },
-    { key: "price", label: "Price", align: "right", render: (v: number) => `$${v?.toLocaleString()}` },
+    { key: "price", label: "Price", align: "right", render: price },
     { key: "scan_signal", label: "Signal", align: "center", render: badge },
     { key: "scan_score", label: "Score", align: "right" },
     { key: "agent_action", label: "Agent", align: "center", render: badgeMd },

--- a/frontend/src/components/ui/holding-row.tsx
+++ b/frontend/src/components/ui/holding-row.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 
 import { Sparkline } from "@/components/ui/sparkline";
 import { HOLDING_STATUS, HOLDING_LABEL } from "@/lib/strings";
+import { formatMoney, isKrwTicker } from "@/lib/format";
 
 // ── Raw input shapes (API response surfaces) ─────────────────
 export interface RawHolding {
@@ -189,8 +190,9 @@ export function buildEnrichedHoldings(
         .sort((a, b) => a.days - b.days)[0];
       const watch: WatchTrigger = upcoming ? { kind: "earnings", daysUntil: upcoming.days } : { kind: "none" };
 
+      // 통화 추론은 lib/format 한 곳 (#1197) — 이전 로컬 판정은 .KQ(코스닥)를 놓쳤다
       const currency: "USD" | "KRW" =
-        h.currency === "KRW" || h.ticker.endsWith(".KS") ? "KRW" : "USD";
+        h.currency === "KRW" || isKrwTicker(h.ticker) ? "KRW" : "USD";
 
       // #214: 일변 (오늘 vs 어제) + sparkline (30일 closes)
       const prevClose = h.previous_close;
@@ -260,10 +262,10 @@ export function buildEnrichedHoldings(
 }
 
 // ── Format helpers ───────────────────────────────────────────
+// 표기는 formatMoney 로 위임 (#1197 codex P2) — 같은 대시보드에서 액션 카드는 $195.50,
+// 보유 행은 $196 으로 갈리던 표기 이원화 제거. USD 는 항상 소수 2자리.
 export function formatPrice(price: number | null, currency: "USD" | "KRW"): string {
-  if (price == null) return "—";
-  if (currency === "KRW") return `₩${Math.round(price).toLocaleString()}`;
-  return price < 100 ? `$${price.toFixed(2)}` : `$${Math.round(price).toLocaleString()}`;
+  return formatMoney(price, { currency });
 }
 
 function statusVisual(s: HoldingStatus): { text: string; className: string } {

--- a/frontend/src/components/ui/price-chart.tsx
+++ b/frontend/src/components/ui/price-chart.tsx
@@ -6,6 +6,7 @@
  * SMA 20/50 오버레이 + 거래량 바.
  */
 import { useState } from "react";
+import { formatMoney } from "@/lib/format";
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -130,8 +131,9 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
               formatter={(value, name) => {
                 const v = Number(value);
                 if (name === "volume") return [formatVolume(v), "Vol"];
-                if (name === "close") return [`$${v.toFixed(2)}`, "Close"];
-                return [`$${v.toFixed(2)}`, String(name).toUpperCase()];
+                // 통화는 티커로 판정 (#1197 codex P2) — KR 종목 헤더는 ₩ 인데 툴팁만 $ 였다
+                if (name === "close") return [formatMoney(v, { ticker }), "Close"];
+                return [formatMoney(v, { ticker }), String(name).toUpperCase()];
               }}
             />
             <Bar

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,37 @@
+// 통화·숫자 포맷 일원화 (#1197 U1b-1) — KRW 판정과 화폐 표기는 여기 한 곳에서만.
+// 배경: 통화 결정이 6곳에 흩어져 .KS 종목이 $ 로 표기되는 버그가 반복됨
+// (ticker 헤더 $1,128,000 · client-table 의 `v > 10000` 휴리스틱 등).
+
+const KRW_TICKER = /\.(KS|KQ)$/;
+
+/** .KS(코스피)/.KQ(코스닥) 티커 여부 — 통화 추론의 유일한 티커 규칙 */
+export function isKrwTicker(ticker: string | null | undefined): boolean {
+  return !!ticker && KRW_TICKER.test(ticker.trim().toUpperCase());
+}
+
+/**
+ * 화폐 표기: KRW 는 ₩ + 정수 천단위, USD 는 $ + 소수 2자리 천단위.
+ * currency("KRW"/"USD")가 있으면 우선, 없으면 ticker 접미사로 판정.
+ */
+export function formatMoney(
+  value: number | null | undefined,
+  opts: { ticker?: string | null; currency?: string | null } = {},
+): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  const krw = opts.currency ? opts.currency.toUpperCase() === "KRW" : isKrwTicker(opts.ticker);
+  return krw
+    ? `₩${Math.round(value).toLocaleString("en-US")}`
+    : `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/** 퍼센트: 부호(+/−) 항상 병기 (색맹 대비 — 색만으로 방향 전달 금지, 스펙 §1) */
+export function formatPct(value: number | null | undefined, digits = 1): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${value > 0 ? "+" : ""}${value.toFixed(digits)}%`;
+}
+
+/** 일반 수치: raw float 노출 금지 (52.9428571... → 52.9) */
+export function formatNum(value: number | null | undefined, digits = 1): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toFixed(digits);
+}


### PR DESCRIPTION
Closes #1197. Evidence Terminal U1b-1 (spec v1.2; follows #1196).

## Bug

- Ticker page header showed `$1,128,000` for an SK Square (402340.KS) close; the price-target card and decisions-list entry price hardcoded `$` the same way
- `client-table.tsx` decided currency by magnitude (`v > 10000` → ₩): a ₩8,145 holding rendered as `$8,145`, and any US stock above $10,000 would flip to ₩
- `action-items.tsx` checked only `.KS`, missing KOSDAQ `.KQ`

## Fix

`src/lib/format.ts` — single currency decision point (`isKrwTicker` .KS/.KQ + `currency` override), `formatMoney` (₩ integer / $ 2-decimals, thousand separators), `formatPct` (sign always carried), `formatNum` (no raw-float leakage). Broken sites replaced; `client-table` price renderer keys on `row.ticker` via the existing `render(value, row)` signature.

## Verification

vitest **1471/1471** green (13 new format lock tests incl. a dedicated regression case for the magnitude heuristic) · format.ts **100%/100%** stmt/branch · full-suite statements 100% (1894/1894) · `next build` clean · doc counts synced (127→128 files)

Deliberately not touched: already-correct duplicate formatters in holding-row/portfolio/explore — they consolidate in U1b-2 with the component retheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)