### PR TITLE
fix(core): never let a future-dated row become the current exchange rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,671 collected across 352 files | |
+| **Backend tests** | 7,674 collected across 352 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,659 collected across 351 files | |
+| **Backend tests** | 7,671 collected across 352 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,659 backend tests across 351 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,671 backend tests across 352 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,671 backend tests across 352 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,674 backend tests across 352 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,659 tests, 351 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,671 tests, 352 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,671 tests, 352 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,674 tests, 352 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -258,11 +258,10 @@ def _collect_context(db_path=None) -> dict:
             """,
             db_path=db_path,
         )
-        rate_row = query(
-            "SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 1",
-            db_path=db_path,
-        )
-        rate = float(rate_row[0]["value"]) if rate_row else 1400.0
+        # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+        from nuri.core.fx import latest_usd_krw_value
+
+        rate = latest_usd_krw_value(db_path=db_path) or 1400.0
         from nuri.core.ticker_names import is_kr_ticker
 
         by_acct: dict[str, float] = {}

--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -37,13 +37,12 @@ class StaleExchangeRateError(Exception):
 
 def get_exchange_rate(db_path=None) -> float:
     """USD/KRW 환율 조회. 7일 이상 오래되면 WARNING, DB에 없으면 에러."""
-    rows = query(
-        "SELECT value, date FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1",
-        db_path=db_path,
-    )
-    if rows:
-        rate = rows[0]["value"]
-        rate_date = rows[0]["date"]
+    # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+    from nuri.core.fx import latest_usd_krw
+
+    got = latest_usd_krw(db_path=db_path)
+    if got:
+        rate, rate_date = got
 
         # 신선도 체크: 7일 초과 시 경고
         from datetime import datetime

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -19,6 +19,7 @@ from nuri.api.limits import heavy_slot
 from nuri.core.axis import is_alpha_flat_sell
 from nuri.core.catalyst import has_recent_catalyst
 from nuri.core.db import query
+from nuri.core.fx import latest_usd_krw_value
 from nuri.core.live_price import DEFAULT_DIVERGENCE_THRESHOLD_PCT, check_divergence
 from nuri.core.rules import get_stop_loss_for_account
 from nuri.core.ticker_names import is_kr_ticker
@@ -678,8 +679,8 @@ def _get_portfolio_map() -> dict[str, dict]:
     if real_accounts:
         rows = [r for r in rows if r["account"] in real_accounts]
 
-    rate_row = query("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1")
-    rate = rate_row[0]["value"] if rate_row else 1400
+    # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+    rate = latest_usd_krw_value() or 1400
 
     # 총 자산 계산 (비중% 산정용)
     total_value = 0

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends
 
 from nuri.api.cache import portfolio_version
 from nuri.api.limits import heavy_slot
+from nuri.core.fx import latest_usd_krw_value
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["dashboard"])
@@ -108,8 +109,8 @@ def _build_dashboard() -> dict:
     pipeline_status = _get_pipeline_status()
 
     # ── 7. 환율 ──
-    rate_row = query("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1")
-    exchange_rate = rate_row[0]["value"] if rate_row else None
+    # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+    exchange_rate = latest_usd_krw_value()
 
     # ── 8. 계좌별 평가액 ──
     account_values = _get_account_values(exchange_rate)

--- a/nuri/api/routes/portfolio.py
+++ b/nuri/api/routes/portfolio.py
@@ -197,8 +197,10 @@ def get_portfolio():
     _enrich_with_history(holdings)
 
     # 환율 조회 (cash 환산용)
-    rate_row = query("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1")
-    exchange_rate = rate_row[0]["value"] if rate_row else None
+    # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+    from nuri.core.fx import latest_usd_krw_value
+
+    exchange_rate = latest_usd_krw_value()
     cash = _get_cash_balances(exchange_rate)
 
     return {"holdings": holdings, "count": len(holdings), "cash": cash}

--- a/nuri/core/fx.py
+++ b/nuri/core/fx.py
@@ -1,0 +1,80 @@
+"""USD/KRW 환율의 **단일 읽기 지점** (#1278).
+
+## 왜 생겼나
+
+"최신 환율" 을 `ORDER BY date DESC LIMIT 1` 로 읽는 곳이 **8군데** 흩어져 있었고,
+전부 **날짜 상한이 없었다.** `macro` 에 미래 날짜 행이 하나라도 들어오면 그게 영구히
+"최신" 자리를 차지한다.
+
+2026-08-29 실측 — dev DB 에 `toss` 소스의 미래 행 3건(`2026-11-08` · `2027-02-06` ·
+`2027-09-14`)이 섞여 있었고, `get_exchange_rate()` 가 **1417.4** 를 반환했다. 같은 시각
+정상 최신 행은 `2026-08-21 1385.01`(FRED), 프로덕션은 `1383.35`. 오차 +2.46% 가
+모든 KRW 환산 총액·계좌 비중·현금 합산에 곱해진다.
+
+`2027-09-14` 행은 **1년 넘게** 최신 자리를 지킨다 — 시간이 지나도 스스로 낫지 않는다.
+
+## 왜 읽는 쪽에 방어를 두나
+
+미래 행의 출처는 미상이다. `collectors/macro.py` 의 toss 경로는 `date: today_kst()` 를
+쓰므로 **자기 힘으로는 미래 날짜를 만들 수 없다** — 테스트/에이전트의 dev DB 오염이
+유력하고, 이 레포는 전례가 있다. **그래서 더더욱 읽는 쪽이 막아야 한다**: 행이 어떻게
+들어왔든 미래 환율을 "현재" 로 쓰면 안 된다. 쓰는 쪽에 규율을 요구하면 새 writer 가
+생길 때마다 다시 샌다 (#1279 캐시 버전 키와 같은 논리).
+
+## 미래 행을 조용히 버리지 않는다
+
+버리기만 하면 수집기 결함이 영영 안 보인다. 발견 시 WARNING 을 남긴다 — 다만 그
+진단이 **본 작업을 게이트하면 안 되므로**(#894) 자체 try 로 감싸고 실패해도 환율은 낸다.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nuri.core.db import DatabaseError, OperationalError, query
+from nuri.core.timezone import today_kst
+
+logger = logging.getLogger(__name__)
+
+
+def _warn_if_future_rows(today: str, db_path=None) -> None:
+    """미래 날짜 행이 있으면 경고. 진단 전용 — 실패해도 호출자를 막지 않는다 (#894)."""
+    try:
+        rows = query(
+            "SELECT COUNT(*) AS n, MAX(date) AS mx FROM macro WHERE indicator = 'usd_krw' AND date > ?",
+            (today,),
+            db_path=db_path,
+        )
+    except (OperationalError, DatabaseError):
+        return
+    if rows and rows[0]["n"]:
+        logger.warning(
+            "usd_krw 에 미래 날짜 행 %d건 (최대 %s) — 무시하고 오늘 이하 최신을 쓴다. "
+            "수집기 결함이거나 DB 오염이니 원인을 확인할 것 (#1278)",
+            rows[0]["n"],
+            rows[0]["mx"],
+        )
+
+
+def latest_usd_krw(db_path=None) -> tuple[float, str] | None:
+    """오늘(KST) 이하에서 가장 최신인 USD/KRW 와 그 날짜. 없으면 `None`.
+
+    **숫자를 지어내지 않는다** — 부재는 `None` 이고, 무엇으로 메울지는 호출자가 정한다
+    (STRATEGY §2.6 의 VIX 게이트와 같은 원칙).
+    """
+    today = today_kst()
+    _warn_if_future_rows(today, db_path=db_path)
+    rows = query(
+        "SELECT value, date FROM macro WHERE indicator = 'usd_krw' AND date <= ? ORDER BY date DESC LIMIT 1",
+        (today,),
+        db_path=db_path,
+    )
+    if not rows or rows[0]["value"] is None:
+        return None
+    return float(rows[0]["value"]), str(rows[0]["date"])
+
+
+def latest_usd_krw_value(db_path=None) -> float | None:
+    """`latest_usd_krw` 의 값만 필요한 호출자를 위한 얇은 래퍼."""
+    got = latest_usd_krw(db_path=db_path)
+    return got[0] if got else None

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -368,7 +368,15 @@ def run_strategy_walkforward(
 
 def _load_fx_series(db_path: Optional[Path] = None) -> pd.Series:
     """macro 의 usd_krw 일별 시계열 (KRW/USD). FX 필수 입력 — 없으면 ValueError."""
-    df = query_df("SELECT date, value FROM macro WHERE indicator='usd_krw' ORDER BY date", db_path=db_path)
+    # #1278: 미래 날짜 행이 꼬리에 붙으면 walk-forward 가 존재하지 않는 미래 FX 를 본다.
+    # 프로덕션에는 그런 행이 없어 실질 no-op 이지만, 백테스트 입력에 오염을 남길 이유가 없다.
+    from nuri.core.timezone import today_kst
+
+    df = query_df(
+        "SELECT date, value FROM macro WHERE indicator='usd_krw' AND date <= ? ORDER BY date",
+        (today_kst(),),
+        db_path=db_path,
+    )
     if df.empty:
         raise ValueError("usd_krw not in macro — FX 필수 (make collect 후 재시도)")
     return pd.Series(df["value"].to_numpy(), index=pd.to_datetime(df["date"]))

--- a/nuri/quant/validation/strategy_walkforward.py
+++ b/nuri/quant/validation/strategy_walkforward.py
@@ -368,15 +368,19 @@ def run_strategy_walkforward(
 
 def _load_fx_series(db_path: Optional[Path] = None) -> pd.Series:
     """macro 의 usd_krw 일별 시계열 (KRW/USD). FX 필수 입력 — 없으면 ValueError."""
-    # #1278: 미래 날짜 행이 꼬리에 붙으면 walk-forward 가 존재하지 않는 미래 FX 를 본다.
-    # 프로덕션에는 그런 행이 없어 실질 no-op 이지만, 백테스트 입력에 오염을 남길 이유가 없다.
-    from nuri.core.timezone import today_kst
-
-    df = query_df(
-        "SELECT date, value FROM macro WHERE indicator='usd_krw' AND date <= ? ORDER BY date",
-        (today_kst(),),
-        db_path=db_path,
-    )
+    # ⚠️ **여기만 날짜 상한을 두지 않는다** (#1278, codex 리뷰 P2 에서 되돌림).
+    #
+    # 다른 8곳은 "지금 환율" 을 읽으므로 미래 행이 곧 오염이다. 하지만 이 함수는
+    # **데이터셋을 평가**한다 — 벽시계로 자르면 두 가지가 깨진다:
+    #   1. 재현 불가 — 같은 DB·같은 코드가 **실행 날짜에 따라** 다른 결과를 낸다.
+    #   2. 더 나쁜 조용한 왜곡 — `_build_us_panel` 은 가격에 상한이 없어서, FX 만 자르면
+    #      `fx_ret … .reindex(prices.index).fillna(0.0)` (238행)이 오늘 이후 구간의 FX
+    #      수익률을 **전부 0(환율 불변)** 으로 채운다. 얼어붙은 리서치 DB 나 미래 구간
+    #      fixture 에서 KRW 결과가 조용히 틀어진다.
+    #
+    # 그리고 상한은 **이득도 없다**: 위 reindex 가 가격 인덱스 밖 FX 날짜를 어차피
+    # 버리므로, 떠도는 미래 행은 이 경로에 도달하지 못한다.
+    df = query_df("SELECT date, value FROM macro WHERE indicator='usd_krw' ORDER BY date", db_path=db_path)
     if df.empty:
         raise ValueError("usd_krw not in macro — FX 필수 (make collect 후 재시도)")
     return pd.Series(df["value"].to_numpy(), index=pd.to_datetime(df["date"]))

--- a/nuri/trading/agents/korean_market.py
+++ b/nuri/trading/agents/korean_market.py
@@ -29,8 +29,13 @@ def _calibrate_fx_thresholds(db_path=None) -> tuple[float, float]:
 
     from nuri.core.db import query_df
 
+    # #1278: 미래 날짜 행이 90일 창에 섞이면 평균·표준편차가 오염된다 — 최신 1건뿐
+    # 아니라 **시계열도** 상한이 필요하다.
+    from nuri.core.timezone import today_kst
+
     df = query_df(
-        "SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 90",
+        "SELECT value FROM macro WHERE indicator='usd_krw' AND date <= ? ORDER BY date DESC LIMIT 90",
+        (today_kst(),),
         db_path=db_path,
     )
     if df.empty or len(df) < _CFG.get("fx_calibration_min", 30):
@@ -158,8 +163,12 @@ class KoreanMarketAgent(BaseAgent):
 
     def _get_fx_rate(self, db_path=None) -> float | None:
         """최신 KRW/USD 환율."""
+        # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py). `_safe_query` 의 예외 삼킴을 유지하려 쿼리 형태만 맞춘다.
+        from nuri.core.timezone import today_kst
+
         rows = self._safe_query(
-            "SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 1",
+            "SELECT value FROM macro WHERE indicator='usd_krw' AND date <= ? ORDER BY date DESC LIMIT 1",
+            (today_kst(),),
             db_path=db_path,
         )
         return rows[0]["value"] if rows else None

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -660,14 +660,16 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
         dict: MDD 위반 정보. 위반 없으면 None.
     """
     # 환율 조회 (KRW → USD 변환용)
-    from nuri.core.db import query as _q
     from nuri.core.rules import PORTFOLIO_STOP
 
     usd_krw = 1400.0  # 폴백
     try:
-        fx_rows = _q("SELECT value FROM macro WHERE indicator = 'usd_krw' ORDER BY date DESC LIMIT 1", db_path=db_path)
-        if fx_rows and fx_rows[0]["value"]:
-            usd_krw = float(fx_rows[0]["value"])
+        # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+        from nuri.core.fx import latest_usd_krw_value
+
+        _fx = latest_usd_krw_value(db_path=db_path)
+        if _fx:
+            usd_krw = _fx
     except Exception:
         pass
 

--- a/tests/core/test_fx_date_ceiling.py
+++ b/tests/core/test_fx_date_ceiling.py
@@ -20,6 +20,7 @@
 그중 2곳만 지목했다.
 """
 
+import pandas as pd
 import pytest
 
 from nuri.core.db import get_db, init_db
@@ -141,6 +142,44 @@ class TestEveryConsumerIsCovered:
         assert agent._get_fx_rate() == pytest.approx(1380.0)
 
 
+#: 날짜 상한을 **일부러 두지 않는** 조회. 사유를 반드시 함께 적는다.
+#: 양방향 검사라 낡은 항목(이제 상한이 생긴 파일)도 FAIL 한다 — allowlist 가 조용히
+#: 커지는 걸 막는 것이 이 목록의 존재 이유다 (`test_cross_stage_imports.py` 와 같은 규율).
+CEILING_EXEMPT: dict[str, str] = {
+    "quant/validation/strategy_walkforward.py": (
+        "데이터셋을 평가하는 백테스트 입력. 벽시계로 자르면 (1) 실행 날짜에 따라 결과가 "
+        "달라져 재현 불가, (2) 가격 패널에는 상한이 없어 FX 만 잘리면 "
+        "`reindex(prices.index).fillna(0.0)` 가 오늘 이후 FX 수익률을 전부 0 으로 채워 "
+        "KRW 결과가 조용히 왜곡된다. 게다가 그 reindex 가 가격 범위 밖 FX 날짜를 "
+        "어차피 버리므로 상한은 이득도 없다 (codex 리뷰 P2)."
+    ),
+}
+
+
+class TestBacktestFxIsBoundedByTheDatasetNotTheClock:
+    """백테스트 FX 는 **벽시계가 아니라 데이터셋 지평**을 따른다 (codex 리뷰 P2).
+
+    초안이 여기에도 상한을 넣었다가 되돌렸다. 두 가지가 깨졌기 때문이다:
+      1. 같은 DB·같은 코드가 **실행 날짜에 따라** 다른 결과를 낸다 (재현 불가).
+      2. `_build_us_panel` 은 가격에 상한이 없어서, FX 만 자르면
+         `fx_ret … .reindex(prices.index).fillna(0.0)` 가 오늘 이후 FX 수익률을
+         **전부 0(환율 불변)** 으로 채운다 — 조용한 왜곡이라 더 나쁘다.
+
+    "미래 행" 방어는 여기 필요 없다: 위 reindex 가 가격 인덱스 밖 FX 날짜를 버린다.
+    """
+
+    def test_series_includes_dates_beyond_today(self, db):
+        """Mutation lock: `_load_fx_series` 에 `AND date <= ?` 를 넣으면 FAIL."""
+        from nuri.quant.validation.strategy_walkforward import _load_fx_series
+
+        _seed(db, [(PAST, 1100.0), (TODAY, 1380.0), (FUTURE, 1500.0)])
+        series = _load_fx_series(db)
+        assert pd.Timestamp(FUTURE) in series.index, (
+            "데이터셋 지평을 벽시계로 잘랐다 — 실행 날짜에 따라 백테스트 결과가 달라진다"
+        )
+        assert len(series) == 3
+
+
 class TestNoUnboundedLatestReadRemains:
     """구조 스윕 — 새 소비자가 상한 없이 또 읽는 걸 막는다.
 
@@ -149,22 +188,33 @@ class TestNoUnboundedLatestReadRemains:
     """
 
     @staticmethod
-    def _offenders() -> list[str]:
+    def _unbounded() -> dict[str, list[int]]:
         import re
         from pathlib import Path
 
         root = Path(__file__).resolve().parents[2] / "nuri"
         pat = re.compile(r"indicator\s*=\s*['\"]usd_krw['\"]")
-        out = []
-        for f in root.rglob("*.py"):
+        out: dict[str, list[int]] = {}
+        for f in sorted(root.rglob("*.py")):
             for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
                 if pat.search(line) and "date <=" not in line and "date >" not in line:
-                    out.append(f"{f.relative_to(root)}:{i}")
+                    out.setdefault(str(f.relative_to(root)), []).append(i)
         return out
 
-    def test_no_usd_krw_query_lacks_a_date_ceiling(self):
-        offenders = self._offenders()
-        assert not offenders, f"날짜 상한 없는 usd_krw 조회: {offenders}"
+    def test_no_unlisted_query_lacks_a_date_ceiling(self):
+        found = self._unbounded()
+        unlisted = {k: v for k, v in found.items() if k not in CEILING_EXEMPT}
+        assert not unlisted, f"상한 없는 usd_krw 조회가 새로 생겼다: {unlisted}"
+
+    def test_every_exemption_is_still_needed(self):
+        """양방향 — 상한이 생긴 파일이 목록에 남아 있으면 그 사유는 이미 거짓이다."""
+        found = self._unbounded()
+        stale = [k for k in CEILING_EXEMPT if k not in found]
+        assert not stale, f"낡은 예외 항목(이미 상한이 있음): {stale}"
+
+    def test_every_exemption_states_a_reason(self):
+        for path, why in CEILING_EXEMPT.items():
+            assert len(why) > 40, f"{path}: 사유가 너무 짧다 — 다음 사람이 판단할 수 없다"
 
     def test_the_sweep_has_eyes(self):
         """카나리아 — 정규식이 조용히 아무것도 안 잡으면 위 테스트는 영원히 초록이다."""

--- a/tests/core/test_fx_date_ceiling.py
+++ b/tests/core/test_fx_date_ceiling.py
@@ -1,0 +1,177 @@
+"""미래 날짜 환율 행이 "현재 환율" 자리를 차지하지 못하게 잠근다 (#1278).
+
+## 무엇이 잘못됐었나
+
+"최신 환율" 을 `ORDER BY date DESC LIMIT 1` 로 읽는 곳이 **9군데** 있었고 전부 날짜
+상한이 없었다. `macro` 에 미래 날짜 행이 하나라도 들어오면 그게 영구히 최신이 된다.
+
+2026-08-29 실측 — dev DB 에 `2027-09-14` 행이 섞여 `get_exchange_rate()` 가 **1417.4**
+를 반환했다. 정상 최신은 `2026-08-21 1385.01`, 프로덕션은 `1383.35`. 오차 +2.46% 가
+모든 KRW 환산 총액·계좌 비중·현금 합산에 곱해진다. 그리고 `2027-09-14` 행은 **1년 넘게**
+최신 자리를 지킨다 — 시간이 지나도 스스로 낫지 않는다.
+
+곁가지로 노후 경고까지 죽어 있었다: `age_days = (now - latest).days` 가 미래 날짜에서
+**음수**라 `age_days > 7` 이 영원히 거짓이었다. 이중으로 눈이 멀어 있었다.
+
+## 왜 여러 소비자를 각각 잠그나
+
+`tests/CLAUDE.md` Time-bomb 2차 발생의 교훈이다 — *"규칙 하나에 잠금이 한 경로만
+걸려 있으면 나머지 경로는 무방비다."* 실제로 이 결함은 9곳에 흩어져 있었고, 이슈는
+그중 2곳만 지목했다.
+"""
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.core.fx import latest_usd_krw, latest_usd_krw_value
+from nuri.core.timezone import today_kst
+
+TODAY = today_kst()
+FUTURE = "2099-01-01"
+PAST = "2020-01-01"
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    import nuri.core.db as db_mod
+
+    path = tmp_path / "fx.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+def _seed(db_path, rows):
+    with get_db(db_path) as conn:
+        conn.executemany(
+            "INSERT INTO macro (indicator, date, value, source) VALUES ('usd_krw', ?, ?, 'test')",
+            rows,
+        )
+
+
+class TestLatestUsdKrwHonoursTheCeiling:
+    def test_future_row_never_becomes_the_rate(self, db):
+        """결함 그 자체. Mutation lock: `AND date <= ?` 를 지우면 FAIL."""
+        _seed(db, [(TODAY, 1380.0), (FUTURE, 9999.0)])
+        assert latest_usd_krw_value() == pytest.approx(1380.0), "미래 행을 현재 환율로 썼다"
+
+    def test_latest_below_ceiling_wins(self, db):
+        """대조군 — 상한 안에서는 여전히 **최신**이어야 한다 (오래된 걸 집으면 안 된다)."""
+        _seed(db, [(PAST, 1100.0), (TODAY, 1380.0)])
+        got = latest_usd_krw()
+        assert got is not None
+        assert got[0] == pytest.approx(1380.0) and got[1] == TODAY
+
+    def test_only_future_rows_means_no_rate(self, db):
+        """미래 행밖에 없으면 **숫자를 지어내지 않는다** — 부재는 None."""
+        _seed(db, [(FUTURE, 9999.0)])
+        assert latest_usd_krw_value() is None
+
+    def test_empty_table_returns_none(self, db):
+        assert latest_usd_krw_value() is None
+
+    def test_future_rows_are_logged_not_silently_dropped(self, db, caplog):
+        """조용히 버리면 수집기 결함이 영영 안 보인다.
+
+        Mutation lock: `_warn_if_future_rows` 호출을 지우면 FAIL.
+        """
+        import logging
+
+        _seed(db, [(TODAY, 1380.0), (FUTURE, 9999.0)])
+        with caplog.at_level(logging.WARNING, logger="nuri.core.fx"):
+            latest_usd_krw_value()
+        assert caplog.records, "미래 행을 발견하고도 경고하지 않았다"
+        assert FUTURE in caplog.text, "어느 날짜가 문제인지 말하지 않는다"
+
+    def test_clean_table_logs_nothing(self, db, caplog):
+        """대조군 — 정상일 때 경고가 뜨면 그 경고는 곧 무시된다 (false-red)."""
+        import logging
+
+        _seed(db, [(TODAY, 1380.0)])
+        with caplog.at_level(logging.WARNING, logger="nuri.core.fx"):
+            latest_usd_krw_value()
+        assert not caplog.records, f"정상인데 경고했다: {caplog.text}"
+
+    def test_db_error_in_diagnostic_is_swallowed(self, db, monkeypatch):
+        """진단이 본 작업을 게이트하면 안 된다 (#894) — 미래행 카운트가 죽어도 환율은 나온다."""
+        import nuri.core.fx as fx
+        from nuri.core.db import OperationalError
+
+        _seed(db, [(TODAY, 1380.0)])
+        real = fx.query
+        calls = {"n": 0}
+
+        def _flaky(sql, *a, **k):
+            calls["n"] += 1
+            if "COUNT(*)" in sql:
+                raise OperationalError("no such table")
+            return real(sql, *a, **k)
+
+        monkeypatch.setattr(fx, "query", _flaky)
+        assert latest_usd_krw_value() == pytest.approx(1380.0), "진단 실패가 환율을 막았다"
+        assert calls["n"] >= 2, "진단 쿼리가 아예 안 돌았다 — 축이 성립 안 함"
+
+
+class TestEveryConsumerIsCovered:
+    """소비자별 잠금 — 한 경로만 잠그면 나머지는 무방비다 (tests/CLAUDE.md)."""
+
+    def test_get_exchange_rate_ignores_future_rows(self, db):
+        from nuri.analysis.portfolio import get_exchange_rate
+
+        _seed(db, [(TODAY, 1380.0), (FUTURE, 9999.0)])
+        assert get_exchange_rate() == pytest.approx(1380.0)
+
+    def test_stale_warning_works_again(self, db, caplog):
+        """미래 행이 있으면 나이가 **음수**가 되어 7일 경고까지 죽었다 — 곁가지 결함."""
+        import logging
+
+        old = "2020-01-01"
+        _seed(db, [(old, 1100.0), (FUTURE, 9999.0)])
+        with caplog.at_level(logging.WARNING, logger="nuri.analysis.portfolio"):
+            from nuri.analysis.portfolio import get_exchange_rate
+
+            assert get_exchange_rate() == pytest.approx(1100.0)
+        assert "경과" in caplog.text, "노후 환율인데 경고가 없다"
+
+    def test_korean_market_fx_rate_ignores_future_rows(self, db):
+        from nuri.trading.agents.korean_market import KoreanMarketAgent
+
+        _seed(db, [(TODAY, 1380.0), (FUTURE, 9999.0)])
+        agent = KoreanMarketAgent()
+        assert agent._get_fx_rate() == pytest.approx(1380.0)
+
+
+class TestNoUnboundedLatestReadRemains:
+    """구조 스윕 — 새 소비자가 상한 없이 또 읽는 걸 막는다.
+
+    동작 잠금은 **지금 존재하는** 소비자만 덮는다. 이 결함이 9곳으로 번진 방식이
+    바로 "새 곳에서 같은 쿼리를 다시 쓰기" 였다.
+    """
+
+    @staticmethod
+    def _offenders() -> list[str]:
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2] / "nuri"
+        pat = re.compile(r"indicator\s*=\s*['\"]usd_krw['\"]")
+        out = []
+        for f in root.rglob("*.py"):
+            for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+                if pat.search(line) and "date <=" not in line and "date >" not in line:
+                    out.append(f"{f.relative_to(root)}:{i}")
+        return out
+
+    def test_no_usd_krw_query_lacks_a_date_ceiling(self):
+        offenders = self._offenders()
+        assert not offenders, f"날짜 상한 없는 usd_krw 조회: {offenders}"
+
+    def test_the_sweep_has_eyes(self):
+        """카나리아 — 정규식이 조용히 아무것도 안 잡으면 위 테스트는 영원히 초록이다."""
+        import re
+
+        pat = re.compile(r"indicator\s*=\s*['\"]usd_krw['\"]")
+        bad = "SELECT value FROM macro WHERE indicator='usd_krw' ORDER BY date DESC LIMIT 1"
+        good = "SELECT value FROM macro WHERE indicator='usd_krw' AND date <= ? ORDER BY date DESC"
+        assert pat.search(bad) and "date <=" not in bad
+        assert pat.search(good) and "date <=" in good


### PR DESCRIPTION
Closes #1278

## 증상 — 2027년 환율이 "현재 환율" 이었다

dev DB 에서 `get_exchange_rate()` 가 **1417.4** 를 반환했습니다. 같은 시각 정상 최신 행은 `2026-08-21 1385.01`(FRED), 프로덕션은 `1383.35` 입니다.

```
2026-11-08  1417.2  toss
2027-02-06  1416.4  toss
2027-09-14  1417.4  toss   ← ORDER BY date DESC 가 집는 행
```

오차 **+2.46%** 가 모든 KRW 환산 총액·계좌 비중·현금 합산에 곱해집니다. 그리고 `2027-09-14` 행은 **1년 넘게** 최신 자리를 지킵니다 — 시간이 지나도 스스로 낫지 않습니다.

### 곁가지 — 노후 경고까지 죽어 있었다

`age_days = (now - latest).days` 가 미래 날짜에서 **음수**라 `age_days > 7` 이 영원히 거짓이었습니다. 값이 틀린 것도 모자라 **틀렸다는 신호마저** 꺼져 있었습니다. 이중 실명입니다.

## 이슈보다 범위가 컸습니다

이슈는 2곳(`portfolio.py:41`, `premarket_brief.py:262`)을 지목했는데, 전수 조사하니 **9곳**이었습니다:

| 파일 | 형태 |
|---|---|
| `analysis/portfolio.py` `get_exchange_rate` | 최신 1건 |
| `alerts/premarket_brief.py` | 최신 1건 |
| `api/routes/actions.py` · `dashboard.py` · `portfolio.py` | 최신 1건 (각자 조회) |
| `trading/recommend/price_targets.py` | 최신 1건 |
| `trading/agents/korean_market.py` | 최신 1건 + **90일 창** |
| `quant/validation/strategy_walkforward.py` | **전체 시계열** |

**2곳만 고치면 사용자 대시보드는 여전히 미래 날짜 환율을 씁니다** — API 라우트 3개가 각자 조회하기 때문입니다. `korean_market` 의 90일 창도 미래 행이 섞이면 평균·표준편차가 오염되므로 포함했습니다. **walk-forward 시계열만 예외**입니다 — 사유는 아래 codex 절 참조.

## 수정 — 단일 읽기 지점

`nuri/core/fx.py` 를 만들고 9곳을 전부 통과시킵니다.

**왜 읽는 쪽에 방어를 두나.** 미래 행의 출처는 미상입니다 — `collectors/macro.py` 의 toss 경로는 `date: today_kst()` 를 쓰므로 **자기 힘으로는 미래 날짜를 만들 수 없습니다.** 테스트/에이전트의 dev DB 오염이 유력하고 이 레포는 전례가 있습니다. 그래서 더더욱 읽는 쪽이 막아야 합니다: 행이 어떻게 들어왔든 미래 환율을 "현재" 로 쓰면 안 됩니다. 쓰는 쪽에 규율을 요구하면 새 writer 가 생길 때마다 다시 샙니다 (#1279 캐시 버전 키와 같은 논리).

**조용히 버리지 않습니다.** 미래 행 발견 시 WARNING 을 남깁니다 — 버리기만 하면 수집기 결함이 영영 안 보입니다. 다만 그 진단이 **본 작업을 게이트하면 안 되므로**(#894) 자체 try 로 감싸고 실패해도 환율은 냅니다.

**부재는 `None`** 입니다. 숫자를 지어내지 않고, 무엇으로 메울지는 호출자가 정합니다 (STRATEGY §2.6 VIX 게이트와 같은 원칙).

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| 날짜 상한 제거 (#1278 그 자체) | **10 FAIL** |
| 미래행 경고 제거 (조용히 버리기) | **2 FAIL** |
| 부재를 `1400` 으로 지어냄 | **2 FAIL** |
| 소비자 **하나**(korean_market)만 상한 제거 | **2 FAIL** |
| walkforward 에 벽시계 상한 재삽입 (codex P2 회귀) | **2 FAIL** |
| allowlist 에 낡은 항목 추가 (양방향 검사) | **2 FAIL** |
| baseline | 15 passed |

M4 가 중요합니다 — 소비자별로 따로 잠갔기에 **한 곳만 되돌려도** 잡힙니다. `tests/CLAUDE.md` Time-bomb 2차 발생의 교훈 그대로입니다(*"규칙 하나에 잠금이 한 경로만 걸려 있으면 나머지 경로는 무방비다"*). 실제로 이 결함이 9곳으로 번진 방식이 바로 "새 곳에서 같은 쿼리를 다시 쓰기" 였으므로, **구조 스윕 + 카나리아**로 새 소비자도 막습니다.

대조군도 짝으로 뒀습니다 — 상한 안에서는 여전히 최신을 집어야 하고(오래된 걸 집으면 안 됨), 정상 테이블에서는 경고가 뜨면 안 됩니다(false-red 는 곧 무시로 이어짐).

## codex 리뷰 — [P2] 1건 수용 (되돌림)

> this new `date <= today_kst()` filter makes those runs depend on the machine's current date instead of the dataset horizon … FX is silently cut off and later zero-filled by `reindex(...).fillna(0.0)`

**맞습니다. 두 주장 다 코드로 확인했습니다** — `strategy_walkforward.py:238` 이 `fx_ret … .reindex(prices.index).fillna(0.0)` 이고, `_build_us_panel`(132행)의 가격 조회에는 상한이 없습니다. 즉 FX 만 자르면 오늘 이후 구간의 FX 수익률이 **전부 0(환율 불변)** 으로 채워져 KRW 결과가 조용히 왜곡됩니다.

그리고 확인하다 하나 더 알았습니다 — **상한은 이득도 없었습니다.** 그 reindex 가 가격 인덱스 밖 FX 날짜를 어차피 버리므로, 떠도는 미래 행은 이 경로에 도달조차 못 합니다. **위험만 있고 효용이 없는 변경**이었습니다.

`_load_fx_series` 의 상한을 되돌리고, 사유와 함께 `CEILING_EXEMPT` 에 등재했습니다. 그 목록은 **양방향**입니다 — 상한이 생긴 파일이 목록에 남아 있어도 FAIL 해서 allowlist 가 조용히 커지는 걸 막습니다. 되돌린 성질 자체(미래 날짜가 시리즈에 남는지)도 동작으로 잠갔습니다.

⚠️ 이 되돌림 중에 **`git checkout --` 으로 커밋 안 된 수정을 날렸습니다** — 뮤테이션 전에 커밋한다는 제 규칙을 어긴 결과입니다. 테스트가 "복원했는데도 2 FAIL" 로 즉시 드러내 재적용했고, 이후 축은 커밋 후에 쟀습니다.

## 실측 — 오염된 dev DB 에서 (미래 행 3건 살아있는 상태)

```
LOG WARNING usd_krw 에 미래 날짜 행 3건 (최대 2027-09-14) — 무시하고 오늘 이하 최신을 쓴다 (#1278)
LOG WARNING USD/KRW 환율 8일 경과 (날짜: 2026-08-21, 값: 1385.0)   ← 이전엔 침묵했던 경고
get_exchange_rate() = 1385.01     (이전: 1417.4)
```

## 스코프 밖 — 지어낸 fallback 6곳

`1400` / `1450` 기본값이 6곳에 있습니다 (`portfolio.py:133,268` · `premarket_brief.py:265` · `actions.py:682` · `dashboard.py:395,451`). 이 PR 은 **날짜 상한**만 다룹니다 — fallback 제거는 4개 라우트에서 None 처리를 각각 판단해야 해 변경 축이 둘이 됩니다. 이번 리팩터로 그것들이 전부 **한 줄로 드러났으니** 후속에서 닫습니다.

## 검증

- `make test-fast` → **7,641 passed / 6 skipped** (rc=0) — 8곳을 고쳤는데 기존 테스트 무손상
- `make verify-doc-counts` 22/22 · `make diagnostics` · `check_privacy_leak.py` → 전부 rc=0
