### PR TITLE
fix(tests): busday_offset roll="forward" — seed must invert busday_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,567 collected across 349 files | |
+| **Backend tests** | 7,611 collected across 349 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,611 collected across 349 files | |
+| **Backend tests** | 7,625 collected across 349 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,611 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,625 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,567 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,611 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,567 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,611 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,611 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,625 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -161,6 +161,30 @@ conftest 전역 mock 은 **yfinance 만** 커버. `MacroCollector.collect()` 는
 **Test:** `tests/trading/recommend/test_tracker.py::TestTrackerTrackOutcomes::test_90d_tracking`
 — `rich_db` 를 리터럴 시작일로 되돌리면 FAIL (2026-08-05~08-10 실제로 FAIL 상태였다).
 
+**3차 발생 (2026-08-29) — 리터럴이 아니라 *역함수를 틀린* 변종** (#1270). 위 두 건을 고치며
+시드를 `today_kst()` 앵커 + 영업일 계산으로 바꿨는데, 그 짝을
+`np.busday_offset(today, -n, roll="backward")` 로 썼다. 프로덕션은 나이를
+`np.busday_count(observed, today)` 로 재므로 시드는 그 **역함수**여야 하는데,
+`roll="backward"` 는 **오늘이 휴장일이면 롤 자체가 영업일 1일을 소비**해 왕복이 `n+1` 이
+된다. 결과: "임계 이내" 로 시드한 경계 행이 임계를 넘어 `None` 이 되고, `make test-fast` 가
+**토·일에만** 2건 빨간불 (`test_vix_within_max_age_is_still_used` ·
+`test_fresh_row_is_used`). `roll="forward"` 가 7요일 전부 왕복 일치한다.
+- **더 낡게 시드하는 테스트(`-(MAX+1)`)는 주말에도 통과**한다 — 결함이 *경계* 테스트에만
+  나타나서 요일이 바뀌기 전까지 아무 신호가 없었다.
+- 이건 dead gate 가 아니라 **false-red** 다. 코드와 무관한 빨간불은 빨간불을 무시하는
+  습관을 만든다는 점에서 같은 값이 나온다.
+**Test:** `tests/trading/recommend/test_buy_candidate_emitter.py::TestBusinessDaysAgoIsTheInverseOfBusdayCount`
++ `tests/quant/test_factors_composite.py::TestBusinessDaysAgoIsTheInverseOfBusdayCount`
+— 7요일 × n 왕복 잠금. `forward` → `backward` 로 되돌리면 **요일과 무관하게** FAIL.
+파일마다 따로 두는 이유는 2차 발생의 교훈 그대로다(한 경로만 잠그면 나머지는 무방비).
+
+⚠️ 이 잠금을 짜면서 **문자열 타깃 monkeypatch 가 조용히 no-op** 인 것도 같이 밟았다.
+`monkeypatch.setattr("tests.trading.recommend.test_buy_candidate_emitter.today_kst", …)` 는
+`tests/` 가 패키지가 아니라 같은 파일의 *두 번째 사본*을 import 해 거기를 패치한다 —
+실행 중인 사본은 그대로다. 증상이 특이하다: 평일 앵커 15개가 전부 FAIL 하고 주말 앵커만
+통과했다(진짜 오늘이 토요일이라). **모듈 객체를 직접 잡을 것**:
+`monkeypatch.setattr(sys.modules[__name__], "today_kst", …)`.
+
 ### 문서 fixer 를 실제 레포에서 돌리는 테스트
 `scripts/doc/sync_doc_counts.sh` 는 검사기가 아니라 **in-place fixer** 다. `tests/verify/` 의
 테스트가 이걸 `REPO_ROOT` env override 없이 실행하면 **백엔드 테스트를 돌릴 때마다 실제

--- a/tests/quant/test_factors_composite.py
+++ b/tests/quant/test_factors_composite.py
@@ -1,5 +1,6 @@
 """Tests for factors_composite — split from test_quant_all.py."""
 
+import sys
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -17,6 +18,19 @@ from tests.quant._helpers import (  # noqa: F401
     _seed_prices,
     _seed_spy_data,
 )
+
+
+def _business_days_ago(n: int) -> str:
+    """n **영업일** 전 날짜 — 프로덕션 `busday_count(observed, today)` 의 역함수 (#1270).
+
+    `roll="forward"` 여야 한다. `"backward"` 는 오늘이 휴장일이면 롤이 영업일 1일을
+    먹어 왕복이 `n+1` 이 되고, 경계 시드가 임계를 넘겨 **토·일에만** 노후로 떨어진다.
+    2026-08-29(토) 에 `test_fresh_row_is_used` 가 실제로 이렇게 깨졌다.
+
+    인라인 표현식을 헬퍼로 뽑은 이유: 같은 식이 두 곳에 복제돼 있어서 한쪽만 고치면
+    나머지가 남는다 — 이 결함이 애초에 두 파일에서 동시에 터진 형태다.
+    """
+    return str(np.busday_offset(today_kst(), -n, roll="forward"))
 
 
 class TestComposite:
@@ -217,7 +231,7 @@ class TestSentimentIsNotFabricated:
         path = tmp_path / "s.db"
         init_db(path)
         monkeypatch.setattr(db_mod, "DB_PATH", path)
-        stale = str(np.busday_offset(today_kst(), -(comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS + 1), roll="backward"))
+        stale = _business_days_ago(comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS + 1)
         upsert_macro([{"indicator": "fear_greed", "date": stale, "value": 42.0, "source": "test"}], path)
         assert comp._market_sentiment() is None
 
@@ -229,7 +243,7 @@ class TestSentimentIsNotFabricated:
         path = tmp_path / "s.db"
         init_db(path)
         monkeypatch.setattr(db_mod, "DB_PATH", path)
-        fresh = str(np.busday_offset(today_kst(), -comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS, roll="backward"))
+        fresh = _business_days_ago(comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS)
         upsert_macro([{"indicator": "fear_greed", "date": fresh, "value": 63.7, "source": "test"}], path)
         assert comp._market_sentiment() == pytest.approx(0.637)
 
@@ -328,3 +342,32 @@ class TestFactorDateIsAMarketDate:
 
         with get_db(db_path_mp) as conn:
             assert [r[0] for r in conn.execute("SELECT DISTINCT date FROM factors").fetchall()] == [today_kst()]
+
+
+class TestBusinessDaysAgoIsTheInverseOfBusdayCount:
+    """시드 헬퍼는 `_market_sentiment` 의 나이 계산의 **역함수**여야 한다 (#1270).
+
+    잠금을 이 파일에도 따로 두는 이유: `tests/CLAUDE.md` "Time-bomb seed dates" 2차
+    발생의 교훈이 그대로 적용된다 — *규칙 하나에 잠금이 한 경로만 걸려 있으면 나머지
+    경로는 무방비다.* emitter 쪽 잠금은 이 파일의 헬퍼를 보지 않는다.
+    """
+
+    @pytest.mark.parametrize(
+        "anchor",
+        ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28", "2026-08-29", "2026-08-30"],
+    )
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_round_trip_holds_on_every_weekday(self, anchor, n, monkeypatch):
+        """Mutation lock: `roll="forward"` → `"backward"` 로 되돌리면 토·일에서 FAIL."""
+        # 문자열 타깃은 `tests/` 가 패키지가 아니라 조용히 no-op 이 된다 — 모듈 객체로.
+        monkeypatch.setattr(sys.modules[__name__], "today_kst", lambda: anchor)
+        age = int(np.busday_count(_business_days_ago(n), anchor))
+        assert age == n, f"{anchor} 기준 {n}영업일 전으로 시드했는데 나이가 {age} 로 읽힌다"
+
+    def test_boundary_seed_is_not_judged_stale(self, monkeypatch):
+        """임계와 같은 나이는 노후가 아니다 — `_market_sentiment` 가 `age > MAX` 로 판정."""
+        from nuri.quant.factors import composite as comp
+
+        monkeypatch.setattr(sys.modules[__name__], "today_kst", lambda: "2026-08-29")
+        age = int(np.busday_count(_business_days_ago(comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS), "2026-08-29"))
+        assert age <= comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS

--- a/tests/quant/test_factors_composite.py
+++ b/tests/quant/test_factors_composite.py
@@ -29,7 +29,13 @@ def _business_days_ago(n: int) -> str:
 
     인라인 표현식을 헬퍼로 뽑은 이유: 같은 식이 두 곳에 복제돼 있어서 한쪽만 고치면
     나머지가 남는다 — 이 결함이 애초에 두 파일에서 동시에 터진 형태다.
+
+    `n == 0` 은 특수 케이스다 (codex P3). 휴장일에 `busday_offset(today, 0, "forward")`
+    는 **다음** 영업일로 굴러가 왕복이 `-1` 이 된다 (2026-08-29 토 → 08-31 월, count=-1).
+    "오늘" 을 시드하려면 오늘을 그대로 줘야 한다.
     """
+    if n == 0:
+        return today_kst()
     return str(np.busday_offset(today_kst(), -n, roll="forward"))
 
 
@@ -356,7 +362,9 @@ class TestBusinessDaysAgoIsTheInverseOfBusdayCount:
         "anchor",
         ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28", "2026-08-29", "2026-08-30"],
     )
-    @pytest.mark.parametrize("n", [1, 2, 3])
+    # n=0 포함 — 휴장일에 `roll="forward"` 가 **다음** 영업일로 굴러가 왕복이 -1 이
+    # 되는 축이다 (codex P3). 가드 없이는 여기서만 드러난다.
+    @pytest.mark.parametrize("n", [0, 1, 2, 3])
     def test_round_trip_holds_on_every_weekday(self, anchor, n, monkeypatch):
         """Mutation lock: `roll="forward"` → `"backward"` 로 되돌리면 토·일에서 FAIL."""
         # 문자열 타깃은 `tests/` 가 패키지가 아니라 조용히 no-op 이 된다 — 모듈 객체로.
@@ -370,4 +378,6 @@ class TestBusinessDaysAgoIsTheInverseOfBusdayCount:
 
         monkeypatch.setattr(sys.modules[__name__], "today_kst", lambda: "2026-08-29")
         age = int(np.busday_count(_business_days_ago(comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS), "2026-08-29"))
-        assert age <= comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS
+        # 등식으로 조인다 — `<=` 만 두면 헬퍼가 "오늘"을 반환해도(age 0) 통과한다.
+        assert age == comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS
+        assert age <= comp.SENTIMENT_MAX_AGE_BUSINESS_DAYS, "판정이 `age > MAX` 라 임계와 같으면 유효"

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
 
 import numpy as np
@@ -128,10 +129,15 @@ def _seed_rsi(db_path, ticker: str, rsi: float):
 def _business_days_ago(n: int) -> str:
     """n **영업일** 전 날짜. 판정이 영업일 기준이라 시드도 그래야 한다 —
     달력일로 빼면 요일에 따라 영업일 수가 달라져 테스트가 요일 의존으로 flaky 해진다.
+
+    ⚠️ `roll="forward"` 다 (#1270). 프로덕션은 나이를 `busday_count(observed, today)` 로
+    재므로 이 헬퍼는 그 **역함수**여야 하는데, `roll="backward"` 는 오늘이 휴장일이면
+    롤 자체가 영업일 1일을 먹어 왕복이 `n+1` 이 된다. 그래서 경계 시드가 임계를 넘겨
+    **토·일에만** 노후로 떨어졌다. `forward` 는 7요일 전부 왕복 일치한다.
     """
     if n == 0:
         return today_kst()
-    return str(np.busday_offset(today_kst(), -n, roll="backward"))
+    return str(np.busday_offset(today_kst(), -n, roll="forward"))
 
 
 def _seed_vix(db_path, value: float, *, days_old: int = 0):
@@ -840,3 +846,41 @@ def test_draft_thesis_counts_as_absent(db, cfg_path):
     res = emit_buy_candidates(config_path=cfg_path)
     assert res.candidates
     assert res.candidates[0].thesis is None
+
+
+class TestBusinessDaysAgoIsTheInverseOfBusdayCount:
+    """시드 헬퍼는 프로덕션 나이 계산의 **역함수**여야 한다 (#1270).
+
+    `vix_gate.latest_vix` 는 `np.busday_count(observed, today)` 로 나이를 잰다.
+    헬퍼가 그 역함수가 아니면 "임계 이내" 로 시드한 행이 임계를 넘어버려,
+    경계 테스트가 **코드와 무관하게** 특정 요일에만 빨간불이 된다.
+
+    `roll="backward"` 는 오늘이 휴장일일 때 롤이 영업일 1일을 소비해 왕복이
+    `n+1` 이 됐다 — 2026-08-29(토) 에 `test_vix_within_max_age_is_still_used` 가
+    실제로 이렇게 깨졌다. 요일 의존이라 평일에는 5/7 확률로 조용했다.
+    """
+
+    # 월~일 전부. 요일 하나만 보면 그게 하필 통과하는 요일일 수 있다.
+    @pytest.mark.parametrize(
+        "anchor",
+        ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28", "2026-08-29", "2026-08-30"],
+    )
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_round_trip_holds_on_every_weekday(self, anchor, n, monkeypatch):
+        """Mutation lock: `roll="forward"` → `"backward"` 로 되돌리면 토·일에서 FAIL."""
+        # ⚠️ 문자열 타깃(`"tests.trading...today_kst"`)은 여기서 **조용히 no-op** 이다.
+        # `tests/` 가 패키지가 아니라 이 모듈이 다른 이름으로 로드돼 있고, 문자열은
+        # 같은 파일의 *두 번째 사본*을 import 해 거기를 패치한다 — 실행 중인 사본은
+        # 그대로다. 실제로 그렇게 짰다가 평일 앵커 15개가 전부 FAIL 했다
+        # (`today_kst` 가 진짜 오늘을 계속 반환). `sys.modules[__name__]` 은 실행 중인
+        # 사본 자신이라 이름 규칙과 무관하다 (tests/CLAUDE.md "conftest import 경로").
+        monkeypatch.setattr(sys.modules[__name__], "today_kst", lambda: anchor)
+        seeded = _business_days_ago(n)
+        age = int(np.busday_count(seeded, anchor))
+        assert age == n, f"{anchor} 기준 {n}영업일 전으로 시드했는데 나이가 {age} 로 읽힌다"
+
+    def test_boundary_seed_is_not_judged_stale(self, monkeypatch):
+        """임계와 같은 나이는 노후가 아니다 — 게이트가 `age > MAX` 로 판정하므로."""
+        monkeypatch.setattr(sys.modules[__name__], "today_kst", lambda: "2026-08-29")
+        age = int(np.busday_count(_business_days_ago(VIX_MAX_AGE_BUSINESS_DAYS), "2026-08-29"))
+        assert age <= VIX_MAX_AGE_BUSINESS_DAYS

--- a/tests/trading/recommend/test_buy_candidate_emitter.py
+++ b/tests/trading/recommend/test_buy_candidate_emitter.py
@@ -865,7 +865,9 @@ class TestBusinessDaysAgoIsTheInverseOfBusdayCount:
         "anchor",
         ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28", "2026-08-29", "2026-08-30"],
     )
-    @pytest.mark.parametrize("n", [1, 2, 3])
+    # n=0 포함 — 휴장일에 `roll="forward"` 가 **다음** 영업일로 굴러가 왕복이 -1 이
+    # 되는 축이다 (codex P3). 가드 없이는 여기서만 드러난다.
+    @pytest.mark.parametrize("n", [0, 1, 2, 3])
     def test_round_trip_holds_on_every_weekday(self, anchor, n, monkeypatch):
         """Mutation lock: `roll="forward"` → `"backward"` 로 되돌리면 토·일에서 FAIL."""
         # ⚠️ 문자열 타깃(`"tests.trading...today_kst"`)은 여기서 **조용히 no-op** 이다.
@@ -883,4 +885,7 @@ class TestBusinessDaysAgoIsTheInverseOfBusdayCount:
         """임계와 같은 나이는 노후가 아니다 — 게이트가 `age > MAX` 로 판정하므로."""
         monkeypatch.setattr(sys.modules[__name__], "today_kst", lambda: "2026-08-29")
         age = int(np.busday_count(_business_days_ago(VIX_MAX_AGE_BUSINESS_DAYS), "2026-08-29"))
-        assert age <= VIX_MAX_AGE_BUSINESS_DAYS
+        # 부등식이 아니라 **등식**이다. `age <= MAX` 는 헬퍼가 "오늘"을 반환해도(age 0)
+        # 통과한다 — 노후 판정을 재는 게 아니라 통과 여부만 재는 약한 단언이 된다.
+        assert age == VIX_MAX_AGE_BUSINESS_DAYS
+        assert age <= VIX_MAX_AGE_BUSINESS_DAYS, "게이트는 `age > MAX` 로 판정 — 임계와 같으면 유효"


### PR DESCRIPTION
Closes #1270

## 증상 — 주말에만 빨간불

`make test-fast` 가 **토·일에만** 2건 실패합니다. 2026-08-29(토) 실측:

```
FAILED tests/quant/test_factors_composite.py::TestSentimentIsNotFabricated::test_fresh_row_is_used
FAILED tests/trading/recommend/test_buy_candidate_emitter.py::test_vix_within_max_age_is_still_used
```

`main`(e0106746) 의 detached worktree 에서 **동일 재현** — 특정 PR 회귀가 아니라 잠복 결함입니다. #1255 를 검증하다 나왔고, 그 PR 의 CI 도 오늘이면 이걸로 막힙니다.

## 근본 원인 — 역함수가 아닌 짝

프로덕션은 나이를 `np.busday_count(observed, today)` 로 잽니다 (`vix_gate.py:66`, `composite._market_sentiment`). 테스트 시드는 그 **역함수**여야 하는데 `np.busday_offset(today, -n, roll="backward")` 를 썼습니다.

`roll="backward"` 는 **오늘이 휴장일이면 롤 자체가 영업일 1일을 소비**합니다. 왕복이 `n` 이 아니라 `n+1` 이 되고, "임계 이내" 로 시드한 경계 행이 임계를 넘겨 `None`(미상)으로 떨어집니다.

7요일 왕복 실측 (n=2):

| 오늘 | backward → count | forward → count |
|---|---|---|
| 월~금 | **2** ✅ | **2** ✅ |
| 토 2026-08-29 | 2026-08-26 → **3** ❌ | 2026-08-27 → **2** ✅ |
| 일 2026-08-30 | 2026-08-26 → **3** ❌ | 2026-08-27 → **2** ✅ |

`roll="forward"` 가 7/7 요일 왕복 일치합니다.

**프로덕션 코드는 무변경** — `busday_count` 쪽이 옳습니다. 고칠 것은 시드뿐입니다.

## 왜 오래 조용했나

더 낡게 시드하는 짝(`-(MAX+1)`)은 주말에도 통과합니다 — 더 낡게 만들면 여전히 낡음이라. 그래서 결함이 **경계 테스트에만** 나타나고, 요일이 바뀌기 전까지 신호가 없었습니다.

dead gate 가 아니라 **false-red** 입니다. 코드와 무관한 빨간불은 빨간불을 무시하는 습관을 만든다는 점에서 결과값이 같습니다.

## 계보 — Time-bomb seed dates 3차 발생

`tests/CLAUDE.md` 의 기존 2건은 *리터럴 절대일*이었고, 그걸 고치며 `today_kst()` 앵커 + 영업일 계산으로 바꾼 게 이 코드입니다. 헬퍼 docstring 이 "달력일로 빼면 요일 의존으로 flaky 해진다" 고 적어뒀는데 — **달력일 flakiness 는 고쳤지만 roll 방향을 틀려 주말 flakiness 를 새로 넣었습니다.**

## 변경

`roll="forward"` 3곳. composite 의 인라인 표현식 2곳은 모듈 헬퍼로 뽑았습니다 — 같은 식이 복제돼 있던 게 이 결함이 두 파일에서 동시에 터진 이유입니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

파일마다 **따로** 잠급니다. `tests/CLAUDE.md` Time-bomb 2차 발생의 교훈 그대로입니다 — *"규칙 하나에 잠금이 한 경로만 걸려 있으면 나머지 경로는 무방비다."* emitter 쪽 잠금은 composite 의 헬퍼를 보지 않습니다.

| 뮤테이션 (호출부만) | 결과 |
|---|---|
| `test_buy_candidate_emitter.py` → `roll="backward"` | **8 FAIL** |
| `test_factors_composite.py` → `roll="backward"` | **8 FAIL** |
| `test_buy_candidate_emitter.py` → `n == 0` 가드 제거 | **2 FAIL** |
| `test_factors_composite.py` → `n == 0` 가드 제거 | **2 FAIL** |
| baseline 복원 | 120 passed |

잠금은 7요일 앵커를 `today_kst` monkeypatch 로 고정하므로 **실제 요일과 무관하게** 발화합니다 (8 = 주말 앵커 6 + 경계 1 + 원래 깨지던 신선도 1).

⚠️ 뮤테이션 1차 시도는 `roll="forward"` 를 단순 치환하려다 **assert 가 막았습니다** — 그 문자열이 독스트링에도 있어 3건이었습니다. 호출부 전문으로 좁혀 다시 쟀습니다.

## codex 리뷰 — [P3] 1건 수용

> `_business_days_ago()` is now documented as the inverse of `busday_count`, but unlike the emitter copy it no longer special-cases `n == 0`.

**맞습니다.** emitter 사본에 있던 `if n == 0: return today_kst()` 가드를 composite 로 옮기며 흘렸습니다. 실측:

```
2026-08-28 (금) n=0 forward -> 2026-08-28  count=0
2026-08-29 (토) n=0 forward -> 2026-08-31  count=-1   ← 다음 영업일로 굴러감
2026-08-30 (일) n=0 forward -> 2026-08-31  count=-1
```

composite 에 0 을 넘기는 호출부는 아직 없어 잠복이지만, **이 PR 의 주장 자체가 "헬퍼는 정확한 역함수"** 라 구멍을 남기면 주장이 거짓이 됩니다. 가드를 복원하고 잠금 파라미터에 `n=0` 을 넣어 양쪽 사본에서 발화하게 했습니다.

자체 리뷰로 하나 더: 경계 테스트의 `age <= MAX` 는 헬퍼가 "오늘"을 반환해도(age 0) 통과하는 약한 단언이라 등식을 같이 겁니다.

## 곁가지 — 문자열 타깃 monkeypatch 가 조용히 no-op

잠금 초안이 `monkeypatch.setattr("tests.trading.recommend.test_buy_candidate_emitter.today_kst", …)` 를 썼는데 **아무 효과가 없었습니다.** `tests/` 가 패키지가 아니라 같은 파일의 *두 번째 사본*을 import 해 거기를 패치하고, 실행 중인 사본은 그대로였습니다.

증상이 진단적이었습니다: **평일 앵커 15개가 전부 FAIL 하고 주말 앵커만 통과** — 진짜 오늘이 토요일이라 패치 안 된 `today_kst()` 가 토요일을 계속 반환한 것입니다. `sys.modules[__name__]` 로 고쳤고 `tests/CLAUDE.md` 에 적었습니다.

## 검증

- `make test-fast` → **7,592 passed / 6 skipped** (rc=0) — 이전 2 FAIL 해소
- `make verify-doc-counts` 22/22 · `make diagnostics` · `check_privacy_leak.py` → 전부 rc=0

## 스코프 밖

`tests/` 를 패키지로 만들거나 영업일 헬퍼를 공용 모듈로 승격하는 건 하지 않았습니다 — 결함을 닫는 데 필요하지 않고, 파일별 잠금이 오히려 2차 발생의 교훈에 맞습니다.
