### PR TITLE
feat(frontend): Evidence Terminal U4b — merged scanner table + pipeline payload summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,521 collected across 345 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,526 across 130 files — 100% statement coverage | |
+| **Frontend tests** | 1,538 across 131 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1526 frontend vitest (130 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,521 backend tests across 345 files + 1538 frontend vitest (131 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1526 tests, 130 files |
+| Frontend tests | 목표 ≥ 90% | 1538 tests, 131 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/UX_REDESIGN_PLAN.md
+++ b/docs/UX_REDESIGN_PLAN.md
@@ -74,8 +74,8 @@
 | U2b-3 | 구성 스택 바 | 도넛→가로 스택 바 · coverage 접이 | 완료 (#1211) |
 | U2b-4 | 델타·ack | NEW+시각 배지 · 확인(ack) 로컬 상태 · 다음 행동 카피 | 완료 (#1213, 커버리지 후속 #1215) |
 | U3 | Decisions | 리스트: 필터·날짜 그룹핑·conf micro-bar·판정일 명시 / 상세: 2컬럼 + 증거 key-value(raw JSON 폐지) + raw float 종결 | 완료 (#1217) |
-| U4a | 주변부 1/2 | ticker(빈 패널 접기·부재 한 줄 스트립)·engine(BLOCKED 다음 행동 링크·빈 상태 한국어 1줄) | 진행 중 (#1218) |
-| U4b | 주변부 2/2 | scanner(중복 테이블 union 병합 — top-15 ⊂ swing 20 실측)·pipeline(타임라인 payload raw JSON 폐지) + 잔여 빈 상태 스윕 | 대기 (#1219) |
+| U4a | 주변부 1/2 | ticker(빈 패널 접기·부재 한 줄 스트립)·engine(BLOCKED 다음 행동 링크·빈 상태 한국어 1줄) | 완료 (#1220) |
+| U4b | 주변부 2/2 | scanner(중복 테이블 union 병합 — top-15 ⊂ swing 20 실측)·pipeline(타임라인 payload raw JSON 폐지) + 잔여 빈 상태 스윕 | 진행 중 (#1219) |
 | U5 | 별도 결정 | evidence matplotlib PNG→네이티브 차트 · Cmd-K · IA 통합(라우트 병합) — 각각 사용자 승인 후 착수 | 보류 |
 
 ### 단계별 공통 게이트

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1526 tests, 130 files)
+npm run test           # vitest run (1538 tests, 131 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -94,4 +94,4 @@ should be **223**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 94 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 95 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,4 +19,4 @@ See [`CLAUDE.md`](CLAUDE.md) for full details. Key points:
 - **Action-First dashboard** — SystemHealth, ActionItems, OpportunityExplorer, MarketContext
 - **API proxy** — Next.js rewrites `/api/*` to FastAPI `:8001`
 - **i18n** — `src/lib/strings.ts` (Korean UI constants, not next-intl)
-- **Tests** — `src/__tests__/{components,lib,pages,coverage}/` (94 files) + 36 co-located (`src/app` / `src/components/ui` / `src/lib`) + `e2e/`
+- **Tests** — `src/__tests__/{components,lib,pages,coverage}/` (95 files) + 36 co-located (`src/app` / `src/components/ui` / `src/lib`) + `e2e/`

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1526 tests, 130 files)
+npm run test           # vitest (1538 tests, 131 files)
 npx playwright test    # E2E (87 tests, 9 specs)
 ```
 

--- a/frontend/src/__tests__/components/client-table.test.tsx
+++ b/frontend/src/__tests__/components/client-table.test.tsx
@@ -51,18 +51,20 @@ describe("ClientTable", () => {
     expect(screen.getByText("degrading")).toBeInTheDocument();
   });
 
-  // ─── Variant: scan ──────────────────────────────────────
-  it("renders scan variant columns", () => {
+  // ─── Variant: scanner ──────────────────────────────────────
+  it("renders scanner variant columns with agent fields (#1219)", () => {
     const data = [
-      { ticker: "TSLA", price: 250.0, change_1d: 2.5, change_5d: -1.3, rsi: 45, signal: "bounce", score: 85 },
+      { ticker: "TSLA", price: 250.0, change_1d: 2.5, change_5d: -1.3, rsi: 45, signal: "bounce", score: 85,
+        agent_action: "BUY", agent_confidence: 72, approved: true, reason: null },
     ];
-    render(<ClientTable variant="scan" data={data} />);
+    render(<ClientTable variant="scanner" data={data} />);
     expect(screen.getByText("Ticker")).toBeInTheDocument();
     expect(screen.getByText("Price")).toBeInTheDocument();
     expect(screen.getByText("1D")).toBeInTheDocument();
-    expect(screen.getByText("5D")).toBeInTheDocument();
     expect(screen.getByText("RSI")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
     expect(screen.getByText("TSLA")).toBeInTheDocument();
+    expect(screen.getAllByText("승인").length).toBeGreaterThan(0); // 헤더 + 태그
   });
 
   // ─── Variant: targets ───────────────────────────────────
@@ -150,17 +152,29 @@ describe("ClientTable", () => {
     expect(table!.className).toContain("text-xs");
   });
 
-  // ─── Variant: swing ─────────────────────────────────────
-  it("renders swing variant columns", () => {
+  // ─── Variant: scanner — union 특유의 null 필드 처리 (#1219) ──
+  it("scanner variant dashes null fields and titles rejection reasons", () => {
     const data = [
-      { ticker: "PLTR", price: 85.0, scan_signal: "breakout", scan_score: 90, agent_action: "BUY", agent_confidence: 72 },
+      // 스윙 전용 행: 모멘텀 필드 null, 미승인 + 사유 title
+      { ticker: "AAPL", price: 230.0, change_1d: null, change_5d: null, rsi: null, signal: "pullback", score: 60,
+        agent_action: "HOLD", agent_confidence: 45, approved: false, reason: "Low conf" },
+      // 스캔 전용 행: 에이전트 필드 null → 승인 컬럼 —
+      { ticker: "MSFT", price: 480.0, change_1d: 1.2, change_5d: 3.4, rsi: 52, signal: "momentum", score: 70,
+        agent_action: null, agent_confidence: null, approved: null, reason: null },
     ];
-    render(<ClientTable variant="swing" data={data} />);
-    expect(screen.getByText("Ticker")).toBeInTheDocument();
-    expect(screen.getByText("Signal")).toBeInTheDocument();
-    expect(screen.getByText("Score")).toBeInTheDocument();
-    expect(screen.getByText("Agent")).toBeInTheDocument();
-    expect(screen.getByText("PLTR")).toBeInTheDocument();
+    render(<ClientTable variant="scanner" data={data} />);
+    const rejected = screen.getByText("미승인");
+    expect(rejected).toHaveAttribute("title", "Low conf");
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(5); // null 필드 전부 —
+  });
+
+  it("scanner variant renders 미승인 without title when reason is null", () => {
+    const data = [
+      { ticker: "INTC", price: 30.0, change_1d: 0.5, change_5d: 1.0, rsi: 40, signal: "bounce", score: 50,
+        agent_action: "HOLD", agent_confidence: 30, approved: false, reason: null },
+    ];
+    render(<ClientTable variant="scanner" data={data} />);
+    expect(screen.getByText("미승인")).not.toHaveAttribute("title");
   });
 
   // ─── Targets row highlighting ──────────────────────────

--- a/frontend/src/__tests__/coverage/client-table-coverage.test.tsx
+++ b/frontend/src/__tests__/coverage/client-table-coverage.test.tsx
@@ -1,6 +1,6 @@
 /**
- * ClientTable — variant coverage (scorecard, scan, gate, conflicts, drift,
- * rebalance, targets, swing, advisor) + branch coverage (signal types, price formats,
+ * ClientTable — variant coverage (scorecard, scanner, gate, conflicts, drift,
+ * rebalance, targets, advisor) + branch coverage (signal types, price formats,
  * negative/zero pct, advisor severity).
  *
  * Split from coverage-push-2.test.tsx (lines 222-255) and coverage-push-5.test.tsx (lines 57-120).
@@ -30,7 +30,7 @@ vi.mock("next/link", () => ({
 describe("ClientTable — variant coverage", () => {
   const variants = [
     { name: "scorecard", data: [{ signal_id: "rsi_oversold", total_trades: 50, win_rate: 0.65, profit_factor: 2.1, avg_return: 3.2 }] },
-    { name: "scan", data: [{ ticker: "AAPL", price: 195, change_1d: 2.1, change_5d: -1.3, rsi: 45, signal: "momentum", score: 72 }] },
+    { name: "scanner", data: [{ ticker: "AAPL", price: 195, change_1d: 2.1, change_5d: -1.3, rsi: 45, signal: "momentum", score: 72, agent_action: "BUY", agent_confidence: 70, approved: true, reason: null }] },
     { name: "gate", data: [{ description: "Prices fresh", phase: "collect", passed: true, detail: "OK" }] },
     { name: "conflicts", data: [{ ticker: "AAPL", conflict_type: "BUY_SELL", severity: "high", buy_signals: ["rsi"], sell_signals: ["macd"] }] },
     { name: "drift", data: [{ signal_id: "rsi_oversold", status: "WARNING", all_time_wr: 0.65, recent_wr: 0.45, drift_pct: -20 }] },
@@ -38,7 +38,7 @@ describe("ClientTable — variant coverage", () => {
     { name: "targets", data: [{ ticker: "AAPL", stock_type: "growth", current_price: 195, stop_loss: 181, target_1: 234, target_2: 273, analyst_target: 250, take_profit_triggered: null, trailing_stop_triggered: false, take_profit_sell_pct: 50 }] },
     { name: "targets", data: [{ ticker: "NVDA", stock_type: "value", current_price: 50000, stop_loss: 45000, target_1: 57500, target_2: 65000, analyst_target: null, take_profit_triggered: "target_1", trailing_stop_triggered: false, take_profit_sell_pct: 50 }] },
     { name: "targets", data: [{ ticker: "TSLA", stock_type: "growth", current_price: 280, stop_loss: 260, target_1: 336, target_2: 392, analyst_target: 350, take_profit_triggered: "target_2", trailing_stop_triggered: true, take_profit_sell_pct: 25 }] },
-    { name: "swing", data: [{ ticker: "TSLA", price: 280, scan_signal: "breakout", scan_score: 85, agent_action: "BUY", agent_confidence: 78 }] },
+    { name: "scanner", data: [{ ticker: "TSLA", price: 280, change_1d: null, change_5d: null, rsi: null, signal: null, score: null, agent_action: null, agent_confidence: null, approved: false, reason: "r" }] },
     { name: "advisor", data: [{ priority: 1, ticker: "BBB", severity: "critical", action: "SELL_ALL", sell_shares: 96, sell_value_usd: 1100, reason: "leveraged ETF" }] },
     { name: "advisor", data: [{ priority: 2, ticker: "AAPL", severity: "high", action: "REDUCE", sell_shares: 5, sell_value_usd: 975, reason: "position limit" }] },
   ];

--- a/frontend/src/__tests__/pages/scan-helpers.test.ts
+++ b/frontend/src/__tests__/pages/scan-helpers.test.ts
@@ -64,10 +64,11 @@ describe("mergeScanSwing", () => {
 });
 
 describe("summarizePayload (#1219 raw JSON 폐지)", () => {
-  it("priority keys win outright, truncated to 80 chars", () => {
+  it("priority keys win outright — stderr alone truncates to 80 (원 동작 패리티)", () => {
     expect(summarizePayload({ stderr: "boom", records: 5 })).toBe("boom");
+    expect(summarizePayload({ stderr: "y".repeat(120) })).toBe("y".repeat(80));
     expect(summarizePayload({ command: "make collect" })).toBe("make collect");
-    expect(summarizePayload({ error: "x".repeat(120) })).toBe("x".repeat(80));
+    expect(summarizePayload({ error: "x".repeat(120) })).toBe("x".repeat(120)); // 전문 통과
   });
 
   it("falls back to a kv summary (max 3 pairs + rest count), not JSON.stringify", () => {

--- a/frontend/src/__tests__/pages/scan-helpers.test.ts
+++ b/frontend/src/__tests__/pages/scan-helpers.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+
+import { mergeScanSwing, type ScanResult, type SwingEntry } from "@/app/scan/helpers";
+import { summarizePayload } from "@/app/pipeline/helpers";
+
+// #1219 U4b: scan/swing union 병합 + pipeline payload 요약 잠금.
+
+const scanRow = (over: Partial<ScanResult> = {}): ScanResult => ({
+  ticker: "AAA", price: 100, change_1d: 1.2, change_5d: -0.5,
+  volume_ratio: 2.0, rsi: 55, signal: "momentum", score: 80, ...over,
+});
+const swingRow = (over: Partial<SwingEntry> = {}): SwingEntry => ({
+  ticker: "AAA", price: 100, scan_signal: "momentum", scan_score: 80,
+  agent_action: "BUY", agent_confidence: 70, approved: true, reason: "ok", ...over,
+});
+
+describe("mergeScanSwing", () => {
+  it("joins swing agent fields onto matching scan rows — one row per ticker", () => {
+    const rows = mergeScanSwing([scanRow()], [swingRow()]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      ticker: "AAA", change_1d: 1.2, rsi: 55, agent_action: "BUY", approved: true,
+    });
+  });
+
+  it("keeps scan order first, appends swing-only tickers with null momentum fields", () => {
+    const rows = mergeScanSwing(
+      [scanRow({ ticker: "AAA" }), scanRow({ ticker: "BBB", score: 60 })],
+      [swingRow({ ticker: "BBB" }), swingRow({ ticker: "CCC", approved: false, reason: "veto" })],
+    );
+    expect(rows.map((r) => r.ticker)).toEqual(["AAA", "BBB", "CCC"]);
+    const ccc = rows[2];
+    expect(ccc.change_1d).toBeNull();
+    expect(ccc.rsi).toBeNull();
+    expect(ccc.signal).toBe("momentum"); // scan_signal 대체
+    expect(ccc.approved).toBe(false);
+    expect(ccc.reason).toBe("veto");
+  });
+
+  it("scan-only rows carry null agent fields and approved: null (평가 없음 ≠ 미승인)", () => {
+    const rows = mergeScanSwing([scanRow()], []);
+    expect(rows[0].agent_action).toBeNull();
+    expect(rows[0].approved).toBeNull();
+  });
+
+  it("empty inputs → empty output", () => {
+    expect(mergeScanSwing([], [])).toEqual([]);
+  });
+
+  // API 실데이터는 타입 선언과 달리 null 필드를 실을 수 있다 (SQLite) — 폴백 arm 잠금.
+  it("falls back to swing values when scan fields are null, and nulls stay null", () => {
+    const nullishScan = { ...scanRow(), price: null, signal: null, score: null, change_1d: null, change_5d: null, rsi: null } as unknown as ScanResult;
+    const rows = mergeScanSwing([nullishScan], [swingRow({ price: 99, scan_signal: "bounce", scan_score: 42 })]);
+    expect(rows[0].price).toBe(99);
+    expect(rows[0].signal).toBe("bounce");
+    expect(rows[0].score).toBe(42);
+    const nullishSwing = { ...swingRow({ ticker: "ZZZ" }), price: null, scan_signal: null, scan_score: null, agent_action: null, agent_confidence: null, reason: null } as unknown as SwingEntry;
+    const only = mergeScanSwing([], [nullishSwing]);
+    expect(only[0]).toMatchObject({ ticker: "ZZZ", price: null, signal: null, score: null, agent_action: null, reason: null });
+    // 스윙 매치도 없는 null 스캔 행 — 최종 ?? null arm
+    const bare = mergeScanSwing([nullishScan], []);
+    expect(bare[0]).toMatchObject({ price: null, signal: null, score: null });
+  });
+});
+
+describe("summarizePayload (#1219 raw JSON 폐지)", () => {
+  it("priority keys win outright, truncated to 80 chars", () => {
+    expect(summarizePayload({ stderr: "boom", records: 5 })).toBe("boom");
+    expect(summarizePayload({ command: "make collect" })).toBe("make collect");
+    expect(summarizePayload({ error: "x".repeat(120) })).toBe("x".repeat(80));
+  });
+
+  it("falls back to a kv summary (max 3 pairs + rest count), not JSON.stringify", () => {
+    const out = summarizePayload({ records: 921551, tickers: 774, elapsed: 12.345, extra: 1, more: 2 });
+    expect(out).toBe("records 921551 · tickers 774 · elapsed 12.35 +2");
+    expect(out).not.toContain("{");
+  });
+
+  it("formats value types and tolerates nested objects", () => {
+    expect(summarizePayload({ ok: true, off: false, note: null })).toBe("ok true · off false · note —");
+    expect(summarizePayload({ step: "collect" })).toBe("step collect"); // 문자열 값 (비우선순위 키)
+    expect(summarizePayload({ nested: { a: 1 } })).toBe('nested {"a":1}');
+  });
+
+  it("survives a circular payload value (JSON.stringify throw)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(summarizePayload({ weird: circular })).toBe("weird [object Object]");
+  });
+
+  it("empty/missing payload → empty string (렌더 억제)", () => {
+    expect(summarizePayload(null)).toBe("");
+    expect(summarizePayload(undefined)).toBe("");
+    expect(summarizePayload({})).toBe("");
+  });
+});

--- a/frontend/src/__tests__/pages/scan.test.tsx
+++ b/frontend/src/__tests__/pages/scan.test.tsx
@@ -70,33 +70,38 @@ describe("ScanPage", () => {
     expect(screen.getByText("Market Scanner")).toBeInTheDocument();
   });
 
-  it("renders scan signal count", async () => {
+  // #1219: 두 테이블 → 병합 단일 테이블. 헤더는 시그널 수 + 승인/거절 집계.
+  it("renders the merged header with signal and approval counts", async () => {
     const { default: ScanPage } = await import("@/app/scan/page");
     await act(async () => {
       render(<ScanPage />);
     });
-
-    expect(screen.getByText("Market Scanner — 3 signals")).toBeInTheDocument();
+    const header = screen.getByText(/시그널/);
+    expect(header.textContent).toContain("3 시그널");
+    expect(header.textContent).toContain("승인 1");
+    expect(header.textContent).toContain("거절 2");
   });
 
-  it("renders swing entry summary with approved/rejected counts", async () => {
+  it("renders one merged table with agent columns, not two tables", async () => {
     const { default: ScanPage } = await import("@/app/scan/page");
+    let container!: HTMLElement;
     await act(async () => {
-      render(<ScanPage />);
+      ({ container } = render(<ScanPage />));
     });
-
-    expect(screen.getByText(/1 approved/)).toBeInTheDocument();
-    expect(screen.getByText(/, 2 rejected/)).toBeInTheDocument();
+    expect(container.querySelectorAll("table")).toHaveLength(1);
+    // 중복 폐지: 병합 후 티커는 테이블에 1회만 (이전엔 scan+swing 두 테이블에 2회)
+    expect(screen.getAllByText("NVDA")).toHaveLength(1);
+    // 에이전트 컬럼 병합 확인
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getAllByText("승인").length).toBeGreaterThan(0); // 컬럼 헤더 + 태그
   });
 
-  it("renders rejected swing entries with reasons", async () => {
+  it("renders rejected swing reasons in the fold", async () => {
     const { default: ScanPage } = await import("@/app/scan/page");
     await act(async () => {
       render(<ScanPage />);
     });
-
-    // Rejected details section
-    expect(screen.getByText("Rejected (2)")).toBeInTheDocument();
+    expect(screen.getByText("미승인 사유 (2)")).toBeInTheDocument();
     expect(screen.getByText("AMD: Confidence below threshold")).toBeInTheDocument();
     expect(screen.getByText("TSLA: Agent verdict SELL")).toBeInTheDocument();
   });
@@ -111,26 +116,26 @@ describe("ScanPage", () => {
     expect(mockFetchAPI).toHaveBeenCalledWith("/api/swing/entries");
   });
 
-  it("shows empty state when no approved swing entries", async () => {
+  // #1219: 스윙 전용 티커(top-N 밖)도 union 으로 테이블에 들어온다 — 모멘텀 필드는 —.
+  it("includes swing-only tickers via union with dashed momentum fields", async () => {
     setupFetchAPI({
       swing: {
         entries: [
-          { ticker: "AMD", price: 120, scan_signal: "momentum", scan_score: 72, agent_action: "HOLD", agent_confidence: 45, approved: false, reason: "Low conf" },
+          ...mockSwing.entries,
+          { ticker: "AAPL", price: 230.0, scan_signal: "pullback", scan_score: 60, agent_action: "BUY", agent_confidence: 66, approved: true, reason: "OK" },
         ],
-        approved: 0,
-        rejected: 1,
+        approved: 2,
+        rejected: 2,
       },
     });
-
     const { default: ScanPage } = await import("@/app/scan/page");
     await act(async () => {
       render(<ScanPage />);
     });
-
-    expect(screen.getByText(/No entries passed agent consensus/)).toBeInTheDocument();
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
   });
 
-  it("renders with no rejected swing entries (no details section)", async () => {
+  it("renders with no rejected swing entries (no fold)", async () => {
     setupFetchAPI({
       swing: {
         entries: [
@@ -146,13 +151,29 @@ describe("ScanPage", () => {
       render(<ScanPage />);
     });
 
-    expect(screen.getByText(/1 approved/)).toBeInTheDocument();
-    expect(screen.queryByText(/Rejected/)).not.toBeInTheDocument();
+    expect(screen.getByText(/승인 1/)).toBeInTheDocument();
+    expect(screen.queryByText(/미승인 사유/)).not.toBeInTheDocument();
   });
 
-  it("renders with empty scan results", async () => {
+  // #1219: 스윙 API 실패는 스캔 테이블을 죽이지 않는다 — 에이전트 컬럼만 — 로.
+  it("renders scan rows with dashed agent fields when the swing API fails", async () => {
+    mockFetchAPI = vi.fn().mockImplementation((path: string) => {
+      if (path.includes("/api/scan")) return Promise.resolve(mockScan);
+      if (path.includes("/api/swing/entries")) return Promise.reject(new Error("500"));
+      return Promise.resolve({});
+    });
+    const { default: ScanPage } = await import("@/app/scan/page");
+    await act(async () => {
+      render(<ScanPage />);
+    });
+    expect(screen.getByText("NVDA")).toBeInTheDocument();
+    expect(screen.getByText(/승인 0/)).toBeInTheDocument();
+  });
+
+  it("shows the one-line empty state when both sources are empty", async () => {
     setupFetchAPI({
       scan: { results: [], count: 0 },
+      swing: { entries: [], approved: 0, rejected: 0 },
     });
 
     const { default: ScanPage } = await import("@/app/scan/page");
@@ -160,6 +181,6 @@ describe("ScanPage", () => {
       render(<ScanPage />);
     });
 
-    expect(screen.getByText("Market Scanner — 0 signals")).toBeInTheDocument();
+    expect(screen.getByText(/스캔 결과 없음/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/pipeline/helpers.ts
+++ b/frontend/src/app/pipeline/helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Pipeline 타임라인 순수 헬퍼 (#1219 U4b).
+ *
+ * payload 는 이벤트별 임의 객체 — 이전에는 stderr/command/error 특례 뒤에
+ * JSON.stringify raw 폴백이 화면에 그대로 노출됐다 (U3 evidence kv 와 같은
+ * 계열의 raw JSON 결함). 사람이 읽는 요약 한 줄로 바꾼다.
+ */
+
+const PRIORITY_KEYS = ["stderr", "command", "error"] as const;
+const MAX_KV = 3;
+
+function fmtValue(v: unknown): string {
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "number") return Number.isInteger(v) ? String(v) : v.toFixed(2);
+  if (typeof v === "string") return v;
+  if (typeof v === "boolean") return v ? "true" : "false";
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+export function summarizePayload(payload: Record<string, unknown> | null | undefined): string {
+  if (!payload || Object.keys(payload).length === 0) return "";
+  // 우선순위 키는 단독 표기 (기존 동작 유지 — 실패 원인이 가장 중요)
+  for (const k of PRIORITY_KEYS) {
+    const v = payload[k];
+    if (v) return String(v).slice(0, 80);
+  }
+  const entries = Object.entries(payload);
+  const shown = entries.slice(0, MAX_KV).map(([k, v]) => `${k} ${fmtValue(v)}`);
+  const rest = entries.length - MAX_KV;
+  return shown.join(" · ") + (rest > 0 ? ` +${rest}` : "");
+}

--- a/frontend/src/app/pipeline/helpers.ts
+++ b/frontend/src/app/pipeline/helpers.ts
@@ -6,7 +6,6 @@
  * 계열의 raw JSON 결함). 사람이 읽는 요약 한 줄로 바꾼다.
  */
 
-const PRIORITY_KEYS = ["stderr", "command", "error"] as const;
 const MAX_KV = 3;
 
 function fmtValue(v: unknown): string {
@@ -23,11 +22,11 @@ function fmtValue(v: unknown): string {
 
 export function summarizePayload(payload: Record<string, unknown> | null | undefined): string {
   if (!payload || Object.keys(payload).length === 0) return "";
-  // 우선순위 키는 단독 표기 (기존 동작 유지 — 실패 원인이 가장 중요)
-  for (const k of PRIORITY_KEYS) {
-    const v = payload[k];
-    if (v) return String(v).slice(0, 80);
-  }
+  // 우선순위 키 단독 표기 — 원 동작 정확 패리티 (codex R1 P2): stderr 만 80자
+  // 절단하고 command/error 는 전문 통과 (시각 절단은 line-clamp-1 몫)
+  if (payload.stderr) return String(payload.stderr).slice(0, 80);
+  if (payload.command) return String(payload.command);
+  if (payload.error) return String(payload.error);
   const entries = Object.entries(payload);
   const shown = entries.slice(0, MAX_KV).map(([k, v]) => `${k} ${fmtValue(v)}`);
   const rest = entries.length - MAX_KV;

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { PIPELINE as PL } from "@/lib/strings";
+import { summarizePayload } from "./helpers";
 
 // === Types ===
 interface PipelineStep {
@@ -446,15 +447,10 @@ export default function PipelinePage() {
                         {ev.event_type}
                       </span>
                     </div>
-                    {ev.payload && (
+                    {/* #1219: raw JSON.stringify 폴백 폐지 — 사람이 읽는 요약 한 줄 */}
+                    {ev.payload && summarizePayload(ev.payload) && (
                       <p className="text-muted-foreground/70 text-[10px] mt-0.5 line-clamp-1">
-                        {ev.payload.stderr
-                          ? String(ev.payload.stderr).slice(0, 80)
-                          : ev.payload.command
-                          ? String(ev.payload.command)
-                          : ev.payload.error
-                          ? String(ev.payload.error)
-                          : JSON.stringify(ev.payload)}
+                        {summarizePayload(ev.payload)}
                       </p>
                     )}
                   </div>

--- a/frontend/src/app/scan/helpers.ts
+++ b/frontend/src/app/scan/helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Scan 페이지 병합 헬퍼 (#1219 U4b).
+ *
+ * Market Scanner(top-N)와 Swing Entries 는 같은 스캔에서 갈라진 두 뷰라
+ * 15/20 행이 중복 렌더됐다 (2026-08-25 실측). ticker 기준 union 으로 한
+ * 테이블에 합친다 — 스캔 쪽 모멘텀 필드(1D/5D/RSI)와 스윙 쪽 에이전트
+ * 판정(action/conf/승인/사유)을 병기하고, 한쪽에만 있는 행은 없는 필드를
+ * null 로 둔다 (렌더는 —).
+ */
+
+export interface ScanResult {
+  ticker: string; price: number; change_1d: number; change_5d: number;
+  volume_ratio: number; rsi: number; signal: string; score: number;
+}
+
+export interface SwingEntry {
+  ticker: string; price: number; scan_signal: string; scan_score: number;
+  agent_action: string; agent_confidence: number; approved: boolean; reason: string;
+}
+
+export interface MergedScanRow {
+  ticker: string;
+  price: number | null;
+  change_1d: number | null;
+  change_5d: number | null;
+  rsi: number | null;
+  signal: string | null;
+  score: number | null;
+  agent_action: string | null;
+  agent_confidence: number | null;
+  /** null = 스윙 평가 자체가 없음 (스캔 전용 행) */
+  approved: boolean | null;
+  reason: string | null;
+}
+
+export function mergeScanSwing(scan: ScanResult[], swing: SwingEntry[]): MergedScanRow[] {
+  const bySwing = new Map(swing.map((e) => [e.ticker, e]));
+  const seen = new Set<string>();
+  const rows: MergedScanRow[] = [];
+
+  // 스캔 순서(스코어 내림차순, API 정렬) 우선 — 스윙 필드를 조인
+  for (const r of scan) {
+    const sw = bySwing.get(r.ticker);
+    seen.add(r.ticker);
+    rows.push({
+      ticker: r.ticker,
+      price: r.price ?? sw?.price ?? null,
+      change_1d: r.change_1d ?? null,
+      change_5d: r.change_5d ?? null,
+      rsi: r.rsi ?? null,
+      signal: r.signal ?? sw?.scan_signal ?? null,
+      score: r.score ?? sw?.scan_score ?? null,
+      agent_action: sw?.agent_action ?? null,
+      agent_confidence: sw?.agent_confidence ?? null,
+      approved: sw ? sw.approved : null,
+      reason: sw?.reason ?? null,
+    });
+  }
+
+  // 스윙 전용 행 (top-N 밖) — 스캔 모멘텀 필드는 없음
+  for (const sw of swing) {
+    if (seen.has(sw.ticker)) continue;
+    rows.push({
+      ticker: sw.ticker,
+      price: sw.price ?? null,
+      change_1d: null,
+      change_5d: null,
+      rsi: null,
+      signal: sw.scan_signal ?? null,
+      score: sw.scan_score ?? null,
+      agent_action: sw.agent_action ?? null,
+      agent_confidence: sw.agent_confidence ?? null,
+      approved: sw.approved,
+      reason: sw.reason ?? null,
+    });
+  }
+  return rows;
+}

--- a/frontend/src/app/scan/page.tsx
+++ b/frontend/src/app/scan/page.tsx
@@ -4,50 +4,38 @@ import { Suspense } from "react";
 import { fetchAPI } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { ClientTable } from "@/components/ui/client-table";
+import { SCAN } from "@/lib/strings";
+import { type ScanResult, type SwingEntry, mergeScanSwing } from "./helpers";
 
-interface ScanResult {
-  ticker: string; price: number; change_1d: number; change_5d: number;
-  volume_ratio: number; rsi: number; signal: string; score: number;
-}
-
-interface SwingEntry {
-  ticker: string; price: number; scan_signal: string; scan_score: number;
-  agent_action: string; agent_confidence: number; approved: boolean; reason: string;
-}
-
-
-async function ScanSection() {
-  const data = await fetchAPI<{ results: ScanResult[]; count: number }>("/api/scan?market=us&top=15");
-  return (
-    <Card className="bg-card border-border">
-      <CardContent className="pt-5">
-        <p className="text-xs text-muted-foreground mb-3">Market Scanner — {data.count} signals</p>
-        <ClientTable variant="scan" data={data.results} />
-      </CardContent>
-    </Card>
-  );
-}
-
-async function SwingSection() {
-  const data = await fetchAPI<{ entries: SwingEntry[]; approved: number; rejected: number }>("/api/swing/entries");
-  const approved = data.entries.filter((e) => e.approved);
-  const rejected = data.entries.filter((e) => !e.approved);
+// #1219 U4b: Market Scanner(top-15)와 Swing Entries(에이전트 합의 뷰)가 15/20 행을
+// 중복 렌더하던 두 테이블을 ticker union 단일 테이블로 병합. 미승인 사유는 접기 유지.
+async function ScannerSection() {
+  const [scanData, swingData] = await Promise.all([
+    fetchAPI<{ results: ScanResult[]; count: number }>("/api/scan?market=us&top=15"),
+    fetchAPI<{ entries: SwingEntry[]; approved: number; rejected: number }>("/api/swing/entries").catch(
+      () => ({ entries: [] as SwingEntry[], approved: 0, rejected: 0 }),
+    ),
+  ]);
+  const rows = mergeScanSwing(scanData.results, swingData.entries);
+  const rejected = swingData.entries.filter((e) => !e.approved);
 
   return (
     <Card className="bg-card border-border">
       <CardContent className="pt-5">
         <p className="text-xs text-muted-foreground mb-3">
-          Swing Entries — <span className="text-emerald-400">{data.approved} approved</span>, {data.rejected} rejected
+          {SCAN.TITLE} — {rows.length} {SCAN.HEADER_SIGNALS} ·{" "}
+          <span className="text-emerald-400">{SCAN.HEADER_APPROVED} {swingData.approved}</span> ·{" "}
+          {SCAN.HEADER_REJECTED} {swingData.rejected}
         </p>
-        {approved.length > 0 ? (
-          <ClientTable variant="swing" data={approved} />
+        {rows.length === 0 ? (
+          <p className="text-xs text-muted-foreground/70 py-3 text-center">{SCAN.EMPTY}</p>
         ) : (
-          <p className="text-xs text-muted-foreground/70 py-3 text-center">No entries passed agent consensus (BUY + conf ≥ 50)</p>
+          <ClientTable variant="scanner" data={rows} />
         )}
         {rejected.length > 0 && (
           <details className="mt-3">
             <summary className="text-[10px] text-muted-foreground/70 cursor-pointer hover:text-muted-foreground">
-              Rejected ({rejected.length})
+              {SCAN.REJECTED_FOLD} ({rejected.length})
             </summary>
             <div className="mt-1.5 space-y-0.5 text-[10px] text-muted-foreground/70 pl-2">
               {rejected.map((e, i) => (
@@ -68,9 +56,8 @@ function Loading() {
 export default function ScanPage() {
   return (
     <div className="space-y-5">
-      <h1 className="text-2xl font-bold">Market Scanner</h1>
-      <Suspense fallback={<Loading />}><ScanSection /></Suspense>
-      <Suspense fallback={<Loading />}><SwingSection /></Suspense>
+      <h1 className="text-2xl font-bold">{SCAN.TITLE}</h1>
+      <Suspense fallback={<Loading />}><ScannerSection /></Suspense>
     </div>
   );
 }

--- a/frontend/src/components/ui/client-table.branchcov.test.tsx
+++ b/frontend/src/components/ui/client-table.branchcov.test.tsx
@@ -29,13 +29,13 @@ describe("ClientTable branch coverage", () => {
 
   it("renders title when provided", () => {
     const { container } = render(
-      <ClientTable variant="scan" data={[]} title="My Title" compact />
+      <ClientTable variant="scanner" data={[]} title="My Title" compact />
     );
     expect(container.textContent).toContain("My Title");
   });
 
   it("renders without title (falsy branch)", () => {
-    const { container } = render(<ClientTable variant="scan" data={[]} />);
+    const { container } = render(<ClientTable variant="scanner" data={[]} />);
     expect(container.textContent).not.toContain("My Title");
   });
 
@@ -61,13 +61,15 @@ describe("ClientTable branch coverage", () => {
     expect(txt).toContain("1.5");
   });
 
-  it("scan: price renderer with number and undefined, pct non-number fallback", () => {
+  it("scanner: price renderer with number and undefined, pct non-number fallback (#1219)", () => {
     const data = [
-      { ticker: "TSLA", price: 250.5, change_1d: 1.2, change_5d: -2.0, rsi: 55.3, signal: "BUY", score: 80 },
-      // change_1d 가 비수치 → pct() 의 `typeof v === "number" ? v.toFixed(1) : v` else 분기 (line 27)
-      { ticker: "NVDA", price: undefined, change_1d: "n/a", change_5d: 0, rsi: "x", signal: "HOLD", score: 0 },
+      { ticker: "TSLA", price: 250.5, change_1d: 1.2, change_5d: -2.0, rsi: 55.3, signal: "BUY", score: 80,
+        agent_action: "BUY", agent_confidence: 70, approved: true, reason: null },
+      // change_1d 가 비수치 → pct() 의 `typeof v === "number" ? v.toFixed(1) : v` else 분기
+      { ticker: "NVDA", price: undefined, change_1d: "n/a", change_5d: 0, rsi: "x", signal: "HOLD", score: 0,
+        agent_action: null, agent_confidence: null, approved: null, reason: null },
     ];
-    const { container } = render(<ClientTable variant="scan" data={data} />);
+    const { container } = render(<ClientTable variant="scanner" data={data} />);
     const txt = container.textContent || "";
     expect(txt).toContain("$250.50");
     // num non-number (rsi: "x") fallback
@@ -166,12 +168,14 @@ describe("ClientTable branch coverage", () => {
     expect(container.querySelector(".bg-emerald-500\\/8")).toBeTruthy();
   });
 
-  it("swing: renderers", () => {
+  it("scanner: agent/approved arms (#1219)", () => {
     const data = [
-      { ticker: "AMD", price: 150.5, scan_signal: "BUY", scan_score: 70, agent_action: "LONG", agent_confidence: 0.8 },
+      { ticker: "AMD", price: 150.5, change_1d: 1.0, change_5d: 2.0, rsi: 50, signal: "BUY", score: 70,
+        agent_action: "LONG", agent_confidence: 80, approved: false, reason: "risk veto" },
     ];
-    const { container } = render(<ClientTable variant="swing" data={data} />);
+    const { container } = render(<ClientTable variant="scanner" data={data} />);
     expect(container.textContent).toContain("AMD");
+    expect(container.textContent).toContain("미승인");
   });
 
   it("advisor: priority 1/2/other, severity critical/high/other, action SELL_ALL/other", () => {

--- a/frontend/src/components/ui/client-table.tsx
+++ b/frontend/src/components/ui/client-table.tsx
@@ -49,14 +49,22 @@ const VARIANTS: Record<string, any[]> = {
     { key: "profit_factor", label: "PF", align: "right", render: num },
     { key: "avg_return", label: "Avg Return", align: "right", render: pct },
   ],
-  scan: [
+  // #1219: scan/swing 두 변형이 같은 스캔의 중복 뷰였다 — union 병합 단일 변형.
+  // 병합 특성상 어느 쪽에도 없는 필드가 있어 렌더러는 전부 null 허용 (—).
+  scanner: [
     { key: "ticker", label: "Ticker", render: ticker },
     { key: "price", label: "Price", align: "right", render: price },
-    { key: "change_1d", label: "1D", align: "right", render: pct },
-    { key: "change_5d", label: "5D", align: "right", render: pct },
-    { key: "rsi", label: "RSI", align: "right", render: num },
-    { key: "signal", label: "Signal", render: badge },
-    { key: "score", label: "Score", align: "right" },
+    { key: "change_1d", label: "1D", align: "right", render: (v: number | null) => (v == null ? dim("—") : pct(v)) },
+    { key: "change_5d", label: "5D", align: "right", render: (v: number | null) => (v == null ? dim("—") : pct(v)) },
+    { key: "rsi", label: "RSI", align: "right", render: (v: number | null) => (v == null ? dim("—") : num(v)) },
+    { key: "signal", label: "Signal", render: (v: string | null) => (v ? badge(v) : dim("—")) },
+    { key: "score", label: "Score", align: "right", render: (v: number | null) => (v == null ? dim("—") : String(v)) },
+    { key: "agent_action", label: "Agent", align: "center", render: (v: string | null) => (v ? badgeMd(v) : dim("—")) },
+    { key: "agent_confidence", label: "Conf", align: "right", render: (v: number | null) => (v == null ? dim("—") : String(v)) },
+    { key: "approved", label: "승인", align: "center", render: (v: boolean | null, row: { reason?: string | null }) =>
+      v === null ? dim("—") : v
+        ? <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-400">승인</span>
+        : <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-zinc-700/40 text-zinc-400" title={row.reason ?? undefined}>미승인</span> },
   ],
   gate: [
     { key: "description", label: "Condition" },
@@ -100,14 +108,6 @@ const VARIANTS: Record<string, any[]> = {
       if (_v === "target_1") return <span className="text-emerald-400 text-[10px] font-medium">TP1 ({row.take_profit_sell_pct}%)</span>;
       return dim("—");
     }},
-  ],
-  swing: [
-    { key: "ticker", label: "Ticker", render: ticker },
-    { key: "price", label: "Price", align: "right", render: price },
-    { key: "scan_signal", label: "Signal", align: "center", render: badge },
-    { key: "scan_score", label: "Score", align: "right" },
-    { key: "agent_action", label: "Agent", align: "center", render: badgeMd },
-    { key: "agent_confidence", label: "Conf", align: "right" },
   ],
   advisor: [
     { key: "priority", label: "#", align: "center", render: (v: number) => {

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -324,6 +324,20 @@ export const TICKER_DETAIL = {
   PANEL_EXTERNAL: "External Data",
 } as const;
 
+/* ── Scan Page (#1219 U4b) ──────────────────────────────────── */
+export const SCAN = {
+  TITLE: "Market Scanner",
+  // 병합 테이블 헤더: 시그널 수 + 스윙 승인/거절 집계
+  HEADER_SIGNALS: "시그널",
+  HEADER_APPROVED: "승인",
+  HEADER_REJECTED: "거절",
+  EMPTY: "스캔 결과 없음 — make quick-scan 실행 필요",
+  TAG_APPROVED: "승인",
+  TAG_REJECTED: "미승인",
+  TAG_NO_EVAL: "—", // 스윙 평가 없음 (스캔 전용 행)
+  REJECTED_FOLD: "미승인 사유",
+} as const;
+
 /* ── Engine Page (#1218 U4a) ────────────────────────────────── */
 export const ENGINE = {
   CONFLICTS_EMPTY: "시그널 충돌 없음",


### PR DESCRIPTION
Closes #1219. Phase U4b (U4 split 2/2) of docs/UX_REDESIGN_PLAN.md — last pre-D3 build phase.

## scan
- **중복 테이블 병합** — top-15 스캔과 스윙 20행이 15행을 두 테이블에 중복 렌더하던 것을 ticker **union 단일 테이블**로: 모멘텀(1D/5D/RSI)은 스캔에서, Agent/Conf/승인은 스윙에서, 없는 쪽은 —. 미승인 태그에 사유 title, 미승인 사유 접기 유지. 스윙 API 실패 시 에이전트 컬럼만 — 로 강등(페이지 생존, graceful-skip 잠금).
- ClientTable `scan`/`swing` 변형 → null-tolerant `scanner` 단일 변형 (병합 특성상 어느 쪽 필드도 빠질 수 있음). 실화면(1440): 20행 union·단일 테이블·헤더 집계(승인 14 · 거절 6) 확인.
- 마지막 인라인 영어 빈 상태 → strings.ts (`스캔 결과 없음`) — U4 '빈 상태 1줄 규칙 전면' 완결.

## pipeline
- 타임라인 payload의 `JSON.stringify` raw 폴백 폐지 → 사람이 읽는 한 줄 요약(stderr/command/error 우선 유지, 이후 kv ≤3쌍 + '+N', 순환 참조 안전) — U3 evidence kv와 동일 원칙.

## Tests / gates
- 순수 헬퍼 2종 + 단위 잠금 17개(null 필드 실데이터 형태, union 순서, 우선순위 키, 순환 payload, 스윙 실패 강등).
- vitest **1538/131** green · build green · lint 0 errors · **touched-files coverage CLEAN (push 전 실측)** · responsive /scan·/pipeline 8/8 · doc counts 22/22 (7곳 동기화).
- 플랜 행: U4a 완료 (#1220), U4b 진행 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)