### PR TITLE
feat(frontend): Evidence Terminal U1b-2 — component retheme + sidebar regroup

### DIFF
--- a/frontend/e2e/decisions.spec.ts
+++ b/frontend/e2e/decisions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { NAV } from "../src/lib/strings";
 
 test.describe("Decisions Page", () => {
   test("renders decision intelligence header and summary cards", async ({ page }) => {
@@ -24,13 +25,14 @@ test.describe("Decisions Page", () => {
     expect(hasEmptyState || hasDecisions).toBe(true);
   });
 
-  test("sidebar has Decisions nav under INTELLIGENCE group", async ({ page }) => {
+  test("sidebar has Decisions nav under 의사결정 group", async ({ page }) => {
     await page.goto("/decisions", { timeout: 15000 });
-    await expect(page.locator("text=INTELLIGENCE").first()).toBeVisible();
+    // 그룹 라벨은 strings.ts NAV 가 정본 (#1200 U1b-2 재그룹)
+    await expect(page.locator(`text=${NAV.DECISIONS}`).first()).toBeVisible();
     const decisionLink = page.locator("a[href='/decisions']");
     await expect(decisionLink).toBeVisible();
-    // Active state: should have emerald color
-    await expect(decisionLink).toHaveClass(/text-emerald/);
+    // Active state: 인터랙션 액센트(blue) — emerald 브랜드 액센트 폐지 (스펙 §1)
+    await expect(decisionLink).toHaveClass(/text-primary/);
   });
 
   test("no hardcoded exchange rate visible", async ({ page }) => {

--- a/frontend/src/__tests__/components/certifications-card.test.tsx
+++ b/frontend/src/__tests__/components/certifications-card.test.tsx
@@ -177,13 +177,13 @@ describe("CertificationsCard rendering", () => {
     const history = makeHistory({ total_in_db: 3, count: 3, items });
     const summary = makeSummary({ count: 3, certified_rate: 100, avg_score: 80 });
     const { container } = render(<CertificationsCard history={history} summary={summary} />);
-    // Distinct states 의 Metric value 는 "3" — color=default (text-zinc-200) 이어야 함
+    // Distinct states 의 Metric value 는 "3" — color=default (text-foreground) 이어야 함
     const distinctLabel = screen.getByText("Distinct states");
     // parent Metric 의 value 엘리먼트를 찾아 클래스 확인
     const metricDiv = distinctLabel.parentElement;
     const valueEl = metricDiv?.querySelector("p.font-semibold");
     expect(valueEl?.textContent).toBe("3");
-    expect(valueEl?.className).toContain("text-zinc-200"); // default color, not red
+    expect(valueEl?.className).toContain("text-foreground"); // default color, not red
     expect(container).toBeTruthy();
   });
 

--- a/frontend/src/__tests__/components/data-table.test.tsx
+++ b/frontend/src/__tests__/components/data-table.test.tsx
@@ -106,16 +106,16 @@ describe("DataTable", () => {
   });
 
   // ─── Compact mode ────────────────────────────────────
-  it("uses normal padding by default", () => {
+  it("uses terminal-density padding by default (#1200)", () => {
     const { container } = render(<DataTable columns={basicColumns} data={basicData} />);
     const th = container.querySelector("th");
-    expect(th!.className).toContain("py-2.5");
+    expect(th!.className).toContain("py-1.5");
   });
 
   it("uses compact padding when compact=true", () => {
     const { container } = render(<DataTable columns={basicColumns} data={basicData} compact />);
     const th = container.querySelector("th");
-    expect(th!.className).toContain("py-1.5");
+    expect(th!.className).toContain("py-1");
   });
 
   it("uses text-xs in compact mode", () => {
@@ -124,10 +124,10 @@ describe("DataTable", () => {
     expect(table!.className).toContain("text-xs");
   });
 
-  it("uses text-sm in normal mode", () => {
+  it("uses text-xs in normal mode too (#1200 density)", () => {
     const { container } = render(<DataTable columns={basicColumns} data={basicData} />);
     const table = container.querySelector("table");
-    expect(table!.className).toContain("text-sm");
+    expect(table!.className).toContain("text-xs");
   });
 
   // ─── onRowClick ──────────────────────────────────────

--- a/frontend/src/__tests__/components/metric.test.tsx
+++ b/frontend/src/__tests__/components/metric.test.tsx
@@ -40,16 +40,16 @@ describe("Metric", () => {
     expect(valueEl.className).toContain("text-red-400");
   });
 
-  it("applies default color class (text-zinc-200)", () => {
+  it("applies default color class (text-foreground)", () => {
     render(<Metric label="Price" value="$168" />);
     const valueEl = screen.getByText("$168");
-    expect(valueEl.className).toContain("text-zinc-200");
+    expect(valueEl.className).toContain("text-foreground");
   });
 
   it("applies default color explicitly", () => {
     render(<Metric label="Price" value="$168" color="default" />);
     const valueEl = screen.getByText("$168");
-    expect(valueEl.className).toContain("text-zinc-200");
+    expect(valueEl.className).toContain("text-foreground");
   });
 
   // ─── Size variants ───────────────────────────────
@@ -69,7 +69,7 @@ describe("Metric", () => {
   it("label has uppercase tracking and small text", () => {
     render(<Metric label="VIX" value="15" />);
     const labelEl = screen.getByText("VIX");
-    expect(labelEl.className).toContain("text-[10px]");
+    expect(labelEl.className).toContain("text-[11px]"); // #1200: 10px→11px (WCAG 소형 텍스트)
     expect(labelEl.className).toContain("uppercase");
     expect(labelEl.className).toContain("tracking-wider");
   });

--- a/frontend/src/__tests__/components/sidebar.test.tsx
+++ b/frontend/src/__tests__/components/sidebar.test.tsx
@@ -72,10 +72,11 @@ describe("Sidebar", () => {
 
   it("renders all navigation groups", () => {
     render(<Sidebar />);
-    expect(screen.getByText("OVERVIEW")).toBeInTheDocument();
-    expect(screen.getByText("ANALYSIS")).toBeInTheDocument();
-    expect(screen.getByText("TRADING")).toBeInTheDocument();
-    expect(screen.getByText("INTELLIGENCE")).toBeInTheDocument();
+    expect(screen.getByText("오늘")).toBeInTheDocument();
+    expect(screen.getByText("의사결정")).toBeInTheDocument();
+    expect(screen.getByText("포트폴리오")).toBeInTheDocument();
+    expect(screen.getByText("리서치")).toBeInTheDocument();
+    expect(screen.getByText("시스템")).toBeInTheDocument();
   });
 
   it("renders all navigation items", () => {
@@ -128,7 +129,7 @@ describe("Sidebar", () => {
 
     // Labels should be hidden
     expect(screen.queryByText("Dashboard")).not.toBeInTheDocument();
-    expect(screen.queryByText("OVERVIEW")).not.toBeInTheDocument();
+    expect(screen.queryByText("오늘")).not.toBeInTheDocument();
   });
 
   it("shows System Online indicator", () => {

--- a/frontend/src/__tests__/components/sidebar.test.tsx
+++ b/frontend/src/__tests__/components/sidebar.test.tsx
@@ -100,10 +100,10 @@ describe("Sidebar", () => {
     mockPathname.mockReturnValue("/portfolio");
     const { container } = render(<Sidebar />);
 
-    // The active link should have emerald text class
+    // 액티브 = 인터랙션 액센트(primary) — emerald 브랜드 액센트 폐지 (#1200, 스펙 §1)
     const activeLink = container.querySelector('a[href="/portfolio"]');
     expect(activeLink).not.toBeNull();
-    expect(activeLink!.className).toContain("text-emerald-400");
+    expect(activeLink!.className).toContain("text-primary");
   });
 
   it("collapses sidebar on chevron click", () => {

--- a/frontend/src/__tests__/components/status-badge.test.tsx
+++ b/frontend/src/__tests__/components/status-badge.test.tsx
@@ -7,10 +7,9 @@ describe("StatusBadge", () => {
   const greenStatuses = ["BUY", "LONG", "READY", "AGGRESSIVE", "bounce", "gap_up"];
   const redStatuses = ["SELL", "SHORT", "BLOCKED", "DEFENSIVE", "gap_down"];
   const amberStatuses = ["REDUCE", "CAUTIOUS", "volume_spike"];
-  const blueStatuses = ["WATCH", "momentum"];
+  const blueStatuses = ["WATCH", "momentum", "breakout"]; // breakout: purple 폐지 → info (#1200 색 예산)
   const zincStatuses = ["HOLD", "NEUTRAL"];
-  const purpleStatuses = ["breakout"];
-
+  
   it.each(greenStatuses)("renders %s with emerald style", (status) => {
     render(<StatusBadge status={status} />);
     const badge = screen.getByText(status);
@@ -44,13 +43,6 @@ describe("StatusBadge", () => {
     const badge = screen.getByText(status);
     expect(badge).toBeInTheDocument();
     expect(badge.className).toContain("text-muted-foreground");
-  });
-
-  it.each(purpleStatuses)("renders %s with purple style", (status) => {
-    render(<StatusBadge status={status} />);
-    const badge = screen.getByText(status);
-    expect(badge).toBeInTheDocument();
-    expect(badge.className).toContain("text-purple-400");
   });
 
   // ─── Unknown / fallback ──────────────────────────────

--- a/frontend/src/__tests__/coverage/sidebar-branch-coverage.test.tsx
+++ b/frontend/src/__tests__/coverage/sidebar-branch-coverage.test.tsx
@@ -80,10 +80,10 @@ describe("Sidebar — collapsed state and branch coverage", () => {
     await act(async () => { render(<Sidebar />); });
 
     // Nav group labels should be visible (not collapsed)
-    expect(screen.getByText("OVERVIEW")).toBeInTheDocument();
-    expect(screen.getByText("ANALYSIS")).toBeInTheDocument();
-    expect(screen.getByText("TRADING")).toBeInTheDocument();
-    expect(screen.getByText("INTELLIGENCE")).toBeInTheDocument();
+    expect(screen.getByText("오늘")).toBeInTheDocument();
+    expect(screen.getByText("의사결정")).toBeInTheDocument();
+    expect(screen.getByText("리서치")).toBeInTheDocument();
+    expect(screen.getByText("시스템")).toBeInTheDocument();
 
     // Current page "/" — Dashboard link should exist
     const dashLink = screen.getByText("Dashboard");

--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -26,8 +26,10 @@ interface DataTableProps {
 }
 
 export function DataTable({ columns, data, compact = false, onRowClick, rowClassName }: DataTableProps) {
-  const py = compact ? "py-1.5" : "py-2.5";
-  const text = compact ? "text-xs" : "text-sm";
+  // 터미널 밀도 (#1200 U1b-2, 스펙 §2): 기본 행 ~32px(구 compact), compact ~28px.
+  // 구 기본값 py-2.5(~40px)는 컨슈머 밀도 — screener 류 표에는 과했다.
+  const py = compact ? "py-1" : "py-1.5";
+  const text = "text-xs";
 
   return (
     <div className="overflow-x-auto">
@@ -37,7 +39,7 @@ export function DataTable({ columns, data, compact = false, onRowClick, rowClass
             {columns.map((col) => (
               <th
                 key={col.key}
-                className={`${py} px-3 font-medium text-muted-foreground ${
+                className={`${py} px-3 font-mono text-[11px] font-medium uppercase tracking-wider text-muted-foreground ${
                   col.align === "right" ? "text-right" :
                   col.align === "center" ? "text-center" : "text-left"
                 }${col.hideOnMobile ? " hidden sm:table-cell" : ""}`}

--- a/frontend/src/components/ui/market-pulse.coverage.test.tsx
+++ b/frontend/src/components/ui/market-pulse.coverage.test.tsx
@@ -65,7 +65,7 @@ describe("MarketPulse — trend variants", () => {
       />,
     );
     const el = screen.getByText("SIDEWAYS");
-    expect(el.className).toContain("text-zinc-200");
+    expect(el.className).toContain("text-foreground");
   });
 
   it("empty trend falls back to UNKNOWN (default color)", () => {
@@ -73,7 +73,7 @@ describe("MarketPulse — trend variants", () => {
       <MarketPulse regime={{ ...baseRegime, trend: "" }} macro={baseMacro} />,
     );
     const el = screen.getByText("UNKNOWN");
-    expect(el.className).toContain("text-zinc-200");
+    expect(el.className).toContain("text-foreground");
   });
 });
 
@@ -93,7 +93,7 @@ describe("MarketPulse — VIX variants", () => {
       <MarketPulse regime={{ ...baseRegime, vix: 20 }} macro={baseMacro} />,
     );
     const el = screen.getByText("20.0");
-    expect(el.className).toContain("text-zinc-200");
+    expect(el.className).toContain("text-foreground");
     // VIX 15-25 sub is "normal"; base volatility metric (normal_vol) also reads
     // "normal" → scope to this VIX metric's own wrapper to avoid a text collision.
     const sub = el.parentElement?.querySelector("p:last-child");
@@ -144,7 +144,7 @@ describe("MarketPulse — Fear & Greed variants", () => {
       />,
     );
     expect(screen.getByText("Fear")).toBeInTheDocument();
-    expect(screen.getByText("30").className).toContain("text-zinc-200");
+    expect(screen.getByText("30").className).toContain("text-foreground");
   });
 
   it("neutral (40-60) shows Neutral and green", () => {
@@ -167,7 +167,7 @@ describe("MarketPulse — Fear & Greed variants", () => {
     );
     expect(screen.getByText("Greed")).toBeInTheDocument();
     // 70 > 60 and <= 75 → default color (not green, not red)
-    expect(screen.getByText("70").className).toContain("text-zinc-200");
+    expect(screen.getByText("70").className).toContain("text-foreground");
   });
 
   it("extreme greed (>75) shows label and red", () => {
@@ -206,7 +206,7 @@ describe("MarketPulse — Macro score variants", () => {
     render(
       <MarketPulse regime={baseRegime} macro={{ score: 50, interpretation: "Neutral" }} />,
     );
-    expect(screen.getByText("50/100").className).toContain("text-zinc-200");
+    expect(screen.getByText("50/100").className).toContain("text-foreground");
   });
 
   it("weak macro (<40) is red", () => {
@@ -277,7 +277,7 @@ describe("MarketPulse — volatility variants", () => {
       />,
     );
     const el = screen.getByText("NORMAL");
-    expect(el.className).toContain("text-zinc-200");
+    expect(el.className).toContain("text-foreground");
     // scope to this metric's wrapper (VIX sub may also read "normal")
     const sub = el.parentElement?.querySelector("p:last-child");
     expect(sub?.textContent).toBe("normal");

--- a/frontend/src/components/ui/metric.tsx
+++ b/frontend/src/components/ui/metric.tsx
@@ -12,14 +12,16 @@ interface MetricProps {
 export function Metric({ label, value, sub, color = "default", size = "sm" }: MetricProps) {
   const colorClass =
     color === "green" ? "text-emerald-400" :
-    color === "red" ? "text-red-400" : "text-zinc-200";
+    color === "red" ? "text-red-400" : "text-foreground";
 
   const sizeClass = size === "lg" ? "text-xl" : "text-sm";
 
   return (
     <div>
-      <p className="text-[10px] text-muted-foreground uppercase tracking-wider">{label}</p>
-      <p className={`${sizeClass} font-semibold ${colorClass}`}>{value}</p>
+      {/* 라벨 11px (#1200 U1b-2, WCAG 실측 — 10px faint 는 소형 텍스트 기준 미달이었음) */}
+      <p className="text-[11px] text-muted-foreground uppercase tracking-wider">{label}</p>
+      {/* 숫자 지표는 mono — 자릿수 무관 정렬 (스펙 §1 타이포) */}
+      <p className={`${sizeClass} font-mono font-semibold ${colorClass}`}>{value}</p>
       {sub && <p className="text-[10px] text-muted-foreground/70">{sub}</p>}
     </div>
   );

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -84,11 +84,11 @@ export function Sidebar() {
           <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
             {!collapsed && (
               <>
-                <span className="text-lg font-bold text-emerald-400 tracking-tight">Nuri-Quant</span>
+                <span className="text-lg font-bold text-foreground tracking-tight">Nuri-Quant</span>
                 <span className="text-[9px] text-muted-foreground/70 font-mono">v0.1</span>
               </>
             )}
-            {collapsed && <span className="text-lg font-bold text-emerald-400">N</span>}
+            {collapsed && <span className="text-lg font-bold text-foreground">N</span>}
           </Link>
           <button
             onClick={() => setCollapsed(!collapsed)}
@@ -119,12 +119,12 @@ export function Sidebar() {
                       flex items-center gap-3 py-2 text-sm transition-colors
                       ${collapsed ? "justify-center px-3" : "px-4"}
                       ${active
-                        ? "text-emerald-400 bg-emerald-400/10 border-r-2 border-emerald-400"
+                        ? "text-primary bg-primary/10 border-r-2 border-primary"
                         : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                       }
                     `}
                   >
-                    <Icon size={20} className={active ? "text-emerald-400" : "text-muted-foreground"} />
+                    <Icon size={20} className={active ? "text-primary" : "text-muted-foreground"} />
                     {!collapsed && <span>{item.label}</span>}
                   </Link>
                 );

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { NAV } from "@/lib/strings";
 import {
   LayoutDashboard,
   Briefcase,
@@ -25,38 +26,45 @@ import {
 
 // 팔란티어 스타일 그룹 네비게이션
 const NAV_GROUPS = [
+  // 5그룹 재편 (#1200 U1b-2, docs/UX_REDESIGN_PLAN.md §1): 사용 빈도·워크플로 기준.
+  // 라우트 삭제·이동 없음 — 그룹핑만 바뀐다. 그룹 라벨은 strings.ts NAV 가 정본.
   {
-    label: "OVERVIEW",
+    label: NAV.TODAY,
     items: [
       { href: "/", label: "Dashboard", icon: LayoutDashboard },
-      { href: "/explore", label: "Explore", icon: Compass },
-      { href: "/pipeline", label: "Pipeline", icon: Workflow },
     ],
   },
   {
-    label: "ANALYSIS",
-    items: [
-      { href: "/portfolio", label: "Portfolio", icon: Briefcase },
-      { href: "/signals", label: "Signals", icon: BarChart3 },
-      { href: "/consensus", label: "Agents", icon: Users },
-      { href: "/scan", label: "Scanner", icon: Search },
-    ],
-  },
-  {
-    label: "TRADING",
-    items: [
-      { href: "/targets", label: "Price Targets", icon: Target },
-      { href: "/advisor", label: "Advisor", icon: ShieldAlert },
-      { href: "/strategy", label: "Strategy", icon: TrendingUp },
-      { href: "/rebalance", label: "Rebalance", icon: Scale },
-    ],
-  },
-  {
-    label: "INTELLIGENCE",
+    label: NAV.DECISIONS,
     items: [
       { href: "/decisions", label: "Decisions", icon: BookOpen },
       { href: "/engine", label: "Certification Engine", icon: Cog },
       { href: "/evidence", label: "Evidence", icon: FileBarChart },
+    ],
+  },
+  {
+    label: NAV.PORTFOLIO,
+    items: [
+      { href: "/portfolio", label: "Portfolio", icon: Briefcase },
+      { href: "/rebalance", label: "Rebalance", icon: Scale },
+      { href: "/targets", label: "Price Targets", icon: Target },
+      { href: "/advisor", label: "Advisor", icon: ShieldAlert },
+    ],
+  },
+  {
+    label: NAV.RESEARCH,
+    items: [
+      { href: "/explore", label: "Explore", icon: Compass },
+      { href: "/scan", label: "Scanner", icon: Search },
+      { href: "/signals", label: "Signals", icon: BarChart3 },
+      { href: "/strategy", label: "Strategy", icon: TrendingUp },
+      { href: "/consensus", label: "Agents", icon: Users },
+    ],
+  },
+  {
+    label: NAV.SYSTEM,
+    items: [
+      { href: "/pipeline", label: "Pipeline", icon: Workflow },
       { href: "/report", label: "AI Report", icon: Bot },
     ],
   },

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -1,41 +1,42 @@
 /**
  * StatusBadge — BUY/SELL/HOLD 등 상태 표시.
+ *
+ * intent 5종(pos/neg/warn/info/neutral)으로 수렴 (#1200 U1b-2, Blueprint minimal-tag).
+ * 이전의 30-엔트리 클래스 문자열 맵은 같은 스타일이 6번씩 복붙되어 있었고 purple 등
+ * 예산 밖 색이 섞여 있었다 — 색 예산(스펙 §1): 인터랙션 blue + intent 4종 + neutral 뿐.
  */
 interface StatusBadgeProps {
   status: string;
   size?: "sm" | "md" | "lg";
 }
 
-const styles: Record<string, string> = {
-  BUY:        "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  SELL:       "bg-red-500/15 text-red-400 border-red-500/20",
-  "매수":   "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  "매도":   "bg-red-500/15 text-red-400 border-red-500/20",
-  "공격":   "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  "관망":   "bg-zinc-500/15 text-muted-foreground border-zinc-500/20",
-  "주의":   "bg-amber-500/15 text-amber-400 border-amber-500/20",
-  "방어":   "bg-red-500/15 text-red-400 border-red-500/20",
-  HOLD:       "bg-zinc-500/15 text-muted-foreground border-zinc-500/20",
-  WATCH:      "bg-blue-500/15 text-blue-400 border-blue-500/20",
-  LONG:       "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  SHORT:      "bg-red-500/15 text-red-400 border-red-500/20",
-  REDUCE:     "bg-amber-500/15 text-amber-400 border-amber-500/20",
-  READY:      "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  BLOCKED:    "bg-red-500/15 text-red-400 border-red-500/20",
-  AGGRESSIVE: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  NEUTRAL:    "bg-zinc-500/15 text-muted-foreground border-zinc-500/20",
-  CAUTIOUS:   "bg-amber-500/15 text-amber-400 border-amber-500/20",
-  DEFENSIVE:  "bg-red-500/15 text-red-400 border-red-500/20",
-  breakout:   "bg-purple-500/15 text-purple-400 border-purple-500/20",
-  momentum:   "bg-blue-500/15 text-blue-400 border-blue-500/20",
-  bounce:     "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  volume_spike: "bg-amber-500/15 text-amber-400 border-amber-500/20",
-  gap_up:       "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
-  gap_down:     "bg-red-500/15 text-red-400 border-red-500/20",
+type Intent = "pos" | "neg" | "warn" | "info" | "neutral";
+
+const INTENT_STYLES: Record<Intent, string> = {
+  pos: "bg-emerald-500/15 text-emerald-400 border-emerald-500/20",
+  neg: "bg-red-500/15 text-red-400 border-red-500/20",
+  warn: "bg-amber-500/15 text-amber-400 border-amber-500/20",
+  info: "bg-blue-500/15 text-blue-400 border-blue-500/20",
+  neutral: "bg-zinc-500/15 text-muted-foreground border-zinc-500/20",
+};
+
+const STATUS_INTENT: Record<string, Intent> = {
+  // 액션/방향
+  BUY: "pos", 매수: "pos", LONG: "pos", 공격: "pos", AGGRESSIVE: "pos", READY: "pos",
+  SELL: "neg", 매도: "neg", SHORT: "neg", 방어: "neg", DEFENSIVE: "neg", BLOCKED: "neg",
+  REDUCE: "warn", CAUTIOUS: "warn", 주의: "warn",
+  HOLD: "neutral", 관망: "neutral", NEUTRAL: "neutral",
+  WATCH: "info",
+  // 시그널 종류 — breakout 은 이전에 purple(예산 밖)이었음: info 로 수렴
+  breakout: "info", momentum: "info",
+  bounce: "pos", gap_up: "pos", gap_down: "neg", volume_spike: "warn",
 };
 
 export function StatusBadge({ status, size = "sm" }: StatusBadgeProps) {
-  const style = styles[status] || "bg-muted/50 text-muted-foreground border-zinc-600/20";
+  const intent = STATUS_INTENT[status] ?? "neutral";
+  const style = STATUS_INTENT[status]
+    ? INTENT_STYLES[intent]
+    : "bg-muted/50 text-muted-foreground border-zinc-600/20";
   const sizeClass = size === "lg" ? "text-sm px-3 py-1" : size === "md" ? "text-xs px-2 py-0.5" : "text-[10px] px-1.5 py-0.5";
 
   return (

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -380,3 +380,12 @@ export const STATUS_BADGE = {
   CAUTIOUS: "\uC8FC\uC758",
   DEFENSIVE: "\uBC29\uC5B4",
 } as const;
+
+// \uC0AC\uC774\uB4DC\uBC14 5\uADF8\uB8F9 (#1200 U1b-2, docs/UX_REDESIGN_PLAN.md \u00A71)
+export const NAV = {
+  TODAY: "\uC624\uB298",
+  DECISIONS: "\uC758\uC0AC\uACB0\uC815",
+  PORTFOLIO: "\uD3EC\uD2B8\uD3F4\uB9AC\uC624",
+  RESEARCH: "\uB9AC\uC11C\uCE58",
+  SYSTEM: "\uC2DC\uC2A4\uD15C",
+} as const;


### PR DESCRIPTION
Closes #1200. Evidence Terminal U1b-2 (docs/UX_REDESIGN_PLAN.md §3; follows #1196/#1198).

## What

- **status-badge**: 30-entry hardcoded class map → 5 intents (pos/neg/warn/info/neutral) + status→intent table; `breakout` purple retired to info (color budget: one interaction blue + 4 intents)
- **metric**: mono value (digit alignment), label 10px→11px (WCAG small-text floor), default color `text-foreground`
- **data-table**: terminal density — default rows ~40px→~32px, compact ~28px; 11px uppercase mono headers
- **sidebar**: 15 items regrouped into 오늘/의사결정/포트폴리오/리서치/시스템 (zero route changes); group labels via `strings.ts NAV`
- **card**: no change — U1a radius pin already renders 4px

## Verification

vitest **1472/1472** green (17 locked assertions updated to the new intents/density/labels) · `next build` clean · eslint clean · live screenshots (1440×900) — regrouped nav + density visible, layout unchanged otherwise

Next per plan: U1c responsive foundation (container/grid caps + `3xl` + responsive.spec.ts) before the U2 dashboard restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)