### PR TITLE
style(frontend): guard the composition palette's "Other" colour (#1301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 |--------|-------|---|
 | **Backend tests** | 7,850 collected across 361 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
-| **Frontend tests** | 1,648 across 140 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
+| **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
 | **Pipeline stages** | 5 as a data model; 1 of them (certify) has no scheduler job of its own | |
 | **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,850 backend tests across 361 files + 1622 frontend vitest (140 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,850 backend tests across 361 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -277,7 +277,7 @@ PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
 | Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,850 tests, 361 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
-| Frontend tests | 목표 ≥ 90% | 1606 tests, 140 files |
+| Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |
 | 네트워크 | 금지 | conftest.py mock |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,7 +13,7 @@ Next.js 16 + React 19 + Tailwind CSS 4 + shadcn/ui. Dark-only theme (zinc-950 ba
 ```bash
 npm run dev            # Dev server (:3000)
 npm run build          # Production build (type-check + compile)
-npm run test           # vitest run (1673 tests, 140 files)
+npm run test           # vitest run (1679 tests, 141 files)
 npm run test:e2e       # playwright (real backend — see "E2E (Playwright)" below)
 npx vitest run src/__tests__/pages/dashboard.test.tsx  # single file
 npx vitest run -t "renders verdict"                    # single test by name
@@ -108,4 +108,4 @@ should be **249**.
 - **vi.mock("recharts") hoisting**: Affects ALL dynamic imports in same vitest worker. Keep recharts-dependent and recharts-free tests in **separate files**. Use `vi.doMock` for per-test control. (#1210 이후 대시보드 트리는 recharts 무관 — price/equity/siege/gate 차트 테스트에만 해당.)
 - Mock `@/lib/api` + `next/navigation` in all page tests.
 - **`window.localStorage` 는 환경 의존**: 로컬 Node 26 jsdom 엔 **없고**(실험적 webstorage 게터가 `--localstorage-file` 없이 undefined), CI Node 22 jsdom 은 **실동작 스토리지**를 제공해 같은 파일 내 테스트 간 상태가 지속된다. 로컬 초록 ≠ CI 초록 — storage 를 쓰는 테스트는 인메모리 스텁 + `beforeEach` 초기화로 결정론화할 것 (CI run 32814106230, #1212). **Test:** `src/__tests__/components/action-items.test.tsx::NEW badge + ack (#1212)` — describe 레벨 스텁이 빠지면 CI 에서 ack 누수로 FAIL.
-- Test files: 104 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).
+- Test files: 105 in `src/__tests__/` (`components/lib/pages/coverage` subdirs + root `api-auth`/`middleware` tests) + 36 co-located next to sources (`src/app/**`, `src/components/ui/**`, `src/lib/**` — `*.coverage.test.tsx` / `*.branchcov.test.tsx`).

--- a/frontend/src/__tests__/components/chart-design-tokens.test.tsx
+++ b/frontend/src/__tests__/components/chart-design-tokens.test.tsx
@@ -67,6 +67,21 @@ const NEUTRAL_HEX = /#(?:fafafa|f4f4f5|e4e4e7|d4d4d8|a1a1aa|71717a|52525b|3f3f46
 /** 같은 이탈의 Tailwind 클래스 문법. hex 스윕만으로는 절반만 잡힌다. */
 const ZINC_CLASS = /\b(?:bg|text|border|fill|stroke|from|to|via)-zinc-\d{2,3}\b/g;
 
+/**
+ * 선언된 계열 팔레트를 걷어낸다 (#1301). 예외를 allowlist 가 아니라 **구조**로 두기 위해서다 —
+ * 팔레트 밖에 색이 생기면 그 순간 스윕에 걸린다.
+ */
+function stripSeriesPalette(src: string): string {
+  return (
+    src
+      // 주석은 선언이 아니다 — 이 파일의 JSDoc 이 측정값으로 hex 를 **인용**한다.
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "")
+      .replace(/export const [A-Z_]+ = \[[\s\S]*?\] as const;/g, "")
+      .replace(/export const OTHER_COLOR = "[^"]*";/g, "")
+  );
+}
+
 const CHART_FILES = [
   "src/components/ui/gate-failure-chart.tsx",
   "src/components/ui/equity-curve-chart.tsx",
@@ -141,6 +156,29 @@ describe("차트 레이어는 다크 토큰을 쓴다 (#1275)", () => {
       if (found.length) offenders.push(`${rel}: ${found.join(", ")}`);
     }
     expect(offenders, `zinc 클래스 잔존:\n${offenders.join("\n")}`).toHaveLength(0);
+  });
+
+  it("holdings-summary 도 스윕이 본다 — 선언된 계열 팔레트만 예외 (#1301)", () => {
+    // #1275 는 이 파일을 범위 밖에 뒀고, 그래서 여기 색값은 **어떤 게이트도 안 봤다**.
+    // 팔레트는 의미를 담은 계열색이라 정당하지만(측정 근거는 `holdings-summary-palette.test.ts`),
+    // 그 **밖에** 새로 박히는 중립 hex 는 잡아야 한다.
+    //
+    // 예외를 allowlist 로 두지 않고 **선언을 걷어낸 나머지**를 스윕한다 — allowlist 는
+    // 항목이 낡아도 조용하지만, 이 방식은 팔레트 밖에 색이 생기는 순간 걸린다.
+    const src = readFileSync(join(process.cwd(), "src/lib/holdings-summary.ts"), "utf8");
+    const outsidePalette = stripSeriesPalette(src);
+    const found = outsidePalette.match(NEUTRAL_HEX) ?? [];
+    expect(found, `팔레트 밖 중립 hex: ${found.join(", ")}`).toHaveLength(0);
+  });
+
+  it("팔레트 제거가 파일 전체를 지우지 않는다 (canary)", () => {
+    // 제거가 과하면 위 검사는 빈 문자열을 스윕하며 영원히 초록이다.
+    const src = readFileSync(join(process.cwd(), "src/lib/holdings-summary.ts"), "utf8");
+    const stripped = stripSeriesPalette(src);
+    expect(stripped).toContain("summarizeHoldings");
+    expect(stripped).not.toContain("#71717a");
+    // 팔레트 밖에 놓인 중립 hex 는 실제로 잡힌다.
+    expect(stripSeriesPalette('const x = "#27272a";').match(NEUTRAL_HEX)).toEqual(["#27272a"]);
   });
 
   it("스윕이 실제로 눈이 있고, 계열색까지 잡지는 않는다 (canary)", () => {

--- a/frontend/src/__tests__/components/composition-section.test.tsx
+++ b/frontend/src/__tests__/components/composition-section.test.tsx
@@ -14,6 +14,7 @@ import {
   parseCompositionTab,
 } from "@/components/ui/composition-section";
 import type { HoldingsSummary } from "@/lib/holdings-summary";
+import { OTHER_COLOR } from "@/lib/holdings-summary";
 
 function summary(over: Partial<HoldingsSummary> = {}): HoldingsSummary {
   return {
@@ -129,7 +130,7 @@ describe("CompositionSection", () => {
             { name: "Semi", weight: 25, valueUsd: 3000, dailyDeltaPct: -0.5, color: "#60a5fa" },
             { name: "ETF", weight: 15, valueUsd: 2000, dailyDeltaPct: null, color: "#f472b6" },
             { name: "Bio", weight: 12, valueUsd: 1500, dailyDeltaPct: 0.2, color: "#a78bfa" },
-            { name: "Other", weight: 8, valueUsd: 1000, dailyDeltaPct: null, color: "#71717a" },
+            { name: "Other", weight: 8, valueUsd: 1000, dailyDeltaPct: null, color: OTHER_COLOR },
           ],
         })}
         totalUsd={12500}

--- a/frontend/src/__tests__/components/holdings-summary-panel.test.tsx
+++ b/frontend/src/__tests__/components/holdings-summary-panel.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from "@testing-library/react";
 // barlist) so this test file doesn't need any chart mocks anymore.
 import { HoldingsSummaryPanel } from "@/components/ui/holdings-summary-panel";
 import type { HoldingsSummary } from "@/lib/holdings-summary";
+import { OTHER_COLOR } from "@/lib/holdings-summary";
 
 function baseSummary(over: Partial<HoldingsSummary> = {}): HoldingsSummary {
   return {
@@ -25,7 +26,7 @@ function baseSummary(over: Partial<HoldingsSummary> = {}): HoldingsSummary {
       { name: "Semi", weight: 28, valueUsd: 21000, dailyDeltaPct: 1.5, color: "#34d399" },
       { name: "BigTech", weight: 19, valueUsd: 14000, dailyDeltaPct: 0.3, color: "#60a5fa" },
       { name: "ETF", weight: 12, valueUsd: 9000, dailyDeltaPct: -0.1, color: "#f472b6" },
-      { name: "Other", weight: 41, valueUsd: 30000, dailyDeltaPct: null, color: "#71717a" },
+      { name: "Other", weight: 41, valueUsd: 30000, dailyDeltaPct: null, color: OTHER_COLOR },
     ],
     topMovers: {
       winners: [

--- a/frontend/src/__tests__/lib/holdings-summary-palette.test.ts
+++ b/frontend/src/__tests__/lib/holdings-summary-palette.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #1301 — composition 팔레트의 "기타" 색이 **형제 뒤로 물러나는지**.
+ *
+ * #1275 가 차트 크롬을 토큰으로 옮길 때 `holdings-summary.ts` 는 범위 밖이었고, 그래서
+ * 이 파일의 색값은 **어떤 게이트도 보지 않았다** — 그게 #1301 이 지적한 결함이다.
+ *
+ * 다만 고치는 방향이 이슈의 가정과 달랐다. 이슈는 `var(--muted-foreground)` 를 유력 후보로
+ * 봤지만 측정이 그걸 기각한다 (다크 `--card` `#1C2127` 기준):
+ *
+ *   `#71717a` (현행)          L 0.167  ← 형제(cyan-400 L 0.531)들 뒤로 물러남
+ *   `var(--muted-foreground)` L 0.447  ← 형제와 **대등**해져 "기타" 가 앞으로 나온다
+ *   `var(--muted)`            L 0.023  ← 사실상 안 보인다
+ *
+ * 그래서 값은 계열색으로 남기고 **요구사항 자체를 잠근다.** 색을 고르는 사람이 바뀌어도
+ * "기타는 명명된 종목보다 어둡다" 는 계약은 여기서 깨진다.
+ */
+import { describe, expect, it } from "vitest";
+import { OTHER_COLOR, SECTOR_COLORS, TICKER_COLORS } from "@/lib/holdings-summary";
+
+/** WCAG 상대 밝기. 대비비가 아니라 **밝기**를 보는 이유는 위계가 밝기 순서이기 때문이다. */
+function luminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+  const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+const SIBLINGS = [...SECTOR_COLORS, ...TICKER_COLORS];
+
+describe("composition 팔레트 (#1301)", () => {
+  it("'기타' 는 명명된 조각 전부보다 어둡다", () => {
+    // 이게 이 색의 **요구사항**이다 — 토큰이냐 hex 냐보다 이쪽이 계약이다.
+    const other = luminance(OTHER_COLOR);
+    const brightest = Math.min(...SIBLINGS.map(luminance));
+    expect(other, `기타(${OTHER_COLOR}, L=${other.toFixed(3)}) 가 형제만큼 밝다`).toBeLessThan(brightest);
+  });
+
+  it("그렇다고 보이지 않을 만큼 어둡지도 않다", () => {
+    // 반대 방향 — `var(--muted)`(L 0.023) 류로 내려가면 조각이 배경에 묻힌다.
+    expect(luminance(OTHER_COLOR)).toBeGreaterThan(0.05);
+  });
+
+  it("팔레트에 중복 색이 없다", () => {
+    // 같은 색 두 조각은 범례를 무의미하게 만든다. 팔레트를 손볼 때 흔한 실수다.
+    for (const [name, palette] of [
+      ["SECTOR_COLORS", SECTOR_COLORS],
+      ["TICKER_COLORS", TICKER_COLORS],
+    ] as [string, readonly string[]][]) {
+      expect(new Set(palette).size, `${name} 에 중복 색`).toBe(palette.length);
+    }
+    expect(SIBLINGS).not.toContain(OTHER_COLOR);
+  });
+
+  it("밝기 계산이 실제로 구분한다 (canary)", () => {
+    // 함수가 상수를 돌려주면 위 검사들이 전부 공허하게 통과한다.
+    expect(luminance("#ffffff")).toBeGreaterThan(luminance("#000000"));
+    expect(luminance("#ABB3BF")).toBeGreaterThan(luminance("#71717a"));
+  });
+});

--- a/frontend/src/__tests__/lib/holdings-summary.branchcov.test.ts
+++ b/frontend/src/__tests__/lib/holdings-summary.branchcov.test.ts
@@ -21,7 +21,7 @@
  * *.coverage.test.* to avoid shared-worker mock leakage.
  */
 import { describe, it, expect } from "vitest";
-import { summarizeHoldings } from "@/lib/holdings-summary";
+import { summarizeHoldings, OTHER_COLOR } from "@/lib/holdings-summary";
 import type { EnrichedHolding } from "@/components/ui/holding-row";
 import type { SummarizeOptions } from "@/lib/holdings-summary";
 
@@ -78,7 +78,6 @@ describe("holdings-summary branch coverage top-up", () => {
   it("byAccount falls back to OTHER_COLOR for the 6th account (line 280)", () => {
     // SECTOR_COLORS has 5 entries (i 0..4). The 6th account (i === 5) must use
     // OTHER_COLOR via the `?? OTHER_COLOR` fallback.
-    const OTHER_COLOR = "#71717a"; // zinc-500 (mirrors source constant)
     const SECTOR_COLORS = ["#34d399", "#60a5fa", "#f472b6", "#fbbf24", "#a78bfa"];
 
     const accountValues = [

--- a/frontend/src/lib/holdings-summary.ts
+++ b/frontend/src/lib/holdings-summary.ts
@@ -152,7 +152,7 @@ export interface SummarizeOptions {
 }
 
 // Palette — tailwind 400-level shades so the donut reads against zinc-950.
-const SECTOR_COLORS = [
+export const SECTOR_COLORS = [
   "#34d399", // emerald-400
   "#60a5fa", // blue-400
   "#f472b6", // pink-400
@@ -160,7 +160,7 @@ const SECTOR_COLORS = [
   "#a78bfa", // violet-400
 ] as const;
 // Larger palette for ticker-level composition (12 distinct colors for top 12).
-const TICKER_COLORS = [
+export const TICKER_COLORS = [
   "#34d399", // emerald-400
   "#60a5fa", // blue-400
   "#f472b6", // pink-400
@@ -174,7 +174,21 @@ const TICKER_COLORS = [
   "#fb923c", // orange-400
   "#e879f9", // fuchsia-400
 ] as const;
-const OTHER_COLOR = "#71717a"; // zinc-500
+/**
+ * "기타" 조각 색 (#1301). **의도적으로 토큰이 아니다.**
+ *
+ * 위 팔레트들과 같은 **계열색**이지 크롬이 아니다 — #1275 가 차트 크롬을 토큰으로 옮기면서
+ * 의미를 담은 계열색은 정당하다고 판정한 그 부류다. 토큰 후보 둘 다 측정으로 기각됐다
+ * (다크 `--card` `#1C2127` 기준 대비 / 상대 밝기 L):
+ *
+ *   현행 `#71717a`            대비 3.35 · L 0.167  ← 형제(cyan L 0.531)들 뒤로 물러남
+ *   `var(--muted-foreground)` 대비 7.66 · L 0.447  ← 형제와 대등해져 **위계가 무너진다**
+ *   `var(--muted)`            대비 1.12 · L 0.023  ← 사실상 안 보인다
+ *
+ * "기타" 는 명명된 보유 종목 **뒤로 물러나야** 하므로 형제보다 어두운 것이 요구사항이다.
+ * 그 요구사항은 색값이 아니라 **테스트로** 잠근다 — `holdings-summary-palette.test.ts`.
+ */
+export const OTHER_COLOR = "#71717a"; // zinc-500
 
 export function summarizeHoldings(
   holdings: EnrichedHolding[],


### PR DESCRIPTION
Closes #1301. The real defect was the one the issue's last paragraph named — **no gate saw this file** — and the fix is not the one it assumed.

## The issue's proposal, measured

#1301 suggested `var(--muted-foreground)`, flagging that the dark palette isn't zinc so contrast should be checked first. It should — and checking it **rejects the proposal**. Against the dark `--card` (`#1C2127`):

| candidate | contrast | relative luminance |
|---|---|---|
| `#71717a` (current) | 3.35 | **0.167** — recedes behind siblings |
| `var(--muted-foreground)` | 7.66 | **0.447** — as bright as cyan-400 (0.531) |
| `var(--muted)` | 1.12 | 0.023 — effectively invisible |

"Other" has to sit **behind** the named holdings. `--muted-foreground` would bring it forward to compete with them; `--muted` would erase it. Neither token is a fit, because these tokens are for text, borders and surfaces — not for a data series.

So the value stays a series colour, like the vivid palette declared beside it, which #1275 already ruled legitimate.

## Locking the requirement instead of the value

A colour is a choice; the hierarchy is the contract. The tests now assert **"Other" is darker than every sibling** and still above an invisibility floor. Whoever revisits the palette can change the colour freely, and will be stopped only if they break the thing that actually matters.

Evidence this is the right axis: the first mutation below is **the issue's own proposal**, and it fails.

## Closing the gate gap

The chart sweep now covers `holdings-summary.ts`, exempting the declared palette **by construction** — it strips the declarations and sweeps the remainder, so a stray neutral hex anywhere else in the file is caught. An allowlist entry would have gone stale quietly, which is the failure mode this repo keeps hitting.

Three tests mirrored the literal (one commented *"mirrors source constant"*); they now import it.

## Verification

4 mutation axes, each with an asserted replacement count:

| Mutation | Test that flips to FAIL |
|---|---|
| set "Other" to `#ABB3BF` (the issue's proposal) | hierarchy lock |
| set "Other" to `#252A31` | visibility floor |
| add a neutral hex outside the palette | file sweep |
| make the palette stripper eat the whole file | stripper canary |

4/4 locked. **141 files / 1679 tests pass**, `tsc --noEmit` clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJHdh34ra6qsbvHZaHBtL7