### PR TITLE
style(frontend): tailwind v4 canonical important suffix in pipeline page

### DIFF
--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -201,7 +201,7 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
       <Handle
         type="target"
         position={Position.Left}
-        className="!bg-muted !border-border !w-2 !h-2"
+        className="bg-muted! border-border! w-2! h-2!"
       />
 
       {/* 상태 표시 + 라벨 — F-003: stepId 기반 lucide 아이콘 (label 은 제목만) */}
@@ -258,7 +258,7 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
       <Handle
         type="source"
         position={Position.Right}
-        className="!bg-muted !border-border !w-2 !h-2"
+        className="bg-muted! border-border! w-2! h-2!"
       />
     </div>
   );
@@ -445,7 +445,7 @@ export default function PipelinePage() {
           <Background color="#27272a" gap={20} size={1} />
           <Controls
             showInteractive={false}
-            className="!bg-card !border-input !shadow-lg [&>button]:!bg-muted [&>button]:!border-input [&>button]:!text-muted-foreground [&>button:hover]:!bg-muted"
+            className="bg-card! border-input! shadow-lg! [&>button]:bg-muted! [&>button]:border-input! [&>button]:text-muted-foreground! [&>button:hover]:bg-muted!"
           />
         </ReactFlow>
       </div>


### PR DESCRIPTION
## Summary

tailwindcss-intellisense `suggestCanonicalClasses` hints on `frontend/src/app/pipeline/page.tsx` (lines 204/261/448): legacy v3 important prefix (`!bg-muted`) → Tailwind 4 canonical suffix (`bg-muted!`). Repo-wide grep confirms these 3 lines were the only occurrences.

Behavior-preserving: compiled CSS still emits `background-color:var(--muted)!important` (verified in `.next/static/chunks` after `next build`).

## Test plan

- pipeline vitest 49/49 green, eslint clean, `next build` green
- built CSS grep shows identical `!important` rules for base, `[&>button]`, and hover variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YZnW13r4XRCrfvQqnSQFN