### PR TITLE
docs(plan): mark U4b and D3 complete — Evidence Terminal redesign closed

### DIFF
--- a/docs/UX_REDESIGN_PLAN.md
+++ b/docs/UX_REDESIGN_PLAN.md
@@ -75,7 +75,7 @@
 | U2b-4 | 델타·ack | NEW+시각 배지 · 확인(ack) 로컬 상태 · 다음 행동 카피 | 완료 (#1213, 커버리지 후속 #1215) |
 | U3 | Decisions | 리스트: 필터·날짜 그룹핑·conf micro-bar·판정일 명시 / 상세: 2컬럼 + 증거 key-value(raw JSON 폐지) + raw float 종결 | 완료 (#1217) |
 | U4a | 주변부 1/2 | ticker(빈 패널 접기·부재 한 줄 스트립)·engine(BLOCKED 다음 행동 링크·빈 상태 한국어 1줄) | 완료 (#1220) |
-| U4b | 주변부 2/2 | scanner(중복 테이블 union 병합 — top-15 ⊂ swing 20 실측)·pipeline(타임라인 payload raw JSON 폐지) + 잔여 빈 상태 스윕 | 진행 중 (#1219) |
+| U4b | 주변부 2/2 | scanner(중복 테이블 union 병합 — top-15 ⊂ swing 20 실측)·pipeline(타임라인 payload raw JSON 폐지) + 잔여 빈 상태 스윕 | 완료 (#1221) |
 | U5 | 별도 결정 | evidence matplotlib PNG→네이티브 차트 · Cmd-K · IA 통합(라우트 병합) — 각각 사용자 승인 후 착수 | 보류 |
 
 ### 단계별 공통 게이트
@@ -90,7 +90,7 @@
 
 - **D1**: U1c 머지 후 — mini 1차 배포 (토큰+통화+반응형 파운데이션 묶음, 프론트 재빌드 필수) — **완료 2026-08-25** (served CSS 토큰 마커 검증)
 - **D2**: U2b 머지 후 — 대시보드 재구조 라이브 검증 (사용자 실경로 QA) — **완료 2026-08-25** (U2b 마커 5종 served 번들 확인, 27066ba)
-- **D3**: U4 머지 후 — 최종 + `/design-review` 라이브 폴리싱 패스
+- **D3**: U4 머지 후 — 최종 + `/design-review` 라이브 폴리싱 패스 — **완료 2026-08-25** (배포 c72a239→01d19e8, U3/U4 마커 served 검증 · /design-review 5건 발견 2건 수정 #1222, Design A- · AI Slop A, 리포트 `~/.gstack/projects/nuri-quant/designs/design-audit-20260825/`)
 
 ## 4. 리스크 / 제약
 


### PR DESCRIPTION
docs/UX_REDESIGN_PLAN.md 상태 규칙(행 갱신 관례)에 따른 마지막 갱신: U4b 완료(#1221), D3 완료(배포 01d19e8 + /design-review #1222, Design A- · AI Slop A). U5(evidence 네이티브 차트·Cmd-K·IA 통합)만 '보류 — 사용자 승인 후 착수'로 남는다. 문서 3줄 변경, 코드 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)