### PR TITLE
feat(frontend): Evidence Terminal U2b-4 — NEW/ack seen-state + rail next-action copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,489 across 129 files — 100% statement coverage | |
+| **Frontend tests** | 1,492 across 129 files — 100% statement coverage | |
 | **E2E tests** | 83 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,477 across 128 files — 100% statement coverage | |
+| **Frontend tests** | 1,489 across 129 files — 100% statement coverage | |
 | **E2E tests** | 83 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1477 frontend vitest (128 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1489 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1489 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1492 frontend vitest (129 files) + 83 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1477 tests, 128 files |
+| Frontend tests | 목표 ≥ 90% | 1489 tests, 129 files |
 | E2E | 핵심 flow | 83 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1489 tests, 129 files |
+| Frontend tests | 목표 ≥ 90% | 1492 tests, 129 files |
 | E2E | 핵심 flow | 83 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/UX_REDESIGN_PLAN.md
+++ b/docs/UX_REDESIGN_PLAN.md
@@ -71,8 +71,8 @@
 | U2a | 대시보드 추출 | `page.tsx`(668줄) 섹션별 컴포넌트 추출 — 동작 보존, 시각 변화 없음 (5개 인라인 색맵 함수 격리) | 대기 |
 | U2b-1 | verdict 배너 + 히어로 축소 | 배너 최상단(placement 잠금 테스트) · MarketStrip verdict 꼬리 제거 · 히어로 3xl→xl | **완료 #1207** |
 | U2b-2 | 액션 테이블 + 시스템 레일 | 카드→32px 밀집 행(quick-peek 확장·확신도 micro-bar·증거 링크) · MarketContext 분해(SystemHealthRail·MacroEventsCard·RegimeShiftBanner) · 좌 2/3 + 우 1/3 그리드 | 완료 (#1209) |
-| U2b-3 | 구성 스택 바 | 도넛→가로 스택 바 · coverage 접이 | 진행 중 (#1210) |
-| U2b-4 | 델타·ack | NEW+시각 배지 · 확인(ack) 로컬 상태 · 다음 행동 카피 | 대기 |
+| U2b-3 | 구성 스택 바 | 도넛→가로 스택 바 · coverage 접이 | 완료 (#1211) |
+| U2b-4 | 델타·ack | NEW+시각 배지 · 확인(ack) 로컬 상태 · 다음 행동 카피 | 진행 중 (#1212) |
 | U3 | Decisions | 리스트: 필터·날짜 그룹핑·conf micro-bar·판정일 명시 / 상세: 2컬럼 + 증거 key-value(raw JSON 폐지) + raw float 종결 | 대기 |
 | U4 | 주변부 | ticker(빈 패널 접기)·scanner(중복 테이블 병합)·engine(BLOCKED 다음 행동)·pipeline(타임라인 구조화) + 빈 상태 1줄 규칙 전면 | 대기 |
 | U5 | 별도 결정 | evidence matplotlib PNG→네이티브 차트 · Cmd-K · IA 통합(라우트 병합) — 각각 사용자 승인 후 착수 | 보류 |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1477 tests, 128 files)
+npm run test           # vitest run (1489 tests, 129 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -75,7 +75,7 @@ Two things that do **not** work, already tried (#913):
 Symptom if someone drops it: eslint prints `Oops! Something went wrong!` with a
 `brace-expansion` stack trace and lints **nothing**. `npm run lint` is silent on success, so
 confirm by file count rather than by absence of output — `npx eslint --format json | jq length`
-should be **221**.
+should be **223**.
 
 ## E2E (Playwright) — runs against the real backend, gated by nothing
 
@@ -93,4 +93,4 @@ should be **221**.
 
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
-- Test files: 92 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 93 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1489 tests, 129 files)
+npm run test           # vitest run (1492 tests, 129 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -93,4 +93,5 @@ should be **223**.
 
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
+- **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
 - Test files: 93 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1477 tests, 128 files)
+npm run test           # vitest (1489 tests, 129 files)
 npx playwright test    # E2E (83 tests, 9 specs)
 ```
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1489 tests, 129 files)
+npm run test           # vitest (1492 tests, 129 files)
 npx playwright test    # E2E (83 tests, 9 specs)
 ```
 

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -309,3 +309,28 @@ describe("ActionItems", () => {
     expect(screen.queryByText(/증거 체인/)).toBeNull();
   });
 });
+
+// #1212 U2b-4: NEW 배지 + 확인(ack) — per-viewer seen-state.
+// 이 jsdom 엔 localStorage 가 없어(action-ack.test.ts 주석 참조) loadAckMap 은
+// {} 로 폴백한다 → 마운트 후 모든 항목이 NEW. ack 는 in-memory 로 동작.
+describe("NEW badge + ack (#1212)", () => {
+  const asOfItem = { ...urgentItem, as_of: "2026-08-25", decision_id: 7 };
+
+  it("marks un-acked rows NEW after mount", () => {
+    render(<ActionItems urgent={[asOfItem]} check={[checkItem]} hold={[]} />);
+    expect(screen.getAllByTestId("action-new-badge")).toHaveLength(2);
+  });
+
+  it("확인 in the quick-peek clears the NEW badge for that row only", () => {
+    render(<ActionItems urgent={[asOfItem]} check={[checkItem]} hold={[]} />);
+    const rows = screen.getAllByTestId("action-row");
+    fireEvent.click(rows[0]); // expand urgent row
+    fireEvent.click(screen.getByTestId("action-ack-button"));
+    expect(screen.getAllByTestId("action-new-badge")).toHaveLength(1); // check 행만 남음
+  });
+
+  it("hold chips never carry NEW badges", () => {
+    render(<ActionItems urgent={[]} check={[]} hold={[holdItem]} />);
+    expect(screen.queryByTestId("action-new-badge")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { ActionItems } from "@/components/ui/action-items";
@@ -312,10 +312,32 @@ describe("ActionItems", () => {
 });
 
 // #1212 U2b-4: NEW 배지 + 확인(ack) — per-viewer seen-state.
-// 이 jsdom 엔 localStorage 가 없어(action-ack.test.ts 주석 참조) loadAckMap 은
-// {} 로 폴백한다 → 마운트 후 모든 항목이 NEW. ack 는 in-memory 로 동작.
+// ⚠️ 스토리지는 환경 의존이다: 로컬 Node 26 jsdom 엔 window.localStorage 가
+// 아예 없고(실험적 webstorage 게터가 undefined), CI Node 22 jsdom 은 실동작
+// 스토리지를 제공한다. 후자에서 ack 이 파일 내 다음 테스트로 지속돼 CI 만
+// 깨졌다 (run 32814106230, expected 2 → got 1). 인메모리 스텁 + 매 테스트
+// 초기화로 양쪽 환경을 동일·결정론적으로 만든다.
 describe("NEW badge + ack (#1212)", () => {
   const asOfItem = { ...urgentItem, as_of: "2026-08-25", decision_id: 7 };
+
+  let ackStore: Record<string, string> = {};
+  const storageStub = {
+    getItem: (k: string) => (k in ackStore ? ackStore[k] : null),
+    setItem: (k: string, v: string) => { ackStore[k] = String(v); },
+    removeItem: (k: string) => { delete ackStore[k]; },
+    clear: () => { ackStore = {}; },
+    key: (i: number) => Object.keys(ackStore)[i] ?? null,
+    get length() { return Object.keys(ackStore).length; },
+  } as Storage;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+  beforeEach(() => {
+    ackStore = {};
+    Object.defineProperty(window, "localStorage", { value: storageStub, configurable: true });
+  });
+  afterAll(() => {
+    if (originalDescriptor) Object.defineProperty(window, "localStorage", originalDescriptor);
+    else delete (window as { localStorage?: Storage }).localStorage;
+  });
 
   it("marks un-acked rows NEW after mount", () => {
     render(<ActionItems urgent={[asOfItem]} check={[checkItem]} hold={[]} />);

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
 import { ActionItems } from "@/components/ui/action-items";
 
 vi.mock("next/link", () => ({
@@ -332,5 +333,27 @@ describe("NEW badge + ack (#1212)", () => {
   it("hold chips never carry NEW badges", () => {
     render(<ActionItems urgent={[]} check={[]} hold={[holdItem]} />);
     expect(screen.queryByTestId("action-new-badge")).not.toBeInTheDocument();
+  });
+
+  // codex R1 P1 잠금: 같은 ticker|account|action 튜플이 두 버킷에 동시에 떠도
+  // ack identity 가 버킷(priority)까지 포함하므로 한쪽 확인이 다른쪽 NEW 를
+  // 지우지 않는다.
+  it("acking a row in one bucket keeps the same tuple NEW in another bucket", () => {
+    const inUrgent = { ...asOfItem, priority: "urgent" };
+    const inPortfolio = { ...asOfItem, priority: "portfolio" };
+    render(<ActionItems urgent={[inUrgent]} check={[]} hold={[]} portfolio={[inPortfolio]} />);
+    expect(screen.getAllByTestId("action-new-badge")).toHaveLength(2);
+    fireEvent.click(screen.getAllByTestId("action-row")[0]); // urgent 행 확장
+    fireEvent.click(screen.getByTestId("action-ack-button"));
+    expect(screen.getAllByTestId("action-new-badge")).toHaveLength(1);
+  });
+
+  // codex R1 P3 잠금: 서버 렌더(HTML 문자열)에는 NEW 배지가 없어야 한다 —
+  // hydration 게이트(useSyncExternalStore 서버 스냅샷 false)가 렌더 시점
+  // loadAckMap() 직독(서버·클라 마크업 불일치)으로 회귀하면 여기서 잡힌다.
+  // (effect 내 동기 setState 회귀는 lint 가 잡는다 — 이 잠금과 역할 분담.)
+  it("server render carries no NEW badge (hydration gate lock)", () => {
+    const html = renderToString(<ActionItems urgent={[asOfItem]} check={[checkItem]} hold={[]} />);
+    expect(html).not.toContain("action-new-badge");
   });
 });

--- a/frontend/src/__tests__/components/market-context.test.tsx
+++ b/frontend/src/__tests__/components/market-context.test.tsx
@@ -68,7 +68,8 @@ describe("MarketContext", () => {
   it("shows SIEGE score with rejected status", () => {
     render(<MarketContext events={[]} health={sampleHealth} />);
     expect(screen.getByText("54%")).toBeTruthy();
-    expect(screen.getByText("미인증")).toBeTruthy();
+    // #1212: 실패 상태 sub 는 다음 행동 카피 포함
+    expect(screen.getByText("미인증 · 게이트 상세 →")).toBeTruthy();
   });
 
   it("shows certified SIEGE status in green", () => {
@@ -132,7 +133,7 @@ describe("MarketContext", () => {
     const failHealth = { ...sampleHealth, freshness: { status: "FAIL", fail_count: 3, warn_count: 0 } };
     render(<MarketContext events={[]} health={failHealth} />);
     expect(screen.getByText("FAIL")).toBeTruthy();
-    expect(screen.getByText("3 fail")).toBeTruthy();
+    expect(screen.getByText("3건 실패 · 파이프라인 확인 →")).toBeTruthy();
   });
 
   it("shows PASS freshness with OK", () => {

--- a/frontend/src/__tests__/lib/action-ack.test.ts
+++ b/frontend/src/__tests__/lib/action-ack.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+
+import { actionKey, isNewItem, loadAckMap, ackItem } from "@/lib/action-ack";
+
+// #1212 U2b-4: seen-state 규칙 잠금 — identity, re-alert, 스토리지 강건성.
+//
+// 이 vitest jsdom 에는 window.localStorage 가 아예 없다 (Node experimental
+// localStorage 로 위임되는데 --localstorage-file 미지정) — 인메모리 스텁을 단다.
+// 라이브러리 자체는 스토리지 부재도 try/catch 로 견딘다 (아래 마지막 테스트).
+function makeStorageStub(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => { store[k] = String(v); },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { store = {}; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  } as Storage;
+}
+const originalDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+Object.defineProperty(window, "localStorage", { value: makeStorageStub(), configurable: true });
+afterAll(() => {
+  if (originalDescriptor) Object.defineProperty(window, "localStorage", originalDescriptor);
+  else delete (window as { localStorage?: Storage }).localStorage;
+});
+
+const item = (over: Partial<{ ticker: string; account?: string; action: string; as_of?: string | null }> = {}) => ({
+  ticker: "AAA",
+  account: "Alpha",
+  action: "SELL",
+  as_of: "2026-08-25",
+  ...over,
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("actionKey", () => {
+  it("composes ticker|account|action, empty account tolerated", () => {
+    expect(actionKey(item())).toBe("AAA|Alpha|SELL");
+    expect(actionKey(item({ account: undefined }))).toBe("AAA||SELL");
+  });
+});
+
+describe("isNewItem", () => {
+  it("null map (pre-mount) → never NEW (hydration safety)", () => {
+    expect(isNewItem(item(), null)).toBe(false);
+  });
+
+  it("no entry → NEW; acked same as_of → not NEW", () => {
+    expect(isNewItem(item(), {})).toBe(true);
+    expect(isNewItem(item(), { "AAA|Alpha|SELL": "2026-08-25" })).toBe(false);
+  });
+
+  // re-alert: 같은 항목이라도 판정일이 갱신되면 다시 NEW
+  it("newer as_of than acked → NEW again", () => {
+    expect(isNewItem(item({ as_of: "2026-08-26" }), { "AAA|Alpha|SELL": "2026-08-25" })).toBe(true);
+  });
+
+  it("null as_of stays acked after one ack", () => {
+    expect(isNewItem(item({ as_of: null }), { "AAA|Alpha|SELL": "" })).toBe(false);
+  });
+});
+
+describe("loadAckMap / ackItem", () => {
+  it("round-trips through localStorage", () => {
+    const next = ackItem({}, item());
+    expect(next).toEqual({ "AAA|Alpha|SELL": "2026-08-25" });
+    expect(loadAckMap()).toEqual({ "AAA|Alpha|SELL": "2026-08-25" });
+  });
+
+  it("null as_of is stored as empty string", () => {
+    expect(ackItem({}, item({ as_of: null }))).toEqual({ "AAA|Alpha|SELL": "" });
+  });
+
+  it("corrupt or non-object storage → empty map, never throws", () => {
+    window.localStorage.setItem("nuri.actions.ack.v1", "{not json");
+    expect(loadAckMap()).toEqual({});
+    window.localStorage.setItem("nuri.actions.ack.v1", "[1,2]");
+    expect(loadAckMap()).toEqual({});
+    window.localStorage.setItem("nuri.actions.ack.v1", JSON.stringify({ a: 1, b: "ok" }));
+    expect(loadAckMap()).toEqual({ b: "ok" }); // 문자열 값만 채택
+  });
+
+  // 스토리지 부재(프라이빗 창·차단 환경·이 jsdom 기본값) — accessor 가 throw/undefined 여도
+  // load 는 {}, ack 는 in-memory 결과를 반환해야 한다.
+  it("survives a missing localStorage entirely", () => {
+    Object.defineProperty(window, "localStorage", { value: undefined, configurable: true });
+    try {
+      expect(loadAckMap()).toEqual({});
+      expect(ackItem({}, item())).toEqual({ "AAA|Alpha|SELL": "2026-08-25" });
+    } finally {
+      Object.defineProperty(window, "localStorage", { value: makeStorageStub(), configurable: true });
+    }
+  });
+});

--- a/frontend/src/__tests__/lib/action-ack.test.ts
+++ b/frontend/src/__tests__/lib/action-ack.test.ts
@@ -25,10 +25,11 @@ afterAll(() => {
   else delete (window as { localStorage?: Storage }).localStorage;
 });
 
-const item = (over: Partial<{ ticker: string; account?: string; action: string; as_of?: string | null }> = {}) => ({
+const item = (over: Partial<{ ticker: string; account?: string; action: string; priority: string; as_of?: string | null }> = {}) => ({
   ticker: "AAA",
   account: "Alpha",
   action: "SELL",
+  priority: "urgent",
   as_of: "2026-08-25",
   ...over,
 });
@@ -38,9 +39,15 @@ beforeEach(() => {
 });
 
 describe("actionKey", () => {
-  it("composes ticker|account|action, empty account tolerated", () => {
-    expect(actionKey(item())).toBe("AAA|Alpha|SELL");
-    expect(actionKey(item({ account: undefined }))).toBe("AAA||SELL");
+  it("composes ticker|account|action|priority, empty account tolerated", () => {
+    expect(actionKey(item())).toBe("AAA|Alpha|SELL|urgent");
+    expect(actionKey(item({ account: undefined }))).toBe("AAA||SELL|urgent");
+  });
+
+  // codex R1 P1: 버킷이 다르면 같은 튜플이라도 별개 identity — 교차 오염 금지,
+  // check→urgent 승격은 재경보.
+  it("distinguishes the same tuple across buckets", () => {
+    expect(actionKey(item({ priority: "urgent" }))).not.toBe(actionKey(item({ priority: "portfolio" })));
   });
 });
 
@@ -51,28 +58,28 @@ describe("isNewItem", () => {
 
   it("no entry → NEW; acked same as_of → not NEW", () => {
     expect(isNewItem(item(), {})).toBe(true);
-    expect(isNewItem(item(), { "AAA|Alpha|SELL": "2026-08-25" })).toBe(false);
+    expect(isNewItem(item(), { "AAA|Alpha|SELL|urgent": "2026-08-25" })).toBe(false);
   });
 
   // re-alert: 같은 항목이라도 판정일이 갱신되면 다시 NEW
   it("newer as_of than acked → NEW again", () => {
-    expect(isNewItem(item({ as_of: "2026-08-26" }), { "AAA|Alpha|SELL": "2026-08-25" })).toBe(true);
+    expect(isNewItem(item({ as_of: "2026-08-26" }), { "AAA|Alpha|SELL|urgent": "2026-08-25" })).toBe(true);
   });
 
   it("null as_of stays acked after one ack", () => {
-    expect(isNewItem(item({ as_of: null }), { "AAA|Alpha|SELL": "" })).toBe(false);
+    expect(isNewItem(item({ as_of: null }), { "AAA|Alpha|SELL|urgent": "" })).toBe(false);
   });
 });
 
 describe("loadAckMap / ackItem", () => {
   it("round-trips through localStorage", () => {
     const next = ackItem({}, item());
-    expect(next).toEqual({ "AAA|Alpha|SELL": "2026-08-25" });
-    expect(loadAckMap()).toEqual({ "AAA|Alpha|SELL": "2026-08-25" });
+    expect(next).toEqual({ "AAA|Alpha|SELL|urgent": "2026-08-25" });
+    expect(loadAckMap()).toEqual({ "AAA|Alpha|SELL|urgent": "2026-08-25" });
   });
 
   it("null as_of is stored as empty string", () => {
-    expect(ackItem({}, item({ as_of: null }))).toEqual({ "AAA|Alpha|SELL": "" });
+    expect(ackItem({}, item({ as_of: null }))).toEqual({ "AAA|Alpha|SELL|urgent": "" });
   });
 
   it("corrupt or non-object storage → empty map, never throws", () => {
@@ -90,7 +97,7 @@ describe("loadAckMap / ackItem", () => {
     Object.defineProperty(window, "localStorage", { value: undefined, configurable: true });
     try {
       expect(loadAckMap()).toEqual({});
-      expect(ackItem({}, item())).toEqual({ "AAA|Alpha|SELL": "2026-08-25" });
+      expect(ackItem({}, item())).toEqual({ "AAA|Alpha|SELL|urgent": "2026-08-25" });
     } finally {
       Object.defineProperty(window, "localStorage", { value: makeStorageStub(), configurable: true });
     }

--- a/frontend/src/components/dashboard/system-rail.tsx
+++ b/frontend/src/components/dashboard/system-rail.tsx
@@ -51,7 +51,8 @@ export function SystemHealthRail({ health }: { health: Partial<SystemHealth> }) 
       <RailRow
         label={CONTEXT.SIEGE}
         value={`${siege.score ?? 0}%`}
-        sub={siege.certified ? CONTEXT.CERTIFIED : CONTEXT.REJECTED}
+        // #1212: 실패 상태는 상태만 말하지 않는다 — 다음 행동(행 링크 목적지)을 카피로
+        sub={siege.certified ? CONTEXT.CERTIFIED : `${CONTEXT.REJECTED} · ${CONTEXT.CHECK_ENGINE}`}
         href="/engine"
         color={siege.certified ? "text-emerald-400" : "text-red-400"}
       />
@@ -72,7 +73,7 @@ export function SystemHealthRail({ health }: { health: Partial<SystemHealth> }) 
       <RailRow
         label={CONTEXT.FRESHNESS}
         value={freshness.status ?? "—"}
-        sub={freshness.fail_count ? `${freshness.fail_count} fail` : "OK"}
+        sub={freshness.fail_count ? `${freshness.fail_count}건 실패 · ${CONTEXT.CHECK_PIPELINE}` : "OK"}
         href="/pipeline"
         color={freshness.status === "PASS" ? "text-emerald-400" : freshness.status === "WARN" ? "text-amber-400" : "text-red-400"}
       />

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useState, Fragment } from "react";
+import { useMemo, useState, useSyncExternalStore, Fragment } from "react";
 import { ACTION } from "@/lib/strings";
 import { formatMoney } from "@/lib/format";
+import { type AckMap, ackItem, isNewItem, loadAckMap } from "@/lib/action-ack";
 
 export interface ActionItem {
   ticker: string;
@@ -35,6 +36,11 @@ interface ActionItemsProps {
   portfolio?: ActionItem[];
 }
 
+// #1212 hydration 게이트용 안정 참조 (useSyncExternalStore 인자)
+const emptySubscribe = () => () => {};
+const getTrue = () => true;
+const getFalse = () => false;
+
 // U2b-2 (#1208): 카드 → 32px 밀집 테이블 행. 버킷(심각도) 구조는 유지 —
 // urgent > portfolio > check 순서가 곧 예외 큐 정렬이다 (plan §4.5).
 const bucketStyles = {
@@ -49,10 +55,17 @@ function actionTagCls(action: string): string {
   return "bg-zinc-700 text-zinc-400";
 }
 
-function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
+interface AckProps {
+  /** null = 마운트 전(미로드) — NEW 미표시로 hydration 안전 (#1212) */
+  ackMap: AckMap | null;
+  onAck: (item: ActionItem) => void;
+}
+
+function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: string } & AckProps) {
   const [expanded, setExpanded] = useState(false);
   const fmt = (v: number | null | undefined) => formatMoney(v, { ticker: item.ticker });
   const confPct = Math.max(0, Math.min(100, item.confidence));
+  const isNew = isNewItem(item, ackMap);
 
   return (
     <Fragment>
@@ -80,6 +93,16 @@ function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
           >
             {item.name || item.ticker}
           </Link>
+          {/* #1212: 미확인 배지 — 판정일(as_of) 갱신 시 재표시 (re-alert) */}
+          {isNew && (
+            <span
+              data-testid="action-new-badge"
+              title={item.as_of ? `판정 ${item.as_of}` : undefined}
+              className="ml-1.5 align-middle text-[9px] font-bold px-1 py-px rounded bg-blue-500/20 text-blue-400"
+            >
+              {ACTION.NEW}
+            </span>
+          )}
         </td>
         <td className="h-8 px-2 whitespace-nowrap hidden md:table-cell text-[11px] text-zinc-400">{item.account ?? "—"}</td>
         <td className="h-8 px-2 whitespace-nowrap">
@@ -134,6 +157,20 @@ function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
                 <span><span className="text-zinc-600">2차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_2)}</span></span>
               )}
               {item.as_of && <span className="text-zinc-600">판정 {item.as_of}</span>}
+              {/* #1212: ack — NEW 해제 (localStorage, per-viewer) */}
+              {isNew && (
+                <button
+                  type="button"
+                  data-testid="action-ack-button"
+                  className="ml-auto text-[11px] px-2 py-0.5 rounded bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAck(item);
+                  }}
+                >
+                  {ACTION.ACK}
+                </button>
+              )}
             </div>
             {item.reasons.length > 1 && (
               <div className="mt-1 space-y-0.5">
@@ -149,7 +186,7 @@ function ActionRow({ item, accent }: { item: ActionItem; accent: string }) {
   );
 }
 
-function ActionBucketTable({ items, kind, title }: { items: ActionItem[]; kind: keyof typeof bucketStyles; title: string }) {
+function ActionBucketTable({ items, kind, title, ackMap, onAck }: { items: ActionItem[]; kind: keyof typeof bucketStyles; title: string } & AckProps) {
   const style = bucketStyles[kind];
   if (items.length === 0) return null;
   return (
@@ -162,7 +199,7 @@ function ActionBucketTable({ items, kind, title }: { items: ActionItem[]; kind: 
         <table className="w-full text-left">
           <tbody>
             {items.map((item) => (
-              <ActionRow key={`${item.ticker}-${item.account}`} item={item} accent={style.accent} />
+              <ActionRow key={`${item.ticker}-${item.account}`} item={item} accent={style.accent} ackMap={ackMap} onAck={onAck} />
             ))}
           </tbody>
         </table>
@@ -173,6 +210,18 @@ function ActionBucketTable({ items, kind, title }: { items: ActionItem[]; kind: 
 
 export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItemsProps) {
   const total = urgent.length + check.length + hold.length + portfolio.length;
+
+  // #1212: seen-state 는 hydration 후에만 읽는다 — SSR 마크업과 첫 클라 렌더가
+  // 일치해야 하므로 useSyncExternalStore 게이트(서버 false → 클라 true)를 쓴다.
+  // (effect 내 동기 setState 는 lint 금지 — cascading render.) hold 칩은 배지
+  // 없음 (노이즈 — 버킷 3종만).
+  const hydrated = useSyncExternalStore(emptySubscribe, getTrue, getFalse);
+  const loadedMap = useMemo(() => (hydrated ? loadAckMap() : null), [hydrated]);
+  const [ackOverride, setAckOverride] = useState<AckMap | null>(null);
+  const ackMap = ackOverride ?? loadedMap;
+  const onAck = (item: ActionItem) => {
+    setAckOverride(ackItem(ackMap ?? {}, item));
+  };
 
   if (total === 0) {
     return (
@@ -185,13 +234,13 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
   return (
     <div className="space-y-3">
       {/* 🔴 즉시 실행 */}
-      <ActionBucketTable items={urgent} kind="urgent" title={ACTION.URGENT} />
+      <ActionBucketTable items={urgent} kind="urgent" title={ACTION.URGENT} ackMap={ackMap} onAck={onAck} />
 
       {/* 📊 포트폴리오 리밸런스 — PR A: SIEGE 룰 위반을 "매도" 로 surface 하지 않기 */}
-      <ActionBucketTable items={portfolio} kind="portfolio" title={ACTION.PORTFOLIO} />
+      <ActionBucketTable items={portfolio} kind="portfolio" title={ACTION.PORTFOLIO} ackMap={ackMap} onAck={onAck} />
 
       {/* 🟡 오늘 확인 */}
-      <ActionBucketTable items={check} kind="check" title={ACTION.CHECK} />
+      <ActionBucketTable items={check} kind="check" title={ACTION.CHECK} ackMap={ackMap} onAck={onAck} />
 
       {/* ✅ 유지 — 칩 유지 (행 승격은 노이즈, 목업 합의) */}
       {hold.length > 0 && (

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useMemo, useState, useSyncExternalStore, Fragment } from "react";
 import { ACTION } from "@/lib/strings";
 import { formatMoney } from "@/lib/format";
-import { type AckMap, ackItem, isNewItem, loadAckMap } from "@/lib/action-ack";
+import { type AckMap, ackItem, actionKey, isNewItem, loadAckMap } from "@/lib/action-ack";
 
 export interface ActionItem {
   ticker: string;
@@ -199,7 +199,9 @@ function ActionBucketTable({ items, kind, title, ackMap, onAck }: { items: Actio
         <table className="w-full text-left">
           <tbody>
             {items.map((item) => (
-              <ActionRow key={`${item.ticker}-${item.account}`} item={item} accent={style.accent} ackMap={ackMap} onAck={onAck} />
+              // key = seen-state identity (codex R1 P2): action/priority 가 바뀐 행이
+              // 같은 ActionRow 인스턴스(expanded 등 로컬 상태)를 물려받지 않게 한다
+              <ActionRow key={actionKey(item)} item={item} accent={style.accent} ackMap={ackMap} onAck={onAck} />
             ))}
           </tbody>
         </table>
@@ -252,7 +254,7 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
           <div className="flex flex-wrap gap-1.5">
             {hold.map((item) => (
               <Link
-                key={`${item.ticker}-${item.account}`}
+                key={actionKey(item)}
                 href={`/ticker/${item.ticker}`}
                 className="inline-flex items-center gap-1 px-2 py-1 rounded bg-zinc-900/60 border border-zinc-800/40 text-[10px] hover:bg-zinc-800/60 transition-colors"
               >

--- a/frontend/src/components/ui/market-context.tsx
+++ b/frontend/src/components/ui/market-context.tsx
@@ -16,11 +16,7 @@ export interface SystemHealth {
   freshness: { status: string; fail_count?: number; warn_count?: number };
 }
 
-interface MarketContextProps {
-  events: MacroEvent[];
-  health: Partial<SystemHealth>;
-}
-
+// MarketContextProps 는 #1208 컴포넌트 삭제 때 남은 고아 — #1212 에서 제거
 export const categoryStyles: Record<string, { emoji: string; color: string }> = {
   geopolitical_escalation: { emoji: "🔴", color: "text-red-400" },
   geopolitical_de_escalation: { emoji: "🟢", color: "text-emerald-400" },

--- a/frontend/src/lib/action-ack.ts
+++ b/frontend/src/lib/action-ack.ts
@@ -2,8 +2,10 @@
  * action-ack (#1212 U2b-4) — 액션 행 seen-state (per-viewer localStorage).
  *
  * 운영자가 이미 확인(ack)한 액션과 새 액션을 구분한다. identity 는
- * `ticker|account|action`, 값은 ack 시점의 판정일(as_of) — 같은 항목이라도
- * 판정일이 갱신되면 다시 NEW 로 뜬다 (re-alert). 서버·타 기기와 공유되지
+ * `ticker|account|action|priority` — priority(버킷)까지 넣어야 같은 튜플이
+ * 두 버킷에 동시에 뜰 때 한쪽 ack 이 다른쪽 NEW 를 지우지 않고, check→urgent
+ * 승격도 새 항목으로 re-alert 된다 (codex R1 P1). 값은 ack 시점의
+ * 판정일(as_of) — 같은 항목이라도 판정일이 갱신되면 다시 NEW (re-alert). 서버·타 기기와 공유되지
  * 않는 뷰어 편의 상태라 localStorage 가 맞는 자리이고, 접근은 전부
  * try/catch (프라이빗 창·차단 환경에서 accessor 자체가 throw 할 수 있다).
  */
@@ -16,11 +18,12 @@ interface AckableItem {
   ticker: string;
   account?: string;
   action: string;
+  priority: string;
   as_of?: string | null;
 }
 
 export function actionKey(item: AckableItem): string {
-  return `${item.ticker}|${item.account ?? ""}|${item.action}`;
+  return `${item.ticker}|${item.account ?? ""}|${item.action}|${item.priority}`;
 }
 
 /** map null = 아직 미로드(SSR/마운트 전) — NEW 를 그리지 않아 hydration 안전 */

--- a/frontend/src/lib/action-ack.ts
+++ b/frontend/src/lib/action-ack.ts
@@ -1,0 +1,60 @@
+/**
+ * action-ack (#1212 U2b-4) — 액션 행 seen-state (per-viewer localStorage).
+ *
+ * 운영자가 이미 확인(ack)한 액션과 새 액션을 구분한다. identity 는
+ * `ticker|account|action`, 값은 ack 시점의 판정일(as_of) — 같은 항목이라도
+ * 판정일이 갱신되면 다시 NEW 로 뜬다 (re-alert). 서버·타 기기와 공유되지
+ * 않는 뷰어 편의 상태라 localStorage 가 맞는 자리이고, 접근은 전부
+ * try/catch (프라이빗 창·차단 환경에서 accessor 자체가 throw 할 수 있다).
+ */
+
+export type AckMap = Record<string, string>;
+
+const STORAGE_KEY = "nuri.actions.ack.v1";
+
+interface AckableItem {
+  ticker: string;
+  account?: string;
+  action: string;
+  as_of?: string | null;
+}
+
+export function actionKey(item: AckableItem): string {
+  return `${item.ticker}|${item.account ?? ""}|${item.action}`;
+}
+
+/** map null = 아직 미로드(SSR/마운트 전) — NEW 를 그리지 않아 hydration 안전 */
+export function isNewItem(item: AckableItem, map: AckMap | null): boolean {
+  if (map === null) return false;
+  const acked = map[actionKey(item)];
+  if (acked === undefined) return true;
+  // ISO(YYYY-MM-DD) 문자열 비교 = 시간 순 비교. as_of 없는 항목은 ack 1회면 종결.
+  return item.as_of != null && item.as_of > acked;
+}
+
+export function loadAckMap(): AckMap {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    const map: AckMap = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === "string") map[k] = v;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+/** ack 후의 새 맵을 반환하고 저장은 best-effort (실패해도 in-memory 는 동작) */
+export function ackItem(map: AckMap, item: AckableItem): AckMap {
+  const next = { ...map, [actionKey(item)]: item.as_of ?? "" };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // 저장 불가 환경 — 세션 내 in-memory ack 만 유지
+  }
+  return next;
+}

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -338,6 +338,8 @@ export const ACTION = {
   PORTFOLIO: "포트폴리오 리밸런스",
   EMPTY: "오늘 실행할 액션이 없습니다.",
   EVIDENCE: "증거 체인", // #1182: 카드 → /decisions/[id]
+  NEW: "NEW", // #1212: 미확인 행 배지 (localStorage seen-state)
+  ACK: "확인", // #1212: quick-peek ack 버튼 — NEW 해제, 판정일 갱신 시 재표시
   // DETAIL/CONF/AGREE/PNL/WEIGHT/DISMISS 는 U2b-2 (#1208) 카드→행 전환으로 제거
 } as const;
 
@@ -366,6 +368,9 @@ export const CONTEXT = {
   FRESHNESS: "데이터",
   CERTIFIED: "인증",
   REJECTED: "미인증",
+  // #1212: FAIL/미인증 행의 다음 행동 카피 (레일 sub — 상태만 말하지 말 것)
+  CHECK_ENGINE: "게이트 상세 →",
+  CHECK_PIPELINE: "파이프라인 확인 →",
 } as const;
 
 /* ── StatusBadge Korean keys ────────────────────────────────── */


### PR DESCRIPTION
Closes #1212. Phase U2b-4 of docs/UX_REDESIGN_PLAN.md — last U2b sub-phase (codex 2R 합의 P2 운영 워크플로 항목).

## What
- **`lib/action-ack.ts`** — per-viewer seen-state on localStorage. Identity `ticker|account|action`; ack stores the item's 판정일(as_of), so the same item re-alerts when a newer adjudication lands. Every storage access is try/catch — a missing/blocked localStorage degrades to in-memory ack (this repo's vitest jsdom actually has no `window.localStorage`, which the tests exploit).
- **ActionItems** — NEW badge (blue chip, title=판정일) on un-acked urgent/portfolio/check rows; 확인 button in the quick-peek clears it per row. Hydration-gated with `useSyncExternalStore` (server snapshot `false` → client `true`) so SSR markup matches the first client render — the naive `setState`-in-effect version is a React 19 lint error. Hold chips carry no badges by design (noise).
- **SystemHealthRail** — FAIL/미인증 row subs now say what to do next (`미인증 · 게이트 상세 →`, `N건 실패 · 파이프라인 확인 →`) instead of bare status; rows already link to those destinations.
- Removes the `MarketContextProps` orphan interface left by #1208 (pre-existing lint warning).

## Tests
- `action-ack.test.ts`: identity, null-map hydration safety, re-alert on newer as_of, null-as_of terminal ack, storage round-trip, corrupt-JSON/array/non-string tolerance, fully-missing-localStorage survival.
- `action-items.test.tsx`: NEW after mount, per-row 확인 clears, hold chips excluded.
- Rail copy assertions updated.
- vitest **1489/129** green · build green · lint 0 errors · `responsive.spec.ts` + dashboard e2e **39 passed** + 1 known data-dependent fail (macro_events stale dev DB, documented non-regression) · doc counts 22/22 (6 sites synced).

## Live QA (dev server, real browser)
7 NEW badges on first visit → 확인 on one row → 6 → **reload → still 6** (localStorage persistence). Rail shows both next-action copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)