### PR TITLE
fix(freshness): detect partial consensus batches in decisions_context (#1266)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,789 collected across 357 files | ✅ |
+| **Backend tests** | 7,794 collected across 357 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,794 collected across 357 files | ✅ |
+| **Backend tests** | 7,795 collected across 357 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,789 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,794 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,794 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,795 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,794 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,795 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,789 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,794 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/portfolio_signals.py
+++ b/nuri/alerts/portfolio_signals.py
@@ -285,6 +285,9 @@ _REMEDY: dict[str, str] = {
     "signals": "technical 잡 확인 — RSI/SMA 가 BUY 점수와 SIEGE 게이트에 들어간다",
     "signals_kr": "technical_close_kr 잡과 KR 가격 수집(stock_kr_universe_daily) 확인",
     "consensus": "합의 잡(07:05) 실행 여부 확인",
+    # decisions 는 합의 잡이 recommendations 를 쓴 **뒤** 이어서 기록한다. 배치가 모자라면
+    # 그 사이에서 프로세스가 죽은 것이라 잡 로그가 아니라 프로세스 생사를 봐야 한다 (#1266).
+    "decisions_context": "합의 잡 확인 — recommendations 는 찼는데 decisions 가 모자라면 잡이 중간에 죽은 것",
     "certification": "SIEGE 인증 실행 여부 확인",
 }
 

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -208,7 +208,12 @@ FRESHNESS_POLICIES: dict[str, dict] = {
         # 진짜 조용한 축은 프로세스 사망이다 — fd 고갈(#778) · 로그인 세션 부재(#1191).
         # 그래서 **같은 날 합의 배치 크기를 분모로** 깔아 행수 floor 를 건다.
         #
-        # 분모는 `agent_verdicts IS NOT NULL` 로 고른다 — 10-agent 합의만 이 컬럼을 채운다.
+        # 분모는 `agent_verdicts IS NOT NULL` 로 고른다. 이 컬럼을 채우는 프로덕션 경로는
+        # 합의 persistence 뿐인데, 그건 **현재 호출 그래프의 성질이지 불변식이 아니다** —
+        # `tracker.save_recommendations(verdicts=...)` 도 채울 수 있고 지금은 아무도 그렇게
+        # 부르지 않을 뿐이다 (Codex P3). 가정으로 두면 다음 호출자가 조용히 분모를 오염시키므로
+        # 호출 형태를 테스트로 잠근다. **Test:** `tests/core/test_freshness.py::
+        # TestDecisionsContextPolicy::test_no_caller_fills_agent_verdicts_outside_consensus`
         # 기각한 분모 3종:
         #  - **포트폴리오 구성**: `portfolio` 에 date 컬럼이 없고, 있어도 감시가 우리 구성에
         #    의존하게 된다(#1147 축). 단 그 반론은 *외부 소스* 정책 얘기다 — 여기 분모는

--- a/nuri/core/freshness.py
+++ b/nuri/core/freshness.py
@@ -199,13 +199,51 @@ FRESHNESS_POLICIES: dict[str, dict] = {
         # (`nuri/core/CLAUDE.md`: 멀쩡한 축이 죽은 축을 가린다).
         # 그래서 **날짜로 묶어 그날 전 행이 완전한 날**만 센다.
         #
-        # 행수 floor 는 여기 두지 않는다 — 분모가 포트폴리오 구성이라(prod 실측 날짜별
-        # 18~21행) 소스 감시가 우리 구성에 의존하게 되고, 그건 `ark`(#1147)에서 한 번
-        # 틀린 축이다. 부분 배치(행이 통째로 모자란 경우)는 별도 근거가 필요해 분리한다.
+        # **완결성만으로는 부분 배치를 못 본다** (#1266). 위 검사는 "그날 있는 행이 전부
+        # 완전한가" 만 묻는다 — 18종목 배치에서 3행만 쓰이고 그 3행이 완전하면 초록이다.
+        # `scheduler.py` 의 consensus 잡은 `save_to_recommendations(results)` 를 먼저,
+        # `record_decisions(results)` 를 나중에 부르므로 **그 사이에 프로세스가 죽으면**
+        # recommendations 18행 / decisions k행 이 남는다. 루프 중간 예외는 이 축이 아니다
+        # (`run_step(..., reraise=True)` 가 step_failed + collector_runs 로 이미 시끄럽다).
+        # 진짜 조용한 축은 프로세스 사망이다 — fd 고갈(#778) · 로그인 세션 부재(#1191).
+        # 그래서 **같은 날 합의 배치 크기를 분모로** 깔아 행수 floor 를 건다.
+        #
+        # 분모는 `agent_verdicts IS NOT NULL` 로 고른다 — 10-agent 합의만 이 컬럼을 채운다.
+        # 기각한 분모 3종:
+        #  - **포트폴리오 구성**: `portfolio` 에 date 컬럼이 없고, 있어도 감시가 우리 구성에
+        #    의존하게 된다(#1147 축). 단 그 반론은 *외부 소스* 정책 얘기다 — 여기 분모는
+        #    같은 잡이 같은 실행에서 낸 자기 산출물이라 교집합 문제가 성립하지 않는다.
+        #  - **행수 롤링 중앙값**: 종목을 실제로 줄이면 발화한다.
+        #  - **`source IS NULL`**: `make recommend` CLI(`tracker.save_recommendations`)가
+        #    스크리닝 종목을 source NULL 로 같이 쓴다(dev 원장 실측 29행, 2026-08-10 은
+        #    17행 전부 CLI). 합의가 결정하지 않은 종목이라 분모만 부풀어 **멀쩡한 날이
+        #    빨간불**이 된다. 게다가 `source` 는 §3.11 사전등록 모집단 컬럼이라
+        #    (`decision_alpha.fetch_sample` 이 `source IS NULL` 로 표본을 고른다) 라벨을
+        #    옮기는 것 자체가 잠긴 판정 기준의 사후 수정이다.
+        #
+        # `>=` 이지 `=` 가 아니다 — 결정이 합의 행보다 많은 날이 실재한다(dev 원장
+        # 2026-04-11: rec 18 / dec 20). 합의 행의 `agent_verdicts` 가 비면 분모가 줄어
+        # floor 가 **약해질 뿐** 거짓 빨간불은 나지 않는다(안전한 방향).
+        #
+        # LEFT JOIN + `COALESCE(r.n, 0)` 이지 INNER JOIN 이 아니다. 분모를 못 구하는 날
+        # (합의 행이 아예 없는 날)을 낙제시키면 **합의 행이 없는 모든 DB 가 빨간불**이 된다
+        # — e2e seed 가 정확히 그 모양이다. 그건 코드 결함이 아닌 빨간불이고, 이 레포는
+        # false-red 가 빨간불을 무시하는 습관을 만든다는 걸 이미 한 번 겪었다(#1270).
+        # 게다가 그 축은 **여기 일이 아니다**: `consensus` 정책이 `recommendations` 를
+        # 직접 보고 있고 그쪽은 `verdict_gate` 소속이라, 배치 부재는 이미 감시된다.
+        # 여기는 배치가 있을 때 그 크기만큼 결정이 남았는지만 본다.
+        #
+        # **못 보는 것**: `analyze_portfolio()` 가 상류에서 잘려 3건만 돌려주는 경우.
+        # 두 writer 가 같은 `results` 를 소비하므로 rec 3 / dec 3 으로 정합해 보인다.
+        # 그건 배치 크기 자체의 감시라 이 정책 밖이다.
         "query": (
-            "SELECT datetime(MAX(date)) FROM (SELECT date FROM decisions "
-            "GROUP BY date "
-            "HAVING SUM(regime IS NOT NULL AND scoring_detail IS NOT NULL) = COUNT(*))"
+            "SELECT datetime(MAX(d.date)) FROM "
+            "(SELECT date, COUNT(*) n, "
+            "        SUM(regime IS NOT NULL AND scoring_detail IS NOT NULL) c "
+            "   FROM decisions GROUP BY date) d "
+            "LEFT JOIN (SELECT date, COUNT(*) n FROM recommendations "
+            "            WHERE agent_verdicts IS NOT NULL GROUP BY date) r ON r.date = d.date "
+            "WHERE d.c = d.n AND d.n >= COALESCE(r.n, 0)"
         ),
         "label": "결정 컨텍스트 (완결)",
     },

--- a/tests/alerts/test_portfolio_signals.py
+++ b/tests/alerts/test_portfolio_signals.py
@@ -532,6 +532,20 @@ def test_stale_payload_gives_the_remedy_for_that_source(db_path):
     assert "가격 수집" in price
 
 
+def test_decisions_context_has_its_own_remedy(db_path):
+    """부분 배치 카드는 fallback 문구로 떨어지면 안 된다 (#1266).
+
+    `decisions_context` 가 `_REMEDY` 에 없으면 `_remedy()` 가 "해당 수집 경로 점검" 을
+    돌려주는데, 이 FAIL 의 원인은 수집이 아니라 **합의 잡이 중간에 죽은 것**이라
+    운영자를 엉뚱한 로그로 보낸다.
+
+    Mutation lock: `_REMEDY["decisions_context"]` 를 지우면 fallback 과 같아져 FAIL.
+    """
+    remedy = portfolio_signals._remedy("decisions_context")
+    assert remedy != portfolio_signals._remedy("__no_such_key__")
+    assert "합의" in remedy
+
+
 def test_missing_data_is_not_reported_as_staleness(db_path):
     """`age_hours=None` 은 '낡음' 이 아니라 '행이 없음' 이다 — 같은 문구면 진짜 상태를 놓친다.
 

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -1,5 +1,6 @@
 """nuri.core.freshness 모듈 테스트 — 데이터 신선도 SLA 체크."""
 
+import pathlib
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -949,7 +950,37 @@ class TestDecisionsContextPolicy:
 
         assert check_freshness("decisions_context", db_path=db_path)["status"] == "PASS"
 
-    def test_absent_consensus_rows_keep_the_prior_verdict(self, db_path):
+    def test_no_caller_fills_agent_verdicts_outside_consensus(self):
+        """분모의 판별자를 **불변식으로** 잠근다 (Codex P3).
+
+        `agent_verdicts` 를 채우는 프로덕션 경로가 합의 persistence 뿐인 것은 현재 호출
+        그래프의 성질일 뿐이다 — `tracker.save_recommendations` 는 `verdicts=` 를 받으면
+        같은 컬럼을 채운다. 누군가 그렇게 부르기 시작하면 분모가 조용히 오염되고,
+        `decisions_context` 가 멀쩡한 날을 빨간불로 만든다.
+
+        위치 인자 3개짜리 호출도 `verdicts` 를 채운다 — 시그니처가
+        `(candidates, actions, verdicts, db_path)` 라서 키워드만 보면 놓친다.
+        """
+        import ast
+
+        root = pathlib.Path(__file__).resolve().parents[2] / "nuri"
+        calls, offenders = 0, []
+        for path in root.rglob("*.py"):
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", None)
+                if name != "save_recommendations":
+                    continue
+                calls += 1
+                if len(node.args) >= 3 or any(k.arg == "verdicts" for k in node.keywords):
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+
+        # 카나리아 — 호출을 하나도 못 찾는 스윕은 눈이 먼 것이고, 그런 스윕은 언제나 통과한다.
+        assert calls >= 1, "save_recommendations 호출을 하나도 찾지 못했다 — 스윕이 죽었다"
+        assert not offenders, f"`verdicts=` 를 넘기는 호출이 생겼다 — decisions_context 분모가 오염된다: {offenders}"
+
+    def test_absent_consensus_rows_do_not_fail_the_day(self, db_path):
         """분모를 못 구하는 날을 낙제시키지 않는다 — 그건 `consensus` 정책 몫이다.
 
         INNER JOIN 으로 조이면 합의 행이 없는 모든 DB(e2e seed 포함)가 빨간불이 된다.

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -864,6 +864,107 @@ class TestDecisionsContextPolicy:
 
         assert check_freshness("decisions_context", db_path=db_path)["status"] == "PASS"
 
+    # ── 행수 floor (#1266): 완결성만으로는 "행이 통째로 모자란" 날을 못 본다 ──────────
+
+    def _seed_consensus_rows(self, db_path, date: str, n: int, *, verdicts=True, pfx="R"):
+        """같은 날 합의 배치를 `recommendations` 에 깐다 — floor 의 분모."""
+        from nuri.core.db import get_db
+
+        with get_db(db_path) as conn:
+            conn.executemany(
+                "INSERT INTO recommendations (date, ticker, action, confidence, agent_verdicts)"
+                " VALUES (:date, :ticker, :action, :confidence, :agent_verdicts)",
+                [
+                    {
+                        "date": date,
+                        "ticker": f"{pfx}{i}",
+                        "action": "HOLD",
+                        "confidence": 50.0,
+                        # 10-agent 합의만 이 컬럼을 채운다 — CLI 경로는 NULL 로 남긴다.
+                        "agent_verdicts": '[{"agent":"a","verdict":"HOLD"}]' if verdicts else None,
+                    }
+                    for i in range(n)
+                ],
+            )
+
+    def test_partial_batch_cannot_keep_the_policy_green(self, db_path):
+        """합의 18행이 남았는데 결정이 3행뿐이면 그날은 신선하지 않다.
+
+        `scheduler.py` 의 consensus 잡은 `save_to_recommendations` → `record_decisions`
+        순서라, **그 사이에 프로세스가 죽으면** 정확히 이 모양이 남는다(fd 고갈 #778 ·
+        로그인 세션 부재 #1191). 남은 3행은 컨텍스트가 완전하므로 완결성 검사는 통과한다.
+
+        Mutation lock: 쿼리에서 floor(`d.n >= COALESCE(r.n, 0)` + recommendations 조인)를
+        걷어내면 오늘이 뽑혀 PASS 로 뒤집힌다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import kst_now, today_kst
+
+        old = (kst_now() - timedelta(days=5)).strftime("%Y-%m-%d")
+        self._seed(db_path, old, regime="bull_low_vol", scoring_detail='{"x":1}')
+
+        today = today_kst()
+        self._seed_consensus_rows(db_path, today, 18)
+        for i in range(3):
+            self._seed(db_path, today, regime="bull_low_vol", scoring_detail='{"x":1}', ticker=f"D{i}")
+
+        result = check_freshness("decisions_context", db_path=db_path)
+        assert result["status"] == "FAIL", result
+        assert result["last_updated"].startswith(old), result
+
+    def test_cli_screening_rows_do_not_inflate_the_denominator(self, db_path):
+        """`make recommend` CLI 가 같은 날 쓴 스크리닝 행은 분모가 아니다.
+
+        `tracker.save_recommendations` 는 합의가 결정하지 않은 종목을 `source` NULL 로
+        쓴다(dev 원장 실측 29행). 분모를 `source IS NULL` 로 잡으면 그 행들이 섞여
+        **멀쩡한 날이 빨간불**이 된다. 그래서 `agent_verdicts IS NOT NULL` 로 고른다.
+
+        Mutation lock: 분모에서 `WHERE agent_verdicts IS NOT NULL` 을 빼면 r.n 이 27 로
+        불어 18 < 27 → FAIL 로 뒤집힌다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        today = today_kst()
+        self._seed_consensus_rows(db_path, today, 18)
+        # CLI 가 덧쓴 스크리닝 종목 9건 — 합의 산출물이 아니다.
+        self._seed_consensus_rows(db_path, today, 9, verdicts=False, pfx="CLI")
+        for i in range(18):
+            self._seed(db_path, today, regime="bull_low_vol", scoring_detail='{"x":1}', ticker=f"D{i}")
+
+        assert check_freshness("decisions_context", db_path=db_path)["status"] == "PASS"
+
+    def test_more_decisions_than_consensus_rows_is_not_stale(self, db_path):
+        """결정이 합의 행보다 많은 날은 정상이다 (dev 원장 2026-04-11: rec 18 / dec 20).
+
+        Mutation lock: floor 를 `d.n = COALESCE(r.n, 0)` 로 조이면 FAIL 로 뒤집힌다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        today = today_kst()
+        self._seed_consensus_rows(db_path, today, 2)
+        for i in range(3):
+            self._seed(db_path, today, regime="bull_low_vol", scoring_detail='{"x":1}', ticker=f"D{i}")
+
+        assert check_freshness("decisions_context", db_path=db_path)["status"] == "PASS"
+
+    def test_absent_consensus_rows_keep_the_prior_verdict(self, db_path):
+        """분모를 못 구하는 날을 낙제시키지 않는다 — 그건 `consensus` 정책 몫이다.
+
+        INNER JOIN 으로 조이면 합의 행이 없는 모든 DB(e2e seed 포함)가 빨간불이 된다.
+        코드 결함이 아닌 빨간불은 빨간불을 무시하는 습관을 만든다 (#1270).
+
+        Mutation lock: `LEFT JOIN` → `JOIN` 또는 `COALESCE(r.n, 0)` → `r.n` 으로 바꾸면
+        FAIL 로 뒤집힌다.
+        """
+        from nuri.core.freshness import check_freshness
+        from nuri.core.timezone import today_kst
+
+        self._seed(db_path, today_kst(), regime="bull_low_vol", scoring_detail='{"x":1}')
+
+        assert check_freshness("decisions_context", db_path=db_path)["status"] == "PASS"
+
     def test_thresholds_absorb_one_degraded_day_but_fail_before_the_third_run(self):
         """임계는 시계 없이 산술로 잠근다 — 이 정책의 설계 지점이 여기다 (Codex P2 라운드 2).
 


### PR DESCRIPTION
Closes #1266.

## Why

`decisions_context` asked only whether the rows present on a day were *complete*. A batch that wrote **3 of 18** rows passed, as long as those 3 rows had `regime` and `scoring_detail`.

The consensus job (`scheduler.py`) writes in this order:

```python
saved    = save_to_recommendations(results)   # recommendations
recorded = record_decisions(results)          # decisions
```

so a **process death between the two calls** leaves exactly that shape. That is the genuinely silent path — fd exhaustion (#778), login-session outage (#1191).

A mid-loop *exception* is **not** this axis, contrary to the issue text: `run_step(..., reraise=True)` re-raises, producing `pipeline_events.step_failed` + `collector_runs(status='failed')`, which `collector_health` already flags.

## What

A row-count floor whose denominator is the same-day consensus batch, discriminated by `agent_verdicts IS NOT NULL` (only the 10-agent consensus fills that column), plus the missing `_REMEDY` entry.

**Rejected denominators**, recorded at the policy site:

| Denominator | Why not |
|---|---|
| portfolio composition | `portfolio` has no date column; also the #1147 axis |
| rolling median of row counts | fires when positions are genuinely cut |
| `source IS NULL` | `make recommend` CLI (`tracker.save_recommendations`) writes screening tickers with a NULL source — **29 such rows in the dev ledger**, and 2026-08-10 is 17 CLI rows and nothing else. Those tickers were never decided by consensus, so the denominator inflates and red-lights healthy days. `source` is also the locked §3.11 pre-registration column (`decision_alpha.fetch_sample` selects on it), so relabeling would amend a locked adjudication population. |

`>=` rather than `=`: days where decisions exceed consensus rows are real (dev ledger 2026-04-11 — rec 18 / dec 20).

`LEFT JOIN` rather than `INNER`: failing days whose denominator is unknown would red-light every DB with no consensus rows — the e2e seed among them. A red light with no defect behind it trains people to ignore red lights (#1270). Batch *absence* is already watched by the `consensus` policy, which reads `recommendations` directly and is in `verdict_gate`; this policy only checks that a batch which exists was fully recorded.

**Stated limitation:** upstream truncation is invisible here. If `analyze_portfolio()` returns 3 instead of 18, both writers consume the same `results` list, so rec 3 / dec 3 looks consistent. Watching the batch size itself is a different policy.

## Verification

5 new tests; each axis mutation-tested with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| floor removed (pre-#1266 query) | `test_partial_batch_cannot_keep_the_policy_green` |
| `WHERE agent_verdicts IS NOT NULL` removed | `test_cli_screening_rows_do_not_inflate_the_denominator` |
| `>=` tightened to `=` | `test_more_decisions_than_consensus_rows_is_not_stale` |
| `LEFT JOIN` → `JOIN` | `test_absent_consensus_rows_keep_the_prior_verdict` |
| `_REMEDY` entry removed | `test_decisions_context_has_its_own_remedy` |

5/5 locked. `tests/core/test_freshness.py` + `tests/alerts/test_portfolio_signals.py`: **98 passed**, including all 61 pre-existing freshness locks unchanged. `make lint` clean, `make diagnostics` rc=0 with no findings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7

---

## Codex review

**PASS — no P1/P2.** Two P3s, both accurate, both addressed in a third commit:

1. **The denominator was isolated by the call graph, not by an invariant.** `tracker.save_recommendations()` fills `agent_verdicts` when passed `verdicts=`; no caller does today, but nothing stopped one from starting, and that would contaminate the denominator and red-light healthy days. The comment now claims only what is true, and a sweep locks the call shape — including the **3-positional-argument** form, which a keyword-only check misses.
2. **`test_absent_consensus_rows_keep_the_prior_verdict` overstated its docstring** — it proves a decisions-only day still passes, not that an older day is selected. Renamed to `test_absent_consensus_rows_do_not_fail_the_day`.

Codex also refuted claim 2 as I had worded it, correctly: this PR *does* introduce a new FAIL state — the partial batch. That is the point of it. What `LEFT JOIN` + `COALESCE` avoids is a new fail state for *"no denominator row exists"*.

Now 6 tests / 7 mutation axes, all locked. Note on method: an earlier run of the two new axes was a **false positive** — the mutation script's `git checkout --` reverted the uncommitted test alongside the mutation, so pytest was exiting non-zero for "no tests ran" rather than for a failing assertion. Re-measured against committed state with a node-collection pre-check.
