### PR TITLE
build(lint): pin ruff exactly so local and CI judge with the same version (#1235)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dev = [
     # to balance shards by historical duration. 갱신: `make sync-test-durations`.
     "pytest-split>=0.10.0",
     "pytest-xdist>=3.8.0",
-    "ruff>=0.8.0",
+    "ruff==0.15.8",  # 정확 핀 — CI ruff-action 이 이 핀을 읽어 로컬/CI 단일 버전 (#1235). 0.16+ 은 openbb-core 가 ruff<0.16 을 하드 핀이라 불가 — cap 이 풀리면 함께 올린다
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2215,7 +2215,7 @@ requires-dist = [
     { name = "quantstats", specifier = ">=0.0.60" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "riskfolio-lib", specifier = ">=7.2.1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
     { name = "scikit-learn", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.12.0" },
     { name = "seaborn", specifier = ">=0.13.2" },


### PR DESCRIPTION
Closes #1235.

## Why
PR #1229's Backend Lint failed on CI with a finding local `make lint` never showed: ruff-action resolves the **latest** ruff (0.16.4) from the `>=0.8.0` range, while the local venv runs the uv.lock-resolved **0.15.8**. Same code, two verdicts.

## What
- `pyproject.toml`: `ruff>=0.8.0` → `ruff==0.15.8` (+ why-comment). ruff-action reads the exact pin from pyproject, `uv sync --extra dev` installs the same — **single source, no workflow edit**.
- `uv.lock`: specifier line only (resolved version was already 0.15.8).

## Why 0.15.8, not 0.16.4
**openbb-core hard-pins `ruff>=0.15,<0.16`** — 0.16.4 is unresolvable without an `override-dependencies` entry, and unlike the fastapi override (we don't run openbb's server) there is no justification to override a linter version. Parity is the goal; newness arrives by bumping the pin when openbb-core lifts its cap.

## Verification
- `uv lock` resolves cleanly (223 packages) · `make lint` green · doc counts 22/22 · privacy clean · pytest collection intact
- The proof lands in this PR's own Backend Lint log: ruff-action should print `Found ruff version ... ==0.15.8` and download 0.15.8 (will verify before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)