### PR TITLE
fix(test): seed_e2e_db macro_events 형태 정합 — 숫자 sentiment + 실제 카테고리 어휘

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,557 collected across 348 files | |
+| **Backend tests** | 7,560 collected across 349 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,557 backend tests across 348 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,560 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,557 tests, 348 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,560 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/dev/seed_e2e_db.py
+++ b/scripts/dev/seed_e2e_db.py
@@ -129,15 +129,25 @@ def seed(db: Path) -> dict[str, int]:
     counts["macro"] = upsert_macro(vix + fg + fx, db_path=db)
 
     # ── 매크로 이벤트: 최근 3일 내 발행 (action-first 스펙의 7d 신선도 요건) ──
+    #
+    # ⚠️ 형태는 **소비자에서 복사한다** (#1262). 이전 판은 두 축이 다 어긋나 있었고,
+    # 그 결과 CI e2e 전 구간에서 매크로/이벤트 스코어 체인이 죽은 채 89개 테스트가 돌았다:
+    #   1. `sentiment` 를 문자열("positive")로 썼다 — 스키마는 `REAL`(migration:480)이고 prod
+    #      5,062행은 전부 숫자다. SQLite 동적 타입이라 제약이 안 걸리고,
+    #      `event_score.py:142` 의 `abs(sentiment)` 가 TypeError 로 터진다 →
+    #      `compute_macro_score` → `map_regime_to_strategy` → `/api/rebalance` 가 **200 + error** 를 냈다.
+    #   2. 카테고리가 `event_score.CATEGORY_WEIGHT` 어휘 밖이었다 (교집합 0개). 타입만 고치면
+    #      `CATEGORY_WEIGHT.get(cat, 0.0)` 이 전부 0 을 줘서 예외는 없어지되 점수가 **정확히 0** 이다.
+    # 그래서 카테고리는 어휘에서, sentiment 는 prod 관측 범위(-0.9~0.9)에서 고른다.
     now = kst_now()
     events = []
     for i, (headline, category, sentiment) in enumerate(
         [
-            ("Fed keeps rates unchanged", "monetary_policy", "neutral"),
-            ("CPI comes in below forecast", "inflation", "positive"),
-            ("Chip sector guidance raised", "earnings", "positive"),
-            ("Oil supply disruption flagged", "commodities", "negative"),
-            ("Jobs report beats estimates", "employment", "positive"),
+            ("Central bank holds policy rate steady", "neutral", 0.05),
+            ("Inflation print lands below forecast", "fed_dovish", 0.45),
+            ("Chip sector guidance raised", "earnings_beat", 0.60),
+            ("Oil supply disruption flagged", "oil_supply_shock", -0.50),
+            ("Export volumes surge on strong demand", "export_surge", 0.70),
         ]
     ):
         events.append(

--- a/tests/scripts/test_seed_e2e_db.py
+++ b/tests/scripts/test_seed_e2e_db.py
@@ -1,0 +1,46 @@
+"""seed_e2e_db 의 macro_events 형태가 프로덕션과 일치하는지 잠근다 (#1262).
+
+왜 이 파일이 있나: 이전 seed 는 `macro_events.sentiment` 에 문자열("positive")을 쓰고
+카테고리도 `event_score.CATEGORY_WEIGHT` 어휘 밖 값을 썼다. 두 축 다 어긋난 채로
+CI `frontend-e2e` 가 3일 넘게 돌았고, 그동안 `/api/rebalance` 는 매 런마다
+`TypeError: bad operand type for abs(): 'str'` 로 죽어 200 + error 를 냈다.
+스키마가 `sentiment REAL` 이어도 SQLite 동적 타입이라 아무 제약도 안 걸린다.
+
+**"예외 안 남" 만으로는 부족하다** — 타입만 고치면 예외는 사라지지만
+`CATEGORY_WEIGHT.get(cat, 0.0)` 이 전부 0 을 줘서 점수가 정확히 0 이 된다.
+그래서 behavioral 잠금은 **0 이 아님**까지 단언한다.
+"""
+
+import pytest
+
+from nuri.core.db import query
+from nuri.quant.regime.event_score import CATEGORY_WEIGHT, compute_event_score
+from scripts.dev.seed_e2e_db import seed
+
+
+@pytest.fixture(scope="module")
+def seeded_db(tmp_path_factory):
+    """seed 는 수 초 걸리므로 모듈당 한 번만 만든다."""
+    db = tmp_path_factory.mktemp("seed_e2e") / "e2e.db"
+    seed(db)
+    return db
+
+
+class TestSeedMacroEventsShape:
+    def test_sentiment_is_numeric(self, seeded_db):
+        """스키마가 REAL 이라도 SQLite 는 TEXT 를 받는다 — 값의 타입을 직접 본다."""
+        rows = query("SELECT sentiment, typeof(sentiment) AS t FROM macro_events", db_path=seeded_db)
+        assert rows, "seed 가 macro_events 를 하나도 안 만들었다"
+        assert {r["t"] for r in rows} == {"real"}, f"sentiment 타입: {sorted({r['t'] for r in rows})}"
+
+    def test_categories_are_in_category_weight_vocabulary(self, seeded_db):
+        """어휘 밖 카테고리는 가중치 0 이라 점수에 기여하지 못한다."""
+        rows = query("SELECT DISTINCT category FROM macro_events", db_path=seeded_db)
+        unknown = sorted({r["category"] for r in rows} - set(CATEGORY_WEIGHT))
+        assert not unknown, f"CATEGORY_WEIGHT 어휘 밖: {unknown}"
+
+    def test_event_score_is_computable_and_nonzero(self, seeded_db):
+        """behavioral 잠금 — 타입-only 수정은 예외는 없애도 점수 0 을 남긴다."""
+        result = compute_event_score(db_path=seeded_db)
+        assert result.event_count > 0, "신뢰도 floor 에 전부 걸렸거나 lookback 밖이다"
+        assert result.score != 0.0, "카테고리가 어휘 밖이면 기여가 전부 0 이 되어 여기서 걸린다"


### PR DESCRIPTION
Closes #1262

## 문제

e2e seed 가 `macro_events` 를 **두 축 다 어긋난 형태**로 만들고 있었습니다. CI `frontend-e2e` 는 초록인데 그 뒤에서 매크로/이벤트 스코어 체인이 죽어 있었습니다.

**축 1 — `sentiment` 타입.** 스키마는 `sentiment REAL` (migration:480) 이고 prod 는 5,062행 전부 숫자인데, seed 는 `'positive'` / `'negative'` / `'neutral'` 문자열을 썼습니다. SQLite 동적 타입이라 제약이 안 걸립니다.

```
event_score.py:142   intensity = abs(sentiment) if abs(sentiment) > 0.01 else 0.5
TypeError: bad operand type for abs(): 'str'
```

`regime_aware_rebalance` → `map_regime_to_strategy` (strategy_map.py:223) → `compute_macro_score` (macro_score.py:326) → `compute_event_score` 로 터지고, `/api/rebalance` 가 이 예외를 삼켜 **HTTP 200 + `{"error": ...}`** 로 내보냈습니다 (routes/rebalance.py:27-29). 그래서 아무 게이트도 안 울렸습니다.

**축 2 — 카테고리 어휘.** seed 의 `monetary_policy` / `inflation` / `earnings` / `commodities` / `employment` 는 `event_score.CATEGORY_WEIGHT` (15개 어휘) 와 **교집합 0개** 입니다. `CATEGORY_WEIGHT.get(cat, 0.0)` 이라, 타입만 고치면 예외는 사라지되 모든 기여가 `0 × …` 이 되어 점수가 **정확히 0** 입니다. 두 축을 같이 고쳐야 체인이 살아납니다.

## 재현 (실 DB vs seed DB, 같은 코드)

```
실 dev DB : regime_aware_rebalance('rp')  → OK, 17 actions
             regime_aware_rebalance('mvo') → OK, 17 actions
seed DB   : regime_aware_rebalance('rp')  → TypeError: bad operand type for abs(): 'str'
```

CI 로그에도 2026-08-25 · 08-26 main run 양쪽에 동일하게 찍혀 있습니다:

```
[WebServer] ERROR rebalance computation failed
[WebServer] TypeError: bad operand type for abs(): 'str'
```

## 수정

카테고리는 `CATEGORY_WEIGHT` 어휘에서, `sentiment` 는 prod 관측 범위(-0.9 ~ 0.9)에서 고릅니다. 헤드라인도 카테고리에 맞게 조정했습니다 (합성 · privacy-safe 유지).

수정 후:

```
sentiment typeof → real (5/5)
compute_event_score  → 8.6      (이전: TypeError)
compute_macro_score  → 70.3
regime_aware_rebalance → 4 actions
```

## Gotcha-Test Pair

`tests/scripts/test_seed_e2e_db.py::TestSeedMacroEventsShape` — 구조 2 + 동작 1.

**"예외 안 남" 만으로는 부족합니다.** 타입만 고친 상태도 예외 없이 통과하므로, 동작 잠금은 **점수가 0 이 아님**까지 단언합니다.

뮤테이션 실측 (커밋 후 축별로 따로, 끝에 baseline 재확인):

| 뮤테이션 | 결과 |
|---|---|
| `sentiment` → 문자열 (카테고리 유지) | **2 failed** (`test_sentiment_is_numeric`, `test_event_score_is_computable_and_nonzero`) |
| 카테고리 → 어휘 밖 (숫자 유지) | **2 failed** (`test_categories_are_in_category_weight_vocabulary`, `test_event_score_is_computable_and_nonzero`) — `score=0.0`, `category_breakdown={'monetary_policy': 0.0, ...}` |
| baseline 복원 | 3 passed |

## 검증

- `make test-fast` → 7,527 passed / 6 skipped (rc=0)
- `make verify-doc-counts` → 22 passed (테스트 파일 1개 추가분 `make sync-doc-counts` 반영)
- `make diagnostics` → rc=0

## 스코프 밖

- `/api/rebalance` 가 예외를 200 으로 삼키는 문제 (#1250 과 같은 클래스) — 별도
- `compute_event_score` 타입 가드 — 두면 이 종류의 seed 오염이 다시 조용해지므로 seed 정합을 먼저 둡니다
- e2e `/explore` 검색 flaky (#1255)
