### PR TITLE
feat(api): extract shared evidence data layer and serve chart JSON (#1224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,539 collected across 346 files | |
+| **Backend tests** | 7,541 collected across 346 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,538 across 131 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,521 collected across 345 files | |
+| **Backend tests** | 7,539 collected across 346 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,538 across 131 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,8 +57,8 @@ Trade execution API (`nuri/api/routes/trades.py`):
 - `PUT /api/trades/{id}` — Update exit info
 ## Dashboard API (Projection-based, <5s)
 `/api/dashboard` reads pre-computed results from DB instead of running analysis inline. Consensus from `recommendations` table (populated by `make consensus`). Response includes `freshness` and `pipeline_status` for data age display. The one-line `verdict` is stale-gated (#1181): when any `verdict_gate` input (`config/freshness.yaml`) is FAIL-stale, the response carries `verdict_level: "stale"` + `verdict_stale_inputs` and the verdict text names the stale inputs instead of advising.
-## API (72 endpoints)
-`nuri/api/routes/` — 72 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 21 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
+## API (73 endpoints)
+`nuri/api/routes/` — 73 REST endpoints on port **8001** (`@router.get/post/put/delete/patch` decorators counted across 21 route modules; excludes FastAPI's `/docs`, `/redoc`, `/openapi.json`, `/docs/oauth2-redirect`). Swagger at `http://localhost:8001/docs`. SSE at `/api/stream` (30s interval). Includes `/api/coverage` (#297) for Universe + Agent data coverage widget.
 ### Action-First Dashboard APIs (PR #264-#266)
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,521 backend tests across 345 files + 1538 frontend vitest (131 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,539 backend tests across 346 files + 1538 frontend vitest (131 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,539 backend tests across 346 files + 1538 frontend vitest (131 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,541 backend tests across 346 files + 1538 frontend vitest (131 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,521 tests, 345 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,539 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1538 tests, 131 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,539 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,541 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1538 tests, 131 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/UX_REDESIGN_PLAN.md
+++ b/docs/UX_REDESIGN_PLAN.md
@@ -76,7 +76,10 @@
 | U3 | Decisions | 리스트: 필터·날짜 그룹핑·conf micro-bar·판정일 명시 / 상세: 2컬럼 + 증거 key-value(raw JSON 폐지) + raw float 종결 | 완료 (#1217) |
 | U4a | 주변부 1/2 | ticker(빈 패널 접기·부재 한 줄 스트립)·engine(BLOCKED 다음 행동 링크·빈 상태 한국어 1줄) | 완료 (#1220) |
 | U4b | 주변부 2/2 | scanner(중복 테이블 union 병합 — top-15 ⊂ swing 20 실측)·pipeline(타임라인 payload raw JSON 폐지) + 잔여 빈 상태 스윕 | 완료 (#1221) |
-| U5 | 별도 결정 | evidence matplotlib PNG→네이티브 차트 · Cmd-K · IA 통합(라우트 병합) — 각각 사용자 승인 후 착수 | 보류 |
+| U5a-1 | evidence 데이터 API | Plotly HTML iframe(플랜의 'matplotlib PNG' 문구는 낡음)의 5개 차트 쿼리를 `evidence_data.py` 공유 함수로 추출 + `/api/evidence/data/{id}` JSON — 생성기(리포트 아카이브 유지)와 단일 소스 | 진행 중 (#1224) |
+| U5a-2 | evidence 네이티브 차트 | iframe 5개 → recharts (`--chart-*` 토큰, 캔들→종가 라인 허용) | 대기 (#1225) |
+| U5b | Cmd-K | 라우트 점프 + 티커 검색 팔레트 (경량 자체 구현 우선) | 대기 (#1226) |
+| U5c | IA 통합 | 라우트 병합 — **병합 맵 제안 후 사용자 확인, 그 전 구현 금지** | 대기 (#1227) |
 
 ### 단계별 공통 게이트
 

--- a/nuri/analysis/evidence_charts.py
+++ b/nuri/analysis/evidence_charts.py
@@ -17,7 +17,18 @@ import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from nuri.core.db import query_df
+from nuri.analysis.evidence_data import (
+    detect_portfolio_violations as _detect_portfolio_violations,
+)
+from nuri.analysis.evidence_data import (
+    load_fear_greed_history,
+    load_portfolio_grouped,
+    load_spy_with_sma,
+    load_vix_history,
+)
+from nuri.analysis.evidence_data import (
+    load_signal_performance as _load_signal_performance,
+)
 from nuri.core.timezone import today_kst
 from nuri.quant.regime.classifier import classify_regime
 
@@ -32,29 +43,16 @@ REPORT_DIR = Path(__file__).parent.parent.parent / "data" / "reports"
 
 
 def generate_regime_chart(output_dir: Path, db_path=None) -> Path:
-    """SPY 캔들스틱 + SMA50/200 + 레짐 영역 + VIX 서브플롯."""
-    # SPY 가격 (1년)
-    spy = query_df(
-        "SELECT date, open, high, low, close, volume FROM prices WHERE ticker='SPY' ORDER BY date DESC LIMIT 252",
-        db_path=db_path,
-    )
+    """SPY 캔들스틱 + SMA50/200 + 레짐 영역 + VIX 서브플롯.
+
+    조회·SMA 조립은 evidence_data 공유 함수 — JSON API 와 단일 소스 (#1224).
+    """
+    spy = load_spy_with_sma(db_path=db_path)
     if spy.empty:
         logger.warning("SPY 가격 데이터 없음")
         return output_dir / "regime_evidence.html"
 
-    spy = spy.sort_values("date").reset_index(drop=True)
-    spy["date"] = pd.to_datetime(spy["date"])
-    spy["sma50"] = spy["close"].rolling(50).mean()
-    spy["sma200"] = spy["close"].rolling(200).mean()
-
-    # VIX
-    vix = query_df(
-        "SELECT date, value FROM macro WHERE indicator='vix' ORDER BY date DESC LIMIT 252",
-        db_path=db_path,
-    )
-    if not vix.empty:
-        vix = vix.sort_values("date").reset_index(drop=True)
-        vix["date"] = pd.to_datetime(vix["date"])
+    vix = load_vix_history(db_path=db_path)
 
     # 현재 레짐
     regime = classify_regime(db_path=db_path)
@@ -229,48 +227,21 @@ def _shade_regime_zones(fig: go.Figure, spy: pd.DataFrame) -> None:
 
 
 def generate_portfolio_heatmap(output_dir: Path, db_path=None) -> Path:
-    """포트폴리오 트리맵: 크기=포지션 가치, 색상=손익%."""
-    from nuri.analysis.portfolio import analyze_portfolio
+    """포트폴리오 트리맵: 크기=포지션 가치, 색상=손익%.
 
-    df = analyze_portfolio(db_path=db_path)
+    합산·위반 판정은 evidence_data.load_portfolio_grouped — JSON API 와 단일 소스 (#1224).
+    """
     output_path = output_dir / "portfolio_heatmap.html"
 
-    if df.empty:
+    grouped = load_portfolio_grouped(db_path=db_path)
+    if grouped.empty:
         logger.warning("포트폴리오 데이터 없음")
         _save_empty_chart("포트폴리오 데이터 없음", output_path)
         return output_path
 
-    # 종목별 합산 (다계좌 동일 종목)
-    grouped = (
-        df.groupby("ticker")
-        .agg(
-            {
-                "current_value_usd": "sum",
-                "pnl_pct": "mean",
-                "weight_pct": "sum",
-                "sector": "first",
-            }
-        )
-        .reset_index()
-    )
-
-    # 위반 감지 (config/rules.yaml 기준)
-    from nuri.core.rules import MAX_SINGLE_POSITION, PORTFOLIO_STOP
-
-    max_single = MAX_SINGLE_POSITION  # 0.15 (15%)
-    stop_loss = PORTFOLIO_STOP  # -10
-    violations = []
-    border_colors = []
-
-    for _, row in grouped.iterrows():
-        color = "#ef5350"  # 기본: 빨간 테두리 없음
-        if row["pnl_pct"] <= stop_loss:
-            violations.append(row["ticker"])
-            color = "#ef5350"
-        elif row["weight_pct"] > max_single * 100:
-            violations.append(row["ticker"])
-            color = "#ffd54f"
-        border_colors.append(color)
+    # violation 컬럼 → 주석 목록·테두리 색 (기존 색 유지: 기본/손절=빨강, 비중=노랑)
+    violations = grouped.loc[grouped["violation"].notna(), "ticker"].tolist()
+    border_colors = ["#ffd54f" if v == "overweight" else "#ef5350" for v in grouped["violation"]]
 
     # 라벨
     labels = [
@@ -343,33 +314,16 @@ def generate_signal_performance_chart(output_dir: Path, db_path=None) -> Path:
     output_path = output_dir / "signal_performance.html"
 
     # 최신 signal_scorecard.csv 찾기
-    scorecard_df = _load_latest_scorecard()
-    if scorecard_df is None or scorecard_df.empty:
+    # 스코어카드+드리프트 조립은 evidence_data — JSON API 와 단일 소스 (#1224)
+    total = _load_signal_performance(db_path=db_path)
+    if total is None or total.empty:
         logger.warning("signal_scorecard.csv 없음 (make validate 먼저 실행)")
         _save_empty_chart("시그널 스코어카드 없음 (make validate 실행 필요)", output_path)
         return output_path
 
-    # 전체 종목 합산 행만 사용 (ticker가 NaN)
-    total = scorecard_df[scorecard_df["ticker"].isna()].copy()
-    if total.empty:
-        total = scorecard_df.head(20)
-
-    total = total.sort_values("win_rate", ascending=True)
-
-    # 드리프트 상태 로드
-    drift_map = _load_drift_map(db_path)
-
     # 색상: 드리프트 상태별
-    colors = []
-    for _, row in total.iterrows():
-        sig_id = row["signal_id"]
-        drift = drift_map.get(sig_id, {}).get("status", "stable")
-        if drift == "critical":
-            colors.append("#ef5350")  # 빨강
-        elif drift == "degrading":
-            colors.append("#ff9800")  # 주황
-        else:
-            colors.append("#42a5f5")  # 파랑 (정상)
+    _drift_color = {"critical": "#ef5350", "degrading": "#ff9800"}
+    colors = [_drift_color.get(d, "#42a5f5") for d in total["drift_status"]]
 
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 
@@ -406,7 +360,7 @@ def generate_signal_performance_chart(output_dir: Path, db_path=None) -> Path:
     # critical/degrading 마커
     for _, row in total.iterrows():
         sig_id = row["signal_id"]
-        drift = drift_map.get(sig_id, {}).get("status", "stable")
+        drift = row["drift_status"]
         if drift in ("critical", "degrading"):
             marker_color = "#ef5350" if drift == "critical" else "#ff9800"
             label = "성과 급락" if drift == "critical" else "성과 하락"
@@ -445,17 +399,12 @@ def generate_fear_greed_chart(output_dir: Path, db_path=None) -> Path:
     """90일 공포·탐욕 지수 라인 + 구간 음영."""
     output_path = output_dir / "fear_greed.html"
 
-    fg = query_df(
-        "SELECT date, value FROM macro WHERE indicator='fear_greed' ORDER BY date DESC LIMIT 90",
-        db_path=db_path,
-    )
+    # 조회는 evidence_data 공유 함수 — JSON API 와 단일 소스 (#1224)
+    fg = load_fear_greed_history(db_path=db_path)
     if fg.empty:
         logger.warning("공포·탐욕 데이터 없음")
         _save_empty_chart("공포·탐욕 데이터 없음", output_path)
         return output_path
-
-    fg = fg.sort_values("date").reset_index(drop=True)
-    fg["date"] = pd.to_datetime(fg["date"])
 
     fig = go.Figure()
 
@@ -693,95 +642,8 @@ def generate_all_evidence(db_path=None) -> list[Path]:
 # ═══════════════════════════════════════════════════════
 
 
-def _load_latest_scorecard() -> pd.DataFrame | None:
-    """최신 signal_scorecard.csv 로드."""
-    if not REPORT_DIR.exists():
-        return None
-    for d in sorted(REPORT_DIR.iterdir(), reverse=True):
-        if not d.is_dir():
-            continue
-        csv_path = d / "signal_scorecard.csv"
-        if csv_path.exists():
-            return pd.read_csv(csv_path)
-    return None
-
-
-def _load_drift_map(db_path=None) -> dict[str, dict]:
-    """Learning Memory에서 시그널별 드리프트 상태 로드."""
-    try:
-        from nuri.trading.engine.memory import detect_drift
-
-        drifts = detect_drift(db_path=db_path)
-        return {d.signal_id: {"status": d.status, "drift_pct": d.drift_pct} for d in drifts}
-    except Exception:
-        return {}
-
-
-def _detect_portfolio_violations(db_path=None) -> list[dict]:
-    """포트폴리오 위반 항목 자동 감지 → 매도 근거 리스트."""
-    try:
-        from nuri.analysis.portfolio import analyze_portfolio
-
-        df = analyze_portfolio(db_path=db_path)
-    except Exception:
-        return []
-
-    if df.empty:
-        return []
-
-    from nuri.core.rules import MAX_SINGLE_POSITION, PORTFOLIO_STOP
-
-    violations = []
-    stop_loss_threshold = PORTFOLIO_STOP  # -10%
-    max_weight = MAX_SINGLE_POSITION * 100  # 15.0%
-
-    # 종목별 합산
-    grouped = (
-        df.groupby("ticker")
-        .agg(
-            {
-                "pnl_pct": "mean",
-                "weight_pct": "sum",
-            }
-        )
-        .reset_index()
-    )
-
-    for _, row in grouped.iterrows():
-        ticker = row["ticker"]
-        pnl = row["pnl_pct"]
-        weight = row["weight_pct"]
-
-        # 손절선 위반
-        if pnl <= stop_loss_threshold:
-            violations.append(
-                {
-                    "ticker": ticker,
-                    "type": "stop_loss",
-                    "severity": abs(pnl),
-                    "action": "SELL ALL",
-                    "recovery": f"손실 {abs(pnl):.1f}% → 회복에 {abs(pnl) / (100 + pnl) * 100:.0f}% 상승 필요"
-                    if pnl > -100
-                    else "회복 불가",
-                }
-            )
-
-        # 비중 초과
-        if weight > max_weight:
-            excess = weight - max_weight
-            violations.append(
-                {
-                    "ticker": ticker,
-                    "type": "overweight",
-                    "severity": excess,
-                    "action": "REDUCE",
-                    "recovery": f"비중 {weight:.1f}% → {max_weight:.0f}%까지 리밸런싱 필요",
-                }
-            )
-
-    # 심각도 내림차순 정렬
-    violations.sort(key=lambda v: v["severity"], reverse=True)
-    return violations
+# _load_latest_scorecard / _load_drift_map / _detect_portfolio_violations 는
+# evidence_data 로 이동 (#1224) — 상단 별칭 import 가 기존 patch 시임을 유지한다.
 
 
 def _save_empty_chart(message: str, output_path: Path) -> None:

--- a/nuri/analysis/evidence_charts.py
+++ b/nuri/analysis/evidence_charts.py
@@ -239,9 +239,9 @@ def generate_portfolio_heatmap(output_dir: Path, db_path=None) -> Path:
         _save_empty_chart("포트폴리오 데이터 없음", output_path)
         return output_path
 
-    # violation 컬럼 → 주석 목록·테두리 색 (기존 색 유지: 기본/손절=빨강, 비중=노랑)
+    # violation 컬럼 → 주석 목록. (원본의 border_colors 는 Treemap 에 배선된 적 없는
+    # 죽은 코드였다 — 리팩터로 F841 이 발화해 제거, #1228 CI)
     violations = grouped.loc[grouped["violation"].notna(), "ticker"].tolist()
-    border_colors = ["#ffd54f" if v == "overweight" else "#ef5350" for v in grouped["violation"]]
 
     # 라벨
     labels = [

--- a/nuri/analysis/evidence_data.py
+++ b/nuri/analysis/evidence_data.py
@@ -1,0 +1,227 @@
+# pyright: reportArgumentType=false, reportCallIssue=false
+"""증거 차트 데이터 — 단일 소스 (#1224 U5a-1).
+
+Plotly HTML 생성기(`evidence_charts.py`, 리포트 아카이브용)와 대시보드의
+`/api/evidence/data/{chart_id}` JSON API 가 **같은 조회·조립을 공유**한다.
+이전에는 생성기 안에 쿼리가 인라인이라 네이티브 차트를 만들면 두 벌이 되어
+드리프트가 필연이었다.
+
+함수들은 DataFrame/list 를 반환한다 — JSON 직렬화는 API 레이어(`routes/evidence.py`)
+몫. db_path 는 받은 값을 모든 DB 리더에 그대로 전달한다 (invariants.md).
+"""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from nuri.core.db import query_df
+
+logger = logging.getLogger(__name__)
+
+REPORT_DIR = Path(__file__).parent.parent.parent / "data" / "reports"
+
+
+# ═══ 1. 레짐: SPY + SMA + VIX ══════════════════════════════════
+
+
+def load_spy_with_sma(db_path=None, limit: int = 252) -> pd.DataFrame:
+    """SPY OHLCV 1년 + SMA50/200. 빈 DataFrame 이면 데이터 없음."""
+    spy = query_df(
+        f"SELECT date, open, high, low, close, volume FROM prices WHERE ticker='SPY' ORDER BY date DESC LIMIT {int(limit)}",
+        db_path=db_path,
+    )
+    if spy.empty:
+        return spy
+    spy = spy.sort_values("date").reset_index(drop=True)
+    spy["date"] = pd.to_datetime(spy["date"])
+    spy["sma50"] = spy["close"].rolling(50).mean()
+    spy["sma200"] = spy["close"].rolling(200).mean()
+    return spy
+
+
+def load_vix_history(db_path=None, limit: int = 252) -> pd.DataFrame:
+    """VIX 히스토리 (macro 테이블). 빈 DataFrame 허용."""
+    vix = query_df(
+        f"SELECT date, value FROM macro WHERE indicator='vix' ORDER BY date DESC LIMIT {int(limit)}",
+        db_path=db_path,
+    )
+    if vix.empty:
+        return vix
+    vix = vix.sort_values("date").reset_index(drop=True)
+    vix["date"] = pd.to_datetime(vix["date"])
+    return vix
+
+
+# ═══ 2. 포트폴리오 히트맵 ══════════════════════════════════════
+
+
+def load_portfolio_grouped(db_path=None) -> pd.DataFrame:
+    """종목별 합산(가치·손익·비중·섹터) + 위반 판정 컬럼.
+
+    violation ∈ {"stop_loss", "overweight", None} — 판정 기준은 config/rules.yaml
+    (PORTFOLIO_STOP / MAX_SINGLE_POSITION). 손절 위반이 비중 위반보다 우선한다
+    (기존 생성기 동작 유지).
+    """
+    from nuri.analysis.portfolio import analyze_portfolio
+
+    df = analyze_portfolio(db_path=db_path)
+    if df.empty:
+        return df
+
+    from nuri.core.rules import MAX_SINGLE_POSITION, PORTFOLIO_STOP
+
+    grouped = (
+        df.groupby("ticker")
+        .agg(
+            {
+                "current_value_usd": "sum",
+                "pnl_pct": "mean",
+                "weight_pct": "sum",
+                "sector": "first",
+            }
+        )
+        .reset_index()
+    )
+
+    def _violation(row) -> str | None:
+        if row["pnl_pct"] <= PORTFOLIO_STOP:
+            return "stop_loss"
+        if row["weight_pct"] > MAX_SINGLE_POSITION * 100:
+            return "overweight"
+        return None
+
+    grouped["violation"] = grouped.apply(_violation, axis=1)
+    return grouped
+
+
+# ═══ 3. 시그널 성과 (scorecard + drift) ════════════════════════
+
+
+def load_latest_scorecard() -> pd.DataFrame | None:
+    """최신 signal_scorecard.csv 로드 (evidence_charts 에서 이동, #1224)."""
+    if not REPORT_DIR.exists():
+        return None
+    for d in sorted(REPORT_DIR.iterdir(), reverse=True):
+        if not d.is_dir():
+            continue
+        csv_path = d / "signal_scorecard.csv"
+        if csv_path.exists():
+            return pd.read_csv(csv_path)
+    return None
+
+
+def load_drift_map(db_path=None) -> dict[str, dict]:
+    """Learning Memory 시그널별 드리프트 상태 (evidence_charts 에서 이동, #1224)."""
+    try:
+        from nuri.trading.engine.memory import detect_drift
+
+        drifts = detect_drift(db_path=db_path)
+        return {d.signal_id: {"status": d.status, "drift_pct": d.drift_pct} for d in drifts}
+    except Exception:
+        return {}
+
+
+def load_signal_performance(db_path=None) -> pd.DataFrame | None:
+    """스코어카드 전체 합산 행(ticker NaN) + drift_status 컬럼. 없으면 None.
+
+    합산 행이 없으면 상위 20행 폴백 (기존 생성기 동작 유지).
+    """
+    scorecard = load_latest_scorecard()
+    if scorecard is None or scorecard.empty:
+        return None
+    total = scorecard[scorecard["ticker"].isna()].copy()
+    if total.empty:
+        total = scorecard.head(20).copy()
+    total = total.sort_values(by="win_rate", ascending=True)
+    drift_map = load_drift_map(db_path=db_path)
+    total["drift_status"] = [drift_map.get(sig, {}).get("status", "stable") for sig in total["signal_id"]]
+    return total
+
+
+# ═══ 4. 공포·탐욕 90일 ═════════════════════════════════════════
+
+
+def load_fear_greed_history(db_path=None, limit: int = 90) -> pd.DataFrame:
+    fg = query_df(
+        f"SELECT date, value FROM macro WHERE indicator='fear_greed' ORDER BY date DESC LIMIT {int(limit)}",
+        db_path=db_path,
+    )
+    if fg.empty:
+        return fg
+    fg = fg.sort_values("date").reset_index(drop=True)
+    fg["date"] = pd.to_datetime(fg["date"])
+    return fg
+
+
+# ═══ 5. 매도 근거 (위반 감지) ═════════════════════════════════
+
+
+def detect_portfolio_violations(db_path=None) -> list[dict]:
+    """포트폴리오 위반 자동 감지 → 매도 근거 리스트 (evidence_charts 에서 이동, #1224).
+
+    반환 형식은 generate_sell_evidence_chart 의 docstring 계약과 동일:
+    [{"ticker", "type", "severity", "action", "recovery"}]
+    """
+    try:
+        from nuri.analysis.portfolio import analyze_portfolio
+
+        df = analyze_portfolio(db_path=db_path)
+    except Exception:
+        return []
+
+    if df.empty:
+        return []
+
+    from nuri.core.rules import MAX_SINGLE_POSITION, PORTFOLIO_STOP
+
+    violations = []
+    stop_loss_threshold = PORTFOLIO_STOP  # -10%
+    max_weight = MAX_SINGLE_POSITION * 100  # 15.0%
+
+    grouped = (
+        df.groupby("ticker")
+        .agg(
+            {
+                "pnl_pct": "mean",
+                "weight_pct": "sum",
+            }
+        )
+        .reset_index()
+    )
+
+    for _, row in grouped.iterrows():
+        ticker = row["ticker"]
+        pnl = row["pnl_pct"]
+        weight = row["weight_pct"]
+
+        # 손절선 위반 — 비중 위반과 독립 (한 종목이 둘 다 낼 수 있다, 원 동작 유지)
+        if pnl <= stop_loss_threshold:
+            violations.append(
+                {
+                    "ticker": ticker,
+                    "type": "stop_loss",
+                    "severity": abs(pnl),
+                    "action": "SELL ALL",
+                    "recovery": f"손실 {abs(pnl):.1f}% → 회복에 {abs(pnl) / (100 + pnl) * 100:.0f}% 상승 필요"
+                    if pnl > -100
+                    else "회복 불가",
+                }
+            )
+
+        # 비중 초과
+        if weight > max_weight:
+            excess = weight - max_weight
+            violations.append(
+                {
+                    "ticker": ticker,
+                    "type": "overweight",
+                    "severity": excess,
+                    "action": "REDUCE",
+                    "recovery": f"비중 {weight:.1f}% → {max_weight:.0f}%까지 리밸런싱 필요",
+                }
+            )
+
+    # 심각도 내림차순 정렬
+    violations.sort(key=lambda v: v["severity"], reverse=True)
+    return violations

--- a/nuri/analysis/evidence_data.py
+++ b/nuri/analysis/evidence_data.py
@@ -11,15 +11,18 @@ Plotly HTML 생성기(`evidence_charts.py`, 리포트 아카이브용)와 대시
 """
 
 import logging
+import re
 from pathlib import Path
 
 import pandas as pd
 
 from nuri.core.db import query_df
+from nuri.core.timezone import today_kst
 
 logger = logging.getLogger(__name__)
 
 REPORT_DIR = Path(__file__).parent.parent.parent / "data" / "reports"
+_DATE_DIR_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 # ═══ 1. 레짐: SPY + SMA + VIX ══════════════════════════════════
@@ -99,12 +102,19 @@ def load_portfolio_grouped(db_path=None) -> pd.DataFrame:
 
 
 def load_latest_scorecard() -> pd.DataFrame | None:
-    """최신 signal_scorecard.csv 로드 (evidence_charts 에서 이동, #1224)."""
+    """최신 signal_scorecard.csv 로드 (evidence_charts 에서 이동, #1224).
+
+    `data/reports/` 에는 비-날짜 디렉터리(briefs/postmarket)와 잘못 생성된
+    **미래 날짜** 디렉터리가 섞여 있다 — routes/evidence.py `_find_latest_report_dir`
+    와 같은 이유로, ISO 날짜이면서 오늘 이하인 디렉터리만 후보로 본다. 원본
+    (전체 역순 정렬)은 미래 디렉터리에 scorecard 가 생기면 그걸 집었다
+    (codex #1228 P1).
+    """
     if not REPORT_DIR.exists():
         return None
-    for d in sorted(REPORT_DIR.iterdir(), reverse=True):
-        if not d.is_dir():
-            continue
+    today = today_kst()
+    dated = [d for d in REPORT_DIR.iterdir() if d.is_dir() and _DATE_DIR_RE.match(d.name) and d.name <= today]
+    for d in sorted(dated, key=lambda p: p.name, reverse=True):
         csv_path = d / "signal_scorecard.csv"
         if csv_path.exists():
             return pd.read_csv(csv_path)

--- a/nuri/api/CLAUDE.md
+++ b/nuri/api/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The dashboard's read surface (72 endpoints). This layer **queries and renders — it never computes strategy**. Anything that decides, scores, or certifies lives in `nuri/trading/` · `nuri/quant/` · `nuri/analysis/` and is imported *lazily inside the handler body* (keeps startup fast; top-level heavy imports are the one convention every file follows).
+The dashboard's read surface (73 endpoints). This layer **queries and renders — it never computes strategy**. Anything that decides, scores, or certifies lives in `nuri/trading/` · `nuri/quant/` · `nuri/analysis/` and is imported *lazily inside the handler body* (keeps startup fast; top-level heavy imports are the one convention every file follows).
 
 Backend `:8001`, Next.js `:3000` proxies `/api/*` — see `.claude/rules/architecture.md` "API Access Pattern" before touching frontend call sites.
 

--- a/nuri/api/routes/evidence.py
+++ b/nuri/api/routes/evidence.py
@@ -74,6 +74,90 @@ def list_evidence():
     return {"charts": available, "date": evidence_dir.parent.name}
 
 
+def _records(df) -> list[dict]:
+    """DataFrame → JSON-안전 records (numpy 누수 방지 — 이 디렉터리 컨벤션).
+
+    to_dict("records") 가 numpy 스칼라를 네이티브로 박싱하므로(pandas maybe_box_native)
+    남는 비-JSON 값은 NaN/NaT/None 과 Timestamp 뿐이다.
+    """
+    import pandas as pd
+
+    out = []
+    for row in df.to_dict("records"):
+        clean = {}
+        for k, v in row.items():
+            if pd.isna(v):
+                clean[k] = None
+            elif isinstance(v, pd.Timestamp):
+                clean[k] = v.strftime("%Y-%m-%d")
+            else:
+                clean[k] = v
+        out.append(clean)
+    return out
+
+
+# literal 세그먼트가 아래 `/evidence/{chart_id}` 와 겹치지 않도록 3-세그먼트 경로
+# (이 파일의 `/evidence/report` 도달 불가 gotcha 참조 — nuri/api/CLAUDE.md).
+@router.get("/evidence/data/{chart_id}")
+def get_evidence_data(chart_id: str):
+    """차트별 JSON 시리즈 — 네이티브(recharts) 렌더용 (#1224).
+
+    Plotly 생성기와 evidence_data 공유 함수를 통해 단일 소스. 데이터 부재는
+    빈 컬렉션으로 응답 (soft — 프론트가 빈 상태 1줄로 강등).
+    """
+    if chart_id not in CHART_TYPES:
+        raise HTTPException(status_code=400, detail=f"유효하지 않은 차트: {chart_id}. 가능: {list(CHART_TYPES.keys())}")
+
+    # 무거운 조립은 핸들러 안에서 lazy import (이 디렉터리 컨벤션)
+    from nuri.analysis import evidence_data as ed
+
+    if chart_id == "regime":
+        spy = ed.load_spy_with_sma()
+        vix = ed.load_vix_history()
+        regime = None
+        if not spy.empty:
+            from nuri.quant.regime.classifier import classify_regime
+
+            state = classify_regime()
+            if state:
+                regime = {
+                    "regime": state.regime,
+                    "trend": state.trend,
+                    "volatility": state.volatility,
+                    "confidence": state.confidence,
+                }
+        return {
+            "spy": _records(spy) if not spy.empty else [],
+            "vix": _records(vix) if not vix.empty else [],
+            "regime": regime,
+            "count": 0 if spy.empty else len(spy),
+        }
+
+    if chart_id == "portfolio_heatmap":
+        grouped = ed.load_portfolio_grouped()
+        items = _records(grouped) if not grouped.empty else []
+        return {"items": items, "count": len(items)}
+
+    if chart_id == "signal_performance":
+        total = ed.load_signal_performance()
+        if total is None or total.empty:
+            return {"signals": [], "count": 0}
+        cols = [
+            c for c in ("signal_id", "win_rate", "profit_factor", "total_trades", "drift_status") if c in total.columns
+        ]
+        signals = _records(total[cols])
+        return {"signals": signals, "count": len(signals)}
+
+    if chart_id == "fear_greed":
+        fg = ed.load_fear_greed_history()
+        history = _records(fg) if not fg.empty else []
+        return {"history": history, "count": len(history)}
+
+    # sell_evidence
+    violations = ed.detect_portfolio_violations()
+    return {"violations": violations, "count": len(violations)}
+
+
 @router.get("/evidence/{chart_id}")
 def get_evidence_chart(chart_id: str):
     """증거 차트 HTML 반환."""

--- a/nuri/api/routes/evidence.py
+++ b/nuri/api/routes/evidence.py
@@ -113,24 +113,27 @@ def get_evidence_data(chart_id: str):
 
     if chart_id == "regime":
         spy = ed.load_spy_with_sma()
+        if spy.empty:
+            # 원 생성기와 동일 — SPY 없으면 차트 자체가 없다. VIX 만 있는
+            # 부분 payload 를 주지 않는다 (codex #1228 P2)
+            return {"spy": [], "vix": [], "regime": None, "count": 0}
         vix = ed.load_vix_history()
         regime = None
-        if not spy.empty:
-            from nuri.quant.regime.classifier import classify_regime
+        from nuri.quant.regime.classifier import classify_regime
 
-            state = classify_regime()
-            if state:
-                regime = {
-                    "regime": state.regime,
-                    "trend": state.trend,
-                    "volatility": state.volatility,
-                    "confidence": state.confidence,
-                }
+        state = classify_regime()
+        if state:
+            regime = {
+                "regime": state.regime,
+                "trend": state.trend,
+                "volatility": state.volatility,
+                "confidence": state.confidence,
+            }
         return {
-            "spy": _records(spy) if not spy.empty else [],
+            "spy": _records(spy),
             "vix": _records(vix) if not vix.empty else [],
             "regime": regime,
-            "count": 0 if spy.empty else len(spy),
+            "count": len(spy),
         }
 
     if chart_id == "portfolio_heatmap":

--- a/tests/analysis/test_evidence_charts.py
+++ b/tests/analysis/test_evidence_charts.py
@@ -1,4 +1,5 @@
 """Tests for nuri.analysis.evidence_charts — split from tests/test_analysis_all.py (#157)."""
+
 from unittest.mock import patch
 
 import numpy as np
@@ -9,8 +10,10 @@ from nuri.core.db import get_db, init_db
 
 class TestEvidenceCharts:
     """From test_coverage_round8.py."""
+
     def test_generate_regime_chart(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_regime_chart
+
         try:
             path = generate_regime_chart(output_dir=tmp_path)
             assert path is None or path.exists()
@@ -19,6 +22,7 @@ class TestEvidenceCharts:
 
     def test_generate_portfolio_heatmap(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_portfolio_heatmap
+
         try:
             path = generate_portfolio_heatmap(output_dir=tmp_path)
             assert path is None or path.exists()
@@ -27,6 +31,7 @@ class TestEvidenceCharts:
 
     def test_generate_signal_performance(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_signal_performance_chart
+
         try:
             path = generate_signal_performance_chart(output_dir=tmp_path)
             assert path is None or path.exists()
@@ -35,6 +40,7 @@ class TestEvidenceCharts:
 
     def test_generate_fear_greed(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_fear_greed_chart
+
         try:
             path = generate_fear_greed_chart(output_dir=tmp_path)
             assert path is None or path.exists()
@@ -44,11 +50,12 @@ class TestEvidenceCharts:
 
 class TestEvidenceSellChart:
     """From test_coverage_round13.py."""
+
     def test_generate_sell_evidence(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_sell_evidence_chart
+
         violations = [
-            {"ticker": "AAPL", "violation_type": "leverage_etf",
-             "severity": "critical", "action": "SELL_ALL"},
+            {"ticker": "AAPL", "violation_type": "leverage_etf", "severity": "critical", "action": "SELL_ALL"},
         ]
         try:
             path = generate_sell_evidence_chart(violations, output_dir=tmp_path)
@@ -59,13 +66,16 @@ class TestEvidenceSellChart:
 
 class TestEvidenceChartsAll:
     """From test_coverage_round15.py."""
+
     def test_regime_chart(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_regime_chart
+
         path = generate_regime_chart(output_dir=tmp_path)
         assert path is not None and path.exists()
 
     def test_portfolio_heatmap(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_portfolio_heatmap
+
         with patch("nuri.analysis.portfolio.get_exchange_rate", return_value=1400.0):
             try:
                 path = generate_portfolio_heatmap(output_dir=tmp_path)
@@ -75,14 +85,17 @@ class TestEvidenceChartsAll:
 
     def test_fear_greed_chart(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_fear_greed_chart
+
         path = generate_fear_greed_chart(output_dir=tmp_path)
         assert path is not None and path.exists()
 
 
 class TestEvidenceChartsDeep:
     """From test_sixty_percent.py."""
+
     def test_regime_chart_with_data(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_regime_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_regime_chart(output_dir, db_path=rich_db)
@@ -90,6 +103,7 @@ class TestEvidenceChartsDeep:
 
     def test_portfolio_heatmap_with_data(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_portfolio_heatmap
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_portfolio_heatmap(output_dir, db_path=rich_db)
@@ -97,6 +111,7 @@ class TestEvidenceChartsDeep:
 
     def test_signal_performance_with_data(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_signal_performance_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_signal_performance_chart(output_dir, db_path=rich_db)
@@ -110,6 +125,7 @@ class TestEvidenceChartsDeep:
                     (f"2026-01-{(i % 28) + 1:02d}", 30.0 + i * 0.5),
                 )
         from nuri.analysis.evidence_charts import generate_fear_greed_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_fear_greed_chart(output_dir, db_path=rich_db)
@@ -118,19 +134,45 @@ class TestEvidenceChartsDeep:
 
 class TestEvidenceCharts_NewModules:
     """From test_new_modules.py."""
+
     def test_portfolio_heatmap(self, db_path, tmp_path):
-        mock_df = pd.DataFrame([
-            {"account": "test", "ticker": "NVDA", "sector": "Semiconductor", "quantity": 20,
-             "avg_price": 100.0, "current_price": 167.99, "currency": "USD",
-             "current_value_usd": 3359.8, "cost_basis_usd": 2642.8,
-             "pnl_usd": 717.0, "pnl_pct": 27.1, "weight_pct": 60.0, "price_date": "2026-03-27"},
-            {"account": "test", "ticker": "BBB", "sector": "SectorB", "quantity": 96,
-             "avg_price": 20.0, "current_price": 11.44, "currency": "USD",
-             "current_value_usd": 1098.24, "cost_basis_usd": 1625.28,
-             "pnl_usd": -527.04, "pnl_pct": -32.4, "weight_pct": 40.0, "price_date": "2026-03-27"},
-        ])
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "account": "test",
+                    "ticker": "NVDA",
+                    "sector": "Semiconductor",
+                    "quantity": 20,
+                    "avg_price": 100.0,
+                    "current_price": 167.99,
+                    "currency": "USD",
+                    "current_value_usd": 3359.8,
+                    "cost_basis_usd": 2642.8,
+                    "pnl_usd": 717.0,
+                    "pnl_pct": 27.1,
+                    "weight_pct": 60.0,
+                    "price_date": "2026-03-27",
+                },
+                {
+                    "account": "test",
+                    "ticker": "BBB",
+                    "sector": "SectorB",
+                    "quantity": 96,
+                    "avg_price": 20.0,
+                    "current_price": 11.44,
+                    "currency": "USD",
+                    "current_value_usd": 1098.24,
+                    "cost_basis_usd": 1625.28,
+                    "pnl_usd": -527.04,
+                    "pnl_pct": -32.4,
+                    "weight_pct": 40.0,
+                    "price_date": "2026-03-27",
+                },
+            ]
+        )
         mock_df.attrs["total_value_usd"] = 4458.04
         from nuri.analysis.evidence_charts import generate_portfolio_heatmap
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=mock_df):
@@ -146,6 +188,7 @@ class TestEvidenceCharts_NewModules:
                     (f"2026-03-{i + 1:02d}", 10.0 + i * 2),
                 )
         from nuri.analysis.evidence_charts import generate_fear_greed_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_fear_greed_chart(output_dir, db_path=db_path)
@@ -153,14 +196,27 @@ class TestEvidenceCharts_NewModules:
 
     def test_sell_evidence_chart(self, tmp_path):
         violations = [
-            {"ticker": "BBB", "violation_type": "leverage_etf", "severity": "critical",
-             "current_value": -32.3, "sell_value_usd": 1100, "action": "SELL_ALL",
-             "reason": "레버리지 ETF 금지"},
-            {"ticker": "CCC", "violation_type": "stop_loss_exceeded", "severity": "critical",
-             "current_value": -59.9, "sell_value_usd": 1011, "action": "SELL_ALL",
-             "reason": "손절 -59.9% 초과"},
+            {
+                "ticker": "BBB",
+                "violation_type": "leverage_etf",
+                "severity": "critical",
+                "current_value": -32.3,
+                "sell_value_usd": 1100,
+                "action": "SELL_ALL",
+                "reason": "레버리지 ETF 금지",
+            },
+            {
+                "ticker": "CCC",
+                "violation_type": "stop_loss_exceeded",
+                "severity": "critical",
+                "current_value": -59.9,
+                "sell_value_usd": 1011,
+                "action": "SELL_ALL",
+                "reason": "손절 -59.9% 초과",
+            },
         ]
         from nuri.analysis.evidence_charts import generate_sell_evidence_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_sell_evidence_chart(violations, output_dir)
@@ -170,6 +226,7 @@ class TestEvidenceCharts_NewModules:
 
     def test_signal_performance_empty(self, db_path, tmp_path):
         from nuri.analysis.evidence_charts import generate_signal_performance_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_signal_performance_chart(output_dir, db_path=db_path)
@@ -178,25 +235,32 @@ class TestEvidenceCharts_NewModules:
 
 class TestEvidenceChartsExtended:
     """From test_coverage_boost.py."""
+
     def test_load_latest_scorecard(self, db_path):
-        from nuri.analysis.evidence_charts import _load_latest_scorecard
-        df = _load_latest_scorecard()
+        # #1224: 로더는 evidence_data 로 이동
+        from nuri.analysis.evidence_data import load_latest_scorecard
+
+        df = load_latest_scorecard()
         assert df is None or isinstance(df, pd.DataFrame)
 
     def test_load_drift_map(self, db_path):
         from nuri.analysis.evidence_charts import _load_drift_map
+
         result = _load_drift_map(db_path=db_path)
         assert isinstance(result, dict)
 
     def test_detect_violations_empty(self, db_path, monkeypatch):
-        monkeypatch.setattr("nuri.analysis.evidence_charts.analyze_portfolio",
-                            lambda **kw: pd.DataFrame(), raising=False)
+        monkeypatch.setattr(
+            "nuri.analysis.evidence_charts.analyze_portfolio", lambda **kw: pd.DataFrame(), raising=False
+        )
         from nuri.analysis.evidence_charts import _detect_portfolio_violations
+
         result = _detect_portfolio_violations(db_path=db_path)
         assert isinstance(result, list)
 
     def test_regime_chart_no_data(self, db_path, tmp_path):
         from nuri.analysis.evidence_charts import generate_regime_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_regime_chart(output_dir, db_path=db_path)
@@ -204,6 +268,7 @@ class TestEvidenceChartsExtended:
 
     def test_generate_all_evidence_empty(self, db_path, tmp_path, monkeypatch):
         import nuri.analysis.evidence_charts as ec_mod
+
         monkeypatch.setattr(ec_mod, "REPORT_DIR", tmp_path)
         results = ec_mod.generate_all_evidence(db_path=db_path)
         assert isinstance(results, list)
@@ -211,8 +276,10 @@ class TestEvidenceChartsExtended:
 
 class TestEvidenceCharts_R19:
     """From test_coverage_round19.py."""
+
     def test_generate_regime_chart_empty_db(self, tmp_path):
         from nuri.analysis.evidence_charts import generate_regime_chart
+
         path = tmp_path / "test.db"
         init_db(path)
         output_dir = tmp_path / "output"
@@ -223,6 +290,7 @@ class TestEvidenceCharts_R19:
     def test_generate_regime_chart_with_data(self, rich_db, tmp_path, monkeypatch):
         from nuri.analysis.evidence_charts import generate_regime_chart
         from nuri.quant.regime import classifier as cls_mod
+
         cls_mod._freshness_warned = False
         monkeypatch.setattr(cls_mod, "_check_data_freshness", lambda db_path=None: True)
         output_dir = tmp_path / "evidence"
@@ -233,6 +301,7 @@ class TestEvidenceCharts_R19:
 
     def test_generate_fear_greed_chart_empty(self, tmp_path):
         from nuri.analysis.evidence_charts import generate_fear_greed_chart
+
         path = tmp_path / "test.db"
         init_db(path)
         output_dir = tmp_path / "output"
@@ -242,6 +311,7 @@ class TestEvidenceCharts_R19:
 
     def test_generate_fear_greed_chart_with_data(self, rich_db, tmp_path):
         from nuri.analysis.evidence_charts import generate_fear_greed_chart
+
         output_dir = tmp_path / "evidence"
         output_dir.mkdir()
         result = generate_fear_greed_chart(output_dir, db_path=rich_db)
@@ -251,6 +321,7 @@ class TestEvidenceCharts_R19:
 
     def test_generate_sell_evidence_no_violations(self, tmp_path):
         from nuri.analysis.evidence_charts import generate_sell_evidence_chart
+
         output_dir = tmp_path / "output"
         output_dir.mkdir()
         result = generate_sell_evidence_chart([], output_dir)
@@ -258,19 +329,19 @@ class TestEvidenceCharts_R19:
 
     def test_generate_sell_evidence_with_violations(self, tmp_path):
         from nuri.analysis.evidence_charts import generate_sell_evidence_chart
+
         output_dir = tmp_path / "output"
         output_dir.mkdir()
         violations = [
-            {"ticker": "TSLA", "type": "stop_loss", "severity": 25.3,
-             "action": "SELL ALL", "recovery": "6-12개월"},
-            {"ticker": "NVDA", "type": "overweight", "severity": 5.2,
-             "action": "REDUCE", "recovery": "리밸런싱 필요"},
+            {"ticker": "TSLA", "type": "stop_loss", "severity": 25.3, "action": "SELL ALL", "recovery": "6-12개월"},
+            {"ticker": "NVDA", "type": "overweight", "severity": 5.2, "action": "REDUCE", "recovery": "리밸런싱 필요"},
         ]
         result = generate_sell_evidence_chart(violations, output_dir)
         assert result.exists()
 
     def test_save_empty_chart(self, tmp_path):
         from nuri.analysis.evidence_charts import _save_empty_chart
+
         output_path = tmp_path / "empty.html"
         _save_empty_chart("No data available", output_path)
         assert output_path.exists()
@@ -281,41 +352,49 @@ class TestEvidenceCharts_R19:
         import plotly.graph_objects as go
 
         from nuri.analysis.evidence_charts import _shade_regime_zones
+
         fig = go.Figure()
         df = pd.DataFrame(columns=["date", "sma50", "sma200"])
         _shade_regime_zones(fig, df)
 
     def test_load_latest_scorecard_no_reports(self, tmp_path, monkeypatch):
-        from nuri.analysis import evidence_charts as ec_mod
-        monkeypatch.setattr(ec_mod, "REPORT_DIR", tmp_path / "nonexistent")
-        result = ec_mod._load_latest_scorecard()
+        # #1224: 로더·REPORT_DIR 은 evidence_data 소속
+        from nuri.analysis import evidence_data as ed_mod
+
+        monkeypatch.setattr(ed_mod, "REPORT_DIR", tmp_path / "nonexistent")
+        result = ed_mod.load_latest_scorecard()
         assert result is None
 
     def test_detect_portfolio_violations_no_data(self):
         from nuri.analysis.evidence_charts import _detect_portfolio_violations
-        with patch("nuri.analysis.portfolio.analyze_portfolio",
-                   return_value=pd.DataFrame()):
+
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=pd.DataFrame()):
             violations = _detect_portfolio_violations()
         assert violations == []
 
     def test_generate_signal_performance_empty(self, tmp_path):
         from nuri.analysis.evidence_charts import generate_signal_performance_chart
+
         output_dir = tmp_path / "output"
         output_dir.mkdir()
-        with patch("nuri.analysis.evidence_charts._load_latest_scorecard", return_value=None):
+        with patch("nuri.analysis.evidence_data.load_latest_scorecard", return_value=None):
             result = generate_signal_performance_chart(output_dir)
         assert result.exists()
 
 
 class TestEvidenceChartsPortfolioViolations:
     """From test_coverage_round19.py."""
+
     def test_violations_detected(self):
         from nuri.analysis.evidence_charts import _detect_portfolio_violations
-        mock_df = pd.DataFrame([
-            {"ticker": "TSLA", "pnl_pct": -25.0, "weight_pct": 8.0},
-            {"ticker": "NVDA", "pnl_pct": 15.0, "weight_pct": 20.0},
-            {"ticker": "AAPL", "pnl_pct": 5.0, "weight_pct": 10.0},
-        ])
+
+        mock_df = pd.DataFrame(
+            [
+                {"ticker": "TSLA", "pnl_pct": -25.0, "weight_pct": 8.0},
+                {"ticker": "NVDA", "pnl_pct": 15.0, "weight_pct": 20.0},
+                {"ticker": "AAPL", "pnl_pct": 5.0, "weight_pct": 10.0},
+            ]
+        )
         with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=mock_df):
             violations = _detect_portfolio_violations()
         assert len(violations) >= 2
@@ -325,32 +404,56 @@ class TestEvidenceChartsPortfolioViolations:
 
     def test_violations_exception_returns_empty(self):
         from nuri.analysis.evidence_charts import _detect_portfolio_violations
-        with patch("nuri.analysis.portfolio.analyze_portfolio",
-                   side_effect=Exception("no data")):
+
+        with patch("nuri.analysis.portfolio.analyze_portfolio", side_effect=Exception("no data")):
             violations = _detect_portfolio_violations()
         assert violations == []
 
 
 class TestSignalPerformanceChart:
     """From test_coverage_round19.py."""
+
     def test_with_scorecard_data(self, tmp_path):
         from nuri.analysis.evidence_charts import generate_signal_performance_chart
+
         output_dir = tmp_path / "output"
         output_dir.mkdir()
-        scorecard_df = pd.DataFrame([
-            {"signal_id": "rsi_oversold", "ticker": None, "total_trades": 10,
-             "win_rate": 0.6, "profit_factor": 1.5, "avg_return": 2.0,
-             "median_return": 1.5, "max_return": 10.0, "max_loss": -5.0,
-             "avg_holding_days": 20},
-            {"signal_id": "macd_golden", "ticker": None, "total_trades": 8,
-             "win_rate": 0.5, "profit_factor": 1.2, "avg_return": 1.0,
-             "median_return": 0.8, "max_return": 8.0, "max_loss": -6.0,
-             "avg_holding_days": 30},
-        ])
-        with patch("nuri.analysis.evidence_charts._load_latest_scorecard",
-                   return_value=scorecard_df), \
-             patch("nuri.analysis.evidence_charts._load_drift_map",
-                   return_value={"rsi_oversold": {"status": "critical", "drift_pct": -15.0}}):
+        scorecard_df = pd.DataFrame(
+            [
+                {
+                    "signal_id": "rsi_oversold",
+                    "ticker": None,
+                    "total_trades": 10,
+                    "win_rate": 0.6,
+                    "profit_factor": 1.5,
+                    "avg_return": 2.0,
+                    "median_return": 1.5,
+                    "max_return": 10.0,
+                    "max_loss": -5.0,
+                    "avg_holding_days": 20,
+                },
+                {
+                    "signal_id": "macd_golden",
+                    "ticker": None,
+                    "total_trades": 8,
+                    "win_rate": 0.5,
+                    "profit_factor": 1.2,
+                    "avg_return": 1.0,
+                    "median_return": 0.8,
+                    "max_return": 8.0,
+                    "max_loss": -6.0,
+                    "avg_holding_days": 30,
+                },
+            ]
+        )
+        # #1224: 로더는 evidence_data 로 이동 — 생성기는 별칭 경유 소비
+        with (
+            patch("nuri.analysis.evidence_data.load_latest_scorecard", return_value=scorecard_df),
+            patch(
+                "nuri.analysis.evidence_data.load_drift_map",
+                return_value={"rsi_oversold": {"status": "critical", "drift_pct": -15.0}},
+            ),
+        ):
             result = generate_signal_performance_chart(output_dir)
         assert result.exists()
         content = result.read_text()
@@ -359,15 +462,19 @@ class TestSignalPerformanceChart:
 
 class TestShadeRegimeZonesWithData:
     """From test_coverage_round19.py."""
+
     def test_zones_applied(self):
         import plotly.graph_objects as go
 
         from nuri.analysis.evidence_charts import _shade_regime_zones
+
         n = 100
-        spy = pd.DataFrame({
-            "date": pd.date_range("2025-01-01", periods=n),
-            "close": np.linspace(450, 500, n),
-        })
+        spy = pd.DataFrame(
+            {
+                "date": pd.date_range("2025-01-01", periods=n),
+                "close": np.linspace(450, 500, n),
+            }
+        )
         spy["sma50"] = spy["close"].rolling(20).mean()
         spy["sma200"] = spy["close"].rolling(50).mean()
         fig = go.Figure()
@@ -376,21 +483,19 @@ class TestShadeRegimeZonesWithData:
 
 class TestGenerateAllEvidence:
     """From test_coverage_round19.py."""
+
     def test_all_evidence_with_mocks(self, tmp_path, monkeypatch, capsys):
         import nuri.analysis.evidence_charts as ec_mod
+
         monkeypatch.setattr(ec_mod, "REPORT_DIR", tmp_path / "reports")
-        with patch.object(ec_mod, "generate_regime_chart",
-                         return_value=tmp_path / "regime.html"), \
-             patch.object(ec_mod, "generate_portfolio_heatmap",
-                         return_value=tmp_path / "heatmap.html"), \
-             patch.object(ec_mod, "generate_signal_performance_chart",
-                         return_value=tmp_path / "signal.html"), \
-             patch.object(ec_mod, "generate_fear_greed_chart",
-                         return_value=tmp_path / "fg.html"), \
-             patch.object(ec_mod, "_detect_portfolio_violations",
-                         return_value=[]), \
-             patch.object(ec_mod, "generate_sell_evidence_chart",
-                         return_value=tmp_path / "sell.html"):
+        with (
+            patch.object(ec_mod, "generate_regime_chart", return_value=tmp_path / "regime.html"),
+            patch.object(ec_mod, "generate_portfolio_heatmap", return_value=tmp_path / "heatmap.html"),
+            patch.object(ec_mod, "generate_signal_performance_chart", return_value=tmp_path / "signal.html"),
+            patch.object(ec_mod, "generate_fear_greed_chart", return_value=tmp_path / "fg.html"),
+            patch.object(ec_mod, "_detect_portfolio_violations", return_value=[]),
+            patch.object(ec_mod, "generate_sell_evidence_chart", return_value=tmp_path / "sell.html"),
+        ):
             paths = ec_mod.generate_all_evidence()
         assert len(paths) == 5
         captured = capsys.readouterr()

--- a/tests/analysis/test_evidence_charts.py
+++ b/tests/analysis/test_evidence_charts.py
@@ -244,9 +244,10 @@ class TestEvidenceChartsExtended:
         assert df is None or isinstance(df, pd.DataFrame)
 
     def test_load_drift_map(self, db_path):
-        from nuri.analysis.evidence_charts import _load_drift_map
+        # #1224: evidence_data 로 이동 (evidence_charts 별칭은 미사용이라 ruff 가 제거)
+        from nuri.analysis.evidence_data import load_drift_map
 
-        result = _load_drift_map(db_path=db_path)
+        result = load_drift_map(db_path=db_path)
         assert isinstance(result, dict)
 
     def test_detect_violations_empty(self, db_path, monkeypatch):

--- a/tests/analysis/test_evidence_charts_branches.py
+++ b/tests/analysis/test_evidence_charts_branches.py
@@ -27,6 +27,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import nuri.analysis.evidence_data as ed
 from nuri.analysis import evidence_charts as ec
 from nuri.core.db import init_db
 
@@ -111,7 +112,8 @@ class TestSignalPerformanceFallback:
                 "profit_factor": [1.0 + i * 0.1 for i in range(5)],
             }
         )
-        with patch.object(ec, "_load_latest_scorecard", return_value=df):
+        # #1224: 로더는 evidence_data 로 이동 — 생성기는 별칭 경유로 소비
+        with patch.object(ed, "load_latest_scorecard", return_value=df):
             out = ec.generate_signal_performance_chart(tmp_path)
         assert out.exists()
         # 차트 본문에 signal_id 들 포함됨 — total empty 가 아니라 head(20) path 가 발화.
@@ -143,8 +145,8 @@ class TestSignalPerformanceDriftColor:
             "sig_b": {"status": "stable", "drift_pct": 0.05},
         }
         with (
-            patch.object(ec, "_load_latest_scorecard", return_value=df),
-            patch.object(ec, "_load_drift_map", return_value=drift_map),
+            patch.object(ed, "load_latest_scorecard", return_value=df),
+            patch.object(ed, "load_drift_map", return_value=drift_map),
         ):
             out = ec.generate_signal_performance_chart(tmp_path)
         body = out.read_text()
@@ -416,7 +418,8 @@ class TestLoadLatestScorecardFound:
         scorecard = pd.DataFrame([{"signal_id": "rsi_oversold", "win_rate": 0.6, "profit_factor": 1.8}])
         scorecard.to_csv(day_dir / "signal_scorecard.csv", index=False)
 
-        monkeypatch.setattr(evidence_charts, "REPORT_DIR", report_root)
-        result = evidence_charts._load_latest_scorecard()
+        # #1224: 로더·REPORT_DIR 은 evidence_data 소속
+        monkeypatch.setattr(ed, "REPORT_DIR", report_root)
+        result = ed.load_latest_scorecard()
         assert result is not None
         assert "signal_id" in result.columns

--- a/tests/analysis/test_evidence_charts_branches.py
+++ b/tests/analysis/test_evidence_charts_branches.py
@@ -265,7 +265,10 @@ class TestLoadDriftMapSwallow:
             "nuri.trading.engine.memory.detect_drift",
             side_effect=RuntimeError("memory db missing"),
         ):
-            out = ec._load_drift_map(db_path=db_path)
+            # #1224: evidence_data 로 이동 (evidence_charts 별칭은 미사용이라 ruff 가 제거)
+            from nuri.analysis.evidence_data import load_drift_map
+
+            out = load_drift_map(db_path=db_path)
         assert out == {}
 
 

--- a/tests/analysis/test_evidence_data.py
+++ b/tests/analysis/test_evidence_data.py
@@ -1,0 +1,121 @@
+"""evidence_data 로더 단위 테스트 (#1224 U5a-1).
+
+이동한 3함수(load_latest_scorecard / load_drift_map / detect_portfolio_violations)는
+기존 test_evidence_charts*.py 가 별칭 경유로 잠근다 — 여기는 신규 쿼리 로더와
+load_portfolio_grouped 의 위반 판정만 직접 잠근다.
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from nuri.analysis import evidence_data as ed
+from nuri.core.db import upsert_macro, upsert_prices
+
+
+def _seed_spy(db_path, n: int = 60) -> None:
+    dates = pd.bdate_range(end=pd.Timestamp.today(), periods=n)
+    upsert_prices(
+        pd.DataFrame(
+            {
+                "ticker": "SPY",
+                "date": dates.strftime("%Y-%m-%d"),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": [100.0 + i for i in range(n)],
+                "volume": 1_000_000,
+                "adj_close": [100.0 + i for i in range(n)],
+            }
+        ),
+        db_path=db_path,
+    )
+
+
+class TestLoadSpyWithSma:
+    def test_empty_db_returns_empty(self, db_path):
+        assert ed.load_spy_with_sma(db_path=db_path).empty
+
+    def test_seeded_sorted_asc_with_sma(self, db_path):
+        _seed_spy(db_path, n=60)
+        spy = ed.load_spy_with_sma(db_path=db_path)
+        assert len(spy) == 60
+        assert spy["date"].is_monotonic_increasing
+        # 60행 → sma50 은 마지막 행에서 유효(최근 50개 close 110..159 의 평균), sma200 은 전부 NaN
+        assert spy["sma50"].iloc[-1] == pytest.approx(134.5)
+        assert int(spy["sma200"].isna().sum()) == 60
+
+    def test_limit_takes_latest_rows(self, db_path):
+        _seed_spy(db_path, n=60)
+        spy = ed.load_spy_with_sma(db_path=db_path, limit=10)
+        assert len(spy) == 10
+        # DESC LIMIT 후 asc 정렬 — 최신 10행이어야 한다 (close 가 단조 증가 seed)
+        assert spy["close"].iloc[0] == 150.0
+
+
+class TestLoadMacroHistories:
+    def test_vix_empty_and_seeded(self, db_path):
+        assert ed.load_vix_history(db_path=db_path).empty
+        upsert_macro(
+            [
+                {"indicator": "vix", "date": "2026-08-20", "value": 18.0, "source": "test"},
+                {"indicator": "vix", "date": "2026-08-21", "value": 19.5, "source": "test"},
+            ],
+            db_path=db_path,
+        )
+        vix = ed.load_vix_history(db_path=db_path)
+        assert list(vix["value"]) == [18.0, 19.5]
+        assert vix["date"].is_monotonic_increasing
+
+    def test_fear_greed_empty_and_limit(self, db_path):
+        assert ed.load_fear_greed_history(db_path=db_path).empty
+        upsert_macro(
+            [
+                {"indicator": "fear_greed", "date": f"2026-08-{d:02d}", "value": float(40 + d), "source": "test"}
+                for d in (19, 20, 21)
+            ],
+            db_path=db_path,
+        )
+        fg = ed.load_fear_greed_history(db_path=db_path, limit=2)
+        # 최신 2행만, asc 정렬
+        assert list(fg["value"]) == [60.0, 61.0]
+
+
+class TestLoadLatestScorecard:
+    def test_skips_non_dir_and_returns_none_when_no_scorecard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(ed, "REPORT_DIR", tmp_path)
+        (tmp_path / "stray.txt").write_text("x")  # 파일 엔트리 → continue
+        (tmp_path / "2026-08-21").mkdir()  # scorecard 없는 날짜 dir
+        # 루프 소진 → None
+        assert ed.load_latest_scorecard() is None
+
+
+class TestLoadPortfolioGrouped:
+    def test_empty_portfolio_returns_empty(self, db_path):
+        assert ed.load_portfolio_grouped(db_path=db_path).empty
+
+    def test_violation_precedence_and_grouping(self, db_path):
+        # 형태는 analyze_portfolio 실반환에서 복사 (mock-shape 규칙, tests/CLAUDE.md)
+        df = pd.DataFrame(
+            [
+                # 손절+비중 동시 위반 → stop_loss 우선
+                {"ticker": "AAA", "current_value_usd": 5000, "pnl_pct": -12.0, "weight_pct": 20.0, "sector": "Tech"},
+                # 비중만 위반
+                {"ticker": "BBB", "current_value_usd": 4000, "pnl_pct": 3.0, "weight_pct": 16.0, "sector": "Health"},
+                # 정상 — 두 계좌 분산 보유 (grouping 확인)
+                {"ticker": "CCC", "current_value_usd": 500, "pnl_pct": 2.0, "weight_pct": 4.0, "sector": "Energy"},
+                {"ticker": "CCC", "current_value_usd": 500, "pnl_pct": 4.0, "weight_pct": 4.0, "sector": "Energy"},
+            ]
+        )
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df):
+            grouped = ed.load_portfolio_grouped(db_path=db_path)
+
+        by_ticker = grouped.set_index("ticker")
+        assert by_ticker.loc["AAA", "violation"] == "stop_loss"
+        assert by_ticker.loc["BBB", "violation"] == "overweight"
+        assert by_ticker.loc["CCC", "violation"] is None
+        # CCC 합산: value sum / pnl mean / weight sum
+        assert by_ticker.loc["CCC", "current_value_usd"] == 1000
+        assert by_ticker.loc["CCC", "pnl_pct"] == pytest.approx(3.0)
+        assert by_ticker.loc["CCC", "weight_pct"] == pytest.approx(8.0)

--- a/tests/analysis/test_evidence_data.py
+++ b/tests/analysis/test_evidence_data.py
@@ -85,10 +85,37 @@ class TestLoadMacroHistories:
 class TestLoadLatestScorecard:
     def test_skips_non_dir_and_returns_none_when_no_scorecard(self, tmp_path, monkeypatch):
         monkeypatch.setattr(ed, "REPORT_DIR", tmp_path)
-        (tmp_path / "stray.txt").write_text("x")  # 파일 엔트리 → continue
+        (tmp_path / "stray.txt").write_text("x")  # 파일 엔트리 → 후보 제외
         (tmp_path / "2026-08-21").mkdir()  # scorecard 없는 날짜 dir
         # 루프 소진 → None
         assert ed.load_latest_scorecard() is None
+
+    def test_future_and_non_date_dirs_are_ignored(self, tmp_path, monkeypatch):
+        """미래/비-날짜 디렉터리의 scorecard 를 집지 않는다 (codex #1228 P1).
+
+        routes/evidence.py `_find_latest_report_dir` 가 고친 것과 같은 부류 —
+        실제 `data/reports/` 에 미래 날짜·postmarket 디렉터리가 섞여 있다.
+        """
+        from nuri.core.timezone import today_kst
+
+        monkeypatch.setattr(ed, "REPORT_DIR", tmp_path)
+        today = today_kst()
+        year = int(today[:4])
+
+        def _seed(name: str, win_rate: float) -> None:
+            d = tmp_path / name
+            d.mkdir()
+            pd.DataFrame([{"signal_id": "s", "ticker": None, "win_rate": win_rate}]).to_csv(
+                d / "signal_scorecard.csv", index=False
+            )
+
+        _seed(today, 0.6)
+        _seed(f"{year + 1}-09-14", 0.1)  # 미래 — 역순 정렬 1등이지만 제외돼야 한다
+        _seed("postmarket", 0.2)  # 비-날짜 — 사전순으로 '20xx-' 보다 뒤
+
+        result = ed.load_latest_scorecard()
+        assert result is not None
+        assert result["win_rate"].iloc[0] == 0.6
 
 
 class TestLoadPortfolioGrouped:

--- a/tests/api/test_evidence.py
+++ b/tests/api/test_evidence.py
@@ -302,3 +302,181 @@ class TestReportDirIsNotFutureDated:
         monkeypatch.setattr(ev_mod, "REPORT_DIR", reports)
 
         assert _find_latest_report_dir() is None
+
+
+class TestEvidenceDataEndpoint:
+    """GET /api/evidence/data/{chart_id} — 네이티브 차트용 JSON (#1224 U5a-1)."""
+
+    @pytest.fixture()
+    def _client(self, db_path, monkeypatch):
+        import nuri.core.db as db_mod
+
+        monkeypatch.setattr(db_mod, "DB_PATH", db_path)
+        from nuri.api.main import app
+
+        return TestClient(app)
+
+    def _seed_spy(self, db_path, n: int = 5) -> None:
+        dates = pd.bdate_range(end=pd.Timestamp.today(), periods=n)
+        upsert_prices(
+            pd.DataFrame(
+                {
+                    "ticker": "SPY",
+                    "date": dates.strftime("%Y-%m-%d"),
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": [100.0 + i for i in range(n)],
+                    "volume": 1_000_000,
+                    "adj_close": [100.0 + i for i in range(n)],
+                }
+            ),
+            db_path=db_path,
+        )
+
+    def test_unknown_chart_id_400(self, _client):
+        r = _client.get("/api/evidence/data/nope")
+        assert r.status_code == 400
+
+    def test_regime_empty_db(self, _client):
+        r = _client.get("/api/evidence/data/regime")
+        assert r.status_code == 200
+        data = r.json()
+        assert data == {"spy": [], "vix": [], "regime": None, "count": 0}
+
+    def test_regime_seeded(self, _client, db_path, monkeypatch):
+        import nuri.quant.regime.classifier as clf_mod
+        from nuri.quant.regime.classifier import RegimeState
+
+        self._seed_spy(db_path, n=5)
+        upsert_macro(
+            [{"indicator": "vix", "date": "2026-08-21", "value": 18.0, "source": "t"}],
+            db_path=db_path,
+        )
+        # 형태는 실 dataclass — 라우트는 핸들러 안 lazy import 라 source-level patch
+        state = RegimeState(
+            date="2026-08-21",
+            trend="bull",
+            volatility="low",
+            regime="bull_low_vol",
+            confidence=0.8,
+            details={},
+        )
+        monkeypatch.setattr(clf_mod, "classify_regime", lambda *a, **kw: state)
+
+        r = _client.get("/api/evidence/data/regime")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] == 5
+        row = data["spy"][0]
+        # ISO 날짜 문자열 + sma NaN → null (numpy 누수 없음: json 왕복 자체가 증명)
+        assert isinstance(row["date"], str) and len(row["date"]) == 10
+        assert row["sma50"] is None
+        assert data["vix"][0]["value"] == 18.0
+        assert data["regime"] == {
+            "regime": "bull_low_vol",
+            "trend": "bull",
+            "volatility": "low",
+            "confidence": 0.8,
+        }
+
+    def test_regime_classifier_returns_none(self, _client, db_path, monkeypatch):
+        import nuri.quant.regime.classifier as clf_mod
+
+        self._seed_spy(db_path, n=5)
+        monkeypatch.setattr(clf_mod, "classify_regime", lambda *a, **kw: None)
+        r = _client.get("/api/evidence/data/regime")
+        assert r.status_code == 200
+        assert r.json()["regime"] is None
+
+    def test_portfolio_heatmap_empty(self, _client):
+        r = _client.get("/api/evidence/data/portfolio_heatmap")
+        assert r.status_code == 200
+        assert r.json() == {"items": [], "count": 0}
+
+    def test_portfolio_heatmap_seeded(self, _client):
+        # 형태는 analyze_portfolio 실반환에서 복사 (mock-shape 규칙)
+        df = pd.DataFrame(
+            [
+                {"ticker": "AAA", "current_value_usd": 5000, "pnl_pct": -12.0, "weight_pct": 20.0, "sector": "Tech"},
+                {"ticker": "BBB", "current_value_usd": 4000, "pnl_pct": 3.0, "weight_pct": 8.0, "sector": "Health"},
+            ]
+        )
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df):
+            r = _client.get("/api/evidence/data/portfolio_heatmap")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] == 2
+        by_ticker = {i["ticker"]: i for i in data["items"]}
+        assert by_ticker["AAA"]["violation"] == "stop_loss"
+        assert by_ticker["BBB"]["violation"] is None
+
+    def test_signal_performance_none(self, _client, tmp_path, monkeypatch):
+        import nuri.analysis.evidence_data as ed
+
+        monkeypatch.setattr(ed, "REPORT_DIR", tmp_path / "no_reports")
+        r = _client.get("/api/evidence/data/signal_performance")
+        assert r.status_code == 200
+        assert r.json() == {"signals": [], "count": 0}
+
+    def test_signal_performance_seeded(self, _client, tmp_path, monkeypatch):
+        import nuri.analysis.evidence_data as ed
+
+        day_dir = tmp_path / "reports" / "2026-08-21"
+        day_dir.mkdir(parents=True)
+        # 형태는 signal_scorecard.csv 실물에서 복사 (mock-shape 규칙)
+        pd.DataFrame(
+            [
+                {
+                    "signal_id": "rsi_oversold",
+                    "ticker": None,
+                    "total_trades": 10,
+                    "win_rate": 0.6,
+                    "profit_factor": 1.5,
+                    "avg_return": 2.0,
+                    "median_return": 1.5,
+                    "max_return": 10.0,
+                    "max_loss": -5.0,
+                    "avg_holding_days": 20,
+                },
+            ]
+        ).to_csv(day_dir / "signal_scorecard.csv", index=False)
+        monkeypatch.setattr(ed, "REPORT_DIR", tmp_path / "reports")
+        monkeypatch.setattr(
+            ed, "load_drift_map", lambda *a, **kw: {"rsi_oversold": {"status": "critical", "drift_pct": -15.0}}
+        )
+
+        r = _client.get("/api/evidence/data/signal_performance")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["count"] == 1
+        sig = data["signals"][0]
+        assert sig["signal_id"] == "rsi_oversold"
+        assert sig["drift_status"] == "critical"
+        # 선택 컬럼만 — ticker(NaN)나 max_return 은 응답에 없다
+        assert "max_return" not in sig
+
+    def test_fear_greed_empty_and_seeded(self, _client, db_path):
+        r = _client.get("/api/evidence/data/fear_greed")
+        assert r.json() == {"history": [], "count": 0}
+        upsert_macro(
+            [{"indicator": "fear_greed", "date": "2026-08-21", "value": 55.0, "source": "t"}],
+            db_path=db_path,
+        )
+        r = _client.get("/api/evidence/data/fear_greed")
+        data = r.json()
+        assert data["count"] == 1
+        assert data["history"][0]["value"] == 55.0
+
+    def test_sell_evidence(self, _client):
+        r = _client.get("/api/evidence/data/sell_evidence")
+        assert r.json() == {"violations": [], "count": 0}
+        df = pd.DataFrame(
+            [{"ticker": "AAA", "current_value_usd": 5000, "pnl_pct": -12.0, "weight_pct": 8.0, "sector": "Tech"}]
+        )
+        with patch("nuri.analysis.portfolio.analyze_portfolio", return_value=df):
+            r = _client.get("/api/evidence/data/sell_evidence")
+        data = r.json()
+        assert data["count"] == 1
+        v = data["violations"][0]
+        assert v["type"] == "stop_loss" and v["action"] == "SELL ALL"

--- a/tests/api/test_evidence.py
+++ b/tests/api/test_evidence.py
@@ -380,6 +380,16 @@ class TestEvidenceDataEndpoint:
             "confidence": 0.8,
         }
 
+    def test_regime_vix_only_returns_fully_empty(self, _client, db_path):
+        """SPY 부재 + VIX 존재 → 원 생성기와 동일하게 차트 전체 부재 (codex #1228 P2)."""
+        upsert_macro(
+            [{"indicator": "vix", "date": "2026-08-21", "value": 18.0, "source": "t"}],
+            db_path=db_path,
+        )
+        r = _client.get("/api/evidence/data/regime")
+        assert r.status_code == 200
+        assert r.json() == {"spy": [], "vix": [], "regime": None, "count": 0}
+
     def test_regime_classifier_returns_none(self, _client, db_path, monkeypatch):
         import nuri.quant.regime.classifier as clf_mod
 

--- a/tests/core/test_cross_stage_imports.py
+++ b/tests/core/test_cross_stage_imports.py
@@ -40,9 +40,9 @@ STAGES = {
 # 줄 번호로 키를 잡지 않는다 — 무관한 편집에도 깨진다.
 ALLOWED: dict[tuple[str, str], str] = {
     (
-        "nuri/analysis/evidence_charts.py",
+        "nuri/analysis/evidence_data.py",
         "nuri.trading.engine.memory",
-    ): "증거 차트가 strategy memory 를 읽어 렌더 — 읽기 전용",
+    ): "증거 데이터가 strategy memory 드리프트를 읽어 조립 — 읽기 전용 (#1224 에서 evidence_charts 로부터 이동)",
     (
         "nuri/trading/agents/consensus/__main__.py",
         "nuri.trading.engine.decisions",


### PR DESCRIPTION
Closes #1224 (U5a-1).

## Why
U5a-2 will render the 5 evidence charts natively (recharts) instead of 450px Plotly iframes. The chart queries lived inline in `evidence_charts.py`; a JSON API would have meant a second copy and guaranteed drift.

## What
- **`nuri/analysis/evidence_data.py` (new)** — single data source: 8 loaders (SPY+SMA, VIX, portfolio grouped w/ violation verdicts, scorecard, drift map, signal performance, fear/greed, violations). `db_path` forwarded to every DB reader (swept by `test_db_path_forwarding`).
- **`evidence_charts.py`** — consumes the shared loaders via aliased imports (existing test patch seams preserved); behavioral parity kept (violation precedence, recovery strings, severity sort, fallback head(20)).
- **`GET /api/evidence/data/{chart_id}`** — 3-segment literal path (no clash with `/evidence/{chart_id}`), sync def, plain dicts, lazy imports, NaN→null / Timestamp→ISO via `_records`, sibling `count`, 400 on unknown id.
- Cross-stage allowlist: `detect_drift` crossing import moved with the code (both directions verified by the AST sweep).
- Plan rows: U5 split into U5a-1/U5a-2/U5b/U5c (#1224–#1227).

## Verification
- `tests/analysis` + `tests/api` + `tests/core`: 1597 passed; `make test-fast` 7506 passed
- Local diff coverage (`--cov-branch`): evidence_data 100%, evidence_charts 100%, routes/evidence 99% (sole partial is a pre-existing arc outside this diff)
- `make diagnostics` (pyright diff-clean, cspell clean) · `make lint` clean · `make verify-doc-counts` 22/22 · privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)