### PR TITLE
ci(frontend): gate tailwind canonical classes in eslint (#1254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 |--------|-------|---|
 | **Backend tests** | 7,805 collected across 358 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,648 across 139 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
+| **Frontend tests** | 1,648 across 140 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 1 of them (certify) has no scheduler job of its own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,805 backend tests across 358 files + 1622 frontend vitest (139 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,805 backend tests across 358 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,805 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 139 files |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 140 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1658 tests, 139 files)
+npm run test           # vitest run (1664 tests, 140 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -88,7 +88,7 @@ Two things that do **not** work, already tried (#913):
 Symptom if someone drops it: eslint prints `Oops! Something went wrong!` with a
 `brace-expansion` stack trace and lints **nothing**. `npm run lint` is silent on success, so
 confirm by file count rather than by absence of output — `npx eslint --format json | jq length`
-should be **247**.
+should be **249**.
 
 ## E2E (Playwright) — runs against the real backend, gated by CI since #1234
 
@@ -108,4 +108,4 @@ should be **247**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 103 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 104 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import betterTailwind from "eslint-plugin-better-tailwindcss";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -13,6 +14,39 @@ const eslintConfig = defineConfig([
     // Auto-generated test coverage reports (gitignored, IDE 가 still 표시).
     "coverage/**",
   ]),
+  // Tailwind canonical-class 게이트 (#1254). 이전엔 IDE(tailwindcss-intellisense) 만
+  // 잡아서, 사용자가 경고를 붙여넣어야 발견되는 구조였다 — #1249 의 legacy important
+  // 접두사(`!bg-muted`)가 그렇게 들어왔다.
+  //
+  // ⚠️ **`error` 다. `warn` 이 아니다.** 이슈는 warn 을 제안했지만, CI 의 Frontend Lint 는
+  // `npm run lint` = 맨 `eslint` 라 `--max-warnings` 가 없고 워크플로 주석도 "errors-only
+  // gate; warnings tolerated" 라고 명시한다. 즉 warn 으로 넣으면 **초록인 채 아무것도 막지
+  // 않는 게이트**가 되고, 그건 이 레포가 반복해서 밟은 dead gate 다 (#910/#911 rc=127,
+  // #953/#954 훅 exit 0). 규칙을 켜기 전에 기존 위반 187건을 0 으로 정규화했으므로
+  // error 가 곧바로 성립한다.
+  //
+  // 켠 규칙은 **정본성(canonical)만** — 클래스 순서·줄바꿈 같은 미용 규칙은 뺐다.
+  // 큰 기계적 diff 만 만들고 잘못된 클래스는 못 잡는다.
+  {
+    files: ["**/*.tsx", "**/*.ts"],
+    plugins: { "better-tailwindcss": betterTailwind },
+    settings: { "better-tailwindcss": { entryPoint: "src/app/globals.css" } },
+    rules: {
+      // #1249 의 실제 결함 축. 현재 위반 0 — 순수 예방용이다.
+      "better-tailwindcss/enforce-consistent-important-position": "error",
+      "better-tailwindcss/enforce-canonical-classes": "error",
+      "better-tailwindcss/no-deprecated-classes": "error",
+      "better-tailwindcss/no-conflicting-classes": "error",
+      "better-tailwindcss/no-duplicate-classes": "error",
+      // ❌ `no-unnecessary-whitespace` 는 **켜지 않는다.** 이 레포의 className 은 조각을
+      // 이어붙이는 형태가 흔한데, 이 규칙은 조각을 **홀로** 보고 앞뒤 연결을 모른다.
+      // 실측(#1254): `data-table.tsx` 의
+      //   `}${col.hideOnMobile ? " hidden sm:table-cell" : ""}`
+      // 에서 선행 조각(`text-left` 등)과 띄우는 **필수 공백**을 지워
+      // `text-lefthidden` 을 만들었다 — 클래스 둘이 동시에 죽는다. autofix 라 조용하다.
+      // 규칙이 잡은 2건이 전부 이 오탐이었으므로 켤 이유가 없다.
+    },
+  },
   // Project-wide rule overrides — pragmatic baseline for a fast-moving dashboard.
   // `any` 광범위 사용 (dynamic API responses) + 의도된 unused params (signature compat) →
   // error→warn 으로 완화. PR 리뷰는 여전히 surface, blocking 만 해제.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9",
         "eslint-config-next": "16.3.1",
+        "eslint-plugin-better-tailwindcss": "^4.7.0",
         "jsdom": "^30.0.1",
         "tailwindcss": "^4",
         "typescript": "^6",
@@ -1081,6 +1082,27 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.5.tgz",
+      "integrity": "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.29.0",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css-tree/node_modules/mdn-data": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.29.0.tgz",
+      "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.6",
@@ -2207,6 +2229,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@playwright/test": {
@@ -3834,6 +3869,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@valibot/to-json-schema": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.7.1.tgz",
+      "integrity": "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "valibot": "^1.4.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.1.0",
@@ -5909,6 +5954,39 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-better-tailwindcss": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-better-tailwindcss/-/eslint-plugin-better-tailwindcss-4.7.0.tgz",
+      "integrity": "sha512-lrdlVW4pzLPj/zX5HRqMhKPesGijDfRhnSRJMlNcsrCyJHsndmHCLKTiRNa1eREUZ6G3D3QjdLc+G4tlfGrmkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/css-tree": "^4.0.4",
+        "@valibot/to-json-schema": "^1.7.1",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "synckit": "^0.11.13",
+        "tailwind-csstree": "^0.3.3",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
+        "valibot": "^1.4.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "oxlint": "^1.35.0",
+        "tailwindcss": "^3.3.0 || ^4.1.17"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "oxlint": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -10634,6 +10712,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-csstree": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/tailwind-csstree/-/tailwind-csstree-0.3.3.tgz",
+      "integrity": "sha512-je9J5UYRsTJqAjYrIBMMlge8T/rreRd44pJxgG5Zx/zeo4kAC/liUKqzztRZrGlYRJLvIf2Cb1DVJMTXSzEShA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      },
+      "peerDependencies": {
+        "@eslint/css": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@eslint/css": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -10847,6 +10963,37 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
@@ -11191,6 +11338,21 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/valibot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9",
     "eslint-config-next": "16.3.1",
+    "eslint-plugin-better-tailwindcss": "^4.7.0",
     "jsdom": "^30.0.1",
     "tailwindcss": "^4",
     "typescript": "^6",

--- a/frontend/src/__tests__/components/data-table.test.tsx
+++ b/frontend/src/__tests__/components/data-table.test.tsx
@@ -167,15 +167,22 @@ describe("DataTable", () => {
     const data = [{ ticker: "AAPL", sector: "Tech" }];
     const { container } = render(<DataTable columns={columns} data={data} />);
 
-    const headerCells = container.querySelectorAll("th");
-    // Sector header should have hidden class
-    expect(headerCells[1].className).toContain("hidden");
-    expect(headerCells[1].className).toContain("sm:table-cell");
+    // ⚠️ **부분 문자열이 아니라 토큰으로 본다** (#1254 codex P2). `toContain("hidden")` 은
+    // `text-lefthidden` 도 통과한다 — 실제로 tailwind autofix 가 앞 조각과 띄우는 필수
+    // 공백을 지워 정확히 그 문자열을 만들었고, 이 테스트는 **초록이었다.** 클래스는 공백으로
+    // 갈리는 토큰이므로 `classList` 로 확인해야 브라우저와 같은 것을 본다.
+    const tokens = (el: Element) => Array.from(el.classList);
 
-    // Sector data cell should also have hidden class
+    const headerCells = container.querySelectorAll("th");
+    expect(tokens(headerCells[1])).toContain("hidden");
+    expect(tokens(headerCells[1])).toContain("sm:table-cell");
+    // 선행 정렬 클래스가 붙어 있어야 한다 — 이게 없으면 공백이 지워진 상태다.
+    expect(tokens(headerCells[1])).toContain("text-left");
+
     const dataCells = container.querySelectorAll("td");
-    expect(dataCells[1].className).toContain("hidden");
-    expect(dataCells[1].className).toContain("sm:table-cell");
+    expect(tokens(dataCells[1])).toContain("hidden");
+    expect(tokens(dataCells[1])).toContain("sm:table-cell");
+    expect(tokens(dataCells[1])).toContain("text-left");
   });
 
   it("does not apply hidden class when hideOnMobile is false", () => {

--- a/frontend/src/__tests__/lib/tailwind-canonical-gate.test.ts
+++ b/frontend/src/__tests__/lib/tailwind-canonical-gate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #1254 — tailwind canonical-class 게이트가 **실제로 막는지**.
+ *
+ * 이 레포의 규약: 게이트는 설정을 grep 해서 확인하지 않고 **돌려서 exit/결과로** 잠근다.
+ * 이유가 기록으로 있다 — `rc=127` 로 3.5개월 no-op 이던 pre-push 테스트 단계(#910/#911)와
+ * `exit 0` 으로 조용했던 PreToolUse 훅 2개(#953/#954). 규칙 이름이 설정 파일에 적혀 있다는
+ * 사실은 그것이 발화한다는 증거가 아니다.
+ *
+ * 그래서 여기서는 프로젝트의 **실제 eslint 설정**으로 합성 위반을 린트해 결과를 본다.
+ *
+ * ⚠️ 심각도가 `error` 인 것까지 확인한다. CI 의 Frontend Lint 는 `npm run lint` = 맨
+ * `eslint` 라 `--max-warnings` 가 없고, 워크플로 주석도 "errors-only gate; warnings
+ * tolerated" 라고 적혀 있다. 즉 `warn` 으로 내려가면 게이트가 **초록인 채 아무것도 막지
+ * 않는다** — 규칙이 켜져 있는지가 아니라 severity 가 이 게이트의 생사다.
+ */
+import { describe, expect, it } from "vitest";
+import { ESLint } from "eslint";
+
+/** 프로젝트 설정 그대로 — 별도 config 를 만들면 "설정이 맞나" 를 검사하지 못한다. */
+const eslint = new ESLint({ cwd: process.cwd() });
+
+const lint = async (code: string) => (await eslint.lintText(code, { filePath: "src/__gate_probe__.tsx" }))[0];
+
+const twMessages = (r: Awaited<ReturnType<typeof lint>>) =>
+  r.messages.filter((m) => m.ruleId?.startsWith("better-tailwindcss/"));
+
+// `new ESLint()` + 전체 설정 해석이 무겁다. CI 러너에서 기본 5s 를 넘겨 실패했으므로
+// (로컬은 통과 — 러너 속도 차이가 그대로 드러나는 축이다) 파일 전체에 여유를 준다.
+describe("tailwind canonical-class 게이트 (#1254)", { timeout: 60_000 }, () => {
+  it("#1249 의 legacy important 접두사를 error 로 막는다", async () => {
+    const res = await lint(`export const A = () => <div className="flex !bg-muted" />;\n`);
+    const hits = twMessages(res);
+
+    expect(hits.length, "위반이 하나도 안 잡혔다 — 게이트가 죽었다").toBeGreaterThan(0);
+    expect(hits.some((m) => m.ruleId === "better-tailwindcss/enforce-consistent-important-position")).toBe(true);
+    // severity 2 = error. 1(warn) 이면 CI 가 통과시킨다.
+    expect(hits.every((m) => m.severity === 2), "severity 가 error 가 아니다 — CI 는 warn 을 통과시킨다").toBe(true);
+    expect(res.errorCount).toBeGreaterThan(0);
+  });
+
+  it("deprecated 클래스와 축약 가능 조합도 error 로 막는다", async () => {
+    // severity 를 **규칙마다** 본다 (codex P2). 한 규칙만 확인하면 나머지가 warn 으로
+    // 내려가도 이 파일이 통과한다 — 게이트 절반이 조용히 죽는 형태다.
+    const dep = twMessages(await lint(`export const A = () => <div className="rounded" />;\n`));
+    const depHit = dep.find((m) => m.ruleId === "better-tailwindcss/no-deprecated-classes");
+    expect(depHit, "no-deprecated-classes 가 안 걸렸다").toBeDefined();
+    expect(depHit?.severity, "no-deprecated-classes 가 error 가 아니다").toBe(2);
+
+    const canon = twMessages(await lint(`export const A = () => <div className="w-12 h-12" />;\n`));
+    const canonHit = canon.find((m) => m.ruleId === "better-tailwindcss/enforce-canonical-classes");
+    expect(canonHit, "enforce-canonical-classes 가 안 걸렸다").toBeDefined();
+    expect(canonHit?.severity, "enforce-canonical-classes 가 error 가 아니다").toBe(2);
+  });
+
+  it("켜 둔 규칙이 하나도 warn 으로 새지 않았다", async () => {
+    // 위 두 검사는 발화하는 규칙만 본다. 설정에 켜진 **전체 집합**의 severity 를 직접 읽어
+    // 아직 위반 예시가 없는 규칙(no-conflicting/no-duplicate)도 같이 잠근다.
+    const cfg = await eslint.calculateConfigForFile("src/__gate_probe__.tsx");
+    const tw = Object.entries(cfg.rules ?? {}).filter(([k]) => k.startsWith("better-tailwindcss/"));
+
+    expect(tw.length, "규칙이 하나도 안 켜져 있다").toBeGreaterThanOrEqual(5);
+    const notError = tw.filter(([, v]) => (Array.isArray(v) ? v[0] : v) !== 2 && (Array.isArray(v) ? v[0] : v) !== "error");
+    expect(notError.map(([k]) => k), "error 가 아닌 규칙이 있다 — CI 는 warn 을 통과시킨다").toHaveLength(0);
+
+    // 이어붙인 className 을 깨뜨리는 규칙은 **꺼져 있어야** 한다 (아래 테스트의 짝).
+    expect(tw.map(([k]) => k)).not.toContain("better-tailwindcss/no-unnecessary-whitespace");
+  });
+
+  it("정본 클래스는 통과한다 (canary)", async () => {
+    // 항상 실패하는 하네스는 위 검사를 무의미하게 만든다 — 반대 방향도 확인한다.
+    const res = await lint(`export const A = () => <div className="flex size-12 rounded-sm bg-muted!" />;\n`);
+    expect(twMessages(res), `정본 클래스가 걸렸다: ${JSON.stringify(twMessages(res))}`).toHaveLength(0);
+  });
+
+  it("이어붙인 className 의 필수 공백을 지우지 않는다", async () => {
+    // `no-unnecessary-whitespace` 는 조각을 **홀로** 보고 앞뒤 연결을 모른다. 실측(#1254):
+    // `}${cond ? " hidden sm:table-cell" : ""}` 의 선행 조각과 띄우는 필수 공백을 지워
+    // `text-lefthidden` 을 만들었다 — autofix 라 조용하고, 클래스 둘이 동시에 죽는다.
+    // 그래서 그 규칙은 켜지 않는다. 누가 되살리면 여기서 걸린다.
+    const code = 'export const A = ({ c }: { c: boolean }) => <div className={`text-left${c ? " hidden sm:table-cell" : ""}`} />;\n';
+    const res = await lint(code);
+    expect(twMessages(res), `이어붙인 공백을 위반으로 잡았다: ${JSON.stringify(twMessages(res))}`).toHaveLength(0);
+    expect(res.output ?? code, "autofix 가 필수 공백을 지웠다").toContain('" hidden sm:table-cell"');
+  });
+
+  it("레포 전체가 이 게이트를 이미 통과한 상태다", async () => {
+    // 규칙을 켜 두고 위반이 남아 있으면 다음 사람이 무관한 PR 에서 빨간불을 만난다.
+    const results = await eslint.lintFiles(["src/**/*.tsx", "src/**/*.ts"]);
+    const offenders = results
+      .flatMap((f) => f.messages.filter((m) => m.ruleId?.startsWith("better-tailwindcss/")).map((m) => `${f.filePath}:${m.line} ${m.ruleId}`));
+    expect(offenders, `잔여 위반:\n${offenders.join("\n")}`).toHaveLength(0);
+  });
+});

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -204,7 +204,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
           <span className="text-xs text-muted-foreground">#{d.id} · {d.date}</span>
         </div>
         <span className="inline-flex items-center gap-1.5" data-testid="decision-outcome">
-          <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${outcomeTag.cls}`}>{outcomeTag.label}</span>
+          <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-sm ${outcomeTag.cls}`}>{outcomeTag.label}</span>
           <span className="text-[10px] text-muted-foreground font-mono tabular-nums">
             {adj.kind === "adjudicated" && `${DECISIONS.ADJ_DONE} ${adj.adjudicationDate}`}
             {adj.kind === "waiting" && `${DECISIONS.ADJ_DONE} ${adj.adjudicationDate} (${DECISIONS.ADJ_DUE_PREFIX}${adj.daysLeft})`}
@@ -216,7 +216,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
       {/* #1257 판정 경로 히어로 — 판정 소스별 3변형. veto 는 "합의 vs 그것을 덮은 규칙"
           대차대조, 나머지는 단일 칸. conf 100 · agreement 20% 가 모순처럼 보이던 문제의 해소. */}
       <Card className="bg-card border-border" data-testid="verdict-hero" data-source={actionSource}>
-        <CardContent className="pt-4 pb-4 space-y-3">
+        <CardContent className="py-4 space-y-3">
           <p className="text-sm font-semibold text-foreground">
             {actionSource === "risk_veto" && DECISIONS.HERO_VETO_TITLE}
             {actionSource === "divergence_penalty" && DECISIONS.HERO_PENALTY_TITLE}
@@ -231,7 +231,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
           </p>
           {actionSource === "risk_veto" ? (
             <div className="grid gap-3 md:grid-cols-2">
-              <div className="rounded bg-muted/40 px-3 py-2.5 space-y-1.5 opacity-80">
+              <div className="rounded-sm bg-muted/40 px-3 py-2.5 space-y-1.5 opacity-80">
                 <p className="text-[10px] text-muted-foreground">{DECISIONS.HERO_CONSENSUS_REF}</p>
                 <div className="flex h-2 rounded-full overflow-hidden" aria-hidden="true">
                   {liveVerdicts.length > 0 && (
@@ -247,7 +247,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
                   {agreementPct !== null && ` — ${DECISIONS.HERO_AGREEMENT_LABEL} ${agreementPct}%`}
                 </p>
               </div>
-              <div className="rounded border border-rose-500/30 bg-rose-500/5 px-3 py-2.5 space-y-1">
+              <div className="rounded-sm border border-rose-500/30 bg-rose-500/5 px-3 py-2.5 space-y-1">
                 <p className="text-[10px] text-rose-400 font-medium">{DECISIONS.HERO_DECIDER_VETO}</p>
                 <p className="text-sm font-semibold text-foreground">
                   {d.action} · {d.confidence === null ? "—" : Math.round(d.confidence)}
@@ -257,7 +257,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
               </div>
             </div>
           ) : (
-            <div className="rounded bg-muted/40 px-3 py-2.5 space-y-1.5">
+            <div className="rounded-sm bg-muted/40 px-3 py-2.5 space-y-1.5">
               <div className="flex h-2 rounded-full overflow-hidden" aria-hidden="true">
                 {liveVerdicts.length > 0 && (
                   <>
@@ -296,7 +296,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
             <span className="text-[10px] text-muted-foreground/70">{DECISIONS.RECHECK_NOTE}</span>
           </div>
           <div className="grid gap-2 md:grid-cols-3">
-            <div className="rounded bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">
+            <div className="rounded-sm bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">
               {DECISIONS.RECHECK_STOP}
               {d.stop_loss !== null && (
                 <span className="block text-[10px] text-muted-foreground font-mono tabular-nums mt-0.5">
@@ -304,8 +304,8 @@ export async function DecisionProvenance({ id }: { id: string }) {
                 </span>
               )}
             </div>
-            <div className="rounded bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">{DECISIONS.RECHECK_VOL}</div>
-            <div className="rounded bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">{DECISIONS.RECHECK_THESIS}</div>
+            <div className="rounded-sm bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">{DECISIONS.RECHECK_VOL}</div>
+            <div className="rounded-sm bg-muted/40 px-2.5 py-2 text-xs text-foreground/90">{DECISIONS.RECHECK_THESIS}</div>
           </div>
           <p className="text-[10px] text-muted-foreground/60">{DECISIONS.RECHECK_PIT}</p>
         </CardContent>
@@ -387,7 +387,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
             )}
             {d.thesis && (
               <span
-                className={`ml-auto text-[10px] px-1.5 py-0.5 rounded ${
+                className={`ml-auto text-[10px] px-1.5 py-0.5 rounded-sm ${
                   VERDICT_TONE[d.thesis.verdict ?? ""] ?? "bg-muted text-muted-foreground"
                 }`}
               >
@@ -399,7 +399,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
             actionSource === "risk_veto" ? (
               // #1257: 규칙 판정(veto)은 논지가 없어도 채점 기준이 있다 — 자동 논지 렌더.
               // DB 쓰기 없음: 파생 표시일 뿐 theses 원장은 건드리지 않는다.
-              <div className="rounded bg-muted/40 px-2.5 py-2 space-y-1" data-testid="auto-thesis">
+              <div className="rounded-sm bg-muted/40 px-2.5 py-2 space-y-1" data-testid="auto-thesis">
                 <p className="text-[10px] text-rose-400">{DECISIONS.AUTO_THESIS_TITLE}</p>
                 <p className="text-xs text-foreground/90">{DECISIONS.AUTO_THESIS_BODY}</p>
               </div>
@@ -411,11 +411,11 @@ export async function DecisionProvenance({ id }: { id: string }) {
           ) : (
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-2">
-                <div className="rounded bg-muted/40 px-2.5 py-2">
+                <div className="rounded-sm bg-muted/40 px-2.5 py-2">
                   <p className="text-[10px] text-emerald-500 mb-1">상승 논리</p>
                   <p className="text-xs text-foreground/90 whitespace-pre-wrap">{d.thesis.bull_case}</p>
                 </div>
-                <div className="rounded bg-muted/40 px-2.5 py-2">
+                <div className="rounded-sm bg-muted/40 px-2.5 py-2">
                   <p className="text-[10px] text-rose-500 mb-1">하락 논리</p>
                   <p className="text-xs text-foreground/90 whitespace-pre-wrap">{d.thesis.bear_case}</p>
                 </div>
@@ -428,7 +428,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
                     반증 기준 ({d.thesis.criteria.length}) — 이게 사실이면 이 판단은 틀린 것
                   </p>
                   {d.thesis.criteria.map((c) => (
-                    <div key={c.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                    <div key={c.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded-sm px-2.5 py-1.5">
                       <span className={`w-14 shrink-0 ${CRITERION_TONE[c.last_result ?? ""] ?? "text-muted-foreground"}`}>
                         {c.last_result ? CRITERION_LABEL[c.last_result] : "미점검"}
                       </span>
@@ -447,7 +447,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
                 <div className="space-y-1.5">
                   <p className="text-[10px] text-muted-foreground">논지 근거 ({d.thesis.evidence.length})</p>
                   {d.thesis.evidence.map((e) => (
-                    <div key={e.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                    <div key={e.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded-sm px-2.5 py-1.5">
                       <span
                         className={`w-10 shrink-0 ${e.side === "bull" ? "text-emerald-500" : "text-rose-500"}`}
                       >
@@ -505,7 +505,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
             </p>
             <div className="space-y-1.5">
               {liveVerdicts.map((v, i) => (
-                <div key={i} className="flex items-center gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                <div key={i} className="flex items-center gap-2 text-xs bg-muted/40 rounded-sm px-2.5 py-1.5">
                   <span className="w-28 shrink-0 text-muted-foreground">{v.agent_name}</span>
                   <StatusBadge status={v.action} />
                   <span className="text-foreground/60">
@@ -525,7 +525,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
                   </summary>
                   <div className="space-y-1.5 mt-1.5">
                     {degradedVerdicts.map((v, i) => (
-                      <div key={i} className="flex items-center gap-2 text-xs bg-muted/20 rounded px-2.5 py-1.5 opacity-70">
+                      <div key={i} className="flex items-center gap-2 text-xs bg-muted/20 rounded-sm px-2.5 py-1.5 opacity-70">
                         <span className="w-28 shrink-0 text-muted-foreground">{v.agent_name}</span>
                         {typeof v.reasoning === "string" && (
                           <span className="truncate text-muted-foreground">{v.reasoning}</span>
@@ -549,7 +549,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
           ) : (
             <div className="space-y-1.5">
               {evidence.map((e) => (
-                <div key={e.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded px-2.5 py-1.5">
+                <div key={e.id} className="flex items-start gap-2 text-xs bg-muted/40 rounded-sm px-2.5 py-1.5">
                   <span className="w-32 shrink-0 text-muted-foreground">{e.source_type}/{e.source_key}</span>
                   {e.action && <StatusBadge status={e.action} />}
                   {e.confidence !== null && <span className="text-foreground/60 shrink-0">{Math.round(e.confidence)}%</span>}
@@ -583,7 +583,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
 function Loading() {
   return (
     <div className="space-y-5">
-      <div className="h-8 bg-card rounded w-64 animate-pulse" />
+      <div className="h-8 bg-card rounded-sm w-64 animate-pulse" />
       {[1, 2, 3, 4].map((i) => (
         <div key={i} className="h-28 bg-card rounded-xl border border-border animate-pulse" />
       ))}

--- a/frontend/src/app/decisions/page.tsx
+++ b/frontend/src/app/decisions/page.tsx
@@ -122,7 +122,7 @@ function FilterChip({ href, active, children }: { href: string; active: boolean;
       href={href}
       scroll={false}
       aria-current={active ? "true" : undefined}
-      className={`px-2.5 py-1 rounded text-[11px] transition-colors ${
+      className={`px-2.5 py-1 rounded-sm text-[11px] transition-colors ${
         active ? "bg-zinc-800 text-zinc-100" : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900/60"
       }`}
     >
@@ -173,7 +173,7 @@ function OutcomeCell({ date, outcome, today }: { date: string; outcome: string; 
   const adj = adjudicationInfo(date, outcome, today);
   return (
     <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-      <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${tag.cls}`}>{tag.label}</span>
+      <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-sm ${tag.cls}`}>{tag.label}</span>
       <span className="text-[10px] text-muted-foreground font-mono tabular-nums" title={`${DECISIONS.ADJ_DONE} ${adj.adjudicationDate}`}>
         {adj.kind === "adjudicated" && adj.adjudicationDate}
         {adj.kind === "waiting" && `${DECISIONS.ADJ_DUE_PREFIX}${adj.daysLeft}`}
@@ -194,7 +194,7 @@ function DecisionTable({ decisions, filtered, today }: { decisions: Decision[]; 
               DECISIONS.EMPTY_FILTERED
             ) : (
               <>
-                {DECISIONS.EMPTY} <code className="text-xs bg-muted px-1 rounded">make consensus</code> {COMMON.RUN_REQUIRED}.
+                {DECISIONS.EMPTY} <code className="text-xs bg-muted px-1 rounded-sm">make consensus</code> {COMMON.RUN_REQUIRED}.
               </>
             )}
           </p>

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -17,7 +17,7 @@ export default function Error({
 
   return (
     <div className="flex flex-col items-center justify-center py-20 space-y-4">
-      <div className="w-12 h-12 rounded-full bg-red-500/10 flex items-center justify-center">
+      <div className="size-12 rounded-full bg-red-500/10 flex items-center justify-center">
         <span className="text-red-400 text-lg font-bold">!</span>
       </div>
       <h2 className="text-lg font-semibold">

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -78,7 +78,7 @@ async function MarketContext() {
 
   if (!hasAny) {
     return (
-      <div className="text-[10px] text-zinc-500 px-2 py-1.5 rounded bg-zinc-900/40 border border-zinc-800/60">
+      <div className="text-[10px] text-zinc-500 px-2 py-1.5 rounded-sm bg-zinc-900/40 border border-zinc-800/60">
         ⚠ {EXPLORE.MARKET_NO_DATA}
       </div>
     );
@@ -89,7 +89,7 @@ async function MarketContext() {
   const tColor = trend === "bull" ? "text-emerald-400" : trend === "bear" ? "text-red-400" : "text-amber-400";
 
   return (
-    <div className="flex items-center gap-3 flex-wrap text-[10px] text-zinc-500 px-2 py-1.5 rounded bg-zinc-900/40 border border-zinc-800/60">
+    <div className="flex items-center gap-3 flex-wrap text-[10px] text-zinc-500 px-2 py-1.5 rounded-sm bg-zinc-900/40 border border-zinc-800/60">
       {trend && (
         <span className="flex items-center gap-1.5">
           <span className={`${tColor} font-semibold`}>{trendKo(trend)}</span>
@@ -154,7 +154,7 @@ function QuickLinkSkeleton() {
 }
 
 function StripSkeleton() {
-  return <div className="h-8 rounded bg-zinc-900/40 border border-zinc-800/60 animate-pulse" />;
+  return <div className="h-8 rounded-sm bg-zinc-900/40 border border-zinc-800/60 animate-pulse" />;
 }
 
 // ── Quicklinks section (single batch fetch for all 12 tickers) ──
@@ -190,7 +190,7 @@ async function QuickLinksGrid() {
       </div>
       {hasAnyMissing && (
         <p className="text-[9px] text-zinc-600 px-1">
-          <Lightbulb className="inline size-2.5 text-zinc-500 mr-0.5" aria-hidden /> 흐린 카드는 가격 미수집 — <code className="text-zinc-500 bg-zinc-800/50 px-1 rounded">{EXPLORE.COLLECT_HINT}</code>
+          <Lightbulb className="inline size-2.5 text-zinc-500 mr-0.5" aria-hidden /> 흐린 카드는 가격 미수집 — <code className="text-zinc-500 bg-zinc-800/50 px-1 rounded-sm">{EXPLORE.COLLECT_HINT}</code>
         </p>
       )}
     </div>

--- a/frontend/src/app/explore/search.tsx
+++ b/frontend/src/app/explore/search.tsx
@@ -77,7 +77,7 @@ export function ExploreSearch() {
   return (
     <div ref={ref} className="relative" data-testid="explore-search">
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-zinc-500" />
         <input
           type="text"
           value={query}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -407,12 +407,12 @@ async function Dashboard({
 function LoadingSkeleton() {
   return (
     <div className="flex flex-col gap-3">
-      <div className="h-16 bg-zinc-900/50 rounded animate-pulse" />
-      <div className="h-8 bg-zinc-900/30 rounded animate-pulse" />
-      <div className="h-3.5 bg-zinc-800 rounded animate-pulse" />
-      <div className="h-24 bg-zinc-900/50 rounded animate-pulse" />
-      <div className="h-32 bg-zinc-900/30 rounded animate-pulse" />
-      <div className="h-6 bg-zinc-800/30 rounded animate-pulse mt-auto" />
+      <div className="h-16 bg-zinc-900/50 rounded-sm animate-pulse" />
+      <div className="h-8 bg-zinc-900/30 rounded-sm animate-pulse" />
+      <div className="h-3.5 bg-zinc-800 rounded-sm animate-pulse" />
+      <div className="h-24 bg-zinc-900/50 rounded-sm animate-pulse" />
+      <div className="h-32 bg-zinc-900/30 rounded-sm animate-pulse" />
+      <div className="h-6 bg-zinc-800/30 rounded-sm animate-pulse mt-auto" />
     </div>
   );
 }

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -193,7 +193,7 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
       <Handle
         type="target"
         position={Position.Left}
-        className="bg-muted! border-border! w-2! h-2!"
+        className="bg-muted! border-border! size-2!"
       />
 
       {/* 상태 표시 + 라벨 — F-003: stepId 기반 lucide 아이콘 (label 은 제목만) */}
@@ -203,11 +203,11 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
           {/* 레코드 수 */}
           <span className="text-[10px] text-muted-foreground/70">{data.recordCount.toLocaleString()}</span>
           {/* 상태 점 */}
-          <span className="relative flex h-2.5 w-2.5">
+          <span className="relative flex size-2.5">
             {status === "running" ? (
-              <span className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 ${STATUS_COLORS[status]}`} />
+              <span className={`animate-ping absolute inline-flex size-full rounded-full opacity-75 ${STATUS_COLORS[status]}`} />
             ) : null}
-            <span className={`relative inline-flex rounded-full h-2.5 w-2.5 ${STATUS_COLORS[status]}`} />
+            <span className={`relative inline-flex rounded-full size-2.5 ${STATUS_COLORS[status]}`} />
           </span>
         </div>
       </div>
@@ -250,7 +250,7 @@ export const PipelineNode = memo(({ data }: { data: PipelineNodeData }) => {
       <Handle
         type="source"
         position={Position.Right}
-        className="bg-muted! border-border! w-2! h-2!"
+        className="bg-muted! border-border! size-2!"
       />
     </div>
   );
@@ -291,7 +291,7 @@ const FetchFailed = memo(function FetchFailed({ body, onRetry }: { body: string;
       <button
         type="button"
         onClick={onRetry}
-        className="text-[10px] px-2 py-1 rounded border border-border text-foreground/80 hover:bg-accent"
+        className="text-[10px] px-2 py-1 rounded-sm border border-border text-foreground/80 hover:bg-accent"
       >
         {ERRORS.RETRY}
       </button>
@@ -465,8 +465,8 @@ export default function PipelinePage() {
         <div className="flex items-center gap-3">
           {/* 실행 중 카운터 */}
           {runningSteps.size > 0 && (
-            <div className="flex items-center gap-1.5 px-2 py-0.5 rounded bg-blue-400/10 text-blue-400 text-[10px] font-medium">
-              <span className="inline-flex h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+            <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-sm bg-blue-400/10 text-blue-400 text-[10px] font-medium">
+              <span className="inline-flex size-2 rounded-full bg-blue-500 animate-pulse" />
               <span>{runningSteps.size}{PL.RUNNING_SUFFIX}</span>
             </div>
           )}
@@ -513,19 +513,19 @@ export default function PipelinePage() {
       {/* 하단 범례 */}
       <div className="flex items-center gap-6 text-[10px] text-muted-foreground">
         <div className="flex items-center gap-1.5">
-          <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+          <span className="inline-flex size-2 rounded-full bg-emerald-500" />
           <span>{PL.LEGEND_OK}</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="inline-flex h-2 w-2 rounded-full bg-amber-500" />
+          <span className="inline-flex size-2 rounded-full bg-amber-500" />
           <span>{PL.LEGEND_WARN}</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="inline-flex h-2 w-2 rounded-full bg-red-500" />
+          <span className="inline-flex size-2 rounded-full bg-red-500" />
           <span>{PL.LEGEND_ERROR}</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="inline-flex h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+          <span className="inline-flex size-2 rounded-full bg-blue-500 animate-pulse" />
           <span>{PL.LEGEND_RUNNING}</span>
         </div>
       </div>
@@ -553,7 +553,7 @@ export default function PipelinePage() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
                       <span className="font-medium text-foreground/80 capitalize">{ev.step}</span>
-                      <span className={`text-[10px] px-1 py-0.5 rounded ${
+                      <span className={`text-[10px] px-1 py-0.5 rounded-sm ${
                         ev.event_type === "success" ? "bg-emerald-500/10 text-emerald-400" :
                         ev.event_type === "error" ? "bg-red-500/10 text-red-400" :
                         "bg-blue-500/10 text-blue-400"
@@ -604,7 +604,7 @@ export default function PipelinePage() {
                       {c.detail}
                     </p>
                   </div>
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded shrink-0 ${
+                  <span className={`text-[10px] px-1.5 py-0.5 rounded-sm shrink-0 ${
                     c.passed ? "bg-emerald-500/10 text-emerald-400" : "bg-red-500/10 text-red-400"
                   }`}>
                     {c.phase}

--- a/frontend/src/app/portfolio/page.tsx
+++ b/frontend/src/app/portfolio/page.tsx
@@ -26,7 +26,7 @@ const FALLBACK_ACCOUNTS = ["test", "demo", "sample"];
 
 export default function PortfolioPage() {
   return (
-    <Suspense fallback={<div className="h-32 bg-muted rounded animate-pulse" />}>
+    <Suspense fallback={<div className="h-32 bg-muted rounded-sm animate-pulse" />}>
       <PortfolioContent />
     </Suspense>
   );
@@ -365,7 +365,7 @@ function PortfolioContent() {
 
       {/* ── Holdings by Account ── */}
       {loading ? (
-        <div className="h-32 bg-muted rounded animate-pulse" />
+        <div className="h-32 bg-muted rounded-sm animate-pulse" />
       ) : Object.keys(grouped).length === 0 ? (
         <Card className={`bg-card border-border ${isOnboarding ? "border-emerald-700" : ""}`}>
           <CardContent className="pt-5 space-y-4">
@@ -379,21 +379,21 @@ function PortfolioContent() {
             </p>
             <div className="space-y-3">
               <div className="flex items-start gap-3">
-                <span className="flex-none w-6 h-6 rounded-full bg-emerald-600 text-white text-xs flex items-center justify-center">1</span>
+                <span className="flex-none size-6 rounded-full bg-emerald-600 text-white text-xs flex items-center justify-center">1</span>
                 <div>
                   <p className="text-sm font-medium">Add holdings</p>
                   <p className="text-xs text-muted-foreground">Click &quot;Add Holding&quot; above to enter your positions manually, or upload a CSV file.</p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
-                <span className="flex-none w-6 h-6 rounded-full bg-zinc-700 text-zinc-300 text-xs flex items-center justify-center">2</span>
+                <span className="flex-none size-6 rounded-full bg-zinc-700 text-zinc-300 text-xs flex items-center justify-center">2</span>
                 <div>
                   <p className="text-sm font-medium">Collect market data</p>
                   <p className="text-xs text-muted-foreground">Run <code className="text-emerald-400">make collect</code> to fetch price/macro data for your tickers.</p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
-                <span className="flex-none w-6 h-6 rounded-full bg-zinc-700 text-zinc-300 text-xs flex items-center justify-center">3</span>
+                <span className="flex-none size-6 rounded-full bg-zinc-700 text-zinc-300 text-xs flex items-center justify-center">3</span>
                 <div>
                   <p className="text-sm font-medium">Run analysis</p>
                   <p className="text-xs text-muted-foreground">Run <code className="text-emerald-400">make full-scan</code> for the complete pipeline, or visit the Dashboard.</p>

--- a/frontend/src/app/rebalance/advisor-section.tsx
+++ b/frontend/src/app/rebalance/advisor-section.tsx
@@ -97,7 +97,7 @@ export async function AdvisorSection() {
           <p className="text-xs text-muted-foreground mb-3">{A.VIOLATION_DIST}</p>
           <div className="flex flex-wrap gap-2">
             {Object.entries(data.violations_by_type).map(([type, count]) => (
-              <span key={type} className="text-xs bg-muted px-2 py-1 rounded">
+              <span key={type} className="text-xs bg-muted px-2 py-1 rounded-sm">
                 {type}: {count}{COMMON.COUNT_SUFFIX}
               </span>
             ))}

--- a/frontend/src/app/signals/page.tsx
+++ b/frontend/src/app/signals/page.tsx
@@ -60,7 +60,7 @@ async function CrossSection() {
                 <p className="text-[10px] text-muted-foreground mb-1.5 font-medium uppercase tracking-wider">{regime}</p>
                 <div className="space-y-1">
                   {rows.slice(0, 5).map((r) => (
-                    <div key={r.signal_id} className="flex justify-between text-xs bg-muted/50 rounded px-2.5 py-1.5">
+                    <div key={r.signal_id} className="flex justify-between text-xs bg-muted/50 rounded-sm px-2.5 py-1.5">
                       <span className="text-foreground/80">{r.signal_id}</span>
                       <span className={pfColor(r.profit_factor)}>PF {pf(r.profit_factor)}</span>
                     </div>

--- a/frontend/src/app/strategy/page.tsx
+++ b/frontend/src/app/strategy/page.tsx
@@ -128,7 +128,7 @@ export async function StrategyDashboard() {
           {actions.length > 0 && (
             <div className="flex flex-wrap gap-2 mt-3">
               {actions.map((a: StrategyAction, i: number) => (
-                <div key={i} className="flex items-center gap-1.5 text-xs bg-muted rounded px-2 py-1">
+                <div key={i} className="flex items-center gap-1.5 text-xs bg-muted rounded-sm px-2 py-1">
                   <StatusBadge status={a.action.replace("open_", "").toUpperCase()} />
                   <span className="font-medium">{a.ticker}</span>
                   <span className="text-muted-foreground hidden sm:inline">{a.reason?.slice(0, 30)}</span>
@@ -252,9 +252,9 @@ export async function StrategyDashboard() {
             <p className="text-xs text-muted-foreground mb-2">Open Positions</p>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
               {positions.map((p: StrategyPosition, i: number) => (
-                <div key={i} className="flex items-center justify-between bg-muted rounded px-2.5 py-1.5 text-xs">
+                <div key={i} className="flex items-center justify-between bg-muted rounded-sm px-2.5 py-1.5 text-xs">
                   <div className="flex items-center gap-1.5">
-                    <span className={`w-1.5 h-1.5 rounded-full ${p.direction === "long" ? "bg-emerald-500" : "bg-red-500"}`} />
+                    <span className={`size-1.5 rounded-full ${p.direction === "long" ? "bg-emerald-500" : "bg-red-500"}`} />
                     <span className="font-medium">{p.ticker}</span>
                   </div>
                   <span className={`${(p.return_pct || 0) > 0 ? "text-emerald-400" : "text-red-400"}`}>
@@ -273,7 +273,7 @@ export async function StrategyDashboard() {
 function Loading() {
   return (
     <div className="space-y-5">
-      <div className="h-8 w-32 bg-muted rounded animate-pulse" />
+      <div className="h-8 w-32 bg-muted rounded-sm animate-pulse" />
       <div className="h-32 bg-card rounded-xl border border-border animate-pulse" />
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
         <div className="h-48 bg-card rounded-xl border border-border animate-pulse lg:col-span-3" />

--- a/frontend/src/app/ticker/[symbol]/page.tsx
+++ b/frontend/src/app/ticker/[symbol]/page.tsx
@@ -298,7 +298,7 @@ export async function TickerDetail({ symbol }: { symbol: string }) {
               <p className="text-xs text-muted-foreground mb-3">Smart Money ({supers.length})</p>
               <div className="space-y-1.5">
                 {supers.map((s: SuperInvestor, i: number) => (
-                  <div key={i} className="flex justify-between text-xs bg-muted/50 rounded px-2.5 py-1.5">
+                  <div key={i} className="flex justify-between text-xs bg-muted/50 rounded-sm px-2.5 py-1.5">
                     <span className="text-foreground/80">{s.investor}</span>
                     <span className="text-muted-foreground font-medium">{s.portfolio_pct?.toFixed(1)}%</span>
                   </div>
@@ -332,7 +332,7 @@ export async function TickerDetail({ symbol }: { symbol: string }) {
               <p className="text-xs text-muted-foreground mb-3">External Data ({external.count})</p>
               <div className="space-y-1.5 text-xs">
                 {external.data?.slice(0, 8).map((d: ExternalRow, i: number) => (
-                  <div key={i} className="flex justify-between bg-muted/50 rounded px-2.5 py-1">
+                  <div key={i} className="flex justify-between bg-muted/50 rounded-sm px-2.5 py-1">
                     <span className="text-muted-foreground">{d.source}/{d.data_type}</span>
                     <span className="text-foreground/80">{d.value}</span>
                   </div>
@@ -357,7 +357,7 @@ export async function TickerDetail({ symbol }: { symbol: string }) {
 function Loading() {
   return (
     <div className="space-y-5">
-      <div className="h-10 bg-card rounded w-48 animate-pulse" />
+      <div className="h-10 bg-card rounded-sm w-48 animate-pulse" />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {[1, 2, 3, 4, 5, 6].map((i) => (
           <div key={i} className="h-48 bg-card rounded-xl border border-border animate-pulse" />

--- a/frontend/src/components/dashboard/dashboard-footer.tsx
+++ b/frontend/src/components/dashboard/dashboard-footer.tsx
@@ -46,7 +46,7 @@ export function DashboardFooter({
           {pipelineSteps.length > 0 && (
             <div className="flex items-center gap-0.5">
               {pipelineSteps.map((s) => (
-                <span key={s.step} className={`inline-flex h-1.5 w-1.5 rounded-full ${pipelineStatusColors[s.status] || "bg-zinc-500"}`} title={`${s.label}: ${s.record_count.toLocaleString()}건`} />
+                <span key={s.step} className={`inline-flex size-1.5 rounded-full ${pipelineStatusColors[s.status] || "bg-zinc-500"}`} title={`${s.label}: ${s.record_count.toLocaleString()}건`} />
               ))}
               <Link href="/pipeline" className="text-[9px] text-zinc-600 hover:text-zinc-400 ml-0.5">&rarr;</Link>
             </div>

--- a/frontend/src/components/dashboard/events-strip.tsx
+++ b/frontend/src/components/dashboard/events-strip.tsx
@@ -17,7 +17,7 @@ export function EventsStrip({ events }: { events: StripEvent[] }) {
       count={events.length}
       emptyText={STRIP.EVENTS_EMPTY}
     >
-      <div className="flex items-start gap-2 px-2 py-1 rounded bg-zinc-900/40 border border-zinc-800/60 pr-6">
+      <div className="flex items-start gap-2 px-2 py-1 rounded-sm bg-zinc-900/40 border border-zinc-800/60 pr-6">
         <span className="text-[10px] text-zinc-400 font-semibold shrink-0">{STRIP.EVENTS_PREFIX} {events.length}{COMMON.COUNT_SUFFIX}</span>
         <div className="flex flex-wrap gap-x-3 gap-y-0.5 flex-1 min-w-0">
           {events.map((ev, i) => {

--- a/frontend/src/components/dashboard/holdings-section.tsx
+++ b/frontend/src/components/dashboard/holdings-section.tsx
@@ -63,7 +63,7 @@ export function HoldingsSection({
                 key={p}
                 href={p === 30 ? "/" : `/?period=${p}`}
                 scroll={false}
-                className={`px-1 rounded normal-case ${
+                className={`px-1 rounded-sm normal-case ${
                   p === sparklinePeriod
                     ? "text-zinc-300 bg-zinc-800/80"
                     : "text-zinc-600 hover:text-zinc-400"

--- a/frontend/src/components/dashboard/market-strip.tsx
+++ b/frontend/src/components/dashboard/market-strip.tsx
@@ -42,7 +42,7 @@ export function MarketStrip({
   const macroInfo = macroLevel(macroScore ?? 0);
 
   return (
-    <div className="flex items-center gap-3 flex-wrap text-[10px] text-zinc-500 px-2 py-1.5 rounded bg-zinc-900/40 border border-zinc-800/60">
+    <div className="flex items-center gap-3 flex-wrap text-[10px] text-zinc-500 px-2 py-1.5 rounded-sm bg-zinc-900/40 border border-zinc-800/60">
       <span className={trend === "bull" ? "text-emerald-400 font-semibold" : trend === "bear" ? "text-red-400 font-semibold" : "text-amber-400 font-semibold"}>
         {trendKo(trend)}
       </span>

--- a/frontend/src/components/dashboard/verdict-banner.tsx
+++ b/frontend/src/components/dashboard/verdict-banner.tsx
@@ -22,9 +22,9 @@ export function VerdictBanner({ verdict, level }: { verdict: string; level: stri
   return (
     <div
       data-testid="verdict-banner"
-      className={`flex items-center gap-3 px-4 py-2.5 rounded border ${s.box}`}
+      className={`flex items-center gap-3 px-4 py-2.5 rounded-sm border ${s.box}`}
     >
-      <span className={`shrink-0 inline-flex items-center h-5 px-2 rounded font-mono text-[11px] font-semibold ${s.tag}`}>
+      <span className={`shrink-0 inline-flex items-center h-5 px-2 rounded-sm font-mono text-[11px] font-semibold ${s.tag}`}>
         {label}
       </span>
       <p className="text-sm font-medium text-zinc-200 min-w-0">{verdict}</p>

--- a/frontend/src/components/evidence/fear-greed-chart.tsx
+++ b/frontend/src/components/evidence/fear-greed-chart.tsx
@@ -43,7 +43,7 @@ export function FearGreedChart({ data }: { data: FearGreedData }) {
     <div className="min-w-0" data-testid="fear-greed-chart" role="img" aria-label={EVIDENCE.TITLE_FEAR_GREED}>
       {latest && (
         <div className="mb-2">
-          <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-foreground">
+          <span className="text-[10px] px-2 py-0.5 rounded-sm bg-muted text-foreground">
             현재 {latest.value.toFixed(0)} · {zoneLabel(latest.value)}
           </span>
         </div>
@@ -84,7 +84,7 @@ export function FearGreedChart({ data }: { data: FearGreedData }) {
       <div className="flex gap-3 mt-1 text-[10px] text-muted-foreground justify-center">
         {FG_ZONES.map((z) => (
           <span key={z.label}>
-            <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: z.color, opacity: 0.6 }} />
+            <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: z.color, opacity: 0.6 }} />
             {z.label}
           </span>
         ))}

--- a/frontend/src/components/evidence/portfolio-treemap.tsx
+++ b/frontend/src/components/evidence/portfolio-treemap.tsx
@@ -113,23 +113,23 @@ export function PortfolioTreemap({ data }: { data: HeatmapData }) {
       </ResponsiveContainer>
       <div className="flex gap-4 mt-1 text-[10px] text-muted-foreground justify-center">
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: "#2e7d32" }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: "#2e7d32" }} />
           이익
         </span>
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: "#d32f2f" }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: "#d32f2f" }} />
           손실
         </span>
         <span>
           <span
-            className="inline-block w-2.5 h-2.5 mr-1 align-middle border-2"
+            className="inline-block size-2.5 mr-1 align-middle border-2"
             style={{ borderColor: VIOLATION_COLORS.stop_loss }}
           />
           손절 위반
         </span>
         <span>
           <span
-            className="inline-block w-2.5 h-2.5 mr-1 align-middle border-2"
+            className="inline-block size-2.5 mr-1 align-middle border-2"
             style={{ borderColor: VIOLATION_COLORS.overweight }}
           />
           비중 초과

--- a/frontend/src/components/evidence/regime-chart.tsx
+++ b/frontend/src/components/evidence/regime-chart.tsx
@@ -63,7 +63,7 @@ export function RegimeChart({ data }: { data: RegimeData }) {
     <div className="min-w-0" data-testid="regime-chart" role="img" aria-label={EVIDENCE.TITLE_REGIME}>
       {chip && (
         <div className="mb-2">
-          <span className="text-[10px] px-2 py-0.5 rounded bg-muted text-foreground">{chip}</span>
+          <span className="text-[10px] px-2 py-0.5 rounded-sm bg-muted text-foreground">{chip}</span>
         </div>
       )}
       <div className="w-full min-w-0 h-64">

--- a/frontend/src/components/evidence/sell-evidence-chart.tsx
+++ b/frontend/src/components/evidence/sell-evidence-chart.tsx
@@ -79,11 +79,11 @@ export function SellEvidenceChart({ data }: { data: SellEvidenceData }) {
       </div>
       <div className="flex gap-4 mt-1 text-[10px] text-muted-foreground justify-center">
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: VIOLATION_COLORS.stop_loss }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: VIOLATION_COLORS.stop_loss }} />
           손절선 위반 (SELL ALL)
         </span>
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: VIOLATION_COLORS.overweight }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: VIOLATION_COLORS.overweight }} />
           비중 초과 (REDUCE)
         </span>
       </div>

--- a/frontend/src/components/evidence/signal-performance-chart.tsx
+++ b/frontend/src/components/evidence/signal-performance-chart.tsx
@@ -92,15 +92,15 @@ export function SignalPerformanceChart({ data }: { data: SignalPerformanceData }
       </div>
       <div className="flex gap-4 mt-1 text-[10px] text-muted-foreground justify-center">
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: "var(--chart-1)" }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: "var(--chart-1)" }} />
           승률 (안정)
         </span>
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: DRIFT_COLORS.degrading }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: DRIFT_COLORS.degrading }} />
           드리프트 열화
         </span>
         <span>
-          <span className="inline-block w-2.5 h-2.5 mr-1 align-middle" style={{ background: DRIFT_COLORS.critical }} />
+          <span className="inline-block size-2.5 mr-1 align-middle" style={{ background: DRIFT_COLORS.critical }} />
           드리프트 위험
         </span>
         <span>

--- a/frontend/src/components/ui/action-items.tsx
+++ b/frontend/src/components/ui/action-items.tsx
@@ -99,7 +99,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
               e.stopPropagation();
               setExpanded(!expanded);
             }}
-            className="mr-1 align-middle inline-flex items-center justify-center w-4 h-4 -my-1 rounded text-zinc-500 hover:text-zinc-200 transition-colors focus-visible:outline-2 focus-visible:outline-blue-400/75"
+            className="mr-1 align-middle inline-flex items-center justify-center size-4 -my-1 rounded-sm text-zinc-500 hover:text-zinc-200 transition-colors focus-visible:outline-2 focus-visible:outline-blue-400/75"
           >
             <span aria-hidden="true" className={`text-[9px] leading-none transition-transform ${expanded ? "rotate-90" : ""}`}>&#9654;</span>
           </button>
@@ -116,7 +116,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
             <span
               data-testid="action-new-badge"
               title={item.as_of ? `${ACTION.PEEK_AS_OF} ${item.as_of}` : undefined}
-              className="ml-1.5 align-middle text-[9px] font-bold px-1 py-px rounded bg-blue-500/20 text-blue-400"
+              className="ml-1.5 align-middle text-[9px] font-bold px-1 py-px rounded-sm bg-blue-500/20 text-blue-400"
             >
               {ACTION.NEW}
             </span>
@@ -124,7 +124,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
         </td>
         <td className="h-8 px-2 whitespace-nowrap hidden md:table-cell text-[11px] text-zinc-400">{item.account ?? "—"}</td>
         <td className="h-8 px-2 whitespace-nowrap">
-          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${actionTagCls(item.action)}`}>{item.action}</span>
+          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-sm ${actionTagCls(item.action)}`}>{item.action}</span>
         </td>
         <td className="h-8 px-2 w-full max-w-0">
           <p className="text-xs text-zinc-400 truncate" title={item.reasons.join(" · ")}>
@@ -188,7 +188,7 @@ function ActionRow({ item, accent, ackMap, onAck }: { item: ActionItem; accent: 
                 <button
                   type="button"
                   data-testid="action-ack-button"
-                  className="ml-auto text-[11px] px-2 py-0.5 rounded bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"
+                  className="ml-auto text-[11px] px-2 py-0.5 rounded-sm bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"
                   onClick={(e) => {
                     e.stopPropagation();
                     onAck(item);
@@ -218,10 +218,10 @@ function ActionBucketTable({ items, kind, title, ackMap, onAck }: { items: Actio
   return (
     <div>
       <h3 className={`text-xs font-semibold ${style.title} mb-1 flex items-center gap-1.5`}>
-        <span className={`w-2 h-2 rounded-full ${style.dot}`} />
+        <span className={`size-2 rounded-full ${style.dot}`} />
         {title} ({items.length})
       </h3>
-      <div className="overflow-x-auto rounded border border-zinc-800/60 bg-zinc-900/30">
+      <div className="overflow-x-auto rounded-sm border border-zinc-800/60 bg-zinc-900/30">
         <table className="w-full text-left">
           {/* design-review F-001: 수익률/비중/확신도 숫자가 무라벨이었다 — 초경량 헤더로 명명.
               th 반응형 클래스는 아래 td 와 1:1 (계좌·비중 = hidden md:table-cell) */}
@@ -294,7 +294,7 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
       {hold.length > 0 && (
         <div>
           <h3 className="text-xs font-semibold text-zinc-500 mb-1.5 flex items-center gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-zinc-500" />
+            <span className="size-2 rounded-full bg-zinc-500" />
             {ACTION.HOLD_SUMMARY} ({hold.length})
           </h3>
           <div className="flex flex-wrap gap-1.5">
@@ -302,7 +302,7 @@ export function ActionItems({ urgent, check, hold, portfolio = [] }: ActionItems
               <Link
                 key={actionKey(item)}
                 href={`/ticker/${item.ticker}`}
-                className="inline-flex items-center gap-1 px-2 py-1 rounded bg-zinc-900/60 border border-zinc-800/40 text-[10px] hover:bg-zinc-800/60 transition-colors"
+                className="inline-flex items-center gap-1 px-2 py-1 rounded-sm bg-zinc-900/60 border border-zinc-800/40 text-[10px] hover:bg-zinc-800/60 transition-colors"
               >
                 <span className="text-zinc-300">{item.name || item.ticker}</span>
                 <span className={`tabular-nums font-medium ${item.action === "BUY" ? "text-emerald-500" : "text-zinc-500"}`}>

--- a/frontend/src/components/ui/agent-trace.tsx
+++ b/frontend/src/components/ui/agent-trace.tsx
@@ -28,7 +28,7 @@ function DataPills({ data }: { data: Record<string, unknown> }) {
   return (
     <div className="flex flex-wrap gap-1 mt-1">
       {entries.map(([k, v]) => (
-        <span key={k} className="text-[9px] bg-muted/50 rounded px-1.5 py-0.5 text-muted-foreground">
+        <span key={k} className="text-[9px] bg-muted/50 rounded-sm px-1.5 py-0.5 text-muted-foreground">
           {k}={typeof v === "number" ? v.toFixed(2) : String(v ?? "")}
         </span>
       ))}
@@ -89,7 +89,7 @@ export function AgentTrace({ ticker }: { ticker: string }) {
                     <DataPills data={v.data_points} />
                   </>
                 ) : (
-                  <div className="h-6 bg-muted/20 rounded" />
+                  <div className="h-6 bg-muted/20 rounded-sm" />
                 )}
               </div>
             );

--- a/frontend/src/components/ui/backtest-sliders.tsx
+++ b/frontend/src/components/ui/backtest-sliders.tsx
@@ -65,7 +65,7 @@ export function BacktestSliders({ onRun, initialParams, loading }: BacktestSlide
             <button
               key={period}
               onClick={() => update("smaPeriod", period)}
-              className={`text-[10px] px-1.5 py-0.5 rounded transition-colors ${
+              className={`text-[10px] px-1.5 py-0.5 rounded-sm transition-colors ${
                 params.smaPeriod === period ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
               }`}
             >
@@ -85,7 +85,7 @@ export function BacktestSliders({ onRun, initialParams, loading }: BacktestSlide
           <button
             key={lookback}
             onClick={() => update("lookback", lookback)}
-            className={`text-[10px] px-1.5 py-0.5 rounded transition-colors ${
+            className={`text-[10px] px-1.5 py-0.5 rounded-sm transition-colors ${
               params.lookback === lookback ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
             }`}
           >
@@ -106,7 +106,7 @@ export function BacktestSliders({ onRun, initialParams, loading }: BacktestSlide
         <button
           onClick={() => onRun(params)}
           disabled={loading}
-          className="ml-auto text-[10px] px-3 py-1 rounded bg-emerald-600 hover:bg-emerald-500 text-white font-medium transition-colors disabled:opacity-50"
+          className="ml-auto text-[10px] px-3 py-1 rounded-sm bg-emerald-600 hover:bg-emerald-500 text-white font-medium transition-colors disabled:opacity-50"
         >
           {loading ? "Running..." : "Run Backtest"}
         </button>

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -38,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        "font-heading text-base/snug font-medium group-data-[size=sm]/card:text-sm",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/certifications-card.tsx
+++ b/frontend/src/components/ui/certifications-card.tsx
@@ -117,7 +117,7 @@ export function CertificationsCard({ history, summary }: CertificationsCardProps
             <p className="text-[10px] text-muted-foreground mb-1">By caller</p>
             <div className="flex flex-wrap gap-2 text-[10px]">
               {Object.entries(summary.by_caller).map(([k, v]) => (
-                <span key={k} className="bg-muted/60 px-2 py-0.5 rounded">
+                <span key={k} className="bg-muted/60 px-2 py-0.5 rounded-sm">
                   {k} <span className="text-muted-foreground/70">×{v}</span>
                 </span>
               ))}
@@ -127,7 +127,7 @@ export function CertificationsCard({ history, summary }: CertificationsCardProps
             <p className="text-[10px] text-muted-foreground mb-1">By regime</p>
             <div className="flex flex-wrap gap-2 text-[10px]">
               {Object.entries(summary.by_regime).map(([k, v]) => (
-                <span key={k} className="bg-muted/60 px-2 py-0.5 rounded">
+                <span key={k} className="bg-muted/60 px-2 py-0.5 rounded-sm">
                   {k} <span className="text-muted-foreground/70">×{v}</span>
                 </span>
               ))}

--- a/frontend/src/components/ui/client-table.tsx
+++ b/frontend/src/components/ui/client-table.tsx
@@ -63,8 +63,8 @@ const VARIANTS: Record<string, any[]> = {
     { key: "agent_confidence", label: "Conf", align: "right", render: (v: number | null) => (v == null ? dim("—") : String(v)) },
     { key: "approved", label: "승인", align: "center", render: (v: boolean | null, row: { reason?: string | null }) =>
       v === null ? dim("—") : v
-        ? <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-400">승인</span>
-        : <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-zinc-700/40 text-zinc-400" title={row.reason ?? undefined}>미승인</span> },
+        ? <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-sm bg-emerald-500/15 text-emerald-400">승인</span>
+        : <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-sm bg-zinc-700/40 text-zinc-400" title={row.reason ?? undefined}>미승인</span> },
   ],
   gate: [
     { key: "description", label: "Condition" },
@@ -117,7 +117,7 @@ const VARIANTS: Record<string, any[]> = {
                    : v === 2 ? "bg-amber-500/20 text-amber-400 border-amber-500/30"
                    : "bg-zinc-500/20 text-muted-foreground border-zinc-500/30";
       // design-review F-004: 무설명 숫자 칩 — 의미를 tooltip 으로
-      return <span title={`매도 우선순위 ${v} (낮을수록 먼저)`} className={`inline-flex items-center justify-center w-5 h-5 rounded-full border text-[10px] font-medium ${color}`}>{v}</span>;
+      return <span title={`매도 우선순위 ${v} (낮을수록 먼저)`} className={`inline-flex items-center justify-center size-5 rounded-full border text-[10px] font-medium ${color}`}>{v}</span>;
     }},
     { key: "ticker", label: "Ticker", render: ticker },
     // design-review F-004: "심각도" 헤더 아래 액션 배지(SELL/REDUCE)를 그리던 헤더-값
@@ -126,7 +126,7 @@ const VARIANTS: Record<string, any[]> = {
       const cls = v === "critical" ? "bg-red-500/20 text-red-400 border-red-500/30"
                 : v === "high" ? "bg-amber-500/20 text-amber-400 border-amber-500/30"
                 : "bg-zinc-500/20 text-muted-foreground border-zinc-500/30";
-      return <span className={`inline-block px-1.5 py-0.5 rounded border text-[10px] font-bold uppercase ${cls}`}>{v}</span>;
+      return <span className={`inline-block px-1.5 py-0.5 rounded-sm border text-[10px] font-bold uppercase ${cls}`}>{v}</span>;
     }},
     { key: "action", label: "조치", align: "center", render: (v: string) => <span className={v === "SELL_ALL" ? "text-red-400 font-medium" : "text-amber-400"}>{v === "SELL_ALL" ? "전량 매도" : "일부 매도"}</span> },
     { key: "sell_shares", label: "수량", align: "right", render: (v: number) => `${v}주` },

--- a/frontend/src/components/ui/collapsible-strip.tsx
+++ b/frontend/src/components/ui/collapsible-strip.tsx
@@ -87,7 +87,7 @@ export function CollapsibleStrip({
       <button
         type="button"
         onClick={toggle}
-        className={`flex items-center gap-1.5 text-[10px] text-zinc-600 hover:text-zinc-300 hover:bg-zinc-900/50 rounded px-2 py-0.5 transition-colors ${className}`}
+        className={`flex items-center gap-1.5 text-[10px] text-zinc-600 hover:text-zinc-300 hover:bg-zinc-900/50 rounded-sm px-2 py-0.5 transition-colors ${className}`}
         data-testid={`strip-collapsed-${id}`}
         aria-label={`${title} ${COLLAPSIBLE.EXPAND_SUFFIX}`}
       >

--- a/frontend/src/components/ui/command-palette.tsx
+++ b/frontend/src/components/ui/command-palette.tsx
@@ -179,9 +179,9 @@ export function CommandPalette() {
         data-testid="palette-trigger"
         aria-label={PALETTE.ARIA}
       >
-        <Search className="h-3 w-3" />
+        <Search className="size-3" />
         {PALETTE.HINT}
-        <kbd className="rounded bg-muted px-1 text-[10px]">⌘K</kbd>
+        <kbd className="rounded-sm bg-muted px-1 text-[10px]">⌘K</kbd>
       </button>
 
       {open && (
@@ -204,7 +204,7 @@ export function CommandPalette() {
             }}
           >
             <div className="flex items-center gap-2 border-b border-border px-4">
-              <Search className="h-4 w-4 text-zinc-500 shrink-0" />
+              <Search className="size-4 text-zinc-500 shrink-0" />
               <input
                 ref={inputRef}
                 type="text"

--- a/frontend/src/components/ui/composition-section.tsx
+++ b/frontend/src/components/ui/composition-section.tsx
@@ -159,7 +159,7 @@ export function CompositionSection({
                 role="tab"
                 aria-selected={active}
                 data-testid={`composition-tab-${t}`}
-                className={`px-2.5 py-1 rounded transition-colors ${
+                className={`px-2.5 py-1 rounded-sm transition-colors ${
                   active
                     ? "bg-zinc-800 text-zinc-100"
                     : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900/60"
@@ -203,12 +203,12 @@ export function CompositionSection({
               return (
                 <div
                   key={row.label}
-                  className="flex items-center gap-3 text-[11px] py-0.5 px-1 rounded hover:bg-zinc-900/40 min-w-0"
+                  className="flex items-center gap-3 text-[11px] py-0.5 px-1 rounded-sm hover:bg-zinc-900/40 min-w-0"
                   data-testid={`composition-legend-${row.label}`}
                 >
                   {/* color dot */}
                   <span
-                    className="inline-block h-2 w-2 rounded-sm shrink-0"
+                    className="inline-block size-2 rounded-sm shrink-0"
                     style={{ background: row.color }}
                   />
                   {/* primary label */}

--- a/frontend/src/components/ui/consensus-table.tsx
+++ b/frontend/src/components/ui/consensus-table.tsx
@@ -118,7 +118,7 @@ export function ConsensusTable({ data, vix }: { data: ConsensusRow[]; vix?: numb
             <th className="py-1.5 px-2 text-right font-medium text-muted-foreground">Conf</th>
             <th className="py-1.5 px-2 text-right font-medium text-muted-foreground hidden sm:table-cell">Agree</th>
             {AGENT_ORDER.map((a) => (
-              <th key={a.key} className="py-1.5 px-1.5 text-center font-medium text-muted-foreground hidden md:table-cell">
+              <th key={a.key} className="p-1.5 text-center font-medium text-muted-foreground hidden md:table-cell">
                 {a.label}
               </th>
             ))}
@@ -181,14 +181,14 @@ export function ConsensusTable({ data, vix }: { data: ConsensusRow[]; vix?: numb
                     </span>
                   </td>
                   {AGENT_ORDER.map((a) => (
-                    <td key={a.key} className="py-1.5 px-1.5 text-center hidden md:table-cell">
+                    <td key={a.key} className="p-1.5 text-center hidden md:table-cell">
                       {agentCell(agentMap[a.key])}
                     </td>
                   ))}
                 </tr>
                 {isExpanded && (
                   <tr className="bg-muted/10">
-                    <td colSpan={4 + AGENT_ORDER.length} className="px-3 py-3">
+                    <td colSpan={4 + AGENT_ORDER.length} className="p-3">
                       {/* A-2c: contributions 에서 agent 별 weighted 값을 lookup.
                           분모는 basis_action bucket 의 action_scores 합 — "basis 방향 결정에 얼마나
                           기여했는가" 가 UI 의도 (codex review LOW 1 — 전체 총합 분모는 semantic drift).

--- a/frontend/src/components/ui/equity-curve-chart.tsx
+++ b/frontend/src/components/ui/equity-curve-chart.tsx
@@ -51,7 +51,7 @@ export function EquityCurveChart({ data }: EquityCurveChartProps) {
           <button
             key={p.label}
             onClick={() => setPeriod(p.days)}
-            className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+            className={`text-[10px] px-2 py-0.5 rounded-sm transition-colors ${
               period === p.days
                 ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground/80"

--- a/frontend/src/components/ui/holding-row.tsx
+++ b/frontend/src/components/ui/holding-row.tsx
@@ -356,7 +356,7 @@ export function HoldingRow({ holding: h, href, macroAwareSectors }: HoldingRowPr
       data-status={h.status.kind}
       // aria-label 을 두지 않는다: 링크 접근명은 보이는 자식(계좌·이름·손익)에서 계산되며,
       // label 은 그 전체를 덮어써 오히려 정보를 잃는다 (codex ship review P2, M4 재검토)
-      className="flex w-fit items-center gap-2 px-2 py-1.5 rounded hover:bg-zinc-800/50 text-xs group"
+      className="flex w-fit items-center gap-2 px-2 py-1.5 rounded-sm hover:bg-zinc-800/50 text-xs group"
     >
       {/* account — wider at 2xl+ so labels like "LONG_TERM" don't truncate. Stays w-10 below
           2xl to keep the lg (1024) row width under the content budget (752 content). */}
@@ -390,7 +390,7 @@ export function HoldingRow({ holding: h, href, macroAwareSectors }: HoldingRowPr
       </span>
       {/* status badge — 항상 */}
       <span
-        className={`inline-flex items-center justify-center text-[10px] font-medium rounded border px-1.5 py-0.5 w-17 shrink-0 ${status.className}`}
+        className={`inline-flex items-center justify-center text-[10px] font-medium rounded-sm border px-1.5 py-0.5 w-17 shrink-0 ${status.className}`}
       >
         {status.text}
       </span>

--- a/frontend/src/components/ui/holdings-summary-panel.tsx
+++ b/frontend/src/components/ui/holdings-summary-panel.tsx
@@ -96,7 +96,7 @@ export function HoldingsSummaryPanel({
                 <div className="relative flex items-center justify-between h-full px-1.5 text-[10px]">
                   <span className="flex items-center gap-1.5 min-w-0">
                     <span
-                      className="inline-block h-1.5 w-1.5 rounded-sm shrink-0"
+                      className="inline-block size-1.5 rounded-sm shrink-0"
                       style={{ background: a.color }}
                     />
                     <span className="truncate text-zinc-200">{a.account}</span>
@@ -131,7 +131,7 @@ export function HoldingsSummaryPanel({
                 <div className="relative flex items-center justify-between h-full px-1.5 text-[10px]">
                   <span className="flex items-center gap-1.5 min-w-0">
                     <span
-                      className="inline-block h-1.5 w-1.5 rounded-sm shrink-0"
+                      className="inline-block size-1.5 rounded-sm shrink-0"
                       style={{ background: s.color }}
                     />
                     <span className="truncate text-zinc-200">{s.name}</span>

--- a/frontend/src/components/ui/interactive-backtest.tsx
+++ b/frontend/src/components/ui/interactive-backtest.tsx
@@ -76,7 +76,7 @@ export function InteractiveBacktest({ initialData, initialMetrics }: Interactive
       <div className="flex items-center gap-1.5">
         <button
           onClick={() => setMode("static")}
-          className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+          className={`text-[10px] px-2 py-0.5 rounded-sm transition-colors ${
             mode === "static" ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
           }`}
         >
@@ -84,7 +84,7 @@ export function InteractiveBacktest({ initialData, initialMetrics }: Interactive
         </button>
         <button
           onClick={() => setMode("interactive")}
-          className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+          className={`text-[10px] px-2 py-0.5 rounded-sm transition-colors ${
             mode === "interactive" ? "bg-muted text-zinc-200" : "text-muted-foreground hover:text-zinc-300"
           }`}
         >

--- a/frontend/src/components/ui/live-indicator.tsx
+++ b/frontend/src/components/ui/live-indicator.tsx
@@ -12,9 +12,9 @@ export function LiveIndicator() {
 
   return (
     <div className="flex items-center gap-2 text-[10px] text-muted-foreground ml-auto shrink-0">
-      <span className="relative flex h-2 w-2">
-        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-        <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+      <span className="relative flex size-2">
+        <span className="animate-ping absolute inline-flex size-full rounded-full bg-emerald-400 opacity-75" />
+        <span className="relative inline-flex rounded-full size-2 bg-emerald-500" />
       </span>
       {data.regime && <span>{data.regime}</span>}
       {data.macro_score != null && <span>M{data.macro_score}</span>}

--- a/frontend/src/components/ui/opportunity-explorer.tsx
+++ b/frontend/src/components/ui/opportunity-explorer.tsx
@@ -80,7 +80,7 @@ function OpportunityCard({ opp }: { opp: Opportunity }) {
             ${opp.price?.toFixed(2) ?? "—"}
           </span>
           {opp.signal && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-400">
+            <span className="text-[10px] px-1.5 py-0.5 rounded-sm bg-blue-500/15 text-blue-400">
               {opp.signal}
             </span>
           )}
@@ -124,8 +124,8 @@ function OpportunityCard({ opp }: { opp: Opportunity }) {
 
       {/* 10-Agent 분석 결과 (인라인) */}
       {analysis && (
-        <div className="flex items-center gap-2 py-1.5 px-2 rounded bg-zinc-800/40 border border-zinc-800/30 text-[10px]">
-          <span className={`font-bold px-1.5 py-0.5 rounded ${
+        <div className="flex items-center gap-2 py-1.5 px-2 rounded-sm bg-zinc-800/40 border border-zinc-800/30 text-[10px]">
+          <span className={`font-bold px-1.5 py-0.5 rounded-sm ${
             analysis.action === "BUY" ? "bg-emerald-500/20 text-emerald-400" :
             analysis.action === "SELL" ? "bg-red-500/20 text-red-400" :
             "bg-zinc-700 text-zinc-400"
@@ -150,7 +150,7 @@ function OpportunityCard({ opp }: { opp: Opportunity }) {
       {/* 판정 + 링크 */}
       <div className="flex items-center justify-between pt-2 border-t border-zinc-800/40">
         <div className="flex items-center gap-1.5">
-          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${style.bg} ${style.text}`}>
+          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-sm ${style.bg} ${style.text}`}>
             {style.label}
           </span>
           <span className="text-[10px] text-zinc-500 truncate max-w-50">{opp.verdict}</span>

--- a/frontend/src/components/ui/price-chart.tsx
+++ b/frontend/src/components/ui/price-chart.tsx
@@ -89,7 +89,7 @@ export function PriceChart({ data, ticker }: PriceChartProps) {
           <button
             key={p.label}
             onClick={() => setPeriod(p.days)}
-            className={`text-[10px] px-2 py-0.5 rounded transition-colors ${
+            className={`text-[10px] px-2 py-0.5 rounded-sm transition-colors ${
               period === p.days
                 ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground/80"

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -143,17 +143,17 @@ export function Sidebar() {
             <div className="flex flex-col items-center gap-2">
               {/* 테마 토글 제거 (#1195 U1a codex P2): 제품은 dark-only (frontend/CLAUDE.md).
                   라이트 전환 시 zinc 램프 재매핑과 시맨틱 토큰이 혼합 테마를 만들던 경로 폐쇄 */}
-              <span className="relative flex h-2 w-2" title={NAV.SYSTEM_ONLINE}>
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+              <span className="relative flex size-2" title={NAV.SYSTEM_ONLINE}>
+                <span className="animate-ping absolute inline-flex size-full rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex rounded-full size-2 bg-emerald-500" />
               </span>
             </div>
           ) : (
             <>
               <div className="flex items-center gap-2">
-                <span className="relative flex h-2 w-2">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+                <span className="relative flex size-2">
+                  <span className="animate-ping absolute inline-flex size-full rounded-full bg-emerald-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full size-2 bg-emerald-500" />
                 </span>
                 <span className="text-[10px] text-muted-foreground">{NAV.SYSTEM_ONLINE}</span>
               </div>

--- a/frontend/src/components/ui/siege-timeline-chart.tsx
+++ b/frontend/src/components/ui/siege-timeline-chart.tsx
@@ -307,11 +307,11 @@ export function SiegeTimelineChart({ items }: SiegeTimelineChartProps) {
       {/* Legend — 결과 색 + 전환 선 + caller shape 분류 */}
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] text-muted-foreground">
         <span>
-          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500 mr-1.5 align-middle" />
+          <span className="inline-block size-2 rounded-full bg-emerald-500 mr-1.5 align-middle" />
           CERTIFIED
         </span>
         <span>
-          <span className="inline-block w-2 h-2 rounded-full bg-red-500 mr-1.5 align-middle" />
+          <span className="inline-block size-2 rounded-full bg-red-500 mr-1.5 align-middle" />
           REJECTED
         </span>
         <span>


### PR DESCRIPTION
Closes #1254.

## Why

The legacy important prefix #1249 fixed (`!bg-muted` instead of v4's `bg-muted!`) was caught **only by tailwindcss-intellisense in the IDE**. No eslint rule, no `make diagnostics`, no CI check looked at it — discovery required the user to paste an IDE warning into the session.

## The issue proposed `warn`. That would not have gated anything.

CI's Frontend Lint runs `npm run lint`, which is bare `eslint` with no `--max-warnings`, and the workflow comment says so outright:

> `# Frontend lint (eslint). Phase 1 (#470): errors-only gate; warnings tolerated`

So a `warn`-level rule would be **green while checking nothing** — the dead-gate shape this repo has already hit twice (`rc=127` pre-push step, 3.5 months, #910/#911; PreToolUse hooks silent at `exit 0`, #953/#954). Rules are set to **`error`**, which is only possible because the first commit normalizes existing violations to zero.

## What

`eslint-plugin-better-tailwindcss@4.7.0` — supports tailwind ^4.1.17 (we run 4.3.3) and eslint ^9 (we run 9.39.5); its `oxlint` peer is optional. Canonical-correctness rules only. **Class ordering and line wrapping are deliberately off**: they produce a large mechanical diff without catching a single wrong class.

Measured violations before enabling: `no-deprecated-classes` 81, `enforce-canonical-classes` 104, `no-unnecessary-whitespace` 2, and — notably — `enforce-consistent-important-position` **0**, confirming #1249's fix holds. That rule is purely preventive, and it is the axis #1249 actually tripped on.

## The normalization is visually neutral — verified, not assumed

`w-12 h-12` → `size-12` is byte-identical, and `pt-4 pb-4` → `py-4` swaps `padding-top`/`bottom` for `padding-block` (equivalent in this app's writing mode).

`rounded` → `rounded-sm` is the one that looks safe and isn't obviously so. Those are **not the same declaration**:

```
.rounded    -> border-radius: 0.25rem;
.rounded-sm -> border-radius: var(--radius-sm);
```

They are equal here only because this project sets `--radius: 0.25rem` and `--radius-sm: var(--radius)`. So the rename is identical today, and afterwards those 81 sites follow the `--radius` token instead of being pinned to a literal — which is what #1195's "4px 전역" intended. Checked by compiling both classes with tailwind 4.3.3 and comparing the generated declarations.

42 files, 134 insertions / 134 deletions — no line-count change.

## Verification

The gate is locked **by running it**, not by grepping the config for a rule name — this repo's rule, for a reason it has on record twice. The test lints synthetic violations through the project's real eslint config and asserts **severity is `error`**, since severity is what decides whether CI blocks.

3 mutation axes, each with an asserted replacement count and a test-node pre-check:

| Mutation | Test that flips to FAIL |
|---|---|
| `error` → `warn` | important-position test (severity assertion) |
| delete the `no-deprecated-classes` rule | deprecated/shorthand test |
| remove the plugin + settings block | important-position test |

3/3 locked. The `error → warn` axis is the important one: without it, a future edit could silently return the gate to inert.

Also asserted: the repo is currently clean under these rules, so nobody inherits a red light in an unrelated PR — plus a canary that canonical classes pass (a harness that always fails proves nothing).

**1662 tests pass**, `tsc --noEmit` clean, `npm run build` succeeds, `eslint src` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7

---

## Codex review — one P1 and two P2, all real

**P1: the normalization was NOT visually neutral.** I had already found and fixed this from the CI signal before codex reported, but it deserves to be recorded because it is the interesting failure here.

`eslint --fix` stripped a **necessary** leading space in `data-table.tsx`:

```js
}${col.hideOnMobile ? " hidden sm:table-cell" : ""}`   // before
}${col.hideOnMobile ? "hidden sm:table-cell" : ""}`    // after
```

The rule read that fragment **in isolation** and did not know it is concatenated onto `text-left`/`text-right`/`text-center`. Result: `text-lefthidden` — both classes destroyed, and mobile-hidden columns become visible at the base breakpoint. Silently, via autofix.

Fix: the space is restored, and **`no-unnecessary-whitespace` is not enabled**. Both of the two sites it flagged were this same false positive, so it had nothing to offer this codebase. A test now locks the hazard, so re-enabling it fails rather than silently fusing class names.

**P2a: the gate test proved `error` for only one rule.** If `no-deprecated-classes` regressed to `warn` while important-position stayed `error`, the file still passed — half the gate could die quietly. Now severity is asserted per rule, plus a sweep that reads the resolved config and checks **every** enabled rule, which also covers rules with no violation example yet (`no-conflicting`, `no-duplicate`).

**P2b: the pre-existing `data-table` test was a false green.** It asserted `className.toContain("hidden")`, which `text-lefthidden` satisfies — so it would never have caught the P1 regression, and indeed it was green while the bug was in. Now asserts class **tokens** via `classList`, the way a browser sees them, including that the preceding alignment class is still separate.

Codex independently confirmed the rest: the `rounded` → `rounded-sm` rationale, `py-*`/`size-*` equivalence (no RTL or vertical writing mode in this app), that `warn` would not gate CI (it ran `npm run lint` and got exit 0 with a warning), that the pre-commit hook is advisory so `error` cannot block commits, and that the new dependency leaves the load-bearing `overrides` intact.

**Final: 7 mutation axes, 7/7 locked**, 140 files / 1664 tests pass.

| Mutation | Test that flips to FAIL |
|---|---|
| `error` → `warn` (important-position) | severity assertion |
| delete the `no-deprecated-classes` rule | deprecated/shorthand test |
| remove the plugin + settings block | important-position test |
| downgrade `no-deprecated-classes` to warn | per-rule severity |
| downgrade any enabled rule to warn | resolved-config severity sweep |
| re-enable `no-unnecessary-whitespace` | config sweep + concatenation lock |
| strip the necessary space in `data-table` | `hideOnMobile` token assertions |
