### PR TITLE
feat(frontend): decisions/[id] argument-structure redesign — verdict-path hero

### DIFF
--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -746,3 +746,32 @@ describe("DecisionProvenance — codex ship-review 수정 잠금 (#1257)", () =>
     expect(within(hero).getByText(/quantum_override/)).toBeInTheDocument();
   });
 });
+
+describe("DecisionProvenance — null-필드 분기 커버 (#1257 codecov patch)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    notFoundMock.mockClear();
+  });
+
+  it("veto 히어로: confidence·agreement·reasoning null + 빈 verdicts 도 안전 렌더", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      action: "SELL",
+      confidence: null,
+      agreement_rate: null,
+      reasoning: null,
+      agent_verdicts: JSON.stringify([]),
+      scoring_detail: JSON.stringify({ final_action_source: "risk_veto" }),
+      thesis: null,
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const hero = screen.getByTestId("verdict-hero");
+    expect(hero.dataset.source).toBe("risk_veto");
+    // confidence null → "—", 분포 바는 0명이라 비어 있고, 일치율 표기는 생략
+    expect(within(hero).getByText(/SELL · —/)).toBeInTheDocument();
+    expect(within(hero).queryByText(/일치율 \d/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -429,7 +429,8 @@ describe("DecisionProvenance — U3 Evidence Terminal (#1216)", () => {
       ({ container } = render(await DecisionProvenance({ id: "531" })));
     });
     const rail = screen.getByTestId("decision-rail");
-    expect(rail.className).toContain("lg:order-2");
+    // #1257: 모바일에서도 본문 우선 — 레일은 모든 브레이크포인트에서 order-2
+    expect(rail.className).toContain("order-2");
     const grid = rail.parentElement!;
     expect(grid.className).toContain("lg:grid-cols-3");
     expect(grid.querySelector(".lg\\:col-span-2")).not.toBeNull();
@@ -511,5 +512,179 @@ describe("DecisionProvenance — U3 Evidence Terminal (#1216)", () => {
     // 2026-04-13 + 90d < 오늘 → pending 은 판정일 도래·미판정으로 드러난다
     expect(outcome.textContent).toContain("대기");
     expect(outcome.textContent).toContain("판정일 도래 · 미판정");
+  });
+});
+
+// ═══════════════════════════════════════════════════════
+// #1257 — 판정 경로 히어로 + 액션별 템플릿 + 에이전트 2단
+// ═══════════════════════════════════════════════════════
+
+describe("DecisionProvenance — 판정 경로 (#1257)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    notFoundMock.mockClear();
+  });
+
+  const vetoDetail = {
+    ...mockDetail,
+    action: "SELL",
+    confidence: 100,
+    agreement_rate: 0.2,
+    reasoning: "리스크 에이전트 거부권 발동: 손절선 돌파 (-11.0% < -7%)",
+    agent_verdicts: JSON.stringify([
+      { agent_name: "risk", action: "SELL", confidence: 100, reasoning: "손절선 돌파" },
+      { agent_name: "technical", action: "SELL", confidence: 100, reasoning: "MACD<Signal" },
+      { agent_name: "options", action: "BUY", confidence: 86, reasoning: "PCR 약한 공포" },
+      { agent_name: "smart_money", action: "HOLD", confidence: 30, reasoning: "스마트머니 데이터 없음" },
+    ]),
+    scoring_detail: JSON.stringify({
+      final_action_source: "risk_veto",
+      degraded_agents: ["smart_money"],
+      panel_coverage: 0.75,
+      risk_veto_fired: true,
+    }),
+    thesis: null,
+  };
+
+  it("risk_veto: 대차대조 히어로 — 합의 참고 vs 판정을 확정한 규칙", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(vetoDetail);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const hero = screen.getByTestId("verdict-hero");
+    expect(hero.dataset.source).toBe("risk_veto");
+    expect(within(hero).getByText(/손실 관리 규칙이 이 판정을 자동 확정/)).toBeInTheDocument();
+    expect(within(hero).getByText(/최종 판정을 확정한 것/)).toBeInTheDocument();
+    // veto 사유는 히어로가 전문 표시 — 별도 "근거" 카드는 중복이라 사라진다
+    expect(within(hero).getByText(/거부권 발동: 손절선 돌파/)).toBeInTheDocument();
+    expect(screen.queryByText("근거")).not.toBeInTheDocument();
+  });
+
+  it("과거 행 fallback: scoring_detail 없이 reasoning 프리픽스만으로 veto 히어로", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({ ...vetoDetail, scoring_detail: null });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByTestId("verdict-hero").dataset.source).toBe("risk_veto");
+  });
+
+  it("weighted_sum(기본): 단일 히어로 + 합의 분포", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(mockDetail);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const hero = screen.getByTestId("verdict-hero");
+    expect(hero.dataset.source).toBe("weighted_sum");
+    expect(within(hero).getByText(/가중 합의가 이 판정을 만들었습니다/)).toBeInTheDocument();
+    // weighted_sum 은 근거 카드 유지
+    expect(screen.getByText("근거")).toBeInTheDocument();
+  });
+
+  it("divergence_penalty: 강등 사유가 히어로에 표시", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      reasoning: "의견 분산 페널티로 HOLD 강등",
+      scoring_detail: JSON.stringify({ final_action_source: "divergence_penalty" }),
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const hero = screen.getByTestId("verdict-hero");
+    expect(hero.dataset.source).toBe("divergence_penalty");
+    expect(within(hero).getByText(/확신도를 낮췄습니다/)).toBeInTheDocument();
+    expect(within(hero).getByText(/의견 분산 페널티로 HOLD 강등/)).toBeInTheDocument();
+  });
+
+  it("SELL 은 매수 사다리를 렌더하지 않는다 — 결정 시점 가격 + Stop 만", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(vetoDetail);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const card = screen.getByTestId("price-card");
+    expect(within(card).queryByText("Target 1")).not.toBeInTheDocument();
+    expect(within(card).queryByText("Entry")).not.toBeInTheDocument();
+    expect(within(card).getByText("결정 시점 가격")).toBeInTheDocument();
+    expect(within(card).getByText(/매수 사다리.*적용되지 않습니다/)).toBeInTheDocument();
+  });
+
+  it("에이전트 2단: degraded 는 접힘 + 유효 의견만 본문 + 커버리지 표기", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(vetoDetail);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText(/에이전트 판정 — 유효 의견 3/)).toBeInTheDocument();
+    expect(screen.getByText(/패널 커버리지 75%/)).toBeInTheDocument();
+    const degraded = screen.getByTestId("degraded-agents");
+    expect(within(degraded).getByText(/의견 미산출 1/)).toBeInTheDocument();
+    expect(within(degraded).getAllByText(/smart_money/).length).toBeGreaterThan(0);
+  });
+
+  it("scoring_detail 없는 과거 행은 평면 리스트 유지 — degraded 를 지어내지 않는다", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({ ...vetoDetail, scoring_detail: null });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.getByText(/에이전트 판정 \(4\)/)).toBeInTheDocument();
+    expect(screen.queryByTestId("degraded-agents")).not.toBeInTheDocument();
+  });
+
+  it("veto + 논지 없음 → 자동 논지 렌더 (채점 기준 공백 방지)", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(vetoDetail);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const auto = screen.getByTestId("auto-thesis");
+    expect(within(auto).getByText(/자동 논지/)).toBeInTheDocument();
+    expect(within(auto).getByText(/판정일에 실현 결과로 채점/)).toBeInTheDocument();
+  });
+
+  it("비-veto + 논지 없음 → 기존 부재 문구 유지 (자동 논지 남발 금지)", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, thesis: null });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    expect(screen.queryByTestId("auto-thesis")).not.toBeInTheDocument();
+    expect(screen.getByText(/기록된 논지 없음/)).toBeInTheDocument();
+  });
+
+  it("판정 후 새 사실 + 재검토 체크가 항상 렌더 — 부재도 정직하게 표시", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue(mockDetail);
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const facts = screen.getByTestId("post-decision-facts");
+    expect(within(facts).getByText(/자동 반영은 아직 없습니다/)).toBeInTheDocument();
+    const recheck = screen.getByTestId("recheck-list");
+    expect(within(recheck).getByText(/매매 권고 아님/)).toBeInTheDocument();
+    expect(within(recheck).getByText(/현재 규칙 기준 재구성/)).toBeInTheDocument();
+  });
+});
+
+describe("verdict-path helpers (#1257)", () => {
+  it("parseScoringDetail: 깨진 JSON·배열·null 은 null", async () => {
+    const { parseScoringDetail } = await import("@/app/decisions/verdict-path");
+    expect(parseScoringDetail("not-json{")).toBeNull();
+    expect(parseScoringDetail(null)).toBeNull();
+    expect(parseScoringDetail(JSON.stringify([1, 2]))).toBeNull();
+    expect(parseScoringDetail({ final_action_source: "weighted_sum" })).toEqual({
+      final_action_source: "weighted_sum",
+    });
+  });
+
+  it("deriveActionSource: 미지의 소스 값은 fallback 경로로", async () => {
+    const { deriveActionSource } = await import("@/app/decisions/verdict-path");
+    expect(deriveActionSource({ final_action_source: "future_mechanism" }, "일반 합의")).toBe("weighted_sum");
+    expect(deriveActionSource(null, "리스크 에이전트 거부권 발동: x")).toBe("risk_veto");
+    expect(deriveActionSource(null, null)).toBe("weighted_sum");
   });
 });

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -595,7 +595,7 @@ describe("DecisionProvenance — 판정 경로 (#1257)", () => {
     });
     const hero = screen.getByTestId("verdict-hero");
     expect(hero.dataset.source).toBe("divergence_penalty");
-    expect(within(hero).getByText(/확신도를 낮췄습니다/)).toBeInTheDocument();
+    expect(within(hero).getByText(/판정을 보수적으로 강등했습니다/)).toBeInTheDocument();
     expect(within(hero).getByText(/의견 분산 페널티로 HOLD 강등/)).toBeInTheDocument();
   });
 
@@ -681,10 +681,68 @@ describe("verdict-path helpers (#1257)", () => {
     });
   });
 
-  it("deriveActionSource: 미지의 소스 값은 fallback 경로로", async () => {
+  it("deriveActionSource: 미지의 소스는 unknown — 가중 합의로 둔갑 금지 (codex P2)", async () => {
     const { deriveActionSource } = await import("@/app/decisions/verdict-path");
-    expect(deriveActionSource({ final_action_source: "future_mechanism" }, "일반 합의")).toBe("weighted_sum");
+    expect(deriveActionSource({ final_action_source: "future_mechanism" }, "일반 합의")).toBe("unknown");
     expect(deriveActionSource(null, "리스크 에이전트 거부권 발동: x")).toBe("risk_veto");
     expect(deriveActionSource(null, null)).toBe("weighted_sum");
+  });
+
+  it("verdictSplit + 히어로 분포는 live 패널 기준 (codex P1)", async () => {
+    const { verdictSplit } = await import("@/app/decisions/verdict-path");
+    expect(verdictSplit([{ action: "SELL" }, { action: "BUY" }, { action: "HOLD" }])).toEqual({
+      buy: 1,
+      sell: 1,
+      rest: 1,
+    });
+  });
+});
+
+describe("DecisionProvenance — codex ship-review 수정 잠금 (#1257)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    notFoundMock.mockClear();
+  });
+
+  it("P1: 히어로 분포가 degraded 를 세지 않는다 — live 패널 기준", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      action: "SELL",
+      reasoning: "리스크 에이전트 거부권 발동: 손절선 돌파",
+      agent_verdicts: JSON.stringify([
+        { agent_name: "risk", action: "SELL", confidence: 100, reasoning: "손절선 돌파" },
+        { agent_name: "options", action: "BUY", confidence: 86, reasoning: "PCR" },
+        { agent_name: "smart_money", action: "HOLD", confidence: 30, reasoning: "데이터 없음" },
+        { agent_name: "crypto", action: "HOLD", confidence: 0, reasoning: "무관" },
+      ]),
+      scoring_detail: JSON.stringify({
+        final_action_source: "risk_veto",
+        degraded_agents: ["smart_money", "crypto"],
+        panel_coverage: 0.5,
+      }),
+      thesis: null,
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const hero = screen.getByTestId("verdict-hero");
+    // degraded 2명(HOLD 자리표시자)이 빠져야 함: live = SELL 1 · BUY 1 · 중립 0
+    expect(within(hero).getByText(/SELL 1 · BUY 1 · 중립 0/)).toBeInTheDocument();
+  });
+
+  it("P2: 백엔드가 모르는 판정 소스 → unknown 히어로 (가중 합의로 오표기 금지)", async () => {
+    mockFetchAPI = vi.fn().mockResolvedValue({
+      ...mockDetail,
+      scoring_detail: JSON.stringify({ final_action_source: "quantum_override" }),
+    });
+    const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+    await act(async () => {
+      render(await DecisionProvenance({ id: "531" }));
+    });
+    const hero = screen.getByTestId("verdict-hero");
+    expect(hero.dataset.source).toBe("unknown");
+    expect(within(hero).getByText(/판정 경로를 해석할 수 없습니다/)).toBeInTheDocument();
+    expect(within(hero).getByText(/quantum_override/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -179,12 +179,16 @@ export async function DecisionProvenance({ id }: { id: string }) {
   // #1257 판정 경로 — scoring_detail(#1256) 우선, 과거 행은 reasoning 프리픽스 fallback.
   const sd = parseScoringDetail(d.scoring_detail);
   const actionSource = deriveActionSource(sd, d.reasoning);
-  const split = verdictSplit(verdicts);
   // "데이터 없음 ≠ 중립" (#1028) — degraded 명단은 scoring_detail 에만 있으므로
   // 과거 행은 분리 없이 기존 평면 리스트를 유지한다 (fallback 으로 지어내지 않는다).
   const degradedNames = new Set(sd?.degraded_agents ?? []);
   const liveVerdicts = verdicts.filter((v) => !degradedNames.has(v.agent_name));
   const degradedVerdicts = verdicts.filter((v) => degradedNames.has(v.agent_name));
+  // 히어로 분포는 **live 패널 기준** — 백엔드 합의 산식(scoring.py)이 degraded 를
+  // 분자·분모에서 빼는 것과 동형이어야 panel_coverage 와 화면이 서로 모순되지 않는다
+  // (codex ship review P1). degraded 분리가 없는 과거 행은 live == 전체라 기존과 동일.
+  const split = verdictSplit(liveVerdicts);
+  const splitRestLabel = degradedVerdicts.length > 0 ? "중립" : "중립/무의견";
   const agreementPct = d.agreement_rate === null ? null : Math.round(d.agreement_rate * 100);
 
   return (
@@ -217,22 +221,30 @@ export async function DecisionProvenance({ id }: { id: string }) {
             {actionSource === "risk_veto" && DECISIONS.HERO_VETO_TITLE}
             {actionSource === "divergence_penalty" && DECISIONS.HERO_PENALTY_TITLE}
             {actionSource === "weighted_sum" && DECISIONS.HERO_WEIGHTED_TITLE}
+            {actionSource === "unknown" && (
+              <>
+                {DECISIONS.HERO_UNKNOWN_TITLE}
+                {typeof sd?.final_action_source === "string" && (
+                  <span className="ml-2 text-[10px] font-mono text-muted-foreground">({sd.final_action_source})</span>
+                )}
+              </>
+            )}
           </p>
           {actionSource === "risk_veto" ? (
             <div className="grid gap-3 md:grid-cols-2">
               <div className="rounded bg-muted/40 px-3 py-2.5 space-y-1.5 opacity-80">
                 <p className="text-[10px] text-muted-foreground">{DECISIONS.HERO_CONSENSUS_REF}</p>
                 <div className="flex h-2 rounded-full overflow-hidden" aria-hidden="true">
-                  {verdicts.length > 0 && (
+                  {liveVerdicts.length > 0 && (
                     <>
-                      <div className="bg-rose-500/70" style={{ width: `${(split.sell / verdicts.length) * 100}%` }} />
-                      <div className="bg-emerald-500/70" style={{ width: `${(split.buy / verdicts.length) * 100}%` }} />
-                      <div className="bg-muted-foreground/30" style={{ width: `${(split.rest / verdicts.length) * 100}%` }} />
+                      <div className="bg-rose-500/70" style={{ width: `${(split.sell / liveVerdicts.length) * 100}%` }} />
+                      <div className="bg-emerald-500/70" style={{ width: `${(split.buy / liveVerdicts.length) * 100}%` }} />
+                      <div className="bg-muted-foreground/30" style={{ width: `${(split.rest / liveVerdicts.length) * 100}%` }} />
                     </>
                   )}
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  SELL {split.sell} · BUY {split.buy} · 중립/무의견 {split.rest}
+                  SELL {split.sell} · BUY {split.buy} · {splitRestLabel} {split.rest}
                   {agreementPct !== null && ` — ${DECISIONS.HERO_AGREEMENT_LABEL} ${agreementPct}%`}
                 </p>
               </div>
@@ -248,16 +260,16 @@ export async function DecisionProvenance({ id }: { id: string }) {
           ) : (
             <div className="rounded bg-muted/40 px-3 py-2.5 space-y-1.5">
               <div className="flex h-2 rounded-full overflow-hidden" aria-hidden="true">
-                {verdicts.length > 0 && (
+                {liveVerdicts.length > 0 && (
                   <>
-                    <div className="bg-rose-500/70" style={{ width: `${(split.sell / verdicts.length) * 100}%` }} />
-                    <div className="bg-emerald-500/70" style={{ width: `${(split.buy / verdicts.length) * 100}%` }} />
-                    <div className="bg-muted-foreground/30" style={{ width: `${(split.rest / verdicts.length) * 100}%` }} />
+                    <div className="bg-rose-500/70" style={{ width: `${(split.sell / liveVerdicts.length) * 100}%` }} />
+                    <div className="bg-emerald-500/70" style={{ width: `${(split.buy / liveVerdicts.length) * 100}%` }} />
+                    <div className="bg-muted-foreground/30" style={{ width: `${(split.rest / liveVerdicts.length) * 100}%` }} />
                   </>
                 )}
               </div>
               <p className="text-xs text-muted-foreground">
-                SELL {split.sell} · BUY {split.buy} · 중립/무의견 {split.rest}
+                SELL {split.sell} · BUY {split.buy} · {splitRestLabel} {split.rest}
                 {agreementPct !== null && ` — ${DECISIONS.HERO_AGREEMENT_LABEL} ${agreementPct}%`}
               </p>
               {actionSource === "divergence_penalty" && d.reasoning && (

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -224,9 +224,8 @@ export async function DecisionProvenance({ id }: { id: string }) {
             {actionSource === "unknown" && (
               <>
                 {DECISIONS.HERO_UNKNOWN_TITLE}
-                {typeof sd?.final_action_source === "string" && (
-                  <span className="ml-2 text-[10px] font-mono text-muted-foreground">({sd.final_action_source})</span>
-                )}
+                {/* unknown 은 정의상 sd.final_action_source 가 비어있지 않은 문자열일 때만 나온다 */}
+                <span className="ml-2 text-[10px] font-mono text-muted-foreground">({String(sd?.final_action_source)})</span>
               </>
             )}
           </p>

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -9,6 +9,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { Metric } from "@/components/ui/metric";
 import { formatMoney } from "@/lib/format";
 import { OUTCOME_TAG, adjudicationInfo, fmtFixed, parseDetailKV, todayKst } from "@/app/decisions/helpers";
+import { deriveActionSource, parseScoringDetail, verdictSplit } from "@/app/decisions/verdict-path";
 import { DECISIONS } from "@/lib/strings";
 
 // === Types ===
@@ -120,6 +121,8 @@ interface DecisionDetail {
   pnl_90d: number | null;
   outcome: string;
   reasoning: string | null;
+  // #1256 부터 persist — 그 이전 행은 null (판정 소스는 reasoning 프리픽스 fallback)
+  scoring_detail: string | Record<string, unknown> | null;
   evidence: Evidence[];
   // 결정 시점(`date`)에 유효했던 논지 — point-in-time 조인이라 논지를 나중에 써도
   // 그 이전 결정들에 소급해 붙는다. 논지가 없으면 null.
@@ -173,6 +176,17 @@ export async function DecisionProvenance({ id }: { id: string }) {
   const outcomeTag = OUTCOME_TAG[d.outcome] ?? OUTCOME_TAG.pending;
   const adj = adjudicationInfo(d.date, d.outcome, todayKst());
 
+  // #1257 판정 경로 — scoring_detail(#1256) 우선, 과거 행은 reasoning 프리픽스 fallback.
+  const sd = parseScoringDetail(d.scoring_detail);
+  const actionSource = deriveActionSource(sd, d.reasoning);
+  const split = verdictSplit(verdicts);
+  // "데이터 없음 ≠ 중립" (#1028) — degraded 명단은 scoring_detail 에만 있으므로
+  // 과거 행은 분리 없이 기존 평면 리스트를 유지한다 (fallback 으로 지어내지 않는다).
+  const degradedNames = new Set(sd?.degraded_agents ?? []);
+  const liveVerdicts = verdicts.filter((v) => !degradedNames.has(v.agent_name));
+  const degradedVerdicts = verdicts.filter((v) => degradedNames.has(v.agent_name));
+  const agreementPct = d.agreement_rate === null ? null : Math.round(d.agreement_rate * 100);
+
   return (
     <div className="space-y-5">
       {/* Header */}
@@ -195,10 +209,102 @@ export async function DecisionProvenance({ id }: { id: string }) {
         </span>
       </div>
 
-      {/* #1216 2컬럼: 본문(논지·근거·판정·증거) 2/3 + 우측 레일(frozen 컨텍스트) 1/3.
-          lg 미만은 레일이 먼저 오는 세로 스택 — 숫자 컨텍스트를 훑고 본문으로. */}
+      {/* #1257 판정 경로 히어로 — 판정 소스별 3변형. veto 는 "합의 vs 그것을 덮은 규칙"
+          대차대조, 나머지는 단일 칸. conf 100 · agreement 20% 가 모순처럼 보이던 문제의 해소. */}
+      <Card className="bg-card border-border" data-testid="verdict-hero" data-source={actionSource}>
+        <CardContent className="pt-4 pb-4 space-y-3">
+          <p className="text-sm font-semibold text-foreground">
+            {actionSource === "risk_veto" && DECISIONS.HERO_VETO_TITLE}
+            {actionSource === "divergence_penalty" && DECISIONS.HERO_PENALTY_TITLE}
+            {actionSource === "weighted_sum" && DECISIONS.HERO_WEIGHTED_TITLE}
+          </p>
+          {actionSource === "risk_veto" ? (
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="rounded bg-muted/40 px-3 py-2.5 space-y-1.5 opacity-80">
+                <p className="text-[10px] text-muted-foreground">{DECISIONS.HERO_CONSENSUS_REF}</p>
+                <div className="flex h-2 rounded-full overflow-hidden" aria-hidden="true">
+                  {verdicts.length > 0 && (
+                    <>
+                      <div className="bg-rose-500/70" style={{ width: `${(split.sell / verdicts.length) * 100}%` }} />
+                      <div className="bg-emerald-500/70" style={{ width: `${(split.buy / verdicts.length) * 100}%` }} />
+                      <div className="bg-muted-foreground/30" style={{ width: `${(split.rest / verdicts.length) * 100}%` }} />
+                    </>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  SELL {split.sell} · BUY {split.buy} · 중립/무의견 {split.rest}
+                  {agreementPct !== null && ` — ${DECISIONS.HERO_AGREEMENT_LABEL} ${agreementPct}%`}
+                </p>
+              </div>
+              <div className="rounded border border-rose-500/30 bg-rose-500/5 px-3 py-2.5 space-y-1">
+                <p className="text-[10px] text-rose-400 font-medium">{DECISIONS.HERO_DECIDER_VETO}</p>
+                <p className="text-sm font-semibold text-foreground">
+                  {d.action} · {d.confidence === null ? "—" : Math.round(d.confidence)}
+                </p>
+                {d.reasoning && <p className="text-xs text-foreground/80">{d.reasoning}</p>}
+                <p className="text-[10px] text-muted-foreground">{DECISIONS.HERO_CONF_NOTE}</p>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded bg-muted/40 px-3 py-2.5 space-y-1.5">
+              <div className="flex h-2 rounded-full overflow-hidden" aria-hidden="true">
+                {verdicts.length > 0 && (
+                  <>
+                    <div className="bg-rose-500/70" style={{ width: `${(split.sell / verdicts.length) * 100}%` }} />
+                    <div className="bg-emerald-500/70" style={{ width: `${(split.buy / verdicts.length) * 100}%` }} />
+                    <div className="bg-muted-foreground/30" style={{ width: `${(split.rest / verdicts.length) * 100}%` }} />
+                  </>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                SELL {split.sell} · BUY {split.buy} · 중립/무의견 {split.rest}
+                {agreementPct !== null && ` — ${DECISIONS.HERO_AGREEMENT_LABEL} ${agreementPct}%`}
+              </p>
+              {actionSource === "divergence_penalty" && d.reasoning && (
+                <p className="text-xs text-foreground/80">{d.reasoning}</p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* #1257 판정 후 새 사실 — 자동 반영은 P1. 부재를 정직하게 표시해야 "제품이
+          회피한다" 는 인상을 막는다 (와이어프레임 v2 codex 검토 #3). */}
+      <Card className="bg-card border-border" data-testid="post-decision-facts">
+        <CardContent className="pt-4 pb-3">
+          <p className="text-[10px] text-muted-foreground mb-1">{DECISIONS.NEW_FACTS_TITLE}</p>
+          <p className="text-xs text-muted-foreground">{DECISIONS.NEW_FACTS_EMPTY}</p>
+        </CardContent>
+      </Card>
+
+      {/* #1257 재검토 체크 — 사실 확인 목록. 매매 권고를 내지 않는다 (invariants). */}
+      <Card className="bg-card border-border" data-testid="recheck-list">
+        <CardContent className="pt-4 pb-3 space-y-2">
+          <div className="flex items-baseline justify-between">
+            <p className="text-[10px] text-muted-foreground">{DECISIONS.RECHECK_TITLE}</p>
+            <span className="text-[10px] text-muted-foreground/70">{DECISIONS.RECHECK_NOTE}</span>
+          </div>
+          <div className="grid gap-2 md:grid-cols-3">
+            <div className="rounded bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">
+              {DECISIONS.RECHECK_STOP}
+              {d.stop_loss !== null && (
+                <span className="block text-[10px] text-muted-foreground font-mono tabular-nums mt-0.5">
+                  {formatMoney(d.stop_loss, { ticker: d.ticker })}
+                </span>
+              )}
+            </div>
+            <div className="rounded bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">{DECISIONS.RECHECK_VOL}</div>
+            <div className="rounded bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">{DECISIONS.RECHECK_THESIS}</div>
+          </div>
+          <p className="text-[10px] text-muted-foreground/60">{DECISIONS.RECHECK_PIT}</p>
+        </CardContent>
+      </Card>
+
+      {/* #1216 2컬럼: 본문(판정·논지·증거) 2/3 + 우측 레일(frozen 컨텍스트) 1/3.
+          #1257: 모바일에서도 본문(히어로가 위에서 답한 "왜" 의 상세)이 먼저 —
+          숫자 레일이 앞서던 순서는 이해 우선 원칙으로 교체 (와이어프레임 v2). */}
       <div className="grid gap-5 lg:grid-cols-3 items-start">
-      <div className="space-y-5 lg:order-2" data-testid="decision-rail">
+      <div className="space-y-5 order-2" data-testid="decision-rail">
 
       {/* Decision-time context (frozen) — #1216: vix 21.040000915… 류 raw float 종결 */}
       <Card className="bg-card border-border">
@@ -215,16 +321,28 @@ export async function DecisionProvenance({ id }: { id: string }) {
         </CardContent>
       </Card>
 
-      {/* Price ladder — #1216: formatMoney 로 ₩/$ 판정 (.KS 204000 → ₩204,000) */}
-      <Card className="bg-card border-border">
+      {/* Price ladder — #1216: formatMoney 로 ₩/$ 판정 (.KS 204000 → ₩204,000).
+          #1257: SELL 은 별도 템플릿 — 매수 사다리(Entry/T1/T2)를 SELL 판정에 그리던
+          액션-템플릿 불일치 종결. 결정 시점 가격 + 손절 기준선만 남긴다. */}
+      <Card className="bg-card border-border" data-testid="price-card">
         <CardContent className="pt-4 pb-3">
           <p className="text-[10px] text-muted-foreground mb-3">{DECISIONS.RAIL_PRICES}</p>
-          <div className="grid grid-cols-2 gap-3">
-            <Metric label="Entry" value={formatMoney(d.entry_price, { ticker: d.ticker })} />
-            <Metric label="Stop" value={formatMoney(d.stop_loss, { ticker: d.ticker })} color="red" />
-            <Metric label="Target 1" value={formatMoney(d.target_1, { ticker: d.ticker })} color="green" />
-            <Metric label="Target 2" value={formatMoney(d.target_2, { ticker: d.ticker })} color="green" />
-          </div>
+          {d.action === "SELL" ? (
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-3">
+                <Metric label={DECISIONS.PRICE_AT_DECISION} value={formatMoney(d.entry_price, { ticker: d.ticker })} />
+                <Metric label="Stop" value={formatMoney(d.stop_loss, { ticker: d.ticker })} color="red" />
+              </div>
+              <p className="text-[10px] text-muted-foreground/70">{DECISIONS.SELL_PRICE_NOTE}</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-3">
+              <Metric label="Entry" value={formatMoney(d.entry_price, { ticker: d.ticker })} />
+              <Metric label="Stop" value={formatMoney(d.stop_loss, { ticker: d.ticker })} color="red" />
+              <Metric label="Target 1" value={formatMoney(d.target_1, { ticker: d.ticker })} color="green" />
+              <Metric label="Target 2" value={formatMoney(d.target_2, { ticker: d.ticker })} color="green" />
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -242,7 +360,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
       </Card>
       </div>
 
-      <div className="space-y-5 lg:col-span-2 lg:order-1">
+      <div className="space-y-5 lg:col-span-2 order-1">
 
       {/* Thesis — 상승/하락 논리 병기 (#1083). 없으면 카드 자체를 숨기지 않고
           "아직 없음" 을 보여준다: 논지가 비어 있다는 사실이 곧 판단 근거의 부재라
@@ -267,9 +385,18 @@ export async function DecisionProvenance({ id }: { id: string }) {
             )}
           </div>
           {!d.thesis ? (
-            <p className="text-xs text-muted-foreground">
-              이 시점에 기록된 논지 없음 — 무엇이 맞으면 이 판단이 옳고 무엇이 틀리면 그른지가 남아 있지 않다.
-            </p>
+            actionSource === "risk_veto" ? (
+              // #1257: 규칙 판정(veto)은 논지가 없어도 채점 기준이 있다 — 자동 논지 렌더.
+              // DB 쓰기 없음: 파생 표시일 뿐 theses 원장은 건드리지 않는다.
+              <div className="rounded bg-muted/40 px-2.5 py-2 space-y-1" data-testid="auto-thesis">
+                <p className="text-[10px] text-rose-400">{DECISIONS.AUTO_THESIS_TITLE}</p>
+                <p className="text-xs text-foreground/90">{DECISIONS.AUTO_THESIS_BODY}</p>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                이 시점에 기록된 논지 없음 — 무엇이 맞으면 이 판단이 옳고 무엇이 틀리면 그른지가 남아 있지 않다.
+              </p>
+            )
           ) : (
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-2">
@@ -339,8 +466,8 @@ export async function DecisionProvenance({ id }: { id: string }) {
         </CardContent>
       </Card>
 
-      {/* Reasoning */}
-      {d.reasoning && (
+      {/* Reasoning — veto 케이스는 히어로 우측 칸이 전문을 이미 보여주므로 중복 렌더 금지 */}
+      {d.reasoning && actionSource !== "risk_veto" && (
         <Card className="bg-card border-border">
           <CardContent className="pt-4 pb-3">
             <p className="text-[10px] text-muted-foreground mb-2">근거</p>
@@ -349,13 +476,24 @@ export async function DecisionProvenance({ id }: { id: string }) {
         </Card>
       )}
 
-      {/* Agent verdicts */}
+      {/* Agent verdicts — #1257 2단: 유효 의견 우선, 의견 미산출(degraded)은 접힘.
+          "데이터 없음" 이 HOLD 30% 로 중립처럼 보이던 문제(#1028 의 UI 대응) 종결.
+          degraded 명단은 scoring_detail(#1256)에만 있어 과거 행은 기존 평면 리스트 유지. */}
       {verdicts.length > 0 && (
         <Card className="bg-card border-border">
           <CardContent className="pt-4 pb-3">
-            <p className="text-[10px] text-muted-foreground mb-3">에이전트 판정 ({verdicts.length})</p>
+            <p className="text-[10px] text-muted-foreground mb-3">
+              {degradedVerdicts.length > 0
+                ? `${DECISIONS.AGENTS_LIVE_TITLE} ${liveVerdicts.length}`
+                : `에이전트 판정 (${verdicts.length})`}
+              {typeof sd?.panel_coverage === "number" && (
+                <span className="ml-2 text-muted-foreground/70">
+                  {DECISIONS.AGENTS_COVERAGE_LABEL} {Math.round(sd.panel_coverage * 100)}%
+                </span>
+              )}
+            </p>
             <div className="space-y-1.5">
-              {verdicts.map((v, i) => (
+              {liveVerdicts.map((v, i) => (
                 <div key={i} className="flex items-center gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
                   <span className="w-28 shrink-0 text-muted-foreground">{v.agent_name}</span>
                   <StatusBadge status={v.action} />
@@ -367,6 +505,25 @@ export async function DecisionProvenance({ id }: { id: string }) {
                   )}
                 </div>
               ))}
+              {degradedVerdicts.length > 0 && (
+                <details data-testid="degraded-agents">
+                  <summary className="text-[11px] text-muted-foreground cursor-pointer px-2.5 py-1.5">
+                    {DECISIONS.AGENTS_DEGRADED_SUMMARY} {degradedVerdicts.length} —{" "}
+                    {degradedVerdicts.map((v) => v.agent_name).join(" · ")}{" "}
+                    <span className="text-muted-foreground/60">({DECISIONS.AGENTS_DEGRADED_NOTE})</span>
+                  </summary>
+                  <div className="space-y-1.5 mt-1.5">
+                    {degradedVerdicts.map((v, i) => (
+                      <div key={i} className="flex items-center gap-2 text-xs bg-muted/20 rounded px-2.5 py-1.5 opacity-70">
+                        <span className="w-28 shrink-0 text-muted-foreground">{v.agent_name}</span>
+                        {typeof v.reasoning === "string" && (
+                          <span className="truncate text-muted-foreground">{v.reasoning}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </details>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/app/decisions/verdict-path.ts
+++ b/frontend/src/app/decisions/verdict-path.ts
@@ -1,0 +1,53 @@
+// #1257: 판정 경로 파생 — "왜 이 판정·이 확신도인가" 를 재구성하는 순수 헬퍼.
+// 정본은 백엔드 scoring_detail(final_action_source, #1256 부터 persist)이고,
+// 그 이전 387행은 reasoning 프리픽스 파싱으로 fallback 한다.
+
+export interface ScoringDetail {
+  final_action_source?: "risk_veto" | "divergence_penalty" | "weighted_sum" | string;
+  degraded_agents?: string[];
+  panel_coverage?: number;
+  risk_veto_fired?: boolean;
+  penalty_applied?: boolean;
+  pre_penalty_action?: string;
+  [key: string]: unknown;
+}
+
+// 백엔드 scoring.py 가 veto 발동 시 reasoning 앞에 붙이는 고정 프리픽스 —
+// scoring_detail 이 없는 과거 행의 유일한 판정 소스 신호.
+export const VETO_REASONING_PREFIX = "리스크 에이전트 거부권 발동";
+
+export type ActionSource = "risk_veto" | "divergence_penalty" | "weighted_sum";
+
+// scoring_detail 은 SELECT * 경유라 JSON 문자열로 도착한다 — 안전 파싱.
+export function parseScoringDetail(raw: unknown): ScoringDetail | null {
+  let obj: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (obj == null || typeof obj !== "object" || Array.isArray(obj)) return null;
+  return obj as ScoringDetail;
+}
+
+// 판정 소스 파생. scoring_detail 우선, 과거 행은 reasoning 프리픽스 fallback,
+// 그 외에는 기본 경로(weighted_sum) — 셋 중 하나로 반드시 수렴한다.
+export function deriveActionSource(sd: ScoringDetail | null, reasoning: string | null): ActionSource {
+  const src = sd?.final_action_source;
+  if (src === "risk_veto" || src === "divergence_penalty" || src === "weighted_sum") return src;
+  if (reasoning?.startsWith(VETO_REASONING_PREFIX)) return "risk_veto";
+  return "weighted_sum";
+}
+
+// 합의 분포 (BUY/SELL/중립·무의견) — 히어로의 분포 바 입력.
+export function verdictSplit(verdicts: { action: string }[]): { buy: number; sell: number; rest: number } {
+  let buy = 0;
+  let sell = 0;
+  for (const v of verdicts) {
+    if (v.action === "BUY") buy += 1;
+    else if (v.action === "SELL") sell += 1;
+  }
+  return { buy, sell, rest: verdicts.length - buy - sell };
+}

--- a/frontend/src/app/decisions/verdict-path.ts
+++ b/frontend/src/app/decisions/verdict-path.ts
@@ -16,7 +16,9 @@ export interface ScoringDetail {
 // scoring_detail 이 없는 과거 행의 유일한 판정 소스 신호.
 export const VETO_REASONING_PREFIX = "리스크 에이전트 거부권 발동";
 
-export type ActionSource = "risk_veto" | "divergence_penalty" | "weighted_sum";
+// "unknown" — 백엔드가 미래에 4번째 메커니즘을 추가했을 때 weighted_sum 으로
+// 조용히 오표기하지 않기 위한 정직한 fallback (codex ship review P2).
+export type ActionSource = "risk_veto" | "divergence_penalty" | "weighted_sum" | "unknown";
 
 // scoring_detail 은 SELECT * 경유라 JSON 문자열로 도착한다 — 안전 파싱.
 export function parseScoringDetail(raw: unknown): ScoringDetail | null {
@@ -32,11 +34,13 @@ export function parseScoringDetail(raw: unknown): ScoringDetail | null {
   return obj as ScoringDetail;
 }
 
-// 판정 소스 파생. scoring_detail 우선, 과거 행은 reasoning 프리픽스 fallback,
-// 그 외에는 기본 경로(weighted_sum) — 셋 중 하나로 반드시 수렴한다.
+// 판정 소스 파생. scoring_detail 우선, 과거 행(소스 필드 부재)은 reasoning 프리픽스
+// fallback → weighted_sum. 소스 필드가 **있는데 모르는 값**이면 "unknown" — 새 메커니즘을
+// 가중 합의로 둔갑시키지 않는다.
 export function deriveActionSource(sd: ScoringDetail | null, reasoning: string | null): ActionSource {
   const src = sd?.final_action_source;
   if (src === "risk_veto" || src === "divergence_penalty" || src === "weighted_sum") return src;
+  if (typeof src === "string" && src.length > 0) return "unknown";
   if (reasoning?.startsWith(VETO_REASONING_PREFIX)) return "risk_veto";
   return "weighted_sum";
 }

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -310,6 +310,37 @@ export const DECISIONS = {
   RAIL_CONTEXT: "결정 시점 컨텍스트 (frozen)",
   RAIL_PRICES: "가격 레벨",
   RAIL_PNL: "실현 결과 (forward PnL %)",
+  // #1257 판정 경로 히어로 — 판정 소스(final_action_source)별 3변형. 일상어 원칙:
+  // "합의 불성립"/"mechanical rung" 같은 시스템 은어 금지 (와이어프레임 v2 codex 검토).
+  HERO_VETO_TITLE: "의견은 갈렸지만, 손실 관리 규칙이 이 판정을 자동 확정했습니다",
+  HERO_PENALTY_TITLE: "에이전트 의견이 크게 갈려 확신도를 낮췄습니다",
+  HERO_WEIGHTED_TITLE: "에이전트 가중 합의가 이 판정을 만들었습니다",
+  HERO_CONSENSUS_REF: "에이전트 합의 — 참고용 (최종 판정에 미반영)",
+  HERO_DECIDER_VETO: "최종 판정을 확정한 것 — 손실 관리 규칙 (리스크 거부권)",
+  HERO_CONF_NOTE: "확신도는 규칙의 확신도 — 에이전트 일치율과 다른 수치인 이유",
+  HERO_AGREEMENT_LABEL: "일치율",
+  // 판정 후 새 사실 슬롯 — P1(이벤트 수집기) 전까지는 부재를 정직하게 표시
+  NEW_FACTS_TITLE: "판정 이후 새로 생긴 사실",
+  NEW_FACTS_EMPTY: "공시·기업 이벤트 자동 반영은 아직 없습니다 — 새 정보가 있다면 아래 재검토 체크로 판단하세요.",
+  // 재검토 체크 — 사실 확인이지 매매 권고가 아니다 (invariants: no ad-hoc calls)
+  RECHECK_TITLE: "이 판단을 재검토하려면 확인할 것",
+  RECHECK_NOTE: "사실 체크 — 매매 권고 아님",
+  RECHECK_STOP: "가격이 손절 기준선 위로 복귀했는가",
+  RECHECK_VOL: "판정 근거의 리스크 조건이 해소됐는가",
+  RECHECK_THESIS: "새 정보가 투자 논지를 무효화하는가",
+  RECHECK_PIT: "기준값은 현재 규칙 기준 재구성 — 판정 당시 규칙 스냅샷이 아님",
+  // SELL 은 매수 사다리(Entry/T1/T2)를 렌더하지 않는다 — 액션별 별도 템플릿
+  SELL_PRICE_NOTE: "SELL 판정 — 매수 사다리(Target)는 적용되지 않습니다",
+  PRICE_AT_DECISION: "결정 시점 가격",
+  // 에이전트 2단 — "데이터 없음 ≠ 중립" (#1028 semantics 를 UI 로)
+  AGENTS_LIVE_TITLE: "에이전트 판정 — 유효 의견",
+  AGENTS_COVERAGE_LABEL: "패널 커버리지",
+  AGENTS_DEGRADED_SUMMARY: "의견 미산출",
+  AGENTS_DEGRADED_NOTE: "가중치 0 — 합의에 미반영",
+  // 규칙 판정(veto)인데 논지가 없으면 자동 논지 렌더 — 채점 기준의 공백 방지
+  AUTO_THESIS_TITLE: "자동 논지 (손절 규율 집행)",
+  AUTO_THESIS_BODY:
+    "손절 규칙에 따른 기계적 청산. 맞으면 — 청산 후 추가 하락을 피한다. 틀리면 — 반등분을 놓친다. 판정일에 실현 결과로 채점.",
 } as const;
 
 /* ── Pipeline Page ──────────────────────────────────────────── */

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -313,8 +313,11 @@ export const DECISIONS = {
   // #1257 판정 경로 히어로 — 판정 소스(final_action_source)별 3변형. 일상어 원칙:
   // "합의 불성립"/"mechanical rung" 같은 시스템 은어 금지 (와이어프레임 v2 codex 검토).
   HERO_VETO_TITLE: "의견은 갈렸지만, 손실 관리 규칙이 이 판정을 자동 확정했습니다",
-  HERO_PENALTY_TITLE: "에이전트 의견이 크게 갈려 확신도를 낮췄습니다",
+  // 엔진은 확신도가 아니라 **판정(액션)을 보수적으로 강등**한다 (scoring.py divergence
+  // penalty — codex ship review P2: "확신도를 낮췄다" 는 SSoT 불일치)
+  HERO_PENALTY_TITLE: "에이전트 의견이 크게 갈려 판정을 보수적으로 강등했습니다",
   HERO_WEIGHTED_TITLE: "에이전트 가중 합의가 이 판정을 만들었습니다",
+  HERO_UNKNOWN_TITLE: "판정 경로를 해석할 수 없습니다 — 화면이 모르는 새 판정 메커니즘",
   HERO_CONSENSUS_REF: "에이전트 합의 — 참고용 (최종 판정에 미반영)",
   HERO_DECIDER_VETO: "최종 판정을 확정한 것 — 손실 관리 규칙 (리스크 거부권)",
   HERO_CONF_NOTE: "확신도는 규칙의 확신도 — 에이전트 일치율과 다른 수치인 이유",


### PR DESCRIPTION
## Summary

Closes #1257. 승인된 와이어프레임 v2(https://claude.ai/code/artifact/ad830690-62b4-48d9-ba5b-c9269fe7daee) 구현 — 결정 상세를 입력 덤프에서 논증 구조로.

- **판정 경로 히어로**: `scoring_detail.final_action_source` 별 변형 — risk_veto(대차대조: 합의 참고 vs 확정 규칙) / divergence_penalty / weighted_sum / **unknown**(새 메커니즘을 가중 합의로 오표기 금지). 과거 행(#1256 이전 387행)은 reasoning 프리픽스 파싱 fallback. conf 100 · agreement 20% 모순 해소.
- **판정 후 새 사실** 슬롯 (P0: 정직한 부재 표시, 자동 수집은 P1) + **재검토 체크리스트** (사실 3종, PIT 한계 라벨, 매매 권고 아님).
- **SELL/BUY 별도 가격 템플릿** — SELL에 매수 사다리(Entry/T1/T2) 렌더 종결.
- **에이전트 2단**: live 우선 + degraded 접힘(가중치 0 표기) + panel_coverage. 과거 행은 평면 유지(지어내지 않음). 히어로 분포도 live 패널 기준(scoring.py 산식과 동형).
- **자동 논지**: veto+논지 없음 → 파생 표시 (DB 무변).
- 모바일 본문 우선 (#1216 레일-우선 순서 교체, 와이어프레임 승인 사항).

codex 리뷰 2회: 와이어프레임 APPROVE_WITH_CHANGES(8건 반영) → diff 리뷰 P1/P2 3건 수정(live-panel split, unknown source, penalty 카피 SSoT).

## Test plan

- decision-detail.test.tsx 38/38 (히어로 4변형 · fallback 파싱 · SELL 템플릿 · 2단/평면 · 자동 논지 게이트 · P1/P2 잠금)
- 전체 vitest 1621/1621 · eslint · `next build` green
- 라이브 QA: /decisions/724 (구 행 fallback 경로) 스크린샷 — 와이어프레임과 일치, 콘솔 무에러

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YZnW13r4XRCrfvQqnSQFN