### PR TITLE
feat(engine): persist scoring_detail + regime fallback in record_decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,552 collected across 348 files | |
+| **Backend tests** | 7,557 collected across 348 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,606 across 134 files — 100% statement coverage | |
 | **E2E tests** | 87 across 9 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,552 backend tests across 348 files + 1606 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,557 backend tests across 348 files + 1606 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,552 tests, 348 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,557 tests, 348 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/engine/decisions.py
+++ b/nuri/trading/engine/decisions.py
@@ -83,6 +83,15 @@ def record_decision(consensus_result, db_path=None) -> int:
         "stop_loss": targets.get("stop_loss"),
         "target_1": targets.get("target_1"),
         "target_2": targets.get("target_2"),
+        # #1256: scoring.py 가 계산하는 판정 감사 정보(final_action_source /
+        # degraded_agents / panel_coverage / contributions)를 decisions 에도 persist.
+        # recommendations 경로(#364)만 저장하고 여기서 버려져 387행 전부 NULL 이었다 —
+        # 결정 상세 페이지의 "왜 이 판정인가" 재구성이 reasoning 문자열 파싱에 갇혀 있던 원인.
+        "scoring_detail": (
+            json.dumps(consensus_result.scoring_detail, ensure_ascii=False)
+            if getattr(consensus_result, "scoring_detail", None)
+            else None
+        ),
     }
 
     decision_id = upsert_decision(decision_data, db_path)
@@ -242,6 +251,19 @@ def _snapshot_market_context(db_path=None) -> dict:
             payload = json.loads(regime_row[0]["payload"])
             context["regime"] = payload.get("regime", payload.get("new_regime"))
         except (json.JSONDecodeError, TypeError):
+            pass
+
+    # #1256: regime_changed 이벤트는 dev/prod 모두 0건이라 위 경로만으로는 regime 이
+    # 항상 NULL 이었다 (결정 상세 frozen 컨텍스트의 "—"). 분류기 직접 호출로 fallback —
+    # 실패는 None 유지 (관측이 본 작업을 게이트하면 안 된다, #894).
+    if not context.get("regime"):
+        try:
+            from nuri.quant.regime.classifier import classify_regime
+
+            state = classify_regime(db_path=db_path)
+            if state is not None:
+                context["regime"] = state.regime
+        except Exception:
             pass
 
     # Macro score — event_score 포함

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -257,6 +257,7 @@ class MockConsensusResult:
     verdicts: list
     dissent: list
     reasoning: str
+    scoring_detail: dict | None = None  # #1256: 실 ConsensusResult 와 동일하게 optional
 
 
 class TestRecordDecision:
@@ -365,6 +366,126 @@ class TestRecordDecision:
         count = record_decisions(results, db_path)
         assert count == 2
         assert len(get_decisions(db_path=db_path)) == 2
+
+
+# ═══════════════════════════════════════════════════════
+# #1256 — scoring_detail persist + regime fallback (Gotcha-Test Pair)
+# ═══════════════════════════════════════════════════════
+
+
+class TestScoringDetailIsPersisted:
+    """scoring.py 가 계산한 판정 감사 정보가 decisions 행까지 도달하는지 잠금.
+
+    #1256 이전: ConsensusResult.scoring_detail 은 recommendations 경로만 persist 되고
+    record_decision 이 버려서 387행 전부 NULL 이었다. persist 줄을 지우면 FAIL.
+    """
+
+    def test_scoring_detail_round_trips(self, db_path):
+        from nuri.trading.engine.decisions import record_decision
+
+        _insert_price(db_path, "NVDA", 120.0)
+        detail = {
+            "source": "consensus",
+            "schema_version": 1,
+            "final_action_source": "risk_veto",
+            "degraded_agents": ["smart_money"],
+            "panel_coverage": 0.9,
+        }
+        result = MockConsensusResult(
+            ticker="NVDA",
+            final_action="SELL",
+            final_confidence=100.0,
+            agreement_rate=0.2,
+            verdicts=[MockAgentVerdict("risk", "NVDA", "SELL", 100.0, "stop breach", {})],
+            dissent=[],
+            reasoning="리스크 에이전트 거부권 발동: 손절선 돌파",
+            scoring_detail=detail,
+        )
+
+        dec_id = record_decision(result, db_path)
+        row = query("SELECT scoring_detail FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
+        assert row["scoring_detail"] is not None
+        assert json.loads(row["scoring_detail"]) == detail
+
+    def test_absent_scoring_detail_stays_null(self, db_path):
+        """scoring_detail 없는 결과(구 호출자·구 mock)는 NULL — 빈 dict/문자열 오염 금지."""
+        from nuri.trading.engine.decisions import record_decision
+
+        _insert_price(db_path, "NVDA", 120.0)
+        result = MockConsensusResult(
+            ticker="NVDA",
+            final_action="BUY",
+            final_confidence=70.0,
+            agreement_rate=0.7,
+            verdicts=[MockAgentVerdict("technical", "NVDA", "BUY", 80.0, "ok", {})],
+            dissent=[],
+            reasoning="plain consensus",
+        )
+
+        dec_id = record_decision(result, db_path)
+        row = query("SELECT scoring_detail FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
+        assert row["scoring_detail"] is None
+
+
+class TestRegimeFallsBackToClassifier:
+    """decisions.regime NULL 상근 버그 (#1256) 잠금.
+
+    _snapshot_market_context 는 pipeline_events.regime_changed 만 읽었는데 그 이벤트는
+    dev/prod 모두 0건 — frozen 컨텍스트의 Regime 이 항상 "—" 였다. fallback 을 지우면 FAIL.
+    """
+
+    def _record_one(self, db_path):
+        from nuri.trading.engine.decisions import record_decision
+
+        _insert_price(db_path, "NVDA", 120.0)
+        result = MockConsensusResult(
+            ticker="NVDA",
+            final_action="BUY",
+            final_confidence=70.0,
+            agreement_rate=0.7,
+            verdicts=[MockAgentVerdict("technical", "NVDA", "BUY", 80.0, "ok", {})],
+            dissent=[],
+            reasoning="regime test",
+        )
+        return record_decision(result, db_path)
+
+    def test_no_event_falls_back_to_classifier(self, db_path, monkeypatch):
+        import nuri.quant.regime.classifier as classifier
+
+        class _State:
+            regime = "bull_low_vol"
+
+        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: _State())
+        dec_id = self._record_one(db_path)
+        row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
+        assert row["regime"] == "bull_low_vol"
+
+    def test_event_still_wins_over_classifier(self, db_path, monkeypatch):
+        """이벤트가 있으면 그 값이 우선 — fallback 이 스냅샷 의미를 바꾸면 안 된다."""
+        import nuri.quant.regime.classifier as classifier
+        from nuri.core.events import emit_event
+
+        emit_event("regime_changed", payload={"regime": "bear_high_vol"}, db_path=db_path)
+        monkeypatch.setattr(
+            classifier,
+            "classify_regime",
+            lambda db_path=None: (_ for _ in ()).throw(AssertionError("classifier must not be called")),
+        )
+        dec_id = self._record_one(db_path)
+        row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
+        assert row["regime"] == "bear_high_vol"
+
+    def test_classifier_failure_leaves_regime_null(self, db_path, monkeypatch):
+        """분류기 실패는 soft-fail — 관측이 본 작업(기록)을 게이트하면 안 된다 (#894)."""
+        import nuri.quant.regime.classifier as classifier
+
+        def _boom(db_path=None):
+            raise RuntimeError("no SPY data")
+
+        monkeypatch.setattr(classifier, "classify_regime", _boom)
+        dec_id = self._record_one(db_path)
+        row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
+        assert row["regime"] is None
 
 
 # ═══════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #1256. 결정 상세 P0 재설계(#1257)의 백엔드 선행 작업.

- `record_decision()`이 `ConsensusResult.scoring_detail`(final_action_source · degraded_agents · panel_coverage · contributions)을 decisions 행에 persist — 기존엔 recommendations 경로(#364)만 저장하고 여기서 버려져 387행 전부 NULL.
- `_snapshot_market_context()` regime: `pipeline_events.regime_changed`(dev/prod 0건) 부재 시 `classify_regime()` fallback, 실패는 soft-fail None (#894 원칙).
- 과거 행 backfill 없음 — 프론트가 reasoning 프리픽스 파싱 fallback (#1257).

## Test plan

- Gotcha-Test Pair (`TestScoringDetailIsPersisted` ×2, `TestRegimeFallsBackToClassifier` ×3): persist round-trip / 부재 시 NULL / fallback / 이벤트 우선 / soft-fail
- 뮤테이션 실측: persist 줄 제거 → 1 FAIL, fallback 블록 제거 → 1 FAIL
- `tests/trading/engine/test_decisions.py` 64/64 + db_path forwarding sweep green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YZnW13r4XRCrfvQqnSQFN