### PR TITLE
test(engine): regime 잠금 실질화 — 삼켜지던 단언 + 살아남던 뮤턴트 3종

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,565 collected across 349 files | |
+| **Backend tests** | 7,567 collected across 349 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,565 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,567 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,565 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,567 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -473,8 +473,17 @@ class TestRegimeFallsBackToClassifier:
         예외가 `BaseException` 을 직접 상속하는 것도 같은 이유이고, 거기 결론이
         "삼켜지는 백스톱은 백스톱이 아니다" 다.
 
-        그래서 스텁은 **다른 canonical regime 을 반환**한다. fallback 이 이벤트 값을
-        덮으면 그 값이 나타나 단언이 깨진다.
+        여기서 잠그는 성질은 **둘**이고, 둘 다 필요하다 (codex adversarial, 2026-08-28):
+          (a) 이벤트 값이 최종 저장값이다 — 스텁이 **다른 canonical regime 을 반환**하므로
+              fallback 이 덮으면 그 값이 나타나 단언이 깨진다.
+          (b) 이벤트가 있으면 분류기를 **호출조차 하지 않는다** — 호출 여부를 기록해
+              테스트 본문에서 단언한다. (a) 만으로는 "분류기를 먼저 부르고 대입만 가드
+              안에서" 하는 뮤턴트가 초록으로 남는다. `classify_regime` 은 SPY 200일
+              히스토리를 읽으므로 불필요한 호출 자체가 회귀다.
+
+        단언을 **프로덕션 try 블록 밖**에 두는 게 핵심이다. 이전 판은 스텁 안에서
+        `AssertionError` 를 던졌는데 그게 정확히 `except Exception: pass` 안이라 삼켜졌다.
+        기록은 스텁이 하고 판정은 테스트가 한다 — 삼켜질 자리가 없다.
         """
         import nuri.quant.regime.classifier as classifier
         from nuri.core.events import emit_event
@@ -482,11 +491,18 @@ class TestRegimeFallsBackToClassifier:
         class _State:
             regime = "bull_low_vol"  # 이벤트 값과 다른 canonical 값
 
+        calls: list = []
+
+        def _stub(db_path=None):
+            calls.append(db_path)
+            return _State()
+
         emit_event("regime_changed", payload={"regime": "bear_high_vol"}, db_path=db_path)
-        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: _State())
+        monkeypatch.setattr(classifier, "classify_regime", _stub)
         dec_id = self._record_one(db_path)
         row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
         assert row["regime"] == "bear_high_vol", "분류기 값이 이벤트 값을 덮었다 — 우선순위 역전"
+        assert calls == [], "이벤트가 있는데 분류기를 호출했다 — 가드가 대입만 막고 호출은 안 막는다"
 
     def test_classifier_failure_leaves_regime_null(self, db_path, monkeypatch):
         """분류기 실패는 soft-fail — 관측이 본 작업(기록)을 게이트하면 안 된다 (#894)."""

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -461,19 +461,32 @@ class TestRegimeFallsBackToClassifier:
         assert row["regime"] == "bull_low_vol"
 
     def test_event_still_wins_over_classifier(self, db_path, monkeypatch):
-        """이벤트가 있으면 그 값이 우선 — fallback 이 스냅샷 의미를 바꾸면 안 된다."""
+        """이벤트가 있으면 그 값이 우선 — fallback 이 스냅샷 의미를 바꾸면 안 된다.
+
+        ⚠️ 스텁은 **예외를 던지지 않는다.** 이전 판은 `AssertionError("classifier must not
+        be called")` 를 던졌는데, 프로덕션이 `decisions.py` 의 `except Exception: pass` 로
+        그걸 삼켜서 이벤트 값이 그대로 남고 단언이 통과했다 — 즉 **우선순위를 전혀
+        잠그지 못했다**. 뮤테이션 실측으로 확인: `if not context.get("regime"):` 를
+        `if True:` 로 바꿔도 3 passed, fallback 이 이벤트 값을 덮어쓰게 바꿔도 3 passed.
+
+        레포는 이 교훈을 이미 갖고 있다 (`tests/CLAUDE.md`): `_forbid_production_db` 의
+        예외가 `BaseException` 을 직접 상속하는 것도 같은 이유이고, 거기 결론이
+        "삼켜지는 백스톱은 백스톱이 아니다" 다.
+
+        그래서 스텁은 **다른 canonical regime 을 반환**한다. fallback 이 이벤트 값을
+        덮으면 그 값이 나타나 단언이 깨진다.
+        """
         import nuri.quant.regime.classifier as classifier
         from nuri.core.events import emit_event
 
+        class _State:
+            regime = "bull_low_vol"  # 이벤트 값과 다른 canonical 값
+
         emit_event("regime_changed", payload={"regime": "bear_high_vol"}, db_path=db_path)
-        monkeypatch.setattr(
-            classifier,
-            "classify_regime",
-            lambda db_path=None: (_ for _ in ()).throw(AssertionError("classifier must not be called")),
-        )
+        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: _State())
         dec_id = self._record_one(db_path)
         row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
-        assert row["regime"] == "bear_high_vol"
+        assert row["regime"] == "bear_high_vol", "분류기 값이 이벤트 값을 덮었다 — 우선순위 역전"
 
     def test_classifier_failure_leaves_regime_null(self, db_path, monkeypatch):
         """분류기 실패는 soft-fail — 관측이 본 작업(기록)을 게이트하면 안 된다 (#894)."""

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -449,16 +449,78 @@ class TestRegimeFallsBackToClassifier:
         )
         return record_decision(result, db_path)
 
+    @staticmethod
+    def _state(regime: str):
+        """실 반환 타입으로 스텁한다 — bare class 는 형태가 갈라진다 (#1180 계열).
+
+        프로덕션은 오늘 `state.regime` 하나만 읽지만, 두 번째 속성을 읽는 순간
+        bare class 는 `AttributeError` 를 내고 그게 `except Exception: pass` 안이라
+        regime 이 조용히 NULL 이 된다 — 테스트는 "regime is None" 이라는 엉뚱한 이유로
+        깨진다. mock 형태는 실 함수 반환에서 복사한다.
+        """
+        from nuri.quant.regime.classifier import RegimeState
+
+        # base regime 은 `{trend}_{volatility}_vol`, special regime(recovery/euphoria/
+        # sector_rotation/stagflation)은 그 형태가 아니다 — 분해를 강제하면 스텁이
+        # ValueError 를 내고 그게 `except Exception: pass` 에 삼켜져 regime 이 조용히
+        # NULL 이 된다 (이 헬퍼를 처음 쓸 때 실제로 밟았다).
+        parts = regime.split("_")
+        return RegimeState(
+            date="2026-04-10",
+            trend=parts[0],
+            volatility=parts[1] if len(parts) >= 3 else "low",
+            regime=regime,
+            confidence=0.8,
+            details={},
+        )
+
+    def _recording_stub(self, regime: str, calls: list):
+        """호출을 기록하고 값을 돌려주는 스텁 — 판정은 테스트 본문이 한다."""
+
+        def _stub(db_path=None):
+            calls.append(db_path)
+            return self._state(regime)
+
+        return _stub
+
     def test_no_event_falls_back_to_classifier(self, db_path, monkeypatch):
+        """이벤트가 없으면 분류기 값이 저장되고, **db_path 가 그대로 전달된다.**
+
+        `calls == [db_path]` 가 배선까지 잠근다: `classify_regime(db_path=db_path)` 에서
+        인자를 떨어뜨리면(=격리 DB 대신 기본 DB 를 보게 되는 #1050 계열 누출) 여기서 FAIL.
+        구조 검사(`tests/core/test_db_path_forwarding.py`)는 이름 기반 sweep 이라
+        동작으로도 한 겹 잠근다.
+        """
         import nuri.quant.regime.classifier as classifier
 
-        class _State:
-            regime = "bull_low_vol"
-
-        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: _State())
+        calls: list = []
+        monkeypatch.setattr(classifier, "classify_regime", self._recording_stub("bull_low_vol", calls))
         dec_id = self._record_one(db_path)
         row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
         assert row["regime"] == "bull_low_vol"
+        assert calls == [db_path], f"db_path 가 분류기에 전달되지 않았다: {calls}"
+
+    def test_empty_payload_falls_through_to_classifier(self, db_path, monkeypatch):
+        """payload 에 regime 키가 없으면 분류기로 내려간다 — 가드는 **존재가 아니라 참**을 본다.
+
+        `decisions.py` 의 `payload.get("regime", payload.get("new_regime"))` 는 두 키가
+        다 없으면 **`None` 을 대입한다.** 그래서 키는 존재하고 값만 falsy 다. 가드를
+        `if "regime" not in context:` 로 바꾸면 이 행이 분류기를 건너뛰어 regime 이
+        영구 NULL 이 된다 — #1247 이 4.5개월 겪은 바로 그 증상이다.
+
+        Mutation lock: `if not context.get("regime"):` → `if "regime" not in context:` 로
+        바꾸면 FAIL (그 뮤턴트는 이 테스트가 없으면 61 passed 로 살아남는다).
+        """
+        import nuri.quant.regime.classifier as classifier
+        from nuri.core.events import emit_event
+
+        calls: list = []
+        emit_event("regime_changed", payload={}, db_path=db_path)
+        monkeypatch.setattr(classifier, "classify_regime", self._recording_stub("recovery", calls))
+        dec_id = self._record_one(db_path)
+        row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
+        assert row["regime"] == "recovery", "빈 payload 가 분류기 fallback 을 막았다"
+        assert calls == [db_path]
 
     def test_event_still_wins_over_classifier(self, db_path, monkeypatch):
         """이벤트가 있으면 그 값이 우선 — fallback 이 스냅샷 의미를 바꾸면 안 된다.
@@ -488,17 +550,10 @@ class TestRegimeFallsBackToClassifier:
         import nuri.quant.regime.classifier as classifier
         from nuri.core.events import emit_event
 
-        class _State:
-            regime = "bull_low_vol"  # 이벤트 값과 다른 canonical 값
-
         calls: list = []
-
-        def _stub(db_path=None):
-            calls.append(db_path)
-            return _State()
-
         emit_event("regime_changed", payload={"regime": "bear_high_vol"}, db_path=db_path)
-        monkeypatch.setattr(classifier, "classify_regime", _stub)
+        # 이벤트 값과 **다른** canonical 값을 돌려준다 — fallback 이 덮으면 값으로 드러난다.
+        monkeypatch.setattr(classifier, "classify_regime", self._recording_stub("bull_low_vol", calls))
         dec_id = self._record_one(db_path)
         row = query("SELECT regime FROM decisions WHERE id = ?", (dec_id,), db_path)[0]
         assert row["regime"] == "bear_high_vol", "분류기 값이 이벤트 값을 덮었다 — 우선순위 역전"
@@ -1082,6 +1137,26 @@ class TestSnapshotMarketContext:
         ctx = _snapshot_market_context(db_path=db_path)
         assert ctx["regime"] == "risk_on"
 
+    def test_latest_event_wins_over_older_one(self, db_path):
+        """이벤트가 여럿이면 **최신** 것이 이긴다 (`ORDER BY timestamp DESC`).
+
+        기존 테스트는 전부 이벤트를 1건만 넣어서 정렬 방향을 아무도 단언하지 않았다 —
+        `DESC` → `ASC` 뮤턴트가 62개 테스트를 통과했다 (2026-08-28 실측).
+        낡은 레짐이 최신 레짐을 이기면 frozen 컨텍스트가 조용히 과거를 가리킨다.
+        """
+        from nuri.trading.engine.decisions import _snapshot_market_context
+
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO pipeline_events (timestamp, event_type, payload) VALUES (?, ?, ?)",
+                [
+                    ("2026-04-09T10:00:00", "regime_changed", json.dumps({"regime": "bear_high_vol"})),
+                    ("2026-04-10T10:00:00", "regime_changed", json.dumps({"regime": "bull_low_vol"})),
+                ],
+            )
+        ctx = _snapshot_market_context(db_path=db_path)
+        assert ctx["regime"] == "bull_low_vol", "낡은 이벤트가 최신 이벤트를 이겼다 — 정렬 방향 역전"
+
     def test_regime_payload_new_regime_fallback(self, db_path):
         """Line 237: payload "regime" missing → fallback "new_regime" key."""
         from nuri.trading.engine.decisions import _snapshot_market_context
@@ -1094,8 +1169,9 @@ class TestSnapshotMarketContext:
         ctx = _snapshot_market_context(db_path=db_path)
         assert ctx["regime"] == "risk_off"
 
-    def test_regime_malformed_json_swallowed(self, db_path):
+    def test_regime_malformed_json_swallowed(self, db_path, monkeypatch):
         """Lines 238-239: invalid JSON payload → except branch, no crash, regime not set."""
+        import nuri.quant.regime.classifier as classifier
         from nuri.trading.engine.decisions import _snapshot_market_context
 
         with get_db(db_path) as conn:
@@ -1103,8 +1179,12 @@ class TestSnapshotMarketContext:
                 "INSERT INTO pipeline_events (timestamp, event_type, payload) VALUES (?, ?, ?)",
                 ("2026-04-10T10:00:00", "regime_changed", "not-json"),
             )
+        # #1256 이 fallback 을 추가한 뒤로 이 단언은 "빈 tmp DB 에 SPY 가 없어서 분류기가
+        # None 을 낸다" 는 **주변 상태**에 의존하게 됐다. 그 fixture 에 SPY 를 시드하는
+        # 순간 조용히 뒤집힌다 — 분류기를 명시적으로 죽여 파싱 실패만 보게 한다.
+        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: None)
         ctx = _snapshot_market_context(db_path=db_path)
-        assert "regime" not in ctx  # 파싱 실패 → 미설정
+        assert "regime" not in ctx  # 파싱 실패 → 미설정 (fallback 도 None)
 
     def test_macro_score_exception_swallowed(self, db_path, monkeypatch):
         """Lines 247-248: compute_macro_score raises → except, macro_score not set."""


### PR DESCRIPTION
Refs #1263

## 문제 — 잠금이 잠그는 게 없었다

`test_event_still_wins_over_classifier` 는 우선순위를 **전혀 잠그지 못했습니다.**

```python
lambda db_path=None: (_ for _ in ()).throw(AssertionError("classifier must not be called"))
```

스텁이 `AssertionError` 를 던지는데, 그게 하필 `nuri/trading/engine/decisions.py` 의 `except Exception: pass` **안**입니다. `AssertionError` 는 `Exception` 하위라 삼켜지고, 이벤트 값이 그대로 남아 단언이 통과합니다.

레포는 이 교훈을 이미 갖고 있습니다 — `tests/CLAUDE.md` 가 `_forbid_production_db` 의 예외를 `BaseException` 직접 상속으로 만든 이유를 적고 결론을 이렇게 냈습니다: **"삼켜지는 백스톱은 백스톱이 아니다."** 같은 실수가 다른 파일에서 재발했습니다.

## 뮤테이션 매트릭스 — 전후 실측

적대적 리뷰가 **모듈 61개 테스트 전체**에 대해 돌렸습니다 (클래스만 돌리면 형제 테스트가 잡아주는 걸 이 클래스 공으로 오인합니다).

| 프로덕션 뮤테이션 | 이전 | 이후 |
|---|---|---|
| `if not context.get("regime"):` → `if True:` | 통과 ❌ | **FAIL** ✅ |
| → `if False:` (fallback 삭제) | FAIL ✅ | FAIL ✅ |
| 분류기를 먼저 호출, 대입만 가드 안에서 | 통과 ❌ | **FAIL** ✅ |
| `if not context.get("regime"):` → `if "regime" not in context:` | 통과 ❌ | **FAIL** ✅ |
| `classify_regime(db_path=db_path)` → `classify_regime()` | 통과 ❌ | **FAIL** ✅ |
| `ORDER BY timestamp DESC` → `ASC` | 통과 ❌ | **FAIL** ✅ |
| `except Exception` → `except ValueError` | FAIL ✅ | FAIL ✅ |

## 무엇을 고쳤나

**1. 단언을 프로덕션 try 블록 밖으로.** 스텁은 호출을 **기록**만 하고 판정은 테스트 본문이 합니다. 삼켜질 자리가 없습니다.

```python
calls: list = []
def _stub(db_path=None):
    calls.append(db_path); return self._state(regime)
...
assert calls == [], "이벤트가 있는데 분류기를 호출했다"
```

성질 **둘**을 잠급니다: (a) 이벤트 값이 최종 저장값, (b) 이벤트가 있으면 분류기를 **호출조차 안 함**. (b)가 원래 raising 스텁이 노리던 성질이고, `classify_regime()` 은 SPY 200일 히스토리를 읽으므로 불필요한 호출 자체가 회귀입니다.

**2. 빈 payload → 분류기 fallback** (`test_empty_payload_falls_through_to_classifier`). `payload.get("regime", payload.get("new_regime"))` 는 두 키가 다 없으면 **`None` 을 대입**합니다 — 키는 존재하고 값만 falsy 입니다. 가드를 존재 검사로 바꾸면 이 행이 분류기를 건너뛰어 regime 이 영구 NULL 이 됩니다. **#1247 이 4.5개월 겪은 바로 그 증상**입니다.

**3. `assert calls == [db_path]`** — `db_path` 배선을 동작으로 잠급니다. `tests/core/test_db_path_forwarding.py` 가 구조로 잡지만 이름 기반 sweep 이라 한 겹 더 둡니다. #1050 계열(격리 DB 를 넘겼는데 한 줄만 기본 DB 로 새는) 누출 형태입니다.

**4. 최신 이벤트 우선** (`test_latest_event_wins_over_older_one`). 기존 테스트가 전부 이벤트를 1건만 넣어 정렬 방향을 아무도 단언하지 않았습니다.

**5. 스텁이 실 `RegimeState` 를 반환.** bare class 는 두 번째 속성을 읽는 순간 `AttributeError` → `except Exception: pass` 에 삼켜짐 → regime 조용히 NULL → 테스트가 "regime is None" 이라는 **엉뚱한 이유**로 깨집니다. 레포의 mock-shape 규칙 그대로이고, 헬퍼를 쓰다 **실제로 밟았습니다** — 첫 판이 `regime.split("_")` 를 3개로 언팩해서 `recovery` 같은 special regime 에서 `ValueError` 를 냈고 정확히 그 misleading NULL 이 나왔습니다.

**6. 인접 time-bomb 제거.** `test_regime_malformed_json_swallowed` 의 `assert "regime" not in ctx` 는 #1256 이 fallback 을 추가한 뒤로 **"빈 tmp DB 에 SPY 가 없다"는 주변 사실**에 의존하게 됐습니다. 그 fixture 에 SPY 를 시드하면 조용히 뒤집힙니다. 분류기를 명시적으로 죽여 파싱 실패만 보게 했습니다.

## 스코프에서 뺀 것 — 죽은 `regime_changed` 읽기 제거

이슈는 읽기 제거도 포함했지만 **드롭합니다.** 방법론이 반증을 냈습니다: 잠금을 유효하게 만든 뒤 읽기를 제거하니 그 잠금이 FAIL 했습니다. 즉 그건 "아무것도 안 하는 죽은 코드"가 아니라 **"생산자가 없는 살아있는 코드"** 이고, 제거는 동작 변경입니다.

유지 근거:
- 비용은 decision 1건당 인덱스 쿼리 1회 (하루 18회)
- 오해 소지는 이미 in-place 해소 — 바로 아래 #1256 주석이 "dev/prod 모두 0건" 을 명시
- NULL 이라는 *결과* 는 #1261 신선도 정책이 감시
- `CLAUDE.md §2/§3` (Simplicity First · Surgical Changes)

## 파생 이슈

**#1268** — writer 3곳 중 `decisions.py:265` 만 `canonical_regime_or_none()` 가드를 안 거칩니다 (`tracker.py:94,204`·`persistence.py:46` 은 거침). 사전 존재 결함이라 분리했습니다.

## 검증

- `make test-fast` → 7,534 passed / 6 skipped (rc=0)
- `make verify-doc-counts` · `make diagnostics` · `check_privacy_leak.py` → 전부 rc=0
- 적대적 패스 2종 (codex + Claude 서브에이전트). codex High 1건 수용·수정, Medium/Low 2건은 근거와 함께 무변경
