### PR TITLE
fix(coverage): v8-ignore the unreachable ack fallback arm

### DIFF
--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -222,6 +222,10 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
   const [ackOverride, setAckOverride] = useState<AckMap | null>(null);
   const ackMap = ackOverride ?? loadedMap;
   const onAck = (item: ActionItem) => {
+    // `?? {}` 는 구조적 도달 불가 (#1214): 확인 버튼은 isNew 일 때만 렌더되고
+    // isNewItem 은 ackMap===null(hydration 전)이면 항상 false — 클릭 시점의
+    // ackMap 은 항상 객체다. 미래 리팩터 대비 방어로만 남긴다.
+    /* v8 ignore next */
     setAckOverride(ackItem(ackMap ?? {}, item));
   };
 


### PR DESCRIPTION
Closes #1214. Post-merge follow-up to #1213 (codecov/patch 97.37%, 1 partial).

The single flagged partial is `setAckOverride(ackItem(ackMap ?? {}, item))` — the `?? {}` arm is unreachable by construction: the 확인 button renders only when `isNew`, and `isNewItem()` returns false while `ackMap === null` (pre-hydration), so `ackMap` is always an object at click time. The fallback stays as a refactor guard, annotated with `/* v8 ignore next */` + reason (repo precedent: system-rail.tsx).

Verified locally: the line-partial disappears from the v8 report; vitest 1492/129 green, build/lint green. No test-count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)