### PR TITLE
docs(readme): redraw the diagrams and correct what the prose got wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,86 +45,130 @@ In production the API binds `127.0.0.1`, not `0.0.0.0`. The Next.js proxy is the
 
 The point of the project is that a recommendation is auditable, not that it is right. Two constraints follow, and both are enforced rather than aspirational:
 
-- **It recommends; it never trades.** A broker adapter with a working `submit_order` does exist (`nuri/trading/execution/broker.py`), but **nothing calls it** — its only callers are its own tests, and it defaults to Alpaca's paper endpoint. The pipeline terminates at a recommendation and an alert; the operator places every order by hand. Wiring execution back in requires a `docs/STRATEGY.md` amendment, not a code change alone (§7.1).
+- **It recommends; it never trades.** A broker adapter with a working `submit_order` does exist (`nuri/trading/execution/broker.py`), and **no pipeline code path calls it.** Being exact, because this is a safety claim: besides its tests, the module's own `main()` will place a one-share test order if you run it by hand with `--live`; without that flag it uses Alpaca's paper endpoint. Nothing scheduled, and nothing in the decision path, reaches it. The pipeline terminates at a recommendation and an alert; the operator places every order by hand. Wiring execution back in requires a `docs/STRATEGY.md` amendment, not a code change alone (§7.1).
 - **No edge is claimed.** `GET /api/alpha` returns `edge_status: "NOT_MEASURABLE"` unconditionally, and it will keep doing so until a pre-registered test passes. The criteria were fixed on 2026-07-08 and cannot be amended before the evaluation date: **a minimum of 200 US BUY decisions, benchmark SPY, ticker-block permutation p below 0.05, evaluated 2027-06-30** (§3.11). Until then, capital following system recommendations is capped inside an experiment sleeve, and the tracking numbers on the dashboard are labeled tracking-completeness, not performance.
 
 If you are looking for a backtested strategy with a published Sharpe ratio, this is not that. It is the measurement apparatus you would need before you could honestly publish one.
 
 ### How it works
 
+Start with what the system is for. It scores **the holdings you already own**, once a day, and records why. It does not screen the market for new names, and it does not place orders.
+
 ```mermaid
-flowchart TB
-    SCHED["APScheduler · 57 cron jobs · in-process<br/>the receiver is the sole writer"]:::driver
-    CFG[/"config/*.yaml<br/>policies"/]:::source
+flowchart LR
+    IN["Your holdings<br/>+ public market data"]
+    RUN["Daily, on a schedule:<br/>score every holding, record why"]
+    DEC["A dated BUY / SELL / HOLD<br/>per holding, with its evidence"]
+    YOU(["You place the order —<br/>the system never does"])
+    LED[("The same decision, scored later<br/>against what actually happened")]
 
-    subgraph Collect["Collect — 26 jobs"]
-        COL(["27 data collectors"]):::pipe
-    end
-    subgraph Decide["Decide — 1 job, 07:05 KST"]
-        CON(["Consensus<br/>10-agent weighted vote"]):::pipe
-        CER(["Record decision<br/>3-D certification gates"]):::pipe
-        CON ==>|in-memory hand-off| CER
-    end
-    subgraph Track["Track — 4 jobs, 07:00-17:00"]
-        TRK(["30 / 60 / 90 d outcomes<br/>agent accuracy"]):::pipe
-    end
-    subgraph Analyze["Analyze — no scheduled job, computed on read"]
-        ANA(["22 signals · 10 regimes · 4-factor composite"]):::lazy
-    end
+    IN --> RUN --> DEC --> YOU
+    DEC --> LED
+    LED -- "agent weights for the next run" --> RUN
 
-    DB[("SQLite WAL · 58 tables<br/>audit · evidence · pipeline events")]:::sink
-
-    SCHED --> Collect
-    SCHED --> Decide
-    SCHED --> Track
-    CFG -. thresholds .-> Decide
-
-    COL --> DB
-    DB --> CON
-    CER --> DB
-    DB --> TRK
-    TRK --> DB
-    DB -. "outcome_30d re-reads weights each call (±30%)" .-> CON
-
-    DB --> ANA
-    ANA --> READ
-    DB --> BRIEF
-
-    BRIEF["Discord outbox → single dispatcher<br/>#brief · #ops · #incidents"]:::out
-    READ["FastAPI 127.0.0.1:8001 → Next.js :3000<br/>read-only, password-gated"]:::out
-    USER(["Operator places every order by hand"]):::user
-
-    BRIEF --> USER
-    READ --> USER
-
-    classDef driver fill:#3f2d56,stroke:#a78bfa,color:#ede9fe
-    classDef source fill:#1e293b,stroke:#64748b,color:#e2e8f0
-    classDef pipe   fill:#0f3057,stroke:#3b82f6,color:#dbeafe
-    classDef lazy   fill:#1e293b,stroke:#3b82f6,color:#dbeafe,stroke-dasharray: 4 3
-    classDef sink   fill:#0f172a,stroke:#334155,color:#cbd5e1
-    classDef out    fill:#134e4a,stroke:#2dd4bf,color:#ccfbf1
-    classDef user   fill:#422006,stroke:#f59e0b,color:#fef3c7
+    classDef step  stroke:#3b82f6,stroke-width:2px
+    classDef store stroke:#64748b,stroke-width:2px
+    classDef human stroke:#f59e0b,stroke-width:2px
+    class IN,RUN,DEC step
+    class LED store
+    class YOU human
 ```
 
-**Nothing chains the stages.** There is no orchestrator: `nuri/scheduler.py` registers 57 independent APScheduler jobs, and a stage becomes runnable when its inputs happen to be in the database. That is what makes any stage re-runnable in isolation, and it is also why the cron order does not match the reading order — outcome tracking runs at 07:02, three minutes *before* the consensus job at 07:05 that consumes what it wrote the previous day.
+The loop at the bottom is the point of the project: a recommendation is not finished when it is made, only when reality has graded it.
+
+#### What actually runs it — no orchestrator
+
+There is no pipeline runner. `nuri/scheduler.py` registers 57 independent APScheduler jobs — **57 cron jobs · in-process**, nothing chaining them — and each becomes runnable when its inputs happen to already be in the database. Stages reach each other through SQLite tables, with exactly one exception.
+
+```mermaid
+flowchart TB
+    CLOCK["APScheduler — 57 registered jobs<br/>no job calls another"]
+
+    subgraph JOBS["What those 57 jobs are"]
+        JC["collect · 29"]
+        JA["analyze · 1"]
+        JD["consensus · 1"]
+        JT["track · 5"]
+        JO["operate · 21<br/>briefs · dispatchers · watchdogs · backup"]
+    end
+
+    DB[("SQLite WAL · 58 tables")]
+    CERT["certify · 0 jobs<br/>runs inside whatever calls it"]
+    OUT["Discord brief · dashboard"]
+
+    CLOCK --> JOBS
+    JC --> DB
+    JA --> DB
+    DB --> JD
+    JD ==> CERT
+    CERT --> DB
+    DB --> JT
+    JT --> DB
+    DB --> JO --> OUT
+
+    classDef step  stroke:#3b82f6,stroke-width:2px
+    classDef store stroke:#64748b,stroke-width:2px
+    classDef out   stroke:#14b8a6,stroke-width:2px
+    classDef zone  fill:none,stroke:#94a3b8,stroke-width:1px
+    class CLOCK,JC,JA,JD,JT,JO,CERT step
+    class DB store
+    class OUT out
+    class JOBS zone
+```
+
+The counts sum to the whole: 29 + 1 + 1 + 5 + 21 = 57. The **thick arrow is the single exception** to DB coupling — `nuri/scheduler.py` hands the consensus result to `record_decisions()` as a Python object, never through a table. That is why `decisions` sat frozen for three and a half months when automation replaced the CLI path and dropped that one call (#897).
+
+**`certify` is the only stage with no job of its own.** It runs inside whichever caller asks for it, and every such call persists a row — including a dashboard health check, which is why the API is not read-only.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
-| **Collect** | 26 jobs, `*/5` during market hours down to weekly | external APIs | `prices` · `fundamentals` · `macro` · `news` |
-| **Analyze** | **no job** — 22 signals (20 per-ticker actionable + 2 market-wide shadow) · 10 regimes (6 base + 4 special) · 4-factor composite are computed when a report or an endpoint asks | `prices` · `macro` | nothing (`news.sentiment` aside) |
-| **Consensus** | `consensus`, `5 7 * * *` | `recommendations.outcome_30d` (for weights) · collector tables | `recommendations` with `agent_verdicts` JSON |
-| **Certify** | **no job of its own** — `record_decisions` runs inside the consensus job; the `certifications` table is written by `premarket_brief` (`0 9 * * 1-5`) | consensus result **in memory** | `decisions` · `agent_decisions` · `certifications` |
-| **Track** | 4 jobs — `decision_pnl` `0 7`, `recommendation_outcomes` `2 7`, `alpha_tracking` `0 17`, `agent_accuracy` weekly | `recommendations` · `prices` | `outcome_{30,60,90}d` · `decision_outcomes` · `strategy_memory` |
+| **Collect** | 29 jobs, `*/5` during market hours down to weekly | external APIs | `prices` · `fundamentals` · `macro` · `news` |
+| **Analyze** | 1 job — `factors`, `10 8 * * *` | `prices` · `macro` | `factors` (and `news.sentiment`) |
+| **Consensus** | 1 job — `consensus`, `5 7 * * *` | `recommendations.outcome_30d` (for weights) · collector tables | `recommendations` with `agent_verdicts` JSON |
+| **Certify** | **no job of its own** — runs inside its callers: the consensus job, `premarket_brief`, and three API routes | consensus result **in memory** | `certifications` |
+| **Track** | 5 jobs — `decision_pnl` `0 7`, `recommendation_outcomes` `2 7`, `thesis_criteria` `20 8`, `alpha_tracking` `0 17`, `agent_accuracy` weekly | `recommendations` · `prices` | `outcome_{30,60,90}d` · `decision_outcomes` · `strategy_memory` |
 
-Two things in that table are worth stating plainly rather than burying.
+#### The clock does not follow the reading order
 
-**Consensus hands off to certification in memory, not through the database.** The scheduler calls `analyze_portfolio()` and passes the resulting objects straight into `record_decisions(results)` (`nuri/scheduler.py`). Every other stage boundary is DB-mediated; this one is not, and it is the reason `decisions` sat frozen for three and a half months when automation replaced the CLI path and dropped that one call (#897).
+`collect → analyze → consensus → certify → track` is the order the stages are *named*, not the order they *run*. Nothing chains them, so the clock is free to violate it — and does.
 
-**Cross-stage isolation holds in one narrow sense, and only that sense is enforced.** The stages map to `nuri/collectors`, `nuri/analysis`, `nuri/trading/agents`, `nuri/trading/engine` and `nuri/trading/recommend` — a mapping no document stated until #922 wrote it down, which is why the older, stronger claim ("DB tables / CSV only") was not merely false but unfalsifiable. An AST sweep finds 17 imports crossing those boundaries over 15 distinct (file, module) pairs. Every one is a deferred function-body import and none is module-level, which is the only sense in which the rule holds: there is no load-time coupling, but each one is a live call path. `certify` and `track` are mutually dependent (`engine/conflicts.py` calls `recommend/candidates.screen_candidates`, which calls `engine/conflicts.detect_conflicts` back) and survive only because of the deferral — hoisting either import breaks the load. `recommend/holdings_monitor.py` states in its own docstring that the local import exists "to avoid a circular import at module load time". `tests/core/test_cross_stage_imports.py` is the gate: it fails on any module-level crossing import, on a crossing pair missing from the allowlist, and on an allowlist entry whose dependency has since been removed, so the list cannot quietly go stale in either direction.
+```mermaid
+flowchart LR
+    T0["07:00<br/>decision_pnl<br/>track"]
+    T1["07:02<br/>recommendation_outcomes<br/>track"]
+    T2["07:05<br/>consensus<br/>consensus"]
+    T3["08:10<br/>factors<br/>analyze"]
+    T4["08:20<br/>thesis_criteria<br/>track"]
+    T5["17:00<br/>alpha_tracking<br/>track"]
+    T6["22:00–23:00 KST<br/>premarket_brief<br/>09:00 US/Eastern"]
 
-The factor composite (`nuri/quant/factors/composite.py`) blends four terms — momentum 0.30, value 0.25, quality 0.25, sentiment 0.20. The first three are per-ticker scorers; sentiment is a single market-wide Fear & Greed value applied to every ticker alike, so it moves the score's level rather than its ranking.
+    RECS[("recommendations")]
 
-That composite is then one input among several to the BUY-candidate scorer (`config/buy_signals.yaml`), which also weighs 5-day momentum, RSI, and 30-day breakout. Two further channels — cross-sectional relative strength and dollar-volume surge — are wired into that same formula at **weight 0**: they are computed and surfaced as evidence but contribute nothing to the score, and they stay that way until a walk-forward test justifies promoting them.
+    T1 -->|closes| RECS
+    RECS -.->|reads| T2
+    T2 -->|writes| RECS
+
+    classDef step  stroke:#3b82f6,stroke-width:2px
+    classDef store stroke:#64748b,stroke-width:2px
+    class T0,T1,T2,T3,T4,T5,T6 step
+    class RECS store
+```
+
+Read the stage labels left to right: track, track, consensus, analyze, track, track, brief. The sharpest case is the three minutes between 07:02 and 07:05 — outcome tracking runs *before* the consensus job that consumes what it wrote, so consensus reads yesterday's closed windows, not today's. `premarket_brief` is the one job with a timezone override (`US/Eastern`), so its `0 9 * * 1-5` lands late in the Korean evening, after everything else.
+
+Every stage is therefore re-runnable in isolation, which is the property the design is actually buying.
+
+#### Cross-stage isolation holds in one narrow sense
+
+The stages map to `nuri/collectors`, `nuri/analysis`, `nuri/trading/agents`, `nuri/trading/engine` and `nuri/trading/recommend` — a mapping no document stated until #922 wrote it down, which is why the older, stronger claim ("DB tables / CSV only") was not merely false but unfalsifiable. An AST sweep finds 17 imports crossing those boundaries over 15 distinct (file, module) pairs. Every one is a deferred function-body import and none is module-level, which is the only sense in which the rule holds: there is no load-time coupling, but each is a live call path. `certify` and `track` are mutually dependent (`engine/conflicts.py` calls `recommend/candidates.screen_candidates`, which calls `engine/conflicts.detect_conflicts` back) and survive only because of the deferral. `tests/core/test_cross_stage_imports.py` fails on any module-level crossing import, on a crossing pair missing from the allowlist, and on an allowlist entry whose dependency has since been removed, so the list cannot go stale in either direction.
+
+#### What the numbers are made of
+
+The analytical vocabulary is small and fixed: 22 signals · 10 regimes · a 4-factor composite.
+
+The factor composite (`nuri/quant/factors/composite.py`) blends four terms — momentum 0.30, value 0.25, quality 0.25, sentiment 0.20. The first three are per-ticker scorers; sentiment is a single market-wide Fear & Greed value applied to every ticker alike, so it moves the score's level rather than its ranking. It is computed and persisted daily by the `factors` job at 08:10; readers query the `factors` table rather than recomputing.
+
+That composite is one input among several to the BUY-candidate scorer (`config/buy_signals.yaml`), which also weighs 5-day momentum, RSI, and 30-day breakout. Two further channels — cross-sectional relative strength and dollar-volume surge — are wired into that same formula at **weight 0**: computed and surfaced as evidence, contributing nothing to the score, and staying that way until a walk-forward test justifies promoting them.
 
 `config/signals.yaml` holds 22 entries of two deliberately unmerged kinds. 20 are **per-ticker and actionable** — the backtest detector registry. The other 2 — yield-curve inversion and HY-OAS widening — are **market-wide shadow** signals: their metadata carries `actionable: false`, their detectors live in `nuri/quant/validation/market_signals.py`, and they surface as warnings only.
 
@@ -139,7 +183,29 @@ A rule that fires because a position is too large is not the same as a rule that
 | **alpha** | `LONG` / `SHORT` / `FLAT` | Thesis change. Stop-loss breach is the **only** mechanical path to `FLAT`. |
 | **portfolio** | `REBALANCE` / `TRIM` / `HEDGE` | Sizing. Concentration, sector cap, and experiment-sleeve breaches resolve here — never as an urgent SELL. |
 
-The risk veto triggers on `alpha_action == FLAT`. A portfolio-axis violation cannot trigger it.
+```mermaid
+flowchart LR
+    TR1["Stop-loss level breached"]
+    TR2["Position · sector · sleeve<br/>over its cap"]
+    AL["alpha_action<br/>LONG · SHORT · FLAT<br/>Should this position exist?"]
+    PO["portfolio_action<br/>REBALANCE · TRIM · HEDGE<br/>Is the book the right shape?"]
+    C1["Risk veto may fire —<br/>operator sees a SELL to consider"]
+    C2["Rebalance advice —<br/>never an urgent SELL"]
+
+    TR1 --> AL
+    TR2 --> PO
+    AL -->|FLAT| C1
+    PO --> C2
+
+    classDef step  stroke:#3b82f6,stroke-width:2px
+    classDef stop  stroke:#dc2626,stroke-width:2px
+    classDef calm  stroke:#f59e0b,stroke-width:2px
+    class TR1,TR2,AL,PO step
+    class C1 stop
+    class C2 calm
+```
+
+The veto reads `alpha_action` only, so a portfolio-shape violation can never become a sell instruction. That separation is not stylistic — collapsing the two axes is what turns "this position is too big" into "sell this position now".
 
 ## Install
 
@@ -167,7 +233,7 @@ Every API key is optional. Collectors whose credentials are absent skip themselv
 ```bash
 make full-scan      # every stage in order, 9 labelled steps (A-H)
 make consensus      # 10-agent analysis + decision recording
-make certify        # Certification (3-D gates)
+make certify        # Certification gates (Account × Asset Class)
 make scan           # Daily swing scan (us_core, 85 tickers)
 make scan-extended  # Weekly swing scan (us_core + S&P 500 extension, 543 tickers)
 
@@ -244,7 +310,7 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 
 **Frontend**
 
-![Next.js](https://img.shields.io/badge/Next.js-16.2.12-000000?logo=nextdotjs&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-16.3.1-000000?logo=nextdotjs&logoColor=white)
 ![React](https://img.shields.io/badge/React-19.2.8-61DAFB?logo=react&logoColor=black)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.3.3-06B6D4?logo=tailwindcss&logoColor=white)
 ![shadcn/ui](https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white)
@@ -270,31 +336,31 @@ Production binds the API to `127.0.0.1`. The dashboard proxy is the only public 
 
 ## Project Stats
 
-Measured against `main` on 2026-08-27. Counts marked ✅ are verified on every PR by `make verify-doc-counts`, which fails CI when a number here drifts from the code.
+Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every PR by `make verify-doc-counts`, which fails CI when the number here drifts from the code. Unmarked rows are **not** gated — read them as a dated snapshot, not a guarantee.
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,721 collected across 354 files | |
-| **Backend statement coverage** | 99% — 17 of 23,311 statements uncovered across 9 files, 81 partial branches (`make ci-cov`, 2026-08-14; Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,622 across 134 files — 100% statement coverage | |
+| **Backend tests** | 7,725 collected across 354 files | ✅ |
+| **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
+| **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
-| **Pipeline stages** | 5 as a data model; 2 of them (analyze, certify) have no scheduler job of their own | |
-| **Data collectors** | 27 collectors (BaseCollector pattern) | ✅ |
+| **Pipeline stages** | 5 as a data model; 1 of them (certify) has no scheduler job of its own | |
+| **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
-| **Actor fleet** | 15 registered actors + 3 infrastructure helpers | |
-| **Scheduler jobs** | 57 cron entries (APScheduler, in-process) | |
+| **Actor fleet** | 15 registered — 8 with a live caller, 7 dormant (implemented and tested, nothing calls them) + 3 infrastructure helpers | |
+| **Scheduler jobs** | 57 cron entries (APScheduler, in-process) — 29 collect · 1 analyze · 1 consensus · 5 track · 21 operate | ✅ |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 — 20 per-ticker (actionable) + 2 market-wide (shadow) | |
-| **API endpoints** | 72 (FastAPI on `:8001`) | |
+| **API endpoints** | 73 declared in `nuri/api/routes/` (76 counting the three declared on the app itself in `main.py`) | ✅ |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
 | **DB tables** | SQLite WAL · 58 tables (56 forward-only migrations) | ✅ |
-| **DB submodules** | 11 — `nuri/core/db/` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
+| **DB submodules** | 13 under `nuri/core/db/` — `connection.py` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation
 
 - [`docs/STRATEGY.md`](docs/STRATEGY.md) — project philosophy, architectural decisions, investment rules. Canonical when documents disagree.
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — detailed code / DB layout, schema, env vars, CI/CD
-- [`docs/CERTIFICATION_SPEC.md`](docs/CERTIFICATION_SPEC.md) — 3-D certification spec
+- [`docs/CERTIFICATION_SPEC.md`](docs/CERTIFICATION_SPEC.md) — certification spec. It specifies three dimensions; the third (execution market hours) is **spec only** — `execution_markets` appears nowhere in `config/rules.yaml` or in `nuri/`, so what runs today is Account × Asset Class
 - [`docs/KIS_INTEGRATION.md`](docs/KIS_INTEGRATION.md) — KIS (Korea Investment & Securities) Open API
 - [`docs/UX_REDESIGN_PLAN.md`](docs/UX_REDESIGN_PLAN.md) — Evidence Terminal UI overhaul: phases, responsive spec, gates
 - [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md) — session-efficiency scripts, pre-push checklist
@@ -326,7 +392,7 @@ Academic foundations: O'Neil _CAN SLIM_, Minervini _SEPA_, Shefrin & Statman 198
 
 Open an issue before writing code so scope can be agreed first — read [`docs/STRATEGY.md`](docs/STRATEGY.md) before proposing any non-trivial change, since it is canonical when documents disagree. PRs are accepted.
 
-CI gates every PR on `Commit count gate (≤ 3)`, `Privacy Leak Scan`, `Doc Count Drift Check`, `codecov/patch`, CodeQL, and Trivy. One issue per PR and English Conventional Commit subjects are conventions the review enforces, not jobs — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow.
+Ten checks are required to merge: `Backend Tests`, `Backend Lint`, `Frontend Tests`, `Frontend Lint`, `Frontend Build`, `Security Scan`, `Shell Lint`, `Universe Coverage Validation`, `Doc Count Drift Check`, and `Privacy Leak Scan`. A commit-count gate (≤ 3), Codecov, CodeQL and Trivy also run, advisory unless separately enforced. One issue per PR and English Conventional Commit subjects are conventions the review enforces, not jobs — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow.
 
 Changing an investment rule, or promoting an escalation-ladder rung, additionally requires a `docs/STRATEGY.md` amendment with backtest evidence. A code change alone is not sufficient, and rungs have been walked back on evidence before.
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ In production the API binds `127.0.0.1`, not `0.0.0.0`. The Next.js proxy is the
 
 The point of the project is that a recommendation is auditable, not that it is right. Two constraints follow, and both are enforced rather than aspirational:
 
-- **It recommends; it never trades.** A broker adapter with a working `submit_order` does exist (`nuri/trading/execution/broker.py`), and **no pipeline code path calls it.** Being exact, because this is a safety claim: besides its tests, the module's own `main()` will place a one-share test order if you run it by hand with `--live`; without that flag it uses Alpaca's paper endpoint. Nothing scheduled, and nothing in the decision path, reaches it. The pipeline terminates at a recommendation and an alert; the operator places every order by hand. Wiring execution back in requires a `docs/STRATEGY.md` amendment, not a code change alone (§7.1).
+- **It recommends; it never trades.** A broker adapter with a working `submit_order` does exist (`nuri/trading/execution/broker.py`), and **no pipeline code path calls it.** Being exact, because this is a safety claim: the module's own `main()` always places a one-share test order when run by hand, and `--live` decides *which broker receives it* — without the flag a `DryRunBroker` that touches no network, with it `AlpacaBroker` against the paper endpoint. Nothing scheduled, and nothing in the decision path, reaches either. The pipeline terminates at a recommendation and an alert; the operator places every order by hand. Wiring execution back in requires a `docs/STRATEGY.md` amendment, not a code change alone (§7.1).
 - **No edge is claimed.** `GET /api/alpha` returns `edge_status: "NOT_MEASURABLE"` unconditionally, and it will keep doing so until a pre-registered test passes. The criteria were fixed on 2026-07-08 and cannot be amended before the evaluation date: **a minimum of 200 US BUY decisions, benchmark SPY, ticker-block permutation p below 0.05, evaluated 2027-06-30** (§3.11). Until then, capital following system recommendations is capped inside an experiment sleeve, and the tracking numbers on the dashboard are labeled tracking-completeness, not performance.
 
 If you are looking for a backtested strategy with a published Sharpe ratio, this is not that. It is the measurement apparatus you would need before you could honestly publish one.
 
 ### How it works
 
-Start with what the system is for. It scores **the holdings you already own**, once a day, and records why. It does not screen the market for new names, and it does not place orders.
+Start with what the system is for. The daily decision loop scores **the holdings you already own** and records why. A separate scan surfaces non-portfolio candidates (`/api/opportunities`, and the BUY candidates in the morning brief), so the two paths are worth keeping apart in your head. Neither places an order.
 
 ```mermaid
 flowchart LR
@@ -93,24 +93,27 @@ flowchart TB
     end
 
     DB[("SQLite WAL · 58 tables")]
-    CERT["certify · 0 jobs<br/>runs inside whatever calls it"]
+    RD["record_decisions()<br/>inside the consensus job"]
+    CERT["certify() · no job<br/>runs inside its callers"]
     OUT["Discord brief · dashboard"]
 
     CLOCK --> JOBS
     JC --> DB
     JA --> DB
     DB --> JD
-    JD ==> CERT
-    CERT --> DB
+    JD ==> RD
+    RD --> DB
     DB --> JT
     JT --> DB
     DB --> JO --> OUT
+    JO --> CERT
+    CERT --> DB
 
     classDef step  stroke:#3b82f6,stroke-width:2px
     classDef store stroke:#64748b,stroke-width:2px
     classDef out   stroke:#14b8a6,stroke-width:2px
     classDef zone  fill:none,stroke:#94a3b8,stroke-width:1px
-    class CLOCK,JC,JA,JD,JT,JO,CERT step
+    class CLOCK,JC,JA,JD,JT,JO,RD,CERT step
     class DB store
     class OUT out
     class JOBS zone
@@ -118,15 +121,15 @@ flowchart TB
 
 The counts sum to the whole: 29 + 1 + 1 + 5 + 21 = 57. The **thick arrow is the single exception** to DB coupling — `nuri/scheduler.py` hands the consensus result to `record_decisions()` as a Python object, never through a table. That is why `decisions` sat frozen for three and a half months when automation replaced the CLI path and dropped that one call (#897).
 
-**`certify` is the only stage with no job of its own.** It runs inside whichever caller asks for it, and every such call persists a row — including a dashboard health check, which is why the API is not read-only.
+**`certify` is the only stage with no job of its own, and the consensus job does not call it.** `certify()` reads a DB snapshot and is invoked by `premarket_brief`, by `engine/remediation`, by its own CLI, and by three API routes (`/api/certify`, `/api/actions` health and violations). Every such call persists a `certifications` row — including a dashboard health check, which is why the API is not read-only.
 
 | Stage | Scheduled as | Reads | Writes |
 |-------|--------------|-------|--------|
 | **Collect** | 29 jobs, `*/5` during market hours down to weekly | external APIs | `prices` · `fundamentals` · `macro` · `news` |
-| **Analyze** | 1 job — `factors`, `10 8 * * *` | `prices` · `macro` | `factors` (and `news.sentiment`) |
+| **Analyze** | 1 job — `factors`, `10 8 * * *` | `prices` · `fundamentals` · `macro` (fear & greed) | `factors` |
 | **Consensus** | 1 job — `consensus`, `5 7 * * *` | `recommendations.outcome_30d` (for weights) · collector tables | `recommendations` with `agent_verdicts` JSON |
-| **Certify** | **no job of its own** — runs inside its callers: the consensus job, `premarket_brief`, and three API routes | consensus result **in memory** | `certifications` |
-| **Track** | 5 jobs — `decision_pnl` `0 7`, `recommendation_outcomes` `2 7`, `thesis_criteria` `20 8`, `alpha_tracking` `0 17`, `agent_accuracy` weekly | `recommendations` · `prices` | `outcome_{30,60,90}d` · `decision_outcomes` · `strategy_memory` |
+| **Certify** | **no job of its own** — runs inside its callers: `premarket_brief`, `engine/remediation`, its own CLI, and three API routes. **Not** the consensus job | a DB snapshot of portfolio state | `certifications` |
+| **Track** | 5 jobs — `decision_pnl` `0 7`, `recommendation_outcomes` `2 7`, `thesis_criteria` `20 8`, `alpha_tracking` `0 17`, `agent_accuracy` weekly | `recommendations` · `prices` · `decisions`; `thesis_criteria` also reads `theses` · `signals` · `factors` · `fundamentals` | `recommendations.outcome_{30,60,90}d` · `decision_outcomes` · `strategy_memory` · `thesis_criteria_checks`; `decision_pnl` writes back into `decisions` |
 
 #### The clock does not follow the reading order
 
@@ -340,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,725 collected across 354 files | ✅ |
+| **Backend tests** | 7,727 collected across 354 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,721 backend tests across 354 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,725 backend tests across 354 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,725 backend tests across 354 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,727 backend tests across 354 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,725 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,727 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,721 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,725 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/doc/sync_doc_counts.sh
+++ b/scripts/doc/sync_doc_counts.sh
@@ -142,6 +142,9 @@ update_claim live_endpoints      nuri/api/CLAUDE.md            'read surface \([
 update_claim live_test_files_be  docs/ARCHITECTURE.md          'backend tests across [0-9]+ files'
 update_claim live_test_files_be  docs/STRATEGY.md              'Backend tests.*tests, [0-9]+ files'
 update_claim live_test_files_be  README.md                     'collected across [0-9]+ files'
+# README 미등록 사이트 2건 추가 (#1288) — verify_doc_counts.sh 와 짝을 맞춘다.
+update_claim live_endpoints      README.md                     '[0-9]+ declared in'
+update_claim live_test_files_fe  README.md                     '[0-9]+ vitest files'
 
 # Frontend test files (2 sites)
 update_claim live_test_files_fe  docs/ARCHITECTURE.md          'frontend vitest \([0-9]+ files\)'

--- a/scripts/verify/verify_doc_counts.sh
+++ b/scripts/verify/verify_doc_counts.sh
@@ -165,11 +165,16 @@ check_claim "collectors"     "$COLL" "README.md"                  '[0-9]+ collec
 check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '## API \([0-9]+ endpoints\)' || true
 check_claim "endpoints"      "$EP"   "docs/ARCHITECTURE.md"       '— [0-9]+ REST endpoints' || true
 check_claim "endpoints"      "$EP"   "nuri/api/CLAUDE.md"         'read surface \([0-9]+ endpoints\)' || true
+# README 사이트 등록 (#1288). 등록 전까지 README 는 72 였고 라이브는 73 이었다 —
+# `live_endpoints` 는 이미 있었는데 **사이트만 미등록**이라 조용히 낡았다.
+check_claim "endpoints"      "$EP"   "README.md"                  '[0-9]+ declared in' || true
 check_claim "test_files_be"  "$TFBE" "docs/ARCHITECTURE.md"       'backend tests across [0-9]+ files' || true
 check_claim "test_files_be"  "$TFBE" "docs/STRATEGY.md"           'Backend tests.*tests, [0-9]+ files' || true
 check_claim "test_files_be"  "$TFBE" "README.md"                  'collected across [0-9]+ files' || true
 check_claim "test_files_fe"  "$TFFE" "docs/ARCHITECTURE.md"       'frontend vitest \([0-9]+ files\)' || true
 check_claim "test_files_fe"  "$TFFE" "docs/STRATEGY.md"           'Frontend tests.*tests, [0-9]+ files' || true
+# 같은 이유로 README 도 등록 — 등록 전 README 는 134, 라이브는 136 이었다.
+check_claim "test_files_fe"  "$TFFE" "README.md"                  '[0-9]+ vitest files' || true
 check_claim "e2e_specs"      "$E2E"  "docs/ARCHITECTURE.md"       'Playwright E2E \([0-9]+ spec files\)' || true
 # Python-dependent checks: skip silently when .venv absent (CI contract — see live_regimes comment)
 if [ -n "$REGIMES" ]; then

--- a/tests/verify/test_readme_structure.py
+++ b/tests/verify/test_readme_structure.py
@@ -172,7 +172,35 @@ class TestMermaidRendersInBothThemes:
                     long_titles.append(f"#{i}: {m.group(1)[:70]}... ({len(m.group(1))}자)")
         assert not long_titles, "subgraph 제목이 너무 길다:\n" + "\n".join(long_titles)
 
+    def test_every_diagram_is_still_there(self):
+        """`>= 3` 은 너무 헐거웠다 — 넷 중 하나를 지워도 통과했다 (codex 리뷰 P3).
+
+        각 다이어그램이 답하는 질문을 **이름으로** 고정한다. 개수만 세면 어느 것이
+        사라졌는지 알 수 없고, 개수를 맞추려고 아무거나 넣어도 통과한다.
+        """
+        text = README.read_text(encoding="utf-8")
+        for anchor in (
+            "Your holdings<br/>+ public market data",  # 무엇을 하는가
+            "no job calls another",  # 무엇이 그것을 돌리는가
+            "premarket_brief<br/>09:00 US/Eastern",  # 하루의 시계
+            "Should this position exist?",  # 두 축
+        ):
+            assert anchor in text, f"다이어그램이 사라졌거나 바뀌었다: {anchor!r}"
+        assert len(_diagrams()) == 4, f"다이어그램 수가 4가 아니다: {len(_diagrams())}"
+
+    def test_no_diagram_asserts_a_dependency_the_code_lacks(self):
+        """의미 검사 — 구조만 보면 **틀린 화살표**가 통과한다 (codex 리뷰 P3).
+
+        실제로 이 PR 초안이 `consensus ==> certify` 를 그렸는데, 합의 잡은 `certify()`
+        를 부르지 않는다 (`record_decisions()` 를 부른다). 그 한 줄이 이 테스트의 이유다.
+        """
+        text = README.read_text(encoding="utf-8")
+        assert "JD ==> RD" in text, "합의 → record_decisions 인메모리 인계가 사라졌다"
+        assert "JD ==> CERT" not in text, (
+            "합의 잡이 certify() 를 부른다고 그렸다 — scheduler.py 는 record_decisions() 를 부른다"
+        )
+
     def test_the_sweep_has_eyes(self):
-        """카나리아 — 다이어그램을 하나도 못 찾으면 위 셋은 영원히 공허하게 통과한다."""
-        assert len(_diagrams()) >= 3, "README 에서 mermaid 블록을 찾지 못했다"
+        """카나리아 — 정규식이 조용히 아무것도 안 잡으면 위 검사들이 공허해진다."""
         assert MERMAID.findall("```mermaid\nflowchart LR\n  A --> B\n```"), "정규식이 눈이 멀었다"
+        assert not MERMAID.findall("```python\nx = 1\n```"), "mermaid 아닌 블록을 잡는다"

--- a/tests/verify/test_readme_structure.py
+++ b/tests/verify/test_readme_structure.py
@@ -117,3 +117,62 @@ class TestShortDescription:
         m = re.search(r"^\*\*(.+?)\*\*$", body, re.M)
         assert m, "굵은 한 줄 요약을 찾지 못함"
         assert len(m.group(1)) < 120, f"{len(m.group(1))}자: {m.group(1)}"
+
+
+# ── Mermaid 다이어그램 (#1288) ──────────────────────────────────────────────
+
+MERMAID = re.compile(r"```mermaid\n(.*?)```", re.S)
+
+
+def _diagrams() -> list[str]:
+    return MERMAID.findall(README.read_text(encoding="utf-8"))
+
+
+class TestMermaidRendersInBothThemes:
+    """GitHub 는 **읽는 사람의 테마**로 렌더한다 — 밝은 팔레트를 박으면 다크에서 깨진다.
+
+    2026-08-29 실측(mermaid 11.17, `mmdc -t dark`): 다이어그램 안의
+    `%%{init: {"theme":"base", ...}}%%` 는 **호스트 테마를 이긴다.** 밝은 fill 을 박은
+    다이어그램은 다크 모드에서도 밝게 렌더돼 `#0d1117` 배경 위의 흰 판때기가 된다.
+
+    그래서 이 레포의 규약은 **stroke 전용 classDef** 다: fill 을 지정하지 않으면
+    mermaid 가 테마에 맞는 배경을 고르고, 글자색도 따라온다.
+    """
+
+    def test_no_diagram_pins_a_theme(self):
+        """Mutation lock: 어떤 다이어그램에든 `%%{init:` 테마 블록을 넣으면 FAIL."""
+        offenders = [i for i, d in enumerate(_diagrams(), 1) if "%%{init:" in d]
+        assert not offenders, f"다이어그램 {offenders} 가 테마를 고정한다 — 다크 모드에서 밝은 판때기가 된다"
+
+    def test_classdefs_never_hardcode_a_fill(self):
+        """`fill:` 을 박으면 글자색까지 같이 박아야 하고, 그러면 테마를 따라가지 못한다.
+
+        `fill:none` 은 예외 — 배경을 지우는 것이지 색을 고르는 게 아니다.
+        """
+        bad: list[str] = []
+        for i, d in enumerate(_diagrams(), 1):
+            for line in d.splitlines():
+                if "classDef" not in line:
+                    continue
+                m = re.search(r"fill:\s*([^,\s]+)", line)
+                if m and m.group(1) != "none":
+                    bad.append(f"#{i}: {line.strip()}")
+        assert not bad, "테마를 따라가지 못하는 fill 이 있다:\n" + "\n".join(bad)
+
+    def test_subgraph_titles_stay_short(self):
+        """긴 subgraph 제목은 클러스터 폭을 그만큼 벌려 다이어그램 전체를 축소시킨다.
+
+        README 컬럼 폭(약 830-900px)을 넘기면 mermaid 가 통째로 축소해 글자가 6-7px 가
+        된다 — 본문이 16px 인데. 문장은 캡션으로 내린다.
+        """
+        long_titles = []
+        for i, d in enumerate(_diagrams(), 1):
+            for m in re.finditer(r'subgraph\s+\w+\["([^"]+)"\]', d):
+                if len(m.group(1)) > 60:
+                    long_titles.append(f"#{i}: {m.group(1)[:70]}... ({len(m.group(1))}자)")
+        assert not long_titles, "subgraph 제목이 너무 길다:\n" + "\n".join(long_titles)
+
+    def test_the_sweep_has_eyes(self):
+        """카나리아 — 다이어그램을 하나도 못 찾으면 위 셋은 영원히 공허하게 통과한다."""
+        assert len(_diagrams()) >= 3, "README 에서 mermaid 블록을 찾지 못했다"
+        assert MERMAID.findall("```mermaid\nflowchart LR\n  A --> B\n```"), "정규식이 눈이 멀었다"


### PR DESCRIPTION
Closes #1288

## 방법 — 서술을 믿지 않고 전수 대조

12-에이전트 검증을 돌렸습니다: ground-truth 프로브 6개(스케줄러 · 수치 · 결정 라이프사이클 · 외부 표면 · 산문 비평 · 렌더링) → 독립 설계안 3개 → 적대적 리뷰 3개(사실 · 렌더링 · 초심자 가독성). 리뷰 셋 모두 세 설계안을 **FLAWED** 로 판정했고, 그 결함들을 반영해 합성했습니다.

**모든 수치는 제가 다시 실측했습니다** — 워크플로가 3커밋 전 스냅샷이라 그 사이 제 PR 들이 몇 개를 움직였습니다.

## 낡은 숫자가 아니라 **틀린 주장** 이었던 것들

| README | 코드 |
|---|---|
| "Analyze — 스케줄러 잡 없음" (**3곳**) | `factors` 잡이 `10 8 * * *` 로 존재. 코드 자신의 `_STAGE_OF_JOB["factors"] = "analyze"` |
| Analyze 는 "아무것도 안 씀" | `factors` 테이블에 씀 |
| 4-factor composite 는 "요청 시 계산" | 08:10 잡이 계산·영속화. 소비자는 테이블을 읽음 |
| `submit_order` 는 "테스트만 부른다" | `broker.py` `main()` 이 **항상** 1주 주문을 냄. `--live` 는 받는 쪽을 `DryRunBroker`↔`AlpacaBroker`(paper)로 가름 — 초안이 이것도 틀렸고 codex 가 잡았습니다(아래 P1) |
| `certifications` 는 `premarket_brief` 가 씀 | API 3경로도 씀 (`actions:health` · `actions:violations` · `targets`) → **API 는 read-only 가 아니다** |
| Collect 26 / Track 4 | 29 / 5 (`thesis_criteria` 누락) |
| 다이어그램 부분합 26+1+4=31 vs 전체 57 | 29+1+1+5+21 = **57, 이제 맞습니다** |
| "3-D gates" | `execution_markets` 는 `config/rules.yaml` **0회**, `nuri/` **0회** — spec only. 도는 건 Account × Asset Class |
| CI 필수 체크 목록 | branch protection 실제 10개와 불일치 |
| Frontend "100% statement coverage" | **99.87%** (2,393/2,396) |

낡은 수치도 정정: endpoints 72→73 · frontend 1,622→1,648 tests / 134→137 files · DB submodules 11→13 · Next.js 배지 16.2.12→16.3.1 · Actor fleet "15 registered" → live caller 8 + dormant 7 (코드 주석이 이미 "wired ≠ validated" 라고 적어둔 구분).

## 다이어그램 — 1개 → 4개

무엇을 하는가 → 무엇이 그것을 돌리는가(오케스트레이터 없음) → 하루의 시계 → 두 축.

마지막 것(alpha vs portfolio)은 **이 시스템에서 가장 중요한 안전 속성**인데 지금까지 산문 표로만 있었습니다.

### 테마 안전성이 설계를 지배했습니다

실측(mermaid 11.17, `mmdc -t dark`): 다이어그램 안의 `%%{init:{"theme":...}}%%` 는 **호스트 테마를 이깁니다.** GitHub 은 읽는 사람의 테마로 렌더하므로, 밝은 팔레트를 박은 다이어그램은 다크 모드에서 `#0d1117` 위의 **흰 판때기**가 됩니다. 세 설계안 중 둘이 이 함정에 빠져 있었습니다.

그래서 네 다이어그램 모두 **stroke 전용 classDef** 이고 `fill` 을 지정하지 않습니다 — mermaid 가 테마에 맞는 배경과 글자색을 고르게 둡니다.

크기도 제약이었습니다: 자연 폭이 약 1,800px 를 넘으면 README 컬럼(830–900px)에서 통째로 축소돼 글자가 6–7px 가 됩니다(본문은 16px). 그래서 노드 수를 억제하고, 문장은 edge label 이나 subgraph 제목이 아니라 캡션에 뒀습니다.

**검증**: 네 블록 전부 mermaid 11 에서 `mermaid.parse()` 통과. 카나리아(깨진 문법)가 FAIL 하는 것도 같이 확인 — 하네스가 눈이 멀지 않았습니다.

## 근본 원인 — 게이트에 사이트가 등록돼 있지 않았다

`sync_doc_counts.sh` 에 `live_endpoints` 와 `live_test_files_fe` 는 **이미 있었습니다.** README 사이트만 등록이 안 돼 있었고, 그래서 72-vs-73 과 134-vs-136 이 조용히 썩었습니다. 양쪽 스크립트에 등록했습니다 (parity 테스트가 두 목록을 잠급니다) — 게이트가 **22 → 24 checks**.

⚠️ 재작성 중 특히 조심한 것: `check_claim` 은 패턴을 못 찾으면 `fail` 이 아니라 **`warn` 을 부르고 스크립트는 exit 0** 입니다 (161행 주석이 이미 인정하고 있습니다). 즉 등록된 문자열을 지우면 **그 검사가 조용히 죽고 게이트는 초록**입니다. 8개 gated 문자열을 재작성 전후로 대조해 전부 보존했고, 실제로 rewrite 직후 2개(`independent APScheduler jobs`, `· 10 regimes`)가 사라진 걸 발견해 되살렸습니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후)

| 뮤테이션 | 결과 |
|---|---|
| 다이어그램에 `%%{init}%%` 테마 고정 추가 | **1 FAIL** |
| `classDef` 에 하드코딩 `fill` 추가 | **1 FAIL** |
| 긴 subgraph 제목 (클러스터 폭 폭발) | **1 FAIL** |
| 다이어그램 전부 제거 (카나리아) | **1 FAIL** |
| baseline | 13 passed |

치환 건수 assert 가 제 오산을 잡았습니다 — `classDef step` 이 3곳인 줄 알았는데 **4곳**이었고, 기대치 불일치로 측정이 중단됐습니다. 실측으로 정정한 뒤 잠금 확인.

## 검증

- `make verify-doc-counts` **24/24** (`sync_doc_counts.sh` 재계산 — 새로 등록한 두 수치는 제가 쓴 값이 라이브와 일치해 sync 가 바꿀 게 없었습니다)
- `tests/verify/` **54 passed** (parity 테스트 포함) → 신규 4건 추가 후 13 passed in that file
- mermaid 4/4 parse (mermaid 11) · `check_privacy_leak.py` rc=0 · `make lint-sh` clean · cspell clean

### 이 PR 과 무관한 red 1건 (귀속 확인)

`make test-fast` 에서 `tests/integration/test_universe_sync_real.py` 3건이 FAIL 합니다 — KRX 실서버 fetch 실패입니다. **clean main 에서 제 변경을 stash 하고 동일하게 재현**했으므로 이 PR 소관이 아닙니다. 다만 "모든 테스트는 network-free" 라는 `tests/CLAUDE.md` 의 계약과 어긋나는 별개 결함이라 별도 이슈로 올릴 값이 있습니다.

---

## codex 리뷰 — [P1] 4건 + [P2] 1건 + [P3] 1건, 전부 수용

**넷 다 제 오류입니다.** 재작성이 새로 만들었거나 그대로 물려받은 것들이고, 코드로 하나씩 확인했습니다.

### [P1] `submit_order` — 양쪽 다 틀렸습니다

> `main()` always calls `broker.submit_order(...)` regardless of flags, and `--live` only switches `get_broker(dry_run=not args.live)`

**맞습니다.** 저는 "`--live` 일 때만 주문을 낸다, 없으면 Alpaca paper" 라고 썼는데 **두 문장 다 거짓**입니다. `main()` 은 **항상** 1주 주문을 내고, `--live` 는 *누가 그 주문을 받는지*를 정합니다 — 없으면 네트워크를 안 타는 `DryRunBroker`, 있으면 `AlpacaBroker`(paper).

안전 주장을 **실제보다 안전한 쪽으로** 틀리게 적은 것이라, 이 절에서 가장 피해야 할 형태입니다.

### [P1] `certify` 배선 — `record_decisions` 와 뭉쳐버렸습니다

> the consensus job calls `record_decisions(results)`, not `certify()`

**맞습니다.** `scheduler.py:328-340` 은 `analyze_portfolio()` → `save_to_recommendations()` → `record_decisions()` 이고 `certify()` 는 없습니다. 저는 둘을 합쳐 `JD ==> CERT` 를 그렸는데, **굵은 인메모리 화살표는 `record_decisions` 쪽**입니다. `certify()` 는 DB 스냅샷을 읽고 `premarket_brief` · `engine/remediation` · 자체 CLI · API 3경로에서 호출됩니다. 표의 "Reads: consensus result in memory" 도 같은 이유로 틀려서 고쳤습니다.

### [P1] "시장을 스크리닝하지 않는다" — 거짓

> `/api/opportunities` calls `scan_market()` and explicitly filters for non-portfolio tickers

**맞습니다.** 초심자용으로 단순화하다 **거짓을 가르쳤습니다** — 적대적 리뷰가 경고한 바로 그 형태("Does the reader learn something FALSE from the simplification?")입니다. 일일 결정 루프는 보유를 채점하고, **별도 스캔**이 비보유 후보를 올린다고 두 경로를 나눠 적었습니다.

### [P1] Analyze 행 — 양방향으로 부정확

`compute_composite` 는 `value`/`quality` 스코어러를 통해 **`fundamentals` 도** 읽습니다(제가 빠뜨림). 쓰는 건 `factors` 뿐이고 `news.sentiment` 는 **스케줄되지 않은 별도 모듈**입니다(제가 잘못 붙임). 참고로 codex 의 지적도 `macro`(fear & greed, `composite.py:42`)를 빠뜨려서, 실측대로 **셋 다** 적었습니다.

### [P2] Track 행 불완전 — 수용

`thesis_criteria` 가 `theses` · `signals` · `factors` · `fundamentals` 를 읽고 `thesis_criteria_checks` 를 쓰며, `decision_pnl` 은 `outcome_*` 이 아니라 **`decisions` 에 되씁니다.**

### [P3] 제 테스트가 이걸 못 잡았습니다 — 수용

> it does not even require four mermaid blocks; `test_the_sweep_has_eyes` only requires `>= 3`

**맞습니다.** 다이어그램이 4개인데 카나리아가 `>= 3` 이라 하나를 지워도 통과했고, **의미 검사가 전혀 없어서** 틀린 `consensus ==> certify` 화살표가 그대로 초록이었습니다. 이제 각 다이어그램을 **앵커 문자열로** 고정하고, 그 화살표를 직접 단언합니다 — 실제로 일어난 실수라서 그걸 잠급니다.

### 반영 후 뮤테이션 (커밋 후, 5축)

| 뮤테이션 | 결과 |
|---|---|
| 테마 고정 블록 추가 | **1 FAIL** |
| `classDef` 하드코딩 `fill` | **1 FAIL** |
| 긴 subgraph 제목 | **1 FAIL** |
| 다이어그램 1개 삭제 (4→3) | **1 FAIL** |
| 틀린 화살표 복원 (`consensus ==> certify`) | **1 FAIL** |
| baseline | 15 passed |

### codex 가 확인해준 것

`29/1/1/5/21 = 57` · `certify` 스케줄 잡 0 · `execution_markets` 0회 · endpoints 73/76 · actor 8+7 · db submodules 13. **게이트도 무결**: README 바인딩 정규식 전부 매치하고, 새로 등록한 두 개가 레포 사본에서 실제로 재작성되는 것까지 확인.

## 재검증 (반영 후)

- `tests/verify/` **60 passed** · mermaid 4/4 parse (mermaid 11) · `make verify-doc-counts` **24/24** · privacy rc=0
