### PR TITLE
test(engine): tie the regime guard check to the write function (#1268 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,795 collected across 357 files | ✅ |
+| **Backend tests** | 7,796 collected across 357 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,795 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,796 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,795 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,796 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/trading/engine/test_regime_canonical_guard.py
+++ b/tests/trading/engine/test_regime_canonical_guard.py
@@ -117,10 +117,23 @@ class TestFreeTextNeverReachesTheColumn:
 #: `UNKNOWN_REGIME`("unknown") 을 정당하게 저장하는데, 그 값은 **의도적으로**
 #: `ALL_REGIMES` 밖이다 (미상을 어휘 안 이름으로 표기하지 않으려고 그렇게 만들었다).
 #: 그 컬럼까지 가드를 걸면 미상을 표현할 방법이 사라진다.
-CANONICAL_VOCAB_WRITERS: dict[str, str] = {
-    "trading/recommend/tracker.py": "recommendations.regime",
-    "trading/agents/consensus/persistence.py": "recommendations.regime",
-    "trading/engine/decisions.py": "decisions.regime",
+#:
+#: 값의 `functions` 는 **가드를 부르는 함수 이름**이다. 파일 단위로만 세면 같은 파일
+#: 어딘가의 죽은 호출 하나로 검사가 만족되고 정작 쓰기 경로는 무가드일 수 있다
+#: (Codex P3, PR #1294). 이 레포가 반복해서 밟는 "눈 없는 스윕" 이라 함수까지 내린다.
+CANONICAL_VOCAB_WRITERS: dict[str, dict] = {
+    "trading/recommend/tracker.py": {
+        "column": "recommendations.regime",
+        "functions": ("save_buy_candidates", "save_recommendations"),
+    },
+    "trading/agents/consensus/persistence.py": {
+        "column": "recommendations.regime",
+        "functions": ("save_to_recommendations",),
+    },
+    "trading/engine/decisions.py": {
+        "column": "decisions.regime",
+        "functions": ("_snapshot_market_context",),
+    },
 }
 
 #: 같은 어휘를 쓰는데 **아직 가드가 없는** writer. 사유와 추적 이슈를 함께 적는다.
@@ -151,11 +164,43 @@ class TestCanonicalVocabColumnsAreGuarded:
             if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "canonical_regime_or_none"
         )
 
+    @staticmethod
+    def _guard_call_functions(rel: str) -> set[str]:
+        """가드를 **호출하는 함수 이름** 집합. 중첩 함수는 가장 안쪽 이름으로 잡힌다."""
+        tree = ast.parse((NURI / rel).read_text(encoding="utf-8"))
+        found = set()
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if any(
+                isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "canonical_regime_or_none"
+                for n in ast.walk(fn)
+            ):
+                found.add(fn.name)
+        return found
+
     @pytest.mark.parametrize("rel", sorted(CANONICAL_VOCAB_WRITERS))
     def test_writer_calls_the_guard(self, rel):
-        """AST 로 **실호출**만 센다 — import 나 주석 언급으로는 통과하지 않는다."""
-        col = CANONICAL_VOCAB_WRITERS[rel]
-        assert self._guard_calls(rel) >= 1, f"{rel} ({col}): 정규화 가드를 호출하지 않는다"
+        """AST 로 **실호출**만 센다 — import 나 주석 언급으로는 통과하지 않는다.
+
+        파일이 아니라 **함수** 단위다: 같은 파일 어딘가의 죽은 호출로는 통과하지 않는다.
+        """
+        entry = CANONICAL_VOCAB_WRITERS[rel]
+        actual = self._guard_call_functions(rel)
+        for func in entry["functions"]:
+            assert func in actual, f"{rel}::{func} ({entry['column']}): 정규화 가드를 호출하지 않는다"
+
+    def test_guard_call_sites_match_the_code(self):
+        """양방향 — 가드 호출이 **다른 함수로 새면** 인벤토리와 어긋나 FAIL 한다.
+
+        이게 없으면 쓰기 함수에서 가드를 빼고 같은 파일의 아무 함수에 하나 남겨두는
+        변경이 조용히 통과한다 (Codex P3 가 지적한 구멍).
+        """
+        for rel, entry in sorted(CANONICAL_VOCAB_WRITERS.items()):
+            assert self._guard_call_functions(rel) == set(entry["functions"]), (
+                f"{rel}: 가드 호출 함수가 인벤토리와 다르다 — "
+                f"코드={sorted(self._guard_call_functions(rel))}, 목록={sorted(entry['functions'])}"
+            )
 
     def test_every_listed_writer_exists(self):
         """양방향 — 파일이 사라지거나 옮겨지면 위 검사가 조용히 공허해진다."""


### PR DESCRIPTION
Follow-up to #1294. Codex raised this as P3 on that PR, but the fix landed after auto-merge had already fired, so it never made it into the squash.

## The hole

`_guard_calls()` counted `canonical_regime_or_none` calls **per file**:

```python
assert self._guard_calls(rel) >= 1
```

A dead call anywhere in the module satisfies that while the actual write path stays unguarded. That is the eyeless-sweep shape this repo has repeatedly been bitten by — the inventory claimed to prove "these writers are guarded" and only proved "these files mention the guard".

## The fix

The inventory now records **which functions** call the guard, and the check runs at function granularity plus a bidirectional set comparison, so the guard cannot drift out of the write path unnoticed.

```python
"trading/recommend/tracker.py": {
    "column": "recommendations.regime",
    "functions": ("save_buy_candidates", "save_recommendations"),
},
```

## Verification

Two mutations, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| add a dead guard call in an unlisted function | `test_guard_call_sites_match_the_code` |
| move the guard out of `_snapshot_market_context` into a dead helper | `test_writer_calls_the_guard` |

Both locked; under the old per-file check the second mutation passed. 27 tests in the file pass; production `decisions.py` restored clean after mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7