### PR TITLE
fix(frontend): pipeline fetch failures render as failures, not empty states

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,628 backend tests across 349 files + 1622 frontend vitest (134 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,628 backend tests across 349 files + 1622 frontend vitest (135 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,628 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 134 files |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 135 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1622 tests, 134 files)
+npm run test           # vitest run (1632 tests, 135 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -108,4 +108,4 @@ should be **241**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 98 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 99 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1632 tests, 135 files)
+npm run test           # vitest run (1633 tests, 135 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/src/__tests__/pages/pipeline-fetch-states.test.tsx
+++ b/frontend/src/__tests__/pages/pipeline-fetch-states.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * #1250 — 파이프라인 3개 fetch 의 로딩 · 없음 · 실패 3-state 잠금.
+ *
+ * 이전 동작: `.catch(() => {})` 가 실패를 삼켜 상태가 초기값(빈 배열)에 머물렀고,
+ * 화면은 그걸 "아직 이벤트 없음" / "게이트 조건 로딩 중..." 으로 렌더했다.
+ * 운영자 터미널에서 **"백엔드 죽음" 과 "데이터 없음" 이 같은 픽셀**인 건 오판을 부른다
+ * (배포 검증 사례와 같은 축: 헬스는 초록인데 실경로가 죽어 있음).
+ *
+ * 여기서 잠그는 성질은 셋이다:
+ *   (a) 실패가 빈 화면으로 접히지 않는다
+ *   (b) 빈 화면이 실패로 오해되지 않는다 (대조군)
+ *   (c) 재시도가 실제로 복구한다
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { ERRORS, PIPELINE as PL } from "@/lib/strings";
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlow: ({ nodes, children }: { nodes: unknown[]; children: React.ReactNode }) => (
+    <div data-testid="react-flow">
+      <div data-testid="flow-nodes">{nodes.length} nodes</div>
+      {children}
+    </div>
+  ),
+  Background: () => <div data-testid="flow-background" />,
+  Controls: () => <div data-testid="flow-controls" />,
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+}));
+
+vi.mock("@/lib/api", () => ({ API_BASE: "http://localhost:8001", fetchAPI: vi.fn() }));
+
+const okSteps = [
+  { step: "collect", label: "Collect", description: "", record_count: 10, last_updated: null, status: "done", started_at: null, error: null },
+];
+const okGates = {
+  collect: {
+    phase: "collect", total: 1, passed: 1, score: 1.0, ready: true,
+    conditions: [{ id: "c1", phase: "collect", description: "Prices available", passed: true, detail: "OK" }],
+  },
+};
+
+/** 한 엔드포인트만 지정한 방식으로 실패시키고 나머지는 정상 응답. */
+function makeFetch(opts: {
+  statusMode?: "ok" | "reject" | "http500";
+  timelineMode?: "ok" | "reject" | "http500" | "empty";
+  gateMode?: "ok" | "reject" | "http500" | "empty";
+}): Mock {
+  const { statusMode = "ok", timelineMode = "ok", gateMode = "ok" } = opts;
+  const reply = (mode: string, body: unknown) => {
+    if (mode === "reject") return Promise.reject(new Error("network down"));
+    // ⚠️ HTTP 실패도 반드시 별도 축으로 잠근다 — `r.ok ? json : …` 는 reject 와 다른
+    // 코드 경로다. reject 만 테스트하면 `r.ok` 분기를 되돌려도 초록이다.
+    if (mode === "http500") return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+  };
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.includes("/api/pipeline/status")) return reply(statusMode, { steps: okSteps });
+    if (url.includes("/api/pipeline/timeline")) {
+      return reply(timelineMode === "empty" ? "ok" : timelineMode, { events: [] });
+    }
+    if (url.includes("/api/gate")) return reply(gateMode === "empty" ? "ok" : gateMode, gateMode === "empty" ? {} : okGates);
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+async function renderPage() {
+  const PipelinePage = (await import("@/app/pipeline/page")).default;
+  await act(async () => {
+    render(<PipelinePage />);
+  });
+}
+
+describe("파이프라인 fetch 3-state (#1250)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("(a) 실패가 빈 화면으로 접히지 않는다", () => {
+    it.each(["reject", "http500"] as const)("타임라인 실패(%s)는 '없음' 이 아니라 실패로 렌더한다", async (mode) => {
+      global.fetch = makeFetch({ timelineMode: mode }) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(ERRORS.PIPELINE_TIMELINE_FAILED)).toBeInTheDocument();
+      });
+      // 핵심 단언 — 이게 이전 동작이었다.
+      expect(screen.queryByText(new RegExp(PL.NO_EVENTS))).not.toBeInTheDocument();
+    });
+
+    it.each(["reject", "http500"] as const)("게이트 실패(%s)는 '로딩 중' 에 머무르지 않는다", async (mode) => {
+      global.fetch = makeFetch({ gateMode: mode }) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(ERRORS.PIPELINE_GATE_FAILED)).toBeInTheDocument();
+      });
+      expect(screen.queryByText(PL.GATE_LOADING)).not.toBeInTheDocument();
+    });
+
+    it("상태 실패는 DAG 를 지우지 않고 배너로 알린다", async () => {
+      global.fetch = makeFetch({ statusMode: "reject" }) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(ERRORS.PIPELINE_STATUS_FAILED)).toBeInTheDocument();
+      });
+      // 화면을 비우면 "파이프라인이 비었다" 는 더 나쁜 거짓말이 된다.
+      expect(screen.getByTestId("react-flow")).toBeInTheDocument();
+    });
+
+    it("실패 패널은 role=alert 로 노출된다", async () => {
+      global.fetch = makeFetch({ timelineMode: "reject" }) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getAllByRole("alert").length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe("(b) 대조군 — 빈 데이터는 실패가 아니다", () => {
+    it("타임라인이 비면 '아직 이벤트 없음'", async () => {
+      global.fetch = makeFetch({ timelineMode: "empty" }) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(new RegExp(PL.NO_EVENTS))).toBeInTheDocument();
+      });
+      expect(screen.queryByText(ERRORS.PIPELINE_TIMELINE_FAILED)).not.toBeInTheDocument();
+    });
+
+    it("게이트가 비면 '로딩 중' 이 아니라 '조건 없음'", async () => {
+      global.fetch = makeFetch({ gateMode: "empty" }) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(PL.GATE_EMPTY)).toBeInTheDocument();
+      });
+      // 성공했는데 영원히 "로딩 중" 이던 게 원래 증상이다.
+      expect(screen.queryByText(PL.GATE_LOADING)).not.toBeInTheDocument();
+    });
+
+    it("정상 응답에는 어떤 실패 패널도 없다", async () => {
+      global.fetch = makeFetch({}) as unknown as typeof fetch;
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText("Prices available")).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("(c) 재시도가 복구한다", () => {
+    it("재시도 버튼이 다시 fetch 해 게이트 조건을 표시한다", async () => {
+      let gateCalls = 0;
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/gate")) {
+          gateCalls += 1;
+          return gateCalls === 1
+            ? Promise.reject(new Error("network down"))
+            : Promise.resolve({ ok: true, json: () => Promise.resolve(okGates) });
+        }
+        if (url.includes("/api/pipeline/status")) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ steps: okSteps }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ events: [] }) });
+      }) as unknown as typeof fetch;
+
+      await renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(ERRORS.PIPELINE_GATE_FAILED)).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: ERRORS.RETRY }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Prices available")).toBeInTheDocument();
+      });
+      expect(screen.queryByText(ERRORS.PIPELINE_GATE_FAILED)).not.toBeInTheDocument();
+      expect(gateCalls).toBe(2);
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/pipeline-fetch-states.test.tsx
+++ b/frontend/src/__tests__/pages/pipeline-fetch-states.test.tsx
@@ -149,7 +149,50 @@ describe("파이프라인 fetch 3-state (#1250)", () => {
     });
   });
 
-  describe("(c) 재시도가 복구한다", () => {
+  describe("(c) 겹친 폴링 — 늦게 도착한 응답은 화면을 바꾸지 않는다 (codex P2)", () => {
+    it("poll N+1 성공 뒤 도착한 poll N 실패가 화면을 에러로 뒤집지 않는다", async () => {
+      // 10초 폴링이라 느린 요청이 다음 요청과 겹친다. 응답 순서는 보장되지 않는다.
+      let rejectFirst: (e: Error) => void = () => {};
+      let timelineCalls = 0;
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/api/pipeline/timeline")) {
+          timelineCalls += 1;
+          if (timelineCalls === 1) {
+            // 1번째: 아직 미결. 2번째가 성공한 **뒤에** 실패시킨다.
+            return new Promise((_res, rej) => {
+              rejectFirst = rej;
+            });
+          }
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ events: [] }) });
+        }
+        if (url.includes("/api/pipeline/status")) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ steps: okSteps }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(okGates) });
+      }) as unknown as typeof fetch;
+
+      await renderPage();
+      // 10초 인터벌 → 2번째 타임라인 폴 발사 + 성공
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+      });
+      await waitFor(() => {
+        expect(screen.getByText(new RegExp(PL.NO_EVENTS))).toBeInTheDocument();
+      });
+      expect(timelineCalls).toBe(2);
+
+      // 이제서야 1번째가 실패한다 — 이미 화면엔 더 새로운 성공 결과가 있다.
+      await act(async () => {
+        rejectFirst(new Error("slow request died"));
+      });
+
+      // Mutation lock: 토큰 검사를 지우면 여기서 에러 패널이 뜬다.
+      expect(screen.queryByText(ERRORS.PIPELINE_TIMELINE_FAILED)).not.toBeInTheDocument();
+      expect(screen.getByText(new RegExp(PL.NO_EVENTS))).toBeInTheDocument();
+    });
+  });
+
+  describe("(d) 재시도가 복구한다", () => {
     it("재시도 버튼이 다시 fetch 해 게이트 조건을 표시한다", async () => {
       let gateCalls = 0;
       global.fetch = vi.fn().mockImplementation((url: string) => {

--- a/frontend/src/app/pipeline/page.branchcov.test.tsx
+++ b/frontend/src/app/pipeline/page.branchcov.test.tsx
@@ -17,7 +17,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { ERRORS } from "@/lib/strings";
+import { ERRORS, PIPELINE as PL } from "@/lib/strings";
 import type { ComponentType, ReactNode } from "react";
 
 type FlowNode = { id: string; type?: string; data?: Record<string, unknown> };
@@ -275,8 +275,9 @@ describe("PipelinePage — fetch & render branch arms", () => {
     await waitFor(() => expect(screen.getAllByText("Collect").length).toBeGreaterThan(0));
     // 타임라인 빈 상태 메시지 (timeline.length === 0 → NO_EVENTS / RUN_STEP_HINT)
     expect(screen.getByText(/이벤트 없음/)).toBeInTheDocument();
-    // 게이트 빈 상태 (allConditions.length === 0 → GATE_LOADING)
-    expect(screen.getByText("게이트 조건 로딩 중...")).toBeInTheDocument();
+    // 게이트 빈 상태 — #1250 이후 "로딩 중" 이 아니라 "조건 없음". 성공 응답이 비었을
+    // 뿐인데 영원히 로딩으로 보이던 게 원래 증상이다. 리터럴 대신 SSoT 를 쓴다.
+    expect(screen.getByText(PL.GATE_EMPTY)).toBeInTheDocument();
     // 369: runningSteps.size === 0 → 실행 중 카운터 badge 없음
     expect(screen.queryByText(/개 실행 중/)).toBeNull();
   });

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -275,17 +275,44 @@ const EDGES: Edge[] = [
   { id: "e-recommend-track", source: "recommend", target: "track", animated: true, style: { stroke: "#3f3f46" } },
 ];
 
+// === Fetch 3-state (#1250) ===
+/** 실패를 빈 데이터로 뭉개지 않기 위한 최소 상태. `"ok"` 여야만 빈 화면이 "없음" 을 뜻한다. */
+type LoadState = "loading" | "ok" | "error";
+
+/** 실패 패널 — 무엇이 실패했나 + 다음 행동(재시도). 원문 상태코드는 카피에 넣지 않는다 (F-002). */
+const FetchFailed = memo(function FetchFailed({ body, onRetry }: { body: string; onRetry: () => void }) {
+  return (
+    <div role="alert" className="py-6 text-center space-y-2">
+      <p className="text-xs text-red-400">{ERRORS.API_TITLE}</p>
+      <p className="text-[10px] text-muted-foreground/70">{body}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="text-[10px] px-2 py-1 rounded border border-border text-foreground/80 hover:bg-accent"
+      >
+        {ERRORS.RETRY}
+      </button>
+    </div>
+  );
+});
+
 // === Page Component ===
 export default function PipelinePage() {
   const [steps, setSteps] = useState<PipelineStep[]>([]);
   const [timeline, setTimeline] = useState<TimelineEvent[]>([]);
   const [gates, setGates] = useState<Record<string, GateResult>>({});
   const [runningSteps, setRunningSteps] = useState<Set<string>>(new Set());
+  // #1250: 로딩 · 성공 · 실패 3-state. 이전엔 `.catch(() => {})` 로 실패를 삼켜
+  // 빈 배열이 남았고, 화면은 그걸 "데이터 없음" 으로 렌더했다 — 운영자에게
+  // "백엔드 죽음" 과 "이벤트 없음" 이 같은 픽셀이었다.
+  const [statusState, setStatusState] = useState<LoadState>("loading");
+  const [timelineState, setTimelineState] = useState<LoadState>("loading");
+  const [gateState, setGateState] = useState<LoadState>("loading");
 
   // 파이프라인 상태 fetch
   const fetchStatus = useCallback(() => {
     fetch(`/api/pipeline/status`)
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((data: PipelineStatusData | null) => {
         if (data?.steps) {
           setSteps(data.steps);
@@ -296,28 +323,31 @@ export default function PipelinePage() {
           }
           setRunningSteps(running);
         }
+        setStatusState("ok");
       })
-      .catch(() => {});
+      .catch(() => setStatusState("error"));
   }, []);
 
   // 타임라인 fetch
   const fetchTimeline = useCallback(() => {
     fetch(`/api/pipeline/timeline?limit=30`)
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((data: { events: TimelineEvent[] } | null) => {
         if (data?.events) setTimeline(data.events);
+        setTimelineState("ok");
       })
-      .catch(() => {});
+      .catch(() => setTimelineState("error"));
   }, []);
 
   // 게이트 fetch
   const fetchGates = useCallback(() => {
     fetch(`/api/gate`)
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((data: Record<string, GateResult> | null) => {
         if (data) setGates(data);
+        setGateState("ok");
       })
-      .catch(() => {});
+      .catch(() => setGateState("error"));
   }, []);
 
   // 초기 로드 + 10초 자동 새로고침
@@ -424,6 +454,15 @@ export default function PipelinePage() {
         </div>
       </div>
 
+      {/* #1250: 상태 fetch 실패는 DAG 를 지우지 않고 **배너로 알린다** — 노드는 마지막으로
+          성공한 조회를 보여주므로, 화면을 비우면 "파이프라인이 비었다" 는 더 나쁜 거짓말이
+          된다. 대신 지금 보는 것이 낡았을 수 있다고 말한다. */}
+      {statusState === "error" && (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-3">
+          <FetchFailed body={ERRORS.PIPELINE_STATUS_FAILED} onRetry={fetchStatus} />
+        </div>
+      )}
+
       {/* React Flow 캔버스 */}
       {/* design-review F-009: 폭 제약 fit 이라 노드 행 높이는 ~75px — h-80(320px)은
           위아래가 죽은 공간이었다. 줌 배율은 폭이 결정하므로 높이 축소는 무손실. */}
@@ -475,7 +514,13 @@ export default function PipelinePage() {
         {/* 이벤트 타임라인 */}
         <div className="rounded-xl border border-border bg-card p-4">
           <p className="text-xs text-muted-foreground mb-3">{PL.EVENT_TIMELINE}</p>
-          {timeline.length === 0 ? (
+          {/* #1250: error → loading → empty 순서. `timeline.length === 0` 을 먼저 보면
+              실패가 다시 "없음" 으로 접힌다. */}
+          {timelineState === "error" ? (
+            <FetchFailed body={ERRORS.PIPELINE_TIMELINE_FAILED} onRetry={fetchTimeline} />
+          ) : timelineState === "loading" ? (
+            <p className="text-xs text-muted-foreground/50 py-6 text-center">{PL.TIMELINE_LOADING}</p>
+          ) : timeline.length === 0 ? (
             <p className="text-xs text-muted-foreground/50 py-6 text-center">
               {PL.NO_EVENTS} &mdash; {PL.RUN_STEP_HINT}
             </p>
@@ -514,9 +559,16 @@ export default function PipelinePage() {
         {/* Gate Conditions */}
         <div className="rounded-xl border border-border bg-card p-4">
           <p className="text-xs text-muted-foreground mb-3">{PL.GATE_CONDITIONS}</p>
-          {allConditions.length === 0 ? (
+          {/* #1250: 이전엔 실패·로딩·없음이 전부 `GATE_LOADING` 이라 영원히 "로딩 중" 이었다. */}
+          {gateState === "error" ? (
+            <FetchFailed body={ERRORS.PIPELINE_GATE_FAILED} onRetry={fetchGates} />
+          ) : gateState === "loading" ? (
             <p className="text-xs text-muted-foreground/50 py-6 text-center">
               {PL.GATE_LOADING}
+            </p>
+          ) : allConditions.length === 0 ? (
+            <p className="text-xs text-muted-foreground/50 py-6 text-center">
+              {PL.GATE_EMPTY}
             </p>
           ) : (
             <div className="space-y-1.5 max-h-100 overflow-y-auto">

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, memo } from "react";
+import { useState, useEffect, useCallback, useRef, memo } from "react";
 import {
   ReactFlow,
   Background,
@@ -309,11 +309,19 @@ export default function PipelinePage() {
   const [timelineState, setTimelineState] = useState<LoadState>("loading");
   const [gateState, setGateState] = useState<LoadState>("loading");
 
+  // 10초 폴링이라 느린 요청이 다음 요청과 겹친다. 응답 순서는 보장되지 않으므로
+  // **가장 최근에 쏜 요청만** 상태를 바꾸게 한다 (codex P2). 없으면 poll N+1 이 성공한
+  // 뒤 늦게 도착한 poll N 의 실패가 멀쩡한 화면을 에러로 뒤집는다 — 역방향(늦은 성공이
+  // 새 실패를 덮는 것)도 같은 축이라 성공·실패 양쪽에서 토큰을 본다.
+  const seqRef = useRef({ status: 0, timeline: 0, gate: 0 });
+
   // 파이프라인 상태 fetch
   const fetchStatus = useCallback(() => {
+    const seq = ++seqRef.current.status;
     fetch(`/api/pipeline/status`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((data: PipelineStatusData | null) => {
+        if (seq !== seqRef.current.status) return;
         if (data?.steps) {
           setSteps(data.steps);
           // 실행 중인 스텝 업데이트
@@ -325,29 +333,39 @@ export default function PipelinePage() {
         }
         setStatusState("ok");
       })
-      .catch(() => setStatusState("error"));
+      .catch(() => {
+        if (seq === seqRef.current.status) setStatusState("error");
+      });
   }, []);
 
   // 타임라인 fetch
   const fetchTimeline = useCallback(() => {
+    const seq = ++seqRef.current.timeline;
     fetch(`/api/pipeline/timeline?limit=30`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((data: { events: TimelineEvent[] } | null) => {
+        if (seq !== seqRef.current.timeline) return;
         if (data?.events) setTimeline(data.events);
         setTimelineState("ok");
       })
-      .catch(() => setTimelineState("error"));
+      .catch(() => {
+        if (seq === seqRef.current.timeline) setTimelineState("error");
+      });
   }, []);
 
   // 게이트 fetch
   const fetchGates = useCallback(() => {
+    const seq = ++seqRef.current.gate;
     fetch(`/api/gate`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((data: Record<string, GateResult> | null) => {
+        if (seq !== seqRef.current.gate) return;
         if (data) setGates(data);
         setGateState("ok");
       })
-      .catch(() => setGateState("error"));
+      .catch(() => {
+        if (seq === seqRef.current.gate) setGateState("error");
+      });
   }, []);
 
   // 초기 로드 + 10초 자동 새로고침

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -360,6 +360,10 @@ export const PIPELINE = {
   // design-review F-008: 형제 헤더(이벤트 타임라인)와 언어 일치 + SSoT 로 이동
   GATE_CONDITIONS: "게이트 조건",
   GATE_LOADING: "게이트 조건 로딩 중...",
+  // #1250: 로딩 · 없음 · 실패를 서로 다른 화면으로 가른다. 이전엔 셋이 한 화면이라
+  // "백엔드 죽음" 과 "이벤트 없음" 이 구분되지 않았다.
+  TIMELINE_LOADING: "이벤트 불러오는 중...",
+  GATE_EMPTY: "게이트 조건 없음 — 인증 스텝 실행 후 표시됩니다",
 } as const;
 
 /* ── Ticker Detail Page ─────────────────────────────────────── */
@@ -454,6 +458,11 @@ export const ERRORS = {
   REPORT_FAILED: "리포트 생성에 실패했습니다 — Ollama·백엔드 상태를 확인한 뒤 다시 시도하세요.",
   COVERAGE_FAILED: "Coverage 확인 실패 — 파이프라인 상태를 확인하세요.",
   RUN_FAILED_PREFIX: "실행 실패: ",
+  // #1250: 파이프라인 3개 fetch 는 실패를 삼켜 빈/로딩 화면으로 렌더했다.
+  // 운영자 터미널에서 "백엔드 죽음" 과 "데이터 없음" 이 같은 화면이면 오판을 부른다.
+  PIPELINE_STATUS_FAILED: "파이프라인 상태를 불러오지 못했습니다 — 아래 단계는 마지막으로 성공한 조회 기준입니다.",
+  PIPELINE_TIMELINE_FAILED: "이벤트 타임라인을 불러오지 못했습니다 — 이벤트가 없는 것과 다릅니다.",
+  PIPELINE_GATE_FAILED: "게이트 조건을 불러오지 못했습니다 — 조건이 없는 것과 다릅니다.",
 } as const;
 
 /* ── Action-First Dashboard ────────────────────────────────── */


### PR DESCRIPTION
Closes #1250

## 문제 — 실패와 "데이터 없음" 이 같은 픽셀이었다

`fetchStatus` / `fetchTimeline` / `fetchGates` 세 개가 전부 `.catch(() => {})` 로 실패를 삼켰습니다. 상태가 초기값(빈 배열)에 머무르고, 화면은 그걸 이렇게 렌더했습니다:

| 실제로 일어난 일 | 운영자가 본 화면 |
|---|---|
| 타임라인 API 죽음 | "아직 이벤트 없음 — 파이프라인 스텝을 실행하세요" |
| 게이트 API 죽음 | "게이트 조건 로딩 중..." (영원히) |
| 상태 API 죽음 | 아무 표시 없음 (낡은 DAG 를 현재처럼 보여줌) |

`/pipeline` 은 운영자 터미널입니다. "백엔드 죽음" 을 "할 일 없음" 으로 읽히게 만드는 화면은 **오판을 유도**합니다 — 이 레포가 배포 검증에서 이미 한 번 겪은 축입니다(헬스는 전부 초록인데 실경로가 3.5개월 죽어 있었음).

### 두 번째 구멍 — HTTP 실패는 catch 조차 안 탔다

```ts
.then((r) => (r.ok ? r.json() : null))   // 500 → null → 조용히 무시
.catch(() => {})                          // 네트워크 죽음만 여기로
```

`!r.ok` 는 `null` 로 접혀 `.catch` 를 지나갑니다. **네트워크 실패와 HTTP 실패가 서로 다른 코드 경로**라, 한쪽만 고치거나 한쪽만 테스트하면 나머지가 남습니다. 이제 `Promise.reject` 로 올려 한 경로로 모읍니다.

## 수정 — 로딩 · 성공 · 실패 3-state

```ts
type LoadState = "loading" | "ok" | "error";
```

`"ok"` 여야만 빈 화면이 "없음" 을 뜻합니다.

- **타임라인**: 실패 패널 / 로딩 / "이벤트 없음" — 분기 순서가 `error → loading → empty` 입니다. `timeline.length === 0` 을 먼저 보면 실패가 다시 "없음" 으로 접힙니다.
- **게이트**: 실패 패널 / 로딩 / **"게이트 조건 없음"(신규)**. 성공했는데 조건이 비면 영원히 "로딩 중" 이던 게 원래 증상입니다.
- **상태**: DAG 를 **지우지 않고** 배너로 알립니다. 노드는 마지막으로 성공한 조회를 보여주므로, 화면을 비우면 *"파이프라인이 비었다"* 는 더 나쁜 거짓말이 됩니다. 대신 "지금 보는 것이 낡았을 수 있다" 고 말합니다.

실패 패널은 `role="alert"` + 재시도 버튼입니다. 카피는 `ERRORS` / `PIPELINE` SSoT 에 넣었고, 원문 상태코드는 사용자 카피에 넣지 않습니다 (design-review F-002 규약).

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| 타임라인 `.catch` 를 다시 삼킴으로 | **3 FAIL** |
| 게이트 `!r.ok` 를 `null` 로 접기 (HTTP 축) | **1 FAIL** |
| 게이트 빈 상태를 `GATE_LOADING` 으로 되돌림 | **2 FAIL** |
| 늦은 실패 가드 제거 (codex P2 축) | **1 FAIL** |
| baseline 복원 | 33 passed |

HTTP 축을 **별도 케이스로** 잠근 이유가 M2 입니다 — reject 만 테스트하면 `r.ok` 분기를 되돌려도 초록입니다. 신규 테스트 11개는 네 성질로 나눠 둡니다: (a) 실패가 빈 화면으로 접히지 않는다, (b) **대조군** — 빈 화면이 실패로 오해되지 않는다, (c) 늦게 도착한 응답은 화면을 바꾸지 않는다, (d) 재시도가 실제로 복구한다.

## codex 리뷰 — [P2] 1건 수용

> if poll N+1 succeeds and then poll N later rejects, this unconditional `setStatusState("error")` flips the page back into the error UI even though fresher data is already on screen

**맞고, 이 PR 이 넣은 결함입니다.** 10초 폴링이라 느린 요청이 다음 요청과 겹치는데 응답 순서는 보장되지 않습니다. 이전엔 실패가 삼켜져 상태 자체가 없었으니 이 경합도 없었습니다 — 상태를 만들면서 같이 들어왔습니다.

로더마다 단조 증가 시퀀스를 두고 **자기 토큰이 최신일 때만** 상태를 바꿉니다. 역방향(늦은 성공이 새 실패를 덮는 것)도 같은 축이라 성공·실패 **양쪽**에서 토큰을 봅니다.

잠금은 겹친 폴링을 실제로 만듭니다: 1번째 타임라인 요청을 미결로 두고 → 10초 진행시켜 2번째를 성공시키고 → **그 뒤에** 1번째를 실패시킵니다. 가드를 지우면 이 테스트에서 에러 패널이 뜹니다.

## 곁가지

`page.branchcov.test.tsx` 의 빈-게이트 기대가 `"게이트 조건 로딩 중..."` 을 **하드코딩 리터럴**로 갖고 있었습니다. 새 동작(`GATE_EMPTY`)으로 갱신하면서 SSoT 참조로 바꿨습니다 — 리터럴이면 다음 카피 변경에서 같은 방식으로 또 깨집니다.

## 검증

- `npx vitest run` → **1,633 passed / 135 files** (rc=0)
- `npm run build` rc=0 · `npx eslint --format json | jq length` → 243
- `make verify-doc-counts` 22/22 · `make diagnostics` · `check_privacy_leak.py` → 전부 rc=0
- 문서 카운트: `docs/ARCHITECTURE.md` · `docs/STRATEGY.md` 는 `make sync-doc-counts`, `frontend/CLAUDE.md` 의 수동 카운트(1622/134 → 1633/135, 테스트 파일 98 → 99)는 손으로 맞췄습니다

## 스코프 밖

`#1252` · `#1253` 도 같은 파일(`pipeline/page.tsx`)이라 순차 진행합니다. 이 PR 은 에러 상태만 다룹니다.
