### PR TITLE
feat(ui): add Cmd-K command palette for route jump and ticker search (#1226)

### DIFF
--- a/.claude/rules/enforcement.md
+++ b/.claude/rules/enforcement.md
@@ -26,7 +26,7 @@ Hook config: `.claude/settings.json`. CI workflows: `.github/workflows/main-ci-c
 
 **CI gates** (every PR): `privacy-scan`, `pr-discipline` (commits ≤ 3 — escape `scope-expand-approved` label), test regression + Codecov 1% relative, `security-scan` (Trivy CRITICAL), `Doc Count Drift Check` (`make verify-doc-counts`).
 
-**게이트에 없는 것 — Playwright e2e.** `frontend/e2e/` 9 파일 87 테스트는 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `frontend/package.json` 의 `test:e2e` 스크립트로만 존재한다. 위 "dead gate" 항목들과 성격이 다르다 — 저건 게이트가 있는데 죽은 것이고, 이건 **처음부터 게이트가 아니다.** 결과: `410d385`(2026-05-04)가 `CONTEXT.SIEGE` 값을 rename 하면서 vitest 는 같이 고치고 e2e 는 두었는데, **3.5개월간 아무 신호가 없었다**(2026-08-20 수동 실행에서 발견, #1118). 배선은 별건이다 — 런타임·안정성 예산이 필요하고, 스위트가 자기 부하로 백엔드를 포화시키는 문제(#1119)가 선행 조건이다. 그 전까지는 대시보드를 건드리면 손으로 돌릴 것. 상세는 `frontend/CLAUDE.md` "E2E (Playwright)".
+**게이트에 없는 것 — Playwright e2e.** `frontend/e2e/` 10 파일 89 테스트는 CI 워크플로 · Makefile · `scripts/verify/` 어디에도 배선돼 있지 않다. `frontend/package.json` 의 `test:e2e` 스크립트로만 존재한다. 위 "dead gate" 항목들과 성격이 다르다 — 저건 게이트가 있는데 죽은 것이고, 이건 **처음부터 게이트가 아니다.** 결과: `410d385`(2026-05-04)가 `CONTEXT.SIEGE` 값을 rename 하면서 vitest 는 같이 고치고 e2e 는 두었는데, **3.5개월간 아무 신호가 없었다**(2026-08-20 수동 실행에서 발견, #1118). 배선은 별건이다 — 런타임·안정성 예산이 필요하고, 스위트가 자기 부하로 백엔드를 포화시키는 문제(#1119)가 선행 조건이다. 그 전까지는 대시보드를 건드리면 손으로 돌릴 것. 상세는 `frontend/CLAUDE.md` "E2E (Playwright)".
 
 ## .claude/ 4-Layer Architecture (STRATEGY §5.10)
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,541 collected across 346 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,597 across 134 files — 100% statement coverage | |
+| **Frontend tests** | 1,598 across 134 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,541 collected across 346 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,571 across 133 files — 100% statement coverage | |
+| **Frontend tests** | 1,588 across 134 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,541 collected across 346 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,588 across 134 files — 100% statement coverage | |
+| **Frontend tests** | 1,597 across 134 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,541 backend tests across 346 files + 1597 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,541 backend tests across 346 files + 1598 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,541 backend tests across 346 files + 1588 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,541 backend tests across 346 files + 1597 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,541 backend tests across 346 files + 1571 frontend vitest (133 files) + 87 Playwright E2E (9 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,541 backend tests across 346 files + 1588 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,541 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1571 tests, 133 files |
+| Frontend tests | 목표 ≥ 90% | 1588 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,541 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1588 tests, 134 files |
+| Frontend tests | 목표 ≥ 90% | 1597 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,541 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1597 tests, 134 files |
+| Frontend tests | 목표 ≥ 90% | 1598 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/docs/UX_REDESIGN_PLAN.md
+++ b/docs/UX_REDESIGN_PLAN.md
@@ -77,8 +77,8 @@
 | U4a | 주변부 1/2 | ticker(빈 패널 접기·부재 한 줄 스트립)·engine(BLOCKED 다음 행동 링크·빈 상태 한국어 1줄) | 완료 (#1220) |
 | U4b | 주변부 2/2 | scanner(중복 테이블 union 병합 — top-15 ⊂ swing 20 실측)·pipeline(타임라인 payload raw JSON 폐지) + 잔여 빈 상태 스윕 | 완료 (#1221) |
 | U5a-1 | evidence 데이터 API | Plotly HTML iframe(플랜의 'matplotlib PNG' 문구는 낡음)의 5개 차트 쿼리를 `evidence_data.py` 공유 함수로 추출 + `/api/evidence/data/{id}` JSON — 생성기(리포트 아카이브 유지)와 단일 소스 | 완료 (#1224 → PR #1228) |
-| U5a-2 | evidence 네이티브 차트 | iframe 5개 → recharts (`--chart-*` 토큰, 캔들→종가 라인 허용) | 진행 중 (#1225) |
-| U5b | Cmd-K | 라우트 점프 + 티커 검색 팔레트 (경량 자체 구현 우선) | 대기 (#1226) |
+| U5a-2 | evidence 네이티브 차트 | iframe 5개 → recharts (`--chart-*` 토큰, 캔들→종가 라인 허용) | 완료 (#1225 → PR #1229) |
+| U5b | Cmd-K | 라우트 점프 + 티커 검색 팔레트 (경량 자체 구현 우선) | 진행 중 (#1226) |
 | U5c | IA 통합 | 라우트 병합 — **병합 맵 제안 후 사용자 확인, 그 전 구현 금지** | 대기 (#1227) |
 
 ### 단계별 공통 게이트

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1588 tests, 134 files)
+npm run test           # vitest run (1597 tests, 134 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1597 tests, 134 files)
+npm run test           # vitest run (1598 tests, 134 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1571 tests, 133 files)
+npm run test           # vitest run (1588 tests, 134 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -75,11 +75,11 @@ Two things that do **not** work, already tried (#913):
 Symptom if someone drops it: eslint prints `Oops! Something went wrong!` with a
 `brace-expansion` stack trace and lints **nothing**. `npm run lint` is silent on success, so
 confirm by file count rather than by absence of output — `npx eslint --format json | jq length`
-should be **237**.
+should be **240**.
 
 ## E2E (Playwright) — runs against the real backend, gated by nothing
 
-`npm run test:e2e` (`npx playwright test`). 9 spec files under `e2e/`, 87 tests. `playwright.config.ts` starts both servers itself (`uvicorn` :8001, `npm run dev` :3000) with `reuseExistingServer: true`.
+`npm run test:e2e` (`npx playwright test`). 10 spec files under `e2e/`, 89 tests. `playwright.config.ts` starts both servers itself (`uvicorn` :8001, `npm run dev` :3000) with `reuseExistingServer: true`.
 
 - **No CI job, no Makefile target, no `scripts/verify/` step runs it.** It is the one suite in this repo that has never gated a merge, which is exactly how `410d385` (2026-05-04) renamed `CONTEXT.SIEGE` to `"Certification"`, updated the matching vitest files, and left three e2e assertions searching for `text=SIEGE` for 3.5 months. Wiring it into a gate is a separate decision (needs a runtime/stability budget); until then, run it by hand before touching the dashboard.
 - **Never inline a user-facing string literal in a spec — import it from `src/lib/strings.ts`.** That file is the single source of truth and specs can import across the directory boundary (`import { ACTION, CONTEXT } from "../src/lib/strings"`). The contrast is on record: `dashboard.spec.ts:19` survived the same rename only because it OR'd several candidate strings, while the three brittle single-literal assertions all broke.
@@ -94,4 +94,4 @@ should be **237**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 97 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 98 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1588 tests, 134 files)
+npm run test           # vitest (1597 tests, 134 files)
 npx playwright test    # E2E (89 tests, 10 specs)
 ```
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,8 +7,8 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1571 tests, 133 files)
-npx playwright test    # E2E (87 tests, 9 specs)
+npm run test           # vitest (1588 tests, 134 files)
+npx playwright test    # E2E (89 tests, 10 specs)
 ```
 
 ## Architecture

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1597 tests, 134 files)
+npm run test           # vitest (1598 tests, 134 files)
 npx playwright test    # E2E (89 tests, 10 specs)
 ```
 

--- a/frontend/e2e/command-palette.spec.ts
+++ b/frontend/e2e/command-palette.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Cmd-K 커맨드 팔레트 (#1226 U5b) — 단축키 오픈 + 라우트 점프 잠금.
+ *
+ * 라우트 목록은 정적(NAV_GROUPS)이라 데이터 의존 없음. 티커 검색 경로는
+ * DB 의존이라 여기서 단언하지 않는다 (vitest 가 mock 으로 잠근다).
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+import { PALETTE } from "../src/lib/strings";
+
+// 트리거 버튼은 SSR 마크업이라 하이드레이션 전에도 보인다 — 단축키 리스너가
+// 붙을 때까지 press 를 재시도해야 결정론적이다 (visible ≠ hydrated).
+async function openPalette(page: Page) {
+  await expect(page.getByTestId("palette-trigger")).toBeVisible({ timeout: 15000 });
+  await expect(async () => {
+    // 이미 열려 있으면 다시 누르지 않는다 — 단축키는 토글이라 재press 가 닫아버린다
+    if (!(await page.getByTestId("command-palette").isVisible())) {
+      await page.keyboard.press("ControlOrMeta+k");
+    }
+    await expect(page.getByTestId("command-palette")).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 15000 });
+}
+
+test("Cmd-K opens the palette and Escape closes it", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded", timeout: 20000 });
+  await openPalette(page);
+  const dialog = page.getByTestId("command-palette");
+  await expect(dialog.getByText(PALETTE.SECTION_ROUTES)).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible();
+});
+
+test("filtering and Enter jumps to the route", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded", timeout: 20000 });
+  await openPalette(page);
+  await page.getByTestId("command-palette-input").fill("deci");
+  await expect(page.getByTestId("palette-route-/decisions")).toBeVisible();
+  await page.keyboard.press("Enter");
+
+  await expect(page).toHaveURL(/\/decisions/, { timeout: 15000 });
+  await expect(page.getByTestId("command-palette")).not.toBeVisible();
+});

--- a/frontend/src/__tests__/components/command-palette.test.tsx
+++ b/frontend/src/__tests__/components/command-palette.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * CommandPalette (#1226 U5b) — 단축키 토글 · 라우트 필터 · 티커 검색 · 키보드 내비.
+ */
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PALETTE } from "@/lib/strings";
+import { NAV_GROUPS } from "@/components/ui/sidebar";
+import {
+  CommandPalette,
+  filterRoutes,
+  flattenRoutes,
+  formatTickerPrice,
+} from "@/components/ui/command-palette";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => pushMock(...args) }),
+  usePathname: () => "/",
+}));
+
+const ROUTES = flattenRoutes(NAV_GROUPS);
+
+describe("pure helpers", () => {
+  it("flattenRoutes: 사이드바 전 라우트를 그룹 라벨과 함께 평탄화", () => {
+    const hrefs = ROUTES.map((r) => r.href);
+    expect(hrefs).toContain("/");
+    expect(hrefs).toContain("/decisions");
+    expect(hrefs).toContain("/evidence");
+    const decisions = ROUTES.find((r) => r.href === "/decisions");
+    expect(decisions?.group.length).toBeGreaterThan(0);
+  });
+
+  it("filterRoutes: 빈 쿼리는 전체, 라벨/그룹 부분 매칭은 대소문자 무시", () => {
+    expect(filterRoutes(ROUTES, "")).toHaveLength(ROUTES.length);
+    const byLabel = filterRoutes(ROUTES, "deci");
+    expect(byLabel.map((r) => r.href)).toContain("/decisions");
+    const byGroup = filterRoutes(ROUTES, ROUTES[0].group);
+    expect(byGroup.length).toBeGreaterThan(0);
+    expect(filterRoutes(ROUTES, "zzz-none")).toHaveLength(0);
+  });
+
+  it("formatTickerPrice: KR=₩ 정수, US<100=소수 2자리, US≥100=정수, null=빈 문자열", () => {
+    expect(formatTickerPrice("005930.KS", 71234.5)).toBe("₩71,235");
+    expect(formatTickerPrice("IONQ", 42.126)).toBe("$42.13");
+    expect(formatTickerPrice("NVDA", 1234.6)).toBe("$1,235");
+    expect(formatTickerPrice("NVDA", null)).toBe("");
+  });
+});
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [{ ticker: "AAA", name: "테스트", price: 12.3, date: "2026-08-25" }] }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("트리거 버튼 클릭 → 다이얼로그 열림, 전 라우트 표시", () => {
+    render(<CommandPalette />);
+    expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("palette-trigger"));
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+    expect(screen.getByTestId("palette-route-/decisions")).toBeInTheDocument();
+    expect(screen.getByText(PALETTE.SECTION_ROUTES)).toBeInTheDocument();
+  });
+
+  it("Cmd-K 토글 · Escape 닫기", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
+    // Ctrl-K (비 macOS)
+    fireEvent.keyDown(window, { key: "K", ctrlKey: true });
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+  });
+
+  it("쿼리로 라우트 필터 + Enter 로 이동 후 닫힘", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "deci" } });
+    expect(screen.getByTestId("palette-route-/decisions")).toBeInTheDocument();
+    expect(screen.queryByTestId("palette-route-/pipeline")).not.toBeInTheDocument();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(pushMock).toHaveBeenCalledWith("/decisions");
+    expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
+  });
+
+  it("ArrowDown/ArrowUp 내비 — Up 은 0 에서 클램프", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(pushMock).toHaveBeenCalledWith(ROUTES[1].href);
+    // 재오픈 후 Up 연타 → 0 클램프 (첫 항목 유지)
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input2 = screen.getByTestId("command-palette-input");
+    fireEvent.keyDown(input2, { key: "ArrowUp" });
+    fireEvent.keyDown(input2, { key: "Enter" });
+    expect(pushMock).toHaveBeenLastCalledWith(ROUTES[0].href);
+  });
+
+  it("mouseEnter 로 선택 이동", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const second = screen.getByTestId(`palette-route-${ROUTES[1].href}`);
+    fireEvent.mouseEnter(second);
+    expect(second).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("티커 검색: 250ms 디바운스 후 결과 렌더, 클릭 → /ticker/[symbol]", async () => {
+    vi.useFakeTimers();
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "AAA" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(fetch).toHaveBeenCalledWith("/api/tickers/search?q=AAA");
+    expect(screen.getByTestId("palette-ticker-AAA")).toBeInTheDocument();
+    expect(screen.getByText(PALETTE.SECTION_TICKERS)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("palette-ticker-AAA"));
+    expect(pushMock).toHaveBeenCalledWith("/ticker/AAA");
+  });
+
+  it("입력을 비우면 티커 결과 즉시 초기화", async () => {
+    vi.useFakeTimers();
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "AAA" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(screen.getByTestId("palette-ticker-AAA")).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "" } });
+    expect(screen.queryByTestId("palette-ticker-AAA")).not.toBeInTheDocument();
+  });
+
+  it("검색 실패는 조용히 빈 결과 (fetch reject)", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.change(screen.getByTestId("command-palette-input"), { target: { value: "AAA" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(screen.queryByTestId("palette-ticker-AAA")).not.toBeInTheDocument();
+    // 라우트 매칭도 없으면 결과 없음 문구
+    fireEvent.change(screen.getByTestId("command-palette-input"), { target: { value: "zzz-none" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(screen.getByText(PALETTE.NO_RESULTS)).toBeInTheDocument();
+  });
+
+  it("res.ok=false 와 results 필드 부재는 빈 결과로 강등", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }));
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.change(screen.getByTestId("command-palette-input"), { target: { value: "AAA" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(screen.queryByTestId("palette-ticker-AAA")).not.toBeInTheDocument();
+
+    // results 키 없는 200 응답 → `?? []` 분기
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }));
+    fireEvent.change(screen.getByTestId("command-palette-input"), { target: { value: "BBB" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    expect(screen.queryByTestId("palette-ticker-BBB")).not.toBeInTheDocument();
+  });
+
+  it("결과 0건에서 Enter 는 아무것도 하지 않는다", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) }));
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "zzz-none" } });
+    await act(async () => {
+      vi.advanceTimersByTime(260);
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+  });
+
+  it("백드롭 클릭 → 닫힘 (패널 내부 클릭은 유지)", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.mouseDown(screen.getByTestId("command-palette"));
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId("command-palette-backdrop"));
+    expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
+  });
+
+  it("접근성: dialog aria-label + option aria-selected", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.getByRole("dialog", { name: PALETTE.ARIA })).toBeInTheDocument();
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    expect(options[1]).toHaveAttribute("aria-selected", "false");
+  });
+});

--- a/frontend/src/__tests__/components/command-palette.test.tsx
+++ b/frontend/src/__tests__/components/command-palette.test.tsx
@@ -343,6 +343,15 @@ describe("CommandPalette", () => {
     expect(pushMock).toHaveBeenCalledTimes(1);
   });
 
+  it("한글 IME 조합 중 Escape 는 조합 취소일 뿐 팔레트를 닫지 않는다 (codex R2)", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.keyDown(window, { key: "Escape", isComposing: true });
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
+  });
+
   it("닫히면 포커스가 트리거 버튼으로 복원 (codex P2)", () => {
     render(<CommandPalette />);
     const trigger = screen.getByTestId("palette-trigger");

--- a/frontend/src/__tests__/components/command-palette.test.tsx
+++ b/frontend/src/__tests__/components/command-palette.test.tsx
@@ -214,6 +214,153 @@ describe("CommandPalette", () => {
     expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
   });
 
+  it("낡은 응답 폐기: A 요청이 B 요청보다 늦게 도착해도 B 결과 유지 (codex P1)", async () => {
+    vi.useFakeTimers();
+    let resolveA: ((v: unknown) => void) | undefined;
+    let resolveB: ((v: unknown) => void) | undefined;
+    const mk = (t: string) => ({ ok: true, json: () => Promise.resolve({ results: [{ ticker: t, name: null, price: 1 }] }) });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockImplementationOnce(() => new Promise((r) => { resolveA = r; }))
+        .mockImplementationOnce(() => new Promise((r) => { resolveB = r; })),
+    );
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "AA" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    fireEvent.change(input, { target: { value: "BB" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    await act(async () => { resolveB?.(mk("BB")); });
+    expect(screen.getByTestId("palette-ticker-BB")).toBeInTheDocument();
+    // 늦게 도착한 A 응답은 무시돼야 한다
+    await act(async () => { resolveA?.(mk("AA")); });
+    expect(screen.getByTestId("palette-ticker-BB")).toBeInTheDocument();
+    expect(screen.queryByTestId("palette-ticker-AA")).not.toBeInTheDocument();
+  });
+
+  it("늦은 reject 가 최신 결과를 지우지 않는다 (codex P1)", async () => {
+    vi.useFakeTimers();
+    let rejectA: ((e: unknown) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockImplementationOnce(() => new Promise((_, rej) => { rejectA = rej; }))
+        .mockImplementationOnce(() =>
+          Promise.resolve({ ok: true, json: () => Promise.resolve({ results: [{ ticker: "BB", name: null, price: 1 }] }) }),
+        ),
+    );
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "AA" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    fireEvent.change(input, { target: { value: "BB" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    expect(screen.getByTestId("palette-ticker-BB")).toBeInTheDocument();
+    await act(async () => { rejectA?.(new Error("late")); });
+    expect(screen.getByTestId("palette-ticker-BB")).toBeInTheDocument();
+  });
+
+  it("json 파싱 중 쿼리가 바뀌어도 낡은 본문은 폐기 (codex P1 — 2차 가드)", async () => {
+    vi.useFakeTimers();
+    let resolveJson: ((v: unknown) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockImplementationOnce(() =>
+          Promise.resolve({ ok: true, json: () => new Promise((r) => { resolveJson = r; }) }),
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({ ok: true, json: () => Promise.resolve({ results: [{ ticker: "BB", name: null, price: 1 }] }) }),
+        ),
+    );
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "AA" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    // fetch 는 끝났지만 json 이 아직 — 이 사이 쿼리 변경
+    fireEvent.change(input, { target: { value: "BB" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    expect(screen.getByTestId("palette-ticker-BB")).toBeInTheDocument();
+    await act(async () => { resolveJson?.({ results: [{ ticker: "AA", name: null, price: 1 }] }); });
+    expect(screen.queryByTestId("palette-ticker-AA")).not.toBeInTheDocument();
+    expect(screen.getByTestId("palette-ticker-BB")).toBeInTheDocument();
+  });
+
+  it("모달 안 Tab 은 갇힌다 (최소 포커스 트랩)", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const notPrevented = fireEvent.keyDown(screen.getByTestId("command-palette"), { key: "Tab" });
+    expect(notPrevented).toBe(false); // preventDefault 호출됨
+  });
+
+  it("ok=false 응답은 이전 쿼리의 결과를 화면에 남기지 않는다 (codex P1)", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [{ ticker: "AAA", name: null, price: 1 }] }) })
+        .mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({}) }),
+    );
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "AAA" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    expect(screen.getByTestId("palette-ticker-AAA")).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "BBB" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    expect(screen.queryByTestId("palette-ticker-AAA")).not.toBeInTheDocument();
+  });
+
+  it("결과 0건에서 ArrowDown 은 음수로 내려가지 않고, 이후 결과에서 Enter 가 산다 (codex P1)", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) }));
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.change(input, { target: { value: "zzz-none" } });
+    await act(async () => { vi.advanceTimersByTime(260); });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    // 라우트가 다시 매칭되면 첫 항목이 선택돼 있어야 하고 Enter 가 동작해야 한다
+    fireEvent.change(input, { target: { value: "deci" } });
+    expect(screen.getByTestId("palette-route-/decisions")).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(pushMock).toHaveBeenCalledWith("/decisions");
+  });
+
+  it("한글 IME 조합 중 Enter 는 내비게이션하지 않는다 (codex P2)", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    expect(pushMock).not.toHaveBeenCalled();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(pushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("닫히면 포커스가 트리거 버튼으로 복원 (codex P2)", () => {
+    render(<CommandPalette />);
+    const trigger = screen.getByTestId("palette-trigger");
+    fireEvent.click(trigger);
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("aria-activedescendant 가 선택을 따라간다 (codex P2)", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByTestId("command-palette-input");
+    expect(input).toHaveAttribute("aria-activedescendant", "palette-opt-0");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant", "palette-opt-1");
+  });
+
   it("접근성: dialog aria-label + option aria-selected", () => {
     render(<CommandPalette />);
     fireEvent.keyDown(window, { key: "k", metaKey: true });

--- a/frontend/src/__tests__/coverage/root-layout.test.tsx
+++ b/frontend/src/__tests__/coverage/root-layout.test.tsx
@@ -18,6 +18,8 @@ vi.mock("next-themes", () => ({
 
 vi.mock("@/components/ui/sidebar", () => ({
   Sidebar: () => <nav data-testid="sidebar">Sidebar</nav>,
+  // #1226: command-palette 가 NAV_GROUPS 를 소비 — mock 에도 존재해야 로드된다
+  NAV_GROUPS: [],
 }));
 
 vi.mock("@/components/ui/live-indicator", () => ({

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist_Mono } from "next/font/google";
 // Pretendard Variable: 한글 UI 본문 (#1195 U1a) — dynamic subset woff2 를 Next 가 번들
 import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 import "./globals.css";
+import { CommandPalette } from "@/components/ui/command-palette";
 import { LiveIndicator } from "@/components/ui/live-indicator";
 import { Sidebar } from "@/components/ui/sidebar";
 import { ThemeProvider } from "next-themes";
@@ -26,6 +27,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {/* Top Bar */}
             <header className="h-11 border-b border-border flex items-center px-6 shrink-0">
               <LiveIndicator />
+              {/* Cmd-K 팔레트 (#1226 U5b) — 트리거 버튼 + fixed 모달 */}
+              <CommandPalette />
             </header>
 
             {/* Page — 컨테이너 캡 (#1202 U1c, UX_REDESIGN_PLAN §2.2): 카드형 콘텐츠가

--- a/frontend/src/components/ui/command-palette.tsx
+++ b/frontend/src/components/ui/command-palette.tsx
@@ -101,6 +101,8 @@ export function CommandPalette() {
   // 전역 단축키: Cmd-K / Ctrl-K 토글, Esc 닫기
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      // IME 조합 중 키는 조합 조작이다 — Escape 조합 취소가 팔레트를 닫으면 안 된다 (codex R2)
+      if (e.isComposing) return;
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setOpen((prev) => !prev);

--- a/frontend/src/components/ui/command-palette.tsx
+++ b/frontend/src/components/ui/command-palette.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+/**
+ * CommandPalette — Cmd-K / Ctrl-K 팔레트 (#1226 U5b).
+ *
+ * 경량 수제 (cmdk 의존성 없음): 라우트 점프(NAV_GROUPS 단일 소스) +
+ * 티커 검색(/api/tickers/search 재사용 — explore 검색과 동일 계약) → /ticker/[symbol].
+ * 헤더 트리거 버튼과 모달을 한 컴포넌트로 묶는다 — 모달은 fixed 라 DOM 위치 무관.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Search } from "lucide-react";
+
+import { NAV_GROUPS } from "@/components/ui/sidebar";
+import { PALETTE } from "@/lib/strings";
+
+export interface PaletteRoute {
+  href: string;
+  label: string;
+  group: string;
+}
+
+export interface TickerResult {
+  ticker: string;
+  name: string | null;
+  price: number | null;
+}
+
+export type PaletteItem =
+  | { kind: "route"; route: PaletteRoute }
+  | { kind: "ticker"; result: TickerResult };
+
+/** NAV_GROUPS → 평탄한 라우트 목록 (아이콘 제외 — 팔레트는 텍스트 밀도 우선) */
+export function flattenRoutes(groups: typeof NAV_GROUPS): PaletteRoute[] {
+  return groups.flatMap((g) => g.items.map((i) => ({ href: i.href, label: i.label, group: g.label })));
+}
+
+/** 라벨/경로/그룹 부분 매칭 (대소문자 무시). 빈 쿼리는 전체. */
+export function filterRoutes(routes: PaletteRoute[], query: string): PaletteRoute[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return routes;
+  return routes.filter(
+    (r) => r.label.toLowerCase().includes(q) || r.href.toLowerCase().includes(q) || r.group.toLowerCase().includes(q),
+  );
+}
+
+/** KR/US 통화 표기 — explore 검색 드롭다운과 동일 규칙 */
+export function formatTickerPrice(ticker: string, price: number | null): string {
+  if (price == null) return "";
+  const isKr = ticker.endsWith(".KS") || ticker.endsWith(".KQ");
+  if (isKr) return `₩${Math.round(price).toLocaleString()}`;
+  return `$${price < 100 ? price.toFixed(2) : Math.round(price).toLocaleString()}`;
+}
+
+const ALL_ROUTES = flattenRoutes(NAV_GROUPS);
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [tickers, setTickers] = useState<TickerResult[]>([]);
+  const [selected, setSelected] = useState(0);
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const routes = useMemo(() => filterRoutes(ALL_ROUTES, query), [query]);
+  const items = useMemo<PaletteItem[]>(
+    () => [
+      ...routes.map((route) => ({ kind: "route" as const, route })),
+      ...tickers.map((result) => ({ kind: "ticker" as const, result })),
+    ],
+    [routes, tickers],
+  );
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setTickers([]);
+    setSelected(0);
+  }, []);
+
+  const navigate = useCallback(
+    (item: PaletteItem) => {
+      close();
+      router.push(item.kind === "route" ? item.route.href : `/ticker/${item.result.ticker}`);
+    },
+    [close, router],
+  );
+
+  // 전역 단축키: Cmd-K / Ctrl-K 토글, Esc 닫기
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      } else if (e.key === "Escape") {
+        close();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [close]);
+
+  // 열리면 입력 포커스
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  // 티커 검색 — explore 와 동일한 250ms 디바운스.
+  // 동기 setState 는 effect 밖(onQueryChange/close)에서 처리 — react-hooks/set-state-in-effect
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!open || query.trim().length === 0) return;
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/tickers/search?q=${encodeURIComponent(query.trim())}`);
+        if (res.ok) {
+          const data = await res.json();
+          setTickers((data.results ?? []).slice(0, 6));
+        }
+      } catch {
+        setTickers([]);
+      }
+    }, 250);
+  }, [open, query]);
+
+  function onQueryChange(value: string) {
+    setQuery(value);
+    setSelected(0);
+    if (value.trim().length === 0) setTickers([]);
+  }
+
+  const clamped = Math.min(selected, Math.max(items.length - 1, 0));
+
+  function onInputKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelected((s) => Math.min(s + 1, items.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelected((s) => Math.max(s - 1, 0));
+    } else if (e.key === "Enter" && items[clamped]) {
+      navigate(items[clamped]);
+    }
+  }
+
+  // 섹션 헤더 위치: 첫 route 항목 앞 / 첫 ticker 항목 앞
+  const firstTickerIdx = routes.length;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="ml-auto flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground/80 transition-colors"
+        data-testid="palette-trigger"
+        aria-label={PALETTE.ARIA}
+      >
+        <Search className="h-3 w-3" />
+        {PALETTE.HINT}
+        <kbd className="rounded bg-muted px-1 text-[10px]">⌘K</kbd>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-100 flex items-start justify-center bg-black/50 pt-[15vh]"
+          data-testid="command-palette-backdrop"
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) close();
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={PALETTE.ARIA}
+            className="w-full max-w-lg rounded-xl border border-border bg-card shadow-2xl overflow-hidden"
+            data-testid="command-palette"
+          >
+            <div className="flex items-center gap-2 border-b border-border px-4">
+              <Search className="h-4 w-4 text-zinc-500 shrink-0" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => onQueryChange(e.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder={PALETTE.PLACEHOLDER}
+                aria-label={PALETTE.PLACEHOLDER}
+                className="w-full bg-transparent py-3 text-sm text-foreground placeholder:text-zinc-600 focus:outline-none"
+                data-testid="command-palette-input"
+              />
+            </div>
+
+            <div role="listbox" aria-label={PALETTE.ARIA} className="max-h-80 overflow-y-auto py-1">
+              {items.length === 0 && (
+                <p className="px-4 py-3 text-xs text-muted-foreground">{PALETTE.NO_RESULTS}</p>
+              )}
+              {items.map((item, idx) => {
+                const isSelected = idx === clamped;
+                const header =
+                  idx === 0 && routes.length > 0
+                    ? PALETTE.SECTION_ROUTES
+                    : idx === firstTickerIdx && tickers.length > 0
+                      ? PALETTE.SECTION_TICKERS
+                      : null;
+                return (
+                  <div key={item.kind === "route" ? item.route.href : `t-${item.result.ticker}`}>
+                    {header && (
+                      <p className="px-4 pt-2 pb-1 text-[10px] uppercase tracking-wide text-zinc-600">{header}</p>
+                    )}
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => navigate(item)}
+                      onMouseEnter={() => setSelected(idx)}
+                      className={`flex w-full items-center justify-between px-4 py-2 text-left text-sm transition-colors ${
+                        isSelected ? "bg-muted text-foreground" : "text-muted-foreground"
+                      }`}
+                      data-testid={
+                        item.kind === "route"
+                          ? `palette-route-${item.route.href}`
+                          : `palette-ticker-${item.result.ticker}`
+                      }
+                    >
+                      {item.kind === "route" ? (
+                        <>
+                          <span>{item.route.label}</span>
+                          <span className="text-[10px] text-zinc-600">{item.route.group}</span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="flex items-center gap-2 min-w-0">
+                            <span className="font-semibold">{item.result.ticker}</span>
+                            {item.result.name && (
+                              <span className="text-[10px] text-zinc-500 truncate">{item.result.name}</span>
+                            )}
+                          </span>
+                          <span className="text-[10px] text-zinc-400 tabular-nums shrink-0 ml-2">
+                            {formatTickerPrice(item.result.ticker, item.result.price)}
+                          </span>
+                        </>
+                      )}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="border-t border-border px-4 py-1.5">
+              <p className="text-[10px] text-zinc-600">{PALETTE.FOOTER}</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/ui/command-palette.tsx
+++ b/frontend/src/components/ui/command-palette.tsx
@@ -61,7 +61,10 @@ export function CommandPalette() {
   const [selected, setSelected] = useState(0);
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // 낡은 응답 폐기용 시퀀스 — A 입력 → B 입력 후 A 응답이 늦게 도착해도 무시 (codex #1230 P1)
+  const reqSeqRef = useRef(0);
 
   const routes = useMemo(() => filterRoutes(ALL_ROUTES, query), [query]);
   const items = useMemo<PaletteItem[]>(
@@ -72,19 +75,27 @@ export function CommandPalette() {
     [routes, tickers],
   );
 
-  const close = useCallback(() => {
+  const reset = useCallback(() => {
     setOpen(false);
     setQuery("");
     setTickers([]);
     setSelected(0);
   }, []);
 
+  // Escape/백드롭 닫기만 트리거로 포커스 복원. 내비게이션 이탈 시 복원하면
+  // Enter keyup 시점에 포커스가 트리거에 가 있어 Chromium 이 클릭을 발화,
+  // 팔레트가 빈 상태로 재오픈된다 (e2e 실측 2026-08-25).
+  const close = useCallback(() => {
+    reset();
+    triggerRef.current?.focus();
+  }, [reset]);
+
   const navigate = useCallback(
     (item: PaletteItem) => {
-      close();
+      reset();
       router.push(item.kind === "route" ? item.route.href : `/ticker/${item.result.ticker}`);
     },
-    [close, router],
+    [reset, router],
   );
 
   // 전역 단축키: Cmd-K / Ctrl-K 토글, Esc 닫기
@@ -93,13 +104,13 @@ export function CommandPalette() {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setOpen((prev) => !prev);
-      } else if (e.key === "Escape") {
+      } else if (e.key === "Escape" && open) {
         close();
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [close]);
+  }, [close, open]);
 
   // 열리면 입력 포커스
   useEffect(() => {
@@ -109,17 +120,23 @@ export function CommandPalette() {
   // 티커 검색 — explore 와 동일한 250ms 디바운스.
   // 동기 setState 는 effect 밖(onQueryChange/close)에서 처리 — react-hooks/set-state-in-effect
   useEffect(() => {
+    // 쿼리가 바뀌면(비우기·닫기 포함) 진행 중이던 요청은 그 시점부터 낡은 것
+    const seq = ++reqSeqRef.current;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!open || query.trim().length === 0) return;
     debounceRef.current = setTimeout(async () => {
       try {
         const res = await fetch(`/api/tickers/search?q=${encodeURIComponent(query.trim())}`);
+        if (seq !== reqSeqRef.current) return; // 낡은 응답 폐기
         if (res.ok) {
           const data = await res.json();
+          if (seq !== reqSeqRef.current) return;
           setTickers((data.results ?? []).slice(0, 6));
+        } else {
+          setTickers([]); // 실패 응답이 이전 쿼리의 결과를 화면에 남기지 않게
         }
       } catch {
-        setTickers([]);
+        if (seq === reqSeqRef.current) setTickers([]);
       }
     }, 250);
   }, [open, query]);
@@ -133,9 +150,12 @@ export function CommandPalette() {
   const clamped = Math.min(selected, Math.max(items.length - 1, 0));
 
   function onInputKeyDown(e: React.KeyboardEvent) {
+    // 한글 IME 조합 중 Enter/화살표는 조합 확정이지 내비게이션이 아니다 (codex #1230 P2)
+    if (e.nativeEvent.isComposing) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelected((s) => Math.min(s + 1, items.length - 1));
+      // items 0개일 때 -1 로 내려가면 이후 결과 도착 시 선택이 죽는다 (codex #1230 P1)
+      setSelected((s) => Math.min(s + 1, Math.max(items.length - 1, 0)));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelected((s) => Math.max(s - 1, 0));
@@ -150,6 +170,7 @@ export function CommandPalette() {
   return (
     <>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen(true)}
         className="ml-auto flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground/80 transition-colors"
@@ -175,6 +196,10 @@ export function CommandPalette() {
             aria-label={PALETTE.ARIA}
             className="w-full max-w-lg rounded-xl border border-border bg-card shadow-2xl overflow-hidden"
             data-testid="command-palette"
+            onKeyDown={(e) => {
+              // 최소 포커스 트랩 — aria-modal 뒤로 Tab 이 빠져나가지 않게 (내비는 화살표)
+              if (e.key === "Tab") e.preventDefault();
+            }}
           >
             <div className="flex items-center gap-2 border-b border-border px-4">
               <Search className="h-4 w-4 text-zinc-500 shrink-0" />
@@ -186,12 +211,16 @@ export function CommandPalette() {
                 onKeyDown={onInputKeyDown}
                 placeholder={PALETTE.PLACEHOLDER}
                 aria-label={PALETTE.PLACEHOLDER}
+                role="combobox"
+                aria-expanded="true"
+                aria-controls="palette-listbox"
+                aria-activedescendant={items.length > 0 ? `palette-opt-${clamped}` : undefined}
                 className="w-full bg-transparent py-3 text-sm text-foreground placeholder:text-zinc-600 focus:outline-none"
                 data-testid="command-palette-input"
               />
             </div>
 
-            <div role="listbox" aria-label={PALETTE.ARIA} className="max-h-80 overflow-y-auto py-1">
+            <div role="listbox" id="palette-listbox" aria-label={PALETTE.ARIA} className="max-h-80 overflow-y-auto py-1">
               {items.length === 0 && (
                 <p className="px-4 py-3 text-xs text-muted-foreground">{PALETTE.NO_RESULTS}</p>
               )}
@@ -211,6 +240,7 @@ export function CommandPalette() {
                     <button
                       type="button"
                       role="option"
+                      id={`palette-opt-${idx}`}
                       aria-selected={isSelected}
                       onClick={() => navigate(item)}
                       onMouseEnter={() => setSelected(idx)}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -24,8 +24,8 @@ import {
   Compass,
 } from "lucide-react";
 
-// 팔란티어 스타일 그룹 네비게이션
-const NAV_GROUPS = [
+// 팔란티어 스타일 그룹 네비게이션 — command-palette 도 소비 (#1226 U5b, 단일 소스)
+export const NAV_GROUPS = [
   // 5그룹 재편 (#1200 U1b-2, docs/UX_REDESIGN_PLAN.md §1): 사용 빈도·워크플로 기준.
   // 라우트 삭제·이동 없음 — 그룹핑만 바뀐다. 그룹 라벨은 strings.ts NAV 가 정본.
   {

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -255,6 +255,17 @@ export const EVIDENCE = {
   TITLE_SELL: "매도 근거 (위반 항목별 심각도)",
 } as const;
 
+/* ── Command Palette (#1226 U5b) ────────────────────────────── */
+export const PALETTE = {
+  PLACEHOLDER: "페이지 이동 또는 티커 검색…",
+  HINT: "검색",
+  SECTION_ROUTES: "페이지",
+  SECTION_TICKERS: "티커",
+  NO_RESULTS: "결과 없음",
+  FOOTER: "↑↓ 이동 · Enter 열기 · Esc 닫기",
+  ARIA: "커맨드 팔레트",
+} as const;
+
 /* ── Portfolio Page ─────────────────────────────────────────── */
 export const PORTFOLIO = {
   QTY_ERROR: "수량은 0보다 커야 합니다",


### PR DESCRIPTION
Closes #1226 (U5b).

## Why
Navigating 15 routes and looking up a ticker both required the mouse and specific pages. A palette makes both one keystroke away from anywhere.

## What
- **`src/components/ui/command-palette.tsx`** — hand-rolled (no cmdk dep): header trigger (`검색 ⌘K`) + fixed modal, mounted once in the root layout.
  - **Route jump**: sidebar's `NAV_GROUPS` now exported and consumed directly (single source — a nav change updates the palette for free). Filter matches label/href/group, case-insensitive.
  - **Ticker search**: reuses `/api/tickers/search` with explore's 250ms debounce and price formatting; lands on `/ticker/[symbol]`. Max 6 results.
  - Keyboard: Cmd/Ctrl-K toggle, ↑↓ + Enter, Esc, backdrop click. ARIA dialog/listbox/option with aria-selected.
  - `react-hooks/set-state-in-effect` respected — sync resets live in the change handler, effects only schedule the async fetch.
- **e2e** `command-palette.spec.ts` (2 tests, route path only — deterministic): includes a hydration-aware retry press, since the SSR'd trigger is visible before the keydown listener attaches.

## Verification
- vitest 1588/134 green (+17 palette tests) · palette coverage **100% stmt/branch/func/line**
- `next build` clean · eslint 0 errors (240 files)
- e2e: command-palette 2/2 · responsive matrix 28/28 (header trigger adds no overflow, 0px at 1280–2560)
- Live QA: palette over dashboard, NVDA search → 티커 section with $217 (screenshot QA); initial miss was cold-fetch timing, not a bug (verified via request/response capture)
- `make verify-doc-counts` 22/22 · privacy scan clean · 1 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)