### PR TITLE
style(frontend): pipeline canvas uses dark tokens, not raw hex or status glow

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,628 backend tests across 349 files + 1622 frontend vitest (135 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,628 backend tests across 349 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,628 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 135 files |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1636 tests, 135 files)
+npm run test           # vitest run (1640 tests, 136 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -88,7 +88,7 @@ Two things that do **not** work, already tried (#913):
 Symptom if someone drops it: eslint prints `Oops! Something went wrong!` with a
 `brace-expansion` stack trace and lints **nothing**. `npm run lint` is silent on success, so
 confirm by file count rather than by absence of output — `npx eslint --format json | jq length`
-should be **241**.
+should be **244**.
 
 ## E2E (Playwright) — runs against the real backend, gated by CI since #1234
 
@@ -108,4 +108,4 @@ should be **241**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 99 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 100 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/src/__tests__/pages/pipeline-design-tokens.test.tsx
+++ b/frontend/src/__tests__/pages/pipeline-design-tokens.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * #1253 — pipeline 캔버스가 다크 토큰 시스템 안에 있는지.
+ *
+ * ReactFlow 는 SVG 속성이라 Tailwind 클래스가 안 먹는다. 그래서 raw hex 를 박아 뒀는데,
+ * 그러면 이 파일만 토큰 시스템 밖에 남아 테마 변경이 여기를 비껴간다. 인라인 스타일이라
+ * CSS 변수는 그대로 해석되므로 hex 를 쓸 이유가 없다.
+ *
+ * 잠금은 두 겹이다:
+ *   - **동작** — 실제로 넘어가는 edge/background 값이 `var(--...)` 인가 (ReactFlow 를
+ *     가로채 값을 그대로 본다)
+ *   - **구조** — 파일에 hex 리터럴이 남지 않았는가 (동작 잠금은 EDGES/Background 만 보므로
+ *     새 하드코딩 지점이 생기면 놓친다)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ReactFlow 를 가로채 실제로 넘어온 edges / Background color 를 노출시킨다.
+const captured: { edges: unknown[]; bgColor: unknown } = { edges: [], bgColor: undefined };
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlow: ({ edges, children }: { edges: unknown[]; children: React.ReactNode }) => {
+    captured.edges = edges;
+    return <div data-testid="react-flow">{children}</div>;
+  },
+  Background: ({ color }: { color?: unknown }) => {
+    captured.bgColor = color;
+    return <div data-testid="flow-background" />;
+  },
+  Controls: () => <div data-testid="flow-controls" />,
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+}));
+
+vi.mock("@/lib/api", () => ({ API_BASE: "http://localhost:8001", fetchAPI: vi.fn() }));
+
+const PAGE_PATH = join(process.cwd(), "src/app/pipeline/page.tsx");
+/** `#fff` / `#3f3f46` 형태의 색 리터럴. 문자열 안이든 JSX 속성이든 잡는다. */
+const HEX_COLOR = /#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\b/g;
+
+describe("pipeline 캔버스는 다크 토큰을 쓴다 (#1253)", () => {
+  beforeEach(() => {
+    captured.edges = [];
+    captured.bgColor = undefined;
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    ) as unknown as typeof fetch;
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("edge stroke 와 캔버스 점이 CSS 변수로 넘어간다", async () => {
+    const PipelinePage = (await import("@/app/pipeline/page")).default;
+    await act(async () => {
+      render(<PipelinePage />);
+    });
+
+    expect(captured.edges.length).toBeGreaterThan(0);
+    for (const e of captured.edges as { id: string; style?: { stroke?: string } }[]) {
+      expect(e.style?.stroke, `edge ${e.id} 의 stroke`).toMatch(/^var\(--/);
+    }
+    expect(captured.bgColor).toMatch(/^var\(--/);
+  });
+
+  it("소스에 색 hex 리터럴이 남아 있지 않다", () => {
+    const src = readFileSync(PAGE_PATH, "utf8");
+    const found = src.match(HEX_COLOR) ?? [];
+    expect(found, `raw hex 잔존: ${found.join(", ")}`).toHaveLength(0);
+  });
+
+  it("hex 스윕이 실제로 눈이 있다 (canary)", () => {
+    // 정규식이 조용히 아무것도 안 잡으면 위 테스트는 영원히 초록이다.
+    expect('style: { stroke: "#3f3f46" }'.match(HEX_COLOR)).toEqual(["#3f3f46"]);
+    expect('<Background color="#27272a" />'.match(HEX_COLOR)).toEqual(["#27272a"]);
+  });
+
+  it("노드는 그림자·상태 글로우 없이 테두리와 점으로만 상태를 말한다", async () => {
+    const { PipelineNode } = await import("@/app/pipeline/page");
+    const { container } = render(
+      <PipelineNode
+        data={{
+          label: "Collect", sub: "", status: "ok", recordCount: 1,
+          lastUpdated: null, stepId: "collect", onRun: vi.fn(), isRunning: false,
+        }}
+      />
+    );
+    const root = container.querySelector("div.relative")!;
+    // `shadow-` 접두사 전체를 막는다 — shadow-lg 만 지우고 글로우가 남는 절반 회귀를 잡는다.
+    expect(root.className).not.toMatch(/\bshadow-/);
+    expect(root.className).toContain("border-emerald-500/30"); // 상태는 테두리가 말한다
+  });
+});

--- a/frontend/src/app/pipeline/page.branchcov.test.tsx
+++ b/frontend/src/app/pipeline/page.branchcov.test.tsx
@@ -96,7 +96,8 @@ describe("PipelineNode — node-body branch arms", () => {
     render(<PipelineNode data={base({ status: "" as unknown as "ok" })} />);
     const root = screen.getByText("Collect").closest("div.relative")!;
     expect(root.className).toContain("border-emerald-500/30");
-    expect(root.className).toContain("shadow-emerald-500/10");
+    // #1253: 상태 글로우(shadow-*-500/10)는 제거됐다 — 상태는 테두리 + 점만으로 말한다.
+    expect(root.className).not.toContain("shadow-emerald-500/10");
   });
 
   it("status running → animate-ping span renders (170 ternary true) + button running text (196/201 true)", async () => {

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -101,13 +101,6 @@ const STATUS_BORDER: Record<string, string> = {
   running: "border-blue-500/30",
 };
 
-const STATUS_GLOW: Record<string, string> = {
-  ok: "shadow-emerald-500/10",
-  warning: "shadow-amber-500/10",
-  error: "shadow-red-500/10",
-  running: "shadow-blue-500/10",
-};
-
 // F-003 (#1237): 이모지 → lucide — 디자인 시스템의 유일한 아이콘 체계 (사이드바와 동일).
 // lucide 의 LucideIcon 별칭은 TS6 JSX 에서 붕괴 사례가 있어 구체 타입(typeof Search)으로.
 type IconComponent = typeof Search;
@@ -193,7 +186,6 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
         relative bg-card border rounded-xl px-5 py-4 min-w-55
         transition-all duration-200
         hover:bg-muted/80 hover:scale-[1.02]
-        shadow-lg ${STATUS_GLOW[status]}
         ${STATUS_BORDER[status]}
       `}
     >
@@ -267,12 +259,23 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
 PipelineNode.displayName = "PipelineNode";
 
 // === Edges ===
+// #1253: ReactFlow 는 SVG 속성이라 Tailwind 클래스가 안 먹는다 — 그렇다고 raw hex 를 박으면
+// 다크 토큰 시스템 밖으로 새서 테마 변경이 여기만 비껴간다. 인라인 스타일이라 CSS 변수는
+// 그대로 해석된다.
+//   EDGE_STROKE = 다이어그램 크롬. 같은 파일의 Controls 가 이미 `border-input!` 을 쓰므로
+//                 크롬 색을 하나로 맞춘다 (기존 zinc-700 과 실측상 가장 가까운 토큰이기도 하다).
+//   CANVAS_DOT  = 캔버스 질감. `--border`(흰색 10%)가 기존 zinc-800 과 사실상 같은 값이다.
+// 값을 hex 로 적지 않는 것도 의도다 — 잠금 테스트가 소스의 hex 리터럴을 스윕하는데,
+// 주석에 적힌 옛 값도 똑같이 잡힌다 (주석만 예외로 빼면 스윕이 눈이 멀 자리를 만든다).
+const EDGE_STROKE = "var(--input)";
+const CANVAS_DOT = "var(--border)";
+
 const EDGES: Edge[] = [
-  { id: "e-collect-validate", source: "collect", target: "validate", animated: true, style: { stroke: "#3f3f46" } },
-  { id: "e-validate-classify", source: "validate", target: "classify", animated: true, style: { stroke: "#3f3f46" } },
-  { id: "e-classify-diagnose", source: "classify", target: "diagnose", animated: true, style: { stroke: "#3f3f46" } },
-  { id: "e-diagnose-recommend", source: "diagnose", target: "recommend", animated: true, style: { stroke: "#3f3f46" } },
-  { id: "e-recommend-track", source: "recommend", target: "track", animated: true, style: { stroke: "#3f3f46" } },
+  { id: "e-collect-validate", source: "collect", target: "validate", animated: true, style: { stroke: EDGE_STROKE } },
+  { id: "e-validate-classify", source: "validate", target: "classify", animated: true, style: { stroke: EDGE_STROKE } },
+  { id: "e-classify-diagnose", source: "classify", target: "diagnose", animated: true, style: { stroke: EDGE_STROKE } },
+  { id: "e-diagnose-recommend", source: "diagnose", target: "recommend", animated: true, style: { stroke: EDGE_STROKE } },
+  { id: "e-recommend-track", source: "recommend", target: "track", animated: true, style: { stroke: EDGE_STROKE } },
 ];
 
 // === Fetch 3-state (#1250) ===
@@ -499,7 +502,7 @@ export default function PipelinePage() {
             animated: true,
           }}
         >
-          <Background color="#27272a" gap={20} size={1} />
+          <Background color={CANVAS_DOT} gap={20} size={1} />
           <Controls
             showInteractive={false}
             className="bg-card! border-input! shadow-lg! [&>button]:bg-muted! [&>button]:border-input! [&>button]:text-muted-foreground! [&>button:hover]:bg-muted!"


### PR DESCRIPTION
Closes #1253

## 문제 — ReactFlow 만 토큰 시스템 밖에 있었다

ReactFlow 는 SVG 속성이라 Tailwind 클래스가 안 먹습니다. 그래서 edge stroke 5곳과 캔버스 점에 raw hex(`zinc-700` / `zinc-800`)가 박혀 있었고, 결과적으로 **이 파일만 다크 토큰 시스템 밖**에 남아 테마 토큰을 바꿔도 여기를 비껴갔습니다.

핵심은 hex 를 쓸 **이유가 없었다**는 것입니다 — 둘 다 인라인 스타일이라 CSS 변수가 그대로 해석됩니다.

| | 이전 | 이후 | 근거 |
|---|---|---|---|
| edge stroke ×5 | zinc-700 | `var(--input)` | 같은 파일의 Controls 가 이미 `border-input!` 을 씀 → 다이어그램 크롬 색을 하나로. 기존 값과 실측상 가장 가까운 토큰이기도 함 |
| 캔버스 점 | zinc-800 | `var(--border)` | 흰색 10% 가 기존 값과 사실상 동일 |

## 글로우 제거

노드의 `shadow-lg` + 상태 글로우(`STATUS_GLOW` — `shadow-emerald-500/10` 등)를 걷었습니다. "diagram card" 톤이라 대시보드의 calm operational surface 와 이질적이었고, **상태는 이미 테두리(`STATUS_BORDER`)와 점이 말합니다.** `STATUS_GLOW` 상수가 orphan 이 되므로 같이 지웠습니다 (내 변경이 만든 orphan만 — `CLAUDE.md §3`).

ReactFlow `Controls` 의 `shadow-lg!` 는 **남겼습니다.** 그건 캔버스 위에 뜨는 오버레이라 elevation 이 의미를 갖습니다 — 이슈가 지목한 것은 노드 톤입니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

잠금이 두 겹인 이유: 동작 잠금은 `EDGES` / `Background` 만 보므로 **새 하드코딩 지점**이 생기면 놓칩니다. 구조 스윕이 그걸 덮습니다.

| 뮤테이션 | 결과 |
|---|---|
| edge stroke 를 raw hex 로 되돌림 | **2 FAIL** (동작 + 구조) |
| `shadow-lg` 만 복원 (**반쪽 되돌림**) | **1 FAIL** |
| 캔버스 점을 raw hex 로 되돌림 | **2 FAIL** |
| baseline 복원 | 26 passed |

- **동작**: ReactFlow 를 가로채 실제로 넘어간 값이 `var(--...)` 인지 봅니다 — 상수 이름이 아니라 도달한 값을 잽니다.
- **구조**: 소스에 hex 리터럴이 남지 않았는지 스윕 + **canary**. 정규식이 조용히 아무것도 안 잡으면 그 테스트는 영원히 초록이라, 스윕에 눈이 있는지 별도로 단언합니다.
- **반쪽 되돌림 방어**: `shadow-lg` 만 복원해도 FAIL 하도록 `not.toMatch(/\bshadow-/)` 로 접두사 전체를 막았습니다. `shadow-emerald-500/10` 하나만 단언했으면 M2 가 통과했을 것입니다.

### 주석에 옛 hex 를 안 적은 것도 의도입니다

처음엔 주석에 이전 값을 hex 로 적었는데 **구조 스윕이 그걸 잡았습니다.** 정직한 동작입니다 — 주석만 예외로 빼면 스윕이 눈이 멀 자리를 만듭니다(따옴표·주석 경계에서 조용히 멀어버리는 건 이 레포가 이미 겪은 형태). Tailwind 이름(`zinc-700`/`zinc-800`)으로 적으면 의미도 더 분명합니다.

## 스코프 밖 — 별도 이슈 #1275

같은 이탈이 **차트 레이어 전반에 17곳 / 9개 파일** 남아 있습니다 (recharts grid stroke · tooltip border · treemap fill). 이 PR 은 `pipeline/page.tsx` 스코프라 손대지 않고 **#1275** 로 분리했습니다. 그 이슈에 두 가지 함정도 같이 적어 뒀습니다: `portfolio-treemap.tsx:41` 의 같은 hex 는 *violation 없음 fallback* 이라 의미가 다르고, `evidence-charts.test.tsx:193` 이 그 값을 단언합니다.

## codex 리뷰 — 지적 없음

> I did not find any discrete correctness issues in the changed frontend code. The new tokenized ReactFlow colors are backed by targeted tests, and the touched files pass focused vitest, TypeScript, and ESLint checks in this environment.

## 검증

- `npx vitest run` → **1,640 passed / 136 files** (rc=0)
- `npm run build` rc=0 · `npx eslint --format json | jq length` → 244
- `make verify-doc-counts` 22/22 · `check_privacy_leak.py` rc=0
- `frontend/CLAUDE.md` 수동 카운트 갱신 (1636/135 → 1640/136, 테스트 파일 99 → 100, eslint 241 → 244 — 241 은 #1250·#1251·#1253 이 파일을 추가하기 전 값이라 이미 낡아 있었습니다)
