### PR TITLE
fix(fx): never fabricate an exchange rate when the rate is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,674 collected across 352 files | |
+| **Backend tests** | 7,694 collected across 353 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,694 collected across 353 files | |
+| **Backend tests** | 7,698 collected across 353 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,694 backend tests across 353 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,698 backend tests across 353 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,674 backend tests across 352 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,694 backend tests across 353 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,694 tests, 353 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,698 tests, 353 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,674 tests, 352 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,694 tests, 353 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -266,7 +266,17 @@ def _collect_context(db_path=None) -> dict:
         from nuri.core.ticker_names import is_kr_ticker
 
         rate = latest_usd_krw_value(db_path=db_path)
-        kr_count = sum(1 for r in rows if is_kr_ticker(r["ticker"]))
+        # 술어는 레포 정본 (`analysis/portfolio.py:208` 등): `currency == "KRW"` 이거나
+        # `.KS/.KQ`. suffix 만 보면 `currency="KRW"` 인 무접미 보유가 "US 전용" 으로
+        # 오분류돼 환율 없이 총액이 나간다 (codex 리뷰 P1).
+        #
+        # `quantity > 0` 도 함께 본다 — 이 쿼리에는 `check_portfolio_mdd` 와 달리 수량
+        # 필터가 없어서, **수량 0 인 낡은 KR 행 하나가** 살아있는 KR 노출이 전혀 없는데도
+        # Portfolio 섹션을 통째로 막는다 (codex 리뷰 P2). 수량 0 은 총액에 0 을 더하므로
+        # 애초에 환산이 필요 없다.
+        kr_count = sum(
+            1 for r in rows if (r["quantity"] or 0) > 0 and (r["currency"] == "KRW" or is_kr_ticker(r["ticker"]))
+        )
 
         # #1283: 환율이 없으면 `or 1400.0` 으로 메웠다. 매일 아침 읽는 브리프에 지어낸
         # 총액을 싣는 것보다 **빈 칸이 정직하다** — 채워져 있으면 수집기가 죽은 걸 모른다.

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -69,6 +69,9 @@ def _collect_context(db_path=None) -> dict:
         "opportunities": None,
         "macro_events": [],
         "portfolio_totals": None,
+        # #1283: 총액을 못 낸 **이유**. 섹션이 그냥 사라지면 결함처럼 보이고, 정작
+        # 원인(환율 미수집)은 로그에만 남아 아침에 읽는 사람에게 도달하지 않는다.
+        "portfolio_totals_blocked": None,
         "shadow_signals": [],  # PR C (codex #3): market-wide crash precursor
         "buy_candidates": None,  # #507 Phase 1: cash deploy candidate emit
         "freshness": None,  # #513: 데이터 신선도 surface (PASS/WARN/FAIL 3-tier)
@@ -260,23 +263,44 @@ def _collect_context(db_path=None) -> dict:
         )
         # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
         from nuri.core.fx import latest_usd_krw_value
-
-        rate = latest_usd_krw_value(db_path=db_path) or 1400.0
         from nuri.core.ticker_names import is_kr_ticker
 
-        by_acct: dict[str, float] = {}
-        total_usd = 0.0
-        for r in rows:
-            px = r["close"] or r["avg_price"] or 0
-            qty = r["quantity"] or 0
-            is_kr = is_kr_ticker(r["ticker"])
-            val_usd = px * qty / rate if is_kr else px * qty
-            by_acct[r["account"]] = by_acct.get(r["account"], 0.0) + val_usd
-            total_usd += val_usd
-        ctx["portfolio_totals"] = {
-            "total_usd": total_usd,
-            "by_account": sorted(by_acct.items(), key=lambda x: -x[1]),
-        }
+        rate = latest_usd_krw_value(db_path=db_path)
+        kr_count = sum(1 for r in rows if is_kr_ticker(r["ticker"]))
+
+        # #1283: 환율이 없으면 `or 1400.0` 으로 메웠다. 매일 아침 읽는 브리프에 지어낸
+        # 총액을 싣는 것보다 **빈 칸이 정직하다** — 채워져 있으면 수집기가 죽은 걸 모른다.
+        # US 전용이면 환율과 무관하므로 그대로 낸다.
+        if rate is None and kr_count:
+            logger.warning(
+                "USD/KRW 미수집 — portfolio_totals 생략 (KR 보유 %d행). 지어낸 환율로 총액을 싣지 않는다 (#1283)",
+                kr_count,
+            )
+            ctx["portfolio_totals_blocked"] = (
+                f"USD/KRW 미수집 — KR 보유 {kr_count}행의 USD 환산 불가 (`make collect` 으로 환율 갱신)"
+            )
+        else:
+            by_acct: dict[str, float] = {}
+            total_usd = 0.0
+            for r in rows:
+                px = r["close"] or r["avg_price"] or 0
+                qty = r["quantity"] or 0
+                if is_kr_ticker(r["ticker"]):
+                    # 위 가드가 보장한다 (kr_count > 0 이면 rate 가 있다). 그래도 명시로
+                    # 좁히는 이유는, 조건이 갈라져 있으면 **도달 불가가 조용히 도달
+                    # 가능해지는** 순간을 타입체커가 잡아주기 때문이다. 폴백 숫자를
+                    # 끼워 넣는 대신 건너뛴다 — 여기서 지어내면 이 PR 이 무의미해진다.
+                    if rate is None:
+                        continue
+                    val_usd = px * qty / rate
+                else:
+                    val_usd = px * qty
+                by_acct[r["account"]] = by_acct.get(r["account"], 0.0) + val_usd
+                total_usd += val_usd
+            ctx["portfolio_totals"] = {
+                "total_usd": total_usd,
+                "by_account": sorted(by_acct.items(), key=lambda x: -x[1]),
+            }
     except Exception:
         logger.warning("portfolio totals 실패", exc_info=True)
 
@@ -485,6 +509,8 @@ def format_brief_embed(ctx: dict) -> dict:
         acct_lines = [f"{a}: ${v:,.0f}" for a, v in totals["by_account"]]
         acct_lines.append(f"**TOTAL: ${totals['total_usd']:,.0f}** (equity only)")
         fields.append({"name": "💰 Portfolio", "value": "\n".join(acct_lines), "inline": False})
+    elif ctx.get("portfolio_totals_blocked"):
+        fields.append({"name": "💰 Portfolio", "value": ctx["portfolio_totals_blocked"], "inline": False})
 
     return {
         "title": f"🌅 Nuri-Quant Pre-market Brief — {today_kst()}",
@@ -641,6 +667,9 @@ def format_brief_markdown(ctx: dict) -> str:
         for a, v in totals["by_account"]:
             lines.append(f"- {a}: ${v:,.0f}")
         lines.append(f"- **TOTAL**: ${totals['total_usd']:,.0f} (equity only)")
+    elif ctx.get("portfolio_totals_blocked"):
+        lines.append("## Portfolio")
+        lines.append(f"- {ctx['portfolio_totals_blocked']}")
 
     return "\n".join(lines)
 

--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -129,7 +129,11 @@ def portfolio_state(db_path=None, config_path: Path | None = None) -> dict:
             positions[str(ticker)] = {"value": value, "sector": sector}
             total_value += value
 
-    rate = get_exchange_rate(db_path=db_path) or 1400.0
+    # `or 1400.0` 폴백이 여기 있었다 (#1283). 도달 불가였다 — `get_exchange_rate` 는 부재 시
+    # `StaleExchangeRateError` 를 던지고, 유일한 falsy 후보였던 0/음수는 이제 `latest_usd_krw`
+    # 가 부재로 접어 역시 예외가 된다. 죽은 폴백을 남겨두면 다음 사람이 "환율이 없어도
+    # 1400 으로 돌아간다" 고 읽는다.
+    rate = get_exchange_rate(db_path=db_path)
     cash = 0.0
     path = config_path or _DEFAULT_PORTFOLIO_YAML
     try:
@@ -264,13 +268,19 @@ def print_summary(df: pd.DataFrame) -> None:
         print("포트폴리오 데이터가 없습니다.")
         return
 
-    usd_krw = df.attrs.get("usd_krw", 1450.0)
+    # 환율이 없으면 KRW 환산을 **생략**한다 (#1283). 예전에는 1450 을 지어냈는데, 나머지
+    # 폴백은 전부 1400 이라 같은 부재에 두 개의 답이 있었다. USD 총액은 환율과 무관하므로
+    # 그대로 낸다 — 못 내는 건 KRW 환산뿐이다.
+    usd_krw = df.attrs.get("usd_krw")
     total_usd = df.attrs.get("total_value_usd", 0)
-    total_krw = total_usd * usd_krw
 
     print("=" * 70)
-    print(f"  Nuri-Quant 포트폴리오 현황  (USD/KRW: {usd_krw:,.0f})")
-    print(f"  총 평가액: ${total_usd:,.0f} (₩{total_krw:,.0f})")
+    if usd_krw:
+        print(f"  Nuri-Quant 포트폴리오 현황  (USD/KRW: {usd_krw:,.0f})")
+        print(f"  총 평가액: ${total_usd:,.0f} (₩{total_usd * usd_krw:,.0f})")
+    else:
+        print("  Nuri-Quant 포트폴리오 현황  (USD/KRW: 미수집)")
+        print(f"  총 평가액: ${total_usd:,.0f} (₩ 환산 불가 — 'make collect' 으로 환율 갱신)")
     print("=" * 70)
 
     # 계좌별 출력

--- a/nuri/core/fx.py
+++ b/nuri/core/fx.py
@@ -71,7 +71,14 @@ def latest_usd_krw(db_path=None) -> tuple[float, str] | None:
     )
     if not rows or rows[0]["value"] is None:
         return None
-    return float(rows[0]["value"]), str(rows[0]["date"])
+    # 환율은 **양수**다. 0 이나 음수는 손상된 행이지 환율이 아니므로 부재로 다룬다 (#1283).
+    # 이 불변식이 없으면 0.0 이 "값이 있다" 로 통과해 호출자마다 다르게 터진다 — 나눗셈
+    # 하는 쪽은 ZeroDivisionError, `or` 폴백을 둔 쪽은 조용히 지어낸 숫자.
+    value = float(rows[0]["value"])
+    if value <= 0:
+        logger.warning("usd_krw 값이 %s (날짜 %s) — 환율이 아니므로 부재로 다룬다 (#1283)", value, rows[0]["date"])
+        return None
+    return value, str(rows[0]["date"])
 
 
 def latest_usd_krw_value(db_path=None) -> float | None:

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -660,24 +660,41 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
         dict: MDD 위반 정보. 위반 없으면 None.
     """
     # 환율 조회 (KRW → USD 변환용)
+    # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
+    # #1283: 부재는 `None` 이다 — 예전의 `usd_krw = 1400.0` 폴백은 지어낸 환율로 MDD 를
+    # 판정했다. 혼합 포트폴리오에서 `total_value/total_cost` 는 rate 에 의존하므로
+    # (`cost_us + cost_kr/rate` 꼴) 그 숫자가 `PORTFOLIO_STOP` 발화 여부를 가른다.
+    # 예전의 `except Exception: pass` 는 **DB 오류를 지어낸 환율로 덮었다** — 조회가
+    # 실패했는데 판정은 계속되고, 그 판정이 1400 기준이었다. 좁혀서 잡는다: DB 오류는
+    # "환율을 모른다" 이지 "1400 이다" 가 아니므로 부재로 접어 아래 가드가 판정을
+    # 포기하게 한다. `Exception` 으로 넓히면 진짜 버그까지 삼킨다.
+    from nuri.core.db import DatabaseError, OperationalError
+    from nuri.core.fx import latest_usd_krw_value
     from nuri.core.rules import PORTFOLIO_STOP
 
-    usd_krw = 1400.0  # 폴백
     try:
-        # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
-        from nuri.core.fx import latest_usd_krw_value
-
-        _fx = latest_usd_krw_value(db_path=db_path)
-        if _fx:
-            usd_krw = _fx
-    except Exception:
-        pass
+        usd_krw = latest_usd_krw_value(db_path=db_path)
+    except (OperationalError, DatabaseError):
+        logger.warning("USD/KRW 조회 실패 — 환율 부재로 다룬다 (#1283)", exc_info=True)
+        usd_krw = None
 
     holdings = query_df(
         "SELECT ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
         db_path=db_path,
     )
     if holdings.empty:
+        return None
+
+    # 환율이 없어도 **US 전용 포트폴리오는 정확히 계산된다** — 일괄 포기는 과잉이다.
+    # KR 보유가 섞여 있을 때만 판정을 포기한다.
+    kr_count = sum(1 for t in holdings["ticker"] if is_kr_ticker(t))
+    if usd_krw is None and kr_count:
+        logger.warning(
+            "USD/KRW 미수집 — 포트폴리오 MDD 판정 포기 (KR 보유 %d종목). "
+            "지어낸 환율로 -%s%% 손절선을 판정하지 않는다 (#1283)",
+            kr_count,
+            abs(PORTFOLIO_STOP),
+        )
         return None
 
     total_cost = 0.0
@@ -692,8 +709,10 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
         current = _get_current_price(ticker, db_path=db_path)
         value = (current or avg_price) * qty
 
-        # KRW 종목은 USD로 변환
-        if is_krw and usd_krw > 0:
+        # KRW 종목은 USD로 변환. `usd_krw` 는 이제 **양수 아니면 None** 이므로 진리값으로
+        # 본다 — `> 0` 은 None 에서 TypeError 다 (지금은 위 가드가 그 조합을 걸러내지만,
+        # 가드와 여기가 따로 놀면 조용히 터진다).
+        if is_krw and usd_krw:
             cost /= usd_krw
             value /= usd_krw
 

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -679,7 +679,7 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
         usd_krw = None
 
     holdings = query_df(
-        "SELECT ticker, avg_price, quantity FROM portfolio WHERE quantity > 0",
+        "SELECT ticker, avg_price, quantity, currency FROM portfolio WHERE quantity > 0",
         db_path=db_path,
     )
     if holdings.empty:
@@ -687,7 +687,14 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
 
     # 환율이 없어도 **US 전용 포트폴리오는 정확히 계산된다** — 일괄 포기는 과잉이다.
     # KR 보유가 섞여 있을 때만 판정을 포기한다.
-    kr_count = sum(1 for t in holdings["ticker"] if is_kr_ticker(t))
+    #
+    # ⚠️ 술어는 **레포 정본**을 쓴다: `currency == "KRW" or is_kr_ticker(ticker)`
+    # (`analysis/portfolio.py:208` · `analysis/sector.py:52` · `alerts/risk_signals.py:135`
+    # 와 동일). suffix 만 보면 `currency="KRW"` 인 무접미 보유가 "US 전용" 으로 오분류돼
+    # 환율 없이 판정이 통과한다 (codex 리뷰 P1). 아래 환산 루프는 아직 suffix 만 보는데
+    # 그건 이 PR 밖의 별도 결함이라 #1286 으로 분리했다 — **가드는 넓은 쪽**을 쓴다.
+    # 환산이 필요할 수 *있으면* 판정하지 않는 편이 지어내는 것보다 낫다.
+    kr_count = sum(1 for _, r in holdings.iterrows() if r["currency"] == "KRW" or is_kr_ticker(str(r["ticker"])))
     if usd_krw is None and kr_count:
         logger.warning(
             "USD/KRW 미수집 — 포트폴리오 MDD 판정 포기 (KR 보유 %d종목). "

--- a/tests/core/test_fx_no_fabricated_fallback.py
+++ b/tests/core/test_fx_no_fabricated_fallback.py
@@ -1,0 +1,379 @@
+"""환율이 없을 때 **숫자를 지어내지 않는다** (#1283).
+
+## 무엇이 잘못됐었나
+
+#1278 이 "최신 환율" 읽기를 `nuri/core/fx.py` 한 곳으로 모으면서 부재를 `None` 으로
+정직하게 냈다 (STRATEGY §2.6). 그런데 그 `None` 을 받는 소비자가 전부 `or 1400` 으로
+즉시 메웠다 — **단일 읽기 지점이 생겼을 뿐 fabrication 은 그대로**였다. 상수도 하나가
+아니었다: 6곳이 1400, `print_summary` 만 1450 이라 같은 부재에 두 개의 답이 있었다.
+
+프로덕션 환율은 1383.52(2026-08-29)라 1400 은 +1.2% 다. **오차 자체는 작다 — 문제는
+부재가 숫자로 둔갑해 수집기가 죽어도 아무도 모른다는 것이다.** #1278 이 정확히 그
+형태였다(미래 행이 노후 경고까지 죽여 이중으로 눈이 멀어 있었다).
+
+## 왜 소비자별로 따로 잠그나
+
+`tests/CLAUDE.md` Time-bomb 2차 발생의 교훈 그대로 — *"규칙 하나에 잠금이 한 경로만
+걸려 있으면 나머지 경로는 무방비다."* 이 결함은 8곳에 흩어져 있었다.
+
+## 대조군이 왜 필요한가
+
+"환율 없으면 None" 만 잠그면 **전부 None 을 반환하는 가짜 수정**이 통과한다. 환율이
+없어도 **US 전용 집계는 정확히 계산된다** — 일괄 포기는 과잉이고, 그 구분이 이 PR 의
+설계다. 그래서 각 경로마다 대조군을 짝지어 둔다.
+
+API/프론트 4곳(`actions.py` · `dashboard.py` ×2 · `page.tsx`)은 응답 형태가 바뀌어
+프론트와 같이 움직여야 하므로 **#1284** 로 분리했다. 아래 `FABRICATION_EXEMPT` 가
+그 4곳 중 Python 3곳을 사유와 함께 붙잡고 있고, #1284 가 랜딩하면 **stale 로 FAIL** 해서
+제거를 강제한다.
+"""
+
+import ast
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.core.fx import latest_usd_krw, latest_usd_krw_value
+from nuri.core.timezone import today_kst
+
+TODAY = today_kst()
+
+#: 합성 종목 — 실제 보유와 무관하다 (public repo, `tests/CLAUDE.md` privacy).
+KR_TICKER = "999999.KS"
+US_TICKER = "ZZZZ"
+ACCOUNT = "Brokerage Alpha"
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    import nuri.core.db as db_mod
+
+    path = tmp_path / "fx.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+def _seed_fx(db_path, value, date=TODAY):
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO macro (indicator, date, value, source) VALUES ('usd_krw', ?, ?, 'test')",
+            (date, value),
+        )
+
+
+def _seed_holding(db_path, ticker, avg_price, quantity, close=None):
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price) VALUES (?, ?, ?, ?)",
+            (ACCOUNT, ticker, quantity, avg_price),
+        )
+        if close is not None:
+            conn.execute(
+                "INSERT INTO prices (ticker, date, close) VALUES (?, ?, ?)",
+                (ticker, TODAY, close),
+            )
+
+
+class TestARateIsPositiveOrAbsent:
+    """0/음수는 환율이 아니라 손상된 행이다 — 부재로 접는다.
+
+    이 불변식이 없으면 `0.0` 이 "값이 있다" 로 통과해 호출자마다 다르게 터진다:
+    나눗셈 하는 쪽은 `ZeroDivisionError`, `or` 폴백을 둔 쪽은 조용히 지어낸 숫자.
+    `portfolio.py` 의 죽은 폴백을 안전하게 지울 수 있는 근거이기도 하다.
+    """
+
+    def test_zero_is_treated_as_absent(self, db):
+        """Mutation lock: `if value <= 0` 가드를 지우면 FAIL."""
+        _seed_fx(db, 0.0)
+        assert latest_usd_krw_value() is None, "0.0 을 환율로 냈다"
+
+    def test_negative_is_treated_as_absent(self, db):
+        _seed_fx(db, -1380.0)
+        assert latest_usd_krw_value() is None
+
+    def test_corrupt_row_is_logged(self, db, caplog):
+        """조용히 버리면 손상 행이 영영 안 보인다."""
+        _seed_fx(db, 0.0)
+        with caplog.at_level(logging.WARNING, logger="nuri.core.fx"):
+            latest_usd_krw_value()
+        assert caplog.records, "손상된 환율 행을 발견하고도 경고하지 않았다"
+
+    def test_positive_rate_still_returned(self, db):
+        """대조군 — 정상 값까지 삼키는 가짜 수정을 막는다."""
+        _seed_fx(db, 1380.0)
+        got = latest_usd_krw()
+        assert got is not None and got[0] == pytest.approx(1380.0)
+
+
+class TestPortfolioStateHasNoFabricatedRate:
+    """`rate = get_exchange_rate(...) or 1400.0` 이 여기 있었다 (도달 불가였다)."""
+
+    def test_corrupt_rate_raises_instead_of_falling_back(self, db):
+        """Mutation lock: `or 1400.0` 을 되살리면 예외 대신 1400 으로 진행해 FAIL."""
+        from nuri.analysis.portfolio import StaleExchangeRateError, portfolio_state
+
+        _seed_fx(db, 0.0)
+        _seed_holding(db, US_TICKER, avg_price=100.0, quantity=10, close=100.0)
+        with pytest.raises(StaleExchangeRateError):
+            portfolio_state(db_path=db)
+
+    def test_valid_rate_still_works(self, db):
+        """대조군 — 정상 환율에서는 예전과 똑같이 동작한다."""
+        from nuri.analysis.portfolio import portfolio_state
+
+        _seed_fx(db, 1380.0)
+        _seed_holding(db, US_TICKER, avg_price=100.0, quantity=10, close=100.0)
+        assert isinstance(portfolio_state(db_path=db), dict)
+
+
+class TestPrintSummaryDoesNotInventARate:
+    """`df.attrs.get("usd_krw", 1450.0)` — 나머지가 전부 1400 인데 여기만 1450 이었다."""
+
+    @staticmethod
+    def _frame(rate):
+        import pandas as pd
+
+        df = pd.DataFrame(
+            [
+                {
+                    "account": ACCOUNT,
+                    "ticker": US_TICKER,
+                    "weight_pct": 100.0,
+                    "current_price": 100.0,
+                    "avg_price": 100.0,
+                    "pnl_pct": 0.0,
+                    "pnl_usd": 0.0,
+                    "current_value_usd": 1000.0,
+                }
+            ]
+        )
+        df.attrs["total_value_usd"] = 1000.0
+        if rate is not None:
+            df.attrs["usd_krw"] = rate
+        return df
+
+    def test_missing_rate_says_so_instead_of_printing_1450(self, capsys):
+        """Mutation lock: 기본값 1450.0 을 되살리면 FAIL."""
+        from nuri.analysis.portfolio import print_summary
+
+        print_summary(self._frame(None))
+        out = capsys.readouterr().out
+        assert "미수집" in out, "환율이 없는데 있는 것처럼 출력했다"
+        assert "1,450" not in out and "1,400" not in out, f"환율을 지어냈다: {out}"
+        assert "$1,000" in out, "USD 총액은 환율과 무관하므로 계속 나와야 한다"
+
+    def test_present_rate_prints_krw_total(self, capsys):
+        """대조군 — 환율이 있으면 예전처럼 KRW 환산을 낸다."""
+        from nuri.analysis.portfolio import print_summary
+
+        print_summary(self._frame(1380.0))
+        out = capsys.readouterr().out
+        assert "1,380" in out and "미수집" not in out
+
+
+class TestPortfolioMddAbstainsRatherThanGuess:
+    """`usd_krw = 1400.0  # 폴백` — 지어낸 환율로 손절선을 판정했다.
+
+    혼합 포트폴리오에서 `total_value/total_cost` 는 rate 에 의존하므로
+    (`cost_us + cost_kr/rate` 꼴) 그 숫자가 `PORTFOLIO_STOP` 발화 여부를 가른다.
+
+    ⚠️ 이 축은 **대조군 없이는 공허하다.** 위반이 없어도 `None` 이라, "환율 없음 → None"
+    만 단언하면 아무것도 잠그지 못한다. 그래서 같은 보유를 환율만 넣어 돌려 **위반이
+    실제로 잡히는지** 먼저 확인한다.
+    """
+
+    @staticmethod
+    def _seed_deeply_underwater_kr(db_path):
+        # 원가 대비 -50% — `PORTFOLIO_STOP`(-10%) 를 확실히 넘긴다.
+        _seed_holding(db_path, KR_TICKER, avg_price=100_000.0, quantity=10, close=50_000.0)
+
+    def test_with_a_rate_the_violation_is_detected(self, db):
+        """대조군 겸 전제 — 이게 없으면 아래 테스트가 공허하다."""
+        from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
+        _seed_fx(db, 1380.0)
+        self._seed_deeply_underwater_kr(db)
+        result = check_portfolio_mdd(db_path=db)
+        assert result is not None and result["severity"] == "critical"
+
+    def test_without_a_rate_it_abstains(self, db, caplog):
+        """Mutation lock: `usd_krw = 1400.0` 폴백을 되살리면 위반 dict 가 나와 FAIL."""
+        from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
+        self._seed_deeply_underwater_kr(db)  # 환율 미시드
+        with caplog.at_level(logging.WARNING, logger="nuri.trading.recommend.price_targets"):
+            assert check_portfolio_mdd(db_path=db) is None, "지어낸 환율로 손절선을 판정했다"
+        assert caplog.records, "판정을 포기하고도 조용했다 — 아무도 수집기 결함을 모른다"
+
+    def test_us_only_portfolio_still_judged_without_a_rate(self, db):
+        """대조군 — 환율이 없어도 US 전용은 정확히 계산된다. 일괄 None 은 과잉이다."""
+        from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
+        _seed_holding(db, US_TICKER, avg_price=100.0, quantity=10, close=50.0)
+        result = check_portfolio_mdd(db_path=db)
+        assert result is not None, "환율과 무관한 US 전용 포트폴리오까지 판정을 포기했다"
+        assert result["pnl_pct"] == pytest.approx(-50.0)
+
+
+class TestBriefOmitsTotalsRatherThanInventingThem:
+    """`rate = latest_usd_krw_value(...) or 1400.0` — 매일 아침 읽는 브리프였다."""
+
+    def test_without_a_rate_totals_are_omitted_with_a_reason(self, db, caplog):
+        """Mutation lock: `or 1400.0` 을 되살리면 totals 가 채워져 FAIL."""
+        from nuri.alerts.premarket_brief import _collect_context
+
+        _seed_holding(db, KR_TICKER, avg_price=100_000.0, quantity=10, close=100_000.0)
+        with caplog.at_level(logging.WARNING, logger="nuri.alerts.premarket_brief"):
+            ctx = _collect_context(db_path=db)
+        assert ctx["portfolio_totals"] is None, "지어낸 환율로 총액을 실었다"
+        assert ctx["portfolio_totals_blocked"], "섹션이 그냥 사라졌다 — 이유가 없으면 결함처럼 보인다"
+
+    def test_the_reason_reaches_both_renderers(self, db):
+        """로그로만 남기면 아침에 읽는 사람에게 도달하지 않는다."""
+        from nuri.alerts.premarket_brief import (
+            _collect_context,
+            format_brief_embed,
+            format_brief_markdown,
+        )
+
+        _seed_holding(db, KR_TICKER, avg_price=100_000.0, quantity=10, close=100_000.0)
+        ctx = _collect_context(db_path=db)
+
+        md = format_brief_markdown(ctx)
+        assert "미수집" in md, "markdown 브리프가 이유를 말하지 않는다"
+
+        embed_text = str(format_brief_embed(ctx))
+        assert "미수집" in embed_text, "Discord embed 가 이유를 말하지 않는다"
+
+    def test_with_a_rate_totals_are_computed(self, db):
+        """대조군 — 환율이 있으면 예전과 똑같이 총액을 낸다."""
+        from nuri.alerts.premarket_brief import _collect_context
+
+        _seed_fx(db, 1380.0)
+        _seed_holding(db, KR_TICKER, avg_price=100_000.0, quantity=10, close=100_000.0)
+        ctx = _collect_context(db_path=db)
+        assert ctx["portfolio_totals"], "환율이 있는데 총액을 못 냈다"
+        assert ctx["portfolio_totals_blocked"] is None
+
+    def test_us_only_totals_computed_without_a_rate(self, db):
+        """대조군 — 환율이 없어도 US 전용 보유는 환산이 필요 없다."""
+        from nuri.alerts.premarket_brief import _collect_context
+
+        _seed_holding(db, US_TICKER, avg_price=100.0, quantity=10, close=100.0)
+        ctx = _collect_context(db_path=db)
+        assert ctx["portfolio_totals"], "환율과 무관한 US 전용까지 총액을 포기했다"
+        assert ctx["portfolio_totals"]["total_usd"] == pytest.approx(1000.0)
+
+
+#: 환율 크기의 리터럴을 **일부러** 들고 있는 곳. 사유를 반드시 함께 적는다.
+#: 양방향 검사라 낡은 항목(이미 정리된 파일)도 FAIL 한다 — allowlist 가 조용히 커지는 걸
+#: 막는 것이 이 목록의 존재 이유다 (`test_cross_stage_imports.py` 와 같은 규율).
+FABRICATION_EXEMPT: dict[str, str] = {
+    "api/routes/actions.py": (
+        "#1284 — 비중% 산정의 `or 1400`. 응답 형태가 바뀌어(집계가 null 이 된다) "
+        "프론트(`page.tsx` · `holdings-summary.ts`)와 한 PR 에서 같이 움직여야 한다. "
+        "백엔드만 먼저 정직해지면 `_compute_actual_allocation` 의 sum 이 TypeError 로 죽는다."
+    ),
+    "api/routes/dashboard.py": (
+        "#1284 — `account_values[].value` 와 `cash_summary` 의 `or 1400` 2곳. "
+        "위와 같은 이유로 프론트와 동시에 움직여야 한다. `/api/dashboard` 는 이미 "
+        "`exchange_rate: number | null` 을 정직하게 내보내는데 프론트가 그 신호를 버린다."
+    ),
+    "trading/agents/korean_market.py": (
+        "**성격이 다르다 — 지어낸 값이 아니다.** `fx_weak_default` / `fx_weak_floor` / "
+        "`fx_strong_ceil` 은 `config/agents.yaml` 이 정본인 **정책 임계값**의 코드 기본값이고, "
+        "무엇을 '원화 약세' 로 볼지의 선택이지 환율 **측정치**가 아니다. 측정 부재를 숫자로 "
+        "메우는 것과 정책 기본값을 두는 것은 다른 일이다 (Config over code 준수)."
+    ),
+}
+
+
+class TestNoNewFabricatedRateAppears:
+    """구조 스윕 — 새 소비자가 또 `or 1400` 을 붙이는 걸 막는다.
+
+    동작 잠금은 **지금 존재하는** 경로만 덮는다. 이 결함이 8곳으로 번진 방식이 바로
+    "새 곳에서 같은 폴백을 다시 쓰기" 였다.
+
+    ⚠️ **텍스트 스윕은 기각했다.** 처음에 정규식으로 짰더니 `core/fx.py` 의 독스트링
+    ("**1417.4** 를 반환했다") 과 `dashboard.py` 의 독스트링("환율 누락 시 1400 기본값")을
+    걸었다 — 코드가 아니라 *설명*이다. 이 레포가 이미 내린 판정과 같다
+    (`test_no_facade_query_patch.py`: "독스트링/주석 언급은 오탐이라 텍스트 sweep 기각").
+    그래서 **숫자 리터럴은 AST 로** 집고(문자열·주석·독스트링이 구조적으로 배제된다),
+    식별자만 같은 물리 행에서 본다.
+    """
+
+    IDENT = re.compile(r"usd_krw|usdkrw|exchange_rate|krw_rate|fx_|_fx\b", re.I)
+
+    @classmethod
+    def _scan(cls, src: str) -> list[int]:
+        """한 소스에서 '환율 크기 리터럴 + 같은 행의 FX 식별자' 행번호.
+
+        카나리아와 실제 스윕이 **같은 함수**를 타야 한다. 로직을 복사해 두면 카나리아는
+        복사본만 검증하고, 정작 스윕이 눈이 멀어도 초록으로 통과한다.
+        """
+        lines = src.splitlines()
+        out: list[int] = []
+        for node in ast.walk(ast.parse(src)):
+            if not isinstance(node, ast.Constant):
+                continue
+            v = node.value
+            # bool 은 int 의 서브클래스라 명시 제외.
+            if isinstance(v, bool) or not isinstance(v, (int, float)):
+                continue
+            # 환율 크기 — KRW/USD 는 네 자리다.
+            if not (1000 <= v < 2000):
+                continue
+            if cls.IDENT.search(lines[node.lineno - 1]):
+                out.append(node.lineno)
+        return sorted(out)
+
+    @classmethod
+    def _fabrications(cls) -> dict[str, list[int]]:
+        root = Path(__file__).resolve().parents[2] / "nuri"
+        out: dict[str, list[int]] = {}
+        for f in sorted(root.rglob("*.py")):
+            found = cls._scan(f.read_text(encoding="utf-8"))
+            if found:
+                out[str(f.relative_to(root))] = found
+        return out
+
+    def test_no_unlisted_file_fabricates_a_rate(self):
+        found = self._fabrications()
+        unlisted = {k: v for k, v in found.items() if k not in FABRICATION_EXEMPT}
+        assert not unlisted, f"환율을 지어내는 곳이 새로 생겼다: {unlisted}"
+
+    def test_every_exemption_is_still_needed(self):
+        """양방향 — #1284 가 랜딩하면 그 항목들이 여기서 FAIL 해 제거를 강제한다."""
+        found = self._fabrications()
+        stale = [k for k in FABRICATION_EXEMPT if k not in found]
+        assert not stale, f"낡은 예외 항목(이미 정리됨): {stale}"
+
+    def test_every_exemption_states_a_reason(self):
+        for path, why in FABRICATION_EXEMPT.items():
+            assert len(why) > 40, f"{path}: 사유가 너무 짧다 — 다음 사람이 판단할 수 없다"
+
+    def test_the_fixed_sites_are_actually_clean(self):
+        """이 PR 이 고친 4곳이 스윕에 안 잡히는지 — 수정이 실제로 먹었다는 증거."""
+        found = self._fabrications()
+        for path in (
+            "analysis/portfolio.py",
+            "alerts/premarket_brief.py",
+            "trading/recommend/price_targets.py",
+            "core/fx.py",
+        ):
+            assert path not in found, f"{path} 에 아직 지어낸 환율이 있다: {found[path]}"
+
+    def test_the_sweep_has_eyes(self):
+        """카나리아 — 스윕이 조용히 아무것도 안 잡으면 위 테스트는 영원히 초록이다.
+
+        **양방향**이다: 옛 결함 형태를 잡는지 + 독스트링을 오탐하지 않는지. 후자가 없으면
+        "전부 통과" 와 "전부 차단" 을 구분할 수 없다 (텍스트 스윕이 실제로 밟은 함정).
+        """
+        bad = "rate = exchange_rate or 1400\n"
+        doc = '"""환율 누락 시 1400 기본값 — 설명일 뿐 코드가 아니다."""\n'
+        assert self._scan(bad) == [1], "옛 결함 형태를 못 잡는다 — 스윕에 눈이 없다"
+        assert self._scan(doc) == [], "독스트링을 코드로 오탐한다 — 텍스트 스윕의 실패를 반복한다"

--- a/tests/core/test_fx_no_fabricated_fallback.py
+++ b/tests/core/test_fx_no_fabricated_fallback.py
@@ -306,7 +306,17 @@ class TestNoNewFabricatedRateAppears:
     식별자만 같은 물리 행에서 본다.
     """
 
-    IDENT = re.compile(r"usd_krw|usdkrw|exchange_rate|krw_rate|fx_|_fx\b", re.I)
+    #: 좁게 시작했다가 넓혔다. `usd_krw|exchange_rate|fx_` 만 보면 **지금 있는 철자만**
+    #: 잡고 `rate = fx or 1400` · `FALLBACK_RATE = 1400` · `rate = get_rate() or 1400`
+    #: 은 전부 빠져나간다 — 백스톱이 현재 코드만 덮으면 백스톱이 아니다.
+    #:
+    #: ⚠️ 경계는 `\b` 가 아니라 **글자 경계**여야 한다. `_` 는 단어 문자라
+    #: `\brate\b` 가 `FALLBACK_RATE` 를 못 잡고, 반대로 맨 `rate` 부분일치는
+    #: `gene`**`rate`**`` · `sepa`**`rate`** 를 잡는다. `(?<![a-z])rate(?![a-z])` 가
+    #: 양쪽을 동시에 만족한다.
+    #:
+    #: 넓힌 뒤에도 `nuri/` 실측은 **동일(7 hits / 3 files)** — 오탐 비용 0 이었다.
+    IDENT = re.compile(r"usd_krw|usdkrw|krw|환율|(?<![a-z])fx(?![a-z])|(?<![a-z])rate(?![a-z])", re.I)
 
     @classmethod
     def _scan(cls, src: str) -> list[int]:
@@ -373,7 +383,38 @@ class TestNoNewFabricatedRateAppears:
         **양방향**이다: 옛 결함 형태를 잡는지 + 독스트링을 오탐하지 않는지. 후자가 없으면
         "전부 통과" 와 "전부 차단" 을 구분할 수 없다 (텍스트 스윕이 실제로 밟은 함정).
         """
-        bad = "rate = exchange_rate or 1400\n"
         doc = '"""환율 누락 시 1400 기본값 — 설명일 뿐 코드가 아니다."""\n'
-        assert self._scan(bad) == [1], "옛 결함 형태를 못 잡는다 — 스윕에 눈이 없다"
         assert self._scan(doc) == [], "독스트링을 코드로 오탐한다 — 텍스트 스윕의 실패를 반복한다"
+
+        # 옛 결함의 **철자 변종**들. 좁은 IDENT 는 아래 3·4·5번을 전부 놓쳤다 —
+        # 실제로 그래서 넓혔다. 변종을 함께 잠가야 "지금 코드만 덮는 백스톱" 으로
+        # 되돌아가는 걸 막는다.
+        for src in (
+            "rate = exchange_rate or 1400\n",
+            "usd_krw = x or 1400\n",
+            "rate = fx or 1400\n",
+            "FALLBACK_RATE = 1400\n",
+            "rate = get_rate() or 1400\n",
+        ):
+            assert self._scan(src) == [1], f"이 형태를 못 잡는다 — 스윕에 눈이 없다: {src!r}"
+
+        # 반대편 — 넓힌 경계가 무관한 단어를 잡으면 오탐이 쌓여 스윕이 무시당한다.
+        # `rate` 를 부분일치로 두면 아래가 전부 걸린다.
+        for src in (
+            "count = generate(1400)\n",
+            "x = separate_thing(1500)\n",
+            "duration_ms = 1500\n",
+            "iterations = 1200\n",
+            "accurate_total = 1100\n",
+        ):
+            assert self._scan(src) == [], f"무관한 단어를 환율로 오탐한다: {src!r}"
+
+    def test_the_magnitude_window_brackets_a_real_rate(self):
+        """1000~2000 창이 실제 환율을 포함하는지 — 창이 빗나가면 스윕은 늘 0건이다.
+
+        프로덕션 실측 1383.52 (2026-08-29), 옛 폴백 1400/1450 이 모두 안에 있다.
+        """
+        for v in (1383.52, 1400, 1450.0):
+            assert self._scan(f"usd_krw = {v}\n") == [1], f"{v} 를 환율 크기로 안 본다"
+        for v in (7.0, 999, 2000, 130_000):
+            assert self._scan(f"usd_krw = {v}\n") == [], f"{v} 는 환율 크기가 아닌데 잡았다"

--- a/tests/core/test_fx_no_fabricated_fallback.py
+++ b/tests/core/test_fx_no_fabricated_fallback.py
@@ -44,6 +44,10 @@ TODAY = today_kst()
 #: 합성 종목 — 실제 보유와 무관하다 (public repo, `tests/CLAUDE.md` privacy).
 KR_TICKER = "999999.KS"
 US_TICKER = "ZZZZ"
+#: 접미사 없이 **통화만** KRW 인 보유. `_classify_asset_class` 가 이걸 `equity_kr` 로
+#: 잠그고 있고(`tests/trading/recommend/test_holdings_monitor.py`), 환산 술어 정본도
+#: `currency == "KRW" or is_kr_ticker(...)` 다. suffix 만 보는 가드는 이걸 놓친다.
+KR_BY_CURRENCY_TICKER = "YYYY"
 ACCOUNT = "Brokerage Alpha"
 
 
@@ -65,11 +69,11 @@ def _seed_fx(db_path, value, date=TODAY):
         )
 
 
-def _seed_holding(db_path, ticker, avg_price, quantity, close=None):
+def _seed_holding(db_path, ticker, avg_price, quantity, close=None, currency="USD"):
     with get_db(db_path) as conn:
         conn.execute(
-            "INSERT INTO portfolio (account, ticker, quantity, avg_price) VALUES (?, ?, ?, ?)",
-            (ACCOUNT, ticker, quantity, avg_price),
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?, ?, ?, ?, ?)",
+            (ACCOUNT, ticker, quantity, avg_price, currency),
         )
         if close is not None:
             conn.execute(
@@ -209,6 +213,27 @@ class TestPortfolioMddAbstainsRatherThanGuess:
             assert check_portfolio_mdd(db_path=db) is None, "지어낸 환율로 손절선을 판정했다"
         assert caplog.records, "판정을 포기하고도 조용했다 — 아무도 수집기 결함을 모른다"
 
+    def test_krw_currency_without_suffix_also_abstains(self, db, caplog):
+        """codex 리뷰 P1 — 접미사가 아니라 **정본 술어**로 KR 을 가른다.
+
+        `currency == "KRW"` 인데 `.KS/.KQ` 가 없는 보유를 suffix 만 보고 "US 전용" 으로
+        판정하면, 환율이 없는데도 판정이 통과한다. Mutation lock: 가드를
+        `is_kr_ticker(...)` 단독으로 되돌리면 FAIL.
+        """
+        from nuri.trading.recommend.price_targets import check_portfolio_mdd
+
+        _seed_holding(
+            db,
+            KR_BY_CURRENCY_TICKER,
+            avg_price=100_000.0,
+            quantity=10,
+            close=50_000.0,
+            currency="KRW",
+        )
+        with caplog.at_level(logging.WARNING, logger="nuri.trading.recommend.price_targets"):
+            assert check_portfolio_mdd(db_path=db) is None, "currency='KRW' 보유를 접미사만 보고 US 전용으로 오분류했다"
+        assert caplog.records
+
     def test_us_only_portfolio_still_judged_without_a_rate(self, db):
         """대조군 — 환율이 없어도 US 전용은 정확히 계산된다. 일괄 None 은 과잉이다."""
         from nuri.trading.recommend.price_targets import check_portfolio_mdd
@@ -259,6 +284,38 @@ class TestBriefOmitsTotalsRatherThanInventingThem:
         assert ctx["portfolio_totals"], "환율이 있는데 총액을 못 냈다"
         assert ctx["portfolio_totals_blocked"] is None
 
+    def test_krw_currency_without_suffix_also_blocks(self, db):
+        """codex 리뷰 P1 — 브리프도 같은 정본 술어를 써야 한다."""
+        from nuri.alerts.premarket_brief import _collect_context
+
+        _seed_holding(
+            db,
+            KR_BY_CURRENCY_TICKER,
+            avg_price=100_000.0,
+            quantity=10,
+            close=100_000.0,
+            currency="KRW",
+        )
+        ctx = _collect_context(db_path=db)
+        assert ctx["portfolio_totals"] is None, (
+            "currency='KRW' 보유를 접미사만 보고 US 전용으로 오분류해 총액을 지어냈다"
+        )
+
+    def test_a_zero_quantity_kr_row_does_not_block(self, db):
+        """codex 리뷰 P2 — 이 쿼리에는 수량 필터가 없다.
+
+        수량 0 인 낡은 KR 행은 총액에 0 을 더하므로 환산이 필요 없다. 그런 행 하나가
+        살아있는 KR 노출이 전혀 없는데도 Portfolio 섹션을 막으면 그건 false-red 다.
+        Mutation lock: `(r["quantity"] or 0) > 0` 조건을 지우면 FAIL.
+        """
+        from nuri.alerts.premarket_brief import _collect_context
+
+        _seed_holding(db, KR_TICKER, avg_price=100_000.0, quantity=0, close=100_000.0)
+        _seed_holding(db, US_TICKER, avg_price=100.0, quantity=10, close=100.0)
+        ctx = _collect_context(db_path=db)
+        assert ctx["portfolio_totals"], "수량 0 인 KR 행 하나가 살아있는 US 총액까지 막았다"
+        assert ctx["portfolio_totals"]["total_usd"] == pytest.approx(1000.0)
+
     def test_us_only_totals_computed_without_a_rate(self, db):
         """대조군 — 환율이 없어도 US 전용 보유는 환산이 필요 없다."""
         from nuri.alerts.premarket_brief import _collect_context
@@ -304,6 +361,21 @@ class TestNoNewFabricatedRateAppears:
     (`test_no_facade_query_patch.py`: "독스트링/주석 언급은 오탐이라 텍스트 sweep 기각").
     그래서 **숫자 리터럴은 AST 로** 집고(문자열·주석·독스트링이 구조적으로 배제된다),
     식별자만 같은 물리 행에서 본다.
+
+    ## 한계 (정직하게)
+
+    **이건 tripwire 지 증명이 아니다.** 한 물리 행 안의 리터럴만 보므로 값이 한 단계라도
+    건너뛰면 전부 빠져나간다 (codex 리뷰 P2, 실측 확인):
+
+    - `FALLBACK = 1400` → `rate = x or FALLBACK` — `FALLBACK = 1400` 행에 FX 식별자가
+      없으면 놓친다 (`FALLBACK_RATE` 처럼 이름에 `rate` 가 들어가야 잡힌다)
+    - `rate = x or 14 * 100` — 1000~2000 리터럴이 아예 없다
+    - `rate = x or cfg.fx_default` — 리터럴이 다른 파일에 있다
+
+    제대로 막으려면 데이터플로 분석이 필요한데, 그 비용은 이 방어의 가치를 넘는다.
+    **진짜 방어는 위쪽 소비자별 동작 잠금**이고, 이 스윕은 *가장 흔한 재발 형태*(옛 코드를
+    복사해 새 자리에 붙이기)를 잡는 값싼 그물이다. 이 한계를 적어두는 이유는, 스윕이
+    초록이라는 걸 "지어낸 환율이 없다" 로 읽으면 안 되기 때문이다.
     """
 
     #: 좁게 시작했다가 넓혔다. `usd_krw|exchange_rate|fx_` 만 보면 **지금 있는 철자만**

--- a/tests/trading/recommend/test_recommend_branch_coverage_v2.py
+++ b/tests/trading/recommend/test_recommend_branch_coverage_v2.py
@@ -1765,42 +1765,49 @@ class TestPriceTargetsTrailingStopBranches:
 class TestPriceTargetsMddBranches:
     """Lines 492-493, 523: MDD function exception + zero total_cost."""
 
-    def test_fx_query_exception_falls_back_to_default(self, fresh_db, monkeypatch):
-        """Line 492-493: usd_krw query raises → fallback 1400.0.
+    def test_fx_query_failure_abstains_instead_of_defaulting(self, fresh_db, monkeypatch, caplog):
+        """환율 조회가 DB 오류로 실패하면 **판정을 포기**한다 (#1283).
 
-        check_portfolio_mdd does `from nuri.core.db import query as _q` locally
-        (line 485), so we patch at the SOURCE module to intercept _q.
+        예전에는 `except Exception: pass` → `usd_krw = 1400.0` 으로 진행해, 조회가
+        실패했는데도 지어낸 환율 기준으로 `PORTFOLIO_STOP` 위반을 선언했다. 이 테스트가
+        바로 그 동작을 잠그고 있었다 (구 이름 `..._falls_back_to_default`).
+
+        DB 오류는 "환율을 모른다" 이지 "1400 이다" 가 아니다.
         """
+        import logging
+
         import nuri.core.db as db_mod
+        from nuri.core.db import OperationalError
         from nuri.trading.recommend import price_targets as pt
 
-        # Insert a holding so we get past the empty-portfolio early-return
+        # 합성 종목 — 실제 보유와 무관하다 (public repo, `tests/CLAUDE.md` privacy).
+        kr_ticker = "999999.KS"
         with get_db(fresh_db) as conn:
             conn.execute(
                 "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?, ?, ?, ?, ?)",
-                ("acct_x", "005930.KS", 100, 70000.0, "KRW"),  # KRW → uses fx
+                ("Brokerage Alpha", kr_ticker, 100, 100_000.0, "KRW"),  # KRW → uses fx
             )
             conn.execute(
                 "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                ("005930.KS", "2026-05-04", 50000, 50000, 50000, 50000, 1, 50000),
+                (kr_ticker, "2026-05-04", 50_000, 50_000, 50_000, 50_000, 1, 50_000),
             )
 
         original_q = db_mod.query
 
         def fake_q(sql, *a, **kw):
             if "usd_krw" in sql:
-                raise RuntimeError("synthetic fx fail")
+                raise OperationalError("synthetic fx fail")
             return original_q(sql, *a, **kw)
 
-        # Patch source so `from nuri.core.db import query as _q` resolves to fake_q
         monkeypatch.setattr(db_mod, "query", fake_q)
 
-        result = pt.check_portfolio_mdd(db_path=fresh_db)
-        # cost = 70000*100/1400 = 5000, value = 50000*100/1400 = ~3571,
-        # pnl_pct = (3571/5000 - 1)*100 = -28.6 → exceeds PORTFOLIO_STOP (-10) → critical dict
-        assert result is not None
-        assert result["severity"] == "critical"
+        with caplog.at_level(logging.WARNING, logger="nuri.trading.recommend.price_targets"):
+            result = pt.check_portfolio_mdd(db_path=fresh_db)
+
+        # -50% 라 환율만 있으면 확실한 위반이다. 그래도 판정하지 않는 것이 요점.
+        assert result is None, "환율 조회가 실패했는데 지어낸 환율로 손절선을 판정했다"
+        assert caplog.records, "판정을 포기하고도 조용했다 — 아무도 조회 실패를 모른다"
 
     def test_zero_total_cost_returns_none(self, fresh_db, monkeypatch):
         """Line 522-523: total_cost <= 0 → return None.


### PR DESCRIPTION
Closes #1283

## 증상 — 부재를 `None` 으로 냈는데 소비자가 전부 다시 메웠다

#1278 이 "최신 환율" 읽기를 `nuri/core/fx.py` 한 곳으로 모으면서 부재를 `None` 으로 냈습니다 (STRATEGY §2.6 — 측정이 없으면 숫자를 지어내지 않는다). 그런데 그 `None` 을 받는 소비자가 전부 `or 1400` 으로 즉시 메웠습니다. **단일 읽기 지점이 생겼을 뿐 fabrication 은 그대로**였습니다.

상수도 하나가 아니었습니다 — 6곳이 1400, `print_summary` 만 1450. 같은 부재에 두 개의 답이 있었고, 묶는 것도 검사하는 것도 없었습니다.

## 왜 고치나 — 오차가 아니라 침묵

프로덕션 환율은 **1383.52** (2026-08-29), 1400 은 +1.2% 입니다. 오차 자체는 작습니다. 문제는 **부재가 숫자로 둔갑해 수집기가 죽어도 아무도 모른다**는 것입니다. #1278 이 정확히 그 형태였습니다 — 미래 행이 노후 경고까지 죽여 이중으로 눈이 멀어 있었습니다.

발화 빈도는 낮습니다(환율 부재는 수집기 장애뿐이고, 전 행 미래날짜는 #1278 이 막았습니다). 그래서 긴급 결함이 아니라 **정직성 회귀 방지**입니다.

## 스코프 — Python 4곳 (응답 형태 불변)

| 위치 | 전 | 후 |
|---|---|---|
| `analysis/portfolio.py:132` | `get_exchange_rate(...) or 1400.0` | 삭제 (도달 불가였음) |
| `analysis/portfolio.py:267` | `df.attrs.get("usd_krw", 1450.0)` | "미수집" 표시, USD 총액은 유지 |
| `recommend/price_targets.py:665` | `usd_krw = 1400.0  # 폴백` | 판정 포기 (`None` + WARNING) |
| `alerts/premarket_brief.py:264` | `or 1400.0` | totals 생략 + **사유 표면화** |

**API·프론트 4곳은 #1284 로 분리**했습니다 — 응답 형태가 바뀌어(집계가 null 이 된다) 프론트와 한 PR 에서 같이 움직여야 합니다. 백엔드만 먼저 정직해지면 `_compute_actual_allocation` 의 `sum()` 과 `holdings-summary.ts` 산술이 죽습니다. 아래 allowlist 가 그 4곳 중 Python 3곳을 사유와 함께 붙잡고 있고, #1284 가 랜딩하면 **stale 로 FAIL** 해서 제거를 강제합니다.

### 이슈 본문의 심각도 판단을 하나 정정했습니다

처음에 `price_targets.py` 를 "리스크 게이트 입력 — 가장 위험" 으로 적었는데 **틀렸습니다**. `check_portfolio_mdd` 의 호출자는 **테스트뿐**입니다 (`grep -rn check_portfolio_mdd nuri/` → 정의 1건). 실제로 배선된 portfolio-stop 경로는 `analysis/evidence_data.py:91` 이고 행별 `pnl_pct` 를 쓰므로 FX 를 타지 않습니다. 지어낸 환율이 이 경로로 실제 판단에 닿지는 않습니다 — 그래도 고치는 이유는 배선되는 순간 조용히 위험해지기 때문입니다.

## 설계 — 환산 불가와 환산 불필요를 가른다

환율이 없어도 **US 전용 집계는 정확히 계산됩니다.** 일괄 `None` 은 과잉이고, 그러면 "전부 None 반환" 이라는 가짜 수정과 구분되지 않습니다. KR 보유가 섞여 있을 때만 포기합니다.

`premarket_brief` 는 **사유까지 싣습니다.** 매일 아침 읽는 브리프에서 Portfolio 섹션이 그냥 사라지면 결함처럼 보이고, 정작 원인은 로그에만 남아 도달하지 않습니다. 두 렌더러(Discord embed · markdown) 모두에 넣었습니다.

### 곁가지 — 환율은 양수다

`latest_usd_krw` 가 `0`/음수를 **부재로 접습니다**. 없으면 `0.0` 이 "값이 있다" 로 통과해 호출자마다 다르게 터집니다 — 나눗셈 하는 쪽은 `ZeroDivisionError`, `or` 폴백을 둔 쪽은 조용히 지어낸 숫자. `portfolio.py` 의 폴백을 **안전하게 지울 수 있는 근거**이기도 합니다 (그게 유일한 falsy 후보였습니다).

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| `fx.py` 양수 불변식 제거 | **4 FAIL** |
| `portfolio.py` 죽은 `or 1400.0` 복원 | **2 FAIL** |
| `print_summary` 1450 기본값 복원 | **3 FAIL** |
| `check_portfolio_mdd` 1400 폴백 복원 | **3 FAIL** |
| `premarket_brief` 1400 폴백 복원 | **4 FAIL** |
| 브리프가 생략 사유를 안 싣는다 (렌더러 2곳) | **1 FAIL** |
| allowlist 에 낡은 항목 추가 (양방향) | **2 FAIL** |
| 스윕 눈멀게 하기 (`IDENT` 무력화) | **2 FAIL** |
| baseline | 20 passed |

치환 건수를 매 축마다 `assert` 했습니다 — 안 하면 `ruff format` 이나 공백 차이로 매칭이 조용히 no-op 이 되고 "잠금 없음" 을 오판합니다 (#1261 실측).

**대조군을 축마다 짝지었습니다.** "환율 없으면 None" 만 잠그면 전부 None 을 반환하는 가짜 수정이 통과합니다. `check_portfolio_mdd` 축이 특히 그렇습니다 — 위반이 없어도 `None` 이라, 같은 보유를 환율만 넣어 돌려 **위반이 실제로 잡히는지** 먼저 확인합니다. 그게 없으면 그 테스트는 공허합니다.

### 구조 스윕은 텍스트가 아니라 AST 입니다

처음에 정규식으로 짰더니 `core/fx.py` 독스트링("**1417.4** 를 반환했다")과 `dashboard.py` 독스트링("환율 누락 시 1400 기본값")을 걸었습니다 — 코드가 아니라 *설명*입니다. 이 레포가 이미 내린 판정과 같습니다 (`test_no_facade_query_patch.py`: "독스트링/주석 언급은 오탐이라 텍스트 sweep 기각"). 그래서 **숫자 리터럴은 AST 로** 집고(문자열·주석·독스트링이 구조적으로 배제), 식별자만 같은 물리 행에서 봅니다.

카나리아는 **양방향**입니다 — 옛 결함 형태를 잡는지 + 독스트링을 오탐하지 않는지. 그리고 카나리아와 실제 스윕이 **같은 함수(`_scan`)** 를 탑니다. 로직을 복사해 두면 카나리아는 복사본만 검증하고 정작 스윕이 눈이 멀어도 초록으로 통과합니다.

`korean_market.py` 는 allowlist 에 **성격이 다르다는 사유**로 등재했습니다 — `fx_weak_default` 등은 `config/agents.yaml` 이 정본인 **정책 임계값**의 코드 기본값이고, 무엇을 '원화 약세' 로 볼지의 선택이지 환율 **측정치**가 아닙니다.

## 기존 테스트 1건을 뒤집었습니다

`test_fx_query_exception_falls_back_to_default` 가 **제거 대상 동작을 잠그고 있었습니다** — FX 조회가 예외로 죽으면 1400 으로 진행해 `PORTFOLIO_STOP` 위반을 선언하는 것. 새 이름은 `test_fx_query_failure_abstains_instead_of_defaulting` 이고 포기를 잠급니다.

이 테스트가 **제 커밋 메시지의 과장을 잡았습니다.** 저는 `except Exception: pass` 를 걷으며 "바로 아래 `query_df` 가 어차피 같은 오류로 터진다" 고 적었는데, 그건 **DB 전체 장애일 때만** 참이고 FX 조회만 실패하는 경우엔 거짓입니다. DB 오류는 "환율을 모른다" 이지 "1400 이다" 가 아니므로, `(OperationalError, DatabaseError)` 만 **좁게** 잡아 부재로 접고 판정을 포기하게 고쳤습니다. `Exception` 으로 넓히면 진짜 버그까지 삼킵니다.

같은 테스트가 실제 보유 종목·가격을 픽스처로 쓰고 있어 합성 값으로 바꿨습니다 (public repo, `tests/CLAUDE.md` privacy).

## 검증

- `make test-fast` → **7,661 passed / 6 skipped** (rc=0)
- `make diagnostics` rc=0 — pyright 166 (ratchet 172 이하). 이 PR 이 새로 만든 1건(`premarket_brief` 의 `float | None` 나눗셈)은 **폴백 숫자를 끼우지 않고** 조건을 갈라 해소했습니다. 도달 불가지만, 타입체커가 "도달 불가가 조용히 도달 가능해지는" 순간을 잡아주게 두는 편이 낫습니다
- `check_privacy_leak.py` (인자 없이 = CI diff 스캔) rc=0
- `make verify-doc-counts` **22/22** (`sync_doc_counts.sh` 로 재계산, 손으로 고치지 않음)

---

## codex 리뷰 — [P1] 1건 + [P2] 2건, 전부 반영

리뷰는 **첫 커밋 시점**에 돌았습니다. P2 의 "철자 변종 evasion" 일부는 그 사이 2번째 커밋이 이미 고쳤습니다.

### [P1] 가드가 접미사만 보고 KR 을 갈랐다 — 수용

> a `currency="KRW"` holding without `.KS/.KQ` is misread as "US-only", so missing FX would still allow a fabricated MDD judgment

**맞고, 이 PR 이 넣은 규칙 자체를 무력화합니다.** 코드로 확인했습니다 — 레포 정본 술어는 `currency == "KRW" or is_kr_ticker(ticker)` 이고 3곳이 인라인으로 씁니다 (`analysis/portfolio.py:208` · `analysis/sector.py:52` · `alerts/risk_signals.py:135`). `tests/trading/recommend/test_holdings_monitor.py` 도 `("BRKR","KRW") → equity_kr` 를 **접미사 없이** 잠그고 있습니다. 제 가드만 좁았습니다. `check_portfolio_mdd` 는 `currency` 를 **SELECT 하지도 않아서** 쿼리에 추가했습니다.

가드는 **넓은 쪽**을 씁니다 — 환산이 필요할 *수 있으면* 판정하지 않는 편이 지어내는 것보다 낫습니다.

**환산 루프 자체는 손대지 않았습니다.** 루프도 접미사만 보는데, 그건 환율 fabrication 이 아니라 **통화 환산 결함**이고(환율이 정상일 때도 1380배 틀립니다) 숫자가 바뀌는 변경이라 같은 PR 에 섞으면 리뷰가 흐려집니다 → **#1286** 으로 분리했습니다.

### [P2] 브리프가 수량 0 인 KR 행에도 막힌다 — 수용

> The query has no `quantity > 0` filter ... A stale zero-quantity KR row can therefore suppress the Portfolio section

**맞습니다.** `check_portfolio_mdd` 는 `WHERE quantity > 0` 이 있는데 브리프 쿼리에는 없어서 두 소비자가 갈렸습니다. 수량 0 행은 총액에 0 을 더하므로 애초에 환산이 필요 없습니다 — 그것 때문에 살아있는 US 총액까지 막히면 **false-red** 입니다. 대조군 테스트로 잠갔습니다.

### [P2] AST 스윕 evasion — 한계로 문서화 (수정 안 함)

> `rate = exchange_rate or 14 * 100`, `rate = exchange_rate or cfg.fx_default` ... all bypass it

**맞습니다.** 한 물리 행 안의 리터럴만 보므로 값이 한 단계라도 건너뛰면 빠져나갑니다. 제대로 막으려면 데이터플로 분석이 필요한데 그 비용이 이 방어의 가치를 넘습니다. **진짜 방어는 소비자별 동작 잠금**이고 스윕은 *가장 흔한 재발 형태*(옛 코드를 복사해 새 자리에 붙이기)를 잡는 값싼 그물입니다. 클래스 독스트링에 **"한계 (정직하게)"** 절로 실측 evasion 3종을 적어 뒀습니다 — 스윕이 초록인 걸 "지어낸 환율이 없다" 로 읽으면 안 되기 때문입니다.

codex 가 지적한 변종 중 `FALLBACK_RATE = 1400` 계열은 2번째 커밋이 이미 잡습니다. 그 커밋에서 배운 것: **`\b` 는 경계로 못 쓴다** — `_` 가 단어 문자라 `\brate\b` 가 `FALLBACK_RATE` 를 놓치고, 반대로 맨 `rate` 부분일치는 `generate`/`separate` 를 잡습니다. `(?<![a-z])rate(?![a-z])` 가 양쪽을 만족합니다. 그리고 **넓히기 전에 "동일 hit 수" 를 근거로 evasion 도 잡힐 거라 추론했는데 틀렸고**, 테스트가 그걸 잡았습니다.

### 반영 후 뮤테이션 (커밋 후, 축 3개 추가 — 총 11개)

| 뮤테이션 | 결과 |
|---|---|
| MDD 가드를 접미사 단독으로 되돌림 (P1) | **1 FAIL** |
| 브리프 가드를 접미사 단독으로 되돌림 (P1) | **2 FAIL** |
| 브리프 가드에서 수량 필터만 제거 (P2) | **1 FAIL** |
| (기존 8축 전부 재측정 — 여전히 잠김) | 1~5 FAIL |
| baseline | 24 passed |

두 번째 실행에서 **치환 0건**이 나와 측정이 중단됐습니다 — `ruff format` 이 여러 줄 조건을 한 줄로 접어서 매칭이 깨진 것입니다. 건수 assert 가 없었으면 "안 잠김" 으로 오판했을 자리입니다 (#1261 과 같은 형태).

### codex 가 문제 없다고 본 것

- `value <= 0` 을 부재로 접는 것 — *"treating nonpositive values as absent is safer than letting callers divide by zero"*
- `check_portfolio_mdd` 의 좁은 `except (OperationalError, DatabaseError)` — *"abstaining on FX-read DB errors is consistent with the new policy, while non-DB bugs still propagate"*
- `premarket_brief` 의 `continue` — 현재 코드에서 도달 불가 (가드와 내부 분기가 같은 술어를 쓴다)

## 재검증 (반영 후)

- `make test-fast` → **7,665 passed / 6 skipped** (rc=0)
- `make diagnostics` rc=0 · `check_privacy_leak.py` rc=0 · `make verify-doc-counts` **22/22**
