### PR TITLE
fix(api,frontend): stop fabricating cross-currency totals when the rate is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,719 collected across 354 files | |
+| **Backend tests** | 7,721 collected across 354 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,698 collected across 353 files | |
+| **Backend tests** | 7,719 collected across 354 files | |
 | **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,719 backend tests across 354 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,721 backend tests across 354 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,698 backend tests across 353 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,719 backend tests across 354 files + 1622 frontend vitest (136 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,698 tests, 353 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,719 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,8 +275,8 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,719 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 136 files |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,721 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/src/__tests__/components/action-items.test.tsx
+++ b/frontend/src/__tests__/components/action-items.test.tsx
@@ -79,6 +79,22 @@ const portfolioItem = {
   priority: "portfolio",
 };
 
+describe("환율 미수집 — 비중 미상 (#1284)", () => {
+  it("position_pct 가 null 이면 터지지 않고 미상으로 표시한다", () => {
+    // Mutation lock: `item.position_pct.toFixed(1)` 로 되돌리면 TypeError 로 FAIL.
+    // 생산자(`/api/actions`)가 이미 nullable 인데 소비자가 number 로 믿고 있었다.
+    const item = {
+      ...urgentItem,
+      ticker: "ZZZZ",
+      reasons: [],
+      position_pct: null as number | null,
+    };
+    render(<ActionItems urgent={[item as never]} check={[]} hold={[]} portfolio={[]} />);
+    expect(screen.getByText("ZZZZ")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("null");
+  });
+});
+
 describe("ActionItems", () => {
   it("renders empty state when no actions", () => {
     render(<ActionItems urgent={[]} check={[]} hold={[]} />);

--- a/frontend/src/__tests__/lib/holdings-summary-merge.test.ts
+++ b/frontend/src/__tests__/lib/holdings-summary-merge.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `mergeAccountTotals` — 미상(null)을 0 으로 접지 않는다 (#1284).
+ *
+ * 이 로직은 원래 `page.tsx` 인라인이었다. 뮤테이션 실측에서 **아무 테스트도 잡지
+ * 못해** 밖으로 뺐다 — 인라인이라 테스트가 닿지 않았고, 닿지 않으면 잠긴 게 아니다.
+ */
+import { describe, expect, it } from "vitest";
+
+import { mergeAccountTotals } from "@/lib/holdings-summary";
+
+describe("mergeAccountTotals (#1284)", () => {
+  it("미상 보유 + 현금이면 계좌 합계가 미상이다", () => {
+    // Mutation lock: `(prev ?? 0) + (value ?? 0)` 로 되돌리면 500 이 나와 FAIL.
+    // 500 은 "이 계좌엔 현금 500 뿐" 이라는 거짓이다 — 보유 평가액을 모를 뿐이다.
+    const merged = mergeAccountTotals(
+      [{ account: "Brokerage Alpha", value: null }],
+      [{ account: "Brokerage Alpha", total_usd: 500 }],
+    );
+    expect(merged).toEqual([{ account: "Brokerage Alpha", value: null }]);
+  });
+
+  it("미상 현금도 같은 방향으로 전파된다", () => {
+    const merged = mergeAccountTotals(
+      [{ account: "Brokerage Alpha", value: 1000 }],
+      [{ account: "Brokerage Alpha", total_usd: null }],
+    );
+    expect(merged[0].value).toBeNull();
+  });
+
+  it("대조군 — 전부 알면 예전처럼 더한다", () => {
+    const merged = mergeAccountTotals(
+      [{ account: "Brokerage Alpha", value: 1000 }],
+      [{ account: "Brokerage Alpha", total_usd: 500 }],
+    );
+    expect(merged).toEqual([{ account: "Brokerage Alpha", value: 1500 }]);
+  });
+
+  it("대조군 — 계좌가 서로 다르면 각각 유지된다", () => {
+    const merged = mergeAccountTotals(
+      [{ account: "Brokerage Alpha", value: 1000 }],
+      [{ account: "Brokerage Beta", total_usd: 500 }],
+    );
+    expect(merged).toEqual([
+      { account: "Brokerage Alpha", value: 1000 },
+      { account: "Brokerage Beta", value: 500 },
+    ]);
+  });
+});

--- a/frontend/src/__tests__/pages/dashboard.test.tsx
+++ b/frontend/src/__tests__/pages/dashboard.test.tsx
@@ -727,10 +727,12 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      const total = screen.getByTestId("hero-total");
-      expect(total.textContent).toContain("—");
-      expect(total.textContent).not.toContain("8,850");
-      expect(total.textContent).toContain(reason);
+      // ⚠️ `hero-total` 컨테이너에 `toContain("—")` 만 걸면 **사유 문자열 안의 em dash**
+      // 가 단언을 대신 만족시킨다 — 값이 "$0" 이어도 통과하는 false lock 이었다
+      // (뮤테이션 실측으로 발각). 값 요소를 직접 본다.
+      const value = screen.getByTestId("hero-total-value");
+      expect(value.textContent).toBe("—");
+      expect(screen.getByTestId("hero-total").textContent).toContain(reason);
     });
   });
 
@@ -748,8 +750,7 @@ describe("DashboardPage", () => {
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
-      const total = screen.getByTestId("hero-total");
-      expect(total.textContent).toContain("$2,500");
+      expect(screen.getByTestId("hero-total-value").textContent).toBe("$2,500");
     });
   });
 

--- a/frontend/src/__tests__/pages/dashboard.test.tsx
+++ b/frontend/src/__tests__/pages/dashboard.test.tsx
@@ -33,6 +33,11 @@ const mockDashboardData = {
   regime: { regime: "bull_low_vol", trend: "bull", volatility: "low", confidence: 78, vix: 18.5, fear_greed: 55 },
   macro: { score: 65, interpretation: "Moderately positive" },
   allocation: { long: 50, short: 10, cash: 40 },
+  // #1284: 실 API 는 이 필드를 **항상** 낸다. 빠뜨려두면 `undefined` 가 되어 예전
+  // `|| 1400` 폴백을 타고, 그 지어낸 값 위에서 기대치가 계산된다 — 잘못된 mock 형태가
+  // 결함을 잠그던 자리다 (`tests/CLAUDE.md` "Mock Shape Locks Bugs").
+  exchange_rate: 1400,
+  fx_unavailable: null,
   actions: [
     { action: "BUY", ticker: "NVDA", confidence: 72, agreement: 80, reason: "Strong multi-factor score" },
     { action: "SELL", ticker: "INTC", confidence: 65, agreement: 70, reason: "Negative momentum" },
@@ -711,17 +716,40 @@ describe("DashboardPage", () => {
     });
   });
 
-  /* ── exchange_rate fallback ── */
-  it("uses fallback exchange rate 1400 when exchange_rate is null", async () => {
-    // KRW holding: 4 * 210000 / 1400 = 600; USD holding: 33 * 250 = 8250; total = 8850
+  /* ── exchange_rate 부재 (#1284) ── */
+  it("shows an em dash and the reason when exchange_rate is null", async () => {
+    // 예전 이름은 "uses fallback exchange rate 1400..." 이었고 지어낸 1400 으로 환산한
+    // $8,850 을 잠그고 있었다. 원화 보유가 있으면 통화 혼합 총액은 **미상**이다.
+    const reason = "USD/KRW 미수집 — 원화 자산이 있어 통화 혼합 합계를 낼 수 없습니다";
     setupMocks({
-      dashboard: { ...mockDashboardData, exchange_rate: null },
+      dashboard: { ...mockDashboardData, exchange_rate: null, fx_unavailable: reason },
     });
     const Page = await import("@/app/page");
     await act(async () => { render(<Page.default />); });
     await waitFor(() => {
       const total = screen.getByTestId("hero-total");
-      expect(total.textContent).toContain("$8,850");
+      expect(total.textContent).toContain("—");
+      expect(total.textContent).not.toContain("8,850");
+      expect(total.textContent).toContain(reason);
+    });
+  });
+
+  it("keeps a USD-only total exact when exchange_rate is null", async () => {
+    // 대조군 — 환산이 필요 없으면 환율 부재와 무관하게 정확하다. 일괄 "—" 는 과잉이다.
+    setupMocks({
+      dashboard: { ...mockDashboardData, exchange_rate: null, fx_unavailable: null },
+      portfolio: {
+        count: 1,
+        holdings: [
+          { ticker: "ZZZZ", quantity: 10, avg_price: 100, latest_price: 250, currency: "USD" },
+        ],
+      },
+    });
+    const Page = await import("@/app/page");
+    await act(async () => { render(<Page.default />); });
+    await waitFor(() => {
+      const total = screen.getByTestId("hero-total");
+      expect(total.textContent).toContain("$2,500");
     });
   });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,7 +16,7 @@ import { ActionItems, type ActionItem } from "@/components/ui/action-items";
 import { OpportunityExplorer, type Opportunity } from "@/components/ui/opportunity-explorer";
 import { type MacroEvent, type SystemHealth } from "@/components/ui/market-context";
 import { SystemHealthRail, MacroEventsCard, RegimeShiftBanner } from "@/components/dashboard/system-rail";
-import { summarizeHoldings } from "@/lib/holdings-summary";
+import { summarizeHoldings, mergeAccountTotals } from "@/lib/holdings-summary";
 import { getMacroImpactedSectors } from "@/lib/macro-impact";
 import Link from "next/link";
 import { SECTION, ACTION, COMMON } from "@/lib/strings";
@@ -267,18 +267,10 @@ async function Dashboard({
   // panel had. Compute once at page level so HeroStats + CompositionSection
   // share it without recomputing. Merge account_values + cash_summary so
   // every account (including pension/IRP) appears in the breakdown.
-  // #1284: 미상(null)은 **0 으로 접지 않는다** — 없는 돈이 아니라 모르는 돈이라,
-  // 0 으로 더하면 그 계좌만 사라지고 나머지 계좌 비중이 조용히 부풀려진다.
-  // 한 계좌에 미상이 하나라도 섞이면 그 계좌 합계 전체가 미상이다.
-  const acctTotals = new Map<string, number | null>();
-  const addToAccount = (account: string, value: number | null) => {
-    const prev = acctTotals.get(account);
-    acctTotals.set(account, prev === null || value === null ? null : (prev ?? 0) + value);
-  };
-  for (const av of accountValues) addToAccount(av.account, av.value);
-  for (const cash of d.cash_summary?.accounts ?? []) addToAccount(cash.account, cash.total_usd);
-  const mergedAccountValues = Array.from(acctTotals.entries()).map(
-    ([account, value]) => ({ account, value }),
+  // #1284: 미상(null)은 0 으로 접지 않는다 — 규칙과 그 근거는 `mergeAccountTotals` 참조.
+  const mergedAccountValues = mergeAccountTotals(
+    accountValues,
+    d.cash_summary?.accounts ?? [],
   );
   const summary = summarizeHoldings(enrichedHoldings, {
     totalPortfolioUsd: totalValue,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -43,17 +43,20 @@ interface DashboardData {
   macro: { score: number; interpretation: string };
   allocation: { long: number; short: number; cash: number };
   target_allocation?: { long: number; short: number; cash: number };
-  actual_allocation?: { long: number; short: number; cash: number };
+  // #1284: 환산 불가면 null — 분모를 모르면 배분도 낼 수 없다.
+  actual_allocation?: { long: number; short: number; cash: number } | null;
   cash_summary?: {
-    accounts: Array<{ account: string; cash_usd: number; cash_krw: number; total_usd: number }>;
-    total_cash_usd: number;
+    accounts: Array<{ account: string; cash_usd: number; cash_krw: number; total_usd: number | null }>;
+    total_cash_usd: number | null;
   };
   actions: Array<{ action: string; ticker: string; name?: string | null; confidence: number; agreement: number; reason: string; account?: string }>;
   alerts: Array<{ level: string; message: string }>;
   gate_score: number;
   n_positions: number;
   exchange_rate: number | null;
-  account_values?: Array<{ account: string; value: number }>;
+  // 환산 불가 사유 (없으면 null). 백엔드가 값과 함께 **이유**를 낸다 — #1284.
+  fx_unavailable?: string | null;
+  account_values?: Array<{ account: string; value: number | null }>;
   upcoming_events?: Array<{ date: string; event_type: string; ticker: string | null; description: string; importance: number }>;
   ticker_accounts?: Record<string, string>;
   account_labels?: Record<string, string>;
@@ -99,7 +102,7 @@ interface PortfolioHolding {
 interface PortfolioData {
   count?: number;
   holdings?: PortfolioHolding[];
-  cash?: { total_cash_usd?: number };
+  cash?: { total_cash_usd?: number | null };
 }
 
 type CertifyCondition = FooterCondition;
@@ -172,15 +175,33 @@ async function Dashboard({
   const holdingCount = portfolio?.count ?? portfolio?.holdings?.length ?? 0;
   if (holdingCount === 0) redirect("/explore");
 
-  const KRW_RATE = d.exchange_rate || 1400;
-  const holdingsValue = portfolio?.holdings?.reduce((sum: number, h: PortfolioHolding) => {
-    const price = h.latest_price || 0;
-    const qty = h.quantity || 0;
-    return sum + (h.ticker?.endsWith(".KS") ? price * qty / KRW_RATE : price * qty);
-  }, 0) || 0;
+  // #1284: `|| 1400` 이 여기 있었다. 백엔드는 `exchange_rate: null` 로 부재를 **정직하게**
+  // 알려주는데 프론트가 그 신호를 버리고 숫자를 지어냈고, 그 값이 헤드라인 총액까지 갔다.
+  const KRW_RATE = d.exchange_rate;
+  // 원화 표시 여부 — `holding-row.tsx` 와 같은 기준(통화 우선, 접미사는 .KS/.KQ 둘 다).
+  // 접미사만 보면 `.KQ`(코스닥)와 무접미 원화 보유를 달러로 오분류한다. 인라인 사본이
+  // 여러 곳에 흩어져 있고 그 통합은 #1286 이 다룬다.
+  const isKrwHolding = (h: PortfolioHolding) =>
+    h.currency === "KRW" || !!h.ticker?.endsWith(".KS") || !!h.ticker?.endsWith(".KQ");
+  const hasKrwHolding = (portfolio?.holdings ?? []).some(isKrwHolding);
+  // 환율이 없고 원화 보유가 있으면 **통화 혼합 합계 자체가 미상**이다 — KR 종목만이
+  // 아니라 총액이 미상이므로 달러 종목의 비중도 말할 수 없다 (분모가 없다).
+  const holdingsValue: number | null =
+    KRW_RATE == null && hasKrwHolding
+      ? null
+      : (portfolio?.holdings?.reduce((sum: number, h: PortfolioHolding) => {
+          const price = h.latest_price || 0;
+          const qty = h.quantity || 0;
+          return sum + (isKrwHolding(h) ? (price * qty) / (KRW_RATE as number) : price * qty);
+        }, 0) ?? 0);
   // #213: 총 자산 = holdings + cash. cash는 portfolio.yaml 기반 /api/portfolio에서 옴.
-  const cashTotalUsd = portfolio?.cash?.total_cash_usd ?? d.cash_summary?.total_cash_usd ?? 0;
-  const totalValue = holdingsValue + cashTotalUsd;
+  // 백엔드가 환산 불가로 판정하면 `total_cash_usd` 도 null 로 온다 (#1284).
+  const cashTotalUsd: number | null =
+    portfolio?.cash?.total_cash_usd ?? d.cash_summary?.total_cash_usd ?? 0;
+  const totalValue: number | null =
+    holdingsValue == null || cashTotalUsd == null ? null : holdingsValue + cashTotalUsd;
+  // 값을 못 낸 **이유**. 조용한 "—" 는 결함처럼 보이므로 배너로 사유를 함께 낸다.
+  const fxUnavailable = d.fx_unavailable ?? null;
 
   const vix = d.regime.vix ?? null;
   const fg = d.regime.fear_greed ?? null;
@@ -246,13 +267,16 @@ async function Dashboard({
   // panel had. Compute once at page level so HeroStats + CompositionSection
   // share it without recomputing. Merge account_values + cash_summary so
   // every account (including pension/IRP) appears in the breakdown.
-  const acctTotals = new Map<string, number>();
-  for (const av of accountValues) {
-    acctTotals.set(av.account, (acctTotals.get(av.account) ?? 0) + av.value);
-  }
-  for (const cash of d.cash_summary?.accounts ?? []) {
-    acctTotals.set(cash.account, (acctTotals.get(cash.account) ?? 0) + cash.total_usd);
-  }
+  // #1284: 미상(null)은 **0 으로 접지 않는다** — 없는 돈이 아니라 모르는 돈이라,
+  // 0 으로 더하면 그 계좌만 사라지고 나머지 계좌 비중이 조용히 부풀려진다.
+  // 한 계좌에 미상이 하나라도 섞이면 그 계좌 합계 전체가 미상이다.
+  const acctTotals = new Map<string, number | null>();
+  const addToAccount = (account: string, value: number | null) => {
+    const prev = acctTotals.get(account);
+    acctTotals.set(account, prev === null || value === null ? null : (prev ?? 0) + value);
+  };
+  for (const av of accountValues) addToAccount(av.account, av.value);
+  for (const cash of d.cash_summary?.accounts ?? []) addToAccount(cash.account, cash.total_usd);
   const mergedAccountValues = Array.from(acctTotals.entries()).map(
     ([account, value]) => ({ account, value }),
   );
@@ -281,6 +305,7 @@ async function Dashboard({
         totalUsd={totalValue}
         cashTotalUsd={cashTotalUsd}
         holdingsValueUsd={holdingsValue}
+        unavailableReason={fxUnavailable}
         summary={summary}
       />
 

--- a/frontend/src/components/dashboard/market-strip.tsx
+++ b/frontend/src/components/dashboard/market-strip.tsx
@@ -13,7 +13,8 @@ interface MarketStripProps {
   vix: number | null;
   fg: number | null;
   macroScore: number | undefined;
-  actualAllocation?: Allocation;
+  // #1284: 환율 미수집이면 백엔드가 null 을 낸다 — 분모를 모르면 배분도 모른다.
+  actualAllocation?: Allocation | null;
   targetAllocation?: Allocation | null;
   fallbackAllocation?: Allocation | null;
 }
@@ -24,11 +25,15 @@ export function MarketStrip({
 }: MarketStripProps) {
   // actual: API always provides this in real responses; mock tests
   // sometimes don't, so default to a sentinel that still renders.
+  // #1284: null 은 "현금 100%" 가 아니라 **미상**이다. 센티널로 접으면 환율이 없을 때
+  // 화면이 "전액 현금" 이라고 주장하게 된다 — 없는 것과 모르는 것은 다르다.
+  const allocationUnknown = actualAllocation === null;
   const actual = actualAllocation ?? { long: 0, short: 0, cash: 100 };
   const target = targetAllocation ?? fallbackAllocation ?? null;
   // Hide 권장 entirely when it's the meaningless 0/100 default
   // (means "no regime data") or matches actual.
   const hasMeaningfulTarget =
+    !allocationUnknown &&
     target != null &&
     (target.long > 0 || target.short > 0) &&
     !(target.long === actual.long && target.cash === actual.cash);
@@ -58,9 +63,15 @@ export function MarketStrip({
         </span>
       )}
       <span className="text-zinc-700">·</span>
-      <span>
-        {MARKET.ACTUAL} <span className="text-emerald-400 font-semibold tabular-nums">{actual.long}%</span> {MARKET.INVEST} / <span className="text-zinc-300 font-semibold tabular-nums">{actual.cash}%</span> {MARKET.CASH}
-      </span>
+      {allocationUnknown ? (
+        <span data-testid="allocation-unknown">
+          {MARKET.ACTUAL} <span className="text-amber-400 font-semibold">—</span>
+        </span>
+      ) : (
+        <span>
+          {MARKET.ACTUAL} <span className="text-emerald-400 font-semibold tabular-nums">{actual.long}%</span> {MARKET.INVEST} / <span className="text-zinc-300 font-semibold tabular-nums">{actual.cash}%</span> {MARKET.CASH}
+        </span>
+      )}
       {hasMeaningfulTarget && target && (
         <>
           <span className="text-zinc-700">→</span>

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -14,7 +14,11 @@ export interface ActionItem {
   agreement?: number | null;
   /** 시세 미수집이면 `null` — 측정 불가이지 0% 가 아니다 (#1279). */
   pnl_pct: number | null;
-  position_pct: number;
+  /**
+   * 환율 미수집이면 `null` — 비중의 분모(통화 혼합 총액)를 모른다 (#1284).
+   * 바로 위 `pnl_pct` 와 **같은 계약**이다: 측정 불가는 0 이 아니다.
+   */
+  position_pct: number | null;
   current_price?: number | null;
   avg_price?: number | null;
   account?: string;
@@ -138,7 +142,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
             : `${item.pnl_pct >= 0 ? "+" : ""}${item.pnl_pct.toFixed(1)}%`}
         </td>
         <td className="h-8 px-2 whitespace-nowrap hidden md:table-cell text-right text-[11px] text-zinc-400 tabular-nums">
-          {item.position_pct.toFixed(1)}%
+          {item.position_pct == null ? ACTION.PNL_UNKNOWN : `${item.position_pct.toFixed(1)}%`}
         </td>
         <td className="h-8 px-2 whitespace-nowrap">
           <span className="inline-flex items-center gap-1.5">
@@ -171,7 +175,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
               {/* <md 에서 행이 숨기는 계좌·비중을 peek 가 복원 (#1208 codex P2) */}
               {item.account && <span className="md:hidden"><span className="text-zinc-600">계좌</span> <span className="text-zinc-300">{item.account}</span></span>}
-              <span className="md:hidden"><span className="text-zinc-600">비중</span> <span className="text-zinc-300 tabular-nums">{item.position_pct.toFixed(1)}%</span></span>
+              <span className="md:hidden"><span className="text-zinc-600">비중</span> <span className="text-zinc-300 tabular-nums">{item.position_pct == null ? ACTION.PNL_UNKNOWN : `${item.position_pct.toFixed(1)}%`}</span></span>
               <span><span className="text-zinc-600">현재가</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></span>
               <span><span className="text-zinc-600">손절</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></span>
               <span><span className="text-zinc-600">1차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></span>

--- a/frontend/src/components/ui/composition-section.tsx
+++ b/frontend/src/components/ui/composition-section.tsx
@@ -33,7 +33,7 @@ export function parseCompositionTab(raw: string | undefined): CompositionTab {
 
 interface CompositionSectionProps {
   summary: HoldingsSummary;
-  totalUsd: number;
+  totalUsd: number | null;
   activeTab: CompositionTab;
 }
 
@@ -136,7 +136,9 @@ export function CompositionSection({
   const slices = built.slices.map(remap);
   const legend = built.legend.map(remap);
   const hasData = slices.length > 0;
-  const totalLabel = `$${totalUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  // #1284: 총액 미상이면 "—". 0 으로 접으면 구성 합계가 0 달러로 보인다.
+  const totalLabel =
+    totalUsd == null ? "—" : `$${totalUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 
   return (
     <section className="flex flex-col gap-2" data-testid="composition-section">

--- a/frontend/src/components/ui/hero-stats.tsx
+++ b/frontend/src/components/ui/hero-stats.tsx
@@ -24,14 +24,18 @@ import type { HoldingsSummary } from "@/lib/holdings-summary";
 import { HERO } from "@/lib/strings";
 
 interface HeroStatsProps {
-  totalUsd: number;
-  cashTotalUsd: number;
-  holdingsValueUsd: number;
+  // #1284: 환율 미수집이면 통화 혼합 합계가 **미상**이다 — null 이 온다.
+  // 0 으로 접으면 "자산 0원" 이라는 거짓을 헤드라인에 띄우게 된다.
+  totalUsd: number | null;
+  cashTotalUsd: number | null;
+  holdingsValueUsd: number | null;
   summary: HoldingsSummary;
+  /** 값을 못 낸 사유 (#1284). 조용한 "—" 는 결함처럼 보이므로 함께 표시한다. */
+  unavailableReason?: string | null;
 }
 
-function formatBigUsd(v: number): string {
-  return `$${v.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+function formatBigUsd(v: number | null): string {
+  return v == null ? "—" : `$${v.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 }
 
 function formatDeltaUsd(v: number): string {
@@ -45,6 +49,7 @@ export function HeroStats({
   cashTotalUsd,
   holdingsValueUsd,
   summary,
+  unavailableReason,
 }: HeroStatsProps) {
   const t = summary.today;
   const c = summary.cumulative;
@@ -68,12 +73,18 @@ export function HeroStats({
               {formatBigUsd(totalUsd)}
             </span>
           </div>
-          {(holdingsValueUsd > 0 || cashTotalUsd > 0) && (
-            <p className="text-xs text-zinc-400 mt-1 tabular-nums">
-              {HERO.HOLDINGS_PREFIX} ${holdingsValueUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-              {" · "}
-              {HERO.CASH_PREFIX} ${cashTotalUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+          {unavailableReason ? (
+            <p className="text-xs text-amber-400/90 mt-1" data-testid="hero-total-unavailable">
+              {unavailableReason}
             </p>
+          ) : (
+            ((holdingsValueUsd ?? 0) > 0 || (cashTotalUsd ?? 0) > 0) && (
+              <p className="text-xs text-zinc-400 mt-1 tabular-nums">
+                {HERO.HOLDINGS_PREFIX} {formatBigUsd(holdingsValueUsd)}
+                {" · "}
+                {HERO.CASH_PREFIX} {formatBigUsd(cashTotalUsd)}
+              </p>
+            )
           )}
         </div>
 

--- a/frontend/src/components/ui/hero-stats.tsx
+++ b/frontend/src/components/ui/hero-stats.tsx
@@ -69,7 +69,10 @@ export function HeroStats({
           <p className="text-[11px] text-zinc-400 uppercase tracking-wide">{HERO.TOTAL_ASSET}</p>
           {/* verdict 배지는 VerdictBanner 로 승격 (#1206) — 히어로는 스냅샷 수치만 */}
           <div className="flex items-baseline gap-2 mt-0.5">
-            <span className="text-xl font-semibold tabular-nums tracking-tight text-zinc-100">
+            <span
+              className="text-xl font-semibold tabular-nums tracking-tight text-zinc-100"
+              data-testid="hero-total-value"
+            >
               {formatBigUsd(totalUsd)}
             </span>
           </div>

--- a/frontend/src/components/ui/holding-row.tsx
+++ b/frontend/src/components/ui/holding-row.tsx
@@ -101,8 +101,10 @@ export interface EnrichedHolding {
  * 비중(%)을 계산한다. 값 누락 시 positionPct 는 null (HoldingRow가 em dash 렌더).
  */
 export interface BuildOptions {
-  totalPortfolioUsd?: number;
-  usdKrwRate?: number;
+  // #1284: 환율 미수집이면 null. `?? 0` 이 받아 `> 0` 가드에서 걸러지므로
+  // 모든 positionPct 가 null 이 된다 — 분모를 모르면 비중도 모른다.
+  totalPortfolioUsd?: number | null;
+  usdKrwRate?: number | null;
 }
 
 // ── Builder ──────────────────────────────────────────────────

--- a/frontend/src/lib/holdings-summary.ts
+++ b/frontend/src/lib/holdings-summary.ts
@@ -114,13 +114,18 @@ export interface HoldingsSummary {
 }
 
 export interface SummarizeOptions {
-  totalPortfolioUsd: number;
+  /**
+   * #1284: 환율 미수집이면 통화 혼합 총액이 **미상**이라 null 이 온다. 그 경우
+   * 상류(`holding-row`)에서 모든 `positionPct` 가 이미 null 이므로 아래 파생값은
+   * 전부 0/빈 배열이 된다 — **틀린 숫자가 아니라 빈 요약**으로 degrade 한다.
+   */
+  totalPortfolioUsd: number | null;
   /**
    * Per-account total USD (holdings + cash). page.tsx merges `account_values`
    * and `cash_summary.accounts` from /api/dashboard before passing in.
    * Empty → byAccount slice is []  (card not rendered).
    */
-  accountValues?: Array<{ account: string; value: number }>;
+  accountValues?: Array<{ account: string; value: number | null }>;
 }
 
 // Palette — tailwind 400-level shades so the donut reads against zinc-950.
@@ -152,7 +157,9 @@ export function summarizeHoldings(
   holdings: EnrichedHolding[],
   options: SummarizeOptions,
 ): HoldingsSummary {
-  const totalUsd = options.totalPortfolioUsd;
+  // 미상이면 0 으로 둔다. 이건 "총액이 0" 이라는 주장이 아니라, 분모를 모를 때
+  // 파생 지표를 **내지 않기** 위한 값이다 (위 주석 참조 — positionPct 가 전부 null).
+  const totalUsd = options.totalPortfolioUsd ?? 0;
 
   // ── NORMALIZATION ─────────────────────────────────────────────────────
   // `positionPct` on each holding is "% of total portfolio (holdings + cash)"
@@ -266,7 +273,10 @@ export function summarizeHoldings(
   //    the main table.
   const rawAccounts = options.accountValues ?? [];
   const byAccount: AccountSlice[] = rawAccounts
-    .filter((a) => a.value > 0)
+    // #1284: 미상(null)은 크기를 모르므로 정렬·비중에 넣을 수 없다. 제외하되
+    // 그 사실은 히어로의 사유 배너가 말한다 — 여기서 0 으로 접으면 다른 계좌
+    // 비중이 조용히 부풀려진다.
+    .filter((a): a is { account: string; value: number } => a.value != null && a.value > 0)
     .sort((a, b) => b.value - a.value)
     .map((a, i): AccountSlice => {
       const agg = accountDeltaAgg.get(a.account);

--- a/frontend/src/lib/holdings-summary.ts
+++ b/frontend/src/lib/holdings-summary.ts
@@ -113,6 +113,29 @@ export interface HoldingsSummary {
   concentration: ConcentrationSummary;
 }
 
+/**
+ * 계좌별 총액 병합 — holdings 평가액 + cash 를 계좌 단위로 합친다 (#1284).
+ *
+ * **미상(null)은 0 으로 접지 않는다.** 없는 돈이 아니라 모르는 돈이라, 0 으로 더하면
+ * 그 계좌가 "현금만 있는 계좌" 처럼 보이고 나머지 계좌 비중이 조용히 부풀려진다.
+ * 한 계좌에 미상이 하나라도 섞이면 그 계좌 합계 전체가 미상이다.
+ *
+ * page.tsx 인라인이었는데 테스트가 닿지 않아 뮤테이션이 **안 잠겼다** — 그래서 뺐다.
+ */
+export function mergeAccountTotals(
+  accountValues: Array<{ account: string; value: number | null }>,
+  cashAccounts: Array<{ account: string; total_usd: number | null }>,
+): Array<{ account: string; value: number | null }> {
+  const totals = new Map<string, number | null>();
+  const add = (account: string, value: number | null) => {
+    const prev = totals.get(account);
+    totals.set(account, prev === null || value === null ? null : (prev ?? 0) + value);
+  };
+  for (const av of accountValues) add(av.account, av.value);
+  for (const c of cashAccounts) add(c.account, c.total_usd);
+  return Array.from(totals.entries()).map(([account, value]) => ({ account, value }));
+}
+
 export interface SummarizeOptions {
   /**
    * #1284: 환율 미수집이면 통화 혼합 총액이 **미상**이라 null 이 온다. 그 경우

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -343,20 +343,33 @@ def _short_ticker_line(item: dict) -> str:
     action = item.get("action", "?")
     conf = item.get("confidence", 0)
     pnl = item.get("pnl_pct", 0)
-    pos = item.get("position_pct", 0)
+    # #1284: 환율 미수집이면 `position_pct` 가 **None** 이다. `.get(key, 0)` 은 키가
+    # 존재하면 기본값을 주지 않으므로 None 이 그대로 흘러와 `:.1f` 에서 터진다 —
+    # 그 예외는 상위 try 가 삼켜 브리프가 조용히 반쪽이 된다.
+    pos = item.get("position_pct")
 
     name = get_ticker_name(t)
     label = f"{name} ({t})" if name else t
-    head = f"{label} ({action} conf {conf}, pnl {pnl:+.1f}%, pos {pos:.1f}%)"
+    pos_txt = "미상" if pos is None else f"{pos:.1f}%"
+    head = f"{label} ({action} conf {conf}, pnl {pnl:+.1f}%, pos {pos_txt})"
 
     accounts = item.get("accounts") or []
     if len(accounts) > 1:
         # 계좌 비중 큰 순으로 정렬. 메인 라인의 `pnl` 는 worst-account 의 손익이라
         # multi-account 종목에선 misleading — breakdown 에 계좌별 pnl 동반 표시.
-        sorted_accounts = sorted(accounts, key=lambda a: a.get("position_pct", 0), reverse=True)
+        # 미상(None)은 크기를 모르므로 정렬 키가 될 수 없다 — 파이썬은 None 과 float 을
+        # 비교하지 못해 TypeError 다. 맨 뒤로 보내고 값은 "미상" 으로 적는다.
+        sorted_accounts = sorted(
+            accounts,
+            key=lambda a: (a.get("position_pct") is None, -(a.get("position_pct") or 0.0)),
+        )
+
+        def _pos(a) -> str:
+            v = a.get("position_pct")
+            return "미상" if v is None else f"{v:.1f}%"
+
         breakdown = " · ".join(
-            f"{a.get('account', '?')} {a.get('position_pct', 0):.1f}%/{a.get('pnl_pct', 0):+.1f}%"
-            for a in sorted_accounts
+            f"{a.get('account', '?')} {_pos(a)}/{a.get('pnl_pct', 0):+.1f}%" for a in sorted_accounts
         )
         return f"{head} [{breakdown}]"
     return head

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -22,7 +22,6 @@ from nuri.core.db import query
 from nuri.core.fx import latest_usd_krw_value
 from nuri.core.live_price import DEFAULT_DIVERGENCE_THRESHOLD_PCT, check_divergence
 from nuri.core.rules import get_stop_loss_for_account
-from nuri.core.ticker_names import is_kr_ticker
 from nuri.core.timezone import kst_now
 
 logger = logging.getLogger(__name__)
@@ -140,7 +139,9 @@ def _build_actions() -> dict:
         holding = portfolio_holdings.get(ticker, {})
         # #1279: 기본값 0 을 주지 않는다 — 미상이 보합으로 둔갑하는 지점이었다.
         pnl_pct = holding.get("pnl_pct")
-        position_pct = holding.get("position_pct", 0)
+        # #1284: 환산 불가면 None 이 온다. #1279 의 `pnl_pct` 와 같은 이유로 0 을 넣지 않는다
+        # — 0 은 "비중 없음" 으로 읽히는데 실제로는 "모른다" 이다.
+        position_pct = holding.get("position_pct")
         # 보유 행이 고른 계좌(worst-PnL)와 **같은 계좌**의 타겟을 본다 — 티커로만
         # 조회하면 둘이 갈라져 서로 다른 원가 기준이 한 줄에 섞인다 (#982).
         # 계좌 라벨이 없으면 조회 자체를 하지 않는다: 키가 (ticker, None) 이 되면
@@ -166,7 +167,7 @@ def _build_actions() -> dict:
             "confidence": confidence,
             "agreement": rec.get("agreement"),
             "pnl_pct": round(pnl_pct, 1) if pnl_pct is not None else None,
-            "position_pct": round(position_pct, 1),
+            "position_pct": round(position_pct, 1) if position_pct is not None else None,
             "current_price": holding.get("current_price"),
             "avg_price": holding.get("avg_price"),
             "account": holding.get("account", ""),
@@ -680,7 +681,14 @@ def _get_portfolio_map() -> dict[str, dict]:
         rows = [r for r in rows if r["account"] in real_accounts]
 
     # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
-    rate = latest_usd_krw_value() or 1400
+    # #1284: `or 1400` 이 여기 있었다. 비중%는 **원화 자산과 달러 자산을 더한 값**을 분모로
+    # 쓰므로, 원화 보유가 하나라도 있고 환율이 없으면 US 종목의 비중까지 말할 수 없다.
+    # 분모가 미상이면 분자가 정확해도 비율은 미상이다.
+    from nuri.core.fx import is_krw_holding
+
+    rate = latest_usd_krw_value()
+    has_krw = any(is_krw_holding(r["ticker"], r["currency"]) for r in rows)
+    weights_unavailable = rate is None and has_krw
 
     # 총 자산 계산 (비중% 산정용)
     total_value = 0
@@ -694,10 +702,17 @@ def _get_portfolio_map() -> dict[str, dict]:
         market_price = r["current_price"]
         price = market_price if market_price is not None else (r["avg_price"] or 0)
         qty = r["quantity"] or 0
-        is_kr = is_kr_ticker(r["ticker"])
-        val = price * qty / rate if is_kr else price * qty
-        total_value += val
+        is_kr = is_krw_holding(r["ticker"], r["currency"])
+        # 원화 보유인데 환율이 없으면 이 행의 USD 값은 미상이다.
+        val = None if (is_kr and rate is None) else (price * qty / rate if is_kr else price * qty)
+        if val is not None:
+            total_value += val
         items.append((r, val, market_price, is_kr))
+
+    # 분모가 미상이면 **모든** 비중이 미상이다 — 달러 종목도 마찬가지다.
+    # 부분합을 분모로 쓰면 남은 종목들의 비중이 조용히 부풀려진다.
+    if weights_unavailable:
+        total_value = None
 
     labels = _get_account_labels()
 
@@ -723,7 +738,14 @@ def _get_portfolio_map() -> dict[str, dict]:
         # 시세가 없으면 **None** — 0.0 은 "보합" 으로 읽히는 지어낸 값이다 (#1279).
         # STRATEGY §2.6 의 VIX 게이트와 같은 원칙: 측정 불가는 숫자로 메우지 않는다.
         pnl = ((price - avg) / avg * 100) if (avg > 0 and price is not None) else None
-        pos_pct = (val / total_value * 100) if total_value > 0 else 0
+        # #1284: 환산 불가면 **None** — 0 은 "비중 없음" 으로 읽히는 지어낸 값이다.
+        # 빈 포트폴리오(total_value == 0)의 0 은 지어낸 값이 아니라 사실이므로 그대로 둔다.
+        if total_value is None or val is None:
+            pos_pct = None
+        elif total_value > 0:
+            pos_pct = val / total_value * 100
+        else:
+            pos_pct = 0
         account_label = labels.get(r["account"], r["account"])
         is_pension = _is_pension_label(account_label)
 
@@ -750,7 +772,12 @@ def _get_portfolio_map() -> dict[str, dict]:
             }
             continue
 
-        existing["position_pct"] += pos_pct
+        # #1284: 미상은 전파된다 — 한 계좌의 비중을 모르면 합산 비중도 모른다.
+        # `None` 을 0 으로 취급해 더하면 다계좌 노출이 과소 보고된다.
+        if existing["position_pct"] is None or pos_pct is None:
+            existing["position_pct"] = None
+        else:
+            existing["position_pct"] += pos_pct
         existing["accounts"].append(per_account)
         # non-pension row 가 들어오면 이전 pension-only state 를 non-pension 으로 승격
         if not is_pension and existing["_pension_only"]:

--- a/nuri/api/routes/actions.py
+++ b/nuri/api/routes/actions.py
@@ -704,7 +704,14 @@ def _get_portfolio_map() -> dict[str, dict]:
         qty = r["quantity"] or 0
         is_kr = is_krw_holding(r["ticker"], r["currency"])
         # 원화 보유인데 환율이 없으면 이 행의 USD 값은 미상이다.
-        val = None if (is_kr and rate is None) else (price * qty / rate if is_kr else price * qty)
+        # 삼항 대신 분기로 쓴다 — 타입체커가 `rate` 를 좁힐 수 있어야 "도달 불가" 가
+        # 조용히 도달 가능해지는 순간을 잡아준다 (#1283 에서 같은 형태를 밟았다).
+        if not is_kr:
+            val = price * qty
+        elif rate is None:
+            val = None
+        else:
+            val = price * qty / rate
         if val is not None:
             total_value += val
         items.append((r, val, market_price, is_kr))

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends
 
 from nuri.api.cache import portfolio_version
 from nuri.api.limits import heavy_slot
-from nuri.core.fx import latest_usd_krw_value
+from nuri.core.fx import cross_currency_unavailable, latest_usd_krw_value
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["dashboard"])
@@ -130,6 +130,14 @@ def _build_dashboard() -> dict:
     cash_summary = _get_cash_balances(exchange_rate)
     actual_allocation = _compute_actual_allocation(account_values, cash_summary["total_cash_usd"])
 
+    # #1284: 환산 불가 **사유**. `exchange_rate: null` 만 내보내면 프론트가 그 신호를 버리고
+    # 스스로 숫자를 지어내기 쉽다 — 실제로 `page.tsx` 가 `|| 1400` 으로 그랬다.
+    # `verdict_stale_inputs` 와 같은 규약: 값을 못 낼 때는 이유를 함께 낸다.
+    fx_unavailable = cross_currency_unavailable(
+        exchange_rate,
+        any(av["value"] is None for av in account_values) or cash_summary["total_cash_usd"] is None,
+    )
+
     return {
         "verdict": verdict,
         "verdict_level": verdict_level,
@@ -148,6 +156,8 @@ def _build_dashboard() -> dict:
         "freshness": freshness,
         "pipeline_status": pipeline_status,
         "exchange_rate": exchange_rate,
+        # 환산 불가 사유 (없으면 None) — 프론트는 이게 있으면 합계 대신 "—" 와 이 문장을 낸다
+        "fx_unavailable": fx_unavailable,
         "account_values": account_values,
         "upcoming_events": upcoming_events,
         "ticker_accounts": ticker_accounts,
@@ -390,12 +400,17 @@ def _get_latest_actions() -> list[dict]:
 
 
 def _get_account_values(exchange_rate: float | None) -> list[dict]:
-    """계좌별 평가액 계산."""
-    from nuri.core.db import query
+    """계좌별 평가액. 환산 불가한 계좌는 `value: None` (#1284).
 
-    rate = exchange_rate or 1400
+    `or 1400` 폴백이 여기 있었다. 계좌 단위로 판단하는 이유는, 환율이 없어도 **달러
+    자산만 담긴 계좌는 정확히 계산되기 때문**이다 — 전부 `None` 으로 지우면 알 수 있는
+    것까지 버린다.
+    """
+    from nuri.core.db import query
+    from nuri.core.fx import is_krw_holding
+
     rows = query("""
-        SELECT p.account, p.ticker, p.quantity,
+        SELECT p.account, p.ticker, p.quantity, p.currency,
                pr.close as latest_price
         FROM portfolio p
         LEFT JOIN (
@@ -403,22 +418,27 @@ def _get_account_values(exchange_rate: float | None) -> list[dict]:
             WHERE (ticker, date) IN (SELECT ticker, MAX(date) FROM prices GROUP BY ticker)
         ) pr ON p.ticker = pr.ticker
     """)
-    from nuri.core.ticker_names import is_kr_ticker
 
     totals: dict[str, float] = {}
+    unknown: set[str] = set()
     for r in rows:
         acc = r["account"]
         price = r["latest_price"] or 0
         qty = r["quantity"] or 0
-        is_kr = is_kr_ticker(r["ticker"])
-        val = price * qty / rate if is_kr else price * qty
-        totals[acc] = totals.get(acc, 0) + val
+        totals.setdefault(acc, 0.0)
+        if is_krw_holding(r["ticker"], r["currency"]):
+            if exchange_rate is None:
+                # 이 계좌는 원화 자산을 담고 있는데 환율이 없다 → 합계 미상.
+                unknown.add(acc)
+                continue
+            totals[acc] += price * qty / exchange_rate
+        else:
+            totals[acc] += price * qty
 
-    account_labels = _get_account_labels()
-    return [
-        {"account": account_labels.get(acc, acc), "value": round(v, 2)}
-        for acc, v in sorted(totals.items(), key=lambda x: -x[1])
-    ]
+    labels = _get_account_labels()
+    # 미상 계좌를 정렬 뒤로 보낸다 — `None` 은 비교 불가라 키를 나눠야 한다.
+    ordered = sorted(totals.items(), key=lambda x: (x[0] in unknown, -x[1]))
+    return [{"account": labels.get(acc, acc), "value": None if acc in unknown else round(v, 2)} for acc, v in ordered]
 
 
 def _get_cash_balances(exchange_rate: float | None = None) -> dict:
@@ -449,42 +469,58 @@ def _get_cash_balances(exchange_rate: float | None = None) -> dict:
         logger.debug("portfolio.yaml cash read failed: %s", e)
         return {"accounts": [], "total_cash_usd": 0.0}
 
-    rate = exchange_rate or 1400.0
     labels = _get_account_labels()
     accounts_out: list[dict] = []
     total_usd = 0.0
+    any_unknown = False
 
     for raw_acc, info in (portfolio.get("accounts") or {}).items():
         if not isinstance(info, dict):
             continue
         cash_usd = float(info.get("cash_usd") or 0)
         cash_krw = float(info.get("cash_krw") or 0)
-        acc_total = cash_usd + (cash_krw / rate if rate > 0 else 0)
-        if acc_total <= 0:
+        # 원화 현금이 있는데 환율이 없으면 그 계좌의 USD 합계는 미상이다 (#1284).
+        # `cash_krw == 0` 이면 환산이 필요 없으므로 예전과 같은 숫자가 나온다.
+        unknown = cash_krw > 0 and exchange_rate is None
+        acc_total = None if unknown else cash_usd + (cash_krw / exchange_rate if cash_krw else 0.0)
+        # 미상 계좌는 금액을 못 세지만 **존재는 숨기지 않는다** — 빈 줄이 0원보다 정직하다.
+        if not unknown and not acc_total:
             continue
         accounts_out.append(
             {
                 "account": labels.get(raw_acc, raw_acc),
                 "cash_usd": round(cash_usd, 2),
                 "cash_krw": round(cash_krw, 2),
-                "total_usd": round(acc_total, 2),
+                "total_usd": None if unknown else round(acc_total or 0.0, 2),
             }
         )
-        total_usd += acc_total
+        if unknown:
+            any_unknown = True
+        else:
+            total_usd += acc_total or 0.0
 
-    return {"accounts": accounts_out, "total_cash_usd": round(total_usd, 2)}
+    # 한 계좌라도 미상이면 **총합도 미상**이다. 미상을 0 으로 접고 더하면 조용히 과소집계된다.
+    return {
+        "accounts": accounts_out,
+        "total_cash_usd": None if any_unknown else round(total_usd, 2),
+    }
 
 
-def _compute_actual_allocation(account_values: list[dict], cash_total_usd: float) -> dict:
+def _compute_actual_allocation(account_values: list[dict], cash_total_usd: float | None) -> dict | None:
     """실제 포트폴리오 구성 비율 — holdings vs cash (USD 기준, #213).
 
     `_get_allocation()`은 regime이 권장하는 **target** 비율을 반환하는 반면
     이 함수는 현재 portfolio의 **actual** 구성 비율을 계산한다.
 
     Returns:
-        {"long": 46, "short": 0, "cash": 54}  — 백분율, 합 100
+        {"long": 46, "short": 0, "cash": 54}  — 백분율, 합 100.
+        입력 중 하나라도 환산 불가(`None`)면 **`None`** — 배분은 분모를 알아야 낼 수 있다 (#1284).
     """
-    holdings_usd = sum(av.get("value", 0) for av in account_values)
+    # #1284: 미상(`None`)을 0 으로 접으면 **비중이 조용히 왜곡된다** — 없는 돈이 아니라
+    # 모르는 돈이다. 하나라도 미상이면 배분 자체를 내지 않는다 (#1279 와 같은 함정).
+    if any(av.get("value") is None for av in account_values) or cash_total_usd is None:
+        return None
+    holdings_usd = sum(av.get("value") or 0 for av in account_values)
     total = holdings_usd + cash_total_usd
     if total <= 0:
         return {"long": 0, "short": 0, "cash": 100}

--- a/nuri/api/routes/dashboard.py
+++ b/nuri/api/routes/dashboard.py
@@ -482,7 +482,13 @@ def _get_cash_balances(exchange_rate: float | None = None) -> dict:
         # 원화 현금이 있는데 환율이 없으면 그 계좌의 USD 합계는 미상이다 (#1284).
         # `cash_krw == 0` 이면 환산이 필요 없으므로 예전과 같은 숫자가 나온다.
         unknown = cash_krw > 0 and exchange_rate is None
-        acc_total = None if unknown else cash_usd + (cash_krw / exchange_rate if cash_krw else 0.0)
+        # 분기로 쓰는 이유는 actions.py 와 같다 — `exchange_rate` 를 실제로 좁힌다.
+        if unknown:
+            acc_total = None
+        elif cash_krw and exchange_rate is not None:
+            acc_total = cash_usd + cash_krw / exchange_rate
+        else:
+            acc_total = cash_usd
         # 미상 계좌는 금액을 못 세지만 **존재는 숨기지 않는다** — 빈 줄이 0원보다 정직하다.
         if not unknown and not acc_total:
             continue

--- a/nuri/core/fx.py
+++ b/nuri/core/fx.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 
 from nuri.core.db import DatabaseError, OperationalError, query
+from nuri.core.ticker_names import is_kr_ticker
 from nuri.core.timezone import today_kst
 
 logger = logging.getLogger(__name__)
@@ -85,3 +86,41 @@ def latest_usd_krw_value(db_path=None) -> float | None:
     """`latest_usd_krw` 의 값만 필요한 호출자를 위한 얇은 래퍼."""
     got = latest_usd_krw(db_path=db_path)
     return got[0] if got else None
+
+
+#: 환산 불가 사유 — 사람이 읽는 문장. 조용한 빈칸은 결함처럼 보이므로 **이유를 같이** 낸다.
+FX_UNAVAILABLE_REASON = (
+    "USD/KRW 미수집 — 원화 자산이 있어 통화 혼합 합계를 낼 수 없습니다 (`make collect` 으로 환율 갱신)"
+)
+
+
+def is_krw_holding(ticker, currency) -> bool:
+    """이 보유가 원화 표시인가. **레포 정본 술어** (#1283 codex P1).
+
+    `currency == "KRW"` 이거나 `.KS`/`.KQ`. 접미사만 보면 `currency="KRW"` 인 무접미
+    보유가 "달러 자산" 으로 오분류된다. 같은 식이 `analysis/portfolio.py` ·
+    `analysis/sector.py` · `alerts/risk_signals.py` 에 인라인으로 흩어져 있고, 그 통합은
+    #1286 이 다룬다 — 여기서는 새 사본을 만들지 않으려고 이 함수를 쓴다.
+    """
+    return currency == "KRW" or is_kr_ticker(str(ticker))
+
+
+def cross_currency_unavailable(rate: float | None, has_krw_exposure: bool) -> str | None:
+    """통화 혼합 합계를 낼 수 있나. 낼 수 있으면 `None`, 없으면 사유 문자열.
+
+    ## 왜 이 판단이 한 곳에 있어야 하나
+
+    환율이 없을 때 무엇이 불가능해지는지는 **분모** 하나로 정해진다. 총 자산·계좌별
+    평가액·비중%·자산배분은 전부 "원화 자산과 달러 자산을 더한 값" 을 분모로 쓰므로,
+    원화 보유가 하나라도 있으면 **그 합계 전체가 미상**이 된다 — KR 종목만 미상인 게
+    아니다. 비중의 분모가 미상이면 US 종목의 비중도 말할 수 없다.
+
+    반대로 **환산이 필요 없는 것은 그대로 정확하다**: 종목별 현재가·수량, 한 통화 안에서
+    계산되는 손익률, 그리고 원화 자산이 전혀 없는 포트폴리오의 모든 합계.
+
+    이 구분을 소비자마다 다시 유도하면 갈린다 — 실제로 #1283 이 고친 4곳이 서로 다른
+    상수(1400 / 1450)를 쓰고 있었다.
+    """
+    if rate is not None or not has_krw_exposure:
+        return None
+    return FX_UNAVAILABLE_REASON

--- a/tests/alerts/test_premarket_brief.py
+++ b/tests/alerts/test_premarket_brief.py
@@ -916,6 +916,53 @@ class TestPremarketBriefStatementCoverage:
         assert ctx["portfolio_totals"] is not None
         assert ctx["portfolio_totals"]["total_usd"] > 0
 
+    def test_short_ticker_line_survives_unknown_position_pct(self):
+        """환율 미수집이면 `position_pct` 가 None 이다 (#1284).
+
+        `.get(key, 0)` 은 **키가 존재하면** 기본값을 주지 않으므로 None 이 그대로
+        `:.1f` 에 들어가 TypeError 가 났다. 그 예외는 상위 try 가 삼켜서 브리프가
+        조용히 반쪽이 된다 — 크래시보다 나쁘다.
+
+        Mutation lock: `pos_txt` 분기를 지우고 `{pos:.1f}%` 로 되돌리면 FAIL.
+        """
+        from nuri.alerts.premarket_brief import _short_ticker_line
+
+        line = _short_ticker_line(
+            {
+                "ticker": "ZZZZ",
+                "action": "HOLD",
+                "confidence": 70,
+                "pnl_pct": 1.0,
+                "position_pct": None,
+            }
+        )
+        assert "미상" in line, f"비중 미상을 표시하지 않는다: {line}"
+        assert "None" not in line
+
+    def test_short_ticker_line_sorts_accounts_with_unknown_weights(self):
+        """정렬 키에 None 이 섞이면 파이썬은 float 과 비교하지 못해 TypeError 다.
+
+        Mutation lock: 정렬 키를 `a.get("position_pct", 0)` 로 되돌리면 FAIL.
+        """
+        from nuri.alerts.premarket_brief import _short_ticker_line
+
+        line = _short_ticker_line(
+            {
+                "ticker": "ZZZZ",
+                "action": "HOLD",
+                "confidence": 70,
+                "pnl_pct": 1.0,
+                "position_pct": None,
+                "accounts": [
+                    {"account": "Brokerage Alpha", "position_pct": None, "pnl_pct": 2.0},
+                    {"account": "Brokerage Beta", "position_pct": 8.0, "pnl_pct": 4.0},
+                ],
+            }
+        )
+        # 미상은 맨 뒤 — 알 수 있는 계좌가 먼저 읽힌다.
+        assert line.index("Brokerage Beta") < line.index("Brokerage Alpha")
+        assert "미상" in line
+
     def test_short_ticker_line_multi_account_breakdown(self):
         """L283-288: multi-account 시 breakdown line 추가."""
         from nuri.alerts.premarket_brief import _short_ticker_line

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -59,10 +59,19 @@ class TestDashboardAPI:
         assert isinstance(result["account_labels"], dict)
 
     def test_dashboard_exposes_actual_allocation_and_cash(self, db_path):
-        """#213: dashboard 응답이 actual_allocation + cash_summary + target_allocation을 노출."""
+        """#213: dashboard 응답이 actual_allocation + cash_summary + target_allocation을 노출.
+
+        #1284: 환율 행을 **직접 시드**한다. `_get_cash_balances` 는 DB 가 아니라 실제
+        `config/portfolio.yaml` 을 읽는데, 그 파일은 gitignored 라 로컬에는 원화 현금이
+        있고 CI 에는 파일 자체가 없다. 환율이 없으면 원화 현금이 있는 쪽만 합계가 미상이
+        되므로, 시드하지 않으면 **로컬 red / CI green** 으로 갈린다.
+        """
         from nuri.api.routes.dashboard import _build_dashboard
 
+        upsert_macro([{"indicator": "usd_krw", "date": "2026-08-29", "value": 1380.0, "source": "test"}])
+
         result = _build_dashboard()
+        assert result["fx_unavailable"] is None, "환율을 시드했는데 환산 불가로 판정했다"
         assert "actual_allocation" in result
         assert "target_allocation" in result
         assert "cash_summary" in result
@@ -1040,25 +1049,48 @@ class TestAccountValues:
         # 70000 * 100 / 1400 = 5000.0
         assert result[0]["value"] == 5000.0
 
-    def test_exchange_rate_none_uses_fallback(self, db_path, monkeypatch):
-        """exchange_rate=None falls back to 1400."""
+    def test_exchange_rate_none_makes_krw_account_unknown(self, db_path, monkeypatch):
+        """환율이 없으면 원화 계좌의 평가액은 **미상**이다 (#1284).
+
+        예전 이름은 `test_exchange_rate_none_uses_fallback` 이었고, 지어낸 1400 으로
+        환산한 5000.0 을 잠그고 있었다 — 제거 대상 동작을 테스트가 지키던 자리다.
+        """
         import nuri.api.routes.dashboard as dash_mod
 
-        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"kr_acc": "Pension"})
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"kr_acc": "Brokerage Alpha"})
+
+        # 합성 종목 — 실제 보유와 무관 (public repo, `tests/CLAUDE.md` privacy).
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
+                ("kr_acc", "999999.KS", 100, 70000, "KRW", "Tech"),
+            )
+            conn.execute(
+                "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+                ("999999.KS", "2025-04-01", 69000, 71000, 68000, 70000, 5000000, 70000),
+            )
+        result = dash_mod._get_account_values(exchange_rate=None)
+        assert len(result) == 1
+        assert result[0]["value"] is None, "지어낸 환율로 원화 계좌를 환산했다"
+
+    def test_exchange_rate_none_leaves_usd_account_exact(self, db_path, monkeypatch):
+        """대조군 — 환율이 없어도 **달러 전용 계좌는 정확하다**. 일괄 None 은 과잉이다."""
+        import nuri.api.routes.dashboard as dash_mod
+
+        monkeypatch.setattr(dash_mod, "_get_account_labels", lambda: {"us_acc": "Brokerage Beta"})
 
         with get_db(db_path) as conn:
             conn.execute(
                 "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency, sector) VALUES (?,?,?,?,?,?)",
-                ("kr_acc", "005930.KS", 100, 70000, "KRW", "Tech"),
+                ("us_acc", "ZZZZ", 10, 100.0, "USD", "Tech"),
             )
             conn.execute(
                 "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
-                ("005930.KS", "2025-04-01", 69000, 71000, 68000, 70000, 5000000, 70000),
+                ("ZZZZ", "2025-04-01", 100, 100, 100, 200.0, 1000, 200.0),
             )
         result = dash_mod._get_account_values(exchange_rate=None)
         assert len(result) == 1
-        # 70000 * 100 / 1400 = 5000.0
-        assert result[0]["value"] == 5000.0
+        assert result[0]["value"] == 2000.0, "환율과 무관한 달러 계좌까지 미상으로 지웠다"
 
     def test_mixed_accounts_sorted_descending(self, db_path, monkeypatch):
         """Multiple accounts are sorted by value descending."""

--- a/tests/api/test_fx_unavailable.py
+++ b/tests/api/test_fx_unavailable.py
@@ -1,0 +1,212 @@
+"""환율이 없을 때 API 가 **통화 혼합 합계를 지어내지 않는다** (#1284).
+
+## 무엇이 잘못됐었나
+
+#1283 이 Python 4곳의 `or 1400` 을 걷었지만, 응답 형태가 바뀌는 4곳은 프론트와 같이
+움직여야 해서 남겨 뒀다 — `actions.py` 비중%, `dashboard.py` 의 계좌 평가액·현금 합계,
+그리고 `page.tsx` 의 `d.exchange_rate || 1400`. 마지막 것이 특히 나빴다: 백엔드가
+`exchange_rate: null` 로 부재를 **정직하게** 알려주는데 프론트가 그 신호를 버리고
+헤드라인 총액을 지어냈다.
+
+## 핵심 규칙 — 분모가 미상이면 비율도 미상이다
+
+총 자산·계좌별 평가액·비중%·자산배분은 전부 "원화 자산 + 달러 자산" 을 분모로 쓴다.
+원화 보유가 하나라도 있고 환율이 없으면 **그 합계 전체가 미상**이고, 따라서 달러
+종목의 비중조차 말할 수 없다. 부분합을 분모로 쓰면 남은 종목 비중이 조용히 부풀려진다.
+
+반대로 **환산이 필요 없는 것은 그대로 정확하다** — 달러 전용 계좌, 원화 현금이 없는
+계좌, 원화 보유가 전혀 없는 포트폴리오. 그래서 아래 테스트마다 대조군이 붙는다.
+"""
+
+import pytest
+
+from nuri.core.db import get_db, upsert_macro
+
+# 합성 종목 — 실제 보유와 무관하다 (public repo, `tests/CLAUDE.md` privacy).
+KR_TICKER = "999999.KS"
+KQ_TICKER = "888888.KQ"
+KR_BY_CURRENCY = "YYYY"
+US_TICKER = "ZZZZ"
+
+
+def _seed(db_path, ticker, qty, price, currency, account="acct_a"):
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency) VALUES (?,?,?,?,?)",
+            (account, ticker, qty, price, currency),
+        )
+        conn.execute(
+            "INSERT INTO prices (ticker, date, open, high, low, close, volume, adj_close) VALUES (?,?,?,?,?,?,?,?)",
+            (ticker, "2026-08-29", price, price, price, price, 1000, price),
+        )
+
+
+def _rate(value=1380.0):
+    upsert_macro([{"indicator": "usd_krw", "date": "2026-08-29", "value": value, "source": "test"}])
+
+
+class TestFxAvailabilityRule:
+    """`cross_currency_unavailable` — 규칙이 한 곳에 있어야 소비자마다 갈리지 않는다."""
+
+    def test_rate_present_is_always_available(self):
+        from nuri.core.fx import cross_currency_unavailable
+
+        assert cross_currency_unavailable(1380.0, True) is None
+        assert cross_currency_unavailable(1380.0, False) is None
+
+    def test_no_rate_without_krw_exposure_is_fine(self):
+        """대조군 — 원화 자산이 없으면 환율은 애초에 필요 없다."""
+        from nuri.core.fx import cross_currency_unavailable
+
+        assert cross_currency_unavailable(None, False) is None
+
+    def test_no_rate_with_krw_exposure_is_unavailable(self):
+        from nuri.core.fx import cross_currency_unavailable
+
+        reason = cross_currency_unavailable(None, True)
+        assert reason and "USD/KRW" in reason, "사유 없이 미상만 내면 결함처럼 보인다"
+
+    @pytest.mark.parametrize(
+        ("ticker", "currency", "expected"),
+        [
+            (KR_TICKER, "KRW", True),
+            (KQ_TICKER, "KRW", True),
+            (KR_BY_CURRENCY, "KRW", True),  # 접미사 없이 통화만 KRW
+            (KR_TICKER, "USD", True),  # 통화가 틀려도 접미사가 KR
+            (US_TICKER, "USD", False),
+        ],
+    )
+    def test_krw_holding_predicate(self, ticker, currency, expected):
+        """정본 술어 — 접미사 **또는** 통화. 한쪽만 보면 절반을 놓친다 (#1283 codex P1)."""
+        from nuri.core.fx import is_krw_holding
+
+        assert is_krw_holding(ticker, currency) is expected
+
+
+class TestDashboardAccountValues:
+    def test_krw_account_is_unknown_without_a_rate(self, db_path, monkeypatch):
+        """Mutation lock: `or 1400` 을 되살리면 숫자가 나와 FAIL."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "_get_account_labels", lambda: {"acct_a": "Brokerage Alpha"})
+        _seed(db_path, KR_TICKER, 10, 100_000.0, "KRW")
+        result = dash._get_account_values(exchange_rate=None)
+        assert result[0]["value"] is None
+
+    def test_usd_account_stays_exact_without_a_rate(self, db_path, monkeypatch):
+        """대조군 — 환산이 필요 없는 계좌까지 지우면 알 수 있는 것을 버리는 것이다."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "_get_account_labels", lambda: {"acct_b": "Brokerage Beta"})
+        _seed(db_path, US_TICKER, 10, 250.0, "USD", account="acct_b")
+        result = dash._get_account_values(exchange_rate=None)
+        assert result[0]["value"] == 2500.0
+
+    def test_currency_only_krw_is_also_unknown(self, db_path, monkeypatch):
+        """접미사가 없어도 통화가 KRW 면 환산 대상이다 (#1283 codex P1 과 같은 축)."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "_get_account_labels", lambda: {"acct_a": "Brokerage Alpha"})
+        _seed(db_path, KR_BY_CURRENCY, 10, 100_000.0, "KRW")
+        result = dash._get_account_values(exchange_rate=None)
+        assert result[0]["value"] is None, "통화만 KRW 인 보유를 달러로 오분류했다"
+
+    def test_rate_present_computes_as_before(self, db_path, monkeypatch):
+        """대조군 — 환율이 있으면 예전과 같은 숫자."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "_get_account_labels", lambda: {"acct_a": "Brokerage Alpha"})
+        _seed(db_path, KR_TICKER, 10, 138_000.0, "KRW")
+        result = dash._get_account_values(exchange_rate=1380.0)
+        assert result[0]["value"] == 1000.0
+
+
+class TestAllocationRefusesUnknownInputs:
+    def test_unknown_account_value_blocks_allocation(self):
+        """Mutation lock: `None` 을 0 으로 접으면 배분이 나와 FAIL."""
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+
+        assert _compute_actual_allocation([{"value": None}], 5000) is None
+
+    def test_unknown_cash_blocks_allocation(self):
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+
+        assert _compute_actual_allocation([{"value": 10000}], None) is None
+
+    def test_known_inputs_still_compute(self):
+        """대조군 — 전부 알면 예전과 같다."""
+        from nuri.api.routes.dashboard import _compute_actual_allocation
+
+        assert _compute_actual_allocation([{"value": 10000}], 0) == {
+            "long": 100,
+            "short": 0,
+            "cash": 0,
+        }
+
+
+class TestDashboardSurfacesTheReason:
+    def test_reason_is_present_when_conversion_is_blocked(self, db_path, monkeypatch):
+        """`exchange_rate: null` 만으로는 부족하다 — 프론트가 그 신호를 버렸다."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "_get_account_labels", lambda: {"acct_a": "Brokerage Alpha"})
+        _seed(db_path, KR_TICKER, 10, 100_000.0, "KRW")
+        result = dash._build_dashboard()
+        assert result["exchange_rate"] is None
+        assert result["fx_unavailable"], "값을 못 냈는데 이유를 말하지 않는다"
+        assert result["actual_allocation"] is None
+
+    def test_no_reason_when_rate_is_present(self, db_path, monkeypatch):
+        """대조군 — 정상일 때 사유가 뜨면 그 사유는 곧 무시된다 (false-red)."""
+        import nuri.api.routes.dashboard as dash
+
+        monkeypatch.setattr(dash, "_get_account_labels", lambda: {"acct_a": "Brokerage Alpha"})
+        _rate()
+        _seed(db_path, KR_TICKER, 10, 138_000.0, "KRW")
+        result = dash._build_dashboard()
+        assert result["fx_unavailable"] is None
+
+
+class TestActionWeightsShareOneDenominator:
+    """비중%의 분모는 **포트폴리오 전체**라, 원화 하나가 미상이면 전부 미상이다."""
+
+    def test_us_weight_is_unknown_when_a_krw_position_cannot_convert(self, db_path, monkeypatch):
+        """가장 놓치기 쉬운 축 — 달러 종목은 정확한데 **비중은 말할 수 없다**.
+
+        Mutation lock: `weights_unavailable` 를 무시하고 부분합을 분모로 쓰면,
+        US 종목이 100% 라는 거짓 비중이 나와 FAIL.
+        """
+        import nuri.api.routes.actions as act
+
+        monkeypatch.setattr(act, "_get_real_accounts", lambda: set())
+        _seed(db_path, KR_TICKER, 10, 100_000.0, "KRW")
+        _seed(db_path, US_TICKER, 10, 250.0, "USD")
+
+        holdings = act._get_portfolio_map()
+        assert holdings[US_TICKER]["position_pct"] is None, (
+            "환율 없이 달러 종목 비중을 냈다 — 분모(전체 자산)를 모르는데 비율을 주장했다"
+        )
+        assert holdings[KR_TICKER]["position_pct"] is None
+
+    def test_us_only_portfolio_keeps_exact_weights(self, db_path, monkeypatch):
+        """대조군 — 원화가 없으면 환율과 무관하게 비중이 정확하다."""
+        import nuri.api.routes.actions as act
+
+        monkeypatch.setattr(act, "_get_real_accounts", lambda: set())
+        _seed(db_path, US_TICKER, 10, 250.0, "USD")
+        _seed(db_path, "WWWW", 10, 250.0, "USD")
+
+        holdings = act._get_portfolio_map()
+        assert holdings[US_TICKER]["position_pct"] == pytest.approx(50.0)
+
+    def test_weights_computed_when_rate_present(self, db_path, monkeypatch):
+        """대조군 — 환율이 있으면 예전과 같이 계산된다."""
+        import nuri.api.routes.actions as act
+
+        monkeypatch.setattr(act, "_get_real_accounts", lambda: set())
+        _rate()
+        _seed(db_path, KR_TICKER, 10, 138_000.0, "KRW")  # = 1000 USD
+        _seed(db_path, US_TICKER, 4, 250.0, "USD")  # = 1000 USD
+
+        holdings = act._get_portfolio_map()
+        assert holdings[US_TICKER]["position_pct"] == pytest.approx(50.0)

--- a/tests/core/test_fx_no_fabricated_fallback.py
+++ b/tests/core/test_fx_no_fabricated_fallback.py
@@ -23,9 +23,10 @@
 설계다. 그래서 각 경로마다 대조군을 짝지어 둔다.
 
 API/프론트 4곳(`actions.py` · `dashboard.py` ×2 · `page.tsx`)은 응답 형태가 바뀌어
-프론트와 같이 움직여야 하므로 **#1284** 로 분리했다. 아래 `FABRICATION_EXEMPT` 가
-그 4곳 중 Python 3곳을 사유와 함께 붙잡고 있고, #1284 가 랜딩하면 **stale 로 FAIL** 해서
-제거를 강제한다.
+프론트와 같이 움직여야 하므로 **#1284** 로 분리했었다. 그 PR 이 랜딩하면서 세 항목이
+`test_every_exemption_is_still_needed` 에서 **stale 로 FAIL** 했고, 그 빨간불이 제거를
+강제했다 — allowlist 가 양방향이어야 하는 이유가 이것이다. 남은 항목은 성격이 다른
+`korean_market.py` 하나뿐이다.
 """
 
 import ast
@@ -330,16 +331,6 @@ class TestBriefOmitsTotalsRatherThanInventingThem:
 #: 양방향 검사라 낡은 항목(이미 정리된 파일)도 FAIL 한다 — allowlist 가 조용히 커지는 걸
 #: 막는 것이 이 목록의 존재 이유다 (`test_cross_stage_imports.py` 와 같은 규율).
 FABRICATION_EXEMPT: dict[str, str] = {
-    "api/routes/actions.py": (
-        "#1284 — 비중% 산정의 `or 1400`. 응답 형태가 바뀌어(집계가 null 이 된다) "
-        "프론트(`page.tsx` · `holdings-summary.ts`)와 한 PR 에서 같이 움직여야 한다. "
-        "백엔드만 먼저 정직해지면 `_compute_actual_allocation` 의 sum 이 TypeError 로 죽는다."
-    ),
-    "api/routes/dashboard.py": (
-        "#1284 — `account_values[].value` 와 `cash_summary` 의 `or 1400` 2곳. "
-        "위와 같은 이유로 프론트와 동시에 움직여야 한다. `/api/dashboard` 는 이미 "
-        "`exchange_rate: number | null` 을 정직하게 내보내는데 프론트가 그 신호를 버린다."
-    ),
     "trading/agents/korean_market.py": (
         "**성격이 다르다 — 지어낸 값이 아니다.** `fx_weak_default` / `fx_weak_floor` / "
         "`fx_strong_ceil` 은 `config/agents.yaml` 이 정본인 **정책 임계값**의 코드 기본값이고, "


### PR DESCRIPTION
Closes #1284

## 증상 — 백엔드가 정직해도 프론트가 다시 지어냈다

#1283 이 Python 4곳의 `or 1400` 을 걷었지만, **응답 형태가 바뀌는 4곳**은 프론트와 같이 움직여야 해서 남겨 뒀습니다. 그중 `page.tsx` 가 가장 나빴습니다:

```ts
const KRW_RATE = d.exchange_rate || 1400;   // 백엔드는 null 로 부재를 알려주는데
```

`/api/dashboard` 는 **이미** `exchange_rate: number | null` 로 부재를 정직하게 내보내고 있었습니다. 프론트가 그 신호를 버리고 숫자를 지어냈고, 그 값이 `holdingsValue → totalValue` 를 타고 **화면에서 가장 큰 글자(총 자산)** 까지 갔습니다.

## 규칙은 네 개가 아니라 하나 — 분모가 문제다

총 자산·계좌별 평가액·비중%·자산배분은 전부 이 꼴의 분모를 씁니다:

```
total = Σ(달러 자산) + Σ(원화 자산) / rate
```

그래서 **환산 불가한 원화 보유가 하나라도 있으면 합계 전체가 미상**이고, 따라서 가격이 완벽히 알려진 **달러 종목의 비중조차 말할 수 없습니다.** 부분합을 분모로 쓰면 남은 종목 비중이 조용히 부풀려집니다 (US 종목 하나가 100% 로 보이는 식).

반대로 **환산이 필요 없는 것은 그대로 정확합니다** — 달러 전용 계좌, 원화 현금이 없는 계좌, 원화가 전혀 없는 포트폴리오. 그래서 테스트마다 대조군이 붙습니다. "환율 없으면 전부 null" 은 알 수 있는 것까지 버리는 과잉이고, 그렇게 하면 **전부 None 을 반환하는 가짜 수정**과 구분되지 않습니다.

이 판단을 `nuri/core/fx.py` 의 `cross_currency_unavailable()` 한 곳에 뒀습니다. 소비자마다 다시 유도하면 갈립니다 — #1283 이 고친 4곳이 **서로 다른 상수(1400 / 1450)** 를 쓰고 있었던 게 정확히 그 결과입니다.

## 값이 아니라 **사유**를 함께 낸다

`exchange_rate: null` 만으로는 부족했습니다 (프론트가 실제로 그 신호를 버렸습니다). 응답에 `fx_unavailable` 사유 문자열을 추가했고, 히어로가 "—" 옆에 그 문장을 렌더합니다. 조용한 빈칸은 결함처럼 보입니다. 기존 `verdict_stale_inputs` 규약과 같은 형태입니다.

## 0 은 주장이고 null 은 사실이다

미상을 0 으로 접는 자리를 전부 걷었습니다. `market-strip` 의 `?? { long: 0, cash: 100 }` 센티널이 같은 결함의 다른 옷이었습니다 — 환율이 없을 때 화면이 **"전액 현금"** 이라고 주장하게 됩니다.

`holding-row` 는 **로직 변경이 필요 없었습니다**: `usdKrwRate ?? 0` 이 이미 `> 0` 가드에 걸려 `positionPct: null` 을 냅니다. 분모를 모르면 비중도 모른다 — 원래 맞게 짜여 있었습니다.

## #1283 의 allowlist 가 이 PR 을 강제했다

`test_every_exemption_is_still_needed` 가 두 항목을 **stale 로 FAIL** 시켰습니다:

```
AssertionError: 낡은 예외 항목(이미 정리됨): ['api/routes/actions.py', 'api/routes/dashboard.py']
```

양방향 allowlist 를 둔 이유가 이것입니다 — 예외가 조용히 남지 않고, 정리하지 않으면 빨간불이 됩니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후, 10축)

| 뮤테이션 | 결과 |
|---|---|
| dashboard 계좌 평가액 `or 1400` 복원 | **4 FAIL** |
| 현금 합계 미상을 0 으로 접음 | **15 FAIL** |
| 배분이 미상 입력을 그냥 계산 | **17 FAIL** |
| 환산 불가 사유를 안 냄 (null 만 냄) | **17 FAIL** |
| 비중 분모를 부분합으로 (`weights_unavailable` 무시) | **1 FAIL** |
| 정본 술어를 접미사 단독으로 (통화 무시) | **2 FAIL** |
| 환율 있어도 환산 불가라고 판정 (false-red 대조군) | **1 FAIL** |
| 프론트 `\|\| 1400` 복원 | **1 FAIL** |
| 미상 계좌를 0 으로 접어 합산 | **2 FAIL** |
| 히어로가 미상을 `$0` 으로 표시 | **1 FAIL** |
| baseline | py 126 passed · fe 48 passed |

### 뮤테이션이 제 테스트의 **false lock** 을 잡았습니다

프론트 2축이 처음에 **안 잠겼습니다.**

1. **히어로 단언이 엉뚱한 요소로 통과하고 있었습니다.** `hero-total` 컨테이너에 `toContain("—")` 를 걸었는데, 사유 문자열(`USD/KRW 미수집 — …`)에 em dash 가 들어 있어 **값이 `$0` 이어도 통과**했습니다. 값 요소에 `data-testid` 를 주고 `toBe("—")` 로 좁혔습니다.
2. **계좌 합산 로직이 `page.tsx` 인라인이라 테스트가 닿지 않았습니다.** null→0 fold 를 넣어도 관측 가능한 변화가 없었습니다. `mergeAccountTotals` 로 빼서 직접 잠갔습니다 — 보유 평가액이 미상이고 현금이 500 인 계좌는 **500 이 아니라 미상**이어야 합니다 (500 은 "이 계좌엔 현금뿐" 이라는 거짓입니다).

두 번째 실행에서 **치환 0건**으로 측정이 중단됐습니다 — 헬퍼를 옮기면서 뮤테이션 타깃이 낡았습니다. 건수 assert 가 없었으면 "잠김" 으로 오판했을 자리입니다.

## 잘못된 mock 형태가 결함을 잠그고 있었습니다

`mockDashboardData` 에 `exchange_rate` 키가 **아예 없었습니다.** 실 API 는 항상 냅니다. 그래서 `undefined → || 1400` 폴백을 타고, 6개 테스트의 기대치($8,850 등)가 **지어낸 값 위에서** 계산돼 있었습니다. mock 을 실 응답 형태에 맞췄더니 같은 기대치가 이제 **진짜 환율(1400)** 로 성립합니다. `tests/CLAUDE.md` "Mock Shape Locks Bugs" 그대로입니다.

폴백을 잠그던 테스트 1건은 이름과 단언을 뒤집었습니다: `uses fallback exchange rate 1400 when exchange_rate is null` → `shows an em dash and the reason when exchange_rate is null`, 그리고 대조군 `keeps a USD-only total exact when exchange_rate is null` 을 추가했습니다.

## 검증

- `make test-fast` → **7,719 passed / 6 skipped** (rc=0)
- `npm run test` → **1,647 passed / 137 files** (rc=0)
- `npx tsc --noEmit` clean · `ruff check` clean
- `check_privacy_leak.py` (인자 없이 = CI diff 스캔) rc=0
- `make verify-doc-counts` **22/22** (`sync_doc_counts.sh` 재계산)

## 남은 것

환산 루프의 KR 판별이 아직 접미사 단독인 곳이 있습니다(`analysis/portfolio.py` 등 4곳의 인라인 사본). 그건 환율 fabrication 이 아니라 **통화 환산 결함**이라 **#1286** 으로 분리돼 있습니다. 이 PR 은 `is_krw_holding()` 을 도입해 **새 사본을 만들지 않는** 선까지만 갑니다.

---

## codex 리뷰 — [P1] 2건 + [P2] 1건, 전부 반영

제가 리뷰에 직접 물은 질문이 **"소비자를 빠뜨렸나?"** 였고, 답이 "그렇다, 둘" 이었습니다. 둘 다 코드로 확인했습니다.

### [P1] `action-items.tsx` 가 `position_pct` 를 number 로 믿고 `.toFixed()` — 수용

> That will crash the dashboard as soon as a KRW position makes weights unknown.

**맞습니다.** 생산자(`/api/actions`)는 이미 nullable 인데 소비자 타입이 `number` 였고, 두 곳에서 무조건 `.toFixed(1)` 을 부릅니다. 원화 보유가 있는 상태로 환율이 빠지면 **대시보드가 그 자리에서 죽습니다.**

가장 뼈아픈 지점: **바로 위 `pnl_pct` 는 이미 같은 처리가 돼 있습니다** (#1279 에서 고친 것). 한 칸 옆에 같은 결함을 두고 지나갔습니다.

### [P1] `premarket_brief._short_ticker_line` — 수용

> `.get("position_pct", 0)` ... so the scheduled brief can either crash or silently coerce the narrative wrong

**맞고, 이쪽이 더 나쁩니다.** `dict.get(key, 0)` 은 **키가 존재하면 기본값을 주지 않습니다** — 값이 `None` 이면 `None` 이 그대로 나옵니다. 그게 `f"{pos:.1f}%"` 와 계좌 정렬 키(`None` vs `float` 비교)로 흘러갑니다.

크래시가 눈에 띄면 차라리 낫습니다. 여기서는 **상위 `try/except` 가 삼켜서** 매일 09:00 브리프가 조용히 반쪽이 됩니다 — 무인 실행 경로라 아무도 모릅니다.

정렬은 `(is_none, -value)` 키로 미상을 맨 뒤로 보내고, 값은 "미상" 으로 적습니다.

### [P2] 두 소비자 모두 테스트가 숫자 비중만 쓰고 있었다 — 수용

`ActionItems` 테스트와 `premarket_brief` 테스트 전부 `position_pct` 가 숫자인 케이스만 돌렸습니다. 그래서 위 두 결함이 **초록불 아래**에 있었습니다. 셋 다 잠갔습니다 (프론트 1 + 브리프 2, 정렬 축 포함).

### codex 가 문제 없다고 본 것

- 대시보드 쪽 null 전파 — `_compute_actual_allocation` / `market-strip` / `hero-stats` / `composition-section` 전부 안전하게 degrade
- `holdings-summary.ts` 의 `totalPortfolioUsd ?? 0` 주석 — 직접 검증하고 *"if `totalValue` is `null` ... every `positionPct` becomes `null`, not a fabricated number"* 로 확인
- 4곳의 KRW 술어가 각 함수의 환산 루프와 일치
- **비중 임계 비교가 조용히 건너뛰는 경로는 없음** — 집중도 판정은 렌더 payload 가 아니라 SIEGE/certify 에서 온다 (제가 가장 걱정한 안전 회귀 축인데, 없다고 확인됐습니다)

## 재검증 (반영 후)

- `make test-fast` → **7,688 passed / 6 skipped** (rc=0)
- `npm run test` → **1,648 passed** (rc=0) · `npx tsc --noEmit` clean
- `ruff check` clean · `check_privacy_leak.py` rc=0 · `make verify-doc-counts` **22/22**
- pre-push 훅이 제 변경 줄에서 pyright 2건을 잡아 분기 재구성으로 해소 (캐스트 아님)
