### PR TITLE
fix(engine): normalize decisions.regime to the canonical vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,763 collected across 356 files | ✅ |
+| **Backend tests** | 7,789 collected across 357 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,763 backend tests across 356 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,789 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,763 tests, 356 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,789 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/engine/CLAUDE.md
+++ b/nuri/trading/engine/CLAUDE.md
@@ -54,3 +54,27 @@ Mechanical ordering when emitting actions: `stop_loss → take_profit → traili
 - Within `take_profit`: sort by `excess%` descending (biggest winner first — lock in gains).
 - Rationale: declining momentum loses more per hour delayed; rising momentum is more forgiving.
 - ⚠️ **이 순서는 코드에 없다 (2026-08-02 감사).** `config/rules.yaml execution_priority` 는 어느 모듈도 읽지 않고(`order` / `stop_loss_sort` / `take_profit_sort` 전부 소비처 0), 이 문서가 "Codified in config" 라고 적어둔 탓에 배선된 것으로 읽혀 왔다. 위 서술은 **설계 의도**이지 현재 동작이 아니다. 실제로 순서를 강제하려면 소비자를 만들어야 하고 그건 매매 동작 변경이라 STRATEGY PR 대상.
+
+## regime 어휘 — canonical 이거나 NULL (#1268)
+
+`decisions.regime` 은 `ALL_REGIMES` 10개 값 또는 NULL 만 담는다. `_snapshot_market_context`
+가 regime 을 채우는 **두 경로**(`pipeline_events` payload · `classify_regime()` fallback)
+합류 지점에서 `canonical_regime_or_none` 으로 한 번 정규화한다 — 경로마다 붙이지 않는 이유는
+새 경로가 생겨도 자동으로 덮이기 때문이다.
+
+payload 경로가 더 위험하다: **다른 생산자가 쓴 임의 JSON** 이라, `#832` 가 이 가드를 만든
+바로 그 free-text 유입 경로다 (`recommendations.regime` 에 `''` · `'[recovery] 비중 축소'`
+가 실제로 남아 있다).
+
+⚠️ **거부는 NULL 이고, NULL 은 `decisions_context` freshness 를 건드린다** (#1267, warn 24h /
+fail 60h). 의도한 것이다 — 어휘 밖 라벨을 조용히 저장하는 것보다 라벨 부재가 보이는 편이 낫다.
+
+⚠️ **"모든 regime writer 에 가드" 는 틀린 원칙이다.** `candidate_runs.regime` 은
+`UNKNOWN_REGIME`("unknown", 의도적으로 `ALL_REGIMES` 밖)을 정당하게 저장한다. 대상은
+**어휘가 `ALL_REGIMES` 인 컬럼**뿐이다.
+
+`certifications.regime` 은 아직 무가드다 — 행수가 12배이고 값이 `.get(regime, {})` 로 가서
+성격이 달라 **#1293** 으로 분리했다.
+
+**Test:** `tests/trading/engine/test_regime_canonical_guard.py` — 어휘 밖 7종 거부 + canonical
+10종 전부 보존(대조군) + writer 대칭 AST 스윕 + known-gap 양방향.

--- a/nuri/trading/engine/decisions.py
+++ b/nuri/trading/engine/decisions.py
@@ -266,6 +266,38 @@ def _snapshot_market_context(db_path=None) -> dict:
         except Exception:
             pass
 
+    # #1268: 위 **두 경로 중 무엇이 채웠든** 여기서 한 번 정규화한다. 형제 writer 2곳
+    # (`recommend/tracker.py` · `agents/consensus/persistence.py`) 은 `canonical_regime_or_none`
+    # 을 통과시키는데 이 파일만 raw 로 넣고 있었다.
+    #
+    # 경로별로 가드를 붙이지 않고 **합류 지점 한 곳**에 두는 이유: 새 경로가 생겨도
+    # 자동으로 덮인다. 그리고 두 경로의 위험도가 다르다 —
+    #   - classifier fallback 은 `classify_regime()` 이 canonical 을 돌려주므로 낮다
+    #   - `pipeline_events` payload 는 **다른 생산자가 쓴 임의 JSON** 이라, `#832` 가
+    #     `canonical_regime_or_none` 을 만든 바로 그 free-text 유입 경로다
+    #     (`"" / "[recovery] 비중 축소"` 가 실제 사례였다)
+    #
+    # free-text 가 새면 `UNKNOWN_REGIME`("unknown", 의도적으로 `ALL_REGIMES` 밖)이
+    # 아니라 표에 **존재하는** 문자열이 되어, 배분 조회가 조용히 기본값을 준다 (#1131:
+    # 미상이 `"neutral"` 로 표기돼 가장 공격적인 0.40 배분을 받았다).
+    #
+    # ⚠️ **이 거부에는 관측 가능한 결과가 있다 — 의도한 것이다.** #1267 이 추가한
+    # `decisions_context` freshness 정책의 술어가 `SUM(regime IS NOT NULL AND
+    # scoring_detail IS NOT NULL) = COUNT(*)` 라, 여기서 NULL 로 떨구면 그날 배치가
+    # 불완전으로 잡혀 warn 24h / fail 60h 로 표면화된다 (`config/freshness.yaml`).
+    # 그게 맞는 방향이다: 어휘 밖 라벨을 조용히 저장하는 것보다, 라벨을 못 붙였다는
+    # 사실이 보이는 편이 낫다 (Escalation Ladder 의 Surface 등급). 알람이 뜨면
+    # 원인은 '분류기/이벤트 생산자가 어휘 밖 값을 냈다' 이지 이 코드가 아니다.
+    # 키를 **없애는** 쪽으로 정규화한다 (`None` 을 넣지 않는다) — 기존 계약이
+    # "모르면 키 자체가 없다" 였고, 소비자와 테스트가 `"regime" not in ctx` 로 그걸 본다.
+    from nuri.quant.regime.classifier import canonical_regime_or_none
+
+    _canonical = canonical_regime_or_none(context.get("regime"))
+    if _canonical is None:
+        context.pop("regime", None)
+    else:
+        context["regime"] = _canonical
+
     # Macro score — event_score 포함
     try:
         from nuri.quant.regime.macro_score import compute_macro_score

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -1132,10 +1132,12 @@ class TestSnapshotMarketContext:
         with get_db(db_path) as conn:
             conn.execute(
                 "INSERT INTO pipeline_events (timestamp, event_type, payload) VALUES (?, ?, ?)",
-                ("2026-04-10T10:00:00", "regime_changed", json.dumps({"regime": "risk_on"})),
+                ("2026-04-10T10:00:00", "regime_changed", json.dumps({"regime": "bull_high_vol"})),
             )
         ctx = _snapshot_market_context(db_path=db_path)
-        assert ctx["regime"] == "risk_on"
+        # #1268: canonical 값이어야 통과한다. 예전 픽스처는 `"risk_on"` 이었는데 그건
+        # `ALL_REGIMES` 에 없는 free-text 였고, 테스트가 무가드 동작을 잠그고 있었다.
+        assert ctx["regime"] == "bull_high_vol"
 
     def test_latest_event_wins_over_older_one(self, db_path):
         """이벤트가 여럿이면 **최신** 것이 이긴다 (`ORDER BY timestamp DESC`).
@@ -1164,10 +1166,10 @@ class TestSnapshotMarketContext:
         with get_db(db_path) as conn:
             conn.execute(
                 "INSERT INTO pipeline_events (timestamp, event_type, payload) VALUES (?, ?, ?)",
-                ("2026-04-10T10:00:00", "regime_changed", json.dumps({"new_regime": "risk_off"})),
+                ("2026-04-10T10:00:00", "regime_changed", json.dumps({"new_regime": "bear_high_vol"})),
             )
         ctx = _snapshot_market_context(db_path=db_path)
-        assert ctx["regime"] == "risk_off"
+        assert ctx["regime"] == "bear_high_vol"
 
     def test_regime_malformed_json_swallowed(self, db_path, monkeypatch):
         """Lines 238-239: invalid JSON payload → except branch, no crash, regime not set."""
@@ -1217,7 +1219,7 @@ class TestRecordDecisionRegimeEvidence:
         with get_db(db_path) as conn:
             conn.execute(
                 "INSERT INTO pipeline_events (timestamp, event_type, payload) VALUES (?, ?, ?)",
-                ("2026-04-10T10:00:00", "regime_changed", json.dumps({"regime": "risk_on"})),
+                ("2026-04-10T10:00:00", "regime_changed", json.dumps({"regime": "bull_high_vol"})),
             )
         _insert_price(db_path, "NVDA", 120.0)
 
@@ -1240,9 +1242,9 @@ class TestRecordDecisionRegimeEvidence:
         assert regime_evidence[0]["source_key"] == "current"
         # regime 값이 detail JSON 안에 들어 있음
         detail = json.loads(regime_evidence[0]["detail"])
-        assert detail["regime"] == "risk_on"
+        assert detail["regime"] == "bull_high_vol"
         # decisions row 의 regime 컬럼 자체도 채워졌는지 확인
-        assert decision["regime"] == "risk_on"
+        assert decision["regime"] == "bull_high_vol"
 
 
 # ═══════════════════════════════════════════════════════

--- a/tests/trading/engine/test_regime_canonical_guard.py
+++ b/tests/trading/engine/test_regime_canonical_guard.py
@@ -1,0 +1,212 @@
+"""`decisions.regime` 도 canonical 어휘만 받는다 — 형제 writer 2곳과 대칭 (#1268).
+
+## 무엇이 잘못됐었나
+
+같은 값을 쓰는 writer 3곳 중 **한 곳만** 정규화 가드를 안 통과했다:
+
+| writer | 가드 |
+|---|---|
+| `recommend/tracker.py` · `agents/consensus/persistence.py` | `canonical_regime_or_none()` ✅ |
+| `engine/decisions.py` | raw ❌ |
+
+그리고 이슈가 지목한 것보다 **경로가 하나 더 있었다.** `_snapshot_market_context` 는
+regime 을 두 곳에서 채운다:
+
+1. `pipeline_events` 의 `regime_changed` payload — **다른 생산자가 쓴 임의 JSON**
+2. `classify_regime()` fallback (#1256) — 분류기가 canonical 을 돌려주므로 낮은 위험
+
+이슈는 2번만 적었는데 **1번이 더 위험하다**: `#832` 가 `canonical_regime_or_none` 을
+만든 이유가 정확히 그 free-text 유입이었다 (`"" / "[recovery] 비중 축소"` 가 실제 사례).
+
+## 왜 어휘 밖 문자열이 위험한가
+
+`UNKNOWN_REGIME = "unknown"` 은 **의도적으로 `ALL_REGIMES` 밖**이다. 어휘 밖 값이
+미상을 뜻하는 게 아니라 **표에 존재하는 다른 이름**으로 새면, 배분 조회의
+`.get(key, default)` 가 조용히 값을 준다 — #1131 에서 미상이 `"neutral"` 로 표기돼
+`buy_signals.yaml` 의 `total_pct_by_regime` 에서 **가장 공격적인 0.40 배분**을 받았다.
+
+## 이 결함의 증거는 레포 안에 있었다
+
+기존 테스트 픽스처가 `"risk_on"` / `"risk_off"` 를 썼다 — 둘 다 `ALL_REGIMES` 에 없는,
+그럴듯하게 들리는 **지어낸 이름**이다. 무가드 동작을 테스트가 잠그고 있었던 셈이고,
+사람이 어휘 밖 이름을 자연스럽게 만들어낸다는 증거이기도 하다.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from nuri.core.db import get_db, init_db
+from nuri.quant.regime.classifier import ALL_REGIMES
+
+NURI = Path(__file__).resolve().parents[3] / "nuri"
+
+#: 어휘 밖이지만 **그럴듯한** 이름들. 사람이 실제로 만들어내는 형태다.
+PLAUSIBLE_BUT_WRONG = ["risk_on", "risk_off", "neutral", "bull", "bear", "", "[recovery] 비중 축소"]
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    import nuri.core.db as db_mod
+
+    path = tmp_path / "d.db"
+    init_db(path)
+    monkeypatch.setattr(db_mod, "DB_PATH", path)
+    return path
+
+
+def _seed_regime_event(db_path, value):
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO pipeline_events (timestamp, event_type, payload) VALUES (?, ?, ?)",
+            ("2026-08-29T10:00:00", "regime_changed", json.dumps({"regime": value})),
+        )
+
+
+class TestFreeTextNeverReachesTheColumn:
+    """이슈가 안 적은 경로 — `pipeline_events` payload 는 임의 JSON 이다."""
+
+    @pytest.mark.parametrize("value", PLAUSIBLE_BUT_WRONG)
+    def test_non_canonical_payload_is_dropped(self, db, value, monkeypatch):
+        """Mutation lock: 정규화를 지우면 이 값들이 그대로 컬럼에 들어가 FAIL."""
+        import nuri.quant.regime.classifier as classifier
+        from nuri.trading.engine.decisions import _snapshot_market_context
+
+        # fallback 분류기를 죽여 **payload 경로만** 본다 — 안 그러면 빈 DB 의 분류기
+        # 결과에 따라 결과가 흔들린다 (주변 상태 의존, 기존 테스트가 밟은 함정).
+        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: None)
+        _seed_regime_event(db, value)
+        ctx = _snapshot_market_context(db_path=db)
+        assert ctx.get("regime") is None, f"어휘 밖 값이 통과했다: {value!r}"
+
+    @pytest.mark.parametrize("value", sorted(ALL_REGIMES))
+    def test_canonical_payload_survives(self, db, value, monkeypatch):
+        """대조군 — 정상 값까지 떨구는 가짜 수정을 막는다.
+
+        `ALL_REGIMES` **전부**를 돈다: 일부만 통과시키는 구현도 잡는다.
+        """
+        import nuri.quant.regime.classifier as classifier
+        from nuri.trading.engine.decisions import _snapshot_market_context
+
+        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: None)
+        _seed_regime_event(db, value)
+        ctx = _snapshot_market_context(db_path=db)
+        assert ctx["regime"] == value
+
+    def test_absent_regime_leaves_the_key_unset(self, db, monkeypatch):
+        """계약 유지 — "모르면 키 자체가 없다". 소비자가 `"regime" not in ctx` 로 본다.
+
+        `None` 을 넣는 구현으로 바꾸면 이 단언이 FAIL 한다. 기능은 같지만 계약이 다르다.
+        """
+        import nuri.quant.regime.classifier as classifier
+        from nuri.trading.engine.decisions import _snapshot_market_context
+
+        monkeypatch.setattr(classifier, "classify_regime", lambda db_path=None: None)
+        _seed_regime_event(db, "risk_on")
+        ctx = _snapshot_market_context(db_path=db)
+        assert "regime" not in ctx
+
+
+#: **어휘가 `ALL_REGIMES` 인 컬럼**의 writer 만 대상이다.
+#:
+#: "모든 regime writer 에 가드" 는 **틀린 원칙**이다 — `candidate_runs.regime` 은
+#: `UNKNOWN_REGIME`("unknown") 을 정당하게 저장하는데, 그 값은 **의도적으로**
+#: `ALL_REGIMES` 밖이다 (미상을 어휘 안 이름으로 표기하지 않으려고 그렇게 만들었다).
+#: 그 컬럼까지 가드를 걸면 미상을 표현할 방법이 사라진다.
+CANONICAL_VOCAB_WRITERS: dict[str, str] = {
+    "trading/recommend/tracker.py": "recommendations.regime",
+    "trading/agents/consensus/persistence.py": "recommendations.regime",
+    "trading/engine/decisions.py": "decisions.regime",
+}
+
+#: 같은 어휘를 쓰는데 **아직 가드가 없는** writer. 사유와 추적 이슈를 함께 적는다.
+#: 양방향 검사라 고치고 나면 stale 로 FAIL 해서 목록 정리를 강제한다.
+KNOWN_UNGUARDED: dict[str, str] = {
+    "trading/engine/certification.py": (
+        "#1293 — `_classify_regime_fresh` 가 무가드. 이 PR 에 묶지 않는 이유는 성격이 "
+        "다르기 때문이다: 행수가 4,525 로 decisions(387)의 12배이고, 값이 "
+        "`RULES...regime_overrides.get(regime, {})` 라는 **조용한 기본값** 경로로 간다. "
+        "별도 이슈에서 동작 잠금과 함께 다뤄야 한다."
+    ),
+}
+
+
+class TestCanonicalVocabColumnsAreGuarded:
+    """어휘가 `ALL_REGIMES` 인 컬럼의 writer 는 **같은** 가드를 통과한다.
+
+    비대칭 자체가 결함이었다: 두 곳은 통과하고 한 곳만 안 하는 상태는, 다음에
+    classifier 반환이 바뀌거나 소비자가 늘 때 조용히 깨질 자리다.
+    """
+
+    @staticmethod
+    def _guard_calls(rel: str) -> int:
+        tree = ast.parse((NURI / rel).read_text(encoding="utf-8"))
+        return sum(
+            1
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "canonical_regime_or_none"
+        )
+
+    @pytest.mark.parametrize("rel", sorted(CANONICAL_VOCAB_WRITERS))
+    def test_writer_calls_the_guard(self, rel):
+        """AST 로 **실호출**만 센다 — import 나 주석 언급으로는 통과하지 않는다."""
+        col = CANONICAL_VOCAB_WRITERS[rel]
+        assert self._guard_calls(rel) >= 1, f"{rel} ({col}): 정규화 가드를 호출하지 않는다"
+
+    def test_every_listed_writer_exists(self):
+        """양방향 — 파일이 사라지거나 옮겨지면 위 검사가 조용히 공허해진다."""
+        missing = [r for r in {**CANONICAL_VOCAB_WRITERS, **KNOWN_UNGUARDED} if not (NURI / r).exists()]
+        assert not missing, f"목록이 낡았다: {missing}"
+
+    def test_inventory_matches_the_code(self):
+        """목록을 **줄여서** 스윕을 피할 수 없게 한다.
+
+        뮤테이션 실측에서 발각: `CANONICAL_VOCAB_WRITERS` 에서 한 줄을 지우면
+        parametrize 가 한 케이스 덜 돌 뿐 **그대로 통과**했다. 목록이 스스로를
+        검증하지 못하면 allowlist 는 회피 수단이 된다.
+
+        그래서 기대 집합을 리터럴이 아니라 **코드에서 유도**한다: 가드를 호출하는
+        모든 모듈은 인벤토리에 있어야 하고, 그 역도 성립해야 한다.
+        """
+        callers = {
+            str(f.relative_to(NURI)) for f in NURI.rglob("*.py") if self._guard_calls(str(f.relative_to(NURI))) > 0
+        }
+        listed = set(CANONICAL_VOCAB_WRITERS)
+        assert callers == listed, (
+            f"인벤토리와 실제 가드 호출자가 다르다.\n"
+            f"  목록에만 있음(가드 호출 안 함): {sorted(listed - callers)}\n"
+            f"  코드에만 있음(인벤토리 누락): {sorted(callers - listed)}"
+        )
+
+    def test_known_gap_is_still_a_gap(self):
+        """양방향 — #1293 이 고치면 이 항목이 stale 로 FAIL 해서 목록 정리를 강제한다.
+
+        이 축이 없으면 known-gap 목록이 영원히 남아 "알고도 안 고친 것" 과
+        "이미 고쳤는데 목록만 낡은 것" 을 구분할 수 없다.
+        """
+        still_unguarded = [r for r in KNOWN_UNGUARDED if self._guard_calls(r) == 0]
+        assert sorted(still_unguarded) == sorted(KNOWN_UNGUARDED), (
+            f"known-gap 이 이미 가드를 갖췄다 — 목록에서 빼고 CANONICAL_VOCAB_WRITERS 로 옮길 것: "
+            f"{sorted(set(KNOWN_UNGUARDED) - set(still_unguarded))}"
+        )
+
+    def test_every_known_gap_states_a_reason(self):
+        for rel, why in KNOWN_UNGUARDED.items():
+            assert len(why) > 40, f"{rel}: 사유가 너무 짧다 — 다음 사람이 판단할 수 없다"
+            assert "#" in why, f"{rel}: 추적 이슈 번호가 없다"
+
+    def test_the_counter_ignores_mentions(self):
+        """카나리아 — 텍스트로 세면 import 줄과 주석이 통과시킨다."""
+        src = "from x import canonical_regime_or_none  # canonical_regime_or_none() 참고\n"
+        tree = ast.parse(src)
+        calls = sum(
+            1
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "canonical_regime_or_none"
+        )
+        assert calls == 0, "import/주석을 호출로 셌다"
+        assert "canonical_regime_or_none" in src, "텍스트 검사라면 통과했을 형태(대조)"


### PR DESCRIPTION
Closes #1268

## 이슈보다 경로가 하나 더 있었고, 그게 더 위험했습니다

이슈는 `decisions.py:265`(classifier fallback) 하나를 지목했습니다. `_snapshot_market_context` 는 regime 을 **두 곳**에서 채웁니다:

| 경로 | 출처 | 위험도 |
|---|---|---|
| `:252` `pipeline_events` payload | **다른 생산자가 쓴 임의 JSON** | **높음** — `#832` 가 가드를 만든 바로 그 free-text 유입 경로 |
| `:265` `classify_regime()` fallback | 분류기가 canonical 을 돌려줌 | 낮음 |

**이슈가 안 적은 쪽이 더 위험합니다.** 증거는 레포 안에 있습니다 — `recommendations.regime` 에 `''` · `'[recovery] 비중 축소'` · `'[recovery] 비중 확대'` 3종이 실제로 남아 있습니다(가드 도입 전 행).

가드를 **경로마다** 붙이지 않고 **합류 지점 한 곳**에 뒀습니다. 새 경로가 생겨도 자동으로 덮입니다.

## 거부는 NULL 이고, NULL 에는 관측 결과가 있습니다 — 의도한 것입니다

이슈는 "소비자는 프론트 표시 2곳뿐이라 None 이 새 경로를 만들지 않는다" 고 적었는데 **이제 사실이 아닙니다.** #1267(2026-08-28)이 `decisions_context` freshness 정책을 추가했고 술어가:

```sql
SUM(regime IS NOT NULL AND scoring_detail IS NOT NULL) = COUNT(*)
```

warn 24h / fail 60h 입니다. 즉 라벨을 떨구면 **알람으로 표면화**됩니다.

그게 맞는 방향이라고 판단했습니다 — 어휘 밖 라벨을 조용히 저장하는 것보다 "라벨을 못 붙였다" 가 보이는 편이 낫습니다(Surface 등급). 다만 **조용한 부작용이 아니라 명시적 결정**이어야 하므로 호출 지점 주석에 적었습니다: 알람이 뜨면 원인은 생산자이지 이 코드가 아닙니다.

## 일반화를 한 단계 좁혔습니다

"모든 regime writer 에 가드" 는 **틀린 원칙**입니다. `candidate_runs.regime` 은 `UNKNOWN_REGIME`("unknown")을 정당하게 저장하는데, 그 값은 **의도적으로** `ALL_REGIMES` 밖입니다(미상을 어휘 안 이름으로 표기하지 않으려고 그렇게 만들었습니다). 거기 가드를 걸면 미상을 표현할 방법이 사라집니다.

올바른 원칙: **어휘가 `ALL_REGIMES` 인 컬럼은 canonical 이거나 NULL.**

## 더 큰 같은 결함은 분리했습니다 (#1293)

| writer | 컬럼 | 행수 | 가드 | 소비자 |
|---|---|---|---|---|
| tracker ×2 · persistence | `recommendations.regime` | 434 | ✅ | 진단 라벨 |
| **decisions.py** | `decisions.regime` | 387 | ✅ **이 PR** | freshness 정책 |
| `certification.py:140` | `certifications.regime` | **4,525** | ❌ | **`.get(regime, {})`** |

`certifications` 는 행수가 12배이고 값이 `RULES...regime_overrides.get(regime, {})` 라는 **조용한 기본값** 경로로 갑니다. 성격이 달라 번들하지 않고 **#1293** 으로 냈으며, 이 PR 의 `KNOWN_UNGUARDED` 목록이 사유·이슈번호와 함께 붙잡고 있습니다 — 양방향이라 #1293 이 고치면 **stale 로 FAIL** 해서 목록 정리를 강제합니다.

## 기존 테스트가 무가드 동작을 잠그고 있었습니다

픽스처가 `"risk_on"` / `"risk_off"` 를 썼습니다 — 둘 다 `ALL_REGIMES` 에 없는, **그럴듯하게 들리는 지어낸 이름**입니다. 사람이 어휘 밖 이름을 자연스럽게 만들어낸다는 증거이기도 합니다. canonical 값으로 바꾸고(그 테스트들의 목적은 **payload 파싱**이지 어휘 검증이 아님), 어휘 검증은 새 테스트로 분리했습니다.

## Gotcha-Test Pair — 뮤테이션 실측 (커밋 후, 4축)

| 뮤테이션 | 결과 |
|---|---|
| 정규화 choke point 제거 (결함 그 자체) | **10 FAIL** |
| 키 제거 대신 `None` 저장 (계약 변경) | **2 FAIL** |
| known-gap 이 이미 고쳐진 척 (양방향) | **1 FAIL** |
| writer 인벤토리 축소 (스윕 회피) | **1 FAIL** |
| baseline | 89 passed |

### 뮤테이션이 allowlist 회피 구멍을 잡았습니다

4번째 축이 처음에 **안 잠겼습니다** — `CANONICAL_VOCAB_WRITERS` 에서 한 줄을 지우면 parametrize 가 한 케이스 덜 돌 뿐 그대로 통과했습니다. **목록을 줄이는 것이 스윕 회피 수단**이 되는 형태입니다.

기대 집합을 리터럴이 아니라 **코드에서 유도**하도록 고쳤습니다: 가드를 호출하는 모든 모듈은 인벤토리에 있어야 하고 그 역도 성립해야 합니다. 이제 목록에서 빼려면 가드 호출도 지워야 하고, 그러면 다른 축이 잡습니다.

**대조군**: `ALL_REGIMES` **10종 전부**를 파라미터로 돌려 보존을 확인합니다 — 일부만 통과시키는 구현도 잡힙니다.

## 검증

- `make test-fast` → **7,744 passed / 8 skipped**, rc=0
- `ruff check` · `check_privacy_leak.py` · `make verify-doc-counts` **24/24** 전부 통과
- Gotcha-Test Pair 인용을 `nuri/trading/engine/CLAUDE.md` 에 추가 — 지금까지 레짐 어휘 불변식이 `recommend/` scoped CLAUDE.md 에만 있어 engine 쪽은 folklore 였습니다
