### PR TITLE
docs: sync frontend/e2e counts + decisions verdict-path convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 
 ## Project Stats
 
-Measured against `main` on 2026-08-25. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
+Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
 
 | Metric | Value | |
 |--------|-------|---|
 | **Backend tests** | 7,557 collected across 348 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,606 across 134 files — 100% statement coverage | |
-| **E2E tests** | 87 across 9 Playwright specs | |
+| **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
+| **E2E tests** | 89 across 10 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,557 backend tests across 348 files + 1606 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,557 backend tests across 348 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1606 tests, 134 files)
+npm run test           # vitest run (1622 tests, 134 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -40,6 +40,19 @@ Client Components: `/report` (LLM generation), `/pipeline` (ReactFlow DAG), `/po
 **VerdictBanner** (오늘의 답, 첫 픽셀 #1207) → Hero (4 stats) → RegimeShiftBanner(조건부) → **ActionItems 밀집 테이블 2/3 + SystemHealthRail·MacroEventsCard 1/3** (#1209) → market/events strips → CompositionSection (가로 스택 바 + tabs, #1210) → Holdings table (top 8) → **OpportunityExplorer** (상위 3개 + /scan 링크) → CoverageStatus (`<details>` 접힘, #1210) → footer.
 
 Data flows through `summarizeHoldings()` in `src/lib/holdings-summary.ts`. Action data from `/api/actions`, `/api/opportunities`, `/api/market-context`.
+
+## Decision Detail (#1257 논증 구조)
+
+`/decisions/[id]` 는 판정 소스별 히어로로 시작한다 — `scoring_detail.final_action_source`
+(`risk_veto` 대차대조 / `divergence_penalty` / `weighted_sum` / **`unknown`** — 화면이 모르는
+새 메커니즘을 가중 합의로 둔갑시키지 않는 정직 fallback). 파생 로직은
+`src/app/decisions/verdict-path.ts` 가 단일 소스: #1258 이전 행(scoring_detail NULL)은
+reasoning 프리픽스(`리스크 에이전트 거부권 발동`) 파싱으로만 veto 를 복원하고, degraded
+에이전트 분리는 **지어내지 않는다** (평면 리스트 유지). 히어로 분포·에이전트 2단은
+live 패널 기준 — 백엔드 합의 산식(scoring.py, degraded 를 분자·분모에서 제외)과 동형이어야
+같은 화면의 `panel_coverage` 와 모순되지 않는다. SELL 은 매수 사다리(Entry/T1/T2)를 렌더하지
+않는 별도 템플릿. **Test:** `src/__tests__/pages/decision-detail.test.tsx` "판정 경로 (#1257)"
++ "codex ship-review 수정 잠금" describe 블록.
 
 ## Auth
 


### PR DESCRIPTION
## Summary

#1248/#1249/#1258/#1259 릴리즈 후 문서 동기화 (/document-release).

- **수치 실측 동기화**: frontend vitest 1,606 → **1,622** (README · frontend/CLAUDE.md · ARCHITECTURE), E2E **87/9 → 89/10** (README — 다른 두 문서는 이미 89/10, README 만 낡아 있었음. 정본: `npx playwright test --list` = "89 tests in 10 files"). Stats 기준일 08-25 → 08-27.
- **frontend/CLAUDE.md 신규 섹션 "Decision Detail (#1257 논증 구조)"**: 판정 소스별 히어로 4변형, verdict-path.ts SSoT, 과거 행 fallback 원칙(degraded 지어내지 않기), live 패널 기준 산식 동형성, SELL 별도 템플릿 — Gotcha-Test Pair 인용 포함.
- decisions 테이블의 scoring_detail 서술(ARCHITECTURE §DB)은 #1258 로 이제 사실이 됨 — 무변경.

문서 부채(참고, 이번 범위 밖): "판정 후 새 사실" 슬롯의 P1 이벤트 수집기 설계는 이슈 본문에만 있음 — 구현 시 ARCHITECTURE 반영.

## Test plan

- `make verify-doc-counts` 22/22 · privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YZnW13r4XRCrfvQqnSQFN