### PR TITLE
style(frontend): move chart chrome onto dark theme tokens (#1275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 |--------|-------|---|
 | **Backend tests** | 7,805 collected across 358 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,648 across 137 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
+| **Frontend tests** | 1,648 across 138 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 1 of them (certify) has no scheduler job of its own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,805 backend tests across 358 files + 1622 frontend vitest (137 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,805 backend tests across 358 files + 1622 frontend vitest (138 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,805 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 137 files |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 138 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1652 tests, 138 files)
+npm run test           # vitest run (1653 tests, 138 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1642 tests, 136 files)
+npm run test           # vitest run (1652 tests, 138 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -88,7 +88,7 @@ Two things that do **not** work, already tried (#913):
 Symptom if someone drops it: eslint prints `Oops! Something went wrong!` with a
 `brace-expansion` stack trace and lints **nothing**. `npm run lint` is silent on success, so
 confirm by file count rather than by absence of output — `npx eslint --format json | jq length`
-should be **244**.
+should be **247**.
 
 ## E2E (Playwright) — runs against the real backend, gated by CI since #1234
 
@@ -108,4 +108,4 @@ should be **244**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 100 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 102 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/src/__tests__/components/chart-design-tokens.test.tsx
+++ b/frontend/src/__tests__/components/chart-design-tokens.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * #1275 — 차트 레이어가 다크 토큰 시스템 안에 있는지.
+ *
+ * recharts 는 grid stroke · tooltip border · tick fill 을 SVG 속성/인라인 스타일로 받아서
+ * Tailwind 클래스가 안 먹는다. 그래서 zinc hex 를 직접 박아 뒀는데(실측 63곳 / 9파일),
+ * 그러면 차트만 토큰 시스템 밖에 남는다. 게다가 이 앱의 다크 팔레트는 **zinc 가 아니다** —
+ * `--background: #111418` · `--popover: #2F343C` · `--muted-foreground: #ABB3BF` 라서
+ * 차트는 테마를 못 따라올 뿐 아니라 지금도 앱 팔레트와 어긋나 있었다.
+ *
+ * #1253 이 `pipeline/page.tsx` 에서 쓴 2겹 잠금을 그대로 따른다:
+ *   - **동작** — 실제로 recharts 에 넘어가는 값이 `var(--...)` 인가 (recharts 를 가로채
+ *     받은 props 를 그대로 본다)
+ *   - **구조** — 소스에 중립 hex 리터럴이 남지 않았는가 (동작 잠금은 한 차트만 보므로
+ *     나머지 8개에 새 하드코딩이 생기면 놓친다)
+ *
+ * ⚠️ #1253 과 달리 **"hex 전면 금지" 가 아니다.** 차트에는 의미를 담은 계열색이
+ * 정당하게 있다(`#10b981` pass, violation 색 등). 스윕이 그것까지 잡으면 멀쩡한 색을
+ * 지우게 되므로 **zinc 계열 중립색만** 겨눈다 — 카나리아가 그 경계를 양쪽으로 확인한다.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CertificationPoint, GateCondition } from "@/components/ui/siege-timeline-chart";
+
+// recharts 를 가로채 실제로 넘어온 props 를 노출시킨다.
+const captured: Record<string, Record<string, unknown>> = {};
+type StubProps = Record<string, unknown> & { children?: React.ReactNode };
+
+vi.mock("recharts", () => {
+  const cap = (name: string, { children, ...props }: StubProps) => {
+    captured[name] = props;
+    return <div data-testid={`rc-${name}`}>{children as React.ReactNode}</div>;
+  };
+  // 명명 함수 선언이다 — 팩토리로 만들면 displayName 을 붙여야 하는데 그 대입이
+  // `react-hooks/immutability` 에 걸린다.
+  function ResponsiveContainer({ children }: StubProps) {
+    return <div>{children as React.ReactNode}</div>;
+  }
+  function BarChart({ children }: StubProps) {
+    return <div>{children as React.ReactNode}</div>;
+  }
+  function CartesianGrid(p: StubProps) {
+    return cap("CartesianGrid", p);
+  }
+  function XAxis(p: StubProps) {
+    return cap("XAxis", p);
+  }
+  function YAxis(p: StubProps) {
+    return cap("YAxis", p);
+  }
+  function Tooltip(p: StubProps) {
+    return cap("Tooltip", p);
+  }
+  function Legend(p: StubProps) {
+    return cap("Legend", p);
+  }
+  function Bar(p: StubProps) {
+    return cap("Bar", p);
+  }
+  return { ResponsiveContainer, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, Legend, Bar };
+});
+
+/** 차트 크롬에 쓰이던 zinc 계열 중립색. 의미를 담은 계열색은 **일부러** 제외한다. */
+const NEUTRAL_HEX = /#(?:fafafa|f4f4f5|e4e4e7|d4d4d8|a1a1aa|71717a|52525b|3f3f46|27272a|18181b|09090b)\b/gi;
+
+const CHART_FILES = [
+  "src/components/ui/gate-failure-chart.tsx",
+  "src/components/ui/equity-curve-chart.tsx",
+  "src/components/ui/price-chart.tsx",
+  "src/components/ui/siege-timeline-chart.tsx",
+  "src/components/evidence/fear-greed-chart.tsx",
+  "src/components/evidence/signal-performance-chart.tsx",
+  "src/components/evidence/regime-chart.tsx",
+  "src/components/evidence/sell-evidence-chart.tsx",
+  "src/components/evidence/portfolio-treemap.tsx",
+];
+
+function makePoint(): CertificationPoint {
+  const condition: GateCondition = {
+    id: "sector_limit",
+    description: "",
+    passed: false,
+    detail: "",
+    severity: "error",
+  };
+  return {
+    id: 1,
+    timestamp: "2026-04-20T10:00:00+09:00",
+    certified: false,
+    score: 55,
+    total_conditions: 10,
+    passed: 7,
+    failed: 1,
+    warnings: 0,
+    regime: null,
+    portfolio_hash: "h",
+    caller: "cli",
+    conditions: [condition],
+  };
+}
+
+describe("차트 레이어는 다크 토큰을 쓴다 (#1275)", () => {
+  it("grid · 축 · 툴팁 · 범례가 CSS 변수로 넘어간다", async () => {
+    const { GateFailureChart } = await import("@/components/ui/gate-failure-chart");
+    render(<GateFailureChart items={[makePoint()]} />);
+
+    const isVar = (v: unknown) => expect(String(v)).toMatch(/var\(--/);
+
+    isVar(captured.CartesianGrid?.stroke);
+    isVar((captured.XAxis?.tick as { fill?: string })?.fill);
+    isVar((captured.YAxis?.tick as { fill?: string })?.fill);
+
+    const content = captured.Tooltip?.contentStyle as { backgroundColor?: string; border?: string };
+    isVar(content?.backgroundColor);
+    isVar(content?.border);
+    isVar((captured.Tooltip?.labelStyle as { color?: string })?.color);
+    isVar((captured.Tooltip?.itemStyle as { color?: string })?.color);
+    isVar((captured.Legend?.wrapperStyle as { color?: string })?.color);
+  });
+
+  it("차트 소스에 중립 hex 리터럴이 남아 있지 않다", () => {
+    const offenders: string[] = [];
+    for (const rel of CHART_FILES) {
+      const found = readFileSync(join(process.cwd(), rel), "utf8").match(NEUTRAL_HEX) ?? [];
+      if (found.length) offenders.push(`${rel}: ${found.join(", ")}`);
+    }
+    expect(offenders, `중립 hex 잔존:\n${offenders.join("\n")}`).toHaveLength(0);
+  });
+
+  it("스윕이 실제로 눈이 있고, 계열색까지 잡지는 않는다 (canary)", () => {
+    // 눈이 있는가 — 정규식이 조용히 아무것도 안 잡으면 위 테스트는 영원히 초록이다.
+    expect('stroke="#27272a"'.match(NEUTRAL_HEX)).toEqual(["#27272a"]);
+    expect('border: "1px solid #3f3f46"'.match(NEUTRAL_HEX)).toEqual(["#3f3f46"]);
+    // 과하지는 않은가 — 의미를 담은 계열색은 정당하므로 잡으면 안 된다.
+    expect('fill="#10b981"'.match(NEUTRAL_HEX)).toBeNull();
+    expect('fill="#ef4444"'.match(NEUTRAL_HEX)).toBeNull();
+  });
+
+  it("역할이 다른 상수는 값도 분리돼 있다", async () => {
+    // 같은 `#27272a` 였지만 격자 선과 treemap 의 '위반 없음' 채움은 의미가 다르다.
+    // 한 상수로 뭉개면 한쪽을 조정할 때 다른 쪽이 따라 움직인다 (#1275 이 명시한 주의).
+    const theme = await import("@/lib/chart-theme");
+    expect(theme.CHART_GRID_STROKE).not.toBe(theme.CHART_EMPTY_FILL);
+    for (const [name, value] of Object.entries(theme)) {
+      expect(String(value), `${name} 이 토큰이 아니다`).toMatch(/var\(--/);
+    }
+  });
+});

--- a/frontend/src/__tests__/components/chart-design-tokens.test.tsx
+++ b/frontend/src/__tests__/components/chart-design-tokens.test.tsx
@@ -64,6 +64,9 @@ vi.mock("recharts", () => {
 /** 차트 크롬에 쓰이던 zinc 계열 중립색. 의미를 담은 계열색은 **일부러** 제외한다. */
 const NEUTRAL_HEX = /#(?:fafafa|f4f4f5|e4e4e7|d4d4d8|a1a1aa|71717a|52525b|3f3f46|27272a|18181b|09090b)\b/gi;
 
+/** 같은 이탈의 Tailwind 클래스 문법. hex 스윕만으로는 절반만 잡힌다. */
+const ZINC_CLASS = /\b(?:bg|text|border|fill|stroke|from|to|via)-zinc-\d{2,3}\b/g;
+
 const CHART_FILES = [
   "src/components/ui/gate-failure-chart.tsx",
   "src/components/ui/equity-curve-chart.tsx",
@@ -128,6 +131,18 @@ describe("차트 레이어는 다크 토큰을 쓴다 (#1275)", () => {
     expect(offenders, `중립 hex 잔존:\n${offenders.join("\n")}`).toHaveLength(0);
   });
 
+  it("차트 소스에 zinc 유틸리티 클래스도 남아 있지 않다", () => {
+    // hex 만 잡으면 절반짜리다 — 같은 이탈이 Tailwind 클래스 문법으로도 있었다(실측 8곳).
+    // 특히 범례 스와치(`bg-zinc-400`)는 이제 `var(--muted-foreground)` 로 그려지는 계열선
+    // 바로 옆에 있어서, 안 고치면 **범례가 자기 계열선과 어긋난다.**
+    const offenders: string[] = [];
+    for (const rel of CHART_FILES) {
+      const found = readFileSync(join(process.cwd(), rel), "utf8").match(ZINC_CLASS) ?? [];
+      if (found.length) offenders.push(`${rel}: ${found.join(", ")}`);
+    }
+    expect(offenders, `zinc 클래스 잔존:\n${offenders.join("\n")}`).toHaveLength(0);
+  });
+
   it("스윕이 실제로 눈이 있고, 계열색까지 잡지는 않는다 (canary)", () => {
     // 눈이 있는가 — 정규식이 조용히 아무것도 안 잡으면 위 테스트는 영원히 초록이다.
     expect('stroke="#27272a"'.match(NEUTRAL_HEX)).toEqual(["#27272a"]);
@@ -135,6 +150,9 @@ describe("차트 레이어는 다크 토큰을 쓴다 (#1275)", () => {
     // 과하지는 않은가 — 의미를 담은 계열색은 정당하므로 잡으면 안 된다.
     expect('fill="#10b981"'.match(NEUTRAL_HEX)).toBeNull();
     expect('fill="#ef4444"'.match(NEUTRAL_HEX)).toBeNull();
+    // 클래스 스윕도 같은 두 방향으로 확인한다.
+    expect('className="bg-zinc-400"'.match(ZINC_CLASS)).toEqual(["bg-zinc-400"]);
+    expect('className="bg-emerald-500"'.match(ZINC_CLASS)).toBeNull();
   });
 
   it("역할이 다른 상수는 값도 분리돼 있다", async () => {

--- a/frontend/src/__tests__/components/evidence-charts.test.tsx
+++ b/frontend/src/__tests__/components/evidence-charts.test.tsx
@@ -190,7 +190,8 @@ describe("buildTreemapData / cellStroke / TreemapCell", () => {
   it("cellStroke: 위반별 테두리색, 정상은 경계색", () => {
     expect(cellStroke("stop_loss")).toBe(VIOLATION_COLORS.stop_loss);
     expect(cellStroke("overweight")).toBe(VIOLATION_COLORS.overweight);
-    expect(cellStroke(null)).toBe("#27272a");
+    // 토큰이어야 한다 — hex 로 되돌리면 테마를 안 따라온다 (#1275).
+    expect(cellStroke(null)).toBe("var(--muted)");
   });
 
   it("TreemapCell: 넓은 셀은 티커+손익 라벨, depth 0 은 빈 그룹", () => {

--- a/frontend/src/__tests__/components/siege-timeline-chart.test.tsx
+++ b/frontend/src/__tests__/components/siege-timeline-chart.test.tsx
@@ -203,7 +203,8 @@ describe("SiegeTimelineChart helpers", () => {
     expect(props.cy).toBe(50);
     expect(props.r).toBe(3.5);
     expect(props.fill).toBe("#10b981");
-    expect(props.stroke).toBe("#18181b");
+    // 셀 구분선도 토큰 — hex 로 되돌리면 다크 배경(#111418)과 어긋난다 (#1275).
+    expect(props.stroke).toBe("var(--background)");
   });
 
   it("renderDot rejected point uses red fill", () => {

--- a/frontend/src/components/evidence/fear-greed-chart.tsx
+++ b/frontend/src/components/evidence/fear-greed-chart.tsx
@@ -43,7 +43,7 @@ export function FearGreedChart({ data }: { data: FearGreedData }) {
     <div className="min-w-0" data-testid="fear-greed-chart" role="img" aria-label={EVIDENCE.TITLE_FEAR_GREED}>
       {latest && (
         <div className="mb-2">
-          <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-zinc-200">
+          <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-foreground">
             현재 {latest.value.toFixed(0)} · {zoneLabel(latest.value)}
           </span>
         </div>

--- a/frontend/src/components/evidence/fear-greed-chart.tsx
+++ b/frontend/src/components/evidence/fear-greed-chart.tsx
@@ -4,6 +4,7 @@
  * FearGreedChart — 공포·탐욕 지수 90일 라인 + 구간 존 (#1225).
  * 존 경계는 CNN Fear & Greed 표준 구간 (Plotly 원본과 동일).
  */
+import { CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import { EVIDENCE } from "@/lib/strings";
 import {
   ResponsiveContainer,
@@ -52,25 +53,25 @@ export function FearGreedChart({ data }: { data: FearGreedData }) {
           <LineChart data={rows} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               interval={Math.floor(rows.length / 6)}
             />
             <YAxis
               domain={[0, 100]}
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               width={30}
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}
-              labelStyle={{ color: "#a1a1aa" }}
+              labelStyle={{ color: CHART_MUTED }}
               formatter={fgTooltipFormatter}
             />
             {FG_ZONES.map((z) => (

--- a/frontend/src/components/evidence/portfolio-treemap.tsx
+++ b/frontend/src/components/evidence/portfolio-treemap.tsx
@@ -5,6 +5,7 @@
  * violation 테두리: 손절=빨강, 비중초과=노랑 — Plotly 원본에서 계산만 되고
  * 배선 안 됐던 테두리를 네이티브에서 실제로 그린다.
  */
+import { CHART_EMPTY_FILL, CHART_LABEL_STRONG, CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import type { ReactElement } from "react";
 import { EVIDENCE } from "@/lib/strings";
 import { ResponsiveContainer, Treemap, Tooltip } from "recharts";
@@ -38,7 +39,7 @@ export function buildTreemapData(data: HeatmapData): TreemapDatum[] {
 }
 
 export function cellStroke(violation: HeatmapItem["violation"]): string {
-  return violation ? VIOLATION_COLORS[violation] : "#27272a";
+  return violation ? VIOLATION_COLORS[violation] : CHART_EMPTY_FILL;
 }
 
 export interface CellProps {
@@ -69,12 +70,12 @@ export function TreemapCell(props: CellProps): ReactElement {
         strokeWidth={violation ? 2 : 1}
       />
       {width > 44 && height > 20 && (
-        <text x={x + 6} y={y + 16} fill="#fafafa" fontSize={11} fontWeight={500}>
+        <text x={x + 6} y={y + 16} fill={CHART_LABEL_STRONG} fontSize={11} fontWeight={500}>
           {name}
         </text>
       )}
       {width > 60 && height > 36 && (
-        <text x={x + 6} y={y + 30} fill="#d4d4d8" fontSize={10}>
+        <text x={x + 6} y={y + 30} fill={CHART_MUTED} fontSize={10}>
           {pnl >= 0 ? "+" : ""}
           {pnl.toFixed(1)}%
         </text>
@@ -101,8 +102,8 @@ export function PortfolioTreemap({ data }: { data: HeatmapData }) {
         >
           <Tooltip
             contentStyle={{
-              backgroundColor: "#18181b",
-              border: "1px solid #3f3f46",
+              backgroundColor: CHART_TOOLTIP_BG,
+              border: CHART_TOOLTIP_BORDER,
               borderRadius: 8,
               fontSize: 12,
             }}

--- a/frontend/src/components/evidence/regime-chart.tsx
+++ b/frontend/src/components/evidence/regime-chart.tsx
@@ -63,7 +63,7 @@ export function RegimeChart({ data }: { data: RegimeData }) {
     <div className="min-w-0" data-testid="regime-chart" role="img" aria-label={EVIDENCE.TITLE_REGIME}>
       {chip && (
         <div className="mb-2">
-          <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-zinc-200">{chip}</span>
+          <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-foreground">{chip}</span>
         </div>
       )}
       <div className="w-full min-w-0 h-64">

--- a/frontend/src/components/evidence/regime-chart.tsx
+++ b/frontend/src/components/evidence/regime-chart.tsx
@@ -4,6 +4,7 @@
  * RegimeChart — SPY 종가 + SMA50/200 라인 + VIX 서브차트 (#1225).
  * Plotly regime 차트의 네이티브 대체. VIX 30 기준선 = rules.yaml 신규 매수 차단선.
  */
+import { CHART_GRID_STROKE, CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import { EVIDENCE } from "@/lib/strings";
 import {
   ResponsiveContainer,
@@ -23,8 +24,8 @@ import type { RegimeData } from "@/components/evidence/chart-data";
 export const VIX_BLOCK_LEVEL = 30;
 
 const TOOLTIP_STYLE = {
-  backgroundColor: "#18181b",
-  border: "1px solid #3f3f46",
+  backgroundColor: CHART_TOOLTIP_BG,
+  border: CHART_TOOLTIP_BORDER,
   borderRadius: 8,
   fontSize: 12,
 } as const;
@@ -68,22 +69,22 @@ export function RegimeChart({ data }: { data: RegimeData }) {
       <div className="w-full min-w-0 h-64">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={200}>
           <ComposedChart data={spy} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               interval={Math.floor(spy.length / 6)}
             />
             <YAxis
               domain={[minClose, maxClose]}
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               tickFormatter={priceTick}
               width={50}
             />
-            <Tooltip contentStyle={TOOLTIP_STYLE} labelStyle={{ color: "#a1a1aa" }} />
+            <Tooltip contentStyle={TOOLTIP_STYLE} labelStyle={{ color: CHART_MUTED }} />
             <Area
               dataKey="close"
               stroke="var(--chart-1)"
@@ -119,12 +120,12 @@ export function RegimeChart({ data }: { data: RegimeData }) {
             <LineChart data={vix} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
               <XAxis dataKey="date" hide />
               <YAxis
-                tick={{ fontSize: 9, fill: "#71717a" }}
+                tick={{ fontSize: 9, fill: CHART_MUTED }}
                 tickLine={false}
                 axisLine={false}
                 width={50}
               />
-              <Tooltip contentStyle={TOOLTIP_STYLE} labelStyle={{ color: "#a1a1aa" }} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} labelStyle={{ color: CHART_MUTED }} />
               <ReferenceLine y={VIX_BLOCK_LEVEL} stroke="#f59e0b" strokeDasharray="4 2" />
               <Line dataKey="vix" stroke="#3FA6DA" strokeWidth={1} dot={false} />
             </LineChart>

--- a/frontend/src/components/evidence/sell-evidence-chart.tsx
+++ b/frontend/src/components/evidence/sell-evidence-chart.tsx
@@ -4,6 +4,7 @@
  * SellEvidenceChart — 위반 항목별 심각도 가로 바 (#1225).
  * 손절=빨강 · 비중초과=노랑, 툴팁에 조치·회복 조건 표시 (Plotly hover 대체).
  */
+import { CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import { EVIDENCE } from "@/lib/strings";
 import { ResponsiveContainer, BarChart, Bar, Cell, XAxis, YAxis, Tooltip } from "recharts";
 
@@ -47,22 +48,22 @@ export function SellEvidenceChart({ data }: { data: SellEvidenceData }) {
           <BarChart data={rows} layout="vertical" margin={{ top: 5, right: 30, bottom: 0, left: 0 }}>
             <XAxis
               type="number"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               tickFormatter={severityTick}
             />
             <YAxis
               type="category"
               dataKey="label"
-              tick={{ fontSize: 10, fill: "#a1a1aa" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               width={150}
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}

--- a/frontend/src/components/evidence/signal-performance-chart.tsx
+++ b/frontend/src/components/evidence/signal-performance-chart.tsx
@@ -4,6 +4,7 @@
  * SignalPerformanceChart — 시그널별 승률 가로 바(드리프트 색) + PF 라인 (#1225).
  * 승률 0.5 기준선 = 동전던지기 (edge 미입증 기준, STRATEGY §3.11).
  */
+import { CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import { EVIDENCE } from "@/lib/strings";
 import {
   ResponsiveContainer,
@@ -49,7 +50,7 @@ export function SignalPerformanceChart({ data }: { data: SignalPerformanceData }
             <XAxis
               type="number"
               domain={[0, 1]}
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               tickFormatter={winRateTick}
             />
@@ -58,21 +59,21 @@ export function SignalPerformanceChart({ data }: { data: SignalPerformanceData }
             <YAxis
               type="category"
               dataKey="signal_id"
-              tick={{ fontSize: 10, fill: "#a1a1aa" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               width={130}
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}
               formatter={signalTooltipFormatter}
             />
-            <ReferenceLine x={COIN_FLIP_WIN_RATE} stroke="#71717a" strokeDasharray="4 2" />
+            <ReferenceLine x={COIN_FLIP_WIN_RATE} stroke={CHART_MUTED} strokeDasharray="4 2" />
             <Bar dataKey="win_rate" barSize={14} isAnimationActive={false}>
               {rows.map((r) => (
                 <Cell key={r.signal_id} fill={driftColor(r.drift_status)} />

--- a/frontend/src/components/ui/equity-curve-chart.tsx
+++ b/frontend/src/components/ui/equity-curve-chart.tsx
@@ -3,6 +3,7 @@
 /**
  * EquityCurveChart — 백테스트 equity curve (Strategy vs SPY + Drawdown).
  */
+import { CHART_GRID_STROKE, CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import { useState } from "react";
 import {
   ResponsiveContainer,
@@ -65,16 +66,16 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
       <div className="w-full min-w-0 h-50">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={200}>
           <ComposedChart data={chartData} syncId="equity" margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               interval={Math.floor(chartData.length / 6)}
               tickFormatter={(v) => String(v).slice(2, 7)}
             />
             <YAxis
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               tickFormatter={(v) => `${v}%`}
@@ -82,12 +83,12 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}
-              labelStyle={{ color: "#a1a1aa" }}
+              labelStyle={{ color: CHART_MUTED }}
               formatter={(value, name) => {
                 const v = Number(value);
                 const label = name === "strategy" ? "Strategy" : "SPY";
@@ -96,7 +97,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
             />
             <Line
               dataKey="spy"
-              stroke="#71717a"
+              stroke={CHART_MUTED}
               strokeWidth={1.5}
               dot={false}
             />
@@ -116,7 +117,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
           <ComposedChart data={chartData} syncId="equity" margin={{ top: 0, right: 5, bottom: 0, left: 0 }}>
             <XAxis dataKey="date" hide />
             <YAxis
-              tick={{ fontSize: 9, fill: "#71717a" }}
+              tick={{ fontSize: 9, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               tickFormatter={(v) => `${v}%`}
@@ -125,8 +126,8 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}

--- a/frontend/src/components/ui/equity-curve-chart.tsx
+++ b/frontend/src/components/ui/equity-curve-chart.tsx
@@ -53,7 +53,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
             onClick={() => setPeriod(p.days)}
             className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
               period === p.days
-                ? "bg-muted text-zinc-200"
+                ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground/80"
             }`}
           >
@@ -148,7 +148,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
       {/* Legend */}
       <div className="flex gap-4 mt-1 text-[10px] text-muted-foreground justify-center">
         <span><span className="inline-block w-3 h-0.5 bg-emerald-500 mr-1 align-middle" />Strategy</span>
-        <span><span className="inline-block w-3 h-0.5 bg-zinc-500 mr-1 align-middle" />SPY</span>
+        <span><span className="inline-block w-3 h-0.5 bg-muted-foreground mr-1 align-middle" />SPY</span>
         <span><span className="inline-block w-3 h-0.5 bg-red-500 mr-1 align-middle" />Drawdown</span>
       </div>
     </div>

--- a/frontend/src/components/ui/gate-failure-chart.tsx
+++ b/frontend/src/components/ui/gate-failure-chart.tsx
@@ -15,6 +15,7 @@
  *
  * 색상은 severity 별 팔레트 — error red 계열 / warning amber 계열.
  */
+import { CHART_GRID_STROKE, CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TOOLTIP_ITEM } from "@/lib/chart-theme";
 import {
   Bar,
   BarChart,
@@ -163,15 +164,15 @@ export function GateFailureChart({ items }: GateFailureChartProps) {
       <div className="w-full min-w-0 h-56">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={200}>
           <BarChart data={rows} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
             <XAxis
               dataKey="short"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               interval={Math.max(0, Math.floor(rows.length / 6) - 1)}
             />
             <YAxis
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               width={28}
@@ -179,17 +180,17 @@ export function GateFailureChart({ items }: GateFailureChartProps) {
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}
-              labelStyle={{ color: "#a1a1aa" }}
-              itemStyle={{ color: "#e4e4e7" }}
+              labelStyle={{ color: CHART_MUTED }}
+              itemStyle={{ color: CHART_TOOLTIP_ITEM }}
               formatter={tooltipValueFormatter as never}
             />
             <Legend
-              wrapperStyle={{ fontSize: 10, color: "#a1a1aa" }}
+              wrapperStyle={{ fontSize: 10, color: CHART_MUTED }}
               formatter={legendFormatter as never}
             />
             {categories.map((c) => (

--- a/frontend/src/components/ui/price-chart.tsx
+++ b/frontend/src/components/ui/price-chart.tsx
@@ -5,6 +5,7 @@
  * 캔들 대신 라인+영역 차트 (가독성 우선).
  * SMA 20/50 오버레이 + 거래량 바.
  */
+import { CHART_GRID_STROKE, CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import { useState } from "react";
 import { formatMoney } from "@/lib/format";
 import {
@@ -103,17 +104,17 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
       <div className="w-full min-w-0 h-70">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={280}>
           <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               interval={Math.floor(chartData.length / 6)}
             />
             <YAxis
               yAxisId="price"
               domain={[minClose, maxClose]}
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               tickFormatter={(v) => v.toFixed(0)}
@@ -122,12 +123,12 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
             <YAxis yAxisId="volume" orientation="right" hide />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}
-              labelStyle={{ color: "#a1a1aa" }}
+              labelStyle={{ color: CHART_MUTED }}
               formatter={(value, name) => {
                 const v = Number(value);
                 if (name === "volume") return [formatVolume(v), "Vol"];
@@ -139,7 +140,7 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
             <Bar
               yAxisId="volume"
               dataKey="volume"
-              fill="#3f3f46"
+              fill={CHART_MUTED}
               opacity={0.3}
               barSize={2}
             />

--- a/frontend/src/components/ui/price-chart.tsx
+++ b/frontend/src/components/ui/price-chart.tsx
@@ -91,7 +91,7 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
             onClick={() => setPeriod(p.days)}
             className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
               period === p.days
-                ? "bg-muted text-zinc-200"
+                ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground/80"
             }`}
           >

--- a/frontend/src/components/ui/siege-timeline-chart.tsx
+++ b/frontend/src/components/ui/siege-timeline-chart.tsx
@@ -9,6 +9,7 @@
  * - Vertical dashed markers: portfolio_hash change (portfolio state transition)
  * - Tooltip: id, regime, caller, passed/failed/warnings
  */
+import { CHART_CELL_STROKE, CHART_GRID_STROKE, CHART_MUTED, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from "@/lib/chart-theme";
 import {
   CartesianGrid,
   Line,
@@ -124,7 +125,7 @@ export function renderDot(dotProps: unknown): React.ReactElement {
   const r = dotRadius(payload.hashChanged);
   const shape = callerShape(payload.caller);
   const key = `dot-${index}`;
-  const commonStroke = { stroke: "#18181b", strokeWidth: 1 };
+  const commonStroke = { stroke: CHART_CELL_STROKE, strokeWidth: 1 };
 
   if (shape === "triangle") {
     const h = r * 1.3;
@@ -173,7 +174,7 @@ export function renderDot(dotProps: unknown): React.ReactElement {
  */
 export function LegendShape({ shape, className = "" }: { shape: DotShape; className?: string }): React.ReactElement {
   const common = "inline-block w-2 h-2 " + className;
-  const fill = "#71717a";
+  const fill = CHART_MUTED;
   if (shape === "triangle") {
     return (
       <svg className={common} viewBox="0 0 8 8" aria-hidden>
@@ -251,15 +252,15 @@ export function SiegeTimelineChart({ items }: SiegeTimelineChartProps) {
       <div className="w-full min-w-0 h-60">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={200}>
           <LineChart data={chartData} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
             <XAxis
               dataKey="short"
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               interval={Math.max(0, Math.floor(chartData.length / 6) - 1)}
             />
             <YAxis
-              tick={{ fontSize: 10, fill: "#71717a" }}
+              tick={{ fontSize: 10, fill: CHART_MUTED }}
               tickLine={false}
               axisLine={false}
               domain={[0, 100]}
@@ -268,12 +269,12 @@ export function SiegeTimelineChart({ items }: SiegeTimelineChartProps) {
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: "#18181b",
-                border: "1px solid #3f3f46",
+                backgroundColor: CHART_TOOLTIP_BG,
+                border: CHART_TOOLTIP_BORDER,
                 borderRadius: 8,
                 fontSize: 12,
               }}
-              labelStyle={{ color: "#a1a1aa" }}
+              labelStyle={{ color: CHART_MUTED }}
               labelFormatter={labelFormatter as never}
               formatter={valueFormatter as never}
             />
@@ -281,21 +282,21 @@ export function SiegeTimelineChart({ items }: SiegeTimelineChartProps) {
               <ReferenceLine
                 key={`t-${i}`}
                 x={chartData[i].short}
-                stroke="#a1a1aa"
+                stroke={CHART_MUTED}
                 strokeDasharray="4 3"
                 strokeWidth={1}
                 ifOverflow="extendDomain"
                 label={{
                   value: "▲",
                   position: "top",
-                  fill: "#a1a1aa",
+                  fill: CHART_MUTED,
                   fontSize: 10,
                 }}
               />
             ))}
             <Line
               dataKey="score"
-              stroke="#71717a"
+              stroke={CHART_MUTED}
               strokeWidth={1.5}
               dot={renderDot as never}
             />

--- a/frontend/src/components/ui/siege-timeline-chart.tsx
+++ b/frontend/src/components/ui/siege-timeline-chart.tsx
@@ -183,7 +183,7 @@ export function LegendShape({ shape, className = "" }: { shape: DotShape; classN
     );
   }
   if (shape === "square") {
-    return <span className={common + " bg-zinc-400"} aria-hidden />;
+    return <span className={common + " bg-muted-foreground"} aria-hidden />;
   }
   if (shape === "diamond") {
     return (
@@ -192,7 +192,7 @@ export function LegendShape({ shape, className = "" }: { shape: DotShape; classN
       </svg>
     );
   }
-  return <span className={common + " rounded-full bg-zinc-400"} aria-hidden />;
+  return <span className={common + " rounded-full bg-muted-foreground"} aria-hidden />;
 }
 
 /** caller 별 count — legend 에 표시 (distinct caller 수를 가시화). */
@@ -315,7 +315,7 @@ export function SiegeTimelineChart({ items }: SiegeTimelineChartProps) {
           REJECTED
         </span>
         <span>
-          <span className="inline-block w-3 h-px bg-zinc-400 mr-1.5 align-middle border-t border-dashed" />
+          <span className="inline-block w-3 h-px bg-muted-foreground mr-1.5 align-middle border-t border-dashed" />
           portfolio state 변경
         </span>
         <span className="w-full mt-0.5 text-muted-foreground/70">caller:</span>

--- a/frontend/src/lib/chart-theme.ts
+++ b/frontend/src/lib/chart-theme.ts
@@ -1,0 +1,47 @@
+/**
+ * recharts 차트의 **중립 크롬 색** — 전부 `globals.css` 토큰을 가리킨다 (#1275).
+ *
+ * 차트들이 zinc 계열 hex 를 직접 박고 있었다(실측 63곳 / 9파일). 이건 위생 문제만이
+ * 아니다 — 이 앱의 다크 팔레트는 **zinc 가 아니다**:
+ *
+ * | 토큰 | 다크 값 | 차트가 쓰던 zinc |
+ * |---|---|---|
+ * | `--background` | `#111418` | `#18181b` |
+ * | `--popover` | `#2F343C` | `#18181b` |
+ * | `--muted-foreground` | `#ABB3BF` | `#a1a1aa` / `#71717a` |
+ * | `--border` | `rgb(255 255 255 / 10%)` | `#27272a` |
+ *
+ * 즉 차트는 테마 토큰을 바꿔도 안 따라올 뿐 아니라 **지금도 앱 팔레트와 어긋나** 있다.
+ * 토큰으로 옮기면 외형이 앱 쪽으로 이동한다 — 의도된 변화다.
+ *
+ * 인라인 스타일도 SVG 속성도 CSS 변수를 해석하므로 hex 를 쓸 이유가 없다 (#1253 이
+ * `pipeline/page.tsx` 에서 확인한 것과 같은 근거).
+ *
+ * ⚠️ **역할이 다르면 상수도 다르다.** 같은 `#27272a` 라도 격자 선과 treemap 의
+ * "위반 없음" 채움은 의미가 다르다 — 한 상수로 뭉개면 한쪽을 조정할 때 다른 쪽이 따라
+ * 움직인다 (#1275 이 명시한 주의).
+ */
+
+/** 격자 선 (`CartesianGrid stroke`). */
+export const CHART_GRID_STROKE = "var(--border)";
+
+/** 축 눈금 · 범례 · 주석 등 **약하게 읽혀야 하는** 모든 중립 텍스트/선. */
+export const CHART_MUTED = "var(--muted-foreground)";
+
+/** 툴팁 배경 — 떠 있는 패널이므로 `--popover`. */
+export const CHART_TOOLTIP_BG = "var(--popover)";
+
+/** 툴팁 테두리. `border` 단축 속성에 그대로 넣는 완성형 문자열이다. */
+export const CHART_TOOLTIP_BORDER = "1px solid var(--input)";
+
+/** 툴팁 **안쪽** 본문 텍스트 (배경이 `--popover` 이므로 그 짝을 쓴다). */
+export const CHART_TOOLTIP_ITEM = "var(--popover-foreground)";
+
+/** 셀 구분선 — 배경색으로 그어 타일을 갈라 보이게 한다 (siege 타임라인 dot). */
+export const CHART_CELL_STROKE = "var(--background)";
+
+/** treemap 의 **위반 없음** 채움. 격자 선과 값이 같아도 의미가 달라 분리한다. */
+export const CHART_EMPTY_FILL = "var(--muted)";
+
+/** 도형 위에 얹는 강조 라벨 (treemap 티커명). */
+export const CHART_LABEL_STRONG = "var(--foreground)";


### PR DESCRIPTION
Closes #1275.

## Why

recharts takes grid stroke, tooltip border and tick fill as **SVG attributes and inline styles**, where Tailwind classes don't apply — so the charts had zinc hex baked in.

This turned out to be more than hygiene. The app's dark palette **is not zinc**:

| token | dark value | what charts hardcoded |
|---|---|---|
| `--background` | `#111418` | `#18181b` |
| `--popover` | `#2F343C` | `#18181b` |
| `--muted-foreground` | `#ABB3BF` | `#a1a1aa` / `#71717a` |
| `--border` | `rgb(255 255 255 / 10%)` | `#27272a` |

So the charts could not follow a theme change **and were already off-palette** against the rest of the app. Moving them onto tokens shifts their appearance toward the app palette — that is the intended outcome, not a side effect.

## Count correction

The issue says 17 sites / 9 files. Measured: **63 sites / 9 files** (it appears to have counted only the grid-stroke and tooltip-border patterns, not axis ticks, legend/label colours, neutral series strokes or treemap labels). All 63 are converted; a sweep asserts zero remain.

## Role separation

Constants are per **role**, not per hex value. The issue flagged this and it holds: the grid stroke and the treemap's no-violation fill were both `#27272a` but mean different things, so `CHART_GRID_STROKE` (`--border`) and `CHART_EMPTY_FILL` (`--muted`) stay distinct — collapsing them would couple two unrelated adjustments. A test asserts they differ.

## Verification

Two layers, following #1253's precedent:

- **Behaviour** — recharts is intercepted and the props it actually receives must match `var(--`: grid stroke, both axis tick fills, tooltip background/border/label/item, legend wrapper.
- **Structure** — a sweep over all 9 chart files for leftover neutral hex.

Unlike #1253 this is deliberately **not** a blanket hex ban: charts legitimately carry semantic series colours (`#10b981` pass, violation colours). The sweep targets the zinc neutrals only, and the canary checks **both edges** — it must match `#27272a` and must **not** match `#10b981`, so an over-broad regex that would force deleting legitimate colours fails too.

5 mutation axes, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| put a hex back in a chart source | structure sweep |
| make the value reaching recharts a hex | behaviour |
| collapse `CHART_EMPTY_FILL` into the grid stroke | role separation |
| turn a theme constant back into a hex | role separation |
| blind the sweep regex | canary |

5/5 locked. Full suite: **138 files / 1652 tests pass**, `tsc --noEmit` clean, eslint clean.

Two existing tests asserted the raw hex (`cellStroke(null)`, siege dot stroke) and now assert the token — those are themselves behavioural locks on real call sites.

## Out of scope, noted

- `src/lib/holdings-summary.ts:177` — `OTHER_COLOR = "#71717a"` is a **data series** colour outside the 9 chart files the issue names, and moving it touches 3 unrelated tests. Left alone; worth its own issue.
- `frontend/CLAUDE.md` still describes the theme as "zinc-950 base", which this PR shows is inaccurate. Not changed here since it predates this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7

---

## Update — the hex sweep was only half the defect

The same 9 files carried **8 Tailwind `zinc-*` classes**, which sit outside the token system exactly the way the hex literals did — and a sweep that caught only hex would have reported the chart layer as fully tokenized when it wasn't.

Converting them is not optional polish here: `bg-zinc-400` / `bg-zinc-500` are the **legend swatches sitting directly beside series lines this PR moved to `var(--muted-foreground)`**. Leaving them would make each legend disagree with the series it labels — a regression introduced by the first commit. `text-zinc-200` sits on `bg-muted` chips, so it becomes `text-foreground`.

The structural sweep now covers both syntaxes, with the canary checking both edges of the class regex too (must match `bg-zinc-400`, must not match `bg-emerald-500`).

**Final: 8 mutation axes, 8/8 locked**, 138 files / 1653 tests pass.

## Verified rather than assumed

The riskiest premise here is that `var()` resolves in **SVG presentation attributes** — `<CartesianGrid stroke="var(--border)">` reaches the DOM as an attribute, not an inline style, and `var()` in presentation attributes is a genuinely different case from `var()` in CSS. If it didn't resolve, every grid line would render with no colour.

Measured in Chromium rather than reasoned about, across all four positions this PR uses:

| position | resolves |
|---|---|
| SVG `stroke` attribute | ✅ `rgb(0, 255, 0)` |
| SVG inline `style` | ✅ `rgb(0, 255, 0)` |
| SVG `fill` attribute | ✅ `rgb(171, 179, 191)` |
| inline `border` shorthand | ✅ `rgb(0, 255, 0)` |
