### PR TITLE
feat(frontend): Evidence Terminal U2b-2 — action dense table + system rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,477 across 129 files — 100% statement coverage | |
+| **Frontend tests** | 1,479 across 129 files — 100% statement coverage | |
 | **E2E tests** | 83 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1477 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1479 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1477 tests, 129 files |
+| Frontend tests | 목표 ≥ 90% | 1479 tests, 129 files |
 | E2E | 핵심 flow | 83 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/UX_REDESIGN_PLAN.md
+++ b/docs/UX_REDESIGN_PLAN.md
@@ -69,7 +69,10 @@
 | U1b-2 | 공용 컴포넌트 리테마 | card/status-badge/metric/data-table — intent minimal-tag 맵, 밀도(행 32px), 사이드바 5그룹 재편(액티브 액센트 blue 전환 포함), StatusBadge 30-엔트리 하드코딩 맵 정리 | **완료 #1201** |
 | U1c | **반응형 파운데이션** | §2 구현: 컨테이너 캡(main `max-w-[1600px]`) + `3xl` 토큰 + `responsive.spec.ts` 매트릭스. 그리드 캡은 컨테이너 캡으로 충족(액션 카드 3열이 캡 안에서 ~440px) — 카드→테이블 전환은 U2b. **U2 재구조보다 선행** | 진행 중 |
 | U2a | 대시보드 추출 | `page.tsx`(668줄) 섹션별 컴포넌트 추출 — 동작 보존, 시각 변화 없음 (5개 인라인 색맵 함수 격리) | 대기 |
-| U2b | 대시보드 재구조 | verdict 배너 최상단 · 액션 밀집 테이블(심각도순) + 우측 시스템 레일 · 도넛→가로 스택 바 · coverage 접이 · NEW/ack·quick-peek·다음 행동 카피 · 히어로 대형 타이포 폐지 | 대기 |
+| U2b-1 | verdict 배너 + 히어로 축소 | 배너 최상단(placement 잠금 테스트) · MarketStrip verdict 꼬리 제거 · 히어로 3xl→xl | **완료 #1207** |
+| U2b-2 | 액션 테이블 + 시스템 레일 | 카드→32px 밀집 행(quick-peek 확장·확신도 micro-bar·증거 링크) · MarketContext 분해(SystemHealthRail·MacroEventsCard·RegimeShiftBanner) · 좌 2/3 + 우 1/3 그리드 | 진행 중 |
+| U2b-3 | 구성 스택 바 | 도넛→가로 스택 바 · coverage 접이 | 대기 |
+| U2b-4 | 델타·ack | NEW+시각 배지 · 확인(ack) 로컬 상태 · 다음 행동 카피 | 대기 |
 | U3 | Decisions | 리스트: 필터·날짜 그룹핑·conf micro-bar·판정일 명시 / 상세: 2컬럼 + 증거 key-value(raw JSON 폐지) + raw float 종결 | 대기 |
 | U4 | 주변부 | ticker(빈 패널 접기)·scanner(중복 테이블 병합)·engine(BLOCKED 다음 행동)·pipeline(타임라인 구조화) + 빈 상태 1줄 규칙 전면 | 대기 |
 | U5 | 별도 결정 | evidence matplotlib PNG→네이티브 차트 · Cmd-K · IA 통합(라우트 병합) — 각각 사용자 승인 후 착수 | 보류 |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1477 tests, 129 files)
+npm run test           # vitest run (1479 tests, 129 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1477 tests, 129 files)
+npm run test           # vitest (1479 tests, 129 files)
 npx playwright test    # E2E (83 tests, 9 specs)
 ```
 

--- a/frontend/e2e/action-first.spec.ts
+++ b/frontend/e2e/action-first.spec.ts
@@ -74,21 +74,18 @@ test.describe("Action-First Dashboard", () => {
     await expect(main).toContainText(reason);
   });
 
-  test("action items have expand/collapse detail button", async ({ page }) => {
+  test("action rows expand quick-peek on click (#1208)", async ({ page }) => {
     await page.goto("/", { timeout: 20000 });
     await page.waitForTimeout(5000);
-    // Find "상세 근거" buttons
-    const detailButtons = page.locator("text=상세 근거");
-    const count = await detailButtons.count();
-    if (count > 0) {
-      // Click first detail button
-      await detailButtons.first().click();
-      // After click, should show price info (현재가, 손절, etc.)
-      await page.waitForTimeout(500);
-      const expanded = await page.textContent("body");
-      const hasDetail = expanded!.includes("현재가") || expanded!.includes("손절") || expanded!.includes("1차익절");
-      expect(hasDetail).toBe(true);
-    }
+    // U2b-2: 카드의 "상세 근거" 버튼 → 행 클릭 quick-peek. 이전 스펙은 if(count>0)
+    // 가드라 버튼이 사라져도 침묵 통과했다 — 행 존재를 하드 assert 한다.
+    const rows = page.getByTestId("action-row");
+    expect(await rows.count(), "액션 행이 없다").toBeGreaterThan(0);
+    await rows.first().click();
+    await expect(page.getByTestId("action-row-peek").first()).toBeVisible();
+    const expanded = await page.textContent("body");
+    const hasDetail = expanded!.includes("현재가") || expanded!.includes("손절") || expanded!.includes("1차익절");
+    expect(hasDetail).toBe(true);
   });
 
   test("renders market context with macro events", async ({ page }) => {

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -187,6 +187,19 @@ describe("ActionItems", () => {
     expect(screen.getByTestId("action-row-peek")).toBeTruthy();
   });
 
+  // #1208 codex P1: 구 카드 버튼의 키보드 접근을 행이 승계 — Enter/Space 토글 잠금
+  it("toggles quick-peek with Enter and Space keys", () => {
+    render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
+    const row = screen.getByTestId("action-row");
+    expect(row.getAttribute("tabindex")).toBe("0");
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(screen.getByTestId("action-row-peek")).toBeTruthy();
+    fireEvent.keyDown(row, { key: " " });
+    expect(screen.queryByTestId("action-row-peek")).toBeNull();
+    fireEvent.keyDown(row, { key: "Escape" }); // 무시되는 키 — 토글 없음
+    expect(screen.queryByTestId("action-row-peek")).toBeNull();
+  });
+
   it("collapses quick-peek on second row click", () => {
     render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
     const row = screen.getByTestId("action-row");

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { ActionItems } from "@/components/ui/action-items";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
   ),
 }));
 
@@ -170,35 +170,36 @@ describe("ActionItems", () => {
     expect(body).toContain("한도");
   });
 
-  it("shows multiple reasons for check items", () => {
+  it("shows first reason inline and the rest in quick-peek (#1208)", () => {
     render(<ActionItems urgent={[]} check={[checkItem]} hold={[]} />);
     expect(screen.getByText(/1차 익절/)).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy(); // 근거 2건 → +1 표기
+    fireEvent.click(screen.getByTestId("action-row"));
     expect(screen.getByText(/공매도/)).toBeTruthy();
   });
 
-  it("expands detail on button click", () => {
+  // U2b-2 (#1208): 확장은 버튼이 아니라 행 클릭(quick-peek)
+  it("expands quick-peek on row click", () => {
     render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
-    const detailBtn = screen.getByText(/상세 근거/);
-    fireEvent.click(detailBtn);
+    fireEvent.click(screen.getByTestId("action-row"));
     expect(screen.getByText("현재가")).toBeTruthy();
     expect(screen.getByText("손절")).toBeTruthy();
+    expect(screen.getByTestId("action-row-peek")).toBeTruthy();
   });
 
-  it("collapses detail on second click", () => {
+  it("collapses quick-peek on second row click", () => {
     render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
-    const detailBtn = screen.getByText(/상세 근거/);
-    fireEvent.click(detailBtn);
+    const row = screen.getByTestId("action-row");
+    fireEvent.click(row);
     expect(screen.getByText("현재가")).toBeTruthy();
-    const collapseBtn = screen.getByText(/접기/);
-    fireEvent.click(collapseBtn);
+    fireEvent.click(row);
     expect(screen.queryByText("현재가")).toBeNull();
   });
 
   it("formats KR prices with won symbol", () => {
     const krItem = { ...urgentItem, ticker: "005930.KS", current_price: 200750, stop_loss: 180675, target_1: 230862 };
     render(<ActionItems urgent={[krItem]} check={[]} hold={[]} />);
-    const detailBtn = screen.getByText(/상세 근거/);
-    fireEvent.click(detailBtn);
+    fireEvent.click(screen.getByTestId("action-row"));
     const body = document.body.textContent;
     expect(body).toContain("₩");
   });
@@ -214,10 +215,10 @@ describe("ActionItems", () => {
     expect(screen.getByText("Main")).toBeTruthy();
   });
 
-  it("shows confidence and weight", () => {
+  it("shows confidence and weight in row cells (#1208 table)", () => {
     render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
-    expect(screen.getByText("확신도 46")).toBeTruthy();
-    expect(screen.getByText("비중 15.4%")).toBeTruthy();
+    expect(screen.getByText("46")).toBeTruthy();
+    expect(screen.getByText("15.4%")).toBeTruthy();
   });
 
   it("hold chips link to ticker page", () => {
@@ -237,11 +238,11 @@ describe("ActionItems", () => {
     expect(screen.getByText("-5.3%")).toBeTruthy();
   });
 
-  it("shows Korean name with ticker subtext", () => {
+  it("shows Korean name with ticker in title attr (#1208 dense row)", () => {
     const krItem = { ...urgentItem, ticker: "005930.KS", name: "삼성전자" };
     render(<ActionItems urgent={[krItem]} check={[]} hold={[]} />);
-    expect(screen.getByText("삼성전자")).toBeTruthy();
-    expect(screen.getByText("005930.KS")).toBeTruthy();
+    const link = screen.getByText("삼성전자");
+    expect(link.getAttribute("title")).toContain("005930.KS");
   });
 
   it("shows ticker when name is null", () => {
@@ -273,7 +274,7 @@ describe("ActionItems", () => {
   it("formats null prices as dash in expanded detail", () => {
     const nullPrices = { ...urgentItem, stop_loss: null, target_1: null };
     render(<ActionItems urgent={[nullPrices]} check={[]} hold={[]} />);
-    fireEvent.click(screen.getByText(/상세 근거/));
+    fireEvent.click(screen.getByTestId("action-row"));
     const body = document.body.textContent ?? "";
     expect(body).toContain("—");
   });
@@ -284,7 +285,9 @@ describe("ActionItems", () => {
     render(<ActionItems urgent={[withDecision]} check={[]} hold={[]} />);
     const link = screen.getByText(/증거 체인/).closest("a");
     expect(link?.getAttribute("href")).toBe("/decisions/42");
-    expect(link?.textContent).toContain("2026-08-25");
+    // as_of 는 quick-peek 로 이동 (#1208)
+    fireEvent.click(screen.getByTestId("action-row"));
+    expect(document.body.textContent).toContain("2026-08-25");
   });
 
   it("omits evidence-chain link when decision_id is null", () => {

--- a/frontend/src/__tests__/components/market-context.test.tsx
+++ b/frontend/src/__tests__/components/market-context.test.tsx
@@ -1,6 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MarketContext } from "@/components/ui/market-context";
+import { type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
+import { SystemHealthRail, MacroEventsCard, RegimeShiftBanner } from "@/components/dashboard/system-rail";
+
+// U2b-2 (#1208): MarketContext 컴포넌트는 SystemHealthRail·MacroEventsCard·
+// RegimeShiftBanner 로 분해됨 — 테스트는 프로덕션 조립(page.tsx)과 동일한 구성을
+// 이 래퍼로 미러링해 기존 assert 를 유지한다.
+function MarketContext({ events, health }: { events: MacroEvent[]; health: Partial<SystemHealth> }) {
+  return (
+    <>
+      <RegimeShiftBanner regime={health.regime ?? {}} />
+      <SystemHealthRail health={health} />
+      <MacroEventsCard events={events} regimeTrend={health.regime?.trend} />
+    </>
+  );
+}
 
 vi.mock("next/link", () => ({
   default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,7 +12,8 @@ import { CompositionSectionLazy as CompositionSection } from "@/components/ui/co
 import { parseCompositionTab } from "@/components/ui/composition-section";
 import { ActionItems, type ActionItem } from "@/components/ui/action-items";
 import { OpportunityExplorer, type Opportunity } from "@/components/ui/opportunity-explorer";
-import { MarketContext, type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
+import { type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
+import { SystemHealthRail, MacroEventsCard, RegimeShiftBanner } from "@/components/dashboard/system-rail";
 import { summarizeHoldings } from "@/lib/holdings-summary";
 import { getMacroImpactedSectors } from "@/lib/macro-impact";
 import Link from "next/link";
@@ -265,21 +266,25 @@ async function Dashboard({
         summary={summary}
       />
 
-      {/* ═══ 시스템 건강 4카드 (compact, 1 row) ═══ */}
-      <MarketContext
-        events={marketCtx?.macro_events ?? []}
-        health={marketCtx?.system_health ?? {}}
-      />
-
-      {/* ═══ 오늘의 액션 (연금 제외, 간결) ═══ */}
-      <div>
-        <h2 className="text-sm font-semibold text-zinc-300 mb-2">{ACTION.TITLE}</h2>
-        <ActionItems
-          urgent={actionsData?.urgent ?? []}
-          check={actionsData?.check ?? []}
-          hold={actionsData?.hold ?? []}
-          portfolio={actionsData?.portfolio ?? []}
-        />
+      {/* ═══ #1208 U2b-2: 좌 2/3 액션 테이블 · 우 1/3 시스템 레일 (lg 미만 스택) ═══ */}
+      <RegimeShiftBanner regime={marketCtx?.system_health?.regime ?? {}} />
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 items-start">
+        <div className="lg:col-span-2 min-w-0">
+          <h2 className="text-sm font-semibold text-zinc-300 mb-2">{ACTION.TITLE}</h2>
+          <ActionItems
+            urgent={actionsData?.urgent ?? []}
+            check={actionsData?.check ?? []}
+            hold={actionsData?.hold ?? []}
+            portfolio={actionsData?.portfolio ?? []}
+          />
+        </div>
+        <div className="flex flex-col gap-3 min-w-0">
+          <SystemHealthRail health={marketCtx?.system_health ?? {}} />
+          <MacroEventsCard
+            events={marketCtx?.macro_events ?? []}
+            regimeTrend={marketCtx?.system_health?.regime?.trend}
+          />
+        </div>
       </div>
 
       {/* ═══ #223 iter 7c: market + allocation compact strip (1 row) ═══ */}

--- a/frontend/src/components/dashboard/system-rail.tsx
+++ b/frontend/src/components/dashboard/system-rail.tsx
@@ -1,0 +1,126 @@
+/**
+ * SystemHealthRail + MacroEventsCard + RegimeShiftBanner (#1208 U2b-2).
+ *
+ * MarketContext(4-card 가로 그리드 + 이벤트 카드)를 분해 — 대시보드가 좌 2/3 액션
+ * 테이블 · 우 1/3 시스템 레일로 재구성되면서 (목업·plan §4), 건강 지표는 세로 컴팩트
+ * 행으로, 이벤트 카드는 레일 하단으로 이동한다. 데이터 계약·색·링크는 기존 그대로.
+ */
+import Link from "next/link";
+import { CONTEXT } from "@/lib/strings";
+import {
+  type MacroEvent, type SystemHealth,
+  shouldPinCard, sparklinePath, categoryStyles, healthColor, regimeStripe, isRegimeShifting,
+} from "@/components/ui/market-context";
+
+/* ── 레짐 전환 배너 (full-width, 조건부) ─────────────────────── */
+export function RegimeShiftBanner({ regime }: { regime: Partial<SystemHealth["regime"]> }) {
+  if (!isRegimeShifting(regime)) return null;
+  return (
+    <div className="rounded-lg bg-amber-950/40 border border-amber-700/50 px-3 py-2 flex items-center gap-2 text-xs">
+      <span className="shrink-0">⚠</span>
+      <span className="text-amber-300 font-semibold">Regime 전환 신호</span>
+      <span className="text-zinc-400">
+        현재 {regime.regime ?? "—"} · 신뢰도{" "}
+        {/* v8 ignore start -- banner renders only when isRegimeShifting (conf 0~60) → confidence always defined, `?? 0` arm unreachable */}
+        {regime.confidence ?? 0}
+        {/* v8 ignore stop */}% — 다음 행동 보류 권고
+      </span>
+    </div>
+  );
+}
+
+/* ── 시스템 상태 레일 (세로 4행 컴팩트) ──────────────────────── */
+function RailRow({ label, value, sub, href, color }: { label: string; value: string; sub: string; href: string; color: string }) {
+  return (
+    <Link href={href} className="flex items-center gap-2.5 px-3 py-2 hover:bg-zinc-800/40 transition-colors">
+      <span className="w-24 shrink-0 text-[11px] text-zinc-400">{label}</span>
+      <span className={`font-mono text-sm font-semibold tabular-nums ${color}`}>{value}</span>
+      <span className="ml-auto text-[11px] text-zinc-500 truncate max-w-[45%]" title={sub}>{sub}</span>
+    </Link>
+  );
+}
+
+export function SystemHealthRail({ health }: { health: Partial<SystemHealth> }) {
+  const siege: Partial<SystemHealth["siege"]> = health.siege || {};
+  const regime: Partial<SystemHealth["regime"]> = health.regime || {};
+  const macro: Partial<SystemHealth["macro"]> = health.macro || {};
+  const freshness: Partial<SystemHealth["freshness"]> = health.freshness || {};
+  return (
+    <div className="rounded-lg bg-zinc-900/60 border border-zinc-800/50 divide-y divide-zinc-800/50" data-testid="system-rail">
+      <p className="px-3 py-2 text-[11px] font-semibold text-zinc-300">{CONTEXT.RAIL_TITLE}</p>
+      <RailRow
+        label={CONTEXT.SIEGE}
+        value={`${siege.score ?? 0}%`}
+        sub={siege.certified ? CONTEXT.CERTIFIED : CONTEXT.REJECTED}
+        href="/engine"
+        color={siege.certified ? "text-emerald-400" : "text-red-400"}
+      />
+      <RailRow
+        label={CONTEXT.REGIME}
+        value={regime.regime?.toUpperCase()?.slice(0, 6) ?? "—"}
+        sub={`${regime.trend ?? "—"} ${regime.confidence ?? 0}%`}
+        href="/strategy"
+        color={regime.trend === "bull" ? "text-emerald-400" : regime.trend === "bear" ? "text-red-400" : "text-amber-400"}
+      />
+      <RailRow
+        label={CONTEXT.MACRO}
+        value={`${macro.score ?? 0}`}
+        sub={macro.interpretation ?? "—"}
+        href="/strategy"
+        color={healthColor(macro.score ?? 0, [40, 60])}
+      />
+      <RailRow
+        label={CONTEXT.FRESHNESS}
+        value={freshness.status ?? "—"}
+        sub={freshness.fail_count ? `${freshness.fail_count} fail` : "OK"}
+        href="/pipeline"
+        color={freshness.status === "PASS" ? "text-emerald-400" : freshness.status === "WARN" ? "text-amber-400" : "text-red-400"}
+      />
+    </div>
+  );
+}
+
+/* ── 매크로 이벤트 카드 (Phase A stripe/bold/sparkline · Phase B pinned) ── */
+export function MacroEventsCard({ events, regimeTrend }: { events: MacroEvent[]; regimeTrend: string | undefined }) {
+  if (events.length === 0) return null;
+  const pinned = shouldPinCard(events);
+  return (
+    <div className={`rounded-lg bg-zinc-900/40 border ${pinned ? "border-amber-500/70 ring-1 ring-amber-500/30 shadow-amber-500/10 shadow-md" : "border-zinc-800/60"} border-l-4 ${regimeStripe(regimeTrend)} p-2.5`}>
+      <div className="flex items-center justify-between mb-1.5">
+        <h4 className="text-[10px] text-zinc-500 font-semibold flex items-center gap-1">
+          {pinned && <span className="text-amber-400" aria-label="pinned attention">📌</span>}
+          {CONTEXT.TITLE}
+          {pinned && <span className="text-[9px] text-amber-300/80 font-bold">ATTENTION</span>}
+        </h4>
+        {(() => {
+          const sl = sparklinePath(events, 60, 14);
+          if (!sl) return null;
+          const trendColor = sl.latest > 0.1 ? "stroke-emerald-400" : sl.latest < -0.1 ? "stroke-red-400" : "stroke-zinc-500";
+          return (
+            <svg width="60" height="14" className={trendColor} aria-label="7d sentiment trend">
+              <path d={sl.path} fill="none" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          );
+        })()}
+      </div>
+      <div className="space-y-1">
+        {events.map((ev, i) => {
+          const style = categoryStyles[ev.category] || { emoji: "📌", color: "text-zinc-400" };
+          const date = ev.published_at?.slice(5, 10) ?? "";
+          const isHighConf = (ev.confidence ?? 0) >= 0.8;
+          const headlineCls = isHighConf ? "text-zinc-300 font-medium" : "text-zinc-500";
+          return (
+            <div key={i} className="flex items-start gap-1.5 text-[11px]">
+              <span className="shrink-0">{style.emoji}</span>
+              <span className={`shrink-0 ${style.color} ${isHighConf ? "font-bold" : "font-medium"}`}>{date}</span>
+              <span className={`shrink-0 ${style.color} ${isHighConf ? "font-bold" : "font-semibold"}`}>{ev.category_ko ?? ev.category}</span>
+              <span className={`${headlineCls} truncate flex-1`} title={ev.headline}>
+                {ev.headline.length > 60 ? ev.headline.slice(0, 57) + "..." : ev.headline}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/action-items.branchcov.test.tsx
+++ b/frontend/src/components/ui/action-items.branchcov.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ActionItems, type ActionItem } from "@/components/ui/action-items";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => <a href={href} {...props}>{children}</a>,
 }));
 
 // 분기 커버리지 전용 테스트 — action-items.tsx 의 모든 branch arm 을
@@ -70,10 +70,10 @@ describe("ActionItems — full branch coverage", () => {
     expect(badge.className).toContain("bg-zinc-700");
   });
 
-  it("name present: shows ticker subtext (line 56 || left, line 58 && right)", () => {
+  it("name present: ticker moves to title attr (#1208 dense row)", () => {
     render(<ActionItems urgent={[{ ...base, ticker: "X4", name: "Named" }]} check={[]} hold={[]} />);
-    expect(screen.getByText("Named")).toBeTruthy();
-    expect(screen.getByText("X4")).toBeTruthy(); // ticker subtext span (line 58)
+    const link = screen.getByText("Named");
+    expect(link.getAttribute("title")).toContain("X4");
   });
 
   it("name null: link shows ticker, no subtext (line 56 || right, line 58 && false)", () => {
@@ -105,31 +105,39 @@ describe("ActionItems — full branch coverage", () => {
     expect(pnl.className).toContain("text-red-400");
   });
 
-  it("priority fallback to hold style when unknown (line 43 || right arm)", () => {
+  it("row accent comes from the bucket, not item.priority (#1208)", () => {
     render(<ActionItems urgent={[{ ...base, ticker: "X10", name: "Unknown", priority: "nope" }]} check={[]} hold={[]} />);
-    const card = screen.getByText("Unknown").closest("div.rounded-lg");
-    expect(card?.className).toContain("border-zinc-800/60"); // priorityStyles.hold.border
+    const row = screen.getByText("Unknown").closest("tr");
+    expect(row?.className).toContain("border-l-red-500/60"); // urgent 버킷 accent
   });
 
-  it("expanded detail toggles (line 84 && + line 97 cond), formats US prices", () => {
+  // #1208: 행 안의 링크 클릭은 peek 토글을 막는다 (stopPropagation 2곳)
+  it("ticker/evidence link clicks do not toggle the quick-peek", () => {
+    render(<ActionItems urgent={[{ ...base, ticker: "X20", name: "LinkCo", decision_id: 7 }]} check={[]} hold={[]} />);
+    fireEvent.click(screen.getByText("LinkCo"));
+    expect(screen.queryByTestId("action-row-peek")).toBeNull();
+    fireEvent.click(screen.getByText(/증거 체인/));
+    expect(screen.queryByTestId("action-row-peek")).toBeNull();
+  });
+
+  it("quick-peek toggles on row click, formats US prices (#1208)", () => {
     render(<ActionItems urgent={[{ ...base, ticker: "X11", name: "Exp" }]} check={[]} hold={[]} />);
-    const btn = screen.getByText(/상세|▼|상세 근거/);
-    fireEvent.click(btn); // expanded = true → line 84 && true, line 97 "▲"
+    const row = screen.getByTestId("action-row");
+    fireEvent.click(row);
     expect(screen.getByText("현재가")).toBeTruthy();
-    const collapse = screen.getByText(/접기|▲/);
-    fireEvent.click(collapse); // expanded = false → line 97 "▼"
+    fireEvent.click(row);
     expect(screen.queryByText("현재가")).toBeNull();
   });
 
   it("KR ticker formats prices with won (line 47 isKr true)", () => {
     render(<ActionItems urgent={[{ ...base, ticker: "005930.KS", name: "KR", current_price: 200750 }]} check={[]} hold={[]} />);
-    fireEvent.click(screen.getByText(/상세|▼/));
+    fireEvent.click(screen.getByTestId("action-row"));
     expect((document.body.textContent ?? "").includes("₩")).toBe(true);
   });
 
   it("null prices render dash (line 46 fmt v == null)", () => {
     render(<ActionItems urgent={[{ ...base, ticker: "X12", name: "Null", current_price: null, stop_loss: null, target_1: null }]} check={[]} hold={[]} />);
-    fireEvent.click(screen.getByText(/상세|▼/));
+    fireEvent.click(screen.getByTestId("action-row"));
     expect((document.body.textContent ?? "").includes("—")).toBe(true);
   });
 

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { ACTION } from "@/lib/strings";
 import { formatMoney } from "@/lib/format";
 
@@ -35,77 +35,125 @@ interface ActionItemsProps {
   portfolio?: ActionItem[];
 }
 
-const priorityStyles = {
-  urgent: { bg: "bg-red-950/30", border: "border-red-900/50", dot: "bg-red-500", text: "text-red-400" },
-  check: { bg: "bg-amber-950/20", border: "border-amber-900/40", dot: "bg-amber-500", text: "text-amber-400" },
-  hold: { bg: "bg-zinc-900/40", border: "border-zinc-800/60", dot: "bg-zinc-500", text: "text-zinc-400" },
-  portfolio: { bg: "bg-sky-950/20", border: "border-sky-900/40", dot: "bg-sky-500", text: "text-sky-400" },
+// U2b-2 (#1208): 카드 → 32px 밀집 테이블 행. 버킷(심각도) 구조는 유지 —
+// urgent > portfolio > check 순서가 곧 예외 큐 정렬이다 (plan §4.5).
+const bucketStyles = {
+  urgent: { dot: "bg-red-500", title: "text-red-400", accent: "border-l-red-500/60" },
+  portfolio: { dot: "bg-sky-500", title: "text-sky-400", accent: "border-l-sky-500/60" },
+  check: { dot: "bg-amber-500", title: "text-amber-400", accent: "border-l-amber-500/60" },
 };
 
-function ActionCard({ item }: { item: ActionItem }) {
+function actionTagCls(action: string): string {
+  if (action === "SELL") return "bg-red-500/20 text-red-400";
+  if (action === "BUY") return "bg-emerald-500/20 text-emerald-400";
+  return "bg-zinc-700 text-zinc-400";
+}
+
+function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
   const [expanded, setExpanded] = useState(false);
-  const style = priorityStyles[item.priority as keyof typeof priorityStyles] || priorityStyles.hold;
-  // 통화 판정은 lib/format 한 곳 (#1197) — 이전 로컬 판정은 .KQ(코스닥)를 놓쳤다
   const fmt = (v: number | null | undefined) => formatMoney(v, { ticker: item.ticker });
+  const confPct = Math.max(0, Math.min(100, item.confidence));
 
   return (
-    <div className={`rounded-lg p-3 ${style.bg} border ${style.border}`}>
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <Link href={`/ticker/${item.ticker}`} className="text-sm font-semibold text-zinc-100 hover:text-white transition-colors">
-              {item.name || item.ticker}
-            </Link>
-            {item.name && <span className="text-[11px] text-zinc-400">{item.ticker}</span>}
-            <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
-              item.action === "SELL" ? "bg-red-500/20 text-red-400" :
-              item.action === "BUY" ? "bg-emerald-500/20 text-emerald-400" :
-              "bg-zinc-700 text-zinc-400"
-            }`}>
-              {item.action}
-            </span>
-            {item.account && <span className="text-[11px] text-zinc-400">{item.account}</span>}
-          </div>
-          <div className="mt-1 space-y-0.5">
-            {item.reasons.map((r, i) => (
-              <p key={i} className="text-xs text-zinc-400 leading-tight">{r}</p>
-            ))}
-          </div>
-        </div>
-        <div className="text-right shrink-0 space-y-0.5">
-          <p className={`text-sm font-semibold tabular-nums ${item.pnl_pct >= 0 ? "text-emerald-400" : "text-red-400"}`}>
-            {item.pnl_pct >= 0 ? "+" : ""}{item.pnl_pct.toFixed(1)}%
-          </p>
-          <p className="text-[11px] text-zinc-400 tabular-nums">{ACTION.WEIGHT} {item.position_pct.toFixed(1)}%</p>
-          <p className="text-[11px] text-zinc-400 tabular-nums">{ACTION.CONF} {item.confidence}</p>
-        </div>
-      </div>
-
-      {/* 확장 상세 */}
-      {expanded && (
-        <div className="mt-2 pt-2 border-t border-zinc-800/50 grid grid-cols-3 gap-2 text-[11px]">
-          <div><span className="text-zinc-600">현재가</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></div>
-          <div><span className="text-zinc-600">손절</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></div>
-          <div><span className="text-zinc-600">1차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></div>
-        </div>
-      )}
-
-      <div className="mt-2 flex gap-2 items-center">
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
-        >
-          {expanded ? "접기" : ACTION.DETAIL} {expanded ? "▲" : "▼"}
-        </button>
-        {/* #1182: 이 판정의 증거 체인 — decision 매칭이 없으면(레거시 행) 링크 생략 */}
-        {item.decision_id != null && (
+    <Fragment>
+      <tr
+        className={`border-b border-zinc-800/40 border-l-2 ${accent} hover:bg-zinc-800/30 cursor-pointer transition-colors`}
+        onClick={() => setExpanded(!expanded)}
+        data-testid="action-row"
+        aria-expanded={expanded}
+      >
+        <td className="h-8 px-2 whitespace-nowrap">
           <Link
-            href={`/decisions/${item.decision_id}`}
-            className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
+            href={`/ticker/${item.ticker}`}
+            className="text-xs font-semibold text-zinc-100 hover:text-white transition-colors"
+            onClick={(e) => e.stopPropagation()}
+            title={item.name ? `${item.name} (${item.ticker})` : item.ticker}
           >
-            {ACTION.EVIDENCE}{item.as_of ? ` (${item.as_of})` : ""} →
+            {item.name || item.ticker}
           </Link>
-        )}
+        </td>
+        <td className="h-8 px-2 whitespace-nowrap hidden md:table-cell text-[11px] text-zinc-400">{item.account ?? "—"}</td>
+        <td className="h-8 px-2 whitespace-nowrap">
+          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${actionTagCls(item.action)}`}>{item.action}</span>
+        </td>
+        <td className="h-8 px-2 w-full max-w-0">
+          <p className="text-xs text-zinc-400 truncate" title={item.reasons.join(" · ")}>
+            {item.reasons[0] ?? "—"}
+            {item.reasons.length > 1 && <span className="text-zinc-600"> +{item.reasons.length - 1}</span>}
+          </p>
+        </td>
+        <td className={`h-8 px-2 whitespace-nowrap text-right text-xs font-semibold tabular-nums ${item.pnl_pct >= 0 ? "text-emerald-400" : "text-red-400"}`}>
+          {item.pnl_pct >= 0 ? "+" : ""}{item.pnl_pct.toFixed(1)}%
+        </td>
+        <td className="h-8 px-2 whitespace-nowrap hidden md:table-cell text-right text-[11px] text-zinc-400 tabular-nums">
+          {item.position_pct.toFixed(1)}%
+        </td>
+        <td className="h-8 px-2 whitespace-nowrap">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="relative inline-block w-12 h-1 rounded-full bg-zinc-800 overflow-hidden align-middle">
+              <span className="absolute inset-y-0 left-0 rounded-full bg-zinc-500" style={{ width: `${confPct}%` }} />
+            </span>
+            <span className="text-[11px] text-zinc-400 tabular-nums">{item.confidence}</span>
+          </span>
+        </td>
+        <td className="h-8 px-2 whitespace-nowrap text-right">
+          {item.decision_id != null ? (
+            <Link
+              href={`/decisions/${item.decision_id}`}
+              className="text-[11px] text-zinc-500 hover:text-zinc-300 transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {ACTION.EVIDENCE} →
+            </Link>
+          ) : (
+            <span className="text-[11px] text-zinc-700">—</span>
+          )}
+        </td>
+      </tr>
+      {/* quick-peek (#1208, codex 2R 합의): 라우트 이동 없이 가격 레벨·전체 근거 확인 */}
+      {expanded && (
+        <tr className="border-b border-zinc-800/40 bg-zinc-900/40" data-testid="action-row-peek">
+          <td colSpan={8} className="px-3 py-2">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
+              <span><span className="text-zinc-600">현재가</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></span>
+              <span><span className="text-zinc-600">손절</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></span>
+              <span><span className="text-zinc-600">1차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></span>
+              {item.target_2 != null && (
+                <span><span className="text-zinc-600">2차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_2)}</span></span>
+              )}
+              {item.as_of && <span className="text-zinc-600">판정 {item.as_of}</span>}
+            </div>
+            {item.reasons.length > 1 && (
+              <div className="mt-1 space-y-0.5">
+                {item.reasons.slice(1).map((r, i) => (
+                  <p key={i} className="text-[11px] text-zinc-500 leading-tight">{r}</p>
+                ))}
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </Fragment>
+  );
+}
+
+function ActionBucketTable({ items, kind, title }: { items: ActionItem[]; kind: keyof typeof bucketStyles; title: string }) {
+  const style = bucketStyles[kind];
+  if (items.length === 0) return null;
+  return (
+    <div>
+      <h3 className={`text-xs font-semibold ${style.title} mb-1 flex items-center gap-1.5`}>
+        <span className={`w-2 h-2 rounded-full ${style.dot}`} />
+        {title} ({items.length})
+      </h3>
+      <div className="overflow-x-auto rounded border border-zinc-800/60 bg-zinc-900/30">
+        <table className="w-full text-left">
+          <tbody>
+            {items.map((item) => (
+              <ActionRow key={`${item.ticker}-${item.account}`} item={item} accent={style.accent} />
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );
@@ -125,45 +173,15 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
   return (
     <div className="space-y-3">
       {/* 🔴 즉시 실행 */}
-      {urgent.length > 0 && (
-        <div>
-          <h3 className="text-xs font-semibold text-red-400 mb-1.5 flex items-center gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-red-500" />
-            {ACTION.URGENT} ({urgent.length})
-          </h3>
-          <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2 items-start">
-            {urgent.map((item) => <ActionCard key={`${item.ticker}-${item.account}`} item={item} />)}
-          </div>
-        </div>
-      )}
+      <ActionBucketTable items={urgent} kind="urgent" title={ACTION.URGENT} />
 
       {/* 📊 포트폴리오 리밸런스 — PR A: SIEGE 룰 위반을 "매도" 로 surface 하지 않기 */}
-      {portfolio.length > 0 && (
-        <div>
-          <h3 className="text-xs font-semibold text-sky-400 mb-1.5 flex items-center gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-sky-500" />
-            {ACTION.PORTFOLIO} ({portfolio.length})
-          </h3>
-          <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2 items-start">
-            {portfolio.map((item) => <ActionCard key={`${item.ticker}-${item.account}`} item={item} />)}
-          </div>
-        </div>
-      )}
+      <ActionBucketTable items={portfolio} kind="portfolio" title={ACTION.PORTFOLIO} />
 
       {/* 🟡 오늘 확인 */}
-      {check.length > 0 && (
-        <div>
-          <h3 className="text-xs font-semibold text-amber-400 mb-1.5 flex items-center gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-amber-500" />
-            {ACTION.CHECK} ({check.length})
-          </h3>
-          <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-2 items-start">
-            {check.map((item) => <ActionCard key={`${item.ticker}-${item.account}`} item={item} />)}
-          </div>
-        </div>
-      )}
+      <ActionBucketTable items={check} kind="check" title={ACTION.CHECK} />
 
-      {/* ✅ 유지 */}
+      {/* ✅ 유지 — 칩 유지 (행 승격은 노이즈, 목업 합의) */}
       {hold.length > 0 && (
         <div>
           <h3 className="text-xs font-semibold text-zinc-500 mb-1.5 flex items-center gap-1.5">

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -57,8 +57,17 @@ function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
   return (
     <Fragment>
       <tr
-        className={`border-b border-zinc-800/40 border-l-2 ${accent} hover:bg-zinc-800/30 cursor-pointer transition-colors`}
+        className={`border-b border-zinc-800/40 border-l-2 ${accent} hover:bg-zinc-800/30 cursor-pointer transition-colors focus-visible:outline-2 focus-visible:outline-blue-400/75`}
         onClick={() => setExpanded(!expanded)}
+        // 키보드 접근 (#1208 codex P1): 구 카드의 <button> 을 행이 대체하므로
+        // 행 자체가 포커스·Enter/Space 토글을 제공해야 한다
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(!expanded);
+          }
+        }}
         data-testid="action-row"
         aria-expanded={expanded}
       >
@@ -115,6 +124,9 @@ function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
         <tr className="border-b border-zinc-800/40 bg-zinc-900/40" data-testid="action-row-peek">
           <td colSpan={8} className="px-3 py-2">
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
+              {/* <md 에서 행이 숨기는 계좌·비중을 peek 가 복원 (#1208 codex P2) */}
+              {item.account && <span className="md:hidden"><span className="text-zinc-600">계좌</span> <span className="text-zinc-300">{item.account}</span></span>}
+              <span className="md:hidden"><span className="text-zinc-600">비중</span> <span className="text-zinc-300 tabular-nums">{item.position_pct.toFixed(1)}%</span></span>
               <span><span className="text-zinc-600">현재가</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></span>
               <span><span className="text-zinc-600">손절</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></span>
               <span><span className="text-zinc-600">1차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></span>

--- a/frontend/src/components/ui/market-context.branchcov.test.tsx
+++ b/frontend/src/components/ui/market-context.branchcov.test.tsx
@@ -1,13 +1,21 @@
 import { render } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import type { ReactNode } from "react";
-import {
-  MarketContext,
-  shouldPinCard,
-  sparklinePath,
-  type MacroEvent,
-  type SystemHealth,
-} from "@/components/ui/market-context";
+import { shouldPinCard, sparklinePath, type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
+import { SystemHealthRail, MacroEventsCard, RegimeShiftBanner } from "@/components/dashboard/system-rail";
+
+// U2b-2 (#1208): MarketContext 컴포넌트는 SystemHealthRail·MacroEventsCard·
+// RegimeShiftBanner 로 분해됨 — 테스트는 프로덕션 조립(page.tsx)과 동일한 구성을
+// 이 래퍼로 미러링해 기존 assert 를 유지한다.
+function MarketContext({ events, health }: { events: MacroEvent[]; health: Partial<SystemHealth> }) {
+  return (
+    <>
+      <RegimeShiftBanner regime={health.regime ?? {}} />
+      <SystemHealthRail health={health} />
+      <MacroEventsCard events={events} regimeTrend={health.regime?.trend} />
+    </>
+  );
+}
 
 // next/link → 단순 anchor (네트워크/라우터 불필요), 기존 coverage 테스트와 동일 패턴
 vi.mock("next/link", () => ({

--- a/frontend/src/components/ui/market-context.coverage.test.tsx
+++ b/frontend/src/components/ui/market-context.coverage.test.tsx
@@ -1,7 +1,21 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MarketContext, shouldPinCard, sparklinePath, type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
+import { shouldPinCard, sparklinePath, type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
+import { SystemHealthRail, MacroEventsCard, RegimeShiftBanner } from "@/components/dashboard/system-rail";
+
+// U2b-2 (#1208): MarketContext 컴포넌트는 SystemHealthRail·MacroEventsCard·
+// RegimeShiftBanner 로 분해됨 — 테스트는 프로덕션 조립(page.tsx)과 동일한 구성을
+// 이 래퍼로 미러링해 기존 assert 를 유지한다.
+function MarketContext({ events, health }: { events: MacroEvent[]; health: Partial<SystemHealth> }) {
+  return (
+    <>
+      <RegimeShiftBanner regime={health.regime ?? {}} />
+      <SystemHealthRail health={health} />
+      <MacroEventsCard events={events} regimeTrend={health.regime?.trend} />
+    </>
+  );
+}
 
 // next/link → 단순 anchor 로 렌더 (네트워크/라우터 불필요)
 vi.mock("next/link", () => ({

--- a/frontend/src/components/ui/market-context.tsx
+++ b/frontend/src/components/ui/market-context.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-import { CONTEXT } from "@/lib/strings";
 
 export interface MacroEvent {
   category: string;
@@ -23,7 +21,7 @@ interface MarketContextProps {
   health: Partial<SystemHealth>;
 }
 
-const categoryStyles: Record<string, { emoji: string; color: string }> = {
+export const categoryStyles: Record<string, { emoji: string; color: string }> = {
   geopolitical_escalation: { emoji: "🔴", color: "text-red-400" },
   geopolitical_de_escalation: { emoji: "🟢", color: "text-emerald-400" },
   oil_supply_shock: { emoji: "🛢", color: "text-amber-400" },
@@ -35,14 +33,14 @@ const categoryStyles: Record<string, { emoji: string; color: string }> = {
   sector_rally: { emoji: "🚀", color: "text-blue-400" },
 };
 
-function healthColor(value: number, thresholds: [number, number]): string {
+export function healthColor(value: number, thresholds: [number, number]): string {
   if (value >= thresholds[1]) return "text-emerald-400";
   if (value >= thresholds[0]) return "text-amber-400";
   return "text-red-400";
 }
 
 // #503 Phase A — regime stripe color (events card 좌측 border)
-function regimeStripe(trend: string | undefined): string {
+export function regimeStripe(trend: string | undefined): string {
   if (trend === "bull") return "border-l-emerald-500/60";
   if (trend === "bear") return "border-l-red-500/60";
   if (trend === "sideways") return "border-l-amber-500/60";
@@ -72,7 +70,7 @@ export function shouldPinCard(events: MacroEvent[]): boolean {
 }
 
 // #503 Phase B — regime banner: regime confidence 가 60% 미만이면 전환 임박 신호.
-function isRegimeShifting(regime: Partial<SystemHealth["regime"]>): boolean {
+export function isRegimeShifting(regime: Partial<SystemHealth["regime"]>): boolean {
   const conf = regime.confidence ?? 100;
   return conf < 60 && conf > 0;
 }
@@ -102,113 +100,6 @@ export function sparklinePath(events: MacroEvent[], width: number, height: numbe
   return { path: `M ${points.join(" L ")}`, latest: means[means.length - 1] };
 }
 
-function HealthCard({ label, value, sub, href, color }: { label: string; value: string; sub: string; href: string; color: string }) {
-  return (
-    <Link href={href} className="flex-1 min-w-20 rounded-lg bg-zinc-900/60 border border-zinc-800/50 p-2.5 hover:bg-zinc-800/60 transition-colors">
-      <p className="text-[11px] text-zinc-400 mb-0.5">{label}</p>
-      <p className={`text-lg font-bold tabular-nums leading-tight ${color}`}>{value}</p>
-      <p className="text-[11px] text-zinc-400 mt-0.5 truncate">{sub}</p>
-    </Link>
-  );
-}
-
-export function MarketContext({ events, health }: MarketContextProps) {
-  const siege: Partial<SystemHealth["siege"]> = health.siege || {};
-  const regime: Partial<SystemHealth["regime"]> = health.regime || {};
-  const macro: Partial<SystemHealth["macro"]> = health.macro || {};
-  const freshness: Partial<SystemHealth["freshness"]> = health.freshness || {};
-
-  const pinned = shouldPinCard(events);
-  const shifting = isRegimeShifting(regime);
-
-  return (
-    <div className="space-y-3">
-      {/* #503 Phase B — regime-shift banner (regime.confidence < 60%) */}
-      {shifting && (
-        <div className="rounded-lg bg-amber-950/40 border border-amber-700/50 px-3 py-2 flex items-center gap-2 text-xs">
-          <span className="shrink-0">⚠</span>
-          <span className="text-amber-300 font-semibold">Regime 전환 신호</span>
-          <span className="text-zinc-400">
-            현재 {regime.regime ?? "—"} · 신뢰도{" "}
-            {/* v8 ignore start -- banner renders only when isRegimeShifting (conf 0~60) → confidence always defined, `?? 0` arm unreachable */}
-            {regime.confidence ?? 0}
-            {/* v8 ignore stop */}% — 다음 행동 보류 권고
-          </span>
-        </div>
-      )}
-
-      {/* 시스템 건강 4-card */}
-      <div className="flex gap-2">
-        <HealthCard
-          label={CONTEXT.SIEGE}
-          value={`${siege.score ?? 0}%`}
-          sub={siege.certified ? CONTEXT.CERTIFIED : CONTEXT.REJECTED}
-          href="/engine"
-          color={siege.certified ? "text-emerald-400" : "text-red-400"}
-        />
-        <HealthCard
-          label={CONTEXT.REGIME}
-          value={regime.regime?.toUpperCase()?.slice(0, 6) ?? "—"}
-          sub={`${regime.trend ?? "—"} ${regime.confidence ?? 0}%`}
-          href="/strategy"
-          color={regime.trend === "bull" ? "text-emerald-400" : regime.trend === "bear" ? "text-red-400" : "text-amber-400"}
-        />
-        <HealthCard
-          label={CONTEXT.MACRO}
-          value={`${macro.score ?? 0}`}
-          sub={macro.interpretation ?? "—"}
-          href="/strategy"
-          color={healthColor(macro.score ?? 0, [40, 60])}
-        />
-        <HealthCard
-          label={CONTEXT.FRESHNESS}
-          value={freshness.status ?? "—"}
-          sub={freshness.fail_count ? `${freshness.fail_count} fail` : "OK"}
-          href="/pipeline"
-          color={freshness.status === "PASS" ? "text-emerald-400" : freshness.status === "WARN" ? "text-amber-400" : "text-red-400"}
-        />
-      </div>
-
-      {/* 매크로 이벤트 — Phase A: stripe/bold/sparkline · Phase B: pinned attention */}
-      {events.length > 0 && (
-        <div className={`rounded-lg bg-zinc-900/40 border ${pinned ? "border-amber-500/70 ring-1 ring-amber-500/30 shadow-amber-500/10 shadow-md" : "border-zinc-800/60"} border-l-4 ${regimeStripe(regime.trend)} p-2.5`}>
-          <div className="flex items-center justify-between mb-1.5">
-            <h4 className="text-[10px] text-zinc-500 font-semibold flex items-center gap-1">
-              {pinned && <span className="text-amber-400" aria-label="pinned attention">📌</span>}
-              {CONTEXT.TITLE}
-              {pinned && <span className="text-[9px] text-amber-300/80 font-bold">ATTENTION</span>}
-            </h4>
-            {(() => {
-              const sl = sparklinePath(events, 60, 14);
-              if (!sl) return null;
-              const trendColor = sl.latest > 0.1 ? "stroke-emerald-400" : sl.latest < -0.1 ? "stroke-red-400" : "stroke-zinc-500";
-              return (
-                <svg width="60" height="14" className={trendColor} aria-label="7d sentiment trend">
-                  <path d={sl.path} fill="none" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              );
-            })()}
-          </div>
-          <div className="space-y-1">
-            {events.map((ev, i) => {
-              const style = categoryStyles[ev.category] || { emoji: "📌", color: "text-zinc-400" };
-              const date = ev.published_at?.slice(5, 10) ?? "";
-              const isHighConf = (ev.confidence ?? 0) >= 0.8;
-              const headlineCls = isHighConf ? "text-zinc-300 font-medium" : "text-zinc-500";
-              return (
-                <div key={i} className="flex items-start gap-1.5 text-[11px]">
-                  <span className="shrink-0">{style.emoji}</span>
-                  <span className={`shrink-0 ${style.color} ${isHighConf ? "font-bold" : "font-medium"}`}>{date}</span>
-                  <span className={`shrink-0 ${style.color} ${isHighConf ? "font-bold" : "font-semibold"}`}>{ev.category_ko ?? ev.category}</span>
-                  <span className={`${headlineCls} truncate flex-1`} title={ev.headline}>
-                    {ev.headline.length > 60 ? ev.headline.slice(0, 57) + "..." : ev.headline}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
+// HealthCard/MarketContext 컴포넌트는 U2b-2 (#1208) 에서
+// components/dashboard/system-rail.tsx 의 SystemHealthRail · MacroEventsCard ·
+// RegimeShiftBanner 로 분해·이관됨. 이 모듈은 타입·판정 유틸·스타일 맵의 정본으로 남는다.

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -363,6 +363,7 @@ export const OPPORTUNITY = {
 export const CONTEXT = {
   TITLE: "시장 컨텍스트",
   SYSTEM_HEALTH: "시스템 건강",
+  RAIL_TITLE: "시스템 상태",
   SIEGE: "Certification",
   REGIME: "레짐",
   MACRO: "매크로",

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -335,14 +335,9 @@ export const ACTION = {
   HOLD: "유지",
   HOLD_SUMMARY: "유지 종목",
   PORTFOLIO: "포트폴리오 리밸런스",
-  DETAIL: "상세 근거",
-  DISMISS: "무시하기",
   EMPTY: "오늘 실행할 액션이 없습니다.",
-  CONF: "확신도",
-  AGREE: "합의",
-  PNL: "손익",
-  WEIGHT: "비중",
   EVIDENCE: "증거 체인", // #1182: 카드 → /decisions/[id]
+  // DETAIL/CONF/AGREE/PNL/WEIGHT/DISMISS 는 U2b-2 (#1208) 카드→행 전환으로 제거
 } as const;
 
 export const OPPORTUNITY = {


### PR DESCRIPTION
Closes #1208. Evidence Terminal U2b-2 (docs/UX_REDESIGN_PLAN.md §3, U2b 2/4; follows #1207).

## What

- **ActionItems**: cards → 32px dense table rows in the same severity buckets (urgent > portfolio > check = exception-queue order). Columns: ticker · account · action tag · first reason (+N) · P&L · weight · confidence micro-bar · evidence link. Row click opens a **quick-peek** expansion (price levels, as_of, remaining reasons) — the codex round-2 merge from the triage-board alternative; link clicks stopPropagation. Hold bucket stays as chips
- **MarketContext decomposed** → `components/dashboard/system-rail.tsx`: `SystemHealthRail` (compact vertical 4-row panel), `MacroEventsCard`, `RegimeShiftBanner`; `market-context.tsx` keeps types/judgment utils/style maps as their canonical home
- **Dashboard grid**: left 2/3 actions + right 1/3 rail (stacks < lg)
- Plan doc: U2b split into U2b-1..4 status rows

## Verification

- vitest **1478/1478** — action-items + market-context suites retargeted; market-context tests use a compat wrapper mirroring the page composition so content asserts survive; new stopPropagation lock
- action-items.tsx 100% stmt/line · full-suite statements 1915/1915 · build/lint clean
- Responsive matrix **24/24** · `action-first` e2e red is the **known dev-DB macro_events staleness** (API returns 0 events; memory-documented data dependency — spec deliberately not weakened)
- Live screenshot matches the approved mockup (banner → compact hero → action table + rail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)