### PR TITLE
fix(engine): normalize certifications.regime to the canonical vocabulary (#1293)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,829 collected across 360 files | ✅ |
+| **Backend tests** | 7,833 collected across 360 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 140 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,829 backend tests across 360 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,833 backend tests across 360 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -275,7 +275,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,829 tests, 360 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,833 tests, 360 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 140 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/engine/CLAUDE.md
+++ b/nuri/trading/engine/CLAUDE.md
@@ -73,6 +73,19 @@ fail 60h). 의도한 것이다 — 어휘 밖 라벨을 조용히 저장하는 �
 `UNKNOWN_REGIME`("unknown", 의도적으로 `ALL_REGIMES` 밖)을 정당하게 저장한다. 대상은
 **어휘가 `ALL_REGIMES` 인 컬럼**뿐이다.
 
+`certifications.regime` 도 같은 규약이다 (#1293). 가드는 `_classify_regime_fresh` 에 있는데,
+그 함수가 **두 경로의 유일한 합류점**이기 때문이다 — `CertSnapshot.regime`(`_build_snapshot`)
+도, snapshot 밖 `_current_regime()` 도 여기서 값을 받는다. `decisions.py` 와 같은 배치 원칙.
+
+이쪽이 셋 중 위험이 가장 컸다: 행수가 `decisions` 의 12배(4,525)이고, 값이
+`_check_regime_overrides` 의 `RULES...regime_overrides.get(regime, {})` 로 간다 —
+`.get` 은 어휘 밖 키에 예외도 경고도 없이 **기본값**을 준다. writer 가 유일한 방어선이다.
+
+⚠️ **이 파일의 다른 테스트들처럼 `_classify_regime_fresh` 를 mock 하면 가드를 건너뛴다.**
+가드를 검증하려면 그 **안쪽**(`classify_regime`)을 mock 할 것.
+**Test:** `tests/trading/engine/test_certification_persist.py::TestSnapshotInvariant::test_free_text_regime_is_persisted_as_null`
+(+ `::test_every_canonical_regime_survives` 대조군 — 없으면 `return None` 구현도 통과한다).
+
 `certifications.regime` 은 아직 무가드다 — 행수가 12배이고 값이 `.get(regime, {})` 로 가서
 성격이 달라 **#1293** 으로 분리했다.
 

--- a/nuri/trading/engine/certification.py
+++ b/nuri/trading/engine/certification.py
@@ -138,13 +138,24 @@ _CERT_SNAPSHOT: ContextVar[CertSnapshot | None] = ContextVar("cert_snapshot", de
 
 
 def _classify_regime_fresh(db_path=None) -> str | None:
-    """DB fresh read. certify snapshot 과 무관하게 항상 재조회 (snapshot capture 용)."""
+    """DB fresh read. certify snapshot 과 무관하게 항상 재조회 (snapshot capture 용).
+
+    반환은 **canonical 이거나 NULL** 이다 (#1293). 가드가 여기 있는 이유는 이 함수가
+    **두 경로의 유일한 합류점**이기 때문이다 — `CertSnapshot.regime` 도(`_build_snapshot`),
+    snapshot 밖 `_current_regime()` 도 여기서 값을 받는다. 호출부마다 붙이면 다음 경로가
+    생길 때 빠진다 (#1268 이 `decisions.py` 에서 택한 것과 같은 배치).
+
+    어휘 밖 값을 막아야 하는 이유는 소비자 쪽이다: `_check_regime_overrides` 가
+    `RULES...regime_overrides.get(regime, {})` 로 읽으므로, free-text 가 들어오면 예외도
+    경고도 없이 **조용히 기본값**을 받는다. `recommendations.regime` 에 `''` 와
+    `'[recovery] 비중 축소'` 가 실제로 들어와 있던 것(#832)이 이게 가정이 아니라는 증거다.
+    """
     try:
         from nuri.core.timezone import today_kst
-        from nuri.quant.regime.classifier import classify_regime
+        from nuri.quant.regime.classifier import canonical_regime_or_none, classify_regime
 
         state = classify_regime(date=today_kst(), db_path=db_path)
-        return state.regime if state else None
+        return canonical_regime_or_none(state.regime) if state else None
     except Exception as e:
         logger.warning(f"regime 조회 실패 — neutral fallback: {e}")
         return None

--- a/tests/trading/engine/test_certification_persist.py
+++ b/tests/trading/engine/test_certification_persist.py
@@ -162,6 +162,7 @@ class TestComputePortfolioHash:
         `portfolio_raw DB read 실패` 로 발생 (rows=None 경로 통과 시).
         """
         import sqlite3
+
         with patch(
             "nuri.trading.engine.certification.query",
             side_effect=sqlite3.OperationalError("database is locked"),
@@ -222,9 +223,7 @@ class TestSnapshotInvariant:
         """_persist_certification 는 snapshot dataclass 을 kwarg 로 받음 (재조회 없음)."""
         from nuri.trading.engine.certification import CertSnapshot
 
-        with patch(
-            "nuri.trading.engine.certification._persist_certification"
-        ) as mock_persist:
+        with patch("nuri.trading.engine.certification._persist_certification") as mock_persist:
             certify(db_path=populated_db_cert, caller="test")
             assert mock_persist.called
             call = mock_persist.call_args
@@ -263,6 +262,68 @@ class TestSnapshotInvariant:
         )
         # Persist 된 regime 이 classify 결과와 일치 (snapshot 을 통과했으므로)
         assert rows[0]["regime"] == "bull_low_vol"
+
+    def test_free_text_regime_is_persisted_as_null(self, populated_db_cert):
+        """어휘 밖 값은 `certifications.regime` 에 NULL 로 남는다 (#1293).
+
+        ⚠️ **`classify_regime` 을 mock 한다 — `_classify_regime_fresh` 가 아니다.**
+        후자를 mock 하면 가드를 통째로 건너뛰어 이 테스트가 아무것도 검증하지 못한다
+        (이 파일의 다른 테스트들이 그렇게 mock 하지만 목적이 다르다).
+
+        Mutation lock: `_classify_regime_fresh` 의 `canonical_regime_or_none` 을 벗기면
+        free-text 가 그대로 persist 돼 FAIL.
+        """
+        from types import SimpleNamespace
+
+        for bad in ("", "neutral", "RISK_ON", "[recovery] 비중 축소"):
+            with patch(
+                "nuri.quant.regime.classifier.classify_regime",
+                return_value=SimpleNamespace(regime=bad),
+            ):
+                certify(db_path=populated_db_cert, caller=f"guard-{bad[:6]}")
+            rows = query(
+                "SELECT regime FROM certifications WHERE caller = ? ORDER BY id DESC LIMIT 1",
+                (f"guard-{bad[:6]}",),
+                db_path=populated_db_cert,
+            )
+            assert rows[0]["regime"] is None, f"어휘 밖 {bad!r} 이 그대로 저장됐다"
+
+    def test_every_canonical_regime_survives(self, populated_db_cert):
+        """대조군 — 가드가 과해서 정상 값까지 지우면 안 된다 (#1293).
+
+        이 축이 없으면 `return None` 으로 바꾼 구현도 위 테스트를 통과한다.
+        """
+        from types import SimpleNamespace
+
+        from nuri.quant.regime.classifier import ALL_REGIMES
+
+        assert len(ALL_REGIMES) == 10, "어휘 크기가 바뀌면 이 테스트의 전제도 다시 본다"
+        for good in ALL_REGIMES:
+            with patch(
+                "nuri.quant.regime.classifier.classify_regime",
+                return_value=SimpleNamespace(regime=good),
+            ):
+                certify(db_path=populated_db_cert, caller=f"ok-{good}")
+            rows = query(
+                "SELECT regime FROM certifications WHERE caller = ? ORDER BY id DESC LIMIT 1",
+                (f"ok-{good}",),
+                db_path=populated_db_cert,
+            )
+            assert rows[0]["regime"] == good, f"canonical {good} 이 보존되지 않았다"
+
+    def test_regime_overrides_keys_are_all_canonical(self):
+        """소비자 쪽 위험을 문서화 + 잠근다 (#1293).
+
+        `_check_regime_overrides` 는 `RULES...regime_overrides.get(regime, {})` 로 읽는다.
+        `.get` 은 어휘 밖 키에 예외도 경고도 없이 **기본값**을 준다 — 그래서 writer 쪽
+        가드가 유일한 방어선이다. config 에 어휘 밖 키가 생기면 그 항목은 영원히 죽은
+        설정이 되므로 그것도 같이 막는다.
+        """
+        from nuri.core.rules import RULES
+        from nuri.quant.regime.classifier import ALL_REGIMES
+
+        keys = set((RULES.get("siege_gates", {}) or {}).get("regime_overrides", {}) or {})
+        assert keys <= set(ALL_REGIMES), f"regime_overrides 에 어휘 밖 키: {sorted(keys - set(ALL_REGIMES))}"
 
     def test_classify_regime_fresh_called_once_per_certify(self, populated_db_cert):
         """`_classify_regime_fresh` 는 certify() 당 1회만 호출 (ContextVar 우선 참조
@@ -410,6 +471,7 @@ class TestRawPortfolioSnapshot:
                 conn.execute("DELETE FROM portfolio WHERE ticker = 'TQQQ'")
 
             from nuri.trading.engine.certification import _check_leverage_ban
+
             cond = _check_leverage_ban(db_path=populated_db_cert)
             # Snapshot 에는 TQQQ 남아있어 FAIL 이어야 함
             assert cond.passed is False
@@ -430,6 +492,7 @@ class TestRawPortfolioSnapshot:
         try:
             # Mid-eval DB 비우기
             from nuri.core.db import get_db
+
             with get_db(populated_db_cert) as conn:
                 conn.execute("DELETE FROM portfolio")
 

--- a/tests/trading/engine/test_regime_canonical_guard.py
+++ b/tests/trading/engine/test_regime_canonical_guard.py
@@ -134,18 +134,20 @@ CANONICAL_VOCAB_WRITERS: dict[str, dict] = {
         "column": "decisions.regime",
         "functions": ("_snapshot_market_context",),
     },
+    # #1293 — 여기가 셋 중 위험이 가장 컸다: 행수가 decisions 의 12배(4,525)이고, 값이
+    # `regime_overrides.get(regime, {})` 라는 **조용한 기본값** 경로로 간다.
+    "trading/engine/certification.py": {
+        "column": "certifications.regime",
+        "functions": ("_classify_regime_fresh",),
+    },
 }
 
 #: 같은 어휘를 쓰는데 **아직 가드가 없는** writer. 사유와 추적 이슈를 함께 적는다.
 #: 양방향 검사라 고치고 나면 stale 로 FAIL 해서 목록 정리를 강제한다.
-KNOWN_UNGUARDED: dict[str, str] = {
-    "trading/engine/certification.py": (
-        "#1293 — `_classify_regime_fresh` 가 무가드. 이 PR 에 묶지 않는 이유는 성격이 "
-        "다르기 때문이다: 행수가 4,525 로 decisions(387)의 12배이고, 값이 "
-        "`RULES...regime_overrides.get(regime, {})` 라는 **조용한 기본값** 경로로 간다. "
-        "별도 이슈에서 동작 잠금과 함께 다뤄야 한다."
-    ),
-}
+#: 같은 어휘를 쓰는데 **아직 가드가 없는** writer. 사유와 추적 이슈를 함께 적는다.
+#: 양방향 검사라 고치고 나면 stale 로 FAIL 해서 목록 정리를 강제한다.
+#: 현재 비어 있다 — #1293 이 마지막 항목(`certification.py`)을 닫았다.
+KNOWN_UNGUARDED: dict[str, str] = {}
 
 
 class TestCanonicalVocabColumnsAreGuarded:


### PR DESCRIPTION
Closes #1293. Last of the three `ALL_REGIMES` writers to be guarded — and the one that mattered most.

## Why this one over #1268

| writer | column | rows (dev) | consumer |
|---|---|---|---|
| `tracker.py` ×2 · `consensus/persistence.py` | `recommendations.regime` | 434 | diagnostic label |
| `engine/decisions.py` | `decisions.regime` | 387 | freshness policy (#1268) |
| **`engine/certification.py`** | **`certifications.regime`** | **4,525** | **`.get(regime, {})`** |

`_check_regime_overrides` reads `RULES...regime_overrides.get(regime, {})`. `.get` hands back a **default** for an out-of-vocabulary key — no exception, no warning. The writer is the only defence.

Not hypothetical: `recommendations.regime` still holds `''` and `'[recovery] 비중 축소'` from before its guard existed (#832).

## Placement

The guard is in `_classify_regime_fresh` because that is the **single point where both paths meet** — `CertSnapshot.regime` (via `_build_snapshot`) and the snapshot-less `_current_regime()` both take their value from it. Same rule as #1268: per-callsite guards go missing the moment a new path appears.

## Inventory

`KNOWN_UNGUARDED` is now **empty**. The check is bidirectional, so leaving the entry behind would have failed as stale — that is the mechanism working as designed rather than a change I had to remember to make.

## A trap worth naming

The other tests in `test_certification_persist.py` mock `_classify_regime_fresh` **itself**, which skips the guard entirely — a test written that way would verify nothing. The new tests mock `classify_regime` *inside* it. This is recorded in the scoped `CLAUDE.md` so the next person doesn't copy the wrong pattern.

The control case matters just as much: without "all ten canonical values survive", a `return None` implementation passes the free-text test perfectly.

## Verification

3 mutation axes, each with an asserted replacement count **and** a node-collection pre-check:

| Mutation | Test that flips to FAIL |
|---|---|
| drop the guard (free-text persists) | `test_free_text_regime_is_persisted_as_null` |
| over-guard (`return None`) | `test_every_canonical_regime_survives` |
| remove the inventory entry | `test_inventory_matches_the_code` |

3/3 locked. A third test pins the consumer side too — every key in `regime_overrides` must itself be canonical, so a typo there cannot become permanently dead config.

`tests/trading/engine/`: **437 passed**. `make lint` clean.

Behavioural impact today: none — measured, free-text and `None` both yield multiplier 1.0. What changes is what gets persisted into an audit column and surfaced by `nuri/api/routes/engine.py`'s `by_regime` / `?regime=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7