### PR TITLE
style(ui): lucide pipeline icons and a reachable collapse button (#1237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 |--------|-------|---|
 | **Backend tests** | 7,541 collected across 346 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,599 across 134 files — 100% statement coverage | |
+| **Frontend tests** | 1,600 across 134 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,541 backend tests across 346 files + 1599 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,541 backend tests across 346 files + 1600 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,541 tests, 346 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1599 tests, 134 files |
+| Frontend tests | 목표 ≥ 90% | 1600 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1599 tests, 134 files)
+npm run test           # vitest run (1600 tests, 134 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme.
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build
-npm run test           # vitest (1599 tests, 134 files)
+npm run test           # vitest (1600 tests, 134 files)
 npx playwright test    # E2E (89 tests, 10 specs)
 ```
 

--- a/frontend/src/app/pipeline/page.branchcov.test.tsx
+++ b/frontend/src/app/pipeline/page.branchcov.test.tsx
@@ -79,7 +79,7 @@ describe("PipelineNode — node-body branch arms", () => {
   afterEach(() => vi.restoreAllMocks());
 
   const base = (over: Partial<NodeData>): NodeData => ({
-    label: "🔍 Collect",
+    label: "Collect",
     sub: "subtitle",
     status: "ok",
     recordCount: 0,
@@ -383,9 +383,22 @@ describe("PipelinePage — fetch & render branch arms", () => {
     await waitFor(() => expect(screen.getByText("err output here")).toBeInTheDocument());
     expect(screen.getByText("make x")).toBeInTheDocument();
     expect(screen.getByText("boom")).toBeInTheDocument();
-    // 437 fallback bullet
-    const bullets = screen.getAllByText((_c, el) => el?.textContent === "•");
-    expect(bullets.length).toBeGreaterThan(0);
+    // EVENT_ICONS 폴백 — 미지 타입은 중립 Circle 아이콘 (F-003 #1237)
+    expect(screen.getByTestId("event-icon-weird")).toBeInTheDocument();
+  });
+
+  it("StepIcon: 라이브 API 어휘 전체가 고유 아이콘 — Circle 폴백은 미지 스텝만 (F-003 #1237)", async () => {
+    const { StepIcon } = await import("@/app/pipeline/page");
+    // 구 이모지 맵은 analyze/consensus/certify 키가 없어 라이브 노드가 무아이콘이었다.
+    // lucide 는 svg 에 lucide-<name> 클래스를 붙이므로 폴백 여부를 클래스로 잠근다.
+    const LIVE_STEPS = ["collect", "analyze", "consensus", "certify", "track"];
+    for (const step of LIVE_STEPS) {
+      const { container, unmount } = render(<StepIcon stepId={step} />);
+      expect(container.querySelector("svg.lucide-circle"), `${step} 이 Circle 폴백`).toBeNull();
+      unmount();
+    }
+    const { container } = render(<StepIcon stepId="unknown-step" />);
+    expect(container.querySelector("svg.lucide-circle")).not.toBeNull();
   });
 
   it("timeline timestamp coercion throws → formatTimestamp catch (136)", async () => {

--- a/frontend/src/app/pipeline/page.branchcov.test.tsx
+++ b/frontend/src/app/pipeline/page.branchcov.test.tsx
@@ -387,18 +387,33 @@ describe("PipelinePage — fetch & render branch arms", () => {
     expect(screen.getByTestId("event-icon-weird")).toBeInTheDocument();
   });
 
-  it("StepIcon: 라이브 API 어휘 전체가 고유 아이콘 — Circle 폴백은 미지 스텝만 (F-003 #1237)", async () => {
+  it("StepIcon: 라이브 어휘가 사이드바 아이덴티티와 동일 아이콘 — Circle 폴백은 미지 스텝만 (F-003 #1237)", async () => {
     const { StepIcon } = await import("@/app/pipeline/page");
-    // 구 이모지 맵은 analyze/consensus/certify 키가 없어 라이브 노드가 무아이콘이었다.
-    // lucide 는 svg 에 lucide-<name> 클래스를 붙이므로 폴백 여부를 클래스로 잠근다.
-    const LIVE_STEPS = ["collect", "analyze", "consensus", "certify", "track"];
-    for (const step of LIVE_STEPS) {
-      const { container, unmount } = render(<StepIcon stepId={step} />);
-      expect(container.querySelector("svg.lucide-circle"), `${step} 이 Circle 폴백`).toBeNull();
-      unmount();
+    const { BarChart3, Users, Cog, Search, MapPin } = await import("lucide-react");
+    // 패리티 잠금 (codex #1238 P3): 기대 아이콘을 직접 렌더해 lucide-* 클래스를 비교 —
+    // 이름 하드코딩 없이 "사이드바와 같은 아이콘" 계약 자체를 검증한다.
+    const lucideClass = (el: Element | null) =>
+      el?.getAttribute("class")?.split(" ").find((c) => c.startsWith("lucide-") && c !== "lucide");
+    const PARITY: Array<[string, React.ComponentType]> = [
+      ["collect", Search],
+      ["analyze", BarChart3], // 사이드바 Signals
+      ["consensus", Users], // 사이드바 Agents
+      ["certify", Cog], // 사이드바 Certification Engine
+      ["track", MapPin],
+    ];
+    for (const [step, Expected] of PARITY) {
+      const want = render(<Expected />);
+      const got = render(<StepIcon stepId={step} />);
+      const wantClass = lucideClass(want.container.querySelector("svg"));
+      expect(wantClass, `${step} 기대 클래스 추출 실패`).toBeTruthy();
+      expect(lucideClass(got.container.querySelector("svg")), `${step} 아이콘 불일치`).toBe(wantClass);
+      // 장식 아이콘 — AT 에 노출하지 않는다 (codex #1238 P3)
+      expect(got.container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+      want.unmount();
+      got.unmount();
     }
     const { container } = render(<StepIcon stepId="unknown-step" />);
-    expect(container.querySelector("svg.lucide-circle")).not.toBeNull();
+    expect(lucideClass(container.querySelector("svg"))).toBe("lucide-circle");
   });
 
   it("timeline timestamp coercion throws → formatTimestamp catch (136)", async () => {

--- a/frontend/src/app/pipeline/page.branchcov.test.tsx
+++ b/frontend/src/app/pipeline/page.branchcov.test.tsx
@@ -414,6 +414,14 @@ describe("PipelinePage — fetch & render branch arms", () => {
     }
     const { container } = render(<StepIcon stepId="unknown-step" />);
     expect(lucideClass(container.querySelector("svg"))).toBe("lucide-circle");
+
+    // EventIcon 도 같은 장식 계약 — 전 타입 aria-hidden (codex #1238 R2)
+    const { EventIcon } = await import("@/app/pipeline/page");
+    for (const type of ["start", "success", "error", "weird"]) {
+      const ev = render(<EventIcon type={type} />);
+      expect(ev.container.querySelector("svg")?.getAttribute("aria-hidden"), `${type} aria-hidden 누락`).toBe("true");
+      ev.unmount();
+    }
   });
 
   it("timeline timestamp coercion throws → formatTimestamp catch (136)", async () => {

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -159,7 +159,7 @@ export function EventIcon({ type }: { type: string }) {
   const Icon = EVENT_ICONS[type] ?? Circle;
   const color =
     type === "success" ? "text-emerald-400" : type === "error" ? "text-red-400" : "text-blue-400";
-  return <Icon size={13} className={`shrink-0 mt-0.5 ${color}`} data-testid={`event-icon-${type}`} />;
+  return <Icon size={13} className={`shrink-0 mt-0.5 ${color}`} aria-hidden="true" data-testid={`event-icon-${type}`} />;
 }
 
 function formatTimestamp(iso: string): string {
@@ -174,7 +174,8 @@ function formatTimestamp(iso: string): string {
 // F-003: 미지의 step 은 중립 원 — 라이브 데이터가 새 step 을 내보내도 깨지지 않게
 export function StepIcon({ stepId }: { stepId: string }) {
   const Icon = STEP_ICONS[stepId] ?? Circle;
-  return <Icon size={15} className="text-muted-foreground" data-testid={`step-icon-${stepId}`} />;
+  // aria-hidden 명시: lucide 기본값에 기대지 않는다 — 장식 아이콘 (codex #1238 P3, 잠금은 branchcov 테스트)
+  return <Icon size={15} className="text-muted-foreground" aria-hidden="true" data-testid={`step-icon-${stepId}`} />;
 }
 
 // === Custom Node Component ===

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -11,6 +11,20 @@ import {
   Position,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import {
+  BarChart3,
+  Bot,
+  Check,
+  CheckCircle2,
+  Circle,
+  ClipboardList,
+  Cog,
+  MapPin,
+  Play,
+  Search,
+  Users,
+  X,
+} from "lucide-react";
 import { PIPELINE as PL } from "@/lib/strings";
 import { summarizePayload } from "./helpers";
 
@@ -89,13 +103,24 @@ const STATUS_GLOW: Record<string, string> = {
   running: "shadow-blue-500/10",
 };
 
-const STEP_ICONS: Record<string, string> = {
-  collect: "\uD83D\uDD0D",
-  validate: "\u2705",
-  classify: "\uD83D\uDCCA",
-  diagnose: "\uD83E\uDD16",
-  recommend: "\uD83D\uDCCB",
-  track: "\uD83D\uDCCD",
+// F-003 (#1237): 이모지 → lucide — 디자인 시스템의 유일한 아이콘 체계 (사이드바와 동일).
+// lucide 의 LucideIcon 별칭은 TS6 JSX 에서 붕괴 사례가 있어 구체 타입(typeof Search)으로.
+type IconComponent = typeof Search;
+
+// 키 2계보: DEFAULT_NODES 어휘(validate/classify/diagnose/recommend) + 라이브 API 어휘
+// (analyze/consensus/certify — README 스테이지 표). 구 이모지 맵은 후자가 없어 라이브
+// 노드가 무아이콘이었다. 아이콘은 사이드바 아이덴티티와 일치 (Signals=BarChart3,
+// Agents=Users, Certification Engine=Cog).
+const STEP_ICONS: Record<string, IconComponent> = {
+  collect: Search,
+  validate: CheckCircle2,
+  classify: BarChart3,
+  diagnose: Bot,
+  recommend: ClipboardList,
+  analyze: BarChart3,
+  consensus: Users,
+  certify: Cog,
+  track: MapPin,
 };
 
 const STEP_HREFS: Record<string, string> = {
@@ -108,10 +133,10 @@ const STEP_HREFS: Record<string, string> = {
 };
 
 // 타임라인 이벤트 아이콘
-const EVENT_ICONS: Record<string, string> = {
-  start: "\u25B6\uFE0F",
-  success: "\u2705",
-  error: "\u274C",
+const EVENT_ICONS: Record<string, IconComponent> = {
+  start: Play,
+  success: Check,
+  error: X,
 };
 
 function formatAge(dateStr: string | null): string {
@@ -129,6 +154,14 @@ function formatAge(dateStr: string | null): string {
   }
 }
 
+// F-003: 이벤트 아이콘 — 뱃지와 같은 intent 색 (success=emerald, error=red, start=blue)
+export function EventIcon({ type }: { type: string }) {
+  const Icon = EVENT_ICONS[type] ?? Circle;
+  const color =
+    type === "success" ? "text-emerald-400" : type === "error" ? "text-red-400" : "text-blue-400";
+  return <Icon size={13} className={`shrink-0 mt-0.5 ${color}`} data-testid={`event-icon-${type}`} />;
+}
+
 function formatTimestamp(iso: string): string {
   try {
     const dt = new Date(iso);
@@ -136,6 +169,12 @@ function formatTimestamp(iso: string): string {
   } catch {
     return iso;
   }
+}
+
+// F-003: 미지의 step 은 중립 원 — 라이브 데이터가 새 step 을 내보내도 깨지지 않게
+export function StepIcon({ stepId }: { stepId: string }) {
+  const Icon = STEP_ICONS[stepId] ?? Circle;
+  return <Icon size={15} className="text-muted-foreground" data-testid={`step-icon-${stepId}`} />;
 }
 
 // === Custom Node Component ===
@@ -159,9 +198,9 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
         className="!bg-muted !border-border !w-2 !h-2"
       />
 
-      {/* 상태 표시 + 라벨 */}
+      {/* 상태 표시 + 라벨 — F-003: stepId 기반 lucide 아이콘 (label 은 제목만) */}
       <div className="flex items-center justify-between mb-1.5">
-        <span className="text-base">{data.label.split(" ")[0]}</span>
+        <StepIcon stepId={data.stepId} />
         <div className="flex items-center gap-2">
           {/* 레코드 수 */}
           <span className="text-[10px] text-muted-foreground/70">{data.recordCount.toLocaleString()}</span>
@@ -177,7 +216,7 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
 
       {/* 제목 */}
       <p className="text-sm font-bold text-foreground mb-0.5">
-        {data.label.split(" ").slice(1).join(" ")}
+        {data.label}
       </p>
 
       {/* 부제 + last updated */}
@@ -333,7 +372,7 @@ export default function PipelinePage() {
         type: "pipeline",
         position: { x: i * 300, y: 80 },
         data: {
-          label: `${STEP_ICONS[s.step] || ""} ${s.label}`,
+          label: s.label,
           sub: s.description,
           status: getNodeStatus(s),
           recordCount: s.record_count,
@@ -435,7 +474,7 @@ export default function PipelinePage() {
             <div className="space-y-1.5 max-h-100 overflow-y-auto">
               {timeline.map((ev, i) => (
                 <div key={`${ev.timestamp}-${i}`} className="flex items-start gap-2 text-xs py-1.5 border-b border-border/30 last:border-0">
-                  <span className="shrink-0 text-sm">{EVENT_ICONS[ev.event_type] || "\u2022"}</span>
+                  <EventIcon type={ev.event_type} />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
                       <span className="font-medium text-foreground/80 capitalize">{ev.step}</span>
@@ -504,36 +543,36 @@ const DEFAULT_NODES: Node[] = [
     id: "collect",
     type: "pipeline",
     position: { x: 0, y: 80 },
-    data: { label: "\uD83D\uDD0D Collect", sub: "15 collectors + 6 sites", status: "warning", recordCount: 0, lastUpdated: null, stepId: "collect", href: "/engine" } as PipelineNodeData,
+    data: { label: "Collect", sub: "15 collectors + 6 sites", status: "warning", recordCount: 0, lastUpdated: null, stepId: "collect", href: "/engine" } as PipelineNodeData,
   },
   {
     id: "validate",
     type: "pipeline",
     position: { x: 300, y: 80 },
-    data: { label: "\u2705 Validate", sub: "Signal backtest + scorecard", status: "warning", recordCount: 0, lastUpdated: null, stepId: "validate", href: "/signals" } as PipelineNodeData,
+    data: { label: "Validate", sub: "Signal backtest + scorecard", status: "warning", recordCount: 0, lastUpdated: null, stepId: "validate", href: "/signals" } as PipelineNodeData,
   },
   {
     id: "classify",
     type: "pipeline",
     position: { x: 600, y: 80 },
-    data: { label: "\uD83D\uDCCA Classify", sub: "6-regime classifier", status: "warning", recordCount: 0, lastUpdated: null, stepId: "classify", href: "/strategy" } as PipelineNodeData,
+    data: { label: "Classify", sub: "6-regime classifier", status: "warning", recordCount: 0, lastUpdated: null, stepId: "classify", href: "/strategy" } as PipelineNodeData,
   },
   {
     id: "diagnose",
     type: "pipeline",
     position: { x: 900, y: 80 },
-    data: { label: "\uD83E\uDD16 Diagnose", sub: "10 agents consensus", status: "warning", recordCount: 0, lastUpdated: null, stepId: "diagnose", href: "/consensus" } as PipelineNodeData,
+    data: { label: "Diagnose", sub: "10 agents consensus", status: "warning", recordCount: 0, lastUpdated: null, stepId: "diagnose", href: "/consensus" } as PipelineNodeData,
   },
   {
     id: "recommend",
     type: "pipeline",
     position: { x: 1200, y: 80 },
-    data: { label: "\uD83D\uDCCB Recommend", sub: "Buy/sell + price targets", status: "warning", recordCount: 0, lastUpdated: null, stepId: "recommend", href: "/targets" } as PipelineNodeData,
+    data: { label: "Recommend", sub: "Buy/sell + price targets", status: "warning", recordCount: 0, lastUpdated: null, stepId: "recommend", href: "/targets" } as PipelineNodeData,
   },
   {
     id: "track",
     type: "pipeline",
     position: { x: 1500, y: 80 },
-    data: { label: "\uD83D\uDCCD Track", sub: "30/60/90d outcomes", status: "warning", recordCount: 0, lastUpdated: null, stepId: "track", href: "/targets" } as PipelineNodeData,
+    data: { label: "Track", sub: "30/60/90d outcomes", status: "warning", recordCount: 0, lastUpdated: null, stepId: "track", href: "/targets" } as PipelineNodeData,
   },
 ];

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -90,7 +90,7 @@ export function Sidebar() {
           </Link>
           <button
             onClick={() => setCollapsed(!collapsed)}
-            className="text-muted-foreground hover:text-foreground/80 transition-colors"
+            className="p-1.5 -m-1.5 text-muted-foreground hover:text-foreground/80 transition-colors"
           >
             {collapsed ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
           </button>


### PR DESCRIPTION
Closes #1237 (design-review deferred F-003 + F-005, user-approved).

## What
- **F-003** — pipeline DAG node + event-feed emoji (the last design-element emoji) → lucide, identity matched to the sidebar (Signals=BarChart3, Agents=Users, Certification Engine=Cog). Two findings fixed along the way:
  - the old emoji map only knew the DEFAULT_NODES vocabulary — **live API steps (analyze/consensus/certify) rendered no icon at all**; the new map keys both vocabularies, Circle fallback for unknown steps
  - the `label.split(" ")[0]` emoji-prefix hack is gone — label is the plain title, icon derives from `stepId`
  - event feed: intent-colored Play/Check/X (same emerald/red/blue as the type badge)
- **F-005** — sidebar collapse button 14×14 → `p-1.5 -m-1.5` (26×26 hit area, layout unmoved)
- TS note: lucide's `LucideIcon` alias collapses to props `{}` under TS 6 at variable-held JSX sites — icon map typed as `typeof Search`

## Verification
- vitest 1600/134 green (+1: StepIcon live-vocabulary lock — `lucide-circle` class as fallback detector; fixture/bullet asserts updated)
- Touched dirs coverage **100% stmt/branch/func/line** · `next build` clean · eslint 0 errors
- responsive 28/28 (pipeline in matrix) · live QA screenshots: 5 live nodes each with a distinct lucide icon, event feed icons intent-colored, 0px overflow
- doc counts 22/22 · privacy clean · 1 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)