### PR TITLE
fix(deploy): compare full SHAs for HEAD sync, not abbreviated ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,654 collected across 351 files | |
+| **Backend tests** | 7,659 collected across 351 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,646 collected across 350 files | |
+| **Backend tests** | 7,654 collected across 351 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,654 backend tests across 351 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,659 backend tests across 351 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,646 backend tests across 350 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,654 backend tests across 351 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,646 tests, 350 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,654 tests, 351 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,654 tests, 351 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,659 tests, 351 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -290,18 +290,20 @@ step 7 "최종 검증"
 # HEAD 비교는 전용 스크립트에 위임한다 (#1277). 이유와 판정 규칙은 그 파일 상단 참조 —
 # 요약하면 **축약 SHA 를 비교하면 안 된다**: 길이가 저장소마다 달라 동기화된 배포마다
 # 거짓 경고가 났다. 별도 파일인 것은 테스트가 **실행해서** 잠글 수 있게 하기 위함이다.
-if HEAD_OUT=$("${SCRIPT_DIR}/verify_head_sync.sh" "${SSH}" "${REMOTE}" "${REMOTE_PATH}"); then
-    HEAD_SYNCED=1
-else
-    HEAD_SYNCED=0
-fi
+# ⚠️ `if cmd; then` 로 감싸면 **모든** 비정상 종료가 "불일치" 로 강등된다 (codex P1).
+# 이전 인라인 코드는 `set -e` 덕에 SSH 실패 시 배포가 **중단**됐는데, 그 성질을 잃으면
+# 마지막 안전 게이트가 안 돌았는데도 "deploy 완료" 가 찍힌다. rc 를 직접 받아 갈래를 나눈다.
+set +e
+HEAD_OUT=$("${SCRIPT_DIR}/verify_head_sync.sh" "${SSH}" "${REMOTE}" "${REMOTE_PATH}")
+HEAD_RC=$?
+set -e
 LOCAL_HEAD=$(printf '%s\n' "${HEAD_OUT}" | sed -n 3p)
 REMOTE_HEAD=$(printf '%s\n' "${HEAD_OUT}" | sed -n 4p)
-if [[ "${HEAD_SYNCED}" == "1" ]]; then
-    ok "git HEAD 일치: ${REMOTE_HEAD}"
-else
-    warn "git HEAD 불일치 — local: ${LOCAL_HEAD} / remote: ${REMOTE_HEAD}"
-fi
+case "${HEAD_RC}" in
+    0) ok "git HEAD 일치: ${REMOTE_HEAD}" ;;
+    1) warn "git HEAD 불일치 — local: ${LOCAL_HEAD} / remote: ${REMOTE_HEAD}" ;;
+    *) fail "HEAD 검증 자체가 실패 (rc=${HEAD_RC}) — 배포 검증 불가. 위 stderr 확인" ;;
+esac
 
 SCHEDULER_PID=$("${SSH}" "${REMOTE}" "launchctl list | grep ${PLIST_NAME%.plist} | awk '{print \$1}'" 2>/dev/null || echo "-")
 if [[ "${SCHEDULER_PID}" != "-" && "${SCHEDULER_PID}" != "" ]]; then

--- a/scripts/deploy/deploy_to_mini.sh
+++ b/scripts/deploy/deploy_to_mini.sh
@@ -287,10 +287,18 @@ done
 # ── 6. 최종 검증 ──
 step 7 "최종 검증"
 
-REMOTE_HEAD=$("${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git log -1 --oneline")
-LOCAL_HEAD=$(git log -1 --oneline)
-if [[ "${REMOTE_HEAD}" == "${LOCAL_HEAD}" ]]; then
-    ok "git HEAD 일치: ${LOCAL_HEAD}"
+# HEAD 비교는 전용 스크립트에 위임한다 (#1277). 이유와 판정 규칙은 그 파일 상단 참조 —
+# 요약하면 **축약 SHA 를 비교하면 안 된다**: 길이가 저장소마다 달라 동기화된 배포마다
+# 거짓 경고가 났다. 별도 파일인 것은 테스트가 **실행해서** 잠글 수 있게 하기 위함이다.
+if HEAD_OUT=$("${SCRIPT_DIR}/verify_head_sync.sh" "${SSH}" "${REMOTE}" "${REMOTE_PATH}"); then
+    HEAD_SYNCED=1
+else
+    HEAD_SYNCED=0
+fi
+LOCAL_HEAD=$(printf '%s\n' "${HEAD_OUT}" | sed -n 3p)
+REMOTE_HEAD=$(printf '%s\n' "${HEAD_OUT}" | sed -n 4p)
+if [[ "${HEAD_SYNCED}" == "1" ]]; then
+    ok "git HEAD 일치: ${REMOTE_HEAD}"
 else
     warn "git HEAD 불일치 — local: ${LOCAL_HEAD} / remote: ${REMOTE_HEAD}"
 fi

--- a/scripts/deploy/verify_head_sync.sh
+++ b/scripts/deploy/verify_head_sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 로컬과 원격의 git HEAD 가 **같은 커밋인지** 판정한다 (#1277).
+#
+# 사용법:
+#   verify_head_sync.sh <ssh_cmd> <remote_host> <remote_path>
+#   (로컬 저장소는 현재 작업 디렉터리)
+#
+# 출력 (stdout 4줄):
+#   1: 로컬 전체 SHA
+#   2: 원격 전체 SHA
+#   3: 로컬 표시용 라벨  ("<축약> <제목>")
+#   4: 원격 표시용 라벨
+# 종료 코드: 0 = 일치, 1 = 불일치
+#
+# ⚠️ **비교는 전체 SHA 로만 한다.** 이전에는 `git log -1 --oneline` 문자열을 비교했는데,
+# 그 축약 SHA 길이는 **저장소마다 다르다** — git 의 auto-abbrev 가 오브젝트 수에서
+# 파생되기 때문이다. 2026-08-29 실측: 같은 커밋 `eab0614…` 가 MBP 에서는 8자,
+# Mac mini 에서는 7자로 찍혀 **완벽히 동기화된 배포마다 "HEAD 불일치" 경고**가 났다
+# (두 번의 배포에서 모두 재현). 커밋 제목까지 비교면에 들어가 있어 공백·개행이 섞이면
+# 오탐 축이 하나 더 생긴다.
+#
+# 거짓 경고는 단순 노이즈가 아니다 — 배포 검증은 상주 데몬이 구코드를 들고 도는 사고
+# (#1024, 7일 잠복)를 잡는 마지막 관문인데, 매번 뜨는 경고는 **진짜 불일치가 났을 때
+# 그 한 줄을 무시하게** 만든다. 이 레포가 반복해서 배운 false-red 형태다.
+#
+# 표시용 라벨은 사람이 읽으라고 따로 낸다 — 축약은 표시에만 쓰고 판정에는 안 쓴다.
+set -euo pipefail
+
+SSH_CMD="${1:?ssh 커맨드 경로가 필요하다}"
+REMOTE="${2:?원격 호스트가 필요하다}"
+REMOTE_PATH="${3:?원격 저장소 경로가 필요하다}"
+
+# 원격은 SSH 왕복 1회로 둘 다 받는다 (판정용 SHA + 표시용 라벨).
+# `%x20` 은 공백 — `--format` 안에서 공백을 그대로 쓰면 인용이 지저분해진다.
+# shellcheck disable=SC2029  # 원격에서 확장되어야 하는 의도된 문자열
+REMOTE_OUT=$("${SSH_CMD}" "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse HEAD && git log -1 --format=%h%x20%s")
+
+REMOTE_SHA=$(printf '%s\n' "${REMOTE_OUT}" | sed -n 1p)
+REMOTE_LABEL=$(printf '%s\n' "${REMOTE_OUT}" | sed -n 2p)
+LOCAL_SHA=$(git rev-parse HEAD)
+LOCAL_LABEL=$(git log -1 --format=%h%x20%s)
+
+printf '%s\n%s\n%s\n%s\n' "${LOCAL_SHA}" "${REMOTE_SHA}" "${LOCAL_LABEL}" "${REMOTE_LABEL}"
+
+[ "${LOCAL_SHA}" = "${REMOTE_SHA}" ]

--- a/scripts/deploy/verify_head_sync.sh
+++ b/scripts/deploy/verify_head_sync.sh
@@ -10,7 +10,16 @@
 #   2: 원격 전체 SHA
 #   3: 로컬 표시용 라벨  ("<축약> <제목>")
 #   4: 원격 표시용 라벨
-# 종료 코드: 0 = 일치, 1 = 불일치
+# 종료 코드:
+#   0 = 일치
+#   1 = **불일치** (양쪽 SHA 를 정상적으로 받았고 서로 다름)
+#   2 = **판정 불가** (SSH 실패 · git 실패 · 응답이 SHA 형태가 아님)
+#
+# 1 과 2 를 나누는 것이 이 스크립트의 두 번째 계약이다 (codex 리뷰 P1). 둘을 뭉뚱그리면
+# **"검사 실패" 가 "검사 결과 불일치" 로 둔갑**한다 — 이 레포가 이미 겪은 형태다
+# (#910/#911: rc=127 이 실패와 구분되지 않아 pre-push 테스트가 3.5개월 no-op).
+# 호출자는 2 를 경고가 아니라 **중단**으로 다뤄야 한다: 마지막 안전 게이트가 돌지 않았는데
+# "deploy 완료" 를 찍으면 게이트가 없는 것과 같다.
 #
 # ⚠️ **비교는 전체 SHA 로만 한다.** 이전에는 `git log -1 --oneline` 문자열을 비교했는데,
 # 그 축약 SHA 길이는 **저장소마다 다르다** — git 의 auto-abbrev 가 오브젝트 수에서
@@ -24,21 +33,36 @@
 # 그 한 줄을 무시하게** 만든다. 이 레포가 반복해서 배운 false-red 형태다.
 #
 # 표시용 라벨은 사람이 읽으라고 따로 낸다 — 축약은 표시에만 쓰고 판정에는 안 쓴다.
-set -euo pipefail
+# `-e` 는 일부러 안 켠다 — 실패를 스스로 분류해 rc 2 로 내보내야 하는데, `-e` 는
+# 하위 명령의 rc 를 그대로 흘려 1(불일치)과 구분할 수 없게 만든다.
+set -uo pipefail
 
 SSH_CMD="${1:?ssh 커맨드 경로가 필요하다}"
 REMOTE="${2:?원격 호스트가 필요하다}"
 REMOTE_PATH="${3:?원격 저장소 경로가 필요하다}"
 
+undetermined() { echo "verify_head_sync: $1" >&2; exit 2; }
+is_sha() { case "$1" in [0-9a-f]*) [ "${#1}" -eq 40 ] ;; *) false ;; esac; }
+
 # 원격은 SSH 왕복 1회로 둘 다 받는다 (판정용 SHA + 표시용 라벨).
 # `%x20` 은 공백 — `--format` 안에서 공백을 그대로 쓰면 인용이 지저분해진다.
 # shellcheck disable=SC2029  # 원격에서 확장되어야 하는 의도된 문자열
-REMOTE_OUT=$("${SSH_CMD}" "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse HEAD && git log -1 --format=%h%x20%s")
+if ! REMOTE_OUT=$("${SSH_CMD}" "${REMOTE}" "cd ${REMOTE_PATH} && git rev-parse HEAD && git log -1 --format=%h%x20%s"); then
+    undetermined "원격 HEAD 조회 실패 (ssh 또는 git) — 판정 불가"
+fi
 
 REMOTE_SHA=$(printf '%s\n' "${REMOTE_OUT}" | sed -n 1p)
 REMOTE_LABEL=$(printf '%s\n' "${REMOTE_OUT}" | sed -n 2p)
-LOCAL_SHA=$(git rev-parse HEAD)
-LOCAL_LABEL=$(git log -1 --format=%h%x20%s)
+
+if ! LOCAL_SHA=$(git rev-parse HEAD 2>/dev/null); then
+    undetermined "로컬 HEAD 조회 실패 — 판정 불가"
+fi
+LOCAL_LABEL=$(git log -1 --format=%h%x20%s 2>/dev/null || echo "(라벨 없음)")
+
+# 형태 검증 — 빈 응답이나 쓰레기를 **불일치로 흘리지 않는다**. SSH 가 rc 0 으로 배너만
+# 뱉는 경우가 있고, 그걸 SHA 로 믿으면 "불일치" 라는 **틀린 이유**를 보고하게 된다.
+is_sha "${LOCAL_SHA}" || undetermined "로컬 SHA 형태 아님: '${LOCAL_SHA}'"
+is_sha "${REMOTE_SHA}" || undetermined "원격 SHA 형태 아님: '${REMOTE_SHA}'"
 
 printf '%s\n%s\n%s\n%s\n' "${LOCAL_SHA}" "${REMOTE_SHA}" "${LOCAL_LABEL}" "${REMOTE_LABEL}"
 

--- a/tests/test_deploy_head_sync.py
+++ b/tests/test_deploy_head_sync.py
@@ -74,6 +74,25 @@ def _fake_ssh(tmp_path: Path) -> Path:
     return p
 
 
+def _broken_ssh(tmp_path: Path, *, rc: int = 255, stdout: str = "") -> Path:
+    """전송 실패 흉내 — 실제 ssh 는 도달 불가 시 255 를 낸다."""
+    p = tmp_path / f"broken_ssh_{rc}_{len(stdout)}.sh"
+    p.write_text(f"#!/usr/bin/env bash\nprintf %s {stdout!r}\nexit {rc}\n", encoding="utf-8")
+    p.chmod(0o755)
+    return p
+
+
+def _garbage_ssh(tmp_path: Path) -> Path:
+    """rc 0 인데 SHA 가 아닌 것을 뱉는 경우 (배너·경고문 등)."""
+    p = tmp_path / "garbage_ssh.sh"
+    p.write_text(
+        '#!/usr/bin/env bash\nprintf "Warning: Permanently added host\\nnot-a-sha\\n"\nexit 0\n',
+        encoding="utf-8",
+    )
+    p.chmod(0o755)
+    return p
+
+
 def _run_verifier(local_repo: Path, ssh: Path, remote_repo: Path):
     return subprocess.run(
         ["bash", str(VERIFIER), str(ssh), "ignored-host", str(remote_repo)],
@@ -132,6 +151,45 @@ class TestHeadSyncIsAbbreviationIndependent:
         assert "initial commit" in lines[2] and "initial commit" in lines[3], "3·4행은 표시용 라벨"
 
 
+class TestFailureIsNotDisguisedAsMismatch:
+    """**검증 실패**(rc 2)와 **검증 결과 불일치**(rc 1)를 나눈다 (codex 리뷰 P1).
+
+    둘을 뭉뚱그리면 "검사 실패" 가 "검사 결과" 로 둔갑한다 — 이 레포가 이미 겪은 형태다
+    (#910/#911: rc=127 이 실패와 구분되지 않아 게이트가 3.5개월 no-op).
+    배포 쪽에서는 더 나쁘다: 마지막 안전 게이트가 **안 돌았는데** "deploy 완료" 가 찍힌다.
+    """
+
+    def test_transport_failure_is_undetermined_not_mismatch(self, tmp_path):
+        """Mutation lock: `undetermined` 를 지우고 실패를 흘리면 rc 가 1 이 되어 FAIL."""
+        a = _make_repo(tmp_path / "local", abbrev=7)
+        r = _run_verifier(a, _broken_ssh(tmp_path, rc=255), tmp_path / "nowhere")
+        assert r.returncode == 2, f"전송 실패를 rc {r.returncode} 로 보고했다 (2 여야 함)\n{r.stderr}"
+        assert r.stderr.strip(), "판정 불가인데 이유를 남기지 않았다"
+
+    def test_remote_exiting_one_is_still_undetermined(self, tmp_path):
+        """가장 위험한 축 — 원격이 rc 1 로 죽으면 '불일치' 와 **정확히 같은 코드**다.
+
+        스크립트가 하위 rc 를 그대로 흘리면(예: `set -e`) 여기서 1 이 나와 배포는
+        '경고' 만 찍고 계속 간다. 반드시 2 로 승격돼야 한다.
+        """
+        a = _make_repo(tmp_path / "local", abbrev=7)
+        r = _run_verifier(a, _broken_ssh(tmp_path, rc=1), tmp_path / "nowhere")
+        assert r.returncode == 2, f"원격 rc 1 을 '불일치'({r.returncode}) 로 흘렸다"
+
+    def test_non_sha_output_is_undetermined(self, tmp_path):
+        """rc 0 인데 SHA 가 아닌 응답 — 그걸 믿으면 **틀린 이유**(불일치)를 보고한다."""
+        a = _make_repo(tmp_path / "local", abbrev=7)
+        r = _run_verifier(a, _garbage_ssh(tmp_path), tmp_path / "nowhere")
+        assert r.returncode == 2, f"SHA 가 아닌 응답을 rc {r.returncode} 로 판정했다"
+
+    def test_real_mismatch_still_reports_one(self, tmp_path):
+        """대조군 — 2 로 다 밀어버리면 진짜 불일치를 놓친다."""
+        a = _make_repo(tmp_path / "local", abbrev=7, content="one")
+        b = _make_repo(tmp_path / "remote", abbrev=7, content="two")
+        r = _run_verifier(a, _fake_ssh(tmp_path), b)
+        assert r.returncode == 1, f"진짜 불일치가 {r.returncode} 로 나왔다"
+
+
 class TestDeployScriptUsesTheVerifier:
     """배선 — 검증기가 있어도 배포가 안 부르면 소용없다 (#1180 계열 wiring 축).
 
@@ -159,6 +217,22 @@ class TestDeployScriptUsesTheVerifier:
         assert "verify_head_sync.sh" in src, "배포가 검증기를 부르지 않는다"
         offenders = self._remote_abbrev_lines(src)
         assert not offenders, f"원격 HEAD 를 축약으로 받고 있다 (#1277 회귀): {offenders}"
+
+    def test_deploy_aborts_when_verification_is_undetermined(self):
+        """rc 2 는 경고가 아니라 **중단**이어야 한다 (codex P1).
+
+        `if cmd; then ... else warn` 로 감싸면 모든 비정상 종료가 경고로 강등된다 —
+        그 형태가 소스에 없는지, 그리고 rc 갈래에 `fail` 이 있는지 본다.
+        """
+        src = DEPLOY.read_text(encoding="utf-8")
+        assert "if HEAD_OUT=$(" not in src, "if 래핑이 되살아났다 — 모든 실패가 경고로 강등된다"
+        assert "HEAD_RC" in src, "rc 를 받지 않는다"
+        # rc 갈래(case) 안에 중단 경로가 있어야 한다.
+        case_block = src.split('case "${HEAD_RC}"', 1)
+        assert len(case_block) == 2, "rc 갈래(case)가 없다"
+        branch = case_block[1].split("esac", 1)[0]
+        assert "fail " in branch, "판정 불가에서 배포를 중단하지 않는다"
+        assert "warn " in branch and "ok " in branch, "일치/불일치 갈래가 없다"
 
     def test_the_sweep_has_eyes(self):
         """카나리아 — sweep 이 조용히 아무것도 안 보는 상태로 썩지 않게.

--- a/tests/test_deploy_head_sync.py
+++ b/tests/test_deploy_head_sync.py
@@ -1,0 +1,172 @@
+"""배포 검증의 HEAD 비교를 **실행해서** 잠근다 (Gotcha-Test Pair, #1277).
+
+## 무엇이 잘못됐었나
+
+`deploy_to_mini.sh` step 7 이 `git log -1 --oneline` **문자열**을 비교했다. 그 축약 SHA
+길이는 저장소마다 다르다 — git 의 auto-abbrev 가 오브젝트 수에서 파생되기 때문이다.
+2026-08-29 실측: 같은 커밋이 MBP 에서 8자, Mac mini 에서 7자로 찍혀 **완벽히 동기화된
+배포마다** "git HEAD 불일치" 경고가 났다 (그날 두 번의 배포에서 모두 재현).
+
+이건 dead gate 가 아니라 **false-red** 다. 배포 검증은 상주 데몬이 구코드를 들고 도는
+사고(#1024, 7일 잠복)를 잡는 마지막 관문인데, 매번 뜨는 경고는 진짜 불일치가 났을 때
+그 한 줄을 무시하게 만든다.
+
+## 왜 grep 이 아니라 실행인가
+
+`tests/test_pre_push_hook.py` · `tests/test_hook_guard_execution.py` 의 전례 그대로다.
+"축약을 안 쓴다" 를 소스에서 grep 하면 *다른 방식으로 축약하는* 회귀를 놓친다. 여기서는
+**축약 길이가 실제로 다른 두 저장소**를 만들어 스크립트를 돌리고 종료 코드만 믿는다.
+
+세 축:
+- 같은 커밋 + 다른 `core.abbrev` → **일치 판정** (결함 그 자체)
+- 다른 커밋 → **불일치 판정** (항상 초록인 가짜 게이트가 아님)
+- 카나리아: 그 두 저장소에서 `--oneline` 출력이 실제로 **다름** — 이게 없으면 첫 축이
+  공허하게 통과할 수 있다 (abbrev 설정이 안 먹었을 경우)
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = REPO_ROOT / "scripts" / "deploy" / "verify_head_sync.sh"
+DEPLOY = REPO_ROOT / "scripts" / "deploy" / "deploy_to_mini.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git 없음")
+
+
+def _git(cwd: Path, *args: str) -> str:
+    env = {
+        "GIT_AUTHOR_NAME": "T",
+        "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "T",
+        "GIT_COMMITTER_EMAIL": "t@example.com",
+        "GIT_AUTHOR_DATE": "2026-01-01T00:00:00+0900",
+        "GIT_COMMITTER_DATE": "2026-01-01T00:00:00+0900",
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        "HOME": str(cwd),
+    }
+    out = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+def _make_repo(path: Path, *, abbrev: int, content: str = "one") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "core.abbrev", str(abbrev))
+    (path / "f.txt").write_text(content, encoding="utf-8")
+    _git(path, "add", "f.txt")
+    _git(path, "commit", "-q", "-m", "initial commit for head-sync test")
+    return path
+
+
+def _fake_ssh(tmp_path: Path) -> Path:
+    """`ssh <host> <cmd>` 흉내 — 호스트를 무시하고 명령을 로컬 셸로 실행한다.
+
+    스크립트가 원격에 보내는 문자열(`cd <path> && git ...`)을 그대로 받으므로,
+    **실제 배포가 타는 코드 경로**를 그대로 돌린다.
+    """
+    p = tmp_path / "fake_ssh.sh"
+    p.write_text('#!/usr/bin/env bash\nshift\nexec bash -c "$*"\n', encoding="utf-8")
+    p.chmod(0o755)
+    return p
+
+
+def _run_verifier(local_repo: Path, ssh: Path, remote_repo: Path):
+    return subprocess.run(
+        ["bash", str(VERIFIER), str(ssh), "ignored-host", str(remote_repo)],
+        cwd=local_repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestHeadSyncIsAbbreviationIndependent:
+    def test_same_commit_different_abbrev_reports_match(self, tmp_path):
+        """결함 그 자체 — 같은 커밋인데 축약 길이만 달라 불일치로 오판했다.
+
+        Mutation lock: `verify_head_sync.sh` 를 `git log -1 --oneline` 비교로 되돌리면 FAIL.
+        """
+        a = _make_repo(tmp_path / "local", abbrev=7)
+        b = _make_repo(tmp_path / "remote", abbrev=12)
+        # 같은 내용·같은 author/committer·같은 날짜 → 같은 커밋 SHA
+        assert _git(a, "rev-parse", "HEAD") == _git(b, "rev-parse", "HEAD"), "전제 실패: 같은 커밋이 아니다"
+
+        r = _run_verifier(a, _fake_ssh(tmp_path), b)
+        assert r.returncode == 0, f"동기화된 배포를 불일치로 판정했다\nstdout={r.stdout}\nstderr={r.stderr}"
+
+    def test_abbrev_settings_actually_differ(self, tmp_path):
+        """카나리아 — 위 테스트가 공허하지 않은지 확인한다.
+
+        `core.abbrev` 가 안 먹으면 두 저장소의 `--oneline` 이 같아져, 축약을 비교하도록
+        되돌려도 첫 테스트가 **통과**한다. 그러면 잠금이 아니라 장식이다.
+        """
+        a = _make_repo(tmp_path / "local", abbrev=7)
+        b = _make_repo(tmp_path / "remote", abbrev=12)
+        assert _git(a, "log", "-1", "--oneline") != _git(b, "log", "-1", "--oneline"), (
+            "축약 길이가 같아 이 테스트 환경은 #1277 을 재현하지 못한다"
+        )
+
+    def test_genuinely_different_commits_report_mismatch(self, tmp_path):
+        """항상 초록인 가짜 게이트가 아님 — 진짜 불일치는 잡아야 한다.
+
+        Mutation lock: 판정을 `true` 로 바꾸면 FAIL.
+        """
+        a = _make_repo(tmp_path / "local", abbrev=7, content="one")
+        b = _make_repo(tmp_path / "remote", abbrev=7, content="two")
+        assert _git(a, "rev-parse", "HEAD") != _git(b, "rev-parse", "HEAD")
+
+        r = _run_verifier(a, _fake_ssh(tmp_path), b)
+        assert r.returncode == 1, f"서로 다른 커밋을 일치로 판정했다\nstdout={r.stdout}"
+
+    def test_output_carries_both_shas_and_labels(self, tmp_path):
+        """호출자(deploy 스크립트)가 표시용 라벨을 3·4행에서 읽는다 — 그 계약을 잠근다."""
+        a = _make_repo(tmp_path / "local", abbrev=7)
+        b = _make_repo(tmp_path / "remote", abbrev=12)
+        r = _run_verifier(a, _fake_ssh(tmp_path), b)
+        lines = r.stdout.strip().splitlines()
+        assert len(lines) == 4, f"4행이어야 한다: {lines}"
+        assert len(lines[0]) == 40 and len(lines[1]) == 40, "1·2행은 전체 SHA(40자)여야 한다"
+        assert "initial commit" in lines[2] and "initial commit" in lines[3], "3·4행은 표시용 라벨"
+
+
+class TestDeployScriptUsesTheVerifier:
+    """배선 — 검증기가 있어도 배포가 안 부르면 소용없다 (#1180 계열 wiring 축).
+
+    ⚠️ 여기는 **구조 검사**다. step 7 만 떼어 실행하려면 배포 스크립트에 테스트 전용
+    모드를 넣어야 하는데, 프로덕션 배포 경로의 제어 흐름을 테스트를 위해 바꾸는 건
+    비용이 더 크다고 판단했다. 대신 판정 로직 자체는 위에서 **실행으로** 잠갔다.
+    """
+
+    def test_verifier_exists_and_is_executable(self):
+        assert VERIFIER.exists(), "검증기 파일이 없다"
+        assert VERIFIER.stat().st_mode & 0o111, "실행 권한이 없다 — 배포가 부를 수 없다"
+
+    @staticmethod
+    def _remote_abbrev_lines(src: str) -> list[str]:
+        """**원격** HEAD 를 축약 문자열로 가져오는 줄 — #1277 의 회귀 형태.
+
+        `--oneline` 자체는 금지하지 않는다. 55행의 `echo "  local HEAD: ..."` 처럼
+        표시용은 정상이고, 그걸 막으면 오탐이 된다. 문제는 그 축약을 **원격에서 받아
+        비교면에 올리는 것**이라, SSH 호출과 축약이 같은 줄에 있는 경우만 본다.
+        """
+        return [ln for ln in src.splitlines() if "${SSH}" in ln and ("--oneline" in ln or "--abbrev" in ln)]
+
+    def test_deploy_delegates_instead_of_comparing_inline(self):
+        src = DEPLOY.read_text(encoding="utf-8")
+        assert "verify_head_sync.sh" in src, "배포가 검증기를 부르지 않는다"
+        offenders = self._remote_abbrev_lines(src)
+        assert not offenders, f"원격 HEAD 를 축약으로 받고 있다 (#1277 회귀): {offenders}"
+
+    def test_the_sweep_has_eyes(self):
+        """카나리아 — sweep 이 조용히 아무것도 안 보는 상태로 썩지 않게.
+
+        위 predicate 가 **옛 코드를 실제로 잡는지**, 그리고 표시용 줄은 **안 잡는지**
+        둘 다 확인한다. 한쪽만 보면 "전부 통과" 와 "전부 차단" 을 구분 못 한다.
+        """
+        old_code = 'REMOTE_HEAD=$("${SSH}" "${REMOTE}" "cd ${REMOTE_PATH} && git log -1 --oneline")'
+        display_only = 'echo "  local HEAD: $(git log -1 --oneline)"'
+        assert self._remote_abbrev_lines(old_code) == [old_code], "옛 결함을 못 잡는다"
+        assert self._remote_abbrev_lines(display_only) == [], "표시용 줄을 오탐한다"


### PR DESCRIPTION
Closes #1277

## 증상 — 동기화된 배포마다 뜨던 거짓 경고

`make deploy-mini` 의 최종 검증이 **완벽히 동기화된 배포에서도** 매번 경고했습니다:

```
⚠ git HEAD 불일치 — local: e6d61148 style(frontend): ... / remote: e6d6114 style(frontend): ...
```

같은 커밋입니다. 2026-08-29 하루에 **두 번의 배포에서 모두 재현**됐고, 이 PR 브랜치에서 다시 확인했습니다:

```
local : 7116eca3   (8자)
remote: eab06fe    (7자)
```

## 원인 — 축약 길이는 저장소마다 다르다

`scripts/deploy/deploy_to_mini.sh` step 7 이 `git log -1 --oneline` **문자열**을 비교했습니다. git 의 auto-abbrev 는 **오브젝트 수에서 파생**되므로 같은 커밋도 저장소마다 다른 길이로 찍힙니다 (`core.abbrev` 는 양쪽 다 unset).

커밋 **제목**까지 비교면에 들어가 있어 오탐 축이 하나 더 있었습니다.

## 왜 고쳐야 하나

dead gate 가 아니라 **false-red** 입니다. 배포 검증은 상주 데몬이 구코드를 들고 도는 사고(#1024, 7일 잠복)를 잡는 마지막 관문인데, **매번 뜨는 경고는 진짜 불일치가 났을 때 그 한 줄을 무시하게 만듭니다.** 사용자가 "과거에 떴던 이슈인데 다시 안 나오게" 라고 지적한 것도 그래서입니다.

## 수정

판정을 `scripts/deploy/verify_head_sync.sh` 로 분리했습니다.

- **비교는 전체 SHA 로만** (`git rev-parse HEAD`)
- 축약은 **표시용으로만** 남기고 판정에 쓰지 않습니다 — 사람이 읽을 라벨은 필요하므로 SSH 왕복 **1회**로 SHA 와 라벨을 같이 받습니다
- 종료 코드 **0 일치 / 1 불일치 / 2 판정 불가**, stdout 4행(로컬 SHA / 원격 SHA / 로컬 라벨 / 원격 라벨). 1 과 2 를 나누는 이유는 아래 codex 절 참조

**별도 파일로 뺀 이유는 테스트가 실행해서 잠글 수 있게 하기 위함입니다.** `tests/test_pre_push_hook.py` · `tests/test_hook_guard_execution.py` 의 전례 그대로 — 셸 게이트는 grep 이 아니라 돌려서 exit code 로 잠급니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| 검증기를 `--oneline` 비교로 되돌림 (#1277 그 자체) | **2 FAIL** |
| 판정을 `true` 로 (항상 초록인 가짜 게이트) | **1 FAIL** |
| 배포가 검증기를 안 부르고 인라인 축약 비교로 회귀 | **1 FAIL** |
| `undetermined` 제거 — 하위 rc 를 그대로 흘림 | **2 FAIL** |
| SHA 형태 검증 제거 | **1 FAIL** |
| 배포가 rc 2 를 경고로 강등 (`if` 래핑 회귀) | **1 FAIL** |
| baseline | 12 passed |

핵심 테스트는 **축약 길이가 실제로 다른 두 저장소**를 만들어 스크립트를 돌립니다 — 같은 내용·같은 author/committer·같은 날짜로 커밋해 SHA 를 일치시키고, `core.abbrev` 만 7 / 12 로 갈라놓습니다. 가짜 SSH(호스트를 무시하고 명령을 로컬 셸로 실행)를 물려 **실제 배포가 타는 코드 경로**를 그대로 돌립니다.

축을 나눠 잠갔습니다:
- 같은 커밋 + 다른 abbrev → **일치 판정** (결함 그 자체)
- 다른 커밋 → **불일치 판정** (항상 초록인 가짜 게이트가 아님)
- **카나리아**: 그 두 저장소의 `--oneline` 출력이 실제로 다른지. 이게 없으면 `core.abbrev` 가 안 먹었을 때 첫 축이 **공허하게 통과**합니다.

### 배선 sweep 은 `--oneline` 자체를 금지하지 않습니다

처음에 `"git log -1 --oneline" not in src` 로 잡았더니 55행의 `echo "  local HEAD: $(git log -1 --oneline)"` 를 걸었습니다. 그건 **표시용이라 정상**이고 막으면 오탐입니다. 결함 형태는 *원격에서 축약을 받아 비교면에 올리는 것*이라, SSH 호출과 축약이 같은 줄에 있는 경우만 봅니다. 카나리아도 **양방향**입니다 — 옛 결함을 잡는지 + 표시용을 오탐하지 않는지 둘 다 확인해야 "전부 통과"와 "전부 차단"을 구분합니다.

### 남은 한계 (정직하게)

배선 잠금은 **구조 검사**입니다. step 7 만 떼어 실행하려면 배포 스크립트에 테스트 전용 모드를 넣어야 하는데, 프로덕션 배포 경로의 제어 흐름을 테스트를 위해 바꾸는 비용이 더 크다고 판단했습니다. **판정 로직 자체는 실행으로 잠겼습니다.**

## codex 리뷰 — [P1] 1건 수용

> If `verify_head_sync.sh` fails for any reason other than an actual SHA mismatch ... this branch now converts that into a mere warning and continues to print `deploy 완료`.

**맞고, 이 PR 이 넣은 회귀입니다.** `if cmd; then … else warn` 래핑이 `set -e` 를 무력화해 **모든 비정상 종료를 "불일치" 경고로 강등**시켰습니다. 이전 인라인 코드는 SSH 실패 시 배포를 중단시켰는데 그 성질을 잃었고, 마지막 안전 게이트가 안 돌았는데 "deploy 완료" 가 찍혔습니다.

이 레포가 이미 겪은 형태입니다 — #910/#911 에서 rc=127 이 실패와 구분되지 않아 pre-push 테스트가 3.5개월 no-op 이었습니다. **제가 그 모호함을 배포 경로에 새로 만든 셈**입니다.

종료 코드를 셋으로 나눴습니다: **0 일치 / 1 불일치 / 2 판정 불가**(SSH 실패·git 실패·SHA 형태 아님). 검증기는 `set -e` 를 끄고 실패를 직접 분류합니다 — `-e` 는 하위 rc 를 그대로 흘려 1 과 구분할 수 없게 만듭니다. 배포는 rc 를 받아 `case` 로 가르고 **rc≥2 는 `fail` 로 중단**합니다.

**가장 위험한 축은 원격이 rc 1 로 죽는 경우**입니다 — 불일치와 정확히 같은 코드라, 하위 rc 를 흘리면 조용히 경고로 내려앉습니다. 별도 테스트로 잠갔습니다.

형태 검증도 넣었습니다: SSH 가 rc 0 으로 배너만 뱉는 경우가 있고, 그걸 SHA 로 믿으면 **"불일치" 라는 틀린 이유**를 보고하게 됩니다.

## 검증

- `make test-fast` → **7,626 passed / 6 skipped** (rc=0)
- `make lint-sh`(shellcheck) · `make diagnostics` · `check_privacy_leak.py` · `make verify-doc-counts` 22/22 → 전부 rc=0
- **실물 원격 대조** (배포 없이 검증기만 실행): 로컬 `7116eca3…` vs 원격 `eab06fec…` → exit 1. 서로 다른 커밋이므로 **정확한 판정**입니다.
- ⚠️ **최종 증명은 머지 후 실제 배포**입니다 — 같은 커밋이 됐을 때 `✓ git HEAD 일치` 가 떠야 합니다. 배포하고 결과를 이 PR 에 남기겠습니다.
