### PR TITLE
fix(api): key portfolio-derived caches on a portfolio version, stop faking unknown P&L

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,641 collected across 350 files | |
+| **Backend tests** | 7,646 collected across 350 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,628 collected across 349 files | |
+| **Backend tests** | 7,641 collected across 350 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,628 backend tests across 349 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,641 backend tests across 350 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,641 backend tests across 350 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,646 backend tests across 350 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,641 tests, 350 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,646 tests, 350 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,628 tests, 349 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,641 tests, 350 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1640 tests, 136 files)
+npm run test           # vitest run (1642 tests, 136 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { ActionItems } from "@/components/ui/action-items";
+import { ACTION } from "@/lib/strings";
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
@@ -233,6 +234,22 @@ describe("ActionItems", () => {
     // 마우스 편의는 유지 — 행 아무 데나 눌러도 펼쳐진다.
     fireEvent.click(row);
     expect(screen.getByTestId("action-row-peek")).toBeTruthy();
+  });
+
+  // #1279: 시세 없는 보유(비상장)는 손익이 null 이다.
+  it("null pnl renders 미상, not a fabricated 0%", () => {
+    const unpriced = { ...urgentItem, ticker: "PRIVATECO", pnl_pct: null, current_price: null };
+    render(<ActionItems urgent={[unpriced]} check={[]} hold={[]} />);
+    expect(screen.getByText(ACTION.PNL_UNKNOWN)).toBeTruthy();
+    // 이전 코드는 `null >= 0` 이 true 라 "+0.0%" 를 초록으로 찍었다 — 보합으로 읽힌다.
+    expect(screen.queryByText("+0.0%")).toBeNull();
+    expect(screen.queryByText("0.0%")).toBeNull();
+  });
+
+  it("numeric pnl still renders with sign and one decimal", () => {
+    render(<ActionItems urgent={[{ ...urgentItem, pnl_pct: -3.14 }]} check={[]} hold={[]} />);
+    expect(screen.getByText("-3.1%")).toBeTruthy();
+    expect(screen.queryByText(ACTION.PNL_UNKNOWN)).toBeNull();
   });
 
   it("each row gets its own aria-controls target", () => {

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -12,7 +12,8 @@ export interface ActionItem {
   action: string;
   confidence: number;
   agreement?: number | null;
-  pnl_pct: number;
+  /** 시세 미수집이면 `null` — 측정 불가이지 0% 가 아니다 (#1279). */
+  pnl_pct: number | null;
   position_pct: number;
   current_price?: number | null;
   avg_price?: number | null;
@@ -127,8 +128,14 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
             {item.reasons.length > 1 && <span className="text-zinc-600"> +{item.reasons.length - 1}</span>}
           </p>
         </td>
-        <td className={`h-8 px-2 whitespace-nowrap text-right text-xs font-semibold tabular-nums ${item.pnl_pct >= 0 ? "text-emerald-400" : "text-red-400"}`}>
-          {item.pnl_pct >= 0 ? "+" : ""}{item.pnl_pct.toFixed(1)}%
+        {/* #1279: `null` 은 미상이다. 이전 코드는 `null >= 0` 이 true 라 **초록 +** 가
+            붙고 `null.toFixed` 로 터졌다 — JS 의 null 강제변환이 만든 두 겹 오류. */}
+        <td className={`h-8 px-2 whitespace-nowrap text-right text-xs font-semibold tabular-nums ${
+          item.pnl_pct == null ? "text-zinc-500" : item.pnl_pct >= 0 ? "text-emerald-400" : "text-red-400"
+        }`}>
+          {item.pnl_pct == null
+            ? ACTION.PNL_UNKNOWN
+            : `${item.pnl_pct >= 0 ? "+" : ""}${item.pnl_pct.toFixed(1)}%`}
         </td>
         <td className="h-8 px-2 whitespace-nowrap hidden md:table-cell text-right text-[11px] text-zinc-400 tabular-nums">
           {item.position_pct.toFixed(1)}%

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -489,6 +489,9 @@ export const ACTION = {
   COL_PNL: "수익률",
   COL_WEIGHT: "비중",
   COL_CONF: "확신도",
+  // #1279: 시세 없는 보유(비상장)의 손익은 측정 불가다. 0.0% 로 렌더하면 "보합" 으로
+  // 읽힌다 — 지어낸 숫자를 사용자 카피로 내보내지 않는다 (STRATEGY §2.6 과 같은 원칙).
+  PNL_UNKNOWN: "미상",
   // DETAIL/CONF/AGREE/PNL/WEIGHT/DISMISS 는 U2b-2 (#1208) 카드→행 전환으로 제거
 } as const;
 

--- a/nuri/api/cache.py
+++ b/nuri/api/cache.py
@@ -1,0 +1,57 @@
+"""API 응답 캐시의 **포트폴리오 버전 키** (#1279).
+
+## 왜 TTL 만으로는 부족한가
+
+`actions.py` / `dashboard.py` 의 모듈 캐시는 프로세스 로컬이고 **write-blind** 다.
+게다가 포트폴리오를 바꾸는 정상 경로(`scripts/ops/import_portfolio.py`)는 API 를
+거치지 않고 **DB 에 직접 쓴다** — POST 조차 아니라서 API 프로세스는 변경 사실을
+알 방법이 없고, TTL 만료(5분)만이 유일한 복구 경로였다.
+
+그 5분이 위험한 이유는 단순히 숫자가 낡아서가 아니다. 2026-08-29 실측: 보유를
+갱신한 직후 `/api/actions` 가 현대차를 **`urgent` 버킷 · conf 100 · "손절선 -20%
+돌파"** 로 반환했는데 실제 손익은 -13.1% 로 돌파하지 않았다. -31.9% 는 갱신 **전**
+평단으로 계산된 값이었다. 그리고 "보유를 갱신하고 바로 대시보드를 연다" 는 가장
+자연스러운 순서라, 거짓 신호 창과 사용자의 확인 시점이 정확히 겹친다.
+
+## 왜 무효화 엔드포인트가 아니라 버전 키인가
+
+`POST /api/cache/invalidate` 를 두고 import 스크립트가 부르게 할 수도 있다. 하지만
+그건 **프로세스 경계를 타는** 해법이라 세 가지로 샌다: (1) API 가 안 떠 있으면
+무효화가 유실되고, (2) 앞으로 생길 다른 writer(수동 SQL, 다른 스크립트, 백필)가
+호출을 빠뜨리면 조용히 되살아나고, (3) 워커가 여러 프로세스면 하나만 비워진다.
+
+버전 키는 **읽는 쪽에 방어를 둔다** — 데이터가 어떻게 바뀌었든 캐시가 스스로
+알아챈다. 이 레포가 반복해서 배운 형태다(쓰는 쪽에 규율을 요구하면 새 writer 가
+생길 때마다 다시 샌다).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nuri.core.db import DatabaseError, OperationalError, query
+
+logger = logging.getLogger(__name__)
+
+#: 버전을 읽지 못했을 때의 고정 sentinel. **매번 다른 값을 돌려주면 안 된다** —
+#: 캐시가 영구 미스가 되어 무거운 핸들러가 매 요청 재계산된다(#1119 의 stampede).
+#: 조회 실패는 TTL-only 동작으로 degrade 시키고, 대신 로그를 남긴다.
+_UNKNOWN = "unknown"
+
+
+def portfolio_version(db_path=None) -> str:
+    """포트폴리오의 현재 버전 문자열. 보유가 바뀌면 값이 바뀐다.
+
+    `COUNT(*)` 와 `MAX(updated_at)` 을 **함께** 쓴다. `MAX` 만 보면 행이 삭제되기만
+    한 경우(남은 행의 타임스탬프는 그대로)를 놓친다. 반대로 `COUNT` 만 보면 수량·평단만
+    바뀐 갱신을 놓친다. 두 축이 서로의 사각을 덮는다.
+    """
+    try:
+        rows = query("SELECT COUNT(*) AS n, MAX(updated_at) AS mx FROM portfolio", db_path=db_path)
+    except (OperationalError, DatabaseError):
+        # 진단이 본 작업을 게이트하면 안 된다 (#894) — 캐시는 TTL 로 계속 동작한다.
+        logger.warning("portfolio 버전 조회 실패 — 캐시가 TTL 만으로 동작한다", exc_info=True)
+        return _UNKNOWN
+    if not rows:
+        return _UNKNOWN
+    return f"{rows[0]['n']}:{rows[0]['mx']}"

--- a/nuri/api/cache.py
+++ b/nuri/api/cache.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 
 from nuri.core.db import DatabaseError, OperationalError, query
@@ -40,18 +41,39 @@ _UNKNOWN = "unknown"
 
 
 def portfolio_version(db_path=None) -> str:
-    """포트폴리오의 현재 버전 문자열. 보유가 바뀌면 값이 바뀐다.
+    """포트폴리오의 현재 버전. **보유 내용 자체**의 해시다.
 
-    `COUNT(*)` 와 `MAX(updated_at)` 을 **함께** 쓴다. `MAX` 만 보면 행이 삭제되기만
-    한 경우(남은 행의 타임스탬프는 그대로)를 놓친다. 반대로 `COUNT` 만 보면 수량·평단만
-    바뀐 갱신을 놓친다. 두 축이 서로의 사각을 덮는다.
+    타임스탬프가 아니라 내용을 해싱하는 이유 — 초안은 `COUNT(*) + MAX(updated_at)` 이었고
+    세 축에서 뚫렸다 (codex 리뷰 P1 + 실측):
+
+    1. **같은 초 안의 연속 갱신** — `upsert_portfolio` 는 `datetime('now')`, 즉 **초
+       해상도**로 찍는다. 1초 안에 같은 행을 두 번 쓰면(연속 수동 편집, 다계좌 일괄 sync)
+       행 수도 타임스탬프도 그대로라 버전이 안 바뀐다. 초안 테스트가 `time.sleep(1.05)`
+       를 넣어야 통과했다는 게 이미 그 증거였다 — 우회로 덮은 셈이다.
+    2. **상쇄되는 변경** — `SUM(quantity)` 같은 집계로 바꿔도 A 에서 -1, B 에서 +1 이면
+       합계가 같아 못 잡는다 (실측 확인).
+    3. 삭제·행 수 변화는 해시가 자연히 덮는다.
+
+    내용 해시는 이 셋을 한 번에 닫는다. 비용은 보유 행 수에 비례하지만 이 테이블은
+    **한 사람의 보유**라 수십 행 규모이고, 캐시 히트를 지키는 대가로 붙는 유일한 DB
+    작업이다 (miss 시 핸들러는 초 단위다).
+
+    반대로 **내용이 같으면 버전도 같아야** 한다 — 재import 가 실제 변경 없이 끝났을 때
+    캐시를 버리면 무거운 핸들러가 헛돈다. 그래서 `updated_at` 은 해시에 넣지 않는다.
     """
     try:
-        rows = query("SELECT COUNT(*) AS n, MAX(updated_at) AS mx FROM portfolio", db_path=db_path)
+        rows = query(
+            "SELECT account, ticker, quantity, avg_price, currency, sector FROM portfolio",
+            db_path=db_path,
+        )
     except (OperationalError, DatabaseError):
         # 진단이 본 작업을 게이트하면 안 된다 (#894) — 캐시는 TTL 로 계속 동작한다.
         logger.warning("portfolio 버전 조회 실패 — 캐시가 TTL 만으로 동작한다", exc_info=True)
         return _UNKNOWN
-    if not rows:
-        return _UNKNOWN
-    return f"{rows[0]['n']}:{rows[0]['mx']}"
+    # SQL 의 행 순서는 보장되지 않는다 — 정렬하지 않으면 같은 내용이 다른 해시를 낸다.
+    payload = "\n".join(
+        sorted(
+            f"{r['account']}|{r['ticker']}|{r['quantity']}|{r['avg_price']}|{r['currency']}|{r['sector']}" for r in rows
+        )
+    )
+    return f"{len(rows)}:{hashlib.blake2b(payload.encode(), digest_size=16).hexdigest()}"

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -650,8 +650,13 @@ def _is_worse(new: float | None, cur: float | None) -> bool:
 
 
 def _pnl_phrase(pnl: float | None) -> str:
-    """근거 문자열의 손익 표기. 미상이면 숫자를 지어내지 않는다 (#1279)."""
-    return f"+{pnl:.0f}%" if pnl is not None else "손익 미상"
+    """근거 문자열의 손익 표기. 미상이면 숫자를 지어내지 않는다 (#1279).
+
+    부호는 **포맷 스펙에 맡긴다** (`:+`). 리터럴 `+` 를 앞에 붙이면 손실이 `+-5%` 로
+    찍힌다 (codex 리뷰 P2). 리더 트레일링은 고점 대비 이탈이라 진입가 아래에서도
+    발화할 수 있어 실제로 도달 가능한 경로다.
+    """
+    return f"{pnl:+.0f}%" if pnl is not None else "손익 미상"
 
 
 def _get_portfolio_map() -> dict[str, dict]:

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -14,6 +14,7 @@ from datetime import timedelta
 
 from fastapi import APIRouter, Depends
 
+from nuri.api.cache import portfolio_version
 from nuri.api.limits import heavy_slot
 from nuri.core.axis import is_alpha_flat_sell
 from nuri.core.catalyst import has_recent_catalyst
@@ -28,14 +29,25 @@ router = APIRouter(tags=["actions"])
 
 # 캐시 (5분 TTL) — dashboard.py와 동일 패턴
 CACHE_TTL = 300  # 5분
-_actions_cache: dict = {"data": None, "timestamp": 0}
-_opportunities_cache: dict = {"data": None, "timestamp": 0}
+# `version` — 포트폴리오가 바뀌면 TTL 이 남아 있어도 캐시를 버린다 (#1279).
+# `_market_context_cache` 는 macro 만 보므로 버전 키가 없다.
+_actions_cache: dict = {"data": None, "timestamp": 0, "version": None}
+_opportunities_cache: dict = {"data": None, "timestamp": 0, "version": None}
 _market_context_cache: dict = {"data": None, "timestamp": 0}
 # single-flight — TTL 만료 시 동시 요청이 전부 재계산하는 걸 막는다 (#1119).
 # `_scan_lock` (아래) 과 같은 이유·같은 패턴이다.
 _actions_lock = threading.Lock()
 _opportunities_lock = threading.Lock()
 _market_context_lock = threading.Lock()
+
+
+def _fresh(cache: dict, now: float, version: str) -> bool:
+    """캐시가 아직 유효한가 — TTL **과** 포트폴리오 버전을 함께 본다 (#1279).
+
+    버전 비교를 빼면 보유를 바꾼 직후 최대 5분간 옛 평단으로 계산된 액션이 나간다.
+    그건 낡은 숫자가 아니라 **거짓 손절 신호**다 (`nuri/api/cache.py` 참조).
+    """
+    return bool(cache["data"]) and (now - cache["timestamp"]) < CACHE_TTL and cache["version"] == version
 
 
 # ─── /api/actions ───
@@ -45,17 +57,22 @@ _market_context_lock = threading.Lock()
 def get_actions():
     """우선순위 분류된 오늘의 액션 리스트."""
     now = time.time()
-    if _actions_cache["data"] and (now - _actions_cache["timestamp"]) < CACHE_TTL:
+    # 버전은 **빌드 전에** 읽어 저장한다 (#1279). 빌드 도중 쓰기가 들어오면 저장된
+    # 버전이 옛 것이라 다음 요청이 한 번 더 재계산할 뿐이다 — 반대로 빌드 후에 읽으면
+    # 새 버전을 옛 데이터에 붙여 **낡은 응답을 신선하다고 판정**한다. 안전한 방향으로 튄다.
+    version = portfolio_version()
+    if _fresh(_actions_cache, now, version):
         return _actions_cache["data"]
     try:
         with _actions_lock:
             # double-check — 락을 기다리는 동안 다른 요청이 채웠을 수 있다 (#1119)
             now = time.time()
-            if _actions_cache["data"] and (now - _actions_cache["timestamp"]) < CACHE_TTL:
+            if _fresh(_actions_cache, now, version):
                 return _actions_cache["data"]
             result = _build_actions()
             _actions_cache["data"] = result
             _actions_cache["timestamp"] = time.time()
+            _actions_cache["version"] = version
             return result
     except Exception:
         logger.exception("actions API error")
@@ -120,7 +137,8 @@ def _build_actions() -> dict:
         portfolio_action = rec.get("portfolio_action")
         confidence = rec["confidence"]
         holding = portfolio_holdings.get(ticker, {})
-        pnl_pct = holding.get("pnl_pct", 0)
+        # #1279: 기본값 0 을 주지 않는다 — 미상이 보합으로 둔갑하는 지점이었다.
+        pnl_pct = holding.get("pnl_pct")
         position_pct = holding.get("position_pct", 0)
         # 보유 행이 고른 계좌(worst-PnL)와 **같은 계좌**의 타겟을 본다 — 티커로만
         # 조회하면 둘이 갈라져 서로 다른 원가 기준이 한 줄에 섞인다 (#982).
@@ -146,7 +164,7 @@ def _build_actions() -> dict:
             "portfolio_action": portfolio_action,
             "confidence": confidence,
             "agreement": rec.get("agreement"),
-            "pnl_pct": round(pnl_pct, 1),
+            "pnl_pct": round(pnl_pct, 1) if pnl_pct is not None else None,
             "position_pct": round(position_pct, 1),
             "current_price": holding.get("current_price"),
             "avg_price": holding.get("avg_price"),
@@ -194,7 +212,9 @@ def _build_actions() -> dict:
             # A-3: 하드코딩 -7 제거. holding 이 최대 비중 계좌의 row 이므로 그
             # account 의 strategy stop_loss 와 비교 — pnl_pct 와 cost basis 일치.
             stop_loss_threshold = get_stop_loss_for_account(holding.get("account"))
-            if pnl_pct < stop_loss_threshold:
+            # 손익을 모르면 돌파를 **주장할 수 없다** (#1279). 미상은 아래 catalyst
+            # 경로로 흘러 "왜 매도?" 맥락을 요구받는다 — 기계적 청산은 측정값에만.
+            if pnl_pct is not None and pnl_pct < stop_loss_threshold:
                 # stop-loss breach — 기계적 실행 (§2.2). catalyst 무관.
                 # "근접" 이 아니라 **돌파**다 (#994). 이 분기 자체가 `pnl_pct <
                 # threshold` — 관찰이 아니라 기계적 청산 신호이고, 초과폭을 같이
@@ -238,7 +258,7 @@ def _build_actions() -> dict:
             from nuri.core.rules import TAKE_PROFIT_LEADER
 
             _ma_p = int(TAKE_PROFIT_LEADER.get("trail_ma", 50))
-            item["reasons"].append(f"⭐ 리더 {_ma_p}일선 이탈 (+{pnl_pct:.0f}%) — 추세 break, 청산 검토")
+            item["reasons"].append(f"⭐ 리더 {_ma_p}일선 이탈 ({_pnl_phrase(pnl_pct)}) — 추세 break, 청산 검토")
             promoted = True
 
         # 2차 익절 도달 (리더는 고정 익절 미적용 → skip)
@@ -258,7 +278,7 @@ def _build_actions() -> dict:
             and item["current_price"]
             and item["current_price"] >= target["target_1"]
         ):
-            item["reasons"].append(f"1차 익절 도달 (+{pnl_pct:.0f}%) — 50% 매도 고려")
+            item["reasons"].append(f"1차 익절 도달 ({_pnl_phrase(pnl_pct)}) — 50% 매도 고려")
             promoted = True
 
         # 높은 공매도 비율
@@ -293,17 +313,21 @@ def _build_actions() -> dict:
 def get_opportunities():
     """비보유 이슈 종목 탐색 — scan + WSB + macro events 기반 판정."""
     now = time.time()
-    if _opportunities_cache["data"] and (now - _opportunities_cache["timestamp"]) < CACHE_TTL:
+    # 보유 종목을 제외하는 목록이라 포트폴리오 파생이다 — 새로 산 종목이 5분간
+    # "기회" 로 계속 뜨면 안 된다 (#1279).
+    version = portfolio_version()
+    if _fresh(_opportunities_cache, now, version):
         return _opportunities_cache["data"]
     try:
         with _opportunities_lock:
             # double-check — 락을 기다리는 동안 다른 요청이 채웠을 수 있다 (#1119)
             now = time.time()
-            if _opportunities_cache["data"] and (now - _opportunities_cache["timestamp"]) < CACHE_TTL:
+            if _fresh(_opportunities_cache, now, version):
                 return _opportunities_cache["data"]
             result = {"opportunities": _build_opportunities(), "generated_at": kst_now().isoformat()}
             _opportunities_cache["data"] = result
             _opportunities_cache["timestamp"] = time.time()
+            _opportunities_cache["version"] = version
             return result
     except Exception:
         logger.exception("opportunities API error")
@@ -611,6 +635,25 @@ def _get_real_accounts() -> set[str]:
     return get_real_accounts()
 
 
+def _is_worse(new: float | None, cur: float | None) -> bool:
+    """worst-PnL 집계에서 `new` 가 `cur` 보다 나쁜가 — None(측정 불가) 안전 (#1279).
+
+    None 은 "가장 나쁨" 이 아니라 **모름**이다. 측정 가능한 쪽이 계좌·손익 자리를 갖는다 —
+    그러지 않으면 비상장 한 줄이 같은 티커의 측정 가능한 보유를 가려 손절 판정을 통째로
+    삼킨다. 둘 다 None 이면 바꿀 이유가 없다.
+    """
+    if new is None:
+        return False
+    if cur is None:
+        return True
+    return new < cur
+
+
+def _pnl_phrase(pnl: float | None) -> str:
+    """근거 문자열의 손익 표기. 미상이면 숫자를 지어내지 않는다 (#1279)."""
+    return f"+{pnl:.0f}%" if pnl is not None else "손익 미상"
+
+
 def _get_portfolio_map() -> dict[str, dict]:
     """보유 종목 → 현재 상태 매핑."""
     from nuri.api.routes.dashboard import _get_account_labels
@@ -637,12 +680,18 @@ def _get_portfolio_map() -> dict[str, dict]:
     total_value = 0
     items = []
     for r in rows:
-        price = r["current_price"] or r["avg_price"] or 0
+        # #1279: 시장가와 **비중 계산용 가격**을 분리한다.
+        # `market_price` 가 None 이면 시세 미수집(예: 비상장) — 손익은 **측정 불가**다.
+        # 반면 비중은 원가로도 말할 수 있고, 0 으로 지우면 다른 종목 비중이 부풀려진다.
+        # 이전에는 하나의 `price` 가 둘을 겸해서, 원가로 대체된 값이 손익 계산에도 들어가
+        # **미상이 0.0%(보합)으로 둔갑**했다.
+        market_price = r["current_price"]
+        price = market_price if market_price is not None else (r["avg_price"] or 0)
         qty = r["quantity"] or 0
         is_kr = is_kr_ticker(r["ticker"])
         val = price * qty / rate if is_kr else price * qty
         total_value += val
-        items.append((r, val, price, is_kr))
+        items.append((r, val, market_price, is_kr))
 
     labels = _get_account_labels()
 
@@ -665,7 +714,9 @@ def _get_portfolio_map() -> dict[str, dict]:
     for r, val, price, is_kr in items:
         ticker = r["ticker"]
         avg = r["avg_price"] or 0
-        pnl = ((price - avg) / avg * 100) if avg > 0 else 0
+        # 시세가 없으면 **None** — 0.0 은 "보합" 으로 읽히는 지어낸 값이다 (#1279).
+        # STRATEGY §2.6 의 VIX 게이트와 같은 원칙: 측정 불가는 숫자로 메우지 않는다.
+        pnl = ((price - avg) / avg * 100) if (avg > 0 and price is not None) else None
         pos_pct = (val / total_value * 100) if total_value > 0 else 0
         account_label = labels.get(r["account"], r["account"])
         is_pension = _is_pension_label(account_label)
@@ -708,7 +759,7 @@ def _get_portfolio_map() -> dict[str, dict]:
         if is_pension and not existing["_pension_only"]:
             continue
         # 동질 (둘 다 pension 이거나 둘 다 non-pension) → worst-pnl 이 승리
-        if pnl < existing["pnl_pct"]:
+        if _is_worse(pnl, existing["pnl_pct"]):
             existing["pnl_pct"] = pnl
             existing["current_price"] = price
             existing["avg_price"] = avg

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -13,33 +13,45 @@ import time
 
 from fastapi import APIRouter, Depends
 
+from nuri.api.cache import portfolio_version
 from nuri.api.limits import heavy_slot
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["dashboard"])
 
 # 캐시 (5분 TTL)
-_cache: dict = {"data": None, "timestamp": 0}
+# `version` — 포트폴리오가 바뀌면 TTL 이 남아 있어도 버린다 (#1279).
+# 액션만 고치고 여기를 두면 같은 화면에서 액션은 새 보유, 히어로 합계는 옛 보유가 되어
+# **패널 간 모순**이 생긴다 — 균일하게 낡은 것보다 나쁘다.
+_cache: dict = {"data": None, "timestamp": 0, "version": None}
 CACHE_TTL = 300  # 5분
 # single-flight — TTL 만료 시 동시 요청이 전부 재계산하는 걸 막는다 (#1119)
 _lock = threading.Lock()
+
+
+def _fresh(cache: dict, now: float, version: str) -> bool:
+    """TTL **과** 포트폴리오 버전을 함께 본다 (#1279). actions.py 와 같은 계약."""
+    return bool(cache["data"]) and (now - cache["timestamp"]) < CACHE_TTL and cache["version"] == version
 
 
 @router.get("/dashboard", dependencies=[Depends(heavy_slot)])
 def get_dashboard():
     """오늘의 투자 판단 요약 — DB 조회 전용 (projection 기반)."""
     now = time.time()
-    if _cache["data"] and (now - _cache["timestamp"]) < CACHE_TTL:
+    # 버전은 빌드 **전에** 읽는다 — 사유는 `nuri/api/cache.py` 및 actions.py 참조.
+    version = portfolio_version()
+    if _fresh(_cache, now, version):
         return _cache["data"]
 
     with _lock:
         # double-check — 락을 기다리는 동안 다른 요청이 채웠을 수 있다
         now = time.time()
-        if _cache["data"] and (now - _cache["timestamp"]) < CACHE_TTL:
+        if _fresh(_cache, now, version):
             return _cache["data"]
         result = _build_dashboard()
         _cache["data"] = result
         _cache["timestamp"] = now
+        _cache["version"] = version
         return result
 
 

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -145,8 +145,9 @@ class TestCacheHitPaths:
         from nuri.api.routes import actions
 
         for cache in (actions._actions_cache, actions._opportunities_cache, actions._market_context_cache):
-            cache["data"] = None
-            cache["timestamp"] = 0
+            # version 도 같이 비운다 (#1279) — 안 비우면 앞 테스트의 버전이 남아
+            # 다음 테스트가 엉뚱하게 hit/miss 한다.
+            cache.update({"data": None, "timestamp": 0, "version": None})
 
     def test_actions_cache_hit(self):
         import time
@@ -157,6 +158,8 @@ class TestCacheHitPaths:
         fake_result = {"urgent": [{"ticker": "CACHED"}], "check": [], "hold": [], "generated_at": "test"}
         actions._actions_cache["data"] = fake_result
         actions._actions_cache["timestamp"] = time.time()
+        # #1279: TTL 만으로는 부족하다 — 현재 포트폴리오 버전이어야 hit 이다.
+        actions._actions_cache["version"] = actions.portfolio_version()
         result = actions.get_actions()
         assert result == fake_result
 
@@ -169,6 +172,7 @@ class TestCacheHitPaths:
         fake_result = {"opportunities": [{"ticker": "CACHED"}], "generated_at": "test"}
         actions._opportunities_cache["data"] = fake_result
         actions._opportunities_cache["timestamp"] = time.time()
+        actions._opportunities_cache["version"] = actions.portfolio_version()
         result = actions.get_opportunities()
         assert result == fake_result
 
@@ -206,8 +210,9 @@ class TestEndpointExceptionFallbacks:
         from nuri.api.routes import actions
 
         for cache in (actions._actions_cache, actions._opportunities_cache, actions._market_context_cache):
-            cache["data"] = None
-            cache["timestamp"] = 0
+            # version 도 같이 비운다 (#1279) — 안 비우면 앞 테스트의 버전이 남아
+            # 다음 테스트가 엉뚱하게 hit/miss 한다.
+            cache.update({"data": None, "timestamp": 0, "version": None})
 
     def test_actions_exception_returns_empty(self):
         self._clear_caches()

--- a/tests/api/test_actions_cache_version.py
+++ b/tests/api/test_actions_cache_version.py
@@ -1,0 +1,198 @@
+"""#1279 — 포트폴리오 쓰기가 캐시를 무효화하고, 미상 손익이 0 으로 둔갑하지 않는다.
+
+## 왜 이 테스트가 있나
+
+`/api/actions` 의 5분 TTL 캐시는 write-blind 였다. 포트폴리오를 갱신하는 정상 경로
+(`scripts/ops/import_portfolio.py`)는 API 를 거치지 않고 DB 에 직접 쓰므로, API 는
+변경 사실을 알 방법이 없었다.
+
+2026-08-29 프로덕션 실측: 보유 갱신 직후 현대차가 **`urgent` · conf 100 ·
+"손절선 -20% 돌파"** 로 나왔는데 실제 손익은 -13.1% 로 돌파하지 않았다. -31.9% 는
+갱신 **전** 평단으로 계산된 값이었다. 낡은 숫자가 아니라 **거짓 청산 신호**다.
+
+곁가지로 같은 함수가 시세 없는 보유(비상장)의 손익을 `0.0%` 로 냈다 — 원가를
+현재가로 대체하면서 생긴 값이라 화면에서는 "보합" 으로 읽혔다.
+"""
+
+import time
+
+import pytest
+
+from nuri.api.cache import portfolio_version
+from nuri.core.db import get_db, init_db, upsert_portfolio
+
+#: 합성 계좌명. 실제 증권사·계좌 식별자는 공개 레포에 넣지 않는다 (STRATEGY §4.4).
+ACCOUNT = "Brokerage Alpha"
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    """격리 DB + **real-account 필터 고정**.
+
+    `_get_portfolio_map` 은 `_get_real_accounts()`(= gitignored `config/portfolio.yaml`)
+    로 행을 거른다. 그대로 두면 이 테스트가 앰비언트 파일에 의존한다 — 로컬에는 파일이
+    있어 합성 계좌가 **걸러지고**, CI 에는 없어 필터가 꺼져 통과한다. 로컬 red / CI green
+    이라는 반대 방향의 분기다. 필터를 명시적으로 고정해 양쪽에서 같은 것을 잰다.
+    """
+    import nuri.core.db as db_mod
+    from nuri.api.routes import actions
+
+    path = tmp_path / "t.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    monkeypatch.setattr(actions, "_get_real_accounts", lambda: {ACCOUNT})
+    return path
+
+
+def _add(db_path, ticker, qty, avg, account=ACCOUNT):
+    # mock 이 아니라 실 writer 를 쓴다 — `sector` 를 포함한 필드 집합이 `upsert_portfolio`
+    # 의 실제 계약이다 (형태가 어긋난 시드는 버그를 잠근다, #1180 계열).
+    upsert_portfolio(
+        [
+            {
+                "account": account,
+                "ticker": ticker,
+                "quantity": qty,
+                "avg_price": avg,
+                "currency": "USD",
+                "sector": "Test",
+            }
+        ],
+        db_path,
+    )
+
+
+class TestPortfolioVersion:
+    """버전 키가 **쓰기를 실제로 감지**하는가."""
+
+    def test_quantity_change_bumps_the_version(self, db):
+        _add(db, "AAA", 10, 100.0)
+        before = portfolio_version()
+        time.sleep(1.05)  # updated_at 은 초 단위 문자열 — 같은 초면 구분 불가
+        _add(db, "AAA", 20, 100.0)
+        assert portfolio_version() != before, "수량이 바뀌었는데 버전이 그대로다"
+
+    def test_row_deletion_bumps_the_version(self, db):
+        """`MAX(updated_at)` 만 보면 놓치는 축 — 삭제는 남은 행의 타임스탬프를 안 바꾼다."""
+        _add(db, "AAA", 10, 100.0)
+        _add(db, "BBB", 5, 50.0)
+        before = portfolio_version()
+        with get_db(db) as conn:
+            conn.execute("DELETE FROM portfolio WHERE ticker = 'BBB'")
+        after = portfolio_version()
+        assert after != before, "행이 지워졌는데 버전이 그대로다 — COUNT 축이 죽었다"
+
+    def test_unchanged_portfolio_keeps_the_version(self, db):
+        """대조군 — 안 바뀌면 그대로여야 캐시가 쓸모 있다 (매번 바뀌면 영구 미스)."""
+        _add(db, "AAA", 10, 100.0)
+        assert portfolio_version() == portfolio_version()
+
+    def test_missing_table_degrades_instead_of_raising(self, tmp_path, monkeypatch):
+        """조회 실패는 TTL-only 로 degrade — 진단이 본 작업을 죽이면 안 된다 (#894).
+
+        그리고 **고정 sentinel** 이어야 한다. 매번 다른 값이면 캐시가 영구 미스가 되어
+        무거운 핸들러가 매 요청 재계산된다 (#1119 stampede).
+        """
+        import nuri.core.db as db_mod
+
+        empty = tmp_path / "no-schema.db"
+        empty.write_bytes(b"")
+        monkeypatch.setattr(db_mod, "DB_PATH", empty)
+        assert portfolio_version() == portfolio_version()
+
+
+class TestActionsCacheHonoursPortfolioWrites:
+    """캐시가 포트폴리오 쓰기를 넘겨받는가 — 이 PR 의 핵심."""
+
+    def _seed_cache(self, actions, payload, version):
+        actions._actions_cache.update({"data": payload, "timestamp": time.time(), "version": version})
+
+    def test_stale_version_is_not_served(self, db, monkeypatch):
+        """Mutation lock: `_fresh` 에서 version 비교를 지우면 FAIL."""
+        from nuri.api.routes import actions
+
+        _add(db, "AAA", 10, 100.0)
+        stale = {"urgent": [{"ticker": "STALE"}], "check": [], "hold": [], "portfolio": []}
+        self._seed_cache(actions, stale, portfolio_version())
+
+        time.sleep(1.05)
+        _add(db, "AAA", 20, 100.0)  # 사용자가 보유를 갱신했다
+
+        rebuilt = {"urgent": [], "check": [], "hold": [], "portfolio": []}
+        monkeypatch.setattr(actions, "_build_actions", lambda: rebuilt)
+        assert actions.get_actions() is rebuilt, "갱신 뒤에도 옛 캐시를 내줬다 — 거짓 신호 창"
+
+    def test_same_version_within_ttl_is_served(self, db, monkeypatch):
+        """대조군 — 버전이 같으면 캐시가 살아 있어야 한다. 아니면 5분 TTL 이 무의미."""
+        from nuri.api.routes import actions
+
+        _add(db, "AAA", 10, 100.0)
+        cached = {"urgent": [{"ticker": "CACHED"}], "check": [], "hold": [], "portfolio": []}
+        self._seed_cache(actions, cached, portfolio_version())
+
+        def _boom():
+            raise AssertionError("캐시가 유효한데 재계산했다")
+
+        monkeypatch.setattr(actions, "_build_actions", _boom)
+        assert actions.get_actions() is cached
+
+
+class TestUnpricedHoldingIsUnknownNotFlat:
+    """시세 없는 보유의 손익은 `0.0` 이 아니라 `None` 이다."""
+
+    def test_pnl_is_none_when_no_market_price(self, db):
+        from nuri.api.routes.actions import _get_portfolio_map
+
+        _add(db, "PRIVATECO", 15, 167.74)  # prices 에 행이 없다 (비상장)
+        m = _get_portfolio_map()
+        h = m["PRIVATECO"]
+        assert h["pnl_pct"] is None, "측정 불가를 숫자로 메웠다 — 화면에서 보합으로 읽힌다"
+        assert h["current_price"] is None, "원가를 현재가로 내보내면 '정확히 평단' 처럼 보인다"
+        # 비중은 남아야 한다 — 보유 자체는 존재하고, 0 으로 지우면 다른 종목이 부풀려진다.
+        assert h["position_pct"] > 0
+
+    def test_priced_holding_still_reports_a_number(self, db):
+        """대조군 — 시세가 있으면 그대로 숫자여야 한다."""
+        from nuri.api.routes.actions import _get_portfolio_map
+
+        _add(db, "AAA", 10, 100.0)
+        with get_db(db) as conn:
+            conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('AAA', '2026-08-29', 90.0)")
+        h = _get_portfolio_map()["AAA"]
+        assert h["pnl_pct"] == pytest.approx(-10.0)
+
+
+class TestWorstPnlAggregationIsNoneSafe:
+    """`_is_worse` — None 은 '가장 나쁨' 이 아니라 '모름' 이다."""
+
+    def test_unknown_never_displaces_a_measured_loss(self):
+        from nuri.api.routes.actions import _is_worse
+
+        # 미상이 측정값을 밀어내면 그 티커의 손절 판정이 통째로 삼켜진다.
+        assert _is_worse(None, -30.0) is False
+
+    def test_measured_replaces_unknown(self):
+        from nuri.api.routes.actions import _is_worse
+
+        assert _is_worse(-5.0, None) is True
+
+    def test_both_unknown_changes_nothing(self):
+        from nuri.api.routes.actions import _is_worse
+
+        assert _is_worse(None, None) is False
+
+    def test_worse_number_wins(self):
+        from nuri.api.routes.actions import _is_worse
+
+        assert _is_worse(-30.0, -5.0) is True
+        assert _is_worse(-5.0, -30.0) is False
+
+
+class TestUnknownPnlNeverClaimsAStopBreach:
+    """손익을 모르면 '손절선 돌파' 를 주장할 수 없다."""
+
+    def test_phrase_does_not_fabricate_a_number(self):
+        from nuri.api.routes.actions import _pnl_phrase
+
+        assert _pnl_phrase(None) == "손익 미상"
+        assert _pnl_phrase(21.8) == "+22%"

--- a/tests/api/test_actions_cache_version.py
+++ b/tests/api/test_actions_cache_version.py
@@ -66,11 +66,66 @@ class TestPortfolioVersion:
     """버전 키가 **쓰기를 실제로 감지**하는가."""
 
     def test_quantity_change_bumps_the_version(self, db):
+        """⚠️ `sleep` 이 **없다**. 초안(`MAX(updated_at)` 기반)은 `time.sleep(1.05)` 가
+        있어야 통과했는데, 그건 수정이 아니라 결함을 우회한 것이었다 (codex P1).
+        내용 해시는 벽시계와 무관하므로 sleep 이 사라진 것 자체가 잠금이다.
+        """
         _add(db, "AAA", 10, 100.0)
         before = portfolio_version()
-        time.sleep(1.05)  # updated_at 은 초 단위 문자열 — 같은 초면 구분 불가
         _add(db, "AAA", 20, 100.0)
         assert portfolio_version() != before, "수량이 바뀌었는데 버전이 그대로다"
+
+    def test_same_second_rewrite_is_detected(self, db):
+        """`upsert_portfolio` 는 `datetime('now')` = **초 해상도**로 찍는다.
+
+        1초 안의 연속 갱신(수동 편집 연타, 다계좌 일괄 sync)에서 행 수도 타임스탬프도
+        그대로면 타임스탬프 기반 키는 눈이 먼다. 이 테스트는 의도적으로 sleep 없이 돈다.
+        """
+        _add(db, "AAA", 10, 100.0)
+        seen = {portfolio_version()}
+        for qty in (11, 12, 13):  # 전부 같은 초 안에서
+            _add(db, "AAA", qty, 100.0)
+            seen.add(portfolio_version())
+        assert len(seen) == 4, f"같은 초 안의 갱신을 놓쳤다 — 서로 다른 버전 {len(seen)}/4"
+
+    def test_offsetting_changes_are_detected(self, db):
+        """합계 기반 키가 놓치는 축 — 한 종목 -1, 다른 종목 +1 이면 SUM 이 같다."""
+        _add(db, "AAA", 10, 100.0)
+        _add(db, "BBB", 10, 100.0)
+        before = portfolio_version()
+        _add(db, "AAA", 9, 100.0)
+        _add(db, "BBB", 11, 100.0)
+        assert portfolio_version() != before, "상쇄되는 변경을 놓쳤다"
+
+    def test_version_is_invariant_to_row_order(self, tmp_path, monkeypatch):
+        """같은 보유는 **삽입 순서와 무관하게** 같은 버전이어야 한다.
+
+        `SELECT ... FROM portfolio` 는 ORDER BY 가 없으면 rowid(=삽입) 순으로 돌려준다.
+        정렬 없이 이어붙이면 같은 내용이 다른 해시를 내고, 캐시가 영구 미스가 되어
+        무거운 핸들러가 매 요청 재계산된다 (#1119 stampede).
+
+        Mutation lock: `sorted(...)` 를 지우면 FAIL.
+        """
+        import nuri.core.db as db_mod
+
+        def _build(order):
+            path = tmp_path / f"{'-'.join(order)}.db"
+            init_db(path)
+            monkeypatch.setattr(db_mod, "DB_PATH", path)
+            for t in order:
+                _add(path, t, 10, 100.0)
+            return portfolio_version()
+
+        assert _build(["AAA", "BBB", "CCC"]) == _build(["CCC", "AAA", "BBB"]), (
+            "삽입 순서가 버전을 바꿨다 — 같은 보유인데 캐시가 매번 미스한다"
+        )
+
+    def test_avg_price_change_bumps_the_version(self, db):
+        """수량이 같아도 평단이 바뀌면 손익이 바뀐다 — #1279 의 실제 사고 형태다."""
+        _add(db, "AAA", 10, 587000.0)
+        before = portfolio_version()
+        _add(db, "AAA", 10, 459857.14)
+        assert portfolio_version() != before, "평단 변경을 놓쳤다"
 
     def test_row_deletion_bumps_the_version(self, db):
         """`MAX(updated_at)` 만 보면 놓치는 축 — 삭제는 남은 행의 타임스탬프를 안 바꾼다."""
@@ -115,8 +170,7 @@ class TestActionsCacheHonoursPortfolioWrites:
         stale = {"urgent": [{"ticker": "STALE"}], "check": [], "hold": [], "portfolio": []}
         self._seed_cache(actions, stale, portfolio_version())
 
-        time.sleep(1.05)
-        _add(db, "AAA", 20, 100.0)  # 사용자가 보유를 갱신했다
+        _add(db, "AAA", 20, 100.0)  # 사용자가 보유를 갱신했다 (sleep 불필요 — 내용 해시)
 
         rebuilt = {"urgent": [], "check": [], "hold": [], "portfolio": []}
         monkeypatch.setattr(actions, "_build_actions", lambda: rebuilt)
@@ -196,3 +250,14 @@ class TestUnknownPnlNeverClaimsAStopBreach:
 
         assert _pnl_phrase(None) == "손익 미상"
         assert _pnl_phrase(21.8) == "+22%"
+
+    def test_loss_keeps_its_minus_sign(self):
+        """codex P2: 리터럴 `+` 를 붙이면 손실이 `+-5%` 로 찍힌다.
+
+        리더 트레일링은 고점 대비 이탈이라 **진입가 아래에서도** 발화할 수 있어
+        실제 도달 가능한 경로다.
+        """
+        from nuri.api.routes.actions import _pnl_phrase
+
+        assert _pnl_phrase(-5.0) == "-5%"
+        assert "+-" not in _pnl_phrase(-5.0)


### PR DESCRIPTION
Closes #1279

## 문제 1 — 거짓 손절 신호

2026-08-29 프로덕션 실측. 보유를 갱신한 직후 `/api/actions` 가 현대차를 **`urgent` 버킷 · conf 100** 으로 반환했습니다:

```
005380.KS  SELL  pnl=-31.9
    · 10-Agent SELL (conf 100)
    · 손실 -31.9% — 손절선 -20% 돌파 (11.9%p 초과)
```

**실제는 −13.1% 로 돌파하지 않았습니다.** 캐시를 우회해 계산 함수를 직접 부르면 `avg=459,857.14 px=399,500 pnl=-13.13%`. −31.9% 는 갱신 **전** 평단(₩587,000)으로 계산된 값입니다: `(399,500/587,000)−1 = −31.94%`.

원인은 5분 TTL 캐시가 write-blind 라는 것이고, 더 나쁜 건 **포트폴리오를 바꾸는 정상 경로가 API 를 거치지 않는다**는 점입니다. `scripts/ops/import_portfolio.py` 는 DB 에 직접 씁니다 — POST 조차 아니라 API 프로세스는 변경 사실을 알 방법이 없고, TTL 만료만이 유일한 복구 경로였습니다.

이게 단순 stale read 보다 나쁜 이유는 정정 전 화면이 "조금 낡은 숫자"가 아니라 **즉시 매도 지시**이고, *"보유를 갱신하고 바로 대시보드를 연다"* 는 가장 자연스러운 순서가 정확히 그 창과 겹치기 때문입니다.

### 왜 무효화 엔드포인트가 아니라 버전 키인가

`POST /api/cache/invalidate` 를 두고 import 스크립트가 부르게 할 수도 있습니다. 그건 **프로세스 경계를 타는** 해법이라 세 갈래로 샙니다: API 가 안 떠 있으면 무효화가 유실되고, 앞으로 생길 다른 writer(수동 SQL·백필·다른 스크립트)가 호출을 빠뜨리면 조용히 되살아나고, 워커가 여럿이면 하나만 비워집니다.

버전 키는 **읽는 쪽에 방어를 둡니다** — 데이터가 어떻게 바뀌었든 캐시가 스스로 알아챕니다. 쓰는 쪽에 규율을 요구하면 새 writer 가 생길 때마다 다시 샌다는 걸 이 레포는 반복해서 배웠습니다.

버전은 **보유 내용 자체의 해시**입니다 (정렬 후 blake2b). 초안은 `COUNT(*) + MAX(updated_at)` 이었고 codex 리뷰(P1)와 실측에서 세 축으로 뚫렸습니다:

1. **같은 초 안의 연속 갱신** — `upsert_portfolio` 는 `datetime('now')`, 즉 **초 해상도**입니다. 1초 안에 같은 행을 두 번 쓰면 행 수도 타임스탬프도 그대로라 버전이 안 바뀝니다. ⚠️ 초안 테스트가 `time.sleep(1.05)` 를 넣어야 통과했다는 게 **이미 그 증거**였습니다 — 수정이 아니라 우회였습니다.
2. **상쇄되는 변경** — 합계(`SUM(quantity)`) 기반으로 바꿔도 A 에서 −1, B 에서 +1 이면 못 잡습니다 (실측 확인).
3. 삭제·행 수 변화는 해시가 자연히 덮습니다.

`updated_at` 은 일부러 **뺐습니다** — 내용이 같으면 버전도 같아야 무의미한 재계산이 안 생깁니다. SQL 행 순서는 보장되지 않으므로 정렬이 필수이고(안 하면 같은 보유가 매번 다른 해시 → 영구 캐시 미스 → #1119 stampede), 그 정렬도 별도로 잠갔습니다.

비용은 행 수에 비례하지만 이 테이블은 **한 사람의 보유**라 수십 행이고, 캐시 히트를 지키는 대가로 붙는 유일한 DB 작업입니다.

조회 실패는 **고정 sentinel** 로 degrade 시킵니다 — 매번 다른 값을 돌려주면 캐시가 영구 미스가 되어 무거운 핸들러가 매 요청 재계산됩니다 (#1119 stampede 재발). 진단이 본 작업을 게이트하면 안 된다는 #894 와 같은 원칙입니다.

**버전은 빌드 전에 읽어 저장합니다.** 빌드 도중 쓰기가 들어오면 저장된 버전이 옛 것이라 다음 요청이 한 번 더 재계산할 뿐입니다 — 반대로 빌드 후에 읽으면 새 버전을 옛 데이터에 붙여 **낡은 응답을 신선하다고 판정**합니다. 안전한 방향으로 틀리게 했습니다.

### dashboard 도 포함한 이유

`dashboard.py:387` 도 `FROM portfolio` 를 읽는 같은 write-blind 캐시입니다. 액션만 고치면 같은 화면에서 **액션은 새 보유, 히어로 합계는 옛 보유**가 되어 패널 간 모순이 생깁니다 — 균일하게 낡은 것보다 나쁩니다. `_market_context_cache` 는 macro 만 보므로 버전 키를 걸지 않았습니다.

## 문제 2 — 미상을 0 으로 메웠다

`_get_portfolio_map` 이 `price = current_price or avg_price` 로 원가를 현재가에 대체하면서, 시세 없는 보유(비상장 SPACEX)의 손익이 `0.0%` 로 나왔습니다. 화면에서는 **"보합"** 으로 읽힙니다.

시장가와 비중 계산용 가격을 분리했습니다:
- **손익**: 시장가가 없으면 `None`. STRATEGY §2.6 의 VIX 게이트와 같은 원칙 — 측정 불가를 숫자로 메우지 않습니다.
- **비중**: 원가로 계속 셉니다. 보유 자체는 존재하고, 0 으로 지우면 다른 종목 비중이 부풀려집니다.

하류 3곳을 None-safe 로 만들었습니다:
- **손절 비교** — 미상으로 돌파를 주장하지 않습니다. 미상은 catalyst 경로로 흘러 "왜 매도?" 맥락을 요구받습니다. 기계적 청산은 측정값에만.
- **근거 문자열** — `_pnl_phrase(None)` → `"손익 미상"`
- **worst-PnL 집계** — `_is_worse` 에서 **측정값이 미상을 이깁니다.** 반대면 비상장 한 줄이 같은 티커의 측정 가능한 보유를 가려 손절 판정을 통째로 삼킵니다.

프론트는 두 겹으로 틀렸습니다: `null >= 0` 이 **true** 라 초록 `+` 가 붙고, 그다음 `null.toFixed` 로 터집니다. JS 의 null 강제변환이 만든 조합입니다. `ACTION.PNL_UNKNOWN`(SSoT)으로 렌더합니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| `_fresh` 에서 version 비교 제거 | **2 FAIL** |
| 버전을 타임스탬프 기반으로 되돌림 (초 해상도) | **5 FAIL** |
| 버전을 합계 기반으로 (상쇄 변경 미감지) | **1 FAIL** |
| 버전을 행 수만으로 (내용 변경 미감지) | **5 FAIL** |
| 해시에서 `sorted()` 제거 (순서 의존) | **1 FAIL** |
| `pnl` 을 다시 `0` 으로 메움 | **1 FAIL** |
| `_is_worse` 를 단순 비교로 (None=최악) | **2 FAIL** |
| `_pnl_phrase` 를 리터럴 `+` 로 되돌림 | **1 FAIL** |
| 프론트가 `null` 을 다시 숫자로 렌더 | **1 FAIL** |
| baseline 복원 | 121 passed (py) / 41 passed (js) |

⚠️ 정렬 축은 **처음엔 안 잡혔습니다.** `sorted()` 를 지워도 테스트가 통과했는데, SQLite 가 작은 테이블에서 안정적 순서를 돌려줘 우연히 결정론적이었기 때문입니다. 같은 보유를 **다른 삽입 순서**로 만든 두 DB 의 버전이 같아야 한다는 테스트를 추가해 실질화했습니다.

신규 테스트 18개는 **대조군을 짝으로** 둡니다 — 버전이 같으면 캐시가 살아 있어야 하고(아니면 TTL 이 무의미), 시세가 있으면 손익은 그대로 숫자여야 하고, 안 바뀐 포트폴리오는 버전이 그대로여야 합니다(매번 바뀌면 영구 미스). 무효화만 잠그면 "항상 미스" 로 되돌려도 통과합니다.

## codex 리뷰 — [P1] + [P2] 2건 수용

**P1 (초 해상도)** — 위 "왜 무효화 엔드포인트가 아니라 버전 키인가" 절에 반영. 재현 실측:

```
before=1:2026-08-28 17:17:05
after =1:2026-08-28 17:17:05    ← 수량 10 → 999 로 바꿨는데 버전 동일
```

**P2 (손실 부호)** — `f"+{pnl:.0f}%"` 가 손실을 `+-5%` 로 찍습니다. 부호를 포맷 스펙(`:+`)에 맡겼습니다. 리더 트레일링은 고점 대비 이탈이라 **진입가 아래에서도** 발화하므로 도달 가능한 경로라는 지적이 맞습니다.

```
_pnl_phrase(-5.0)  이전: '+-5%'   이후: '-5%'
```

곁가지: codecov 가 지적한 `cache.py` 미커버 분기(`if not rows`)는 이 재작성으로 사라졌습니다. 세 파일 로컬 branch coverage **100% / partial 0**.

## 검증

- `make test-fast` → **7,613 passed / 6 skipped** (rc=0)
- `npx vitest run` → **1,642 passed / 136 files** · `npm run build` rc=0
- `make verify-doc-counts` 22/22 · `make diagnostics` · `check_privacy_leak.py` → 전부 rc=0

## 스코프 밖

같은 write-blind 캐시가 `agents.py` · `targets.py` · `ticker.py` · `learning_memory.py` · `swing.py` 에도 있습니다. 이 PR 은 **포트폴리오 파생**(actions · opportunities · dashboard)만 다룹니다 — 나머지는 보유를 읽지 않거나 거짓 매매 신호를 만들지 않습니다.
