### PR TITLE
style(design): design-review polish — fg chip overflow + emoji residue sweep

### DIFF
--- a/frontend/src/__tests__/components/freshness-bar.test.tsx
+++ b/frontend/src/__tests__/components/freshness-bar.test.tsx
@@ -62,17 +62,17 @@ describe("FreshnessBar", () => {
   // ─── Status icons ───────────────────────────────────
   it("shows checkmark icon for PASS", () => {
     render(<FreshnessBar items={[makeItem({ status: "PASS" })]} />);
-    expect(screen.getByText("\u2705")).toBeInTheDocument();
+    expect(screen.getByText("\u2713")).toBeInTheDocument(); // FINDING-002: 이모지→글리프
   });
 
   it("shows warning icon for WARN", () => {
     render(<FreshnessBar items={[makeItem({ status: "WARN" })]} />);
-    expect(screen.getByText("\u26A0\uFE0F")).toBeInTheDocument();
+    expect(screen.getByText("\u25B3")).toBeInTheDocument();
   });
 
   it("shows cross icon for FAIL", () => {
     render(<FreshnessBar items={[makeItem({ status: "FAIL" })]} />);
-    expect(screen.getByText("\u274C")).toBeInTheDocument();
+    expect(screen.getByText("\u2715")).toBeInTheDocument();
   });
 
   // ─── Age formatting ─────────────────────────────────

--- a/frontend/src/__tests__/components/siege-timeline-chart.test.tsx
+++ b/frontend/src/__tests__/components/siege-timeline-chart.test.tsx
@@ -155,7 +155,7 @@ describe("SiegeTimelineChart helpers", () => {
     });
     const [text, label] = valueFormatter(85, "score", { payload: p });
     expect(label).toBe("score");
-    expect(text).toContain("✅ CERTIFIED");
+    expect(text).toContain("✓ CERTIFIED");
     expect(text).toContain("(85)");
     expect(text).toContain("0F/1W");
     expect(text).toContain("regime=bull_low_vol");
@@ -171,7 +171,7 @@ describe("SiegeTimelineChart helpers", () => {
       caller: null,
     });
     const [text] = valueFormatter(45, "score", { payload: p });
-    expect(text).toContain("❌ REJECTED");
+    expect(text).toContain("✕ REJECTED");
     expect(text).toContain("(45)");
     expect(text).toContain("2F/3W");
     expect(text).toContain("regime=-");

--- a/frontend/src/__tests__/coverage/client-table-coverage.test.tsx
+++ b/frontend/src/__tests__/coverage/client-table-coverage.test.tsx
@@ -127,7 +127,7 @@ describe("ClientTable branches", () => {
       { description: "Fresh", phase: "validate", passed: false, detail: "Stale" },
     ]} compact title="Gate" />);
     expect(screen.getByText("Gate")).toBeInTheDocument();
-    expect(screen.getByText("✅")).toBeInTheDocument();
-    expect(screen.getByText("❌")).toBeInTheDocument();
+    expect(screen.getByText("✓")).toBeInTheDocument(); // FINDING-002
+    expect(screen.getByText("✕")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/market-strip.tsx
+++ b/frontend/src/components/dashboard/market-strip.tsx
@@ -48,7 +48,8 @@ export function MarketStrip({
       )}
       {fg != null && (
         <span>
-          {MARKET.SENTIMENT} <span className={`inline-flex items-center justify-center h-4 w-4 rounded-full text-[9px] font-bold tabular-nums ${fgColor(fg)}`}>{fg}</span> <span className="text-zinc-600">{fgLabel(fg)}</span>
+          {/* FINDING-001: w-4 고정폭은 "52.5" 같은 소수값이 넘쳐 라벨과 붙어 보인다 — pill 로 */}
+          {MARKET.SENTIMENT} <span className={`inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-[9px] font-bold tabular-nums ${fgColor(fg)}`}>{fg}</span> <span className="text-zinc-600">{fgLabel(fg)}</span>
         </span>
       )}
       {hasMacroScore && (

--- a/frontend/src/components/ui/client-table.branchcov.test.tsx
+++ b/frontend/src/components/ui/client-table.branchcov.test.tsx
@@ -85,8 +85,8 @@ describe("ClientTable branch coverage", () => {
     ];
     const { container } = render(<ClientTable variant="gate" data={data} />);
     const txt = container.textContent || "";
-    expect(txt).toContain("✅");
-    expect(txt).toContain("❌");
+    expect(txt).toContain("✓"); // FINDING-002
+    expect(txt).toContain("✕");
     // dim with value
     expect(txt).toContain("ok");
     // dim with null → "—"

--- a/frontend/src/components/ui/client-table.tsx
+++ b/frontend/src/components/ui/client-table.tsx
@@ -69,7 +69,9 @@ const VARIANTS: Record<string, any[]> = {
   gate: [
     { key: "description", label: "Condition" },
     { key: "phase", label: "Phase", align: "center", render: badge },
-    { key: "passed", label: "Status", align: "center", render: (v: boolean) => v ? "✅" : "❌" },
+    { key: "passed", label: "Status", align: "center", render: (v: boolean) => v
+      ? <span className="text-emerald-400">✓</span>
+      : <span className="text-red-400">✕</span> },
     { key: "detail", label: "Detail", render: dim },
   ],
   conflicts: [

--- a/frontend/src/components/ui/coverage-status.tsx
+++ b/frontend/src/components/ui/coverage-status.tsx
@@ -56,7 +56,8 @@ export function CoverageStatus({ data }: { data: CoverageData }) {
   const allPass = data.fail === 0;
   const total = data.checks.length;
   const headerColor = allPass ? "text-emerald-400" : "text-red-400";
-  const headerIcon = allPass ? "\u2705" : "\u274C";
+  // FINDING-002 (design-review): 이모지 → intent-색 글리프 (headerColor 가 색을 이미 나른다)
+  const headerIcon = allPass ? "\u2713" : "\u2715";
 
   return (
     <details className="rounded-md border border-border bg-card/40 p-3 group" data-testid="coverage-details">

--- a/frontend/src/components/ui/freshness-bar.tsx
+++ b/frontend/src/components/ui/freshness-bar.tsx
@@ -13,10 +13,12 @@ interface FreshnessItem {
   message: string;
 }
 
+// FINDING-002 (design-review): 칩이 이미 intent 색(bg+text)을 갖고 있어 컬러 이모지는
+// 중복 장식이었다 — 시스템 전역의 이모지 배제 원칙에 맞춰 텍스트 글리프로 (intent 색 상속).
 const statusStyles: Record<string, { bg: string; text: string; icon: string }> = {
-  PASS: { bg: "bg-emerald-500/15 border-emerald-500/20", text: "text-emerald-400", icon: "\u2705" },
-  WARN: { bg: "bg-amber-500/15 border-amber-500/20", text: "text-amber-400", icon: "\u26A0\uFE0F" },
-  FAIL: { bg: "bg-red-500/15 border-red-500/20", text: "text-red-400", icon: "\u274C" },
+  PASS: { bg: "bg-emerald-500/15 border-emerald-500/20", text: "text-emerald-400", icon: "\u2713" },
+  WARN: { bg: "bg-amber-500/15 border-amber-500/20", text: "text-amber-400", icon: "\u25B3" },
+  FAIL: { bg: "bg-red-500/15 border-red-500/20", text: "text-red-400", icon: "\u2715" },
 };
 
 function formatAge(hours: number): string {

--- a/frontend/src/components/ui/siege-timeline-chart.tsx
+++ b/frontend/src/components/ui/siege-timeline-chart.tsx
@@ -79,7 +79,7 @@ export function labelFormatter(_label: unknown, payload?: { payload?: ChartPoint
 
 export function valueFormatter(value: unknown, _name: unknown, item: { payload: ChartPoint }): [string, string] {
   const p = item.payload;
-  const status = p.certified ? "✅ CERTIFIED" : "❌ REJECTED";
+  const status = p.certified ? "✓ CERTIFIED" : "✕ REJECTED";
   return [
     `${status} (${value}) — ${p.failed}F/${p.warnings}W  regime=${p.regime ?? "-"}  caller=${p.caller ?? "-"}`,
     "score",


### PR DESCRIPTION
docs/UX_REDESIGN_PLAN.md D3 마지막 절차인 /design-review 라이브 패스 결과. 감사 리포트: ~/.gstack/projects/nuri-quant/designs/design-audit-20260825/.

## Fixes (atomic, finding당 1커밋)
- **FINDING-001** — MarketStrip Fear&Greed 값 칩이 `w-4`(16px) 고정폭이라 "52.5" 같은 소수 스코어가 넘쳐 라벨과 밀착 렌더 → `min-w-4 px-1` pill.
- **FINDING-002** — 이모지 상태 아이콘 잔재 스윕: freshness 칩(✅⚠️❌)·gate 테이블(✅❌)·siege 툴팁·coverage 헤더 → intent 색을 상속하는 텍스트 글리프(✓/△/✕). 칩이 이미 bg+text 로 intent 를 나르므로 컬러 이모지는 중복 장식이었고, 시스템 전역 이모지 배제 원칙(plan §1)의 마지막 잔재.

## Deferred (리포트 기록)
pipeline 노드/이벤트 이모지 아이콘(아이덴티티 결정 필요), 기회 카드 밀도(no-fix 판정), 사이드바 접기 버튼 크기.

## Gates
vitest 1538/131 green (이모지 assertion 6곳 글리프로 동행 갱신) · build green · before/after 스크린샷 검증 (심리 칩 간격 정상화, 푸터/커버리지 글리프 전환).

Design Score A- 유지 · AI Slop Score **A** (블랙리스트 잔존 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)