### PR TITLE
refactor(frontend): page headings + specs share the route label key (#1300)

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1671 tests, 140 files)
+npm run test           # vitest run (1673 tests, 140 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name

--- a/frontend/src/__tests__/components/sidebar.test.tsx
+++ b/frontend/src/__tests__/components/sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Sidebar } from "@/components/ui/sidebar";
+import { NAV } from "@/lib/strings";
 
 // Mock @/lib/api
 vi.mock("@/lib/api", () => ({
@@ -81,20 +82,20 @@ describe("Sidebar", () => {
 
   it("renders all navigation items", () => {
     render(<Sidebar />);
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
-    expect(screen.getByText("Pipeline")).toBeInTheDocument();
-    expect(screen.getByText("Portfolio")).toBeInTheDocument();
-    expect(screen.getByText("Signals")).toBeInTheDocument();
-    expect(screen.getByText("Agents")).toBeInTheDocument();
-    expect(screen.getByText("Scanner")).toBeInTheDocument();
-    expect(screen.getByText("Price Targets")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_DASHBOARD)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_PIPELINE)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_PORTFOLIO)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_SIGNALS)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_AGENTS)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_SCANNER)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_TARGETS)).toBeInTheDocument();
     // #1227: Advisor 는 /rebalance 로 통합 — 재추가되면 FAIL (IA 병합 잠금)
     expect(screen.queryByText("Advisor")).not.toBeInTheDocument();
-    expect(screen.getByText("Strategy")).toBeInTheDocument();
-    expect(screen.getByText("Rebalance")).toBeInTheDocument();
-    expect(screen.getByText("Certification Engine")).toBeInTheDocument();
-    expect(screen.getByText("Evidence")).toBeInTheDocument();
-    expect(screen.getByText("AI Report")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_STRATEGY)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_REBALANCE)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_ENGINE)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_EVIDENCE)).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_REPORT)).toBeInTheDocument();
   });
 
   it("highlights active nav item", () => {
@@ -135,7 +136,7 @@ describe("Sidebar", () => {
 
   it("shows System Online indicator", () => {
     render(<Sidebar />);
-    expect(screen.getByText("System Online")).toBeInTheDocument();
+    expect(screen.getByText(NAV.SYSTEM_ONLINE)).toBeInTheDocument();
   });
 
   it("does not render SIEGE badge (moved to dashboard)", async () => {

--- a/frontend/src/__tests__/coverage/sidebar-branch-coverage.test.tsx
+++ b/frontend/src/__tests__/coverage/sidebar-branch-coverage.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { NAV } from "@/lib/strings";
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
@@ -86,7 +87,7 @@ describe("Sidebar — collapsed state and branch coverage", () => {
     expect(screen.getByText("시스템")).toBeInTheDocument();
 
     // Current page "/" — Dashboard link should exist
-    const dashLink = screen.getByText("Dashboard");
+    const dashLink = screen.getByText(NAV.ROUTE_DASHBOARD);
     expect(dashLink).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/coverage/strategy-page-coverage.test.tsx
+++ b/frontend/src/__tests__/coverage/strategy-page-coverage.test.tsx
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { NAV } from "@/lib/strings";
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
@@ -65,7 +66,7 @@ describe("Strategy page branches", () => {
 
     const Page = await import("@/app/strategy/page");
     await act(async () => { render(<Page.default />); });
-    await waitFor(() => { expect(screen.getByText("Strategy")).toBeInTheDocument(); });
+    await waitFor(() => { expect(screen.getByText(NAV.ROUTE_STRATEGY)).toBeInTheDocument(); });
     expect(screen.queryByText(/confidence/)).not.toBeInTheDocument();
     expect(screen.queryByText(/^Long \d/)).not.toBeInTheDocument();
   });

--- a/frontend/src/__tests__/lib/strings-ssot.test.ts
+++ b/frontend/src/__tests__/lib/strings-ssot.test.ts
@@ -18,6 +18,16 @@ import { describe, expect, it } from "vitest";
 import { NAV, PIPELINE, ACTION, CONTEXT, OPPORTUNITY } from "@/lib/strings";
 
 /** 이관 대상 (#1252 이 지목한 파일). */
+/** 라우트 라벨을 헤딩으로 쓰는 페이지 (#1300) — 리터럴 복귀를 여기서 막는다. */
+const ROUTE_HEADING_PAGES: Record<string, keyof typeof NAV> = {
+  "src/app/engine/page.tsx": "ROUTE_ENGINE",
+  "src/app/consensus/page.tsx": "ROUTE_AGENTS",
+  "src/app/explore/page.tsx": "ROUTE_EXPLORE",
+  "src/app/signals/page.tsx": "ROUTE_SIGNALS",
+  "src/app/strategy/page.tsx": "ROUTE_STRATEGY",
+  "src/app/targets/page.tsx": "ROUTE_TARGETS",
+};
+
 const MIGRATED = [
   "src/components/ui/sidebar.tsx",
   "src/app/pipeline/page.tsx",
@@ -76,6 +86,27 @@ describe("사용자 카피는 strings.ts SSoT 를 거친다 (#1252)", () => {
     ];
     const pipeOffenders = nodeCopy.filter((v) => pipe.includes(`"${v}"`));
     expect(pipeOffenders, `pipeline 에 리터럴로 남은 노드 카피: ${pipeOffenders.join(", ")}`).toHaveLength(0);
+  });
+
+  it("페이지 헤딩이 라우트 라벨을 리터럴로 되돌리지 않았다", () => {
+    // #1300: 헤딩과 내비가 **같은 개념**(이 페이지의 이름)이라 키를 공유한다. 한쪽만
+    // 리터럴로 되돌리면 이름이 두 벌이 되고, 그 순간부터 조용히 갈라진다.
+    const offenders: string[] = [];
+    for (const [rel, key] of Object.entries(ROUTE_HEADING_PAGES)) {
+      const src = read(rel);
+      if (src.includes(`>${NAV[key]}</h1>`)) offenders.push(`${rel} (${NAV[key]})`);
+      if (!src.includes(`NAV.${key}`)) offenders.push(`${rel}: NAV.${key} 참조 없음`);
+    }
+    expect(offenders, `헤딩이 SSoT 를 안 쓴다:\n${offenders.join("\n")}`).toHaveLength(0);
+  });
+
+  it("차트 계열명은 라우트 라벨과 묶지 않는다", () => {
+    // `EquityCurveChart` 범례의 "Strategy" 는 SPY·Drawdown 과 나란한 **계열 이름**이지
+    // 내비 항목이 아니다. 문자열이 같다는 이유로 NAV.ROUTE_STRATEGY 에 묶으면 라우트
+    // 이름을 바꿀 때 차트 범례가 따라 바뀐다 — 우연한 일치를 계약으로 굳히는 것.
+    const chart = read("src/components/ui/equity-curve-chart.tsx");
+    expect(chart).toContain('"Strategy"');
+    expect(chart, "차트가 NAV 를 참조하기 시작했다 — 계열명과 라우트가 묶였다").not.toContain("NAV.");
   });
 
   it("이관한 키가 실제로 SSoT 에 있다", () => {

--- a/frontend/src/__tests__/pages/consensus.test.tsx
+++ b/frontend/src/__tests__/pages/consensus.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import { NAV } from "@/lib/strings";
 
 // Mock next/link
 vi.mock("next/link", () => ({
@@ -74,7 +75,7 @@ describe("ConsensusPage", () => {
       render(<ConsensusPage />);
     });
 
-    expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_AGENTS)).toBeInTheDocument();
   });
 
   it("renders consensus verdict count summary", async () => {

--- a/frontend/src/__tests__/pages/engine.test.tsx
+++ b/frontend/src/__tests__/pages/engine.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { NAV } from "@/lib/strings";
 
 // Mock next/link — 반드시 전체 props spread (#1218: children/href 만 넘기면 data-testid 소실)
 vi.mock("next/link", () => ({
@@ -91,7 +92,7 @@ describe("EnginePage", () => {
     const Page = await import("@/app/engine/page");
     const element = await Page.default();
     render(element);
-    expect(screen.getByText("Certification Engine")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_ENGINE)).toBeInTheDocument();
   });
 
   it("renders gate section with conditions", async () => {
@@ -107,7 +108,7 @@ describe("EnginePage", () => {
     // We render the full page which uses Suspense — the server components resolve inline
     const element = await mod.default();
     render(element);
-    expect(screen.getByText("Certification Engine")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_ENGINE)).toBeInTheDocument();
   });
 
   // #1218: BLOCKED 페이즈만 다음 행동 링크(/pipeline) — READY 는 없다
@@ -149,7 +150,7 @@ describe("EnginePage", () => {
     const mod = await import("@/app/engine/page");
     const element = await mod.default();
     render(element);
-    expect(screen.getByText("Certification Engine")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_ENGINE)).toBeInTheDocument();
   });
 
   it("renders conflict details when conflicts exist", async () => {

--- a/frontend/src/__tests__/pages/pipeline.test.tsx
+++ b/frontend/src/__tests__/pages/pipeline.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
-import { PIPELINE as PL } from "@/lib/strings";
+import { PIPELINE as PL, NAV } from "@/lib/strings";
 
 // Mock @xyflow/react
 vi.mock("@xyflow/react", () => ({
@@ -98,7 +98,7 @@ describe("PipelinePage", () => {
     await act(async () => {
       render(<PipelinePage />);
     });
-    expect(screen.getByText("Pipeline")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_PIPELINE)).toBeInTheDocument();
   });
 
   it("renders ReactFlow canvas", async () => {

--- a/frontend/src/__tests__/pages/signals.test.tsx
+++ b/frontend/src/__tests__/pages/signals.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import { NAV } from "@/lib/strings";
 
 // Mock next/link
 vi.mock("next/link", () => ({
@@ -57,7 +58,7 @@ describe("SignalsPage", () => {
       render(<SignalsPage />);
     });
 
-    expect(screen.getByText("Signals")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_SIGNALS)).toBeInTheDocument();
   });
 
   it("renders scorecard date label", async () => {
@@ -105,7 +106,7 @@ describe("SignalsPage", () => {
       render(<SignalsPage />);
     });
 
-    expect(screen.getByText("Signals")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_SIGNALS)).toBeInTheDocument();
   });
 
   it("hides cross-analysis when error returned", async () => {

--- a/frontend/src/__tests__/pages/strategy.test.tsx
+++ b/frontend/src/__tests__/pages/strategy.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
+import { NAV } from "@/lib/strings";
 
 // Mock next/link
 vi.mock("next/link", () => ({
@@ -97,7 +98,7 @@ describe("StrategyPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Strategy")).toBeInTheDocument();
+      expect(screen.getByText(NAV.ROUTE_STRATEGY)).toBeInTheDocument();
     });
   });
 
@@ -205,7 +206,7 @@ describe("StrategyPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Strategy")).toBeInTheDocument();
+      expect(screen.getByText(NAV.ROUTE_STRATEGY)).toBeInTheDocument();
     });
 
     expect(screen.queryByText("Open Positions")).not.toBeInTheDocument();

--- a/frontend/src/__tests__/pages/targets.test.tsx
+++ b/frontend/src/__tests__/pages/targets.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, act } from "@testing-library/react";
-import { COMMON } from "@/lib/strings";
+import { COMMON, NAV } from "@/lib/strings";
 
 // Mock next/link
 vi.mock("next/link", () => ({
@@ -61,7 +61,7 @@ describe("TargetsPage", () => {
       render(<TargetsPage />);
     });
 
-    expect(screen.getByText("Price Targets")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_TARGETS)).toBeInTheDocument();
     expect(screen.getByText(/전 종목 매수가/)).toBeInTheDocument();
   });
 

--- a/frontend/src/app/consensus/page.tsx
+++ b/frontend/src/app/consensus/page.tsx
@@ -5,7 +5,7 @@ import { fetchAPI } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { ConsensusTable, type ConsensusRow } from "@/components/ui/consensus-table";
 import { StatusBadge } from "@/components/ui/status-badge";
-import { COMMON, CONSENSUS as CS } from "@/lib/strings";
+import { COMMON, CONSENSUS as CS, NAV } from "@/lib/strings";
 
 export function VixBanner({ vix }: { vix: number | null }) {
   if (!vix || vix < 25) return null;
@@ -95,7 +95,7 @@ function Loading() { return <div className="h-48 bg-card rounded-xl border borde
 export default function ConsensusPage() {
   return (
     <div className="space-y-5">
-      <h1 className="text-2xl font-bold">Agents</h1>
+      <h1 className="text-2xl font-bold">{NAV.ROUTE_AGENTS}</h1>
       <Suspense fallback={<Loading />}><ConsensusSection /></Suspense>
       <Suspense fallback={<Loading />}><DissentSection /></Suspense>
     </div>

--- a/frontend/src/app/engine/page.coverage.test.tsx
+++ b/frontend/src/app/engine/page.coverage.test.tsx
@@ -41,6 +41,7 @@ import {
 } from "./page";
 import EnginePage from "./page";
 import { fetchAPI } from "@/lib/api";
+import { NAV } from "@/lib/strings";
 
 const mockFetchAPI = vi.mocked(fetchAPI);
 
@@ -197,6 +198,6 @@ describe("engine/page sections (coverage)", () => {
 
     // 정적 헤더는 동기 렌더; Suspense fallback(Loading) 가 마운트되어 default export +
     // Loading 컴포넌트 statement 를 커버한다.
-    expect(screen.getByText("Certification Engine")).toBeInTheDocument();
+    expect(screen.getByText(NAV.ROUTE_ENGINE)).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/engine/page.tsx
+++ b/frontend/src/app/engine/page.tsx
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import { Suspense } from "react";
 import Link from "next/link";
 import { fetchAPI } from "@/lib/api";
-import { COMMON, ENGINE } from "@/lib/strings";
+import { COMMON, ENGINE, NAV } from "@/lib/strings";
 import { Card, CardContent } from "@/components/ui/card";
 import { ClientTable } from "@/components/ui/client-table";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -209,7 +209,7 @@ function Loading() {
 export default function EnginePage() {
   return (
     <div className="space-y-5">
-      <h1 className="text-2xl font-bold">Certification Engine</h1>
+      <h1 className="text-2xl font-bold">{NAV.ROUTE_ENGINE}</h1>
 
       {/* V2 — SIEGE history 관찰 loop (E4-0a persist + V1 API 소비) */}
       <Suspense fallback={<Loading />}>

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { Lightbulb } from "lucide-react";
 import { fetchAPI } from "@/lib/api";
 import { StatusBadge } from "@/components/ui/status-badge";
-import { EXPLORE, REGIME_GUIDE } from "@/lib/strings";
+import { EXPLORE, REGIME_GUIDE, NAV } from "@/lib/strings";
 import { trendKo, vixZone, fgLabel, macroLevel, signalKo, formatPrice, formatDelta, tickerDisplay, POPULAR_US, POPULAR_KR } from "./helpers";
 
 // ── Types ──
@@ -202,7 +202,7 @@ export default function ExplorePage() {
   return (
     <div className="flex flex-col gap-5 max-w-4xl">
       <div>
-        <h1 className="text-lg font-semibold">Explore</h1>
+        <h1 className="text-lg font-semibold">{NAV.ROUTE_EXPLORE}</h1>
         <p className="text-xs text-muted-foreground mt-1">
           {EXPLORE.SEARCH_HINT}
         </p>

--- a/frontend/src/app/signals/page.tsx
+++ b/frontend/src/app/signals/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { Suspense } from "react";
 import { fetchAPI } from "@/lib/api";
-import { ERRORS } from "@/lib/strings";
+import { ERRORS, NAV } from "@/lib/strings";
 import { Card, CardContent } from "@/components/ui/card";
 import { ClientTable } from "@/components/ui/client-table";
 
@@ -80,7 +80,7 @@ function Loading() { return <div className="h-48 bg-card rounded-xl border borde
 export default function SignalsPage() {
   return (
     <div className="space-y-5">
-      <h1 className="text-2xl font-bold">Signals</h1>
+      <h1 className="text-2xl font-bold">{NAV.ROUTE_SIGNALS}</h1>
       <Suspense fallback={<Loading />}><ScorecardSection /></Suspense>
       <Suspense fallback={<Loading />}><CrossSection /></Suspense>
     </div>

--- a/frontend/src/app/strategy/page.tsx
+++ b/frontend/src/app/strategy/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { Suspense } from "react";
 import { fetchAPI } from "@/lib/api";
-import { COMMON } from "@/lib/strings";
+import { COMMON, NAV } from "@/lib/strings";
 import { Card, CardContent } from "@/components/ui/card";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { InteractiveBacktestLazy as InteractiveBacktest, type EquityPoint, type BacktestMetrics } from "@/components/ui/interactive-backtest-lazy";
@@ -93,7 +93,7 @@ export async function StrategyDashboard() {
 
   return (
     <div className="space-y-5">
-      <h1 className="text-2xl font-bold">Strategy</h1>
+      <h1 className="text-2xl font-bold">{NAV.ROUTE_STRATEGY}</h1>
 
       {/* ── Row 1: Regime + Allocation + Actions ── */}
       <Card className="bg-card border-border">

--- a/frontend/src/app/targets/page.tsx
+++ b/frontend/src/app/targets/page.tsx
@@ -5,7 +5,7 @@ import { fetchAPI } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { ClientTable } from "@/components/ui/client-table";
 import { Metric } from "@/components/ui/metric";
-import { TARGETS as T, COMMON } from "@/lib/strings";
+import { TARGETS as T, COMMON, NAV } from "@/lib/strings";
 
 // === Types ===
 interface PriceTarget {
@@ -75,7 +75,7 @@ export default function TargetsPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-lg font-semibold">Price Targets</h1>
+        <h1 className="text-lg font-semibold">{NAV.ROUTE_TARGETS}</h1>
         <p className="text-xs text-muted-foreground mt-1">
           {T.SUBTITLE}
         </p>

--- a/frontend/src/components/ui/sidebar.coverage.test.tsx
+++ b/frontend/src/components/ui/sidebar.coverage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Sidebar } from "./sidebar";
+import { NAV } from "@/lib/strings";
 
 // next/navigation: usePathname is the only nav hook the component uses.
 vi.mock("next/navigation", () => ({
@@ -12,7 +13,7 @@ describe("Sidebar — dark-only footer (#1195 U1a)", () => {
     render(<Sidebar />);
     // Expanded shows the full brand label.
     expect(screen.getByText("Nuri-Quant")).toBeInTheDocument();
-    expect(screen.getByText("System Online")).toBeInTheDocument();
+    expect(screen.getByText(NAV.SYSTEM_ONLINE)).toBeInTheDocument();
   });
 
   // 잠금 (codex P2): 제품은 dark-only (frontend/CLAUDE.md). 테마 토글이 되살아나면


### PR DESCRIPTION
Closes #1300. Follow-up to #1252, which moved copy into `strings.ts` but left the same strings duplicated elsewhere.

## The decision this issue required

#1300 asked whether a page heading and its nav label are **the same concept**. Measured rather than assumed — all six are byte-identical:

| route | nav | `<h1>` |
|---|---|---|
| `/engine` | Certification Engine | Certification Engine |
| `/consensus` | Agents | Agents |
| `/explore` | Explore | Explore |
| `/signals` | Signals | Signals |
| `/strategy` | Strategy | Strategy |
| `/targets` | Price Targets | Price Targets |

They name the same thing — *what this page is called* — so they share `NAV.ROUTE_*`. A rename becomes one edit, and if a heading ever needs to diverge, splitting the key becomes a deliberate act instead of silent drift.

## Specs

27 assertions held route labels as literals. That is what `frontend/CLAUDE.md` forbids for e2e, and the reason is on record: three assertions died silently for 3.5 months after a rename (#1118). The rule applies to vitest for exactly the same reason.

## Two matches deliberately left alone

`charts.test.tsx` and `equity-curve-chart-coverage.test.tsx` assert `"Strategy"` as the **EquityCurve legend's series name**, sitting beside `"SPY"` and `"Drawdown"`. That string equals a route label by coincidence. Binding it to `NAV.ROUTE_STRATEGY` would make renaming a route change a chart legend — turning an accident into a contract.

A test now states that explicitly: the chart must **not** reference `NAV`. Without it, the next person tidying up would reasonably "fix" the inconsistency.

## Also out of scope, with reason

`client-table.tsx` was on the issue's list, but its `label: "Signals"` is a **table column header** meaning *signal list*, not the route — and its neighbours (`현재가`, `손절가`, `1차 익절`) differ from the peek labels they resemble (`손절` vs `손절가`). Migrating it properly means a column-label SSoT for ~20 headers, which is a different concern from route naming. Left for its own issue rather than folded in.

## Verification

3 mutation axes, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| put a heading literal back | heading sweep |
| remove the key reference without adding a literal | heading sweep (bidirectional) |
| bind the chart series to `NAV.ROUTE_STRATEGY` | series-separation lock |

3/3 locked. The second matters: deleting the literal without wiring the key would otherwise look clean.

**140 files / 1673 tests pass**, `tsc --noEmit` clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7