### PR TITLE
fix(ci): respell "not integration" wherever pytest is given -m

### DIFF
--- a/.github/workflows/main-ci-cd.yml
+++ b/.github/workflows/main-ci-cd.yml
@@ -574,7 +574,10 @@ jobs:
         # 23 slow tests (LLM/scheduler) → 2 shards × xdist 4 workers. 단일 shard
         # 2:16 wall 의 critical path 를 절반 ~1:00-1:15 로 단축 — fast lane (shard
         # 4 분할 후 ~2:11 wall) 과 같은 critical path 안에 들어옴.
-        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow" --splits 2 --group ${{ matrix.shard }} --cov=nuri --cov-branch --cov-report= --cov-report=term
+        # `-m` 은 pyproject addopts 의 `-m "not integration"` 을 **덮어쓴다**(합쳐지지
+        # 않는다). 여기 `not integration` 을 다시 안 적으면 slow lane 이 실외부
+        # 네트워크 테스트를 끌어들여 CI 가 외부 사이트 상태로 빨개진다 (#1290).
+        run: .venv/bin/python -m pytest tests/ -q --tb=short -n auto --dist worksteal -m "slow and not integration" --splits 2 --group ${{ matrix.shard }} --cov=nuri --cov-branch --cov-report= --cov-report=term
         timeout-minutes: 5
 
       - name: Upload .coverage artifact

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,13 @@ setup-hooks: ## Install repo-tracked git hooks (pre-commit auto-fix). Idempotent
 test:
 	$(PYTHON) -m pytest tests/ -v --cov=nuri --cov-branch -n auto --dist worksteal
 
+# ⚠️ `-m` 은 addopts 의 `-m` 을 **덮어쓴다** (합쳐지지 않는다). pyproject 의
+# `addopts = -m "not integration"` 은 여기서 무효가 되므로 **직접 다시 적어야 한다**.
+# 안 적으면 실외부 네트워크를 타는 integration 테스트가 fast 게이트에 섞여, KRX 가
+# 죽은 날 코드와 무관하게 빨간불이 뜬다 (#1290). CI 샤드는 원래 둘 다 적고 있었다 —
+# 로컬만 갈라져 있었다.
 test-fast:
-	$(PYTHON) -m pytest tests/ -v --cov=nuri --cov-branch -n auto --dist worksteal -m "not slow"
+	$(PYTHON) -m pytest tests/ -v --cov=nuri --cov-branch -n auto --dist worksteal -m "not slow and not integration"
 
 # ─── CI artifact ground-truth coverage (Issue #616 verification protocol) ───
 # 직전 main CI run 의 6 shards (.coverage artifacts) 다운로드 + combine →
@@ -153,8 +158,10 @@ postmortem-kr:    ## Post-market brief (KR session, KST 16:00 — KOSPI close + 
 postmortem-us:    ## Post-market brief (US session, NYSE 16:00 ET + 30min)
 	@.venv/bin/python -m nuri.alerts.postmarket_brief --session us
 
+# `not integration` 은 여기도 필요하다 — 같은 이유(위 test-fast 주석). integration 은
+# `make test-integration` 으로만 돈다.
 test-slow:
-	$(PYTHON) -m pytest tests/ -v -n auto --dist worksteal -m "slow"
+	$(PYTHON) -m pytest tests/ -v -n auto --dist worksteal -m "slow and not integration"
 
 lint:
 	$(PYTHON) -m ruff check nuri/ tests/ scripts/

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,755 collected across 355 files | ✅ |
+| **Backend tests** | 7,763 collected across 356 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,755 backend tests across 355 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,763 backend tests across 356 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,755 tests, 355 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,763 tests, 356 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/verify/test_pytest_marker_selection.py
+++ b/tests/verify/test_pytest_marker_selection.py
@@ -1,0 +1,163 @@
+"""`-m` 을 넘기는 pytest 호출은 `not integration` 을 **다시 적어야 한다** (#1290).
+
+## 무엇이 잘못됐었나
+
+`pyproject.toml` 은 `addopts = "-v --tb=short -m \\"not integration\\""` 로 실외부
+네트워크 테스트를 기본 제외한다. 그런데 **pytest 의 `-m` 은 합쳐지지 않고 덮어쓴다.**
+그래서 커맨드라인에 `-m` 을 주는 순간 addopts 의 `not integration` 이 **사라진다.**
+
+2026-08-29 실측:
+
+```
+$ pytest tests/integration/test_universe_sync_real.py --collect-only
+no tests collected (9 deselected)          ← addopts 가 먹는다
+
+$ pytest tests/integration/test_universe_sync_real.py -m "not slow" --collect-only
+9 tests collected                          ← addopts 의 -m 이 덮여 사라졌다
+```
+
+`make test-fast` 가 `-m "not slow"` 를 넘기고 있었으므로, **가장 자주 도는 게이트에만**
+KRX 실서버를 치는 테스트 3건이 섞여 있었다. KRX 가 응답하지 않는 날이면 코드와 무관하게
+빨간불이 뜬다 — false-red 다. 이 레포가 반복해서 배운 형태고(#1270 요일 의존 FAIL,
+#1277 배포 검증 거짓 경고), 매번 뜨는 빨간불은 **진짜 빨간불을 무시하는 습관**을 만든다.
+
+## 방향이 거꾸로였다
+
+`make test` (전체)는 `-m` 을 안 줘서 addopts 가 그대로 먹어 **정상**이었고,
+`make test-fast` (수시로 도는 것)만 깨져 있었다. CI 샤드는 처음부터
+`-m "not slow and not integration"` 으로 **둘 다 적고 있었다** — 로컬만 갈라진
+CI-parity 결함이라 CI 는 영원히 초록이었다.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO / "Makefile"
+CI = REPO / ".github" / "workflows" / "main-ci-cd.yml"
+
+#: `-m` 을 넘기면서 `not integration` 을 **일부러 안 적는** 호출. 사유 필수.
+#: 양방향 검사라 낡은 항목(이제 적게 된 것)도 FAIL 한다.
+MARKER_EXEMPT: dict[str, str] = {
+    "-m integration": (
+        "`make test-integration` 자체 — integration 만 골라 도는 것이 목적이다. "
+        "네트워크가 필요하다는 사실은 타깃 이름과 help 문구에 명시돼 있고, "
+        "이건 수시로 도는 게이트가 아니라 사람이 의도적으로 부르는 명령이다."
+    ),
+}
+
+
+def _pytest_invocations_with_marker() -> list[tuple[str, str]]:
+    """`-m <expr>` 를 넘기는 pytest 호출 전부. (출처, 마커식) 목록."""
+    out: list[tuple[str, str]] = []
+    for src in (MAKEFILE, CI):
+        if not src.exists():
+            continue
+        for line in src.read_text(encoding="utf-8").splitlines():
+            code = line.split("#")[0]
+            if "pytest" not in code:
+                continue
+            # ⚠️ `python -m pytest` 의 `-m` 은 **모듈 플래그**지 마커가 아니다.
+            # 처음에 줄 전체를 훑었더니 그게 잡혀 `-m pytest` 가 마커식으로 보고됐다.
+            # `pytest` 라는 단어 **뒤쪽**만 본다.
+            tail = code.split("pytest", 1)[1]
+            m = re.search(r'-m\s+"([^"]+)"|-m\s+(\S+)', tail)
+            if m:
+                out.append((src.name, (m.group(1) or m.group(2)).strip()))
+    return out
+
+
+class TestEveryMarkerExpressionKeepsIntegrationOut:
+    """구조 스윕 — `-m` 을 새로 넘기는 곳이 생겨도 배제가 유지되는지."""
+
+    def test_no_invocation_silently_drops_the_exclusion(self):
+        bad = [
+            (src, expr)
+            for src, expr in _pytest_invocations_with_marker()
+            if "not integration" not in expr and f"-m {expr}" not in MARKER_EXEMPT
+        ]
+        assert not bad, (
+            f"`-m` 이 addopts 의 `not integration` 을 덮어쓴다 — 이 호출들이 실네트워크 테스트를 다시 끌어들인다: {bad}"
+        )
+
+    def test_every_exemption_is_still_used(self):
+        """양방향 — 예외가 사라졌는데 목록에 남아 있으면 그 사유는 이미 거짓이다."""
+        live = {f"-m {expr}" for _, expr in _pytest_invocations_with_marker()}
+        stale = [k for k in MARKER_EXEMPT if k not in live]
+        assert not stale, f"낡은 예외 항목: {stale}"
+
+    def test_every_exemption_states_a_reason(self):
+        for key, why in MARKER_EXEMPT.items():
+            assert len(why) > 40, f"{key}: 사유가 너무 짧다"
+
+    def test_the_sweep_has_eyes(self):
+        """카나리아 — 스윕이 아무것도 못 찾으면 위 검사는 영원히 공허하다."""
+        found = _pytest_invocations_with_marker()
+        assert len(found) >= 3, f"pytest -m 호출을 못 찾았다: {found}"
+        # 옛 결함 형태를 실제로 잡는지 (양방향)
+        broken = 'pytest tests/ -m "not slow"'
+        m = re.search(r'-m\s+"([^"]+)"', broken)
+        assert m and "not integration" not in m.group(1), "옛 결함 형태를 못 잡는다"
+        # `python -m pytest` 의 모듈 플래그를 마커로 오탐하지 않는지 — 실제로 밟았다.
+        assert all(expr != "pytest" for _, expr in found), "`python -m pytest` 의 `-m` 을 마커식으로 오탐한다"
+
+
+class TestSelectionActuallyExcludesTheNetworkTests:
+    """동작 잠금 — 구조가 맞아도 실제 선택이 틀릴 수 있다.
+
+    수집 단계만 돌린다(`--collect-only`). 실행하면 그 자체로 네트워크를 타므로,
+    이 테스트가 자기가 막으려는 문제를 일으키게 된다.
+    """
+
+    @staticmethod
+    def _collected(marker: str) -> int:
+        r = subprocess.run(
+            [
+                ".venv/bin/python",
+                "-m",
+                "pytest",
+                "tests/integration/",
+                "-m",
+                marker,
+                "-q",
+                "--collect-only",
+                "-p",
+                "no:cacheprovider",
+            ],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+        )
+        m = re.search(r"(\d+) tests? collected", r.stdout)
+        return int(m.group(1)) if m else 0
+
+    def test_fast_selection_collects_no_integration_test(self):
+        """Mutation lock: Makefile 을 `-m "not slow"` 로 되돌리면 FAIL."""
+        assert self._collected("not slow and not integration") == 0
+
+    def test_slow_selection_collects_no_integration_test(self):
+        assert self._collected("slow and not integration") == 0
+
+    def test_integration_target_still_collects_them(self):
+        """대조군 — 배제가 과해서 `make test-integration` 까지 죽으면 안 된다.
+
+        이게 없으면 "전부 배제" 라는 가짜 수정이 통과한다.
+        """
+        assert self._collected("integration") > 0, "integration 타깃이 아무것도 못 고른다"
+
+
+class TestTheMarkerContractIsDocumented:
+    def test_makefile_explains_why_the_exclusion_is_respelled(self):
+        """다음 사람이 '중복' 이라고 지우지 않도록 이유가 Makefile 에 있어야 한다.
+
+        addopts 에 이미 있는데 왜 또 적나 — 답(`-m` 이 덮어쓴다)이 없으면 지워진다.
+        """
+        src = MAKEFILE.read_text(encoding="utf-8")
+        assert "덮어쓴다" in src and "#1290" in src, (
+            "Makefile 에 `-m` 이 addopts 를 덮어쓴다는 설명이 없다 — 중복으로 보여 지워진다"
+        )


### PR DESCRIPTION
Closes #1290

## 근본 원인 — 마커가 없어서가 아니라, `-m` 이 **덮어쓰기** 때문

이슈를 올릴 땐 "마커를 붙이자" 고 적었는데, 조사해보니 **마커는 처음부터 있었습니다**:

```python
# tests/integration/test_universe_sync_real.py
pytestmark = pytest.mark.integration
```

그리고 `pyproject.toml` 이 기본 제외까지 하고 있습니다:

```toml
addopts = "-v --tb=short -m \"not integration\""
```

문제는 **pytest 의 `-m` 이 합쳐지지 않고 덮어쓴다**는 것입니다. 커맨드라인에 `-m` 을 주는 순간 addopts 의 `not integration` 이 **사라집니다.**

```
$ pytest tests/integration/test_universe_sync_real.py --collect-only
no tests collected (9 deselected)          ← addopts 가 먹는다

$ pytest tests/integration/test_universe_sync_real.py -m "not slow" --collect-only
9 tests collected                          ← 덮여서 사라졌다
```

`make test-fast` 가 `-m "not slow"` 를 넘기고 있었으므로, **가장 자주 도는 게이트**에만 KRX 실서버를 치는 테스트 3건이 섞여 있었습니다.

## 방향이 거꾸로였습니다

| 타깃 | `-m` | integration 실행? |
|---|---|---|
| `make test` (전체) | 없음 → addopts 적용 | ✅ 제외 |
| **`make test-fast`** | `-m "not slow"` | ❌ **포함** |
| **`make test-slow`** | `-m "slow"` | ❌ **포함** |
| CI fast shard | `-m "not slow and not integration"` | ✅ 제외 |
| **CI slow lane** | `-m "slow"` | ❌ **포함** |

**전체 스위트는 정상인데 수시로 도는 fast 게이트만 깨져 있었습니다.** CI fast shard 는 처음부터 둘 다 적고 있어서 CI 는 영원히 초록이었고 — 전형적인 **로컬/CI 분기** 결함입니다.

## 회귀 테스트가 제가 놓친 두 번째 구멍을 잡았습니다

처음엔 grep 으로 `-m` 사용처를 찾아 Makefile 2곳만 고쳤습니다. 구조 스윕을 쓰자 **CI slow lane** (`-m "slow" --splits 2`) 이 같은 구멍을 갖고 있다고 즉시 FAIL 했습니다. 손 grep 이 놓친 걸 스윕이 잡은 사례입니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후, 5축)

| 뮤테이션 | 결과 |
|---|---|
| `test-fast` → `-m "not slow"` (결함 그 자체) | **1 FAIL** |
| `test-slow` → `-m "slow"` | **1 FAIL** |
| CI slow lane 되돌림 | **1 FAIL** |
| Makefile 설명 주석 제거 | **1 FAIL** |
| allowlist 에 낡은 항목 (양방향) | **2 FAIL** |
| baseline | 8 passed |

**주석 제거를 잠근 이유**: `addopts` 에 이미 있는 걸 왜 또 적나 — 이유(`-m` 이 덮어쓴다)가 없으면 다음 사람이 "중복" 이라고 지웁니다. 그러면 결함이 그대로 복원됩니다.

**대조군**: `make test-integration` 이 여전히 9건을 고르는지 확인합니다. 없으면 "전부 배제" 라는 가짜 수정이 통과합니다.

**동작 잠금은 `--collect-only` 로만** 합니다 — 실행하면 이 테스트 자신이 네트워크를 타서, 막으려는 문제를 스스로 일으킵니다.

### 스윕 카나리아가 제 정규식 오류를 잡았습니다

첫 구현이 줄 전체에서 `-m` 을 찾아 **`python -m pytest` 의 모듈 플래그**를 마커식으로 오탐했습니다(9건 전부 `-m pytest` 로 보고). `pytest` 단어 뒤쪽만 보도록 고치고, 그 오탐 축을 카나리아에 넣었습니다.

## 검증

- `make test-fast` → **7,719 passed / 8 skipped, rc=0** — 이번 세션 첫 완전 초록입니다 (KRX red 3건 소멸)
- `make test-integration` 은 그대로 9건 수집
- `ruff check` · `make lint-sh` · `check_privacy_leak.py` · `make verify-doc-counts` **24/24** 전부 통과
