### PR TITLE
fix(frontend): give ActionRow a real disclosure button, not a focusable <tr>

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1633 tests, 135 files)
+npm run test           # vitest run (1636 tests, 135 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -188,17 +188,58 @@ describe("ActionItems", () => {
     expect(screen.getByTestId("action-row-peek")).toBeTruthy();
   });
 
-  // #1208 codex P1: 구 카드 버튼의 키보드 접근을 행이 승계 — Enter/Space 토글 잠금
-  it("toggles quick-peek with Enter and Space keys", () => {
+  // #1251 (was #1208 codex P1): 키보드 접근의 **주체가 행에서 버튼으로** 옮겨졌다.
+  //
+  // #1208 은 `<tr>` 에 tabIndex/onKeyDown/aria-expanded 를 달아 키보드를 열었다. 동작은
+  // 했지만 `<tr>` 의 암묵 role 은 `row` 라 스크린리더가 disclosure 로 읽지 못했고, 행마다
+  // 쓸모없는 탭 스톱이 하나씩 생겼다. 이제 네이티브 `<button>` 이 컨트롤이다 —
+  // Enter/Space 활성화·role·포커스를 **플랫폼이** 준다.
+  //
+  // ⚠️ 이 잠금이 `fireEvent.keyDown(button, {key:"Enter"})` 이 아닌 이유: jsdom 은 네이티브
+  // 버튼의 키 입력을 click 으로 합성하지 않는다(그건 브라우저 동작이고 user-event 가 흉내낸다.
+  // 이 레포엔 user-event 가 없다). keyDown 을 쏘면 **버튼이 아니어도 통과**하는 가짜 잠금이
+  // 되므로, 활성화 대신 **그 활성화를 보장하는 성질**(네이티브 button 인가)을 직접 잰다.
+  it("quick-peek toggle is a native button — keyboard activation comes from the platform", () => {
+    render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
+    const toggle = screen.getByTestId("action-row-toggle");
+    expect(toggle.tagName).toBe("BUTTON");
+    expect(toggle.getAttribute("type")).toBe("button"); // submit 이면 폼 안에서 오작동
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("action-row-peek")).toBeTruthy();
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId("action-row-peek")).toBeNull();
+  });
+
+  it("toggle announces disclosure state and points at the panel it controls", () => {
+    render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
+    const toggle = screen.getByTestId("action-row-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    // 접근명에 종목이 들어가야 행이 여럿일 때 "상세 펼치기" 가 구분된다.
+    expect(toggle.getAttribute("aria-label")).toContain(urgentItem.ticker);
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    const controls = toggle.getAttribute("aria-controls");
+    expect(controls).toBeTruthy();
+    // 관계가 **실제로** 이어져야 한다 — 속성만 있고 대상이 없으면 SR 에겐 없는 것과 같다.
+    expect(screen.getByTestId("action-row-peek").getAttribute("id")).toBe(controls);
+  });
+
+  it("row is no longer a phantom tab stop or a fake disclosure", () => {
     render(<ActionItems urgent={[urgentItem]} check={[]} hold={[]} />);
     const row = screen.getByTestId("action-row");
-    expect(row.getAttribute("tabindex")).toBe("0");
-    fireEvent.keyDown(row, { key: "Enter" });
+    expect(row.getAttribute("tabindex")).toBeNull();
+    expect(row.getAttribute("aria-expanded")).toBeNull();
+    // 마우스 편의는 유지 — 행 아무 데나 눌러도 펼쳐진다.
+    fireEvent.click(row);
     expect(screen.getByTestId("action-row-peek")).toBeTruthy();
-    fireEvent.keyDown(row, { key: " " });
-    expect(screen.queryByTestId("action-row-peek")).toBeNull();
-    fireEvent.keyDown(row, { key: "Escape" }); // 무시되는 키 — 토글 없음
-    expect(screen.queryByTestId("action-row-peek")).toBeNull();
+  });
+
+  it("each row gets its own aria-controls target", () => {
+    render(<ActionItems urgent={[urgentItem]} check={[checkItem]} hold={[]} />);
+    const ids = screen.getAllByTestId("action-row-toggle").map((b) => b.getAttribute("aria-controls"));
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2); // 공유하면 SR 이 엉뚱한 패널을 가리킨다
   });
 
   it("collapses quick-peek on second row click", () => {

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState, useSyncExternalStore, Fragment } from "react";
+import { useId, useMemo, useState, useSyncExternalStore, Fragment } from "react";
 import { ACTION } from "@/lib/strings";
 import { formatMoney } from "@/lib/format";
 import { type AckMap, ackItem, actionKey, isNewItem, loadAckMap } from "@/lib/action-ack";
@@ -63,6 +63,10 @@ interface AckProps {
 
 function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: string } & AckProps) {
   const [expanded, setExpanded] = useState(false);
+  // #1251: 확장 패널과 컨트롤을 aria-controls 로 잇는다. `useId` 는 SSR/CSR 간
+  // 안정적이라 hydration 경고가 없다 (actionKey 로 만들면 티커에 공백·특수문자가 섞여
+  // 유효하지 않은 id 가 될 수 있다).
+  const peekId = useId();
   const fmt = (v: number | null | undefined) => formatMoney(v, { ticker: item.ticker });
   const confPct = Math.max(0, Math.min(100, item.confidence));
   const isNew = isNewItem(item, ackMap);
@@ -71,20 +75,29 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
     <Fragment>
       <tr
         className={`border-b border-zinc-800/40 border-l-2 ${accent} hover:bg-zinc-800/30 cursor-pointer transition-colors focus-visible:outline-2 focus-visible:outline-blue-400/75`}
+        // 마우스 편의: 행 아무 데나 눌러도 펼쳐진다. **시맨틱은 아래 버튼이 갖는다** —
+        // #1208 은 이 행에 tabIndex/onKeyDown/aria-expanded 를 달아 키보드를 열었지만,
+        // `<tr>` 의 암묵 role 은 `row` 라 스크린리더가 disclosure 로 읽지 못하고
+        // 행마다 쓸모없는 탭 스톱만 하나씩 생겼다 (#1251). 네이티브 `<button>` 은
+        // Enter/Space 활성화·role·포커스를 플랫폼에서 받는다.
         onClick={() => setExpanded(!expanded)}
-        // 키보드 접근 (#1208 codex P1): 구 카드의 <button> 을 행이 대체하므로
-        // 행 자체가 포커스·Enter/Space 토글을 제공해야 한다
-        tabIndex={0}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            setExpanded(!expanded);
-          }
-        }}
         data-testid="action-row"
-        aria-expanded={expanded}
       >
         <td className="h-8 px-2 whitespace-nowrap">
+          <button
+            type="button"
+            data-testid="action-row-toggle"
+            aria-expanded={expanded}
+            aria-controls={peekId}
+            aria-label={`${item.name || item.ticker} ${expanded ? ACTION.PEEK_COLLAPSE : ACTION.PEEK_EXPAND}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded(!expanded);
+            }}
+            className="mr-1 align-middle inline-flex items-center justify-center w-4 h-4 -my-1 rounded text-zinc-500 hover:text-zinc-200 transition-colors focus-visible:outline-2 focus-visible:outline-blue-400/75"
+          >
+            <span aria-hidden="true" className={`text-[9px] leading-none transition-transform ${expanded ? "rotate-90" : ""}`}>&#9654;</span>
+          </button>
           <Link
             href={`/ticker/${item.ticker}`}
             className="text-xs font-semibold text-zinc-100 hover:text-white transition-colors"
@@ -146,7 +159,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
       </tr>
       {/* quick-peek (#1208, codex 2R 합의): 라우트 이동 없이 가격 레벨·전체 근거 확인 */}
       {expanded && (
-        <tr className="border-b border-zinc-800/40 bg-zinc-900/40" data-testid="action-row-peek">
+        <tr id={peekId} className="border-b border-zinc-800/40 bg-zinc-900/40" data-testid="action-row-peek">
           <td colSpan={8} className="px-3 py-2">
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
               {/* <md 에서 행이 숨기는 계좌·비중을 peek 가 복원 (#1208 codex P2) */}

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -477,6 +477,10 @@ export const ACTION = {
   EVIDENCE: "증거 체인", // #1182: 카드 → /decisions/[id]
   NEW: "NEW", // #1212: 미확인 행 배지 (localStorage seen-state)
   ACK: "확인", // #1212: quick-peek ack 버튼 — NEW 해제, 판정일 갱신 시 재표시
+  // #1251: 행 자체가 disclosure 였는데 시맨틱은 테이블 행이라 스크린리더가
+  // 컨트롤로 announce 하지 못했다. 실제 버튼의 접근명 — 종목명을 붙여 행마다 구분된다.
+  PEEK_EXPAND: "상세 펼치기",
+  PEEK_COLLAPSE: "상세 접기",
   // design-review F-001: 숫자 3개(수익률/비중/확신도)가 무라벨이라 추측을 요구했다
   COL_TICKER: "종목",
   COL_ACCOUNT: "계좌",


### PR DESCRIPTION
Closes #1251

## 문제 — 행이 disclosure 인 척했다

`ActionRow` 는 `<tr>` 에 `tabIndex={0}` · `onKeyDown` · `aria-expanded` 를 달아 클릭/키보드 확장을 구현했습니다 (#1208 codex P1 대응). **동작은 했지만** 시맨틱이 없었습니다:

- `<tr>` 의 암묵 role 은 `row` 입니다. 스크린리더는 이걸 **disclosure 컨트롤로 announce 하지 않습니다** — 사용자는 "여기서 뭔가 펼칠 수 있다" 는 것 자체를 알 수 없습니다.
- `aria-controls` 가 없어 **어떤 패널이 열리는지** 관계가 끊겨 있었습니다.
- 부수 피해: 행마다 아무것도 announce 하지 않는 **탭 스톱이 하나씩** 생겼습니다. 액션이 10건이면 쓸모없는 탭 스톱 10개입니다.

## 수정 — 네이티브 `<button>` 이 컨트롤을 갖는다

티커 셀 앞에 작은 chevron 버튼을 둡니다. `role`·포커스·**Enter/Space 활성화를 플랫폼이** 줍니다 — 손으로 재구현하지 않습니다.

- `aria-expanded` — 상태를 읽어줍니다
- `aria-controls={peekId}` → peek 행의 `id` (`useId`). 티커 기반으로 만들면 공백·특수문자가 섞여 유효하지 않은 id 가 될 수 있고, `useId` 는 SSR/CSR 간 안정적이라 hydration 경고도 없습니다
- `aria-label` 에 **종목명을 포함** — 행이 여럿일 때 "상세 펼치기" 가 서로 구분돼야 합니다

행에서는 `tabIndex`/`onKeyDown`/`aria-expanded` 를 걷고 `onClick` 만 남깁니다. **마우스 편의는 그대로**(행 아무 데나 눌러도 펼쳐짐), 시맨틱만 버튼으로 옮겼습니다. `e2e/action-first.spec.ts:84` 의 행 클릭 경로도 그대로 동작합니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| 행에 `tabIndex`/`aria-expanded` 복원 (#1208 상태로) | **1 FAIL** |
| `aria-controls` 제거 | **2 FAIL** |
| 모든 행이 같은 `id` 를 공유 | **1 FAIL** |
| 접근명에서 종목 제거 | **1 FAIL** |
| baseline 복원 | 39 passed |

`aria-controls` 축은 **속성 존재가 아니라 관계 성립**을 잽니다 — 속성만 있고 가리키는 대상이 없으면 스크린리더에겐 없는 것과 같습니다:

```ts
expect(screen.getByTestId("action-row-peek").getAttribute("id")).toBe(controls);
```

## ⚠️ 왜 `fireEvent.keyDown(button, {key:"Enter"})` 으로 잠그지 않았나

jsdom 은 네이티브 버튼의 키 입력을 click 으로 **합성하지 않습니다**. 그건 브라우저 동작이고 `user-event` 가 흉내내는데, 이 레포에는 `user-event` 가 없습니다 (`@testing-library/react` + `jest-dom` 만).

그래서 `keyDown` 으로 잠그면 **컨트롤이 버튼이 아니어도 통과하는 가짜 잠금**이 됩니다 — 이 PR 이 없애려는 바로 그 상태(`<tr>` + 수동 `onKeyDown`)에서도 초록입니다. 활성화 대신 **그 활성화를 보장하는 성질**을 직접 쟀습니다:

```ts
expect(toggle.tagName).toBe("BUTTON");
expect(toggle.getAttribute("type")).toBe("button");  // submit 이면 폼 안에서 오작동
```

M1 뮤테이션이 이 선택을 검증합니다 — 행 방식으로 되돌리면 FAIL 합니다.

## 검증

- `npx vitest run` → **1,636 passed / 135 files** (rc=0)
- `npm run build` rc=0 · `npx eslint --format json | jq length` → 242
- `make verify-doc-counts` 22/22 · `check_privacy_leak.py` rc=0
- `frontend/CLAUDE.md` 수동 카운트 1633 → 1636

## codex 리뷰 — 지적 없음

> The change cleanly moves the disclosure control from the table row to a native button, updates the related strings, and adds targeted regression tests for the new accessibility behavior. I did not find a discrete bug in the diff that would warrant blocking or follow-up fixes.

(코덱스 샌드박스에서 `next build` 는 포트 바인딩 불가로 실패했습니다 — 코드와 무관합니다. 로컬 `npm run build` 는 rc=0.)

## 스코프 밖

같은 design-review 아크의 `#1252`(strings SSoT) · `#1253`(pipeline 토큰) · `#1254`(tailwind lint 게이트)는 별도입니다. 이 PR 은 ActionRow 의 disclosure 시맨틱만 다룹니다.
