### PR TITLE
fix(repo): untrack .venv symlink and make venv ignore patterns type-agnostic (#1316)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,8 +140,10 @@ wheels/
 MANIFEST
 
 # ─── Virtual environments ──────────────────────────────────────
-.venv/
-venv/
+# 끝 슬래시 없이 — 슬래시는 디렉터리만 매치해서 .venv "심볼릭 링크"가 add -A 에
+# 쓸려 들어간다 (#1316: d1bfc4a3 이 링크를 커밋 → pull 이 실제 venv 를 파괴)
+.venv
+venv
 env/
 ENV/
 

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/Users/ehbebe/workspace/nuri-quant/.venv

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,850 collected across 361 files | ✅ |
+| **Backend tests** | 7,853 collected across 362 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,850 backend tests across 361 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,853 backend tests across 362 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,850 tests, 361 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,853 tests, 362 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/tests/test_no_tracked_venv_symlink.py
+++ b/tests/test_no_tracked_venv_symlink.py
@@ -1,0 +1,80 @@
+"""추적 파일에 절대 경로 심볼릭 링크가 없음을 잠근다 (Gotcha-Test Pair, #1316).
+
+`d1bfc4a3` (#1313) 이 `.venv` 를 mode 120000 심볼릭 링크(타깃: 로컬 절대 경로)로
+커밋했다. `.gitignore` 의 `.venv/` 는 **끝 슬래시 탓에 디렉터리만 매치**해서,
+worktree 세션이 만든 `.venv` "링크" 는 ignore 를 통과해 `git add -A` 에 쓸려 들어갔다.
+
+피해가 조용하고 파괴적이다: ignored 디렉터리는 git 이 clobber 가능하므로, 이 커밋을
+pull 한 모든 체크아웃에서 **실제 venv 디렉터리가 삭제되고 링크로 교체**됐다 —
+Mac mini 는 링크가 자기 경로를 가리켜 자기참조 루프가 됐고 (`uv sync` os error 62,
+scheduler down), MBP 는 실제 venv 를 잃었다. 교체 후 `git status` 는 clean 이라
+**아무 신호가 없다**.
+
+두 축을 나눠 잠근다:
+- 인덱스 축: 절대 경로 타깃 심볼릭 링크는 머신 종속이라 public repo 에 존재할 수 없다
+- .gitignore 축: venv 패턴이 심볼릭 링크 "타입" 도 매치해야 한다 (끝 슬래시 금지)
+"""
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(*args: str, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def _tracked_symlinks() -> list[tuple[str, str]]:
+    """인덱스의 (경로, 링크 타깃) 목록 — mode 120000 만."""
+    out = _git("ls-files", "-s").stdout
+    links = []
+    for line in out.splitlines():
+        mode, sha, _rest = line.split(maxsplit=2)
+        if mode != "120000":
+            continue
+        path = line.split("\t", 1)[1]
+        target = _git("cat-file", "blob", sha).stdout
+        links.append((path, target))
+    return links
+
+
+def test_venv_is_not_tracked():
+    """`.venv` 인덱스 등재는 어떤 mode 든 결함이다 — #1316 의 결함 그 자체.
+
+    `git update-index --cacheinfo` 로 되살리든 ignore 를 뚫고 add 되든, 여기서 잡힌다.
+    """
+    tracked = _git("ls-files", "--", ".venv", "venv").stdout.strip()
+    assert tracked == "", (
+        f".venv/venv 가 git 에 추적되고 있다: {tracked!r} — 이 커밋을 pull 하는 모든 "
+        "체크아웃의 실제 venv 가 파괴된다 (#1316, mini production down 실측)"
+    )
+
+
+def test_no_tracked_symlink_with_absolute_target():
+    """절대 경로 타깃 심볼릭 링크는 머신 종속 — public repo 에 존재할 수 없다.
+
+    `.venv` 사고의 클래스 잠금: 타깃이 `/Users/...` 인 링크는 다른 머신에서 깨지거나
+    (최악) 자기 경로와 일치해 자기참조 루프가 된다. 상대 경로 링크는 허용 (현재 0건).
+    """
+    bad = [(p, t) for p, t in _tracked_symlinks() if t.startswith("/")]
+    assert bad == [], (
+        f"절대 경로 타깃 심볼릭 링크가 추적되고 있다: {bad} — 머신 종속 경로는 fresh checkout 을 깨뜨린다 (#1316)"
+    )
+
+
+def test_gitignore_venv_pattern_matches_symlink_type(tmp_path):
+    """레포의 .gitignore 가 `.venv` **심볼릭 링크**를 ignore 하는지 실행으로 확인.
+
+    끝 슬래시(`.venv/`)로 되돌리면 링크가 `??` 로 노출되어 FAIL — 패턴 형태를
+    grep 하지 않고 git 의 실제 매칭 동작으로 잠근다 (dead-gate 계열 교훈).
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / ".gitignore").write_text((REPO_ROOT / ".gitignore").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / ".venv").symlink_to(tmp_path / "nonexistent-target")
+
+    status = _git("status", "--porcelain", "--", ".venv", cwd=tmp_path).stdout.strip()
+    assert status == "", (
+        f".venv 심볼릭 링크가 ignore 되지 않는다: {status!r} — "
+        ".gitignore 의 venv 패턴에 끝 슬래시가 돌아왔는지 확인 (#1316)"
+    )


### PR DESCRIPTION
Closes #1316

## What

`d1bfc4a3` (#1313) accidentally committed `.venv` as a mode-120000 symlink whose target is a machine-specific absolute path. Every checkout that pulled it had its real venv clobbered — git treats ignored paths as expendable, so checkout replaced the whole directory with the link:

- **Mac mini (production)**: the link's target resolves to its own repo root → self-referential loop → `uv sync --frozen` fails with 'Too many levels of symbolic links (os error 62)' → deploy-mini step 5 left the scheduler unloaded (**production down**, measured 2026-08-29).
- **MBP (dev)**: real venv silently destroyed on pull; `git status` stays clean because the link matches the index.
- Every fresh worktree/clone inherits the broken link (found while reproducing #1314).

## Why the ignore rule missed it

`.gitignore` had `.venv/` — a trailing slash matches **directories only**, so a `.venv` *symlink* sailed through `git add -A` in the #1313 worktree session.

## Fix

- `git rm --cached .venv`
- `.gitignore`: `.venv/` → `.venv`, `venv/` → `venv` (match any file type)
- Gotcha-Test Pair (`tests/test_no_tracked_venv_symlink.py`, 3 tests):
  - index axis: `.venv`/`venv` never tracked + no tracked symlink with an absolute target (mutation-verified: re-adding the index entry → 2 FAIL)
  - gitignore axis: a `.venv` symlink must be ignored, verified by running git in a temp repo with the real `.gitignore` copied in (mutation-verified: reverting to `.venv/` → 1 FAIL)

## Verification

- `make test-fast`: 7,809 passed / 8 skipped (fresh venv, Python 3.12.13)
- codex review (`--base main`): no findings
- doc counts synced (7,850 → 7,853)

## Recovery path

After merge, `make deploy-mini` heals the mini autonomously: ff-pull deletes the tracked link → `uv sync --frozen` rebuilds the venv → scheduler reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh