### PR TITLE
fix(hooks): pre-push resolves the pushing tree, not injected GIT_DIR (#1314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,853 collected across 362 files | ✅ |
+| **Backend tests** | 7,855 collected across 362 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,853 backend tests across 362 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,855 backend tests across 362 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,853 tests, 362 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,855 tests, 362 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -22,6 +22,13 @@
 
 set -uo pipefail
 
+# linked worktree 에서 git 은 훅에 GIT_DIR(경우에 따라 GIT_WORK_TREE)을 주입한다.
+# 이 값이 환경에 남으면 아래 rev-parse 와, exec 로 이어받는 게이트 내부의 모든 git
+# 호출이 push 하는 트리가 아닌 다른 트리를 볼 수 있다 (#1314 실측: 게이트가 메인
+# 체크아웃의 미커밋 파일 수백 개로 false-block — 역방향이면 false-pass). 훅의 cwd 는
+# 항상 push 하는 트리의 최상위이므로(githooks(5)) cwd 기반 발견이 정답이다.
+unset GIT_DIR GIT_WORK_TREE
+
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     echo "pre-push: not inside a git repository — refusing to push unchecked." >&2
     exit 1

--- a/tests/test_pre_push_hook.py
+++ b/tests/test_pre_push_hook.py
@@ -18,6 +18,7 @@ exit code 도 없다. 그래서 여기서도 훅을 grep 하지 않고 **셸로 
   보고하지 않는다
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -91,6 +92,98 @@ def test_missing_gate_blocks_instead_of_passing_silently(tmp_path):
         text=True,
     )
     assert proc.returncode != 0, "게이트 부재를 exit 0 으로 넘기면 훅이 있으나 마나다"
+
+
+def test_polluted_git_env_does_not_redirect_the_gate_to_another_tree(tmp_path):
+    """GIT_DIR/GIT_WORK_TREE 오염이 게이트를 다른 트리로 보내지 않는다 (#1314).
+
+    linked worktree push 에서 게이트가 push 트리가 아닌 메인 체크아웃을 검사했다
+    (실측: 다른 세션의 미커밋 파일 수백 개를 근거로 false-block — 역방향이면
+    false-pass). git 2.54 재현 실측으로는 건강한 worktree 의 훅 주입
+    (GIT_DIR=<main>/.git/worktrees/<wt>) 단독으로는 오해석이 없고, GIT_DIR 과
+    GIT_WORK_TREE 가 **둘 다** 다른 트리를 가리킬 때 재현된다 — 그 조합이
+    카나리아다. 훅의 `unset GIT_DIR GIT_WORK_TREE` 를 걷어내면 victim 게이트가
+    실행되어 FAIL (mutation 실측).
+    """
+    victim = tmp_path / "victim"
+    pusher = tmp_path / "pusher"
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    for repo, name in ((victim, "victim"), (pusher, "pusher")):
+        (repo / "scripts" / "verify").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        (repo / GATE_REL).write_text(f'#!/usr/bin/env bash\npwd -P > "{logs / name}"\nexit 0\n', encoding="utf-8")
+    hook_copy = pusher / "scripts" / "hooks" / "pre-push"
+    hook_copy.parent.mkdir(parents=True)
+    shutil.copy2(HOOK, hook_copy)
+
+    env = {**os.environ, "GIT_DIR": str(victim / ".git"), "GIT_WORK_TREE": str(victim)}
+    proc = subprocess.run(
+        ["bash", str(hook_copy), "origin", "git@example.invalid:x/y.git"],
+        cwd=pusher,
+        env=env,
+        input=_PUSH_LINE + "\n",
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, f"훅 rc={proc.returncode}\n{proc.stderr}"
+    assert not (logs / "victim").exists(), "게이트가 오염된 env 를 따라 다른 트리를 검사했다"
+    assert (logs / "pusher").exists(), "push 트리의 게이트가 실행되지 않았다"
+    gate_cwd = (logs / "pusher").read_text(encoding="utf-8").strip()
+    assert Path(gate_cwd) == Path(os.path.realpath(pusher)), f"게이트 cwd 가 push 트리가 아니다: {gate_cwd}"
+
+
+def test_push_from_linked_worktree_gates_the_worktree_not_the_main_checkout(tmp_path):
+    """실제 `git push` 로 훅을 발화 — 게이트는 push 하는 worktree 에서 돈다 (#1314).
+
+    git 이 훅에 주입하는 env 를 시뮬레이션하지 않고 진짜 push 로 잠근다. git 버전이
+    주입 방식을 바꿔도 관측 가능한 계약(게이트 cwd == worktree 루트)이 유지되는지를
+    본다. 글로벌 core.hooksPath / 사용자 gitconfig 간섭은 GIT_CONFIG_GLOBAL/SYSTEM
+    으로 차단 — 임시 레포 push 가 개발자 로컬 설정에 따라 흔들리면 안 된다.
+    """
+    main_repo = tmp_path / "main"
+    bare = tmp_path / "origin.git"
+    gate_log = tmp_path / "gate_cwd.txt"
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], env=env, check=True)
+    (main_repo / "scripts" / "verify").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=main_repo, env=env, check=True)
+    (main_repo / GATE_REL).write_text(f'#!/usr/bin/env bash\npwd -P >> "{gate_log}"\nexit 0\n', encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=main_repo, env=env, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.invalid", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=main_repo,
+        env=env,
+        check=True,
+    )
+    hook_installed = main_repo / ".git" / "hooks" / "pre-push"
+    shutil.copy2(HOOK, hook_installed)
+
+    worktree = tmp_path / "wt"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(worktree), "-b", "feature"],
+        cwd=main_repo,
+        env=env,
+        check=True,
+    )
+
+    proc = subprocess.run(
+        ["git", "push", str(bare), "HEAD:refs/heads/feature"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, f"push rc={proc.returncode}\n{proc.stderr}"
+    assert gate_log.exists(), "pre-push 훅이 게이트를 실행하지 않았다"
+    gate_cwd = gate_log.read_text(encoding="utf-8").strip()
+    assert Path(gate_cwd) == Path(os.path.realpath(worktree)), (
+        f"게이트가 worktree 가 아닌 트리에서 돌았다: {gate_cwd} — "
+        "false-pass 방향(다른 트리는 깨끗한데 push 트리가 더러움)이 열린다"
+    )
 
 
 def test_absent_interpreter_reports_non_execution_not_a_finding():


### PR DESCRIPTION
Closes #1314

## What

The pre-push hook now runs `unset GIT_DIR GIT_WORK_TREE` before resolving the repo root. The hook's cwd is always the top of the pushing tree (githooks(5)), so cwd-based discovery is the contract; leftover git env can redirect the hook — and every git call inside the exec'd gate, `check_drift.py` included — to a different tree than the one being pushed. Measured as a false-block (linked-worktree push judged by the main checkout's hundreds of uncommitted files); the reverse direction is a false-pass.

## Repro measurements (git 2.54, this machine)

- Healthy linked worktree + real push: git injects `GIT_DIR=<main>/.git/worktrees/<wt>` and toplevel resolves **correctly** — injection alone did not reproduce the misread (4 variants tried: sibling worktree, in-repo `.claude/worktrees/` path, subdir push, `core.hooksPath` set).
- The main-tree read reproduces when `GIT_DIR` **and** `GIT_WORK_TREE` both point at another tree (ambient pollution). The fix defends both cases; the healthy path is unchanged.

## Lock tests (`tests/test_pre_push_hook.py`, execute-don't-grep pattern)

- **Polluted-env axis** (mutation lock): hook run with both vars aimed at a victim repo must still gate the pushing repo. Mutation measured: removing the `unset` → victim gate runs → FAIL; restore → 7 passed.
- **Integration axis**: real `git push` from a linked worktree of a temp repo; asserts gate cwd == worktree root. `GIT_CONFIG_GLOBAL/SYSTEM` neutralized so a developer's global `core.hooksPath` can't skew the temp-repo push (codex consult flake-risk point).

## Verification

- `make test-fast`: 7,811 passed / 8 skipped
- codex review (`--base main`): no findings
- shellcheck clean; doc counts synced (7,853 → 7,855)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh