### PR TITLE
fix(core): one predicate for whether a holding is denominated in KRW

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,727 collected across 354 files | ✅ |
+| **Backend tests** | 7,748 collected across 355 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,748 collected across 355 files | ✅ |
+| **Backend tests** | 7,755 collected across 355 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,727 backend tests across 354 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,748 backend tests across 355 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,748 backend tests across 355 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,755 backend tests across 355 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,727 tests, 354 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,748 tests, 355 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,748 tests, 355 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,755 tests, 355 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/premarket_brief.py
+++ b/nuri/alerts/premarket_brief.py
@@ -262,8 +262,7 @@ def _collect_context(db_path=None) -> dict:
             db_path=db_path,
         )
         # #1278: 날짜 상한 + 미래행 경고는 공용 리더가 담당한다 (nuri/core/fx.py).
-        from nuri.core.fx import latest_usd_krw_value
-        from nuri.core.ticker_names import is_kr_ticker
+        from nuri.core.fx import is_krw_holding, latest_usd_krw_value
 
         rate = latest_usd_krw_value(db_path=db_path)
         # 술어는 레포 정본 (`analysis/portfolio.py:208` 등): `currency == "KRW"` 이거나
@@ -274,9 +273,7 @@ def _collect_context(db_path=None) -> dict:
         # 필터가 없어서, **수량 0 인 낡은 KR 행 하나가** 살아있는 KR 노출이 전혀 없는데도
         # Portfolio 섹션을 통째로 막는다 (codex 리뷰 P2). 수량 0 은 총액에 0 을 더하므로
         # 애초에 환산이 필요 없다.
-        kr_count = sum(
-            1 for r in rows if (r["quantity"] or 0) > 0 and (r["currency"] == "KRW" or is_kr_ticker(r["ticker"]))
-        )
+        kr_count = sum(1 for r in rows if (r["quantity"] or 0) > 0 and is_krw_holding(r["ticker"], r["currency"]))
 
         # #1283: 환율이 없으면 `or 1400.0` 으로 메웠다. 매일 아침 읽는 브리프에 지어낸
         # 총액을 싣는 것보다 **빈 칸이 정직하다** — 채워져 있으면 수집기가 죽은 걸 모른다.
@@ -295,7 +292,9 @@ def _collect_context(db_path=None) -> dict:
             for r in rows:
                 px = r["close"] or r["avg_price"] or 0
                 qty = r["quantity"] or 0
-                if is_kr_ticker(r["ticker"]):
+                # #1286: 위 가드와 **같은 술어**를 쓴다. 어긋나 있으면 가드는 환산
+                # 불가로 판정했는데 루프는 달러로 계산하는 모순이 생긴다.
+                if is_krw_holding(r["ticker"], r["currency"]):
                     # 위 가드가 보장한다 (kr_count > 0 이면 rate 가 있다). 그래도 명시로
                     # 좁히는 이유는, 조건이 갈라져 있으면 **도달 불가가 조용히 도달
                     # 가능해지는** 순간을 타입체커가 잡아주기 때문이다. 폴백 숫자를

--- a/nuri/alerts/risk_signals.py
+++ b/nuri/alerts/risk_signals.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Literal, Optional
 
 from nuri.core.db import query
+from nuri.core.fx import is_krw_holding
 from nuri.core.rules import (
     BRIEF_BENCHMARK,
     BRIEF_EARNINGS_WINDOW_DAYS,
@@ -132,7 +133,7 @@ def _single_currency_account_totals(rows: list[dict[str, Any]]) -> dict[str, flo
     currencies: dict[str, set[str]] = {}
     for r in rows:
         acct, close, qty = r["account"], r["current"], r["quantity"]
-        cur = "KRW" if (r.get("currency") == "KRW" or is_kr_ticker(str(r["ticker"]))) else "USD"
+        cur = "KRW" if is_krw_holding(str(r["ticker"]), r.get("currency")) else "USD"
         currencies.setdefault(acct, set()).add(cur)
         if close and qty:
             by_account[acct] = by_account.get(acct, 0.0) + float(close) * float(qty)

--- a/nuri/analysis/portfolio.py
+++ b/nuri/analysis/portfolio.py
@@ -20,8 +20,8 @@ from pathlib import Path
 import pandas as pd
 
 from nuri.core.db import query, query_df
+from nuri.core.fx import is_krw_holding
 from nuri.core.rules import LEVERAGE_ETFS, MAX_SINGLE_POSITION
-from nuri.core.ticker_names import is_kr_ticker
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +205,7 @@ def analyze_portfolio(db_path=None) -> pd.DataFrame:
 
         # 현재가치 (USD 기준으로 통일)
         # KR(.KS/.KQ) 종목은 계좌 통화와 무관하게 KRW로 처리 (#764)
-        is_krw = currency == "KRW" or is_kr_ticker(ticker)
+        is_krw = is_krw_holding(ticker, currency)
         if is_krw:
             current_value_usd = (current_price * qty) / usd_krw
             cost_basis_usd = (avg_price * qty) / usd_krw

--- a/nuri/analysis/sector.py
+++ b/nuri/analysis/sector.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from nuri.analysis.portfolio import get_exchange_rate
 from nuri.core.db import query, query_df
+from nuri.core.fx import is_krw_holding
 from nuri.core.ticker_names import is_kr_ticker
 
 logger = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ def analyze_sector() -> tuple[pd.DataFrame, pd.DataFrame, list[str]]:
 
         price = latest[0]["close"]
         qty = row["total_qty"]
-        is_krw = row["currency"] == "KRW" or is_kr_ticker(row["ticker"])
+        is_krw = is_krw_holding(row["ticker"], row["currency"])
         current_value = (price * qty / usd_krw) if is_krw else (price * qty)
         region = "KR" if is_kr_ticker(row["ticker"]) else "US"
 

--- a/nuri/core/fx.py
+++ b/nuri/core/fx.py
@@ -102,7 +102,10 @@ def is_krw_holding(ticker, currency) -> bool:
     `analysis/sector.py` · `alerts/risk_signals.py` 에 인라인으로 흩어져 있고, 그 통합은
     #1286 이 다룬다 — 여기서는 새 사본을 만들지 않으려고 이 함수를 쓴다.
     """
-    return currency == "KRW" or is_kr_ticker(str(ticker))
+    # 대소문자를 무시한다 — `holdings_monitor._classify_asset_class` 가 이미
+    # `currency.upper()` 로 그렇게 하고 있었다. 통합하면서 좁히면 그쪽 동작이 조용히
+    # 바뀌므로, **넓은 쪽**으로 맞춘다: 환산이 필요할 수 있으면 KRW 로 본다 (#1286).
+    return str(currency or "").upper() == "KRW" or is_kr_ticker(str(ticker))
 
 
 def cross_currency_unavailable(rate: float | None, has_krw_exposure: bool) -> str | None:

--- a/nuri/trading/recommend/holdings_monitor.py
+++ b/nuri/trading/recommend/holdings_monitor.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from nuri.core.db import query, query_df
 from nuri.core.events import emit_event
+from nuri.core.fx import is_krw_holding
 from nuri.core.rules import RULES
 from nuri.core.timezone import kst_now
 
@@ -93,9 +94,9 @@ def _classify_asset_class(ticker: str, currency: str | None) -> str:
     Crypto excluded explicitly (futures PR per Codex Plan). Anything not US/KR
     equity is treated as out-of-scope for v1.
     """
-    if currency and currency.upper() == "KRW":
-        return "equity_kr"
-    if ticker.endswith(".KS") or ticker.endswith(".KQ"):
+    # #1286: 통화 OR 접미사 — 정본 술어 하나로 통합. 예전에는 같은 판정이 이 파일 포함
+    # 5곳에 인라인 복사돼 있었고, 그중 2곳이 접미사만 봐서 서로 어긋나 있었다.
+    if is_krw_holding(ticker, currency):
         return "equity_kr"
     if ticker in {"BTC-USD", "ETH-USD"} or ticker.endswith("-USD"):
         return "crypto"

--- a/nuri/trading/recommend/price_targets.py
+++ b/nuri/trading/recommend/price_targets.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 from nuri.core.db import query, query_df
+from nuri.core.fx import is_krw_holding
 from nuri.core.rules import (
     STOCK_STOP_LOSS,
     STOCK_STOP_LOSS_VALUE,
@@ -688,13 +689,13 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
     # 환율이 없어도 **US 전용 포트폴리오는 정확히 계산된다** — 일괄 포기는 과잉이다.
     # KR 보유가 섞여 있을 때만 판정을 포기한다.
     #
-    # ⚠️ 술어는 **레포 정본**을 쓴다: `currency == "KRW" or is_kr_ticker(ticker)`
+    # ⚠️ 술어는 **레포 정본** `is_krw_holding()` 하나다 (#1286 이 사본 5개를 통합).
     # (`analysis/portfolio.py:208` · `analysis/sector.py:52` · `alerts/risk_signals.py:135`
     # 와 동일). suffix 만 보면 `currency="KRW"` 인 무접미 보유가 "US 전용" 으로 오분류돼
     # 환율 없이 판정이 통과한다 (codex 리뷰 P1). 아래 환산 루프는 아직 suffix 만 보는데
     # 그건 이 PR 밖의 별도 결함이라 #1286 으로 분리했다 — **가드는 넓은 쪽**을 쓴다.
     # 환산이 필요할 수 *있으면* 판정하지 않는 편이 지어내는 것보다 낫다.
-    kr_count = sum(1 for _, r in holdings.iterrows() if r["currency"] == "KRW" or is_kr_ticker(str(r["ticker"])))
+    kr_count = sum(1 for _, r in holdings.iterrows() if is_krw_holding(str(r["ticker"]), r["currency"]))
     if usd_krw is None and kr_count:
         logger.warning(
             "USD/KRW 미수집 — 포트폴리오 MDD 판정 포기 (KR 보유 %d종목). "
@@ -710,7 +711,9 @@ def check_portfolio_mdd(db_path: Optional[Path] = None) -> dict | None:
         ticker = row["ticker"]
         avg_price = row["avg_price"] or 0
         qty = row["quantity"] or 0
-        is_krw = is_kr_ticker(ticker)
+        # #1286: 통화 질문이므로 **정본 술어**. 접미사만 보면 `currency="KRW"` 인
+        # 무접미 보유가 달러로 취급돼 환산이 통째로 빠진다 (환율이 정상이어도 틀린다).
+        is_krw = is_krw_holding(ticker, row["currency"])
 
         cost = avg_price * qty
         current = _get_current_price(ticker, db_path=db_path)

--- a/tests/core/test_krw_predicate_is_single.py
+++ b/tests/core/test_krw_predicate_is_single.py
@@ -1,0 +1,181 @@
+"""원화 표시 여부를 묻는 술어는 **하나뿐이다** (#1286).
+
+## 무엇이 잘못됐었나
+
+"이 보유가 원화인가" 라는 판정이 **5곳에 인라인 복사**돼 있었고, 그중 2곳은 통화를
+보지 않고 **접미사만** 봤다:
+
+- `analysis/portfolio.py` · `analysis/sector.py` · `alerts/risk_signals.py` — `currency == "KRW" or is_kr_ticker(...)`
+- `recommend/holdings_monitor.py` — 같은 판정을 `if` 두 개로 펼쳐 씀 (게다가 `.upper()`)
+- `recommend/price_targets.py` · `alerts/premarket_brief.py` — **`is_kr_ticker()` 단독** ← 결함
+
+접미사만 보면 `currency="KRW"` 인데 `.KS`/`.KQ` 가 없는 보유가 **달러로 취급**된다.
+환율이 정상일 때도 틀리고, 오차가 1,380배다. `premarket_brief` 에서는 #1284 가 넣은
+가드(정본 술어)와 환산 루프(접미사 단독)가 **서로 어긋나** 있어서, 가드는 "환산 불가"
+라고 판정하는데 루프는 달러로 계산하는 모순이 있었다.
+
+## ⚠️ 왜 단순 스윕이 아닌가
+
+`is_kr_ticker()` 는 **두 가지 다른 질문**에 쓰인다:
+
+1. **통화** — "이 보유가 원화 표시인가" → `currency` 도 봐야 한다 (이 파일의 대상)
+2. **시장/세션/유니버스** — "이게 한국 시장 종목인가" → **접미사 단독이 맞다**
+   (`collectors/base.py` 의 market 필터, `risk_signals.py` 의 session 게이트,
+   `sector.py:54` 의 `region`, `forward_outcome_tracker.py` 의 `market`)
+
+`analysis/sector.py` 는 두 질문을 **나란히** 쓴다 — 52행은 통화(환산), 54행은 지역.
+그래서 "`is_kr_ticker` 를 전부 바꿔라" 식의 스윕은 **정상 코드를 오탐**한다. 여기서는
+대신 **인라인 사본이 다시 생기는 것**을 막는다: 그게 실제 재발 경로였다.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from nuri.core.fx import is_krw_holding
+
+NURI = Path(__file__).resolve().parents[2] / "nuri"
+#: 술어의 유일한 정의처. 여기 말고 어디에도 같은 식이 다시 나타나면 안 된다.
+HOME = "core/fx.py"
+
+
+class TestThePredicateItself:
+    @pytest.mark.parametrize(
+        ("ticker", "currency", "expected"),
+        [
+            ("999999.KS", "KRW", True),  # 둘 다
+            ("888888.KQ", None, True),  # 접미사만 — 코스닥
+            ("YYYY", "KRW", True),  # 통화만 (접미사 없음) ← 결함이던 축
+            ("YYYY", "krw", True),  # 대소문자 무시 (holdings_monitor 가 하던 것)
+            ("999999.KS", "USD", True),  # 통화가 틀려도 접미사가 KR
+            ("ZZZZ", "USD", False),
+            ("ZZZZ", None, False),
+            ("ZZZZ", "", False),
+        ],
+    )
+    def test_currency_or_suffix(self, ticker, currency, expected):
+        assert is_krw_holding(ticker, currency) is expected
+
+    def test_none_currency_never_raises(self):
+        """`.get("currency")` 가 None 을 주는 호출자가 있다 — 터지면 안 된다."""
+        assert is_krw_holding("ZZZZ", None) is False
+
+
+class TestNoInlineCopyRemains:
+    """구조 스윕 — 사본이 다시 생기는 걸 막는다.
+
+    동작 잠금은 지금 있는 소비자만 덮는다. 이 결함이 5곳으로 번진 방식이 바로
+    "새 곳에서 같은 식을 다시 쓰기" 였다.
+    """
+
+    #: 인라인 사본의 형태 — 같은 줄에서 `currency` 와 `is_kr_ticker` 를 함께 보는 것.
+    INLINE = re.compile(r'currency.*==.*["\']KRW["\'].*is_kr_ticker|is_kr_ticker.*currency.*==.*["\']KRW["\']')
+
+    @classmethod
+    def _copies(cls) -> dict[str, list[int]]:
+        out: dict[str, list[int]] = {}
+        for f in sorted(NURI.rglob("*.py")):
+            rel = str(f.relative_to(NURI))
+            if rel == HOME:
+                continue
+            for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+                code = line.split("#")[0]
+                if cls.INLINE.search(code):
+                    out.setdefault(rel, []).append(i)
+        return out
+
+    def test_no_module_reimplements_the_predicate(self):
+        found = self._copies()
+        assert not found, f"원화 판정을 인라인으로 다시 구현한 곳: {found}"
+
+    def test_the_sweep_has_eyes(self):
+        """카나리아 — 양방향. 옛 사본 형태를 잡고, 정상 코드를 오탐하지 않아야 한다."""
+        bad = '        is_krw = currency == "KRW" or is_kr_ticker(ticker)'
+        bad2 = '        cur = "KRW" if (r.get("currency") == "KRW" or is_kr_ticker(t)) else "USD"'
+        # 시장 질문 — 접미사 단독은 **정상**이다. 오탐하면 안 된다.
+        ok1 = '        region = "KR" if is_kr_ticker(row["ticker"]) else "US"'
+        ok2 = '        if session == "kr" and not is_kr_ticker(ticker):'
+        ok3 = '        market = "kr" if is_kr_ticker(ticker) else "us"'
+        assert self.INLINE.search(bad), "옛 사본 형태를 못 잡는다"
+        assert self.INLINE.search(bad2), "괄호 낀 변종을 못 잡는다"
+        for ok in (ok1, ok2, ok3):
+            assert not self.INLINE.search(ok), f"시장 질문을 오탐한다: {ok.strip()}"
+
+
+class TestCurrencySitesUseThePredicate:
+    """환산하는 곳은 **정본 술어**를 경유한다 — 접미사 단독으로 돌아가면 FAIL.
+
+    시장 질문(`region` / `session` / `market` / universe 필터)은 대상이 아니다.
+    """
+
+    #: 통화 환산을 하는 함수와, 그 안에서 술어를 부르는지 확인할 파일.
+    CONVERSION_SITES = (
+        "analysis/portfolio.py",
+        "analysis/sector.py",
+        "alerts/risk_signals.py",
+        "alerts/premarket_brief.py",
+        "trading/recommend/price_targets.py",
+        "trading/recommend/holdings_monitor.py",
+    )
+
+    @pytest.mark.parametrize("rel", CONVERSION_SITES)
+    def test_site_calls_the_predicate(self, rel):
+        src = (NURI / rel).read_text(encoding="utf-8")
+        assert "is_krw_holding(" in src, f"{rel}: 정본 술어를 쓰지 않는다"
+
+    def test_every_listed_site_exists(self):
+        """양방향 — 파일이 사라지거나 이름이 바뀌면 위 검사가 조용히 공허해진다."""
+        missing = [r for r in self.CONVERSION_SITES if not (NURI / r).exists()]
+        assert not missing, f"목록이 낡았다 (파일 없음): {missing}"
+
+
+class TestGuardAndLoopAgree:
+    """가드와 환산 루프가 **같은 술어**를 써야 한다 (#1286 의 핵심 모순).
+
+    `premarket_brief` 에서 가드는 정본, 루프는 접미사 단독이었다. 그러면 가드가
+    "환산 불가" 로 판정한 보유를 루프는 달러로 계산한다 — 한 함수 안에서 두 판정이
+    서로 반대되는 상태다.
+
+    ⚠️ **호출 수는 AST 로 센다.** 처음엔 `src.count("is_krw_holding(")` 로 셌는데,
+    같은 파일의 **주석**에 `is_krw_holding()` 이 들어 있어 카운트가 하나 부풀었고,
+    루프를 접미사 단독으로 되돌리는 뮤테이션이 **통과**했다 (실측). 이 레포가 이미
+    아는 함정이다 — `test_no_facade_query_patch.py` 가 "독스트링/주석 언급은 오탐" 이라
+    텍스트 스윕을 기각한 것과 같은 이유.
+    """
+
+    @staticmethod
+    def _calls(rel: str) -> int:
+        tree = ast.parse((NURI / rel).read_text(encoding="utf-8"))
+        return sum(
+            1
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "is_krw_holding"
+        )
+
+    def test_premarket_brief_uses_one_predicate(self):
+        """Mutation lock: 가드나 루프 중 하나를 접미사 단독으로 되돌리면 FAIL."""
+        assert self._calls("alerts/premarket_brief.py") >= 2, (
+            "가드와 루프 중 한쪽이 접미사 단독으로 돌아갔다 — 같은 함수 안에서 판정이 갈린다"
+        )
+
+    def test_price_targets_uses_one_predicate(self):
+        assert self._calls("trading/recommend/price_targets.py") >= 2, "MDD 가드와 환산 루프의 술어가 갈렸다"
+
+    def test_the_counter_ignores_comments(self):
+        """카나리아 — 주석 속 언급을 세면 위 두 잠금이 조용히 헐거워진다 (실제로 그랬다)."""
+        import tempfile
+
+        src = "# is_krw_holding() 를 쓴다\nx = is_krw_holding(a, b)\n"
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "m.py"
+            f.write_text(src, encoding="utf-8")
+            tree = ast.parse(f.read_text(encoding="utf-8"))
+            n = sum(
+                1
+                for x in ast.walk(tree)
+                if isinstance(x, ast.Call) and isinstance(x.func, ast.Name) and x.func.id == "is_krw_holding"
+            )
+        assert n == 1, f"주석을 호출로 셌다: {n}"
+        assert src.count("is_krw_holding(") == 2, "텍스트 카운트는 실제로 부풀어야 한다(대조)"

--- a/tests/core/test_krw_predicate_is_single.py
+++ b/tests/core/test_krw_predicate_is_single.py
@@ -104,78 +104,109 @@ class TestNoInlineCopyRemains:
             assert not self.INLINE.search(ok), f"시장 질문을 오탐한다: {ok.strip()}"
 
 
-class TestCurrencySitesUseThePredicate:
-    """환산하는 곳은 **정본 술어**를 경유한다 — 접미사 단독으로 돌아가면 FAIL.
+def _calls_in(rel: str, func: str | None = None) -> dict[str, int]:
+    """`rel` 안에서 술어 호출 수를 센다. `func` 를 주면 **그 함수 본문만** 본다.
 
-    시장 질문(`region` / `session` / `market` / universe 필터)은 대상이 아니다.
+    ⚠️ 텍스트 카운트가 아니라 AST **Call 노드**를 센다. 처음엔 `src.count(...)` 로 셌다가
+    같은 파일 **주석**에 `is_krw_holding()` 이 있어 카운트가 부풀었고, 루프를 되돌리는
+    뮤테이션이 통과했다 (실측). 이 레포가 이미 아는 함정이다
+    (`test_no_facade_query_patch.py`: "독스트링/주석 언급은 오탐").
+
+    ⚠️ 그리고 **함수 단위**로 센다. 파일 전체를 세면, 대상 분기가 접미사 단독으로
+    회귀해도 파일 어딘가에 무관한 호출이 하나 더 생기면 잠금이 헐거워진다
+    (codex 리뷰 P3).
+    """
+    tree = ast.parse((NURI / rel).read_text(encoding="utf-8"))
+    scope: ast.AST = tree
+    if func is not None:
+        found = [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == func]
+        assert found, f"{rel}: 함수 {func} 를 찾지 못했다 — 이름이 바뀌면 잠금이 공허해진다"
+        scope = found[0]
+    out = {"is_krw_holding": 0, "is_kr_ticker": 0}
+    for n in ast.walk(scope):
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id in out:
+            out[n.func.id] += 1
+    return out
+
+
+class TestCurrencySitesUseThePredicate:
+    """환산하는 곳은 **정본 술어**를 실제로 **호출**한다.
+
+    codex 리뷰 P3: 예전에는 파일에 문자열이 있기만 하면 통과해서, import 나 주석만
+    남고 정작 환산 분기가 접미사 단독으로 회귀해도 초록이었다.
     """
 
-    #: 통화 환산을 하는 함수와, 그 안에서 술어를 부르는지 확인할 파일.
+    #: (파일, 환산 함수) — 함수 단위로 확인한다. `None` 은 **같은 함수 안에서 시장
+    #: 질문도 하는 곳**이라 "접미사 단독 호출 0개" 규칙을 적용할 수 없다는 뜻이다:
+    #:   - `sector.analyze_sector` — 53행 통화(환산), 55행 `region`(시장). 두 줄 간격.
+    #:   - `risk_signals` — session 게이트가 접미사 단독으로 판정하는 게 **맞다**.
+    #: 이 둘은 술어 **호출 여부**만 확인하고, 접미사 금지는 걸지 않는다.
     CONVERSION_SITES = (
-        "analysis/portfolio.py",
-        "analysis/sector.py",
-        "alerts/risk_signals.py",
-        "alerts/premarket_brief.py",
-        "trading/recommend/price_targets.py",
-        "trading/recommend/holdings_monitor.py",
+        ("analysis/portfolio.py", "analyze_portfolio"),
+        ("analysis/sector.py", None),
+        ("alerts/risk_signals.py", None),
+        ("alerts/premarket_brief.py", "_collect_context"),
+        ("trading/recommend/price_targets.py", "check_portfolio_mdd"),
+        ("trading/recommend/holdings_monitor.py", "_classify_asset_class"),
     )
 
-    @pytest.mark.parametrize("rel", CONVERSION_SITES)
-    def test_site_calls_the_predicate(self, rel):
-        src = (NURI / rel).read_text(encoding="utf-8")
-        assert "is_krw_holding(" in src, f"{rel}: 정본 술어를 쓰지 않는다"
+    @pytest.mark.parametrize(("rel", "func"), CONVERSION_SITES)
+    def test_site_calls_the_predicate(self, rel, func):
+        counts = _calls_in(rel, func)
+        where = f"{rel}::{func}" if func else rel
+        assert counts["is_krw_holding"] >= 1, f"{where}: 정본 술어를 호출하지 않는다"
+
+    @pytest.mark.parametrize(("rel", "func"), CONVERSION_SITES)
+    def test_no_conversion_site_still_asks_only_the_suffix(self, rel, func):
+        """환산 함수 안에 `is_kr_ticker` 직접 호출이 남아 있으면 술어가 갈린 것이다.
+
+        Mutation lock: 어느 환산 분기든 `is_kr_ticker(...)` 로 되돌리면 FAIL — 파일
+        어딘가의 무관한 호출로는 우회되지 않는다 (함수 스코프).
+        """
+        if func is None:
+            pytest.skip("같은 함수 안에서 시장 질문도 하는 곳 — 위 CONVERSION_SITES 주석 참조")
+        counts = _calls_in(rel, func)
+        assert counts["is_kr_ticker"] == 0, (
+            f"{rel}::{func}: 환산 함수 안에서 접미사 단독 판정을 쓴다 "
+            f"({counts['is_kr_ticker']}회) — 통화 질문에는 `is_krw_holding` 을 쓴다"
+        )
 
     def test_every_listed_site_exists(self):
         """양방향 — 파일이 사라지거나 이름이 바뀌면 위 검사가 조용히 공허해진다."""
-        missing = [r for r in self.CONVERSION_SITES if not (NURI / r).exists()]
+        missing = [r for r, _ in self.CONVERSION_SITES if not (NURI / r).exists()]
         assert not missing, f"목록이 낡았다 (파일 없음): {missing}"
 
 
 class TestGuardAndLoopAgree:
-    """가드와 환산 루프가 **같은 술어**를 써야 한다 (#1286 의 핵심 모순).
+    """가드와 환산 루프가 **같은 술어**를 쓴다 (#1286 의 핵심 모순).
 
-    `premarket_brief` 에서 가드는 정본, 루프는 접미사 단독이었다. 그러면 가드가
-    "환산 불가" 로 판정한 보유를 루프는 달러로 계산한다 — 한 함수 안에서 두 판정이
-    서로 반대되는 상태다.
-
-    ⚠️ **호출 수는 AST 로 센다.** 처음엔 `src.count("is_krw_holding(")` 로 셌는데,
-    같은 파일의 **주석**에 `is_krw_holding()` 이 들어 있어 카운트가 하나 부풀었고,
-    루프를 접미사 단독으로 되돌리는 뮤테이션이 **통과**했다 (실측). 이 레포가 이미
-    아는 함정이다 — `test_no_facade_query_patch.py` 가 "독스트링/주석 언급은 오탐" 이라
-    텍스트 스윕을 기각한 것과 같은 이유.
+    `premarket_brief` 에서 가드는 정본, 루프는 접미사 단독이었다 — 가드가 "환산 불가"
+    로 판정한 보유를 같은 함수의 루프가 달러로 계산했다.
     """
 
-    @staticmethod
-    def _calls(rel: str) -> int:
-        tree = ast.parse((NURI / rel).read_text(encoding="utf-8"))
-        return sum(
-            1
-            for n in ast.walk(tree)
-            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "is_krw_holding"
-        )
+    def test_premarket_brief_guard_and_loop(self):
+        c = _calls_in("alerts/premarket_brief.py", "_collect_context")
+        assert c["is_krw_holding"] >= 2, "가드와 루프 중 한쪽이 접미사 단독으로 돌아갔다"
 
-    def test_premarket_brief_uses_one_predicate(self):
-        """Mutation lock: 가드나 루프 중 하나를 접미사 단독으로 되돌리면 FAIL."""
-        assert self._calls("alerts/premarket_brief.py") >= 2, (
-            "가드와 루프 중 한쪽이 접미사 단독으로 돌아갔다 — 같은 함수 안에서 판정이 갈린다"
-        )
+    def test_price_targets_guard_and_loop(self):
+        c = _calls_in("trading/recommend/price_targets.py", "check_portfolio_mdd")
+        assert c["is_krw_holding"] >= 2, "MDD 가드와 환산 루프의 술어가 갈렸다"
 
-    def test_price_targets_uses_one_predicate(self):
-        assert self._calls("trading/recommend/price_targets.py") >= 2, "MDD 가드와 환산 루프의 술어가 갈렸다"
+    def test_the_counter_is_function_scoped(self):
+        """카나리아 — 파일 전체를 세면 무관한 호출이 잠금을 헐겁게 한다 (codex P3)."""
+        whole = _calls_in("trading/recommend/price_targets.py")
+        scoped = _calls_in("trading/recommend/price_targets.py", "check_portfolio_mdd")
+        assert scoped["is_krw_holding"] <= whole["is_krw_holding"], "스코프가 파일보다 넓다"
+        assert scoped["is_krw_holding"] >= 2
 
     def test_the_counter_ignores_comments(self):
-        """카나리아 — 주석 속 언급을 세면 위 두 잠금이 조용히 헐거워진다 (실제로 그랬다)."""
-        import tempfile
-
+        """카나리아 — 주석 속 언급을 세면 잠금이 조용히 헐거워진다 (실제로 그랬다)."""
         src = "# is_krw_holding() 를 쓴다\nx = is_krw_holding(a, b)\n"
-        with tempfile.TemporaryDirectory() as d:
-            f = Path(d) / "m.py"
-            f.write_text(src, encoding="utf-8")
-            tree = ast.parse(f.read_text(encoding="utf-8"))
-            n = sum(
-                1
-                for x in ast.walk(tree)
-                if isinstance(x, ast.Call) and isinstance(x.func, ast.Name) and x.func.id == "is_krw_holding"
-            )
+        tree = ast.parse(src)
+        n = sum(
+            1
+            for x in ast.walk(tree)
+            if isinstance(x, ast.Call) and isinstance(x.func, ast.Name) and x.func.id == "is_krw_holding"
+        )
         assert n == 1, f"주석을 호출로 셌다: {n}"
         assert src.count("is_krw_holding(") == 2, "텍스트 카운트는 실제로 부풀어야 한다(대조)"


### PR DESCRIPTION
Closes #1286

## 증상 — 같은 판정이 5곳에 복사돼 있었고, 그중 2곳이 틀렸다

"이 보유가 원화 표시인가" 라는 판정이 인라인으로 흩어져 있었습니다:

| 위치 | 형태 |
|---|---|
| `analysis/portfolio.py` · `analysis/sector.py` · `alerts/risk_signals.py` | `currency == "KRW" or is_kr_ticker(...)` |
| `recommend/holdings_monitor.py` | 같은 판정을 `if` 두 개로 펼쳐 씀 (게다가 `.upper()`) |
| `recommend/price_targets.py` · `alerts/premarket_brief.py` | **`is_kr_ticker()` 단독** ← 결함 |

접미사만 보면 `currency="KRW"` 인데 `.KS`/`.KQ` 가 없는 보유가 **달러로 취급**됩니다. 환산이 통째로 빠지므로 **환율이 완벽히 정상일 때도 틀리고**, 오차가 환율 배수(약 1,380배)입니다.

`premarket_brief` 는 #1284 이후 **자기모순** 상태였습니다: 가드는 정본 술어를, 환산 루프는 접미사 단독을 썼습니다. 가드가 "환산 불가" 로 판정한 보유를 같은 함수의 루프가 달러로 계산합니다.

## 왜 "전부 바꾸기" 가 아닌가 — 두 개의 다른 질문

`is_kr_ticker()` 는 **성격이 다른 두 질문**에 쓰입니다:

1. **통화** — "원화 표시인가" → `currency` 도 봐야 한다 (이 PR 의 대상)
2. **시장 / 세션 / 유니버스** — "한국 시장 종목인가" → **접미사 단독이 맞다**

`analysis/sector.py` 가 둘을 **두 줄 간격으로** 씁니다:

```python
is_krw = is_krw_holding(row["ticker"], row["currency"])   # 통화 → 환산
region = "KR" if is_kr_ticker(row["ticker"]) else "US"    # 시장 → 그대로 정상
```

그래서 `is_kr_ticker` 를 일괄 치환하는 스윕은 **정상 코드를 오탐**합니다. 손대지 않은 시장 질문: collector market 필터 · `risk_signals` session 게이트 · `sector` 의 `region` · `forward_outcome_tracker` 의 `market` · `decision_alpha` universe 필터.

## 통합 방향 — 좁히지 않고 **넓혔다**

`is_krw_holding()` 을 대소문자 무시로 만들었습니다. `holdings_monitor` 가 이미 `currency.upper()` 로 그렇게 하고 있었고, 아래로 맞추면 그쪽 동작이 조용히 바뀝니다. 넓히는 쪽이 안전한 방향입니다 — **불필요한 환산을 한 번 하는 비용**은 있어도, **필요한 환산을 빠뜨리는 일**은 없습니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후, 6축)

| 뮤테이션 | 결과 |
|---|---|
| 술어를 접미사 단독으로 되돌림 (결함 그 자체) | **5 FAIL** |
| 술어를 대소문자 구분으로 되돌림 | **1 FAIL** |
| `price_targets` 환산 루프를 접미사 단독으로 | **1 FAIL** |
| `premarket_brief` 환산 루프를 접미사 단독으로 (가드와 어긋나게) | **1 FAIL** |
| 인라인 사본 부활 (`sector.py`) | **2 FAIL** |
| 인라인 사본 부활 (`holdings_monitor.py`) | **1 FAIL** |
| baseline | 61 passed |

### 뮤테이션이 제 테스트의 헐거움을 잡았습니다

`price_targets` 축이 처음에 **안 잠겼습니다.** 가드와 루프가 같은 술어를 쓰는지 `src.count("is_krw_holding(")` 로 셌는데, **같은 파일의 주석**에 `is_krw_holding()` 이 들어 있어 카운트가 3이었고, 루프를 되돌려 2가 돼도 `>= 2` 를 통과했습니다.

**AST 로 실제 `Call` 노드만** 세도록 고쳤고, 카나리아(주석 1줄 + 호출 1줄 → AST 1, 텍스트 2)를 붙였습니다. 이 레포가 이미 아는 함정입니다 — `test_no_facade_query_patch.py` 가 "독스트링/주석 언급은 오탐" 이라 텍스트 스윕을 기각한 것과 같은 이유고, 저는 그걸 알면서 또 밟았습니다.

구조 스윕의 카나리아도 **양방향**입니다: 옛 사본 형태 2종을 잡는지 + 시장 질문 3종을 오탐하지 않는지. 후자가 없으면 "전부 차단" 과 "제대로 구분" 을 구별할 수 없습니다.

## 검증

- `make test-fast` → **7,711 passed / 6 skipped**. 별개 red 3건은 KRX 실서버 fetch 실패로 **clean main 에서 재현** 확인 — #1290 으로 분리
- `ruff check` clean · `make diagnostics` rc=0 (pyright 162, ratchet 172 이하 — 이 PR 이 새로 만든 건 없고 `sector.py` 의 기존 1건은 오히려 줄었습니다)
- `check_privacy_leak.py` rc=0 · `make verify-doc-counts` **24/24**

---

## codex 리뷰 — **PASS**, [P3] 2건 수용

P1·P2 없음. 두 P3 모두 **"테스트가 독스트링만큼 강하지 않다"** 였고, 맞습니다.

### [P3] `test_site_calls_the_predicate` 가 텍스트 존재 검사였다

> It passes if a file still contains `is_krw_holding(` in an import, comment, or dead code while the actual conversion branch regresses back to suffix-only logic.

**맞고, 방금 옆 클래스에서 고친 것과 같은 함정입니다.** 호출 수는 AST 로 바꿔놓고 이 검사는 텍스트 그대로 뒀습니다. AST `Call` 노드로 교체했습니다.

실측으로 확인: 호출을 `is_kr_ticker(...)` 로 되돌리고 주석에 `is_krw_holding()` 을 남기는 뮤테이션이 **이제 2 FAIL** 합니다 — 옛 검사로는 통과하던 형태입니다.

### [P3] `>= 2` 카운트가 파일 전체 기준이었다

> it can still pass if one targeted branch regresses and an unrelated third `is_krw_holding()` call appears elsewhere in the file

**맞습니다.** 대상 함수(`_collect_context` · `check_portfolio_mdd`) **스코프**로 좁혔습니다.

### 좁히니 진짜 뉘앙스가 드러났습니다

함수 스코프로 "이 함수 안에 접미사 단독 호출 0개" 를 걸었더니 `sector.py` 가 FAIL 했습니다 — **같은 함수가 두 질문을 다 하기 때문**입니다 (53행 통화 환산, 55행 `region` 시장). `risk_signals` 의 session 게이트도 같습니다. 둘은 **사유를 적어** 접미사 금지에서 제외하고, 술어 호출 여부만 확인합니다.

그리고 함수명을 잘못 짚었을 때(`analyze_sectors` — 실제로는 `analyze_sector`) **stale-name assert 가 즉시 잡았습니다.** 이름이 바뀌면 잠금이 조용히 공허해지는 걸 막는 장치가 실제로 발화한 셈입니다.

### 추가 뮤테이션 (P3 반영 후, 4축)

| 뮤테이션 | 결과 |
|---|---|
| `price_targets` 환산 루프 → 접미사 단독 | **3 FAIL** |
| `premarket_brief` 환산 루프 → 접미사 단독 | **2 FAIL** |
| `holdings_monitor` → 접미사 단독 | **2 FAIL** |
| 호출 제거 + 주석에만 이름 남김 (codex 가 지적한 정확한 시나리오) | **2 FAIL** |
| baseline | 26 passed / 2 skipped |

### codex 가 확인해준 것

- **누락된 환산 사이트 없음** — 백엔드 전수 스캔 결과 나머지 환산 지점(`dashboard.py` · `actions.py`)은 이미 `is_krw_holding()` 을 경유
- **시장 질문을 통화 질문으로 잘못 바꾼 곳 없음** — `collectors/base.py` · `risk_signals` session · `sector` region · `decision_alpha` universe 전부 접미사 단독 유지
- `holdings_monitor` 의 **KRW-before-crypto 순서 보존** — crypto 분기 동작 불변
- `currency=None` 은 여전히 non-KRW (접미사가 KR 이 아닌 한), `KeyError`/silent-None 위험 없음
