### PR TITLE
refactor(frontend): move remaining hardcoded copy into strings.ts (#1252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 |--------|-------|---|
 | **Backend tests** | 7,805 collected across 358 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,648 across 138 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
+| **Frontend tests** | 1,648 across 139 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 1 of them (certify) has no scheduler job of its own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,805 backend tests across 358 files + 1622 frontend vitest (138 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,805 backend tests across 358 files + 1622 frontend vitest (139 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,805 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 138 files |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 139 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1657 tests, 139 files)
+npm run test           # vitest run (1658 tests, 139 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1653 tests, 138 files)
+npm run test           # vitest run (1657 tests, 139 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -108,4 +108,4 @@ should be **247**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 102 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 103 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/e2e/action-first.spec.ts
+++ b/frontend/e2e/action-first.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ACTION, CONTEXT } from "../src/lib/strings";
+import { ACTION, CONTEXT, OPPORTUNITY } from "../src/lib/strings";
 
 // 라벨 리터럴을 여기 박지 않는다 — strings.ts 가 단일 출처다. 410d385 가
 // CONTEXT.SIEGE 값을 "SIEGE" → "Certification" 으로 바꿨을 때 vitest 는 같이
@@ -102,8 +102,9 @@ test.describe("Action-First Dashboard", () => {
     await page.waitForTimeout(5000);
     const body = await page.textContent("body");
     // Opportunities should show tickers NOT in portfolio (e.g., INTC, SNOW, PLTR)
-    const hasOpportunity = body!.includes("이슈 종목") || body!.includes("기회 탐색") ||
-      body!.includes("매수 고려") || body!.includes("관망") || body!.includes("매수 금지");
+    const hasOpportunity = body!.includes(OPPORTUNITY.SUBTITLE) || body!.includes(OPPORTUNITY.TITLE) ||
+      body!.includes(OPPORTUNITY.POSITIVE) || body!.includes(OPPORTUNITY.NEUTRAL) ||
+      body!.includes(OPPORTUNITY.DANGER);
     expect(hasOpportunity).toBe(true);
   });
 

--- a/frontend/src/__tests__/lib/strings-ssot.test.ts
+++ b/frontend/src/__tests__/lib/strings-ssot.test.ts
@@ -65,8 +65,12 @@ describe("사용자 카피는 strings.ts SSoT 를 거친다 (#1252)", () => {
     const offenders = labels.filter((v) => src.includes(`"${v}"`));
     expect(offenders, `사이드바에 리터럴로 남은 라벨: ${offenders.join(", ")}`).toHaveLength(0);
 
-    const pipe = read("src/app/pipeline/page.tsx");
+    // 주석을 걷고 본다 — 이 파일 주석이 라우트 이름을 언급하고 있어 그대로 보면 오탐이다.
+    const pipe = stripComments(read("src/app/pipeline/page.tsx"));
     const nodeCopy = [
+      PIPELINE.TITLE, // codex P3: 타이틀이 빠져 있어 하드코딩 복귀를 못 잡았다
+      PIPELINE.NODE_COLLECT, PIPELINE.NODE_VALIDATE, PIPELINE.NODE_CLASSIFY,
+      PIPELINE.NODE_DIAGNOSE, PIPELINE.NODE_RECOMMEND, PIPELINE.NODE_TRACK,
       PIPELINE.NODE_COLLECT_SUB, PIPELINE.NODE_VALIDATE_SUB, PIPELINE.NODE_CLASSIFY_SUB,
       PIPELINE.NODE_DIAGNOSE_SUB, PIPELINE.NODE_RECOMMEND_SUB, PIPELINE.NODE_TRACK_SUB,
     ];

--- a/frontend/src/__tests__/lib/strings-ssot.test.ts
+++ b/frontend/src/__tests__/lib/strings-ssot.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #1252 — 사용자 노출 카피는 `src/lib/strings.ts` 를 거친다.
+ *
+ * SSoT 밖의 카피는 두 가지를 망가뜨린다: UI 가 반영반한(半英半韓)이 되고, e2e/vitest 의
+ * "문자열은 strings.ts 에서 import" 원칙(`frontend/CLAUDE.md`)이 **적용될 수가 없다.**
+ * 후자가 실제 사고로 이어진 적이 있다 — `410d385` 가 `CONTEXT.SIEGE` 를 rename 했을 때
+ * 리터럴을 박아 둔 e2e 단언 3개가 3.5개월간 조용히 죽어 있었다 (#1118).
+ *
+ * 잠금은 두 축이다:
+ *   - **한글 카피** — 이관 대상 파일에 주석을 뺀 한글이 남아 있지 않은가 (새로 하드코딩하면
+ *     여기서 걸린다). 정규식 한 줄이라 신규 카피에도 자동으로 적용된다.
+ *   - **영문 라벨** — 한글 스윕이 못 보는 축이다. 라우트 라벨처럼 영문인 카피는 SSoT 에
+ *     키가 있고 소비자 파일에는 리터럴이 없어야 한다.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { NAV, PIPELINE, ACTION, CONTEXT, OPPORTUNITY } from "@/lib/strings";
+
+/** 이관 대상 (#1252 이 지목한 파일). */
+const MIGRATED = [
+  "src/components/ui/sidebar.tsx",
+  "src/app/pipeline/page.tsx",
+  "src/components/ui/action-items.tsx",
+  "src/components/dashboard/system-rail.tsx",
+  "src/app/page.tsx",
+];
+
+const HANGUL = /[가-힣]/;
+
+/** 주석은 카피가 아니다 — 이 레포는 한국어 주석이 규약이라 안 걷어내면 스윕이 전부 걸린다. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "") // JSX 주석
+    .replace(/\/\*[\s\S]*?\*\//g, "") // 블록 주석
+    .replace(/^\s*\/\/.*$/gm, "") // 줄 주석
+    .replace(/\s\/\/[^\n]*$/gm, ""); // 후행 주석
+}
+
+const read = (rel: string) => readFileSync(join(process.cwd(), rel), "utf8");
+
+describe("사용자 카피는 strings.ts SSoT 를 거친다 (#1252)", () => {
+  it("이관 대상 파일에 주석 밖 한글 카피가 남아 있지 않다", () => {
+    const offenders: string[] = [];
+    for (const rel of MIGRATED) {
+      stripComments(read(rel))
+        .split("\n")
+        .forEach((line, i) => {
+          if (HANGUL.test(line)) offenders.push(`${rel}:${i + 1} ${line.trim().slice(0, 80)}`);
+        });
+    }
+    expect(offenders, `SSoT 밖 한글 카피:\n${offenders.join("\n")}`).toHaveLength(0);
+  });
+
+  it("영문 라벨도 리터럴로 남아 있지 않다", () => {
+    // 한글 스윕이 **못 보는 축**이다. 사이드바 라우트 라벨이 전부 영문이라 이 검사가
+    // 없으면 "이관 완료" 가 절반만 참인 채로 초록이 된다.
+    const src = read("src/components/ui/sidebar.tsx");
+    const labels = [
+      NAV.ROUTE_DASHBOARD, NAV.ROUTE_DECISIONS, NAV.ROUTE_ENGINE, NAV.ROUTE_EVIDENCE,
+      NAV.ROUTE_PORTFOLIO, NAV.ROUTE_REBALANCE, NAV.ROUTE_TARGETS, NAV.ROUTE_EXPLORE,
+      NAV.ROUTE_SCANNER, NAV.ROUTE_SIGNALS, NAV.ROUTE_STRATEGY, NAV.ROUTE_AGENTS,
+      NAV.ROUTE_PIPELINE, NAV.ROUTE_REPORT, NAV.SYSTEM_ONLINE,
+    ];
+    const offenders = labels.filter((v) => src.includes(`"${v}"`));
+    expect(offenders, `사이드바에 리터럴로 남은 라벨: ${offenders.join(", ")}`).toHaveLength(0);
+
+    const pipe = read("src/app/pipeline/page.tsx");
+    const nodeCopy = [
+      PIPELINE.NODE_COLLECT_SUB, PIPELINE.NODE_VALIDATE_SUB, PIPELINE.NODE_CLASSIFY_SUB,
+      PIPELINE.NODE_DIAGNOSE_SUB, PIPELINE.NODE_RECOMMEND_SUB, PIPELINE.NODE_TRACK_SUB,
+    ];
+    const pipeOffenders = nodeCopy.filter((v) => pipe.includes(`"${v}"`));
+    expect(pipeOffenders, `pipeline 에 리터럴로 남은 노드 카피: ${pipeOffenders.join(", ")}`).toHaveLength(0);
+  });
+
+  it("이관한 키가 실제로 SSoT 에 있다", () => {
+    // 소비자에서 리터럴만 지우고 키를 안 만들면 위 두 검사는 통과한다 — 반대 방향도 본다.
+    for (const [group, keys] of [
+      [NAV, ["ROUTE_DASHBOARD", "ROUTE_REPORT", "SYSTEM_ONLINE"]],
+      [PIPELINE, ["TITLE", "RUN", "RUNNING", "NODE_COLLECT", "NODE_TRACK_SUB"]],
+      [ACTION, ["PEEK_CURRENT", "PEEK_STOP", "PEEK_TP1", "PEEK_TP2", "PEEK_AS_OF"]],
+      [CONTEXT, ["REGIME_SHIFT", "ATTENTION", "FAIL_SUFFIX"]],
+      [OPPORTUNITY, ["ALL_PREFIX", "ALL_SUFFIX"]],
+    ] as [Record<string, string>, string[]][]) {
+      for (const k of keys) {
+        expect(group[k], `${k} 키 부재`).toBeTruthy();
+      }
+    }
+  });
+
+  it("스윕이 실제로 눈이 있다 (canary)", () => {
+    // 주석 제거가 과해서 본문까지 지워 버리면 위 스윕은 영원히 초록이다.
+    expect(HANGUL.test(stripComments('const x = "손절";'))).toBe(true);
+    expect(HANGUL.test(stripComments("{/* 한국어 주석 */}"))).toBe(false);
+    expect(HANGUL.test(stripComments("// 한국어 줄 주석"))).toBe(false);
+    expect(stripComments('const a = 1; // 주석\nconst b = "현재가";')).toContain("현재가");
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,7 +19,7 @@ import { SystemHealthRail, MacroEventsCard, RegimeShiftBanner } from "@/componen
 import { summarizeHoldings, mergeAccountTotals } from "@/lib/holdings-summary";
 import { getMacroImpactedSectors } from "@/lib/macro-impact";
 import Link from "next/link";
-import { SECTION, ACTION, COMMON } from "@/lib/strings";
+import { SECTION, ACTION, COMMON, OPPORTUNITY } from "@/lib/strings";
 
 // #1204 U2a: 섹션·헬퍼는 components/dashboard/ 로 추출 — 이 파일은 데이터 fetch +
 // enrichment + 조립만 담당한다. 동작·마크업 불변.
@@ -372,10 +372,10 @@ async function Dashboard({
             <div className="flex items-center justify-between mb-2">
               <h2 className="text-sm font-semibold text-zinc-300 flex items-center gap-1.5">
                 <Search className="size-3.5 text-zinc-500" aria-hidden />
-                기회 탐색
+                {OPPORTUNITY.TITLE}
               </h2>
               <Link href="/scan" className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors">
-                전체 {opportunitiesData.opportunities.length}건 →
+                {OPPORTUNITY.ALL_PREFIX} {opportunitiesData.opportunities.length}{OPPORTUNITY.ALL_SUFFIX}
               </Link>
             </div>
             <OpportunityExplorer opportunities={topOpportunities} />

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -236,7 +236,7 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
           }
         `}
       >
-        {data.isRunning ? "\uC2E4\uD589 \uC911..." : "\uC2E4\uD589"}
+        {data.isRunning ? PL.RUNNING : PL.RUN}
       </button>
 
       {/* 에러 표시 */}
@@ -461,7 +461,7 @@ export default function PipelinePage() {
   return (
     <div className="space-y-5">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Pipeline</h1>
+        <h1 className="text-2xl font-bold">{PL.TITLE}</h1>
         <div className="flex items-center gap-3">
           {/* 실행 중 카운터 */}
           {runningSteps.size > 0 && (
@@ -625,36 +625,36 @@ const DEFAULT_NODES: Node[] = [
     id: "collect",
     type: "pipeline",
     position: { x: 0 * NODE_PITCH_X, y: 80 },
-    data: { label: "Collect", sub: "15 collectors + 6 sites", status: "warning", recordCount: 0, lastUpdated: null, stepId: "collect", href: "/engine" } as PipelineNodeData,
+    data: { label: PL.NODE_COLLECT, sub: PL.NODE_COLLECT_SUB, status: "warning", recordCount: 0, lastUpdated: null, stepId: "collect", href: "/engine" } as PipelineNodeData,
   },
   {
     id: "validate",
     type: "pipeline",
     position: { x: 1 * NODE_PITCH_X, y: 80 },
-    data: { label: "Validate", sub: "Signal backtest + scorecard", status: "warning", recordCount: 0, lastUpdated: null, stepId: "validate", href: "/signals" } as PipelineNodeData,
+    data: { label: PL.NODE_VALIDATE, sub: PL.NODE_VALIDATE_SUB, status: "warning", recordCount: 0, lastUpdated: null, stepId: "validate", href: "/signals" } as PipelineNodeData,
   },
   {
     id: "classify",
     type: "pipeline",
     position: { x: 2 * NODE_PITCH_X, y: 80 },
-    data: { label: "Classify", sub: "6-regime classifier", status: "warning", recordCount: 0, lastUpdated: null, stepId: "classify", href: "/strategy" } as PipelineNodeData,
+    data: { label: PL.NODE_CLASSIFY, sub: PL.NODE_CLASSIFY_SUB, status: "warning", recordCount: 0, lastUpdated: null, stepId: "classify", href: "/strategy" } as PipelineNodeData,
   },
   {
     id: "diagnose",
     type: "pipeline",
     position: { x: 3 * NODE_PITCH_X, y: 80 },
-    data: { label: "Diagnose", sub: "10 agents consensus", status: "warning", recordCount: 0, lastUpdated: null, stepId: "diagnose", href: "/consensus" } as PipelineNodeData,
+    data: { label: PL.NODE_DIAGNOSE, sub: PL.NODE_DIAGNOSE_SUB, status: "warning", recordCount: 0, lastUpdated: null, stepId: "diagnose", href: "/consensus" } as PipelineNodeData,
   },
   {
     id: "recommend",
     type: "pipeline",
     position: { x: 4 * NODE_PITCH_X, y: 80 },
-    data: { label: "Recommend", sub: "Buy/sell + price targets", status: "warning", recordCount: 0, lastUpdated: null, stepId: "recommend", href: "/targets" } as PipelineNodeData,
+    data: { label: PL.NODE_RECOMMEND, sub: PL.NODE_RECOMMEND_SUB, status: "warning", recordCount: 0, lastUpdated: null, stepId: "recommend", href: "/targets" } as PipelineNodeData,
   },
   {
     id: "track",
     type: "pipeline",
     position: { x: 5 * NODE_PITCH_X, y: 80 },
-    data: { label: "Track", sub: "30/60/90d outcomes", status: "warning", recordCount: 0, lastUpdated: null, stepId: "track", href: "/targets" } as PipelineNodeData,
+    data: { label: PL.NODE_TRACK, sub: PL.NODE_TRACK_SUB, status: "warning", recordCount: 0, lastUpdated: null, stepId: "track", href: "/targets" } as PipelineNodeData,
   },
 ];

--- a/frontend/src/components/dashboard/system-rail.tsx
+++ b/frontend/src/components/dashboard/system-rail.tsx
@@ -19,12 +19,12 @@ export function RegimeShiftBanner({ regime }: { regime: Partial<SystemHealth["re
   return (
     <div className="rounded-lg bg-amber-950/40 border border-amber-700/50 px-3 py-2 flex items-center gap-2 text-xs">
       <TriangleAlert className="shrink-0 size-3.5 text-amber-400" aria-hidden />
-      <span className="text-amber-300 font-semibold">Regime 전환 신호</span>
+      <span className="text-amber-300 font-semibold">{CONTEXT.REGIME_SHIFT}</span>
       <span className="text-zinc-400">
-        현재 {regime.regime ?? "—"} · 신뢰도{" "}
+        {CONTEXT.REGIME_SHIFT_NOW} {regime.regime ?? "—"} · {CONTEXT.REGIME_SHIFT_CONF}{" "}
         {/* v8 ignore start -- banner renders only when isRegimeShifting (conf 0~60) → confidence always defined, `?? 0` arm unreachable */}
         {regime.confidence ?? 0}
-        {/* v8 ignore stop */}% — 다음 행동 보류 권고
+        {/* v8 ignore stop */}{CONTEXT.REGIME_SHIFT_ADVICE}
       </span>
     </div>
   );
@@ -74,7 +74,7 @@ export function SystemHealthRail({ health }: { health: Partial<SystemHealth> }) 
       <RailRow
         label={CONTEXT.FRESHNESS}
         value={freshness.status ?? "—"}
-        sub={freshness.fail_count ? `${freshness.fail_count}건 실패 · ${CONTEXT.CHECK_PIPELINE}` : "OK"}
+        sub={freshness.fail_count ? `${freshness.fail_count}${CONTEXT.FAIL_SUFFIX} · ${CONTEXT.CHECK_PIPELINE}` : "OK"}
         href="/pipeline"
         color={freshness.status === "PASS" ? "text-emerald-400" : freshness.status === "WARN" ? "text-amber-400" : "text-red-400"}
       />
@@ -92,7 +92,7 @@ export function MacroEventsCard({ events, regimeTrend }: { events: MacroEvent[];
         <h4 className="text-[10px] text-zinc-500 font-semibold flex items-center gap-1">
           {pinned && <Pin className="size-3 text-amber-400" aria-label="pinned attention" />}
           {CONTEXT.TITLE}
-          {pinned && <span className="text-[9px] text-amber-300/80 font-bold">ATTENTION</span>}
+          {pinned && <span className="text-[9px] text-amber-300/80 font-bold">{CONTEXT.ATTENTION}</span>}
         </h4>
         {(() => {
           const sl = sparklinePath(events, 60, 14);

--- a/frontend/src/components/ui/action-items.branchcov.test.tsx
+++ b/frontend/src/components/ui/action-items.branchcov.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ActionItems, type ActionItem } from "@/components/ui/action-items";
+import { ACTION } from "@/lib/strings";
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => <a href={href} {...props}>{children}</a>,
@@ -127,6 +128,23 @@ describe("ActionItems — full branch coverage", () => {
     expect(screen.getByText("현재가")).toBeTruthy();
     fireEvent.click(row);
     expect(screen.queryByText("현재가")).toBeNull();
+  });
+
+  it("quick-peek: 계좌 없음 · 비중 미상 (#1252 로 바뀐 줄의 나머지 분기)", () => {
+    // 이 두 분기는 base fixture 가 둘 다 채워져 있어 열려 있었다. #1252 가 같은 줄의
+    // 라벨을 SSoT 로 옮기면서 그 줄이 patch 대상이 되어 드러났다.
+    render(
+      <ActionItems
+        urgent={[{ ...base, ticker: "X13", name: "NoAccNoPct", account: "", position_pct: null }]}
+        check={[]}
+        hold={[]}
+      />
+    );
+    fireEvent.click(screen.getByTestId("action-row"));
+    const peek = screen.getByTestId("action-row-peek");
+    expect(peek.textContent).toContain(ACTION.PNL_UNKNOWN);
+    // 계좌가 비면 peek 의 계좌 조각 자체가 렌더되지 않는다.
+    expect(peek.textContent).not.toContain(ACTION.COL_ACCOUNT);
   });
 
   it("KR ticker formats prices with won (line 47 isKr true)", () => {

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -115,7 +115,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
           {isNew && (
             <span
               data-testid="action-new-badge"
-              title={item.as_of ? `판정 ${item.as_of}` : undefined}
+              title={item.as_of ? `${ACTION.PEEK_AS_OF} ${item.as_of}` : undefined}
               className="ml-1.5 align-middle text-[9px] font-bold px-1 py-px rounded bg-blue-500/20 text-blue-400"
             >
               {ACTION.NEW}
@@ -174,15 +174,15 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
           <td colSpan={8} className="px-3 py-2">
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
               {/* <md 에서 행이 숨기는 계좌·비중을 peek 가 복원 (#1208 codex P2) */}
-              {item.account && <span className="md:hidden"><span className="text-zinc-600">계좌</span> <span className="text-zinc-300">{item.account}</span></span>}
-              <span className="md:hidden"><span className="text-zinc-600">비중</span> <span className="text-zinc-300 tabular-nums">{item.position_pct == null ? ACTION.PNL_UNKNOWN : `${item.position_pct.toFixed(1)}%`}</span></span>
-              <span><span className="text-zinc-600">현재가</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></span>
-              <span><span className="text-zinc-600">손절</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></span>
-              <span><span className="text-zinc-600">1차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></span>
+              {item.account && <span className="md:hidden"><span className="text-zinc-600">{ACTION.COL_ACCOUNT}</span> <span className="text-zinc-300">{item.account}</span></span>}
+              <span className="md:hidden"><span className="text-zinc-600">{ACTION.COL_WEIGHT}</span> <span className="text-zinc-300 tabular-nums">{item.position_pct == null ? ACTION.PNL_UNKNOWN : `${item.position_pct.toFixed(1)}%`}</span></span>
+              <span><span className="text-zinc-600">{ACTION.PEEK_CURRENT}</span> <span className="text-zinc-300 tabular-nums">{fmt(item.current_price)}</span></span>
+              <span><span className="text-zinc-600">{ACTION.PEEK_STOP}</span> <span className="text-red-400 tabular-nums">{fmt(item.stop_loss)}</span></span>
+              <span><span className="text-zinc-600">{ACTION.PEEK_TP1}</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_1)}</span></span>
               {item.target_2 != null && (
-                <span><span className="text-zinc-600">2차익절</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_2)}</span></span>
+                <span><span className="text-zinc-600">{ACTION.PEEK_TP2}</span> <span className="text-emerald-400 tabular-nums">{fmt(item.target_2)}</span></span>
               )}
-              {item.as_of && <span className="text-zinc-600">판정 {item.as_of}</span>}
+              {item.as_of && <span className="text-zinc-600">{ACTION.PEEK_AS_OF} {item.as_of}</span>}
               {/* #1212: ack — NEW 해제 (localStorage, per-viewer) */}
               {isNew && (
                 <button

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -30,40 +30,40 @@ export const NAV_GROUPS = [
   {
     label: NAV.TODAY,
     items: [
-      { href: "/", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/", label: NAV.ROUTE_DASHBOARD, icon: LayoutDashboard },
     ],
   },
   {
     label: NAV.DECISIONS,
     items: [
-      { href: "/decisions", label: "Decisions", icon: BookOpen },
-      { href: "/engine", label: "Certification Engine", icon: Cog },
-      { href: "/evidence", label: "Evidence", icon: FileBarChart },
+      { href: "/decisions", label: NAV.ROUTE_DECISIONS, icon: BookOpen },
+      { href: "/engine", label: NAV.ROUTE_ENGINE, icon: Cog },
+      { href: "/evidence", label: NAV.ROUTE_EVIDENCE, icon: FileBarChart },
     ],
   },
   {
     label: NAV.PORTFOLIO,
     items: [
-      { href: "/portfolio", label: "Portfolio", icon: Briefcase },
-      { href: "/rebalance", label: "Rebalance", icon: Scale },
-      { href: "/targets", label: "Price Targets", icon: Target },
+      { href: "/portfolio", label: NAV.ROUTE_PORTFOLIO, icon: Briefcase },
+      { href: "/rebalance", label: NAV.ROUTE_REBALANCE, icon: Scale },
+      { href: "/targets", label: NAV.ROUTE_TARGETS, icon: Target },
     ],
   },
   {
     label: NAV.RESEARCH,
     items: [
-      { href: "/explore", label: "Explore", icon: Compass },
-      { href: "/scan", label: "Scanner", icon: Search },
-      { href: "/signals", label: "Signals", icon: BarChart3 },
-      { href: "/strategy", label: "Strategy", icon: TrendingUp },
-      { href: "/consensus", label: "Agents", icon: Users },
+      { href: "/explore", label: NAV.ROUTE_EXPLORE, icon: Compass },
+      { href: "/scan", label: NAV.ROUTE_SCANNER, icon: Search },
+      { href: "/signals", label: NAV.ROUTE_SIGNALS, icon: BarChart3 },
+      { href: "/strategy", label: NAV.ROUTE_STRATEGY, icon: TrendingUp },
+      { href: "/consensus", label: NAV.ROUTE_AGENTS, icon: Users },
     ],
   },
   {
     label: NAV.SYSTEM,
     items: [
-      { href: "/pipeline", label: "Pipeline", icon: Workflow },
-      { href: "/report", label: "AI Report", icon: Bot },
+      { href: "/pipeline", label: NAV.ROUTE_PIPELINE, icon: Workflow },
+      { href: "/report", label: NAV.ROUTE_REPORT, icon: Bot },
     ],
   },
 ];
@@ -143,7 +143,7 @@ export function Sidebar() {
             <div className="flex flex-col items-center gap-2">
               {/* 테마 토글 제거 (#1195 U1a codex P2): 제품은 dark-only (frontend/CLAUDE.md).
                   라이트 전환 시 zinc 램프 재매핑과 시맨틱 토큰이 혼합 테마를 만들던 경로 폐쇄 */}
-              <span className="relative flex h-2 w-2" title="System Online">
+              <span className="relative flex h-2 w-2" title={NAV.SYSTEM_ONLINE}>
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
               </span>
@@ -155,7 +155,7 @@ export function Sidebar() {
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
                 </span>
-                <span className="text-[10px] text-muted-foreground">System Online</span>
+                <span className="text-[10px] text-muted-foreground">{NAV.SYSTEM_ONLINE}</span>
               </div>
             </>
           )}

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -364,6 +364,22 @@ export const PIPELINE = {
   // "백엔드 죽음" 과 "이벤트 없음" 이 구분되지 않았다.
   TIMELINE_LOADING: "이벤트 불러오는 중...",
   GATE_EMPTY: "게이트 조건 없음 — 인증 스텝 실행 후 표시됩니다",
+  // #1252: 페이지 타이틀 · 실행 버튼 · 노드 카피가 SSoT 밖에 있었다.
+  TITLE: "Pipeline",
+  RUN: "실행",
+  RUNNING: "실행 중...",
+  NODE_COLLECT: "Collect",
+  NODE_COLLECT_SUB: "15 collectors + 6 sites",
+  NODE_VALIDATE: "Validate",
+  NODE_VALIDATE_SUB: "Signal backtest + scorecard",
+  NODE_CLASSIFY: "Classify",
+  NODE_CLASSIFY_SUB: "6-regime classifier",
+  NODE_DIAGNOSE: "Diagnose",
+  NODE_DIAGNOSE_SUB: "10 agents consensus",
+  NODE_RECOMMEND: "Recommend",
+  NODE_RECOMMEND_SUB: "Buy/sell + price targets",
+  NODE_TRACK: "Track",
+  NODE_TRACK_SUB: "30/60/90d outcomes",
 } as const;
 
 /* ── Ticker Detail Page ─────────────────────────────────────── */
@@ -492,6 +508,12 @@ export const ACTION = {
   // #1279: 시세 없는 보유(비상장)의 손익은 측정 불가다. 0.0% 로 렌더하면 "보합" 으로
   // 읽힌다 — 지어낸 숫자를 사용자 카피로 내보내지 않는다 (STRATEGY §2.6 과 같은 원칙).
   PNL_UNKNOWN: "미상",
+  // #1252: quick-peek 라벨. 계좌는 COL_ACCOUNT 를 재사용한다 — 같은 뜻에 키를 둘 두지 않는다.
+  PEEK_CURRENT: "현재가",
+  PEEK_STOP: "손절",
+  PEEK_TP1: "1차익절",
+  PEEK_TP2: "2차익절",
+  PEEK_AS_OF: "판정",
   // DETAIL/CONF/AGREE/PNL/WEIGHT/DISMISS 는 U2b-2 (#1208) 카드→행 전환으로 제거
 } as const;
 
@@ -508,6 +530,10 @@ export const OPPORTUNITY = {
   NEUTRAL: "관망",
   DANGER: "매수 금지",
   MUTED: "데이터 부족",
+  // #1252: "전체 {n}건 →" — 숫자를 사이에 끼우므로 접두/접미로 나눈다
+  // (`PIPELINE.RUNNING_SUFFIX` 와 같은 관례).
+  ALL_PREFIX: "전체",
+  ALL_SUFFIX: "건 →",
 } as const;
 
 export const CONTEXT = {
@@ -523,6 +549,13 @@ export const CONTEXT = {
   // #1212: FAIL/미인증 행의 다음 행동 카피 (레일 sub — 상태만 말하지 말 것)
   CHECK_ENGINE: "게이트 상세 →",
   CHECK_PIPELINE: "파이프라인 확인 →",
+  // #1252: 레짐 전환 배너 카피
+  REGIME_SHIFT: "Regime 전환 신호",
+  REGIME_SHIFT_NOW: "현재",
+  REGIME_SHIFT_CONF: "신뢰도",
+  REGIME_SHIFT_ADVICE: "% — 다음 행동 보류 권고",
+  ATTENTION: "ATTENTION",
+  FAIL_SUFFIX: "건 실패",
 } as const;
 
 /* ── StatusBadge Korean keys ────────────────────────────────── */
@@ -545,4 +578,21 @@ export const NAV = {
   // \uC544\uC774\uCF58 \uC804\uC6A9 \uC811\uAE30 \uD1A0\uAE00\uC758 \uC811\uADFC\uBA85 (codex design audit M5 / ship review P3 SSoT)
   SIDEBAR_EXPAND: "\uC0AC\uC774\uB4DC\uBC14 \uD3BC\uCE58\uAE30",
   SIDEBAR_COLLAPSE: "\uC0AC\uC774\uB4DC\uBC14 \uC811\uAE30",
+  // 라우트 라벨 (#1252). 소비자는 사이드바 하나뿐이지만, SSoT 밖에 있으면 e2e 가
+  // 문자열을 직접 박게 되고 그게 #1118 의 3.5개월 무신호 회귀를 만든 경로다.
+  ROUTE_DASHBOARD: "Dashboard",
+  ROUTE_DECISIONS: "Decisions",
+  ROUTE_ENGINE: "Certification Engine",
+  ROUTE_EVIDENCE: "Evidence",
+  ROUTE_PORTFOLIO: "Portfolio",
+  ROUTE_REBALANCE: "Rebalance",
+  ROUTE_TARGETS: "Price Targets",
+  ROUTE_EXPLORE: "Explore",
+  ROUTE_SCANNER: "Scanner",
+  ROUTE_SIGNALS: "Signals",
+  ROUTE_STRATEGY: "Strategy",
+  ROUTE_AGENTS: "Agents",
+  ROUTE_PIPELINE: "Pipeline",
+  ROUTE_REPORT: "AI Report",
+  SYSTEM_ONLINE: "System Online",
 } as const;


### PR DESCRIPTION
Closes #1252.

## Why

User-facing copy sat outside the `strings.ts` SSoT in five files. Two consequences: the UI reads half-Korean/half-English, and the "specs import from `strings.ts`" rule in `frontend/CLAUDE.md` **cannot be applied** to copy that has no key.

That second one has already cost us: `410d385` renamed `CONTEXT.SIEGE`, and the three e2e assertions holding the literal died silently for **3.5 months** (#1118).

## Moved

| file | copy |
|---|---|
| `sidebar.tsx` | 14 route labels + `System Online` (×2 sites) |
| `pipeline/page.tsx` | page title, run/running button, 6 node label+sub pairs |
| `action-items.tsx` | quick-peek labels (현재가 · 손절 · 1차익절 · 2차익절 · 판정) |
| `system-rail.tsx` | regime-shift banner, `ATTENTION`, `건 실패` |
| `page.tsx` | opportunity heading + count link |

**Two were literal duplicates of keys that already existed** — `OPPORTUNITY.TITLE` (`"기회 탐색"`) and `ACTION.COL_ACCOUNT` (`"계좌"`). Those now reference the existing key rather than adding a second one for the same meaning.

## One issue item was already done

The issue also lists `holding-row.tsx`'s "macro-aware aria text". That file already routes its aria labels through `HOLDING_LABEL.*`, and the one place without an aria-label omits it deliberately (a comment explains the accessible name comes from the visible children). Nothing to move.

## Verification

Locked on **two axes**, because a Korean-only sweep would have reported success while every English route label stayed hardcoded — the failure mode this repo calls a half-blind gate:

- comment-stripped **Hangul sweep** over all five files — catches copy added later too, not just what this PR moved
- explicit **English literal** check for the route labels and node subs
- **reverse** check that the keys actually exist in `strings.ts` (deleting the literal without adding the key would otherwise pass)
- **canary** proving comment-stripping doesn't eat real copy (this repo's Korean-comment convention means an over-eager stripper would blind the sweep entirely)

4 mutation axes, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| hardcode a Korean label again | Hangul sweep |
| hardcode an English route label again | English literal check |
| make comment-stripping eat body text | canary |
| rename a key out of the SSoT | reverse key check |

4/4 locked. **139 files / 1657 tests pass**, `tsc --noEmit` clean, eslint 0 errors (1 pre-existing warning in `login/page.tsx`, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7

---

## Codex review

**No P1/P2.** It independently confirmed the copy-preservation claims — in particular that the two risky interpolated joins are byte-identical:

- `전체 {n}건 →` keeps the same single space before the number
- `현재 {regime} · 신뢰도 {confidence}% — 다음 행동 보류 권고` is unchanged

and that `holding-row.tsx` genuinely needed no change (all its aria labels already route through `HOLDING_LABEL`). It also confirmed the `OPPORTUNITY.TITLE` / `ACTION.COL_ACCOUNT` reuse is the same concept in both places, not a coincidental string match.

Independent corroboration that nothing shifted: `market-context.test.tsx` asserts the regime banner text verbatim, and `sidebar.test.tsx` asserts `"Signals"` / `"Agents"` / `"Pipeline"` / `"AI Report"` / `"System Online"` as rendered text — all still pass.

### P3 (a) — fixed

The English literal check covered the sidebar labels and node subs but **not** the pipeline title or node labels, so reintroducing a hardcoded `"Pipeline"` would have slipped through. Now covered (reading the file with comments stripped, since its comments name routes). Two more mutation axes, both locked — **6/6 total**.

### P3 (b) — real, and out of scope

`strings.ts` is not a frontend-wide SSoT for these values: the same strings still exist as literals in other pages' headings — `engine/page.tsx` (`"Certification Engine"`), `consensus/page.tsx` (`"Agents"`), `explore/page.tsx`, `signals/page.tsx`, `strategy/page.tsx`, `targets/page.tsx`, plus `client-table.tsx` (`"Signals"`, `"현재가"`). Vitest specs also still inline moved sidebar labels.

That is true and worth its own issue. It is outside the five files #1252 names, and folding a repo-wide sweep into this PR would break scope discipline — so it is recorded here rather than done silently. What this PR does close is the one spec that the issue's own rationale points at: `action-first.spec.ts` now imports the opportunity copy instead of inlining it.
