### PR TITLE
fix(frontend): allow 127.0.0.1 in allowedDevOrigins — dev chunks 403'd on loopback IP

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -14,6 +14,10 @@ import type { NextConfig } from "next";
  * Production (`next build`) ignores this setting entirely.
  */
 const DEFAULT_DEV_ORIGINS = [
+  // 루프백 IP (#1245). dev 서버는 기동 호스트네임(localhost)만 기본 허용하는데,
+  // 127.0.0.1:3000 으로 열면 turbopack module 청크가 CORS 모드로 Origin 을 붙여
+  // 403, HMR WS 도 차단된다 — 페이지(SSR)는 떠서 조용히 hydration 만 죽는다.
+  "127.0.0.1",
   "*.local",        // Bonjour / mDNS hostnames (macOS Network)
   "192.168.*.*",   // Home Wi-Fi / 홈 공유기 (Class C private)
   "10.*.*.*",      // Enterprise / Docker bridge (Class A private)


### PR DESCRIPTION
Closes #1245.

## Symptom (user-reported, 2026-08-26 02:25 KST)

Browsing the dev dashboard at `http://127.0.0.1:3000` produced console errors: four turbopack chunks `net::ERR_ABORTED 403 (Forbidden)` plus a repeatedly failing HMR WebSocket. The page itself rendered (SSR), so the breakage was silent — the 403'd module chunks mean hydration partially dies in that tab. `http://localhost:3000` was fully healthy.

## Root cause (deterministic repro)

Next 16's dev server blocks cross-origin requests to dev assets, permitting only the hostname it booted with (`localhost` by default) plus `allowedDevOrigins` (`node_modules/next/dist/docs/.../allowedDevOrigins.md`). The #214 allowlist covers `*.local` and RFC1918 ranges — but not loopback. Turbopack loads chunks as module scripts, which send an `Origin` header even same-origin (CORS mode), and the HMR WebSocket always sends one.

curl against the same chunk on the same socket:
- `Origin: http://127.0.0.1:3000` → **403**
- `Origin: http://localhost:3000` → **200**
- no Origin header (document navigation) → 200 — which is why the page renders and only sub-resources die

Playwright e2e never caught it because `baseURL` is `http://localhost:3000` — the allowed path.

## Fix

Add `"127.0.0.1"` to `DEFAULT_DEV_ORIGINS` with a comment recording the failure shape. Dev-only setting (`next build` ignores it). Verified after a dev-server restart: both origins now 200; `tsc` clean; lint 0 errors (the 1 warning is a pre-existing login-page item, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)