### PR TITLE
feat(frontend): Evidence Terminal U2b-1 — verdict banner first, compact hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,476 across 129 files — 100% statement coverage | |
+| **Frontend tests** | 1,477 across 129 files — 100% statement coverage | |
 | **E2E tests** | 83 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1476 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1477 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1476 tests, 129 files |
+| Frontend tests | 목표 ≥ 90% | 1477 tests, 129 files |
 | E2E | 핵심 flow | 83 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1476 tests, 129 files)
+npm run test           # vitest run (1477 tests, 129 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1476 tests, 129 files)
+npm run test           # vitest (1477 tests, 129 files)
 npx playwright test    # E2E (83 tests, 9 specs)
 ```
 

--- a/frontend/src/__tests__/components/hero-stats.test.tsx
+++ b/frontend/src/__tests__/components/hero-stats.test.tsx
@@ -34,7 +34,6 @@ describe("HeroStats", () => {
         cashTotalUsd={40240}
         holdingsValueUsd={33996}
         summary={summary()}
-        verdictLabel="관망"
       />,
     );
     expect(screen.getByTestId("hero-stats")).toBeInTheDocument();
@@ -44,20 +43,18 @@ describe("HeroStats", () => {
     expect(screen.getByTestId("hero-winrate")).toBeInTheDocument();
   });
 
-  it("renders 총 자산 with formatted USD + verdict badge", () => {
+  it("renders 총 자산 with formatted USD (verdict badge moved to VerdictBanner, #1206)", () => {
     render(
       <HeroStats
         totalUsd={74237}
         cashTotalUsd={40240}
         holdingsValueUsd={33996}
         summary={summary()}
-        verdictLabel="관망"
       />,
     );
     const total = screen.getByTestId("hero-total");
     expect(total.textContent).toContain("총 자산");
     expect(total.textContent).toContain("$74,237");
-    expect(total.textContent).toContain("관망");
     // sub-line shows holdings + cash
     expect(total.textContent).toContain("보유");
     expect(total.textContent).toContain("$33,996");
@@ -71,7 +68,6 @@ describe("HeroStats", () => {
         cashTotalUsd={0}
         holdingsValueUsd={74237}
         summary={summary()}
-        verdictLabel="관망"
       />,
     );
     const today = screen.getByTestId("hero-today");
@@ -90,7 +86,6 @@ describe("HeroStats", () => {
         summary={summary({
           today: { totalUsd: -300, totalPct: -1.2, upCount: 2, downCount: 8 },
         })}
-        verdictLabel="주의"
       />,
     );
     const today = screen.getByTestId("hero-today");
@@ -107,7 +102,6 @@ describe("HeroStats", () => {
         cashTotalUsd={0}
         holdingsValueUsd={74237}
         summary={summary()}
-        verdictLabel="관망"
       />,
     );
     const cum = screen.getByTestId("hero-cumulative");
@@ -124,7 +118,6 @@ describe("HeroStats", () => {
         summary={summary({
           winRate: { winners: 9, losers: 1, flat: 0, winRatePct: 90 },
         })}
-        verdictLabel="관망"
       />,
     );
     const wr = screen.getByTestId("hero-winrate");
@@ -142,7 +135,6 @@ describe("HeroStats", () => {
         summary={summary({
           winRate: { winners: 5, losers: 5, flat: 0, winRatePct: 50 },
         })}
-        verdictLabel="관망"
       />,
     );
     const wr = screen.getByTestId("hero-winrate");
@@ -158,7 +150,6 @@ describe("HeroStats", () => {
         summary={summary({
           winRate: { winners: 2, losers: 8, flat: 0, winRatePct: 20 },
         })}
-        verdictLabel="주의"
       />,
     );
     const wr = screen.getByTestId("hero-winrate");
@@ -174,7 +165,6 @@ describe("HeroStats", () => {
         summary={summary({
           winRate: { winners: 0, losers: 0, flat: 5, winRatePct: 0 },
         })}
-        verdictLabel="관망"
       />,
     );
     const wr = screen.getByTestId("hero-winrate");
@@ -189,7 +179,6 @@ describe("HeroStats", () => {
         cashTotalUsd={0}
         holdingsValueUsd={0}
         summary={summary()}
-        verdictLabel="관망"
       />,
     );
     const total = screen.getByTestId("hero-total");
@@ -206,7 +195,6 @@ describe("HeroStats provenance (#1185)", () => {
         cashTotalUsd={2000}
         holdingsValueUsd={8000}
         summary={summary()}
-        verdictLabel="관망"
       />,
     );
     const strip = screen.getByTestId("hero-provenance");
@@ -224,7 +212,6 @@ describe("HeroStats provenance (#1185)", () => {
         cashTotalUsd={2000}
         holdingsValueUsd={8000}
         summary={summary({ winRate: { winners: 3, losers: 7, flat: 0, winRatePct: 30 } })}
-        verdictLabel="관망"
       />,
     );
     const winrate = screen.getByTestId("hero-winrate");
@@ -238,7 +225,6 @@ describe("HeroStats provenance (#1185)", () => {
         cashTotalUsd={2000}
         holdingsValueUsd={8000}
         summary={summary({ winRate: { winners: 2, losers: 2, flat: 3, winRatePct: 50 } })}
-        verdictLabel="관망"
       />,
     );
     const winrate = screen.getByTestId("hero-winrate");

--- a/frontend/src/__tests__/components/market-strip.test.tsx
+++ b/frontend/src/__tests__/components/market-strip.test.tsx
@@ -15,8 +15,6 @@ const base = {
   actualAllocation: { long: 57, short: 0, cash: 43 },
   targetAllocation: { long: 50, short: 0, cash: 50 },
   fallbackAllocation: null,
-  verdict: "테스트 verdict",
-  verdictTextClass: "text-zinc-400",
 };
 
 describe("MarketStrip", () => {
@@ -29,7 +27,7 @@ describe("MarketStrip", () => {
   it("omits economy chip without crashing when macroScore is undefined (missing d.macro)", () => {
     render(<MarketStrip {...base} macroScore={undefined} />);
     expect(screen.queryByText(MARKET.ECONOMY)).not.toBeInTheDocument();
-    expect(screen.getByText("테스트 verdict")).toBeInTheDocument();
+    // verdict 는 VerdictBanner 소관 (#1206) — 스트립은 시장 사실만
   });
 
   it("omits economy chip when macroScore is 0 (no data sentinel)", () => {

--- a/frontend/src/__tests__/pages/dashboard.test.tsx
+++ b/frontend/src/__tests__/pages/dashboard.test.tsx
@@ -147,6 +147,29 @@ describe("DashboardPage", () => {
     });
   });
 
+  // U2b-1 계약 잠금 (#1206): "오늘의 답"이 첫 픽셀 — 배너가 대시보드 루트의 첫
+  // 요소이고, 히어로는 더 이상 verdict 배지를 갖지 않는다. 배너가 히어로 아래로
+  // 내려가거나 배지가 부활하면 FAIL.
+  it("verdict banner is the FIRST dashboard element and hero owns no badge (#1206)", async () => {
+    setupMocks();
+    const Page = await import("@/app/page");
+    let container!: HTMLElement;
+    await act(async () => { ({ container } = render(<Page.default />)); });
+    await waitFor(() => {
+      const banner = container.querySelector('[data-testid="verdict-banner"]');
+      expect(banner).not.toBeNull();
+      const root = banner!.parentElement!;
+      expect(root.firstElementChild).toBe(banner);
+      const hero = container.querySelector('[data-testid="hero-stats"]');
+      expect(hero).not.toBeNull();
+      // 배너가 히어로보다 DOM 상 앞선다
+      expect(banner!.compareDocumentPosition(hero!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      // 히어로 총자산 셀에 verdict 라벨 배지 없음
+      const total = container.querySelector('[data-testid="hero-total"]');
+      expect(total!.textContent).not.toContain("관망");
+    });
+  });
+
   it("renders allocation values in compact market strip (#223 iter 7)", async () => {
     setupMocks();
     const Page = await import("@/app/page");

--- a/frontend/src/app/page.branchcov.test.tsx
+++ b/frontend/src/app/page.branchcov.test.tsx
@@ -752,7 +752,7 @@ describe("page.tsx branch coverage", () => {
   });
 
   // L213/L214 arm1 + L227 arm1 — fallback arms: unknown verdict_level makes the
-  // levelStyles / verdictLabels lookup undefined (`|| neutral` / `|| NEUTRAL`),
+  // VerdictBanner 의 verdictLabels/BANNER_STYLES lookup undefined (`?? neutral`),
   // and an empty trend hits `d.regime.trend || "unknown"`.
   it("falls back on unknown verdict_level + empty trend (L213/L214/L227 arm1)", async () => {
     await renderWith({

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,16 +16,16 @@ import { MarketContext, type MacroEvent, type SystemHealth } from "@/components/
 import { summarizeHoldings } from "@/lib/holdings-summary";
 import { getMacroImpactedSectors } from "@/lib/macro-impact";
 import Link from "next/link";
-import { VERDICT, SECTION, ACTION } from "@/lib/strings";
+import { SECTION, ACTION } from "@/lib/strings";
 
 // #1204 U2a: 섹션·헬퍼는 components/dashboard/ 로 추출 — 이 파일은 데이터 fetch +
 // enrichment + 조립만 담당한다. 동작·마크업 불변.
 import {
-  verdictLabels, levelStyles,
   trendKo, vixZone, fgLabel, fgColor, macroLevel, accountKo,
   parseSparklinePeriod,
 } from "@/components/dashboard/helpers";
 import { MarketStrip } from "@/components/dashboard/market-strip";
+import { VerdictBanner } from "@/components/dashboard/verdict-banner";
 import { EventsStrip } from "@/components/dashboard/events-strip";
 import { HoldingsSection } from "@/components/dashboard/holdings-section";
 import { DashboardFooter, type FooterCondition } from "@/components/dashboard/dashboard-footer";
@@ -153,8 +153,6 @@ async function Dashboard({
   const holdingCount = portfolio?.count ?? portfolio?.holdings?.length ?? 0;
   if (holdingCount === 0) redirect("/explore");
 
-  const style = levelStyles[d.verdict_level] || levelStyles.neutral;
-  const verdictLabel = verdictLabels[d.verdict_level] || VERDICT.NEUTRAL;
   const KRW_RATE = d.exchange_rate || 1400;
   const holdingsValue = portfolio?.holdings?.reduce((sum: number, h: PortfolioHolding) => {
     const price = h.latest_price || 0;
@@ -256,13 +254,15 @@ async function Dashboard({
 
   return (
     <div className="flex flex-col gap-4 h-full">
-      {/* ═══ #223 NEW HERO: 4 big metrics row (총자산 · 오늘 · 누적 · 배당) ═══ */}
+      {/* ═══ #1206 U2b-1: 한 줄 판단이 첫 픽셀 — "오늘의 답" 배너 ═══ */}
+      <VerdictBanner verdict={d.verdict} level={d.verdict_level} />
+
+      {/* ═══ #223 HERO: 4 metrics row — U2b-1 에서 컴팩트로 축소 ═══ */}
       <HeroStats
         totalUsd={totalValue}
         cashTotalUsd={cashTotalUsd}
         holdingsValueUsd={holdingsValue}
         summary={summary}
-        verdictLabel={verdictLabel}
       />
 
       {/* ═══ 시스템 건강 4카드 (compact, 1 row) ═══ */}
@@ -291,8 +291,6 @@ async function Dashboard({
         actualAllocation={d.actual_allocation}
         targetAllocation={d.target_allocation}
         fallbackAllocation={d.allocation}
-        verdict={d.verdict}
-        verdictTextClass={style.text}
       />
 
       {/* ═══ Collapsible strips removed — replaced by Action-First sections above.

--- a/frontend/src/components/dashboard/helpers.ts
+++ b/frontend/src/components/dashboard/helpers.ts
@@ -9,13 +9,7 @@ export const verdictLabels: Record<string, string> = {
   aggressive: VERDICT.AGGRESSIVE, neutral: VERDICT.NEUTRAL, cautious: VERDICT.CAUTIOUS, defensive: VERDICT.DEFENSIVE,
   stale: VERDICT.STALE,
 };
-export const levelStyles: Record<string, { text: string }> = {
-  aggressive: { text: "text-emerald-400" },
-  neutral:    { text: "text-zinc-400" },
-  cautious:   { text: "text-amber-400" },
-  defensive:  { text: "text-red-400" },
-  stale:      { text: "text-amber-400" }, // 판단 보류 — 경고색 (#1180)
-};
+// levelStyles 는 U2b-1 (#1206) 에서 VerdictBanner 의 BANNER_STYLES 로 대체·삭제됨.
 export const pipelineStatusColors: Record<string, string> = {
   idle: "bg-zinc-500", running: "bg-blue-500 animate-pulse", done: "bg-emerald-500", error: "bg-red-500",
 };

--- a/frontend/src/components/dashboard/market-strip.tsx
+++ b/frontend/src/components/dashboard/market-strip.tsx
@@ -16,14 +16,11 @@ interface MarketStripProps {
   actualAllocation?: Allocation;
   targetAllocation?: Allocation | null;
   fallbackAllocation?: Allocation | null;
-  verdict: string;
-  verdictTextClass: string;
 }
 
 export function MarketStrip({
   trend, vix, fg, macroScore,
   actualAllocation, targetAllocation, fallbackAllocation,
-  verdict, verdictTextClass,
 }: MarketStripProps) {
   // actual: API always provides this in real responses; mock tests
   // sometimes don't, so default to a sentinel that still renders.
@@ -71,9 +68,8 @@ export function MarketStrip({
           </span>
         </>
       )}
-      <span className={`ml-auto text-[10px] ${verdictTextClass} truncate max-w-[40%]`} title={verdict}>
-        {verdict}
-      </span>
+      {/* verdict 는 VerdictBanner 로 승격 (#1206) — 가장 중요한 문장이 truncate 꼬리에
+          파묻히던 결함 종결. 이 스트립은 시장 사실만 담는다 */}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/verdict-banner.tsx
+++ b/frontend/src/components/dashboard/verdict-banner.tsx
@@ -1,0 +1,33 @@
+/**
+ * VerdictBanner (#1206 U2b-1) — "오늘의 답"이 첫 픽셀.
+ *
+ * 이전에는 한 줄 판단이 MarketStrip 우측 꼬리(ml-auto·truncate·max-w-40%)에 파묻혀
+ * 가장 중요한 문장이 가장 안 보였다 (감사 결함 B-5). 전폭 배너로 승격한다.
+ * stale 이면 amber — API verdict 텍스트가 이미 낡은 입력·억제 판단·자동 해제 시점을
+ * 서술하므로 (#1181) 배너는 표면화만 담당한다 (Surface rung).
+ */
+import { verdictLabels } from "./helpers";
+
+const BANNER_STYLES: Record<string, { box: string; tag: string }> = {
+  aggressive: { box: "bg-emerald-500/10 border-emerald-500/30", tag: "bg-emerald-500/15 text-emerald-400" },
+  neutral:    { box: "bg-zinc-800/40 border-zinc-700/60",       tag: "bg-zinc-500/15 text-zinc-300" },
+  cautious:   { box: "bg-amber-500/10 border-amber-500/30",     tag: "bg-amber-500/15 text-amber-400" },
+  defensive:  { box: "bg-red-500/10 border-red-500/30",         tag: "bg-red-500/15 text-red-400" },
+  stale:      { box: "bg-amber-500/10 border-amber-500/40",     tag: "bg-amber-500/15 text-amber-400" },
+};
+
+export function VerdictBanner({ verdict, level }: { verdict: string; level: string }) {
+  const s = BANNER_STYLES[level] ?? BANNER_STYLES.neutral;
+  const label = verdictLabels[level] ?? verdictLabels.neutral;
+  return (
+    <div
+      data-testid="verdict-banner"
+      className={`flex items-center gap-3 px-4 py-2.5 rounded border ${s.box}`}
+    >
+      <span className={`shrink-0 inline-flex items-center h-5 px-2 rounded font-mono text-[11px] font-semibold ${s.tag}`}>
+        {label}
+      </span>
+      <p className="text-sm font-medium text-zinc-200 min-w-0">{verdict}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/hero-stats.tsx
+++ b/frontend/src/components/ui/hero-stats.tsx
@@ -20,7 +20,6 @@
 
 import Link from "next/link";
 
-import { StatusBadge } from "@/components/ui/status-badge";
 import type { HoldingsSummary } from "@/lib/holdings-summary";
 import { HERO } from "@/lib/strings";
 
@@ -29,7 +28,6 @@ interface HeroStatsProps {
   cashTotalUsd: number;
   holdingsValueUsd: number;
   summary: HoldingsSummary;
-  verdictLabel: string;
 }
 
 function formatBigUsd(v: number): string {
@@ -47,7 +45,6 @@ export function HeroStats({
   cashTotalUsd,
   holdingsValueUsd,
   summary,
-  verdictLabel,
 }: HeroStatsProps) {
   const t = summary.today;
   const c = summary.cumulative;
@@ -65,11 +62,11 @@ export function HeroStats({
         {/* 1. 총 자산 */}
         <div className="flex flex-col" data-testid="hero-total">
           <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.TOTAL_ASSET}</p>
+          {/* verdict 배지는 VerdictBanner 로 승격 (#1206) — 히어로는 스냅샷 수치만 */}
           <div className="flex items-baseline gap-2 mt-0.5">
-            <span className="text-3xl font-semibold tabular-nums tracking-tight text-zinc-100">
+            <span className="text-xl font-semibold tabular-nums tracking-tight text-zinc-100">
               {formatBigUsd(totalUsd)}
             </span>
-            <StatusBadge status={verdictLabel} />
           </div>
           {(holdingsValueUsd > 0 || cashTotalUsd > 0) && (
             <p className="text-xs text-zinc-400 mt-1 tabular-nums">
@@ -84,7 +81,7 @@ export function HeroStats({
         <div className="flex flex-col" data-testid="hero-today">
           <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.TODAY_PNL}</p>
           <div className={`flex items-baseline gap-2 mt-0.5 ${todayColor}`}>
-            <span className="text-3xl font-semibold tabular-nums tracking-tight">
+            <span className="text-xl font-semibold tabular-nums tracking-tight">
               {todayArrow} {formatDeltaUsd(t.totalUsd)}
             </span>
             <span className="text-sm tabular-nums">
@@ -103,7 +100,7 @@ export function HeroStats({
         <div className="flex flex-col" data-testid="hero-cumulative">
           <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.CUMULATIVE_RETURN}</p>
           <div className={`flex items-baseline gap-2 mt-0.5 ${cumColor}`}>
-            <span className="text-3xl font-semibold tabular-nums tracking-tight">
+            <span className="text-xl font-semibold tabular-nums tracking-tight">
               {cumArrow} {formatDeltaUsd(c.totalUsd)}
             </span>
             <span className="text-sm tabular-nums">
@@ -131,7 +128,7 @@ export function HeroStats({
             <div className="flex flex-col" data-testid="hero-winrate">
               <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.WIN_RATE}</p>
               <div className={`flex items-baseline gap-2 mt-0.5 ${wrColor}`}>
-                <span className="text-3xl font-semibold tabular-nums tracking-tight">
+                <span className="text-xl font-semibold tabular-nums tracking-tight">
                   {movers > 0 ? `${wr.winRatePct.toFixed(0)}%` : "—"}
                 </span>
                 <span className="text-sm tabular-nums">


### PR DESCRIPTION
Closes #1206. Evidence Terminal U2b-1 (docs/UX_REDESIGN_PLAN.md §3, U2b split 1/4; follows #1205).

## What

- **VerdictBanner** (new): the one-line verdict — previously an `ml-auto truncate max-w-[40%]` tail on the market strip (the audit's "most important line rendered least visibly" defect) — becomes a full-width banner as the dashboard's first element. Stale → amber with the #1181 API text (names stale inputs + auto-clear); other levels keep intent tints; unknown level falls back to neutral (locked by the existing branchcov test)
- **MarketStrip** drops the verdict tail — market facts only
- **HeroStats**: verdict badge removed (banner owns it), 4 stats shrink text-3xl → text-xl — the win-rate figure carrying a "not system performance" disclaimer no longer gets the page's largest type

## Verification

vitest **1476/1476** (hero/strip expectations updated to the new ownership) · tsc/build/eslint clean · responsive matrix + dashboard e2e **30/30** · live screenshot: banner first, verdict untruncated, above-the-fold budget improved

Next: U2b-2 (action dense table + right system rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)