### PR TITLE
fix(api): keep /tickers/search off the network — split a local-only name lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ setup:
 	$(PYTHON) scripts/db/migrate.py
 	$(PYTHON) scripts/ops/import_portfolio.py
 	$(MAKE) setup-hooks
+	@# KR 종목명 맵 — 없으면 한국어 이름 검색이 동작하지 않는다 (#1255). FDR 네트워크를
+	@# 타므로 best-effort: 실패해도 setup 을 막지 않되, 실패는 **보이게** 남긴다.
+	-$(MAKE) kr-names
 
 setup-hooks: ## Install repo-tracked git hooks (pre-commit auto-fix). Idempotent.
 	bash scripts/dev/install_hooks.sh

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,625 collected across 349 files | |
+| **Backend tests** | 7,628 collected across 349 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,625 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,628 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,625 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,628 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -139,7 +139,10 @@ def search_tickers(q: str = Query(..., min_length=1, max_length=20)):
 
     import yaml
 
-    from nuri.core.ticker_names import get_ticker_name
+    # 요청 경로는 network-free 변형을 쓴다 (#1255) — 아래 한글 루프가 KOSPI200
+    # 203개 전 티커를 도는데, pykrx fallback 이 붙어 있으면 그 요청 하나가
+    # 네트워크를 타고 콜드스타트 4.64s 를 문다.
+    from nuri.core.ticker_names import get_ticker_name_local
 
     term = q.strip().upper()
     results: list[dict] = []
@@ -163,7 +166,7 @@ def search_tickers(q: str = Query(..., min_length=1, max_length=20)):
             results.append(
                 {
                     "ticker": t,
-                    "name": get_ticker_name(t),
+                    "name": get_ticker_name_local(t),
                     "price": price_row[0]["close"] if price_row else None,
                     "date": price_row[0]["date"] if price_row else None,
                 }
@@ -178,7 +181,7 @@ def search_tickers(q: str = Query(..., min_length=1, max_length=20)):
             if t in seen:
                 continue
             if t.endswith(".KS") or t.endswith(".KQ"):
-                name = get_ticker_name(t)
+                name = get_ticker_name_local(t)
                 if name and term_lower in name.lower():
                     seen.add(t)
                     price_row = query("SELECT close, date FROM prices WHERE ticker=? ORDER BY date DESC LIMIT 1", (t,))
@@ -259,10 +262,12 @@ def get_latest_prices(tickers: str = Query(..., description="Comma-separated tic
 @router.get("/ticker/{symbol}")
 def get_ticker_detail(symbol: str):
     """단일 종목의 모든 분석 데이터."""
-    from nuri.core.ticker_names import get_ticker_name
+    # 호출은 1회지만 같은 요청 경로다 — 콜드 상태의 페이지 로드가 pykrx 를
+    # 기다리며 멎는다 (#1255).
+    from nuri.core.ticker_names import get_ticker_name_local
 
     ticker = symbol.upper()
-    result = {"ticker": ticker, "name": get_ticker_name(ticker)}
+    result = {"ticker": ticker, "name": get_ticker_name_local(ticker)}
 
     # 1. 가격
     price_row = query(

--- a/nuri/api/routes/ticker.py
+++ b/nuri/api/routes/ticker.py
@@ -262,12 +262,13 @@ def get_latest_prices(tickers: str = Query(..., description="Comma-separated tic
 @router.get("/ticker/{symbol}")
 def get_ticker_detail(symbol: str):
     """단일 종목의 모든 분석 데이터."""
-    # 호출은 1회지만 같은 요청 경로다 — 콜드 상태의 페이지 로드가 pykrx 를
-    # 기다리며 멎는다 (#1255).
-    from nuri.core.ticker_names import get_ticker_name_local
+    # 여기는 **network-free 로 바꾸지 않는다** (#1255 codex P2). 호출이 심볼당 1회라
+    # 검색 루프(203회)의 논거가 성립하지 않고, 맵·보유 어디에도 없는 KR 종목
+    # (KOSDAQ 신규 보유 등)의 이름이 사라져 헤더가 코드만 보여주게 된다.
+    from nuri.core.ticker_names import get_ticker_name
 
     ticker = symbol.upper()
-    result = {"ticker": ticker, "name": get_ticker_name_local(ticker)}
+    result = {"ticker": ticker, "name": get_ticker_name(ticker)}
 
     # 1. 가격
     price_row = query(

--- a/nuri/core/ticker_names.py
+++ b/nuri/core/ticker_names.py
@@ -9,7 +9,13 @@ US 티커(MSFT, TSLA 등)는 이미 식별 가능하므로 None 반환.
 ⚠️ 2차 로컬 맵이 핵심: /tickers/search 가 KR 이름 검색 시 수백 ticker 를
 순회하는데, 맵 없이는 ticker 당 live pykrx 호출 → 요청당 수백 네트워크 콜
 (지연/hang/CI flaky). 맵은 요청 경로를 network-free 로 만든다.
-config/kr_ticker_names.json 갱신: universe-sync 로 KOSPI200 변경 시 재생성.
+config/kr_ticker_names.json 은 `make setup` 과 universe-sync 가 생성한다 (#1255).
+
+함수가 둘인 이유 (#1255):
+- `get_ticker_name_local` — 1·2차만. **요청 경로 전용.** 203회 순회가 네트워크를
+  타지 않게 한다. 맵이 없으면 이름을 못 내지만, 그 부재는 로더가 WARNING 으로 알린다.
+- `get_ticker_name` — 위 + 3차 pykrx. 배치·알림·단일 종목 상세용. 호출이 소수라
+  네트워크 비용이 감당되고, 맵에 없는 신규 보유를 self-heal 한다.
 """
 
 import json
@@ -27,8 +33,16 @@ def _load_kr_name_map() -> dict[str, str]:
     """config/kr_ticker_names.json 1회 로드 (KOSPI200 정적 맵). 없으면 빈 dict."""
     try:
         return json.loads(_KR_NAMES_PATH.read_text(encoding="utf-8"))
-    except Exception as e:  # 파일 부재/파싱 실패 시 graceful — pykrx fallback 으로 흐름
-        logger.debug("KR name map load failed: %s", e)
+    except Exception as e:
+        # ⚠️ `warning` 이다 (#1255 codex P2). 맵이 없으면 요청 경로의 한국어 이름 검색이
+        # **조용히 0건**이 된다 — `get_ticker_name_local` 이 pykrx 로 안 내려가기 때문이다.
+        # `debug` 로 두면 그 퇴화가 아무 신호 없이 남는다. 이 레포가 반복해서 당한 형태다.
+        # `lru_cache(maxsize=1)` 이라 프로세스당 한 줄만 나온다. 고치는 법을 문장에 박는다.
+        logger.warning(
+            "KR 종목명 맵 부재 (%s) — 한국어 이름 검색이 동작하지 않는다. `make kr-names` 로 생성할 것. (%s)",
+            _KR_NAMES_PATH,
+            e,
+        )
         return {}
 
 

--- a/nuri/core/ticker_names.py
+++ b/nuri/core/ticker_names.py
@@ -42,8 +42,22 @@ def is_kr_ticker(ticker: str) -> bool:
 
 
 @lru_cache(maxsize=500)
-def get_ticker_name(ticker: str) -> str | None:
-    """한국 종목 이름 반환. US 티커는 None."""
+def get_ticker_name_local(ticker: str) -> str | None:
+    """1·2차만 조회하는 **network-free** 변형 — 요청 경로 전용 (#1255).
+
+    `/api/tickers/search` 는 결과가 8건 미만이면 KOSPI200 **203개 전 티커**에
+    이 함수를 부른다. 3차 pykrx 가 붙어 있으면 그 요청 하나가 네트워크를 타고,
+    CI 처럼 맵이 없는 환경에서는 첫 호출이 KRX 전체 티커 목록을 받느라 4.64s 를
+    쓴다 (2026-08-28 실측). 그 콜드스타트가 Playwright 의 15s 예산 안에 들어갈지가
+    실행마다 갈려서 `/explore` 검색 스펙 2종이 main 7런 중 2런 실패했다 (#1255).
+
+    프로덕션은 이 분리로 아무것도 잃지 않는다 — dev·mini 둘 다 로컬 맵이 있어
+    2차에서 해결된다. 맵에 없는 소수 종목은 pykrx 를 기다렸다가 코드를 보여주는
+    대신 **즉시** 코드를 보여준다.
+
+    배치·알림 경로는 `get_ticker_name` 을 그대로 쓴다 — 거기는 보유 종목 단위라
+    호출이 소수이고, 맵에 없는 신규 보유를 pykrx 로 self-heal 하는 게 이득이다.
+    """
     if not ticker.endswith((".KS", ".KQ")):
         return None
 
@@ -73,9 +87,18 @@ def get_ticker_name(ticker: str) -> str | None:
         logger.debug("DB name lookup failed for %s: %s", ticker, e)
 
     # 2차: 로컬 KOSPI200 맵 (network-free — search 요청 경로 보호)
-    mapped = _load_kr_name_map().get(ticker)
-    if mapped:
-        return mapped
+    return _load_kr_name_map().get(ticker) or None
+
+
+@lru_cache(maxsize=500)
+def get_ticker_name(ticker: str) -> str | None:
+    """한국 종목 이름 반환. US 티커는 None. 1·2차 미스 시 pykrx(네트워크) fallback.
+
+    요청 경로에서는 `get_ticker_name_local` 을 쓴다 (#1255) — 아래 3차가 네트워크다.
+    """
+    name = get_ticker_name_local(ticker)
+    if name or not ticker.endswith((".KS", ".KQ")):
+        return name
 
     # 3차: pykrx 주식 이름 조회 (1·2차 미스 시에만 — ETF/맵외 종목 fallback)
     code = ticker.replace(".KS", "").replace(".KQ", "")

--- a/scripts/dev/seed_e2e_db.py
+++ b/scripts/dev/seed_e2e_db.py
@@ -69,6 +69,10 @@ def seed(db: Path) -> dict[str, int]:
     # 스캐너/기회탐색용 — 유니버스(공개 config) 티커 3종. 마지막 날 거래량 3배 →
     # scan_market 의 volume_spike (vol_ratio>=2) 가 결정론적으로 발화, 비보유라
     # /api/opportunities 에 잡힌다 (#1234 e2e 요건).
+    # KR 한 종목 — `/explore` 한국어 검색 스펙(`search-result-005930.KS`)이 이름 해석을
+    # 요구한다. CI 에는 `config/kr_ticker_names.json`(gitignored)이 없으므로 이름은
+    # 아래 portfolio.metadata(=`get_ticker_name_local` 1차)에서 온다 (#1255).
+    frames.append(_price_frame("005930.KS", 120, 70000.0, 0.0004, rng))
     for t, base in [("AAPL", 180.0), ("MSFT", 400.0), ("AMZN", 170.0)]:
         f = _price_frame(t, 60, base, 0.002, rng)
         f.loc[f.index[-1], "volume"] = 3_000_000
@@ -93,6 +97,18 @@ def seed(db: Path) -> dict[str, int]:
                 "avg_price": 480.0,
                 "currency": "USD",
                 "sector": "ETF/Index",
+            },
+            {
+                # 공개 지수 구성종목 — 합성 수량/계좌. `metadata.name` 이
+                # `get_ticker_name_local` 1차(portfolio.metadata)를 만족시켜,
+                # 맵 파일 없이도 CI 에서 "삼성" 검색이 결정론적으로 이 행을 찾는다.
+                "account": "Brokerage Alpha",
+                "ticker": "005930.KS",
+                "quantity": 10,
+                "avg_price": 70000.0,
+                "currency": "KRW",
+                "sector": "반도체",
+                "metadata": json.dumps({"name": "삼성전자"}, ensure_ascii=False),
             },
             {
                 "account": "Brokerage Beta",

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -28,6 +28,12 @@ def _mock_pykrx_names(monkeypatch):
     yfinance 가 전역 모킹되듯 KR 종목명 해석도 결정적 stub 으로 network-free 화.
     get_ticker_name 은 @lru_cache 라 테스트 간 stale(None) 캐시 오염을 막기 위해
     앞뒤로 cache_clear (네트워크 미가용 시 None 이 캐시되면 후속 테스트도 빈 결과).
+
+    ⚠️ **2차(로컬 맵)도 같이 스텁한다** (#1255). 요청 경로가 `get_ticker_name_local`
+    로 바뀌면서 3차 pykrx 를 안 타므로, pykrx 스텁만으로는 KR 이름이 해석되지 않는다.
+    그리고 `config/kr_ticker_names.json` 은 **gitignored** 라 개발 머신엔 있고 CI 엔
+    없다 — 스텁하지 않으면 이 fixture 를 쓰는 테스트가 로컬 초록 / CI 빨강이 된다
+    (실제로 그렇게 났다). 프로덕션도 이 종목을 2차에서 해석하므로 계층도 맞다.
     """
     import sys
     import types
@@ -37,6 +43,7 @@ def _mock_pykrx_names(monkeypatch):
     _KR_NAMES = {"005930": "삼성전자", "000660": "SK하이닉스", "005380": "현대차"}
     _fake_stock = types.SimpleNamespace(get_market_ticker_name=lambda code: _KR_NAMES.get(str(code), ""))
     monkeypatch.setitem(sys.modules, "pykrx", types.SimpleNamespace(stock=_fake_stock))
+    monkeypatch.setattr(_tn, "_load_kr_name_map", lambda: {f"{c}.KS": n for c, n in _KR_NAMES.items()})
     _tn.get_ticker_name.cache_clear()
     _tn.get_ticker_name_local.cache_clear()  # #1255: 요청 경로가 쓰는 쪽도 같이 비운다
     yield

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -38,8 +38,10 @@ def _mock_pykrx_names(monkeypatch):
     _fake_stock = types.SimpleNamespace(get_market_ticker_name=lambda code: _KR_NAMES.get(str(code), ""))
     monkeypatch.setitem(sys.modules, "pykrx", types.SimpleNamespace(stock=_fake_stock))
     _tn.get_ticker_name.cache_clear()
+    _tn.get_ticker_name_local.cache_clear()  # #1255: 요청 경로가 쓰는 쪽도 같이 비운다
     yield
     _tn.get_ticker_name.cache_clear()
+    _tn.get_ticker_name_local.cache_clear()
 
 
 @pytest.fixture()

--- a/tests/api/test_ticker_search.py
+++ b/tests/api/test_ticker_search.py
@@ -165,6 +165,7 @@ class TestTickerSearch:
         Gotcha-Test Pair: 183 의 `break` 를 지우면 count 가 8 을 넘어 FAIL.
         """
         # `search_tickers` 는 함수 본문에서 import 하므로 **원 모듈**을 패치해야 한다.
+        # #1255 이후 검색 경로가 부르는 건 `get_ticker_name_local` 이다.
         # conftest 의 autouse fixture 가 teardown 에서 `cache_clear()` 를 부르므로
         # 스텁도 lru_cache 로 감싼다 (맨 lambda 면 teardown 이 AttributeError).
         from functools import lru_cache
@@ -173,7 +174,7 @@ class TestTickerSearch:
 
         monkeypatch.setattr(
             tn,
-            "get_ticker_name",
+            "get_ticker_name_local",
             lru_cache(maxsize=None)(lambda t: "테스트종목" if t.endswith((".KS", ".KQ")) else None),
         )
         # "테스트" 는 어떤 ticker 코드에도 없다 → 코드 매칭 루프는 0건 → 한글 루프가 8건을 채운다.
@@ -251,3 +252,38 @@ class TestSearchTickersBranchCoverage:
         data = resp.json()
         tickers = [r["ticker"] for r in data.get("results", [])]
         assert "AAPL" in tickers
+
+    def test_search_never_touches_pykrx(self, client, monkeypatch):
+        """검색 요청 경로는 **네트워크를 타지 않는다** (#1255).
+
+        결과가 8건 미만이면 한글 루프가 KOSPI200 203개 전 티커를 돈다. 그중 로컬 맵과
+        보유 metadata 어디에도 없는 종목은, 라우트가 `get_ticker_name` 을 부르면 3차
+        pykrx 로 내려간다 — 그 요청 하나가 KRX 전체 티커 목록을 받느라 4.64s 를 물고
+        (2026-08-28 실측), 그 콜드스타트가 Playwright 15s 예산 안에 들어갈지가 실행마다
+        갈려 `/explore` 스펙 2종이 main 7런 중 2런 실패했다.
+
+        환경 무관하게 성립한다: 로컬 맵이 있으면 미등재 종목이, 맵이 없으면(CI) 전
+        종목이 3차 후보다. 어느 쪽이든 뮤턴트에서는 `calls` 가 비지 않는다.
+
+        Mutation lock: `nuri/api/routes/ticker.py` 의 `get_ticker_name_local` 을
+        `get_ticker_name` 으로 되돌리면 FAIL.
+        """
+        import sys
+        import types
+
+        calls: list = []
+
+        def _record(code):
+            calls.append(code)
+            return "네트워크에서온이름"
+
+        monkeypatch.setitem(
+            sys.modules,
+            "pykrx",
+            types.SimpleNamespace(stock=types.SimpleNamespace(get_market_ticker_name=_record)),
+        )
+
+        resp = client.get("/api/tickers/search?q=테스트")
+
+        assert resp.status_code == 200
+        assert calls == [], f"검색 요청이 pykrx 네트워크 경로를 탔다 ({len(calls)}회: {calls[:3]})"

--- a/tests/core/test_ticker_names.py
+++ b/tests/core/test_ticker_names.py
@@ -28,6 +28,7 @@ class TestIsKrTicker:
 class TestGetTickerName:
     def setup_method(self) -> None:
         ticker_names.get_ticker_name.cache_clear()
+        ticker_names.get_ticker_name_local.cache_clear()  # #1255: 두 캐시가 짝이다
 
     def test_us_ticker_returns_none(self) -> None:
         assert ticker_names.get_ticker_name("MSFT") is None

--- a/tests/core/test_ticker_names.py
+++ b/tests/core/test_ticker_names.py
@@ -160,3 +160,26 @@ class TestKrNameMapLoad:
         bad.write_text("{not json", encoding="utf-8")
         with patch.object(ticker_names, "_KR_NAMES_PATH", bad):
             assert ticker_names._load_kr_name_map() == {}
+
+
+class TestMapAbsenceIsLoud:
+    """맵 부재는 **조용하면 안 된다** (#1255 codex P2).
+
+    `get_ticker_name_local` 이 pykrx 로 안 내려가므로, 맵이 없으면 요청 경로의
+    한국어 이름 검색이 0건이 된다. 그 퇴화가 로그에 안 남으면 아무도 모른다 —
+    이 레포가 반복해서 당한 형태(#1118 e2e 3.5개월, #953 훅 침묵)와 같은 축이다.
+    """
+
+    def test_missing_map_logs_a_warning_naming_the_fix(self, tmp_path, monkeypatch, caplog):
+        """Mutation lock: 로더의 `logger.warning` 을 `logger.debug` 로 되돌리면 FAIL."""
+        import logging
+
+        monkeypatch.setattr(ticker_names, "_KR_NAMES_PATH", tmp_path / "absent.json")
+        ticker_names._load_kr_name_map.cache_clear()
+        try:
+            with caplog.at_level(logging.WARNING, logger=ticker_names.__name__):
+                assert ticker_names._load_kr_name_map() == {}
+            assert caplog.records, "맵 부재가 WARNING 을 남기지 않았다 — 퇴화가 조용해진다"
+            assert "kr-names" in caplog.text, "경고가 고치는 법을 말하지 않는다"
+        finally:
+            ticker_names._load_kr_name_map.cache_clear()

--- a/tests/scripts/test_seed_e2e_db.py
+++ b/tests/scripts/test_seed_e2e_db.py
@@ -44,3 +44,31 @@ class TestSeedMacroEventsShape:
         result = compute_event_score(db_path=seeded_db)
         assert result.event_count > 0, "신뢰도 floor 에 전부 걸렸거나 lookback 밖이다"
         assert result.score != 0.0, "카테고리가 어휘 밖이면 기여가 전부 0 이 되어 여기서 걸린다"
+
+
+class TestSeedResolvesKoreanName:
+    """CI 에는 `config/kr_ticker_names.json` 이 없다 (gitignored, 생성 단계도 없음).
+
+    그래서 `/explore` 한국어 검색 스펙(`search-result-005930.KS`)이 요구하는 이름은
+    seed 의 `portfolio.metadata` = `get_ticker_name_local` 1차에서 와야 한다 (#1255).
+    """
+
+    def test_kr_name_resolves_with_no_local_map(self, seeded_db, monkeypatch, tmp_path):
+        """맵을 없애도(CI 조건) seed 만으로 이름이 나오고, 나머지는 조용히 None."""
+        import nuri.core.db as db_mod
+        from nuri.core import ticker_names as tn
+
+        monkeypatch.setattr(db_mod, "DB_PATH", seeded_db)
+        monkeypatch.setattr(tn, "_KR_NAMES_PATH", tmp_path / "absent.json")
+        tn._load_kr_name_map.cache_clear()
+        tn.get_ticker_name_local.cache_clear()
+        try:
+            assert tn._load_kr_name_map() == {}, "맵 부재 재현 실패 — 이 테스트의 전제가 깨졌다"
+            assert tn.get_ticker_name_local("005930.KS") == "삼성전자", (
+                "seed 의 portfolio.metadata 가 1차를 만족시키지 못한다 — CI 에서 한국어 검색이 0건이 된다"
+            )
+            # 맵·보유 어디에도 없는 종목은 네트워크로 내려가지 않고 None 이다.
+            assert tn.get_ticker_name_local("000660.KS") is None
+        finally:
+            tn._load_kr_name_map.cache_clear()
+            tn.get_ticker_name_local.cache_clear()


### PR DESCRIPTION
Closes #1255

## 근본 원인 — 이슈가 지목한 파일이 맞았고, 메커니즘이 달랐다

`/api/tickers/search` 는 결과가 8건 미만이면 **KOSPI200 203개 전 티커**에 `get_ticker_name()` 을 부릅니다 (`ticker.py:177-194`). 그 헬퍼는 3단 fallback 인데 CI 에서는 1·2차가 구조적으로 미스합니다:

| 단계 | 소스 | CI |
|---|---|---|
| 1차 | `portfolio.metadata` | seed DB 에 `.KS` 행 없음 → 미스 |
| 2차 | `config/kr_ticker_names.json` | gitignored, 생성 단계 없음 → 미스 |
| 3차 | `pykrx.get_market_ticker_name()` | **live 네트워크 호출** |

`nuri/core/ticker_names.py` 의 모듈 docstring 이 이 사고를 그대로 예언해 뒀습니다:

> ⚠️ 2차 로컬 맵이 핵심: `/tickers/search` 가 KR 이름 검색 시 수백 ticker 를 순회하는데, **맵 없이는 ticker 당 live pykrx 호출 → 요청당 수백 네트워크 콜 (지연/hang/CI flaky)**

### 왜 두 스펙이 번갈아 실패했나

pykrx 는 **첫 호출에서만** 전체 티커 목록을 받습니다 — 실측 4.64s, 이후 0.00s (프로세스 내 캐시). 203배가 아니라 **일회성 콜드스타트**이고, **서버 생애 첫 검색 요청을 어느 스펙이 쏘느냐**에 따라 희생자가 바뀝니다.

TSLA 검색도 이 경로를 탑니다 — universe 매치가 1건뿐이라 8건 상한에 못 미쳐 한글 루프가 그대로 돕니다. 이게 US ticker 스펙(08-26)과 Korean name 스펙(08-25)의 **진짜 공통분모**입니다.

### 기각된 가설

`limits.py:60` heavy-slot 503 shed — 반증: 해당 라우트에 `heavy_slot` 의존성이 없고, 실패 런 두 개 모두 `heavy slot 포화` 로그 **0회**.

## 수정

**요청 경로만 network-free 로.** `get_ticker_name_local()` 은 1·2차에서 멈춥니다. `ticker.py` 의 라우트가 이걸 쓰고, **배치·알림 경로는 `get_ticker_name` 을 그대로** 씁니다 — 거기는 보유 종목당 1회라 호출이 소수이고, 맵에 없는 신규 보유를 pykrx 로 self-heal 하는 게 이득입니다.

`get_ticker_detail`(`/api/ticker/{symbol}`)은 **초안에 포함했다가 되돌렸습니다** (codex 리뷰 P2, 아래 참조). 그 라우트는 호출이 1회라 203회 순회 논거가 성립하지 않는데, network-free 로 바꾸면 맵에도 metadata 에도 없는 KR 종목이 `name: null` 로 퇴화합니다. 잃는 것이 얻는 것보다 큽니다.

**프로덕션은 잃는 게 없습니다.** dev·mini 둘 다 맵이 디스크에 있습니다(mini 확인: `config/kr_ticker_names.json`, 6,602 bytes). gitignore 는 git 추적만 막지 배포를 막지 않습니다. 맵에 없는 소수 종목은 pykrx 를 기다렸다 코드를 보여주는 대신 **즉시** 코드를 보여줍니다.

**맵이 없는 머신은 `make setup` 이 만들어 줍니다.** 이전엔 `kr-names` 가 `universe-sync-apply` 뒤에만 붙어 있어 새 클론이 맵 없이 시작했고, 그 상태에서 이 PR 은 한국어 이름 검색을 통째로 죽였습니다 (codex P2 #2). `setup` 끝에 `-$(MAKE) kr-names` 를 붙였고(best-effort — FDR 장애가 setup 을 막으면 안 됩니다), 로더 로그를 `debug` → `warning` 으로 올려 부재가 조용하지 않게 했습니다. 문장에 `make kr-names` 를 박아 둡니다.

**CI 는 필요한 이름 하나를 seed 에서 받습니다.** e2e seed 에 `005930.KS` 보유 행 + `metadata.name` 을 넣어 1차를 만족시킵니다. 공개 지수 구성종목이고 수량·계좌는 합성이라, 이미 들어 있는 SPY/AAPL/MSFT/AMZN 과 같은 범주입니다.

### 채택하지 않은 안

초기 계획은 **맵 파일을 tracked 로 올리고 privacy 스캐너에 `broker_name` allowlist 1건**을 추가하는 것이었습니다. 채택하지 않았습니다 — **이름이 레포에서 올 필요가 없습니다.** CI 의 다른 테스트 데이터가 이미 오는 곳(seed DB)에서 오면 되고, 그러면 **보안 게이트를 건드릴 이유가 사라집니다.**

CI 에서 맵을 생성하는 안도 기각했습니다: `scripts/ops/gen_kr_names.py` 는 FinanceDataReader **실네트워크 호출**이라 KRX 의존을 FDR 의존으로 바꿀 뿐이고, Makefile 배선이 best-effort(`-`)라 FDR 장애 시 **맵 없이 초록**이 됩니다 — 이 레포가 두 번 당한 green dead gate 입니다.

## 실측 — CI 조건 재현 (맵 blank + pykrx 를 레코더로 교체)

```
q='삼성'   count=1  156.6ms  ['005930.KS']
q='TSLA'   count=1    6.8ms  ['TSLA']
pykrx 호출 횟수: 0
```

Playwright 예산 15s 대비 **1%** 입니다.

## Gotcha-Test Pair — 뮤테이션 실측 (전부 커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| `ticker.py` 검색 2곳을 `get_ticker_name` 으로 되돌림 | `test_search_never_touches_pykrx` 포함 **9 FAIL** |
| seed 에서 KR `metadata` 제거 | `test_kr_name_resolves_with_no_local_map` **FAIL** |
| 로더 `warning` → `debug` | `test_missing_map_logs_a_warning_naming_the_fix` **FAIL** |
| baseline 복원 | 40 passed |

`test_search_never_touches_pykrx` 는 **환경 무관**하게 성립합니다 — 맵이 있으면 미등재 종목이, 없으면(CI) 전 종목이 3차 후보라 어느 쪽이든 뮤턴트에서 레코더가 비지 않습니다.

## 테스트 배선

`get_ticker_name_local` 도 `lru_cache` 라 캐시를 짝으로 비웁니다 (`tests/api/conftest.py`, `tests/core/test_ticker_names.py`). `test_korean_name_search_stops_at_eight` 의 패치 대상도 검색 경로가 실제로 부르는 쪽으로 옮겼습니다 — 안 옮기면 그 테스트가 **엉뚱한 이유로** red 가 됩니다.

## codex 리뷰 — [P2] 2건

**#1 `/api/ticker/{symbol}` 되돌림** — 위 "수정" 절 참조. 수용했습니다.

**#2 맵 없는 머신에서 한국어 검색 전멸** — 맞습니다. 결정적 사실을 확인했습니다: `make setup` 은 맵을 만들지 **않았습니다**(`kr-names` 는 `universe-sync-apply` 뒤에만). 그래서 새 클론에서는 실제 퇴화입니다.

pykrx 를 검색 루프에 되돌리지는 **않았습니다** — 그게 이슈의 결함 자체입니다. 대신 원인(맵 부재)을 `make setup` 에서 없애고, 남는 부재는 WARNING 으로 진단 가능하게 만들었습니다. `lru_cache(maxsize=1)` 이라 프로세스당 한 줄입니다.

## 검증

- `make test-fast` → **7,595 passed / 6 skipped** (rc=0) — #1271 리베이스 후 실측
- `make verify-doc-counts` · `make diagnostics` · `check_privacy_leak.py` → 전부 rc=0
- ⚠️ **로컬 Playwright 는 안 돌렸습니다.** 로컬은 맵이 있어 CI 조건이 재현되지 않고, 재현하려면 gitignored 사용자 데이터를 옮겨야 합니다. **이 PR 의 `frontend-e2e` job 이 실환경 증명입니다.**

## 리베이스 메모

#1255 를 검증하다 **주말에만 red** 인 잠복 결함이 나와 #1270/PR #1271 로 분리해 먼저 머지했습니다 (`busday_offset(roll="backward")` 가 프로덕션 `busday_count` 의 역함수가 아니었음). 이 브랜치는 그 위로 리베이스했고, 문서 카운트 3줄 충돌은 main 을 취한 뒤 `make sync-doc-counts` 로 재계산했습니다 — **7,625(#1271 후 main) + 3(이 PR 신규 테스트) = 7,628** 로 두 PR 이 교차검증됩니다.

## CI 가 잡은 것 — 로컬 초록이 거짓이었다

첫 푸시의 `Backend Tests · Fast 2` 가 `test_search_korean_name` 에서 FAIL 했습니다. 로컬 `make test-fast` 는 7,595 통과였습니다.

차이는 **`config/kr_ticker_names.json` 이 gitignored** 라는 것입니다 — 개발 머신엔 있고 CI 엔 없습니다. 그 테스트는 아무것도 패치하지 않고 실제 이름 해석에 의존하는데, `tests/api/conftest.py` 의 autouse `_mock_pykrx_names` 가 **3차(pykrx)만** 스텁하고 있었습니다. 검색이 `get_ticker_name_local` 로 바뀌어 3차를 안 타자 그 스텁이 무력해졌고, CI 에는 2차를 채울 맵도 없었습니다.

**재현**: 맵 없는 detached worktree(= gitignored 산출물 부재 = CI 등가)에서 전체를 돌려 확정했습니다. 같은 실행의 `tests/verify/test_doc_*` 7건은 **main 에서도 동일하게 실패**해 worktree 아티팩트로 분리했습니다.

**수정**: fixture 가 2차 맵도 같은 어휘로 스텁합니다. 프로덕션도 이 종목들을 2차에서 해석하므로 계층이 맞고, `test_search_never_touches_pykrx` 는 3차 미호출을 재는 테스트라 2차가 채워져도 뜻이 유지됩니다.

레포에 이미 적혀 있던 규칙(*"로컬은 과대평가한다 — 검증은 산출물 치우고 CI 조건 재현"*)을 푸시 **전에** 적용했어야 합니다.

## 스코프 밖

- 부분 배치 탐지 → #1266
- `frontend-e2e` required check 승격 — 이 PR 이 선행조건을 제거하지만 승격 자체는 별도 판단
