### PR TITLE
chore(ops): backfill decisions.regime from agent_verdicts (#1264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,796 collected across 357 files | ✅ |
+| **Backend tests** | 7,805 collected across 358 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,796 backend tests across 357 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,805 backend tests across 358 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,796 tests, 357 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,805 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/ops/backfill_decision_regime.py
+++ b/scripts/ops/backfill_decision_regime.py
@@ -1,0 +1,167 @@
+"""decisions.regime 백필 — 행 내부 `agent_verdicts` 에서 복사 (#1264).
+
+#1258 이전 epoch 의 `decisions.regime` 은 NULL 이다 (그 시점 writer 가 컬럼을 채우지
+않았다). 값은 **이미 같은 행 안에 있다** — 합의 배치가 `agent_verdicts` 에 macro
+에이전트의 verdict 를 통째로 저장했고, 그 `data_points.regime` 이 그날 라이브로 쓰인
+레짐이다. 이 스크립트는 그 값을 컬럼으로 옮긴다.
+
+**왜 이 소스인가** (#1264 에서 후보 4개 중 3개 탈락):
+
+- `reasoning` 정규식 → supporter-only 산문이라 커버리지가 action 에 상관 (SELL 76행 중 1행)
+- `recommendations` join → 같은 run 이지만 **다른 함수의 별도 `classify_regime()` 호출**
+- `classify_regime(date=...)` 재실행 → freshness 게이트가 `if date is None` 안에 있어
+  날짜를 주면 우회되고, `prices`/`macro` 는 INSERT OR REPLACE 라 vintage 가 없다.
+  **라이브가 내지 않기로 한 라벨을 제조**하게 된다
+
+PIT 관점: 미래 데이터로 역추정하는 게 아니라 같은 결정 산출물 안에 이미 포착된 동시대
+값을 **행 안에서 복사**하는 것이다. `db_migrations.py` 의 "legacy row 는 NULL 유지 —
+lossy retrofit 금지" 는 신규 스키마를 휴리스틱 추정으로 채우지 말라는 규정이라, 행 내부
+canonical 값의 결정론적 복사는 그 사정거리 밖이다.
+
+⚠️ **비대칭을 남긴다 — 의도한 것이다.** post-#1258 행은 `decision_evidence` 에
+`source_type='regime'` 뒷받침 행을 갖지만, 백필된 행은 갖지 않는다. evidence 행까지
+만들면 사후 복사를 **라이브 증거로 위장**하게 되므로 만들지 않는다. 원장을 읽는 쪽은
+"regime 은 있는데 evidence 가 없는 행 = 백필된 행" 으로 구분할 수 있다.
+
+원장은 **prod(Mac mini) 단일 적용** — dev 는 read-replica 다 (STRATEGY §3.11).
+
+사용법:
+    .venv/bin/python scripts/ops/backfill_decision_regime.py --dry-run   # write 없음
+    .venv/bin/python scripts/ops/backfill_decision_regime.py             # 실제 백필
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+#: regime 을 내는 에이전트. **이름으로 강제한다** — "regime 을 담은 첫 verdict" 로 두면
+#: 어느 에이전트의 값인지가 데이터 모양에 달린 가정이 되고, 다른 에이전트가 같은 키를
+#: 쓰기 시작하면 조용히 그쪽 값을 백필한다 (Codex P2). dev 원장 실측: 두 방식의 결과가
+#: 364행 전부 동일하고 regime 을 담은 에이전트는 macro 뿐이라, 강제해도 커버리지 손실 0.
+_REGIME_AGENT = "macro"
+
+
+def _regime_from_verdicts(parsed) -> str | None:
+    """verdict 배열에서 **macro** 에이전트의 `data_points.regime`. 형태가 다르면 None.
+
+    배열 인덱스를 고정하지 않는다 — 에이전트 순서는 계약이 아니라서 이름으로 찾는다.
+    배열이 아니거나 원소가 dict 가 아니면 소스 없음으로 본다.
+
+    ⚠️ **추출을 SQL 로 하지 않는다.** `json_each` 는 깨진 JSON 을 만나면 그 행을 건너뛰는
+    게 아니라 `OperationalError: malformed JSON` 으로 **쿼리 전체를 죽인다** — 행 하나가
+    백필 전체를 막는다. dev 원장에 실제로 그런 행이 1건 있다(id 20, `json_type` 은
+    'array' 인데 `json_valid` 는 0). `CASE WHEN json_valid(...)` 로 감싸도 소용없다:
+    최상위가 객체이거나 배열 원소에 문자열이 섞이면 가드를 통과한 뒤 `json_extract` 가
+    같은 예외로 죽는다(실측). `pipeline_events.payload` 가 같은 모양으로 당했고
+    (`nuri/core/CLAUDE.md`), 이 컬럼은 프로덕션 읽기 경로도 이미 깨진 JSON 을 방어한다
+    (`test_decisions.py::test_regime_malformed_json_swallowed`) — 실재하는 입력이다.
+    """
+    if not isinstance(parsed, list):
+        return None
+    for item in parsed:
+        if not isinstance(item, dict) or item.get("agent_name") != _REGIME_AGENT:
+            continue
+        data_points = item.get("data_points")
+        if isinstance(data_points, dict) and data_points.get("regime") is not None:
+            return data_points["regime"]
+    return None
+
+
+def _coverage(db_path=None) -> tuple[int, int]:
+    """(regime 이 canonical 인 행 수, 전체 행 수)."""
+    from nuri.core.db import query
+    from nuri.quant.regime.classifier import ALL_REGIMES
+
+    placeholders = ",".join("?" * len(ALL_REGIMES))
+    total = query("SELECT COUNT(*) AS c FROM decisions", db_path=db_path)[0]["c"]
+    labeled = query(
+        f"SELECT COUNT(*) AS c FROM decisions WHERE regime IN ({placeholders})",
+        tuple(ALL_REGIMES),
+        db_path=db_path,
+    )[0]["c"]
+    return labeled, total
+
+
+def backfill_decision_regime(db_path=None, dry_run: bool = False) -> dict:
+    """NULL 인 `decisions.regime` 을 같은 행의 `agent_verdicts` 에서 복사.
+
+    canonical 값이 이미 있는 행은 건드리지 않는다(멱등). 추출값이 `ALL_REGIMES` 멤버가
+    아니면(free-text·빈문자열·부재) **NULL 을 유지한다** — 어휘 밖 값을 원장에 넣지 않는다.
+
+    Returns:
+        stats dict — candidates / backfilled / no_source / non_canonical / malformed /
+        coverage_before / coverage_after
+    """
+    from nuri.core.db import get_db, query
+    from nuri.quant.regime.classifier import ALL_REGIMES
+
+    labeled_before, total = _coverage(db_path)
+
+    # canonical 이 이미 있는 행은 후보가 아니다 — 재실행이 write 0 이 되는 지점.
+    rows = query(
+        "SELECT id, agent_verdicts FROM decisions WHERE regime IS NULL",
+        db_path=db_path,
+    )
+
+    updates: list[tuple[str, int]] = []
+    no_source = 0  # agent_verdicts 부재 또는 regime 을 담은 verdict 없음 → NULL 유지
+    non_canonical = 0  # 값은 있는데 어휘 밖 → NULL 유지
+    malformed = 0  # agent_verdicts 가 깨진 JSON → NULL 유지 (운영자에게 따로 보고한다)
+    for r in rows:
+        raw = r["agent_verdicts"]
+        if raw is None:
+            no_source += 1
+            continue
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            malformed += 1
+            continue
+
+        src = _regime_from_verdicts(parsed)
+        if src is None:
+            no_source += 1
+        elif src in ALL_REGIMES:
+            updates.append((src, r["id"]))
+        else:
+            non_canonical += 1
+
+    if updates and not dry_run:
+        with get_db(db_path) as conn:
+            conn.executemany("UPDATE decisions SET regime = ? WHERE id = ?", updates)
+
+    labeled_after = labeled_before if dry_run else _coverage(db_path)[0]
+    return {
+        "candidates": len(rows),
+        "backfilled": len(updates),
+        "no_source": no_source,
+        "non_canonical": non_canonical,
+        "malformed": malformed,
+        "coverage_before": f"{labeled_before}/{total}",
+        "coverage_after": f"{labeled_after}/{total}" + (" (dry-run, write 없음)" if dry_run else ""),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="decisions.regime 백필 — agent_verdicts 에서 복사 (#1264)")
+    parser.add_argument("--dry-run", action="store_true", help="DB write 없이 변경 예정 카운트만 출력")
+    args = parser.parse_args(argv)
+
+    stats = backfill_decision_regime(dry_run=args.dry_run)
+    print(f"백필 대상 행 (regime IS NULL): {stats['candidates']}")
+    print(f"  canonical 복사: {stats['backfilled']}")
+    print(f"  소스 없음 → NULL 유지: {stats['no_source']}")
+    print(f"  어휘 밖 값 → NULL 유지: {stats['non_canonical']}")
+    print(f"  agent_verdicts 깨진 JSON → NULL 유지: {stats['malformed']}")
+    print(f"커버리지: {stats['coverage_before']} → {stats['coverage_after']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_backfill_decision_regime.py
+++ b/tests/scripts/test_backfill_decision_regime.py
@@ -1,0 +1,217 @@
+"""Tests for scripts/ops/backfill_decision_regime.py — decisions.regime 백필 (#1264).
+
+Gotcha-Test Pair: 이 백필의 위험은 "채우는 것" 이 아니라 **채우면 안 되는 행을 채우는
+것**이다. 소스가 없거나 어휘 밖이면 NULL 이 정답이고, 그 규칙이 지워지면 원장에
+사후 추정값이 들어간다.
+
+tmp_path DB 격리 (tests/CLAUDE.md), 티커는 전부 합성 placeholder (privacy).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nuri.core.db import get_db, init_db, query
+from scripts.ops.backfill_decision_regime import backfill_decision_regime
+
+
+def _verdicts(regime) -> str:
+    """실 writer 형태를 복사한다 — 10-agent 배열이고 macro 만 regime 을 담는다.
+
+    잘못된 형태의 mock 은 버그를 잠근다(#1180). 배열 안에서 macro 의 **위치도 고정하지
+    않는다** — 스크립트가 인덱스가 아니라 `json_each` 로 찾는다는 계약을 같이 지킨다.
+    """
+    macro = {
+        "agent_name": "macro",
+        "ticker": "TST_A",
+        "action": "HOLD",
+        "confidence": 60.0,
+        "reasoning": "합성",
+        "data_points": {"macro_score": 55.0, "confidence_pct": 60.0},
+    }
+    if regime is not None:
+        macro["data_points"]["regime"] = regime
+    other = {
+        "agent_name": "technical",
+        "ticker": "TST_A",
+        "action": "HOLD",
+        "confidence": 50.0,
+        "reasoning": "합성",
+        "data_points": {"rsi": 50.0},
+    }
+    return json.dumps([other, macro, other], ensure_ascii=False)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+def _seed(db_path, ticker, *, regime_col, verdicts, date="2026-05-01"):
+    with get_db(db_path) as conn:
+        conn.execute(
+            "INSERT INTO decisions (date, ticker, action, confidence, regime, agent_verdicts)"
+            " VALUES (?, ?, 'HOLD', 50.0, ?, ?)",
+            (date, ticker, regime_col, verdicts),
+        )
+
+
+def _regime_of(db_path, ticker):
+    return query("SELECT regime FROM decisions WHERE ticker = ?", (ticker,), db_path=db_path)[0]["regime"]
+
+
+def test_backfills_canonical_value_from_the_row(db_path):
+    """행 안의 macro verdict 가 canonical 이면 컬럼으로 복사된다."""
+    _seed(db_path, "TST_A", regime_col=None, verdicts=_verdicts("bull_low_vol"))
+
+    stats = backfill_decision_regime(db_path=db_path)
+
+    assert stats["backfilled"] == 1
+    assert _regime_of(db_path, "TST_A") == "bull_low_vol"
+
+
+def test_missing_macro_regime_stays_null(db_path):
+    """macro verdict 에 regime 이 없는 행은 백필 후에도 NULL 이다.
+
+    lossy retrofit 금지 잠금 (`db_migrations.py` 의 forward-only NULL 정책과 같은 축).
+    소스가 없을 때 무엇이든 지어내면 원장이 사후 추정값을 사실처럼 담게 된다.
+
+    Mutation lock: `src is None` 분기를 지우고 기본값을 넣으면 FAIL.
+    """
+    _seed(db_path, "TST_A", regime_col=None, verdicts=_verdicts(None))
+    _seed(db_path, "TST_B", regime_col=None, verdicts=None)  # agent_verdicts 자체가 없는 행
+
+    stats = backfill_decision_regime(db_path=db_path)
+
+    assert stats["backfilled"] == 0
+    assert stats["no_source"] == 2
+    assert _regime_of(db_path, "TST_A") is None
+    assert _regime_of(db_path, "TST_B") is None
+
+
+def test_non_canonical_value_is_not_written(db_path):
+    """free-text / 빈 문자열은 기록하지 않는다 — 어휘 밖 값은 NULL 로 둔다.
+
+    `recommendations.regime` 이 '' 와 '[recovery] 비중 축소' 를 실제로 담고 있었다(#832).
+    같은 오염을 `decisions` 로 옮기지 않는다.
+
+    Mutation lock: `src in ALL_REGIMES` 검사를 지우면 FAIL.
+    """
+    _seed(db_path, "TST_A", regime_col=None, verdicts=_verdicts("[recovery] 비중 축소"))
+    _seed(db_path, "TST_B", regime_col=None, verdicts=_verdicts(""))
+
+    stats = backfill_decision_regime(db_path=db_path)
+
+    assert stats["backfilled"] == 0
+    assert stats["non_canonical"] == 2
+    assert _regime_of(db_path, "TST_A") is None
+    assert _regime_of(db_path, "TST_B") is None
+
+
+def test_one_malformed_row_does_not_abort_the_backfill(db_path):
+    """깨진 `agent_verdicts` 한 행이 백필 전체를 죽이면 안 된다.
+
+    `json_each` 는 깨진 JSON 을 만나면 그 행을 건너뛰는 게 아니라
+    `OperationalError: malformed JSON` 으로 **쿼리째** 죽인다 — 가드가 없으면 행 하나가
+    나머지 386행의 백필을 막는다. `pipeline_events.payload` 가 같은 모양으로 당했고
+    (`nuri/core/CLAUDE.md`), 이 컬럼은 프로덕션 읽기 경로도 이미 깨진 JSON 을 방어한다
+    (`test_decisions.py::test_regime_malformed_json_swallowed`) — 실재하는 입력이다.
+
+    Mutation lock: `_EXTRACT_REGIME` 의 `CASE WHEN json_valid(...)` 가드를 걷어내면
+    OperationalError 로 FAIL.
+    """
+    _seed(db_path, "TST_OK", regime_col=None, verdicts=_verdicts("bull_low_vol"))
+    _seed(db_path, "TST_BAD", regime_col=None, verdicts="이건 JSON 이 아니다")
+    _seed(db_path, "TST_OBJ", regime_col=None, verdicts='{"agent_name": "macro"}')  # 배열 아닌 객체
+    # 스칼라 JSON — `isinstance(parsed, list)` 검사가 없으면 `for item in 5` 가 TypeError 로
+    # 백필 전체를 죽인다. 객체/문자열로는 이 축이 안 잡힌다(순회는 되고 결과가 같다).
+    _seed(db_path, "TST_NUM", regime_col=None, verdicts="5")
+
+    stats = backfill_decision_regime(db_path=db_path)
+
+    # 멀쩡한 행은 그대로 채워진다 — 깨진 이웃이 막지 않는다.
+    assert _regime_of(db_path, "TST_OK") == "bull_low_vol"
+    assert stats["backfilled"] == 1
+    assert stats["malformed"] == 1
+    assert stats["no_source"] == 2  # 객체 + 스칼라
+    assert _regime_of(db_path, "TST_BAD") is None
+    assert _regime_of(db_path, "TST_OBJ") is None
+    assert _regime_of(db_path, "TST_NUM") is None
+
+
+def test_only_the_macro_agent_supplies_the_regime(db_path):
+    """다른 에이전트가 `data_points.regime` 을 담아도 그 값을 쓰지 않는다 (Codex P2).
+
+    "regime 을 담은 첫 verdict" 로 두면 어느 에이전트의 값인지가 **데이터 모양에 달린
+    가정**이 된다. 다른 에이전트가 같은 키를 쓰기 시작하면 조용히 그쪽 값이 원장에 박힌다.
+    provenance 는 가정이 아니라 이름으로 강제한다.
+
+    Mutation lock: `item.get("agent_name") != _REGIME_AGENT` 검사를 지우면 배열 앞쪽의
+    non-macro 값이 채택돼 FAIL.
+    """
+    verdicts = json.dumps(
+        [
+            # macro 보다 **앞에** 있고 같은 키를 담는다 — 순서로 이기지 못하게 한다.
+            {"agent_name": "technical", "data_points": {"regime": "bear_high_vol"}},
+            {"agent_name": "macro", "data_points": {"regime": "bull_low_vol"}},
+        ],
+        ensure_ascii=False,
+    )
+    _seed(db_path, "TST_A", regime_col=None, verdicts=verdicts)
+
+    backfill_decision_regime(db_path=db_path)
+
+    assert _regime_of(db_path, "TST_A") == "bull_low_vol"
+
+
+def test_regime_from_a_non_macro_agent_alone_is_not_used(db_path):
+    """macro 가 없고 다른 에이전트만 regime 을 담은 행은 NULL 을 유지한다."""
+    verdicts = json.dumps([{"agent_name": "technical", "data_points": {"regime": "bull_low_vol"}}])
+    _seed(db_path, "TST_A", regime_col=None, verdicts=verdicts)
+
+    stats = backfill_decision_regime(db_path=db_path)
+
+    assert stats["backfilled"] == 0
+    assert stats["no_source"] == 1
+    assert _regime_of(db_path, "TST_A") is None
+
+
+def test_idempotent_rerun_skips_existing(db_path):
+    """재실행은 write 0 — 이미 canonical 인 행은 후보가 아니다.
+
+    Mutation lock: 후보 쿼리에서 `WHERE d.regime IS NULL` 을 지우면 2회차 candidates 가
+    0 이 아니게 되어 FAIL.
+    """
+    _seed(db_path, "TST_A", regime_col=None, verdicts=_verdicts("bull_low_vol"))
+
+    first = backfill_decision_regime(db_path=db_path)
+    second = backfill_decision_regime(db_path=db_path)
+
+    assert first["backfilled"] == 1
+    assert second["candidates"] == 0
+    assert second["backfilled"] == 0
+    assert _regime_of(db_path, "TST_A") == "bull_low_vol"
+
+
+def test_existing_canonical_value_is_never_overwritten(db_path):
+    """이미 라벨된 행은 소스와 달라도 건드리지 않는다 — 백필은 채우기지 재작성이 아니다."""
+    _seed(db_path, "TST_A", regime_col="sideways_low_vol", verdicts=_verdicts("bull_low_vol"))
+
+    backfill_decision_regime(db_path=db_path)
+
+    assert _regime_of(db_path, "TST_A") == "sideways_low_vol"
+
+
+def test_dry_run_writes_nothing(db_path):
+    """--dry-run 은 카운트만 낸다."""
+    _seed(db_path, "TST_A", regime_col=None, verdicts=_verdicts("bull_low_vol"))
+
+    stats = backfill_decision_regime(db_path=db_path, dry_run=True)
+
+    assert stats["backfilled"] == 1  # 예정 건수는 보고한다
+    assert _regime_of(db_path, "TST_A") is None  # 그러나 원장은 그대로
+    assert "dry-run" in stats["coverage_after"]


### PR DESCRIPTION
Closes #1264.

## Why

Pre-#1258 `decisions` rows carry a NULL `regime` — the writer of that era didn't fill the column. But **the value is already in the row**: the consensus batch stored the macro agent's verdict verbatim in `agent_verdicts`, and its `data_points.regime` is the regime that was live that day. This copies it into the column.

The issue rejected three other candidate sources; the reasons are recorded in the script docstring so they aren't re-litigated later. The important one is re-running `classify_regime(date=...)`: the freshness gate sits inside `if date is None`, so passing a date bypasses it, and `prices`/`macro` are `INSERT OR REPLACE` with no vintage — it would **manufacture a label the live path deliberately declined to emit**.

Point-in-time: this is not back-inference from future data, it is a deterministic copy of a contemporaneous value already captured inside the same decision record. `db_migrations.py`'s "legacy row stays NULL — no lossy retrofit" governs filling new schema by heuristic estimation, which this is not.

## Deliberate asymmetry

Backfilled rows get **no** `decision_evidence` row. Writing one would disguise an after-the-fact copy as live evidence. Rows with a regime but no supporting evidence row are exactly the backfilled ones — documented in the script docstring rather than left silent.

No schema change (no `backfill_source` / `regime_backfilled_at` columns — nothing would read them). Ledger application is production-only; dev is a read-replica.

## Verification

Dry run against the dev ledger reproduces an independent query of the same data exactly:

```
백필 대상 행 (regime IS NULL): 387
  canonical 복사: 364
  소스 없음 → NULL 유지: 23
  어휘 밖 값 → NULL 유지: 0
```

The dev ledger is 94.1% extractable, not the 100% the issue cites for production — the 23 sourceless rows are precisely the case the NULL-preservation lock covers. All extracted values were canonical; zero free-text. The dry run wrote nothing (verified: 0 non-NULL rows after).

7 tests, 7 mutation axes, each with an asserted replacement count **and** a test-node collection pre-check:

| Mutation | Test that flips to FAIL |
|---|---|
| manufacture a default when the source is missing | `test_missing_macro_regime_stays_null` |
| drop the `ALL_REGIMES` membership check | `test_non_canonical_value_is_not_written` |
| drop `WHERE d.regime IS NULL` | `test_idempotent_rerun_skips_existing` |
| same, via the overwrite axis | `test_existing_canonical_value_is_never_overwritten` |
| let `--dry-run` write | `test_dry_run_writes_nothing` |

5/5 locked. The mock copies the real writer's shape (10-agent array, `agent_name`, nested `data_points`) and deliberately does **not** fix macro's index, so the `json_each` contract is locked rather than an array position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7


---

## Update — a real defect found before merge

While reviewing the extraction I checked whether `json_each` tolerates a bad row. It does not: **one malformed `agent_verdicts` aborts the entire backfill** with `OperationalError: malformed JSON`, so a single bad row would block the other 386. That is the same shape that poisoned `pipeline_events.payload` (`nuri/core/CLAUDE.md`), and this column is not hypothetical — the production read path already defends against broken JSON here (`test_decisions.py::test_regime_malformed_json_swallowed`), and the **dev ledger contains one such row** (id 20, `json_type` = `array` but `json_valid` = 0).

Guarding with `CASE WHEN json_valid(...)` did **not** fix it: if the top level is an object, or the array holds a string element, the guard passes and `json_extract` then dies the same way (measured).

So extraction moved from SQL into Python — `json.loads` in a `try`, then a shape-checked walk. 387 rows makes performance irrelevant, and it is far easier to reason about. It also *recovers* the row SQLite rejected: Python's parser accepts it, so the dev dry run is back to 364 copied with 0 malformed.

Two axes were added to the mutation set as a result:

| Mutation | Test that flips to FAIL |
|---|---|
| drop the `try`/`except` around `json.loads` | `test_one_malformed_row_does_not_abort_the_backfill` |
| drop the `isinstance(parsed, list)` check | same |

The second needed care: with a JSON **object** the check is redundant (iterating a dict yields keys, which aren't dicts, so the result is identical) — it only bites on a **scalar**, where `for item in 5` raises `TypeError`. The test seeds a scalar row for exactly that reason; without it the axis measured as "not locked".

7/7 locked.


---

## Codex review

Codex reviewed the commit as it stood **before** the rewrite above, so its P1 (malformed JSON aborts the run) and P3 (tests don't cover the malformed / non-array cases) are the same defect I had already found and fixed. Its **P2 is new and did still apply** to the Python version:

> the SQL does not guarantee macro provenance. It picks the first element anywhere in `agent_verdicts` whose `$.data_points.regime` is non-null; there is no `agent_name = 'macro'` predicate.

Correct, and the same class of problem as the one raised on #1295: which agent supplied the value was a property of the current data shape, not something enforced. If another agent starts writing that key, the backfill would silently take its value.

Now enforced by name. Measured first — it costs nothing: across the dev ledger both formulations produce **364 rows, zero divergence**, and `macro` is the only carrier of the key.

Codex also confirmed independently: idempotency holds, the `classify_regime(date=...)` freshness-bypass claim is accurate, `db_path` forwarding is correct, and no consumer breaks on the missing evidence rows (`get_decision_with_evidence()` tolerates an empty list).

**Final state: 9 tests, 8 mutation axes, 8/8 locked**, adding:

| Mutation | Test that flips to FAIL |
|---|---|
| drop the `agent_name == "macro"` predicate | `test_only_the_macro_agent_supplies_the_regime` |

The provenance test puts a non-macro verdict carrying a regime **ahead** of macro in the array, so position can't win by accident.
