### PR TITLE
fix(frontend): mark backfilled regime as lacking decision-time evidence (#1303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,805 collected across 358 files | ✅ |
+| **Backend tests** | 7,806 collected across 358 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 140 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,806 collected across 358 files | ✅ |
+| **Backend tests** | 7,807 collected across 358 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 140 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,806 backend tests across 358 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,807 backend tests across 358 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,805 backend tests across 358 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,806 backend tests across 358 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,806 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,807 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 140 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,805 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,806 tests, 358 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 140 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1670 tests, 140 files)
+npm run test           # vitest run (1671 tests, 140 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1667 tests, 140 files)
+npm run test           # vitest run (1670 tests, 140 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1664 tests, 140 files)
+npm run test           # vitest run (1667 tests, 140 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, act, within } from "@testing-library/react";
+import { DECISIONS } from "@/lib/strings";
 
 vi.mock("next/link", () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => (
@@ -76,6 +77,45 @@ describe("DecisionProvenance", () => {
     expect(screen.getByText("technical")).toBeInTheDocument();
     expect(screen.getByText(/증거 체인/)).toBeInTheDocument();
     expect(screen.getByText("agent/technical")).toBeInTheDocument();
+  });
+
+  // ── #1303: 백필된 regime 은 라이브 기록과 구분돼야 한다 ──────────────────────
+  describe("백필된 regime 표식 (#1303)", () => {
+    const regimeEv = {
+      id: 9, decision_id: 531, source_type: "regime", source_key: "bull_low_vol",
+      action: null, confidence: null, detail: null,
+    };
+
+    it("뒷받침 evidence 가 없으면 백필로 표시한다", async () => {
+      // #1264 는 백필 행에 evidence 를 **일부러 안 만든다** — 그 비대칭이 유일한 구분자다.
+      mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, regime: "bull_low_vol", evidence: [] });
+      const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+      await act(async () => {
+        render(await DecisionProvenance({ id: "531" }));
+      });
+      expect(screen.getByText(DECISIONS.REGIME_BACKFILLED)).toBeInTheDocument();
+    });
+
+    it("라이브로 기록된 regime 은 표시하지 않는다", async () => {
+      // 이쪽이 더 중요한 축이다 — 멀쩡한 기록에 "증거 없음" 을 붙이면 표식이 거짓말이 된다.
+      mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, regime: "bull_low_vol", evidence: [regimeEv] });
+      const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+      await act(async () => {
+        render(await DecisionProvenance({ id: "531" }));
+      });
+      expect(screen.getByText("bull_low_vol")).toBeInTheDocument();
+      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED)).toBeNull();
+    });
+
+    it("regime 자체가 없으면 표식도 없다", async () => {
+      // 값이 없는 것과 값의 출처가 불분명한 것은 다른 상태다 — 둘을 같은 문구로 덮지 않는다.
+      mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, regime: null, evidence: [] });
+      const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
+      await act(async () => {
+        render(await DecisionProvenance({ id: "531" }));
+      });
+      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED)).toBeNull();
+    });
   });
 
   it("calls notFound when the decision fetch fails (404)", async () => {

--- a/frontend/src/__tests__/pages/decision-detail.test.tsx
+++ b/frontend/src/__tests__/pages/decision-detail.test.tsx
@@ -80,31 +80,43 @@ describe("DecisionProvenance", () => {
   });
 
   // ── #1303: 백필된 regime 은 라이브 기록과 구분돼야 한다 ──────────────────────
-  describe("백필된 regime 표식 (#1303)", () => {
+  describe("검증 불가 regime 표식 (#1303)", () => {
     const regimeEv = {
       id: 9, decision_id: 531, source_type: "regime", source_key: "bull_low_vol",
       action: null, confidence: null, detail: null,
     };
 
-    it("뒷받침 evidence 가 없으면 백필로 표시한다", async () => {
-      // #1264 는 백필 행에 evidence 를 **일부러 안 만든다** — 그 비대칭이 유일한 구분자다.
+    it("뒷받침 evidence 가 없으면 표시한다", async () => {
+      // 원인은 백필일 수도, 기록 중단일 수도 있다 — 표식은 **관측한 사실만** 말한다.
       mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, regime: "bull_low_vol", evidence: [] });
       const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
       await act(async () => {
         render(await DecisionProvenance({ id: "531" }));
       });
-      expect(screen.getByText(DECISIONS.REGIME_BACKFILLED)).toBeInTheDocument();
+      expect(screen.getByText(DECISIONS.REGIME_NO_EVIDENCE)).toBeInTheDocument();
     });
 
-    it("라이브로 기록된 regime 은 표시하지 않는다", async () => {
-      // 이쪽이 더 중요한 축이다 — 멀쩡한 기록에 "증거 없음" 을 붙이면 표식이 거짓말이 된다.
+    it("증거 행이 있으면 표시하지 않는다", async () => {
+      // 이쪽이 더 중요한 축이다 — 증거가 있는 행에 "증거 없음" 을 붙이면 표식이 거짓말이 된다.
       mockFetchAPI = vi.fn().mockResolvedValue({ ...mockDetail, regime: "bull_low_vol", evidence: [regimeEv] });
       const { DecisionProvenance } = await import("@/app/decisions/[id]/page");
       await act(async () => {
         render(await DecisionProvenance({ id: "531" }));
       });
       expect(screen.getByText("bull_low_vol")).toBeInTheDocument();
-      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED)).toBeNull();
+      expect(screen.queryByText(DECISIONS.REGIME_NO_EVIDENCE)).toBeNull();
+    });
+
+    it("표식이 원인을 단정하지 않는다", () => {
+      // codex P2: `record_decision` 은 컬럼(`upsert_decision`)과 evidence
+      // (`upsert_decision_evidence`)를 **다른 트랜잭션**으로 쓴다. 그 사이에서 프로세스가
+      // 죽으면 **정상 기록된 행**도 evidence 만 없는 모양이 되고, 원장에서 백필과 구분되지
+      // 않는다. 그래서 짧은 문구는 원인을 적지 않는다 — 적으면 멀쩡한 행을 오인 고발한다.
+      expect(DECISIONS.REGIME_NO_EVIDENCE).not.toMatch(/백필|보완/);
+      expect(DECISIONS.REGIME_NO_EVIDENCE_TAG).not.toMatch(/백필|보완/);
+      // 대신 전체 문구는 **두 가능성을 모두** 말한다 — 하나만 적으면 그게 곧 단정이다.
+      expect(DECISIONS.REGIME_NO_EVIDENCE_FULL).toMatch(/보완/);
+      expect(DECISIONS.REGIME_NO_EVIDENCE_FULL).toMatch(/중단/);
     });
 
     it("regime 자체가 없으면 표식도 없다", async () => {
@@ -114,7 +126,7 @@ describe("DecisionProvenance", () => {
       await act(async () => {
         render(await DecisionProvenance({ id: "531" }));
       });
-      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED)).toBeNull();
+      expect(screen.queryByText(DECISIONS.REGIME_NO_EVIDENCE)).toBeNull();
     });
   });
 

--- a/frontend/src/__tests__/pages/decisions.test.tsx
+++ b/frontend/src/__tests__/pages/decisions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import { DECISIONS } from "@/lib/strings";
 
 // Mock next/link
 vi.mock("next/link", () => ({
@@ -57,6 +58,38 @@ describe("DecisionsPage", () => {
     await act(async () => { render(await DecisionsPage()); });
     expect(screen.getByText("Decision Intelligence")).toBeInTheDocument();
     expect(screen.getByText(/의사결정 저널/)).toBeInTheDocument();
+  });
+
+  // #1303: 백필된 regime 을 목록에서도 구분한다. 백필 후에는 과거 행 대부분이 regime 을
+  // 갖게 되므로, 표시가 없으면 훑어보는 사람이 "처음부터 레짐 맥락이 있었다" 로 읽는다.
+  describe("백필된 regime 표식 (#1303)", () => {
+    const row = (extra: Record<string, unknown>) => ({
+      ...mockDecisionsResponse.decisions[0], ...extra,
+    });
+    const resp = (decisions: unknown[]) => ({ ...mockDecisionsResponse, decisions, count: decisions.length });
+
+    it("evidence 없는 regime 에 표식을 붙인다", async () => {
+      setupFetchAPI(resp([row({ id: 1, ticker: "AAA", regime_has_evidence: 0 })]));
+      const { default: DecisionsPage } = await import("@/app/decisions/page");
+      await act(async () => { render(await DecisionsPage()); });
+      expect(screen.getByText(DECISIONS.REGIME_BACKFILLED_TAG)).toBeInTheDocument();
+      // 축약 태그만으로는 뜻이 안 통한다 — 전체 문구가 title 로 붙어 있어야 한다.
+      expect(screen.getByTitle(DECISIONS.REGIME_BACKFILLED)).toBeInTheDocument();
+    });
+
+    it("라이브로 기록된 regime 에는 붙이지 않는다", async () => {
+      setupFetchAPI(resp([row({ id: 1, ticker: "AAA", regime_has_evidence: 1 })]));
+      const { default: DecisionsPage } = await import("@/app/decisions/page");
+      await act(async () => { render(await DecisionsPage()); });
+      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED_TAG)).toBeNull();
+    });
+
+    it("regime 자체가 없으면 표식도 없다", async () => {
+      setupFetchAPI(resp([row({ id: 1, ticker: "AAA", regime: null, regime_has_evidence: 0 })]));
+      const { default: DecisionsPage } = await import("@/app/decisions/page");
+      await act(async () => { render(await DecisionsPage()); });
+      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED_TAG)).toBeNull();
+    });
   });
 
   it("renders summary cards with correct labels", async () => {

--- a/frontend/src/__tests__/pages/decisions.test.tsx
+++ b/frontend/src/__tests__/pages/decisions.test.tsx
@@ -60,35 +60,36 @@ describe("DecisionsPage", () => {
     expect(screen.getByText(/의사결정 저널/)).toBeInTheDocument();
   });
 
-  // #1303: 백필된 regime 을 목록에서도 구분한다. 백필 후에는 과거 행 대부분이 regime 을
-  // 갖게 되므로, 표시가 없으면 훑어보는 사람이 "처음부터 레짐 맥락이 있었다" 로 읽는다.
-  describe("백필된 regime 표식 (#1303)", () => {
+  // #1303: 결정 시점 증거가 없는 regime 을 목록에서도 구분한다. 백필 후에는 과거 행
+  // 대부분이 regime 을 갖게 되므로, 표시가 없으면 훑어보는 사람이 "처음부터 레짐 맥락이
+  // 있었다" 로 읽는다.
+  describe("검증 불가 regime 표식 (#1303)", () => {
     const row = (extra: Record<string, unknown>) => ({
       ...mockDecisionsResponse.decisions[0], ...extra,
     });
     const resp = (decisions: unknown[]) => ({ ...mockDecisionsResponse, decisions, count: decisions.length });
 
-    it("evidence 없는 regime 에 표식을 붙인다", async () => {
+    it("증거 행 없는 regime 에 표식을 붙인다", async () => {
       setupFetchAPI(resp([row({ id: 1, ticker: "AAA", regime_has_evidence: 0 })]));
       const { default: DecisionsPage } = await import("@/app/decisions/page");
       await act(async () => { render(await DecisionsPage()); });
-      expect(screen.getByText(DECISIONS.REGIME_BACKFILLED_TAG)).toBeInTheDocument();
+      expect(screen.getByText(DECISIONS.REGIME_NO_EVIDENCE_TAG)).toBeInTheDocument();
       // 축약 태그만으로는 뜻이 안 통한다 — 전체 문구가 title 로 붙어 있어야 한다.
-      expect(screen.getByTitle(DECISIONS.REGIME_BACKFILLED)).toBeInTheDocument();
+      expect(screen.getByTitle(DECISIONS.REGIME_NO_EVIDENCE_FULL)).toBeInTheDocument();
     });
 
-    it("라이브로 기록된 regime 에는 붙이지 않는다", async () => {
+    it("증거 행이 있으면 붙이지 않는다", async () => {
       setupFetchAPI(resp([row({ id: 1, ticker: "AAA", regime_has_evidence: 1 })]));
       const { default: DecisionsPage } = await import("@/app/decisions/page");
       await act(async () => { render(await DecisionsPage()); });
-      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED_TAG)).toBeNull();
+      expect(screen.queryByText(DECISIONS.REGIME_NO_EVIDENCE_TAG)).toBeNull();
     });
 
     it("regime 자체가 없으면 표식도 없다", async () => {
       setupFetchAPI(resp([row({ id: 1, ticker: "AAA", regime: null, regime_has_evidence: 0 })]));
       const { default: DecisionsPage } = await import("@/app/decisions/page");
       await act(async () => { render(await DecisionsPage()); });
-      expect(screen.queryByText(DECISIONS.REGIME_BACKFILLED_TAG)).toBeNull();
+      expect(screen.queryByText(DECISIONS.REGIME_NO_EVIDENCE_TAG)).toBeNull();
     });
   });
 

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -172,11 +172,13 @@ export async function DecisionProvenance({ id }: { id: string }) {
 
   const verdicts = parseVerdicts(d.agent_verdicts);
   const evidence = d.evidence ?? [];
-  // #1303: regime 은 있는데 그것을 뒷받침하는 evidence 행이 없으면 **백필된 값**이다.
-  // #1264 가 evidence 행을 일부러 만들지 않았기 때문에 이 비대칭이 유일한 구분자다
-  // (prod 실측: 라이브로 기록된 행은 예외 없이 `source_type='regime'` 을 갖는다).
-  // 이 표식이 없으면 사후 복사가 당시 근거처럼 읽힌다.
-  const regimeBackfilled = d.regime != null && !evidence.some((e) => e.source_type === "regime");
+  // #1303: regime 은 있는데 뒷받침하는 결정 시점 evidence 행이 없다.
+  //
+  // 원인을 단정하지 않는다 (codex P2): 백필(#1264)이 컬럼만 채운 경우일 수도 있고,
+  // `record_decision` 이 컬럼과 evidence 를 **다른 트랜잭션**으로 쓰는 사이에 죽어
+  // **정상 기록이 반만 남은** 경우일 수도 있다. 둘은 원장에서 구분되지 않는다.
+  // 사용자에게 중요한 뜻은 어느 쪽이든 같다 — 이 값은 당시 증거로 검증할 수 없다.
+  const regimeUnverifiable = d.regime != null && !evidence.some((e) => e.source_type === "regime");
   // #1216: 판정 상태 — outcome intent 태그 + 판정 기준일/D-n (리스트와 동일 규칙)
   const outcomeTag = OUTCOME_TAG[d.outcome] ?? OUTCOME_TAG.pending;
   const adj = adjudicationInfo(d.date, d.outcome, todayKst());
@@ -329,7 +331,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
           <div className="grid grid-cols-3 gap-3">
             <Metric label="Confidence" value={d.confidence === null ? "—" : `${Math.round(d.confidence)}%`} />
             <Metric label="Agreement" value={d.agreement_rate === null ? "—" : `${Math.round(d.agreement_rate * 100)}%`} />
-            <Metric label="Regime" value={d.regime ?? "—"} sub={regimeBackfilled ? DECISIONS.REGIME_BACKFILLED : undefined} />
+            <Metric label="Regime" value={d.regime ?? "—"} sub={regimeUnverifiable ? DECISIONS.REGIME_NO_EVIDENCE : undefined} />
             <Metric label="VIX" value={fmtFixed(d.vix)} />
             <Metric label="Fear&Greed" value={d.fear_greed === null ? "—" : String(Math.round(d.fear_greed))} />
             <Metric label="Macro" value={fmtFixed(d.macro_score)} />

--- a/frontend/src/app/decisions/[id]/page.tsx
+++ b/frontend/src/app/decisions/[id]/page.tsx
@@ -172,6 +172,11 @@ export async function DecisionProvenance({ id }: { id: string }) {
 
   const verdicts = parseVerdicts(d.agent_verdicts);
   const evidence = d.evidence ?? [];
+  // #1303: regime 은 있는데 그것을 뒷받침하는 evidence 행이 없으면 **백필된 값**이다.
+  // #1264 가 evidence 행을 일부러 만들지 않았기 때문에 이 비대칭이 유일한 구분자다
+  // (prod 실측: 라이브로 기록된 행은 예외 없이 `source_type='regime'` 을 갖는다).
+  // 이 표식이 없으면 사후 복사가 당시 근거처럼 읽힌다.
+  const regimeBackfilled = d.regime != null && !evidence.some((e) => e.source_type === "regime");
   // #1216: 판정 상태 — outcome intent 태그 + 판정 기준일/D-n (리스트와 동일 규칙)
   const outcomeTag = OUTCOME_TAG[d.outcome] ?? OUTCOME_TAG.pending;
   const adj = adjudicationInfo(d.date, d.outcome, todayKst());
@@ -324,7 +329,7 @@ export async function DecisionProvenance({ id }: { id: string }) {
           <div className="grid grid-cols-3 gap-3">
             <Metric label="Confidence" value={d.confidence === null ? "—" : `${Math.round(d.confidence)}%`} />
             <Metric label="Agreement" value={d.agreement_rate === null ? "—" : `${Math.round(d.agreement_rate * 100)}%`} />
-            <Metric label="Regime" value={d.regime ?? "—"} />
+            <Metric label="Regime" value={d.regime ?? "—"} sub={regimeBackfilled ? DECISIONS.REGIME_BACKFILLED : undefined} />
             <Metric label="VIX" value={fmtFixed(d.vix)} />
             <Metric label="Fear&Greed" value={d.fear_greed === null ? "—" : String(Math.round(d.fear_greed))} />
             <Metric label="Macro" value={fmtFixed(d.macro_score)} />

--- a/frontend/src/app/decisions/page.tsx
+++ b/frontend/src/app/decisions/page.tsx
@@ -30,7 +30,7 @@ interface Decision {
   action: string;
   confidence: number;
   regime: string | null;
-  // #1303: 결정 시점에 기록된 regime 인지 (백필분은 false)
+  // #1303: 결정 시점 evidence 행이 있는지 (백필분·기록중단분 모두 false)
   regime_has_evidence?: boolean | number;
   macro_score: number | null;
   vix: number | null;
@@ -262,8 +262,8 @@ function DecisionTable({ decisions, filtered, today }: { decisions: Decision[]; 
                     <td className="px-3 py-1 hidden md:table-cell text-xs text-muted-foreground">
                       {d.regime ?? "—"}
                       {d.regime && !d.regime_has_evidence && (
-                        <span className="ml-1 text-[9px] text-muted-foreground/60" title={DECISIONS.REGIME_BACKFILLED}>
-                          {DECISIONS.REGIME_BACKFILLED_TAG}
+                        <span className="ml-1 text-[9px] text-muted-foreground/60" title={DECISIONS.REGIME_NO_EVIDENCE_FULL}>
+                          {DECISIONS.REGIME_NO_EVIDENCE_TAG}
                         </span>
                       )}
                     </td>

--- a/frontend/src/app/decisions/page.tsx
+++ b/frontend/src/app/decisions/page.tsx
@@ -30,6 +30,8 @@ interface Decision {
   action: string;
   confidence: number;
   regime: string | null;
+  // #1303: 결정 시점에 기록된 regime 인지 (백필분은 false)
+  regime_has_evidence?: boolean | number;
   macro_score: number | null;
   vix: number | null;
   fear_greed: number | null;
@@ -259,6 +261,11 @@ function DecisionTable({ decisions, filtered, today }: { decisions: Decision[]; 
                     </td>
                     <td className="px-3 py-1 hidden md:table-cell text-xs text-muted-foreground">
                       {d.regime ?? "—"}
+                      {d.regime && !d.regime_has_evidence && (
+                        <span className="ml-1 text-[9px] text-muted-foreground/60" title={DECISIONS.REGIME_BACKFILLED}>
+                          {DECISIONS.REGIME_BACKFILLED_TAG}
+                        </span>
+                      )}
                     </td>
                     <td className="px-3 py-1 text-right hidden md:table-cell font-mono text-xs tabular-nums">
                       {d.entry_price ? formatMoney(d.entry_price, { ticker: d.ticker }) : "—"}

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -308,6 +308,10 @@ export const DECISIONS = {
   FILTER_ACTION_LABEL: "액션",
   FILTERED_NOTE_SUFFIX: "건 표시 · 요약 카드는 전체 기준", // 필터 중 전역 요약과의 혼동 방지 (codex R1 P2)
   RAIL_CONTEXT: "결정 시점 컨텍스트 (frozen)",
+  // #1303: 백필된 regime 표식. #1264 는 evidence 행을 **일부러 안 만들었다** — 사후 복사를
+  // 라이브 증거로 위장하지 않기 위해서다. 그 구분이 원장에만 있고 화면에 없으면 사용자는
+  // 근거 없는 값을 근거 있는 값과 똑같이 읽는다.
+  REGIME_BACKFILLED: "기록 후 보완 · 당시 증거 없음",
   RAIL_PRICES: "가격 레벨",
   RAIL_PNL: "실현 결과 (forward PnL %)",
   // #1257 판정 경로 히어로 — 판정 소스(final_action_source)별 3변형. 일상어 원칙:

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -312,6 +312,8 @@ export const DECISIONS = {
   // 라이브 증거로 위장하지 않기 위해서다. 그 구분이 원장에만 있고 화면에 없으면 사용자는
   // 근거 없는 값을 근거 있는 값과 똑같이 읽는다.
   REGIME_BACKFILLED: "기록 후 보완 · 당시 증거 없음",
+  // 목록의 좁은 칸용 축약 — 전체 문구는 title 로 붙는다.
+  REGIME_BACKFILLED_TAG: "보완",
   RAIL_PRICES: "가격 레벨",
   RAIL_PNL: "실현 결과 (forward PnL %)",
   // #1257 판정 경로 히어로 — 판정 소스(final_action_source)별 3변형. 일상어 원칙:

--- a/frontend/src/lib/strings.ts
+++ b/frontend/src/lib/strings.ts
@@ -308,12 +308,18 @@ export const DECISIONS = {
   FILTER_ACTION_LABEL: "액션",
   FILTERED_NOTE_SUFFIX: "건 표시 · 요약 카드는 전체 기준", // 필터 중 전역 요약과의 혼동 방지 (codex R1 P2)
   RAIL_CONTEXT: "결정 시점 컨텍스트 (frozen)",
-  // #1303: 백필된 regime 표식. #1264 는 evidence 행을 **일부러 안 만들었다** — 사후 복사를
-  // 라이브 증거로 위장하지 않기 위해서다. 그 구분이 원장에만 있고 화면에 없으면 사용자는
-  // 근거 없는 값을 근거 있는 값과 똑같이 읽는다.
-  REGIME_BACKFILLED: "기록 후 보완 · 당시 증거 없음",
+  // #1303: regime 에 결정 시점 증거 행이 없을 때의 표식.
+  //
+  // ⚠️ **"백필됨" 이라고 말하지 않는다.** 원인을 단정할 수 없기 때문이다 (codex P2):
+  // `record_decision` 은 컬럼과 evidence 행을 **다른 트랜잭션**으로 쓰므로
+  // (`upsert_decision` → `upsert_decision_evidence`, 각자 커밋), 그 사이에서 프로세스가
+  // 죽으면 **정상 기록된 행**도 같은 모양이 된다. 백필(#1264)과 구분할 방법이 없다.
+  // 그래서 관측한 사실만 말한다 — 원인이 무엇이든 사용자에게 중요한 뜻은 같다:
+  // **이 regime 은 결정 시점 증거로 검증할 수 없다.**
+  REGIME_NO_EVIDENCE: "당시 증거 행 없음",
+  REGIME_NO_EVIDENCE_FULL: "이 regime 을 뒷받침하는 결정 시점 증거 행이 없습니다 — 사후 보완이거나 기록이 중단된 경우입니다",
   // 목록의 좁은 칸용 축약 — 전체 문구는 title 로 붙는다.
-  REGIME_BACKFILLED_TAG: "보완",
+  REGIME_NO_EVIDENCE_TAG: "증거없음",
   RAIL_PRICES: "가격 레벨",
   RAIL_PNL: "실현 결과 (forward PnL %)",
   // #1257 판정 경로 히어로 — 판정 소스(final_action_source)별 3변형. 일상어 원칙:

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -187,8 +187,17 @@ def get_decisions(
         conditions.append("outcome = ?")
         params.append(outcome)
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    # `regime_has_evidence` — 이 행의 regime 이 **결정 시점에 기록된 것인지** (#1303).
+    # `record_decision` 은 컬럼과 evidence 행을 **같은 조건**(`if context.get("regime")`)으로
+    # 쓰므로 라이브 행은 둘을 같이 갖는다. 백필(#1264)은 컬럼만 채우고 evidence 는
+    # 일부러 안 만들기 때문에, 이 비대칭이 사후 복사를 가려낼 유일한 신호다.
+    # 목록에서도 필요하다: 백필 후에는 과거 행 대부분이 regime 을 갖게 되는데, 표시가
+    # 없으면 훑어보는 사람은 "처음부터 레짐 맥락이 있었다" 로 읽는다.
     return query(
-        f"SELECT * FROM decisions {where} ORDER BY date DESC LIMIT ?",
+        f"SELECT *, EXISTS(SELECT 1 FROM decision_evidence e "
+        f"                 WHERE e.decision_id = decisions.id AND e.source_type = 'regime') "
+        f"       AS regime_has_evidence "
+        f"FROM decisions {where} ORDER BY date DESC LIMIT ?",
         (*params, limit),
         db_path,
     )

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -222,6 +222,42 @@ class TestQueryDecisions:
         assert by_ticker["AAA"]["regime_has_evidence"], "라이브 기록인데 evidence 없음으로 읽힌다"
         assert not by_ticker["BBB"]["regime_has_evidence"], "백필인데 라이브로 읽힌다"
 
+    def test_detail_query_does_not_filter_out_regime_evidence(self, db_path):
+        """상세 조회가 `source_type='regime'` evidence 를 그대로 돌려준다 (#1303 codex P3).
+
+        화면의 "당시 증거 행 없음" 표식은 상세 API 가 이 행을 **빼지 않는다**는 전제 위에
+        선다. 나중에 조회가 source_type 을 필터하기 시작하면 표식이 **모든 행에** 붙어
+        정상 기록까지 오인 고발한다. 프론트 테스트는 fetch 를 mock 하므로 그 축을 못 잡는다.
+
+        Mutation lock: 조회에 `WHERE source_type != 'regime'` 류 필터를 넣으면 FAIL.
+        """
+        from nuri.core.db import get_decision_with_evidence, upsert_decision_evidence
+
+        upsert_decision(
+            {"date": "2026-04-10", "ticker": "AAA", "action": "BUY", "confidence": 70.0, "regime": "bull_low_vol"},
+            db_path,
+        )
+        did = get_decisions(db_path=db_path)[0]["id"]
+        upsert_decision_evidence(
+            did,
+            [
+                {
+                    "source_type": "agent",
+                    "source_key": "technical",
+                    "action": "BUY",
+                    "confidence": 80.0,
+                    "detail": "{}",
+                },
+                {"source_type": "regime", "source_key": "current", "action": None, "confidence": None, "detail": "{}"},
+            ],
+            db_path,
+        )
+
+        detail = get_decision_with_evidence(did, db_path)
+        assert detail is not None
+        kinds = {e["source_type"] for e in detail["evidence"]}
+        assert "regime" in kinds, "상세 조회가 regime evidence 를 떨어뜨린다 — 화면 표식이 전부 오인 고발이 된다"
+
     def test_get_decisions_filter_ticker(self, db_path):
         upsert_decision({"date": "2026-04-10", "ticker": "NVDA", "action": "BUY", "confidence": 75.0}, db_path)
         upsert_decision({"date": "2026-04-10", "ticker": "TSLA", "action": "SELL", "confidence": 60.0}, db_path)

--- a/tests/trading/engine/test_decisions.py
+++ b/tests/trading/engine/test_decisions.py
@@ -191,6 +191,37 @@ class TestQueryDecisions:
         rows = get_decisions(db_path=db_path)
         assert len(rows) == 2
 
+    def test_get_decisions_flags_regime_without_evidence(self, db_path):
+        """`regime_has_evidence` 가 라이브 기록과 백필을 가른다 (#1303).
+
+        `record_decision` 은 regime 컬럼과 evidence 행을 **같은 조건**
+        (`if context.get("regime")`)으로 쓴다 — 라이브 행은 둘을 같이 갖는다. 백필(#1264)은
+        컬럼만 채우고 evidence 를 일부러 안 만들므로, 이 비대칭이 사후 복사를 가려낼 유일한
+        신호다. 이 플래그가 없으면 목록 화면이 둘을 구분하지 못한다.
+
+        Mutation lock: 쿼리에서 EXISTS 서브쿼리를 지우면 KeyError 로 FAIL.
+        """
+        from nuri.core.db import upsert_decision_evidence
+
+        upsert_decision(
+            {"date": "2026-04-10", "ticker": "AAA", "action": "BUY", "confidence": 70.0, "regime": "bull_low_vol"},
+            db_path,
+        )
+        upsert_decision(
+            {"date": "2026-04-10", "ticker": "BBB", "action": "BUY", "confidence": 70.0, "regime": "bull_low_vol"},
+            db_path,
+        )
+        live = [r for r in get_decisions(db_path=db_path) if r["ticker"] == "AAA"][0]
+        upsert_decision_evidence(
+            live["id"],
+            [{"source_type": "regime", "source_key": "current", "action": None, "confidence": None, "detail": "{}"}],
+            db_path,
+        )
+
+        by_ticker = {r["ticker"]: r for r in get_decisions(db_path=db_path)}
+        assert by_ticker["AAA"]["regime_has_evidence"], "라이브 기록인데 evidence 없음으로 읽힌다"
+        assert not by_ticker["BBB"]["regime_has_evidence"], "백필인데 라이브로 읽힌다"
+
     def test_get_decisions_filter_ticker(self, db_path):
         upsert_decision({"date": "2026-04-10", "ticker": "NVDA", "action": "BUY", "confidence": 75.0}, db_path)
         upsert_decision({"date": "2026-04-10", "ticker": "TSLA", "action": "SELL", "confidence": 60.0}, db_path)


### PR DESCRIPTION
Closes #1303. **Must ship before #1264's backfill runs** — the other order leaves a window where a copied value and a recorded one are indistinguishable on screen.

## Why

#1264 backfills `decisions.regime` for 591 pre-#1258 rows and **deliberately writes no `decision_evidence` row**, so an after-the-fact copy is not disguised as live evidence. That decision is right. But the warning lived only in the script docstring, while the page rendered the value plainly:

```tsx
<Metric label="Regime" value={d.regime ?? "—"} />
```

So a backfilled row would read exactly like one whose regime was recorded at decision time. For a system whose premise is *proving the basis of a recommendation rather than issuing one*, that is the wrong default.

## Why the discriminator is trustworthy

The asymmetry is the only signal available, and production confirms it is reliable: **every** row that currently carries a regime also carries its `source_type='regime'` evidence row — 54 of 54, no exceptions. So "regime present, regime evidence absent" identifies backfilled rows exactly.

## This page is the entire value of the backfill

Measured before building this:

- **Nothing reads `decisions.regime` for analysis.** `strategy_map` computes regime from prices (`date_to_regime`), not from this column. The only SQL consumer is the freshness completeness predicate.
- **That consumer is unaffected**: the 591 rows have a NULL `scoring_detail` too, so they cannot satisfy `regime IS NOT NULL AND scoring_detail IS NOT NULL` regardless. Simulated by dropping the regime condition entirely — the resulting date is unchanged (`2026-08-29`).
- §3.11's locked sample is a different column (`recommendations.source`), confirmed earlier on #1264.

So this detail page is the sole consumer, which makes its honesty the whole point.

## Verification

4 mutation axes, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| remove the marker | backfilled row shows marker |
| ignore the evidence check (brand everything backfilled) | live row shows no marker |
| typo `source_type` to `"regimes"` | live row shows no marker |
| drop the `regime != null` guard | null regime shows no marker |

4/4 locked. The second and third matter most: a marker that fires on healthy rows is worse than no marker, since it would call correctly-recorded evidence missing.

Copy goes through `strings.ts` per #1252. **140 files / 1667 tests pass**, `tsc --noEmit` clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7

---

## The list page was the other half

Codex's file sweep surfaced that `/decisions/page.tsx` also renders `{d.regime ?? "—"}`, and the list endpoint returns no evidence — so it could not tell the two apart at all.

That matters **more** there than on the detail page: after #1264 runs, most historical rows will carry a regime, so an unmarked list tells anyone scanning it that the system has had regime context all along. Shipping only the detail-page marker would have left the most-viewed surface misleading.

`get_decisions` now returns `regime_has_evidence` via an `EXISTS` subquery. The list cell is narrow and desktop-only, so it shows a short tag with the full sentence as its `title` — a bare tag would be the kind of cryptic marker this repo has ruled against, and a test asserts the title is present, not just the tag.

## The discriminator is sound by construction

Stronger than the 54/54 observation I started from: `record_decision` writes the regime **column** and the regime **evidence row** under the *same* condition —

```python
"regime": context.get("regime"),        # column
...
if context.get("regime"):               # evidence row
```

so a live row has both or neither. Backfill writes only the column. The asymmetry cannot drift.

## Final verification

9 mutation axes, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| remove the detail marker | detail: backfilled shows marker |
| ignore the evidence check | detail: live shows no marker |
| typo `source_type` | detail: live shows no marker |
| drop the `regime != null` guard | detail: null shows no marker |
| remove the `EXISTS` subquery | backend flag test |
| typo `source_type` in SQL | backend flag test |
| remove the list marker | list: backfilled shows tag |
| invert the evidence check | list: live shows no tag |
| drop the `title` (leave a cryptic tag) | list: title assertion |

9/9 locked. **140 files / 1670 tests** frontend, backend suites green, `tsc` clean, `make lint` clean.


---

## Codex review — P2 refuted the premise I built this on

I claimed the marker was **sound by construction**, because `record_decision` writes the regime column and the regime evidence row under the same `if context.get("regime")` condition. That is true of the *condition* and false of the *persistence*:

```python
upsert_decision(...)            # opens get_db(), commits
...
upsert_decision_evidence(...)   # opens its own get_db(), commits separately
```

A process death between those two commits leaves a **legitimately recorded** row with a regime and no evidence — indistinguishable in the ledger from a backfilled one. And this system dies that way for real: fd exhaustion (#778), the login-session outage (#1191).

So the marker would have accused a healthy row of being backfilled — the exact failure I had called *worse than having no marker at all* two sections above. My "54/54 in production" was evidence that it hasn't happened yet, not that it can't.

### The fix: say what was observed, not why

The copy no longer names a cause. It states the fact — **there is no decision-time evidence row for this regime** — which is true under both origins and carries the same meaning to a reader either way: *this value cannot be verified against decision-time evidence.* The long form names **both** possibilities, since naming one is itself a claim.

This is the same discipline as STRATEGY §2.6 (absence is `None`, never a fabricated value), applied to copy instead of numbers.

### Also fixed (P3)

The whole marker rests on the detail query returning `source_type='regime'` evidence unfiltered. The frontend tests mock `fetchAPI`, so they could never catch that drifting — if the query later filtered those rows out, the marker would appear on **every** row and accuse everything. A backend test now pins it.

Codex's third point was that my prompt's phrasing "nothing reads `decisions.regime`" was wrong — freshness does. The PR body already said this correctly ("the only SQL consumer is the freshness completeness predicate"); the sloppy wording was in what I asked codex, not in the change.

### Final

**12 mutation axes, 12/12 locked.** Beyond the 9 above:

| Mutation | Test that flips to FAIL |
|---|---|
| put a cause back in the short copy | honesty lock |
| drop one possibility from the long copy | honesty lock |
| make the detail query filter out regime evidence | backend API lock |

140 files / **1671 tests** frontend, backend green, `tsc` clean, `make lint` clean, cspell clean.
