### PR TITLE
feat(ops): off-box dead-man heartbeat — detection leaves the machine (#1191 option C)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -640,6 +640,7 @@
     "nums",
     "nunique",
     "nuri",
+    "offbox",
     "ohlc",
     "ohlcv",
     "ollama",

--- a/.github/workflows/heartbeat-watch.yml
+++ b/.github/workflows/heartbeat-watch.yml
@@ -36,7 +36,9 @@ jobs:
           THRESHOLD_MIN=45
 
           # ref 부재도 침묵이다 — 브랜치가 지워졌거나 첫 push 전이면 곧장 알린다.
-          ts=$(gh api "repos/${GITHUB_REPOSITORY}/branches/ops/heartbeat-mini" \
+          # 슬래시는 %2F 로 — 미인코딩도 동작함을 2026-08-29 실측했지만(리뷰 P1 반박),
+          # 인코딩 형태가 GitHub 라우팅의 관용에 의존하지 않는다.
+          ts=$(gh api "repos/${GITHUB_REPOSITORY}/branches/ops%2Fheartbeat-mini" \
                  --jq '.commit.commit.committer.date' 2>/dev/null || echo "MISSING")
 
           now_epoch=$(date -u +%s)

--- a/.github/workflows/heartbeat-watch.yml
+++ b/.github/workflows/heartbeat-watch.yml
@@ -1,0 +1,66 @@
+# 기계 밖 감시의 감시 절반 — dead-man heartbeat staleness 검사 (#1191 옵션 C).
+#
+# mini 의 스케줄러가 10분마다 `ops/heartbeat-mini` ref 를 갱신한다
+# (`nuri/alerts/offbox_heartbeat.py`). 이 워크플로는 GitHub 쪽에서 그 커밋
+# 시각의 staleness 를 재고, 임계(45분) 초과 시 #ops Discord webhook 으로 알린다.
+# mini 는 인바운드 불가(사설망, API 127.0.0.1 전용)라 pull 감시가 불가능하고,
+# 송신자의 어떤 사망도 "침묵" 으로 수렴하는 dead-man 구조가 유일한 형태다.
+#
+# - 임계 45분 = ping 10분 × 4~5회 결손 여유. 배포의 scheduler bounce(~수 분)와
+#   Actions cron 지연(공식적으로 best-effort, 수십 분 늦을 수 있음)을 흡수한다.
+# - 침묵이 지속되면 20분 주기로 알림이 반복된다 — 진행 중 prod 장애의 리마인더는
+#   #ops 의 역할이라 의도된 동작이다 (stateless 라 dedupe 상태를 두지 않는다).
+# - 공개 레포의 스케줄 워크플로는 60일 무활동 시 자동 비활성화된다 — 이 레포는
+#   일상 커밋이 있어 해당 없음. 장기 방치 시 이 줄이 그 이유를 알려줄 것.
+name: Heartbeat Watch
+
+on:
+  schedule:
+    - cron: "*/20 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check-staleness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check heartbeat staleness and alert on silence
+        env:
+          DISCORD_WEBHOOK_OPS: ${{ secrets.DISCORD_WEBHOOK_OPS }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          THRESHOLD_MIN=45
+
+          # ref 부재도 침묵이다 — 브랜치가 지워졌거나 첫 push 전이면 곧장 알린다.
+          ts=$(gh api "repos/${GITHUB_REPOSITORY}/branches/ops/heartbeat-mini" \
+                 --jq '.commit.commit.committer.date' 2>/dev/null || echo "MISSING")
+
+          now_epoch=$(date -u +%s)
+          if [ "$ts" = "MISSING" ]; then
+            age_min=99999
+            last_seen="(ref 없음)"
+          else
+            hb_epoch=$(date -u -d "$ts" +%s)
+            age_min=$(( (now_epoch - hb_epoch) / 60 ))
+            last_seen="$ts"
+          fi
+          echo "heartbeat age: ${age_min}min (last: ${last_seen}, threshold: ${THRESHOLD_MIN}min)"
+
+          if [ "$age_min" -le "$THRESHOLD_MIN" ]; then
+            echo "healthy"
+            exit 0
+          fi
+
+          # 알림은 의미+영향+조치 순 (alert readability 원칙). 실패해도 job 은
+          # 성공 처리하지 않는다 — webhook 죽음도 보여야 한다.
+          payload=$(jq -n \
+            --arg age "${age_min}" \
+            --arg last "${last_seen}" \
+            '{content: ("🔇 **mini heartbeat 침묵 " + $age + "분** (마지막: " + $last + ")\n영향: 스케줄러·로그인 세션·머신·네트워크 중 하나가 죽었을 수 있음 — 수집/브리프/알림 전체 정지 가능.\n조치: mini 전원·네트워크 확인 → 재부팅됐다면 FileVault 잠금 해제 + 콘솔 로그인 (LaunchAgents 는 로그인까지 미로드, #1191). 원격 진단: ssh 후 `pgrep -f nuri.scheduler`, `last reboot`.")}')
+          curl -sf -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$DISCORD_WEBHOOK_OPS"
+          echo "alert sent (${age_min}min stale)"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The loop at the bottom is the point of the project: a recommendation is not fini
 
 #### What actually runs it — no orchestrator
 
-There is no pipeline runner. `nuri/scheduler.py` registers 57 independent APScheduler jobs — **57 cron jobs · in-process**, nothing chaining them — and each becomes runnable when its inputs happen to already be in the database. Stages reach each other through SQLite tables, with exactly one exception.
+There is no pipeline runner. `nuri/scheduler.py` registers 58 independent APScheduler jobs — **58 cron jobs · in-process**, nothing chaining them — and each becomes runnable when its inputs happen to already be in the database. Stages reach each other through SQLite tables, with exactly one exception.
 
 ```mermaid
 flowchart TB
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,864 collected across 363 files | ✅ |
+| **Backend tests** | 7,871 collected across 364 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
@@ -351,7 +351,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered — 8 with a live caller, 7 dormant (implemented and tested, nothing calls them) + 3 infrastructure helpers | |
-| **Scheduler jobs** | 57 cron entries (APScheduler, in-process) — 29 collect · 1 analyze · 1 consensus · 5 track · 21 operate | ✅ |
+| **Scheduler jobs** | 58 cron entries (APScheduler, in-process) — 29 collect · 1 analyze · 1 consensus · 5 track · 21 operate | ✅ |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 — 20 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 73 declared in `nuri/api/routes/` (76 counting the three declared on the app itself in `main.py`) | ✅ |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 57 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 58 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,864 backend tests across 363 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,871 backend tests across 364 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,864 tests, 363 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,871 tests, 364 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/alerts/offbox_heartbeat.py
+++ b/nuri/alerts/offbox_heartbeat.py
@@ -1,0 +1,129 @@
+"""기계 밖 감시의 송신 절반 — dead-man heartbeat push (#1191 옵션 C).
+
+## 왜 이 모양인가
+
+42h 침묵 사고(#1191)의 축은 "감시자가 감시 대상과 같은 기계" 였다. mini 위의
+어떤 장치도(watchdog 포함) 로그인 세션과 함께 죽고, FileVault ON 이라 LaunchDaemon
+이관(B)은 pre-boot 잠금 앞에서 무효다. 그래서 **탐지를 기계 밖으로** 뺀다:
+
+- **송신(이 모듈, mini)**: 스케줄러 job 이 10분마다 빈-트리 커밋을
+  `refs/heads/ops/heartbeat-mini` 로 push. 로그인 세션 소멸·머신 다운·네트워크
+  단절·스케줄러 사망 **전부가 "침묵" 으로 수렴**한다 — 송신자가 죽는 것이 곧
+  신호라서, 송신자를 살리려는 어떤 장치도 필요 없다 (dead-man 패턴).
+- **감시(기계 밖)**: `.github/workflows/heartbeat-watch.yml` 이 ref 의 커밋 시각
+  staleness 를 검사해 임계 초과 시 `#ops` webhook 으로 알린다.
+
+## 설계 결정
+
+- **스케줄러 job 이지 launchd 가 아니다** — autopull + deploy 만으로 배포되고,
+  스케줄러 사망도 침묵에 포함시키는 게 목적에 맞다 (스케줄러 생존 중의 개별
+  고장은 on-box watchdog 담당 — 반경이 다르다).
+- **`is_production()` 게이트** — `NURI_ROLE` 은 mini 의 launchd plist 에만 있다
+  (.env 는 sync 로 양쪽에 복사되므로 판별자가 될 수 없다 — DEV2_HOST 교훈).
+  MBP 에서 스케줄러를 돌려도 heartbeat 가 mini 의 침묵을 가리지 않는다.
+- **전용 deploy key** — mini 의 origin 은 https(익명 fetch 전용)고 gh 토큰도
+  없다. repo 한정 write key(`~/.ssh/nuri_heartbeat_deploy`)만 쓰며, main 은
+  branch protection 이 지킨다. 키 부재/만료도 침묵 → 감시자가 잡는다.
+- **빈-트리 + 무부모 커밋을 force-push** — 브랜치가 커밋 1개로 고정되어 히스토리가
+  자라지 않는다 (10분 간격 = 연 5만 커밋을 체인으로 쌓지 않기 위해).
+- **push 실패는 조용히 실패해도 안전하다** — 실패 = 침묵 = 알림. 여기서 재시도나
+  경보를 쌓으면 감시자와 역할이 겹치고, #894 계열(관측이 본 작업을 게이트)로 간다.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from nuri.alerts.alpha_report import is_production
+
+logger = logging.getLogger(__name__)
+
+#: git 의 잘 알려진 빈 트리 오브젝트 — 어떤 레포에도 존재한다.
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+HEARTBEAT_REF = "refs/heads/ops/heartbeat-mini"
+
+#: mini 의 origin 은 https(익명 fetch 전용)라 push 대상은 ssh URL 을 명시한다.
+REMOTE_URL = "git@github.com:researcherhojin/nuri-quant.git"
+
+#: repo 한정 write deploy key (mini 에만 존재, 2026-08-29 등록 id 161664449).
+DEPLOY_KEY = Path.home() / ".ssh" / "nuri_heartbeat_deploy"
+
+#: 커밋 ident — 실 이메일을 쓰지 않는다 (author 익명화 방침).
+_IDENT_ENV = {
+    "GIT_AUTHOR_NAME": "nuri-heartbeat",
+    "GIT_AUTHOR_EMAIL": "heartbeat@localhost",
+    "GIT_COMMITTER_NAME": "nuri-heartbeat",
+    "GIT_COMMITTER_EMAIL": "heartbeat@localhost",
+}
+
+
+def send_heartbeat(repo_root: Path | None = None, remote_url: str | None = None) -> str | None:
+    """빈-트리 커밋을 만들어 heartbeat ref 로 force-push. 성공 시 sha, 실패/skip 시 None.
+
+    커밋의 committer 시각 자체가 heartbeat 페이로드다 — 메시지는 사람이 브랜치를
+    봤을 때의 안내일 뿐, 감시자는 시각만 읽는다.
+    """
+    if not is_production():
+        logger.debug("[offbox_heartbeat] NURI_ROLE != production — skip (dev 은 침묵이 정상)")
+        return None
+
+    import os
+
+    cwd = str(repo_root) if repo_root else None
+    env = {**os.environ, **_IDENT_ENV}
+    if DEPLOY_KEY.exists():
+        env["GIT_SSH_COMMAND"] = f"ssh -4 -i {DEPLOY_KEY} -o IdentitiesOnly=yes -o ConnectTimeout=10"
+
+    try:
+        sha = subprocess.run(
+            ["git", "commit-tree", EMPTY_TREE, "-m", "offbox heartbeat — 감시자는 커밋 시각만 읽는다 (#1191)"],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            # --no-verify: pre-push 게이트는 코드 push 용이다 — 빈 트리 ref 갱신에
+            # 드리프트/린트 검사를 돌릴 이유가 없고, 게이트 red 가 heartbeat 를
+            # 죽이면 가짜 침묵 알림이 된다.
+            ["git", "push", "--no-verify", "--force", remote_url or REMOTE_URL, f"{sha}:{HEARTBEAT_REF}"],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        logger.info(f"[offbox_heartbeat] pushed {sha[:8]} → {HEARTBEAT_REF}")
+        return sha
+    except subprocess.SubprocessError as e:
+        # 실패 = 침묵 = 기계 밖 감시자가 알린다. 여기서는 로그만 남긴다 (독트린은
+        # 모듈 독스트링 마지막 항목).
+        detail = getattr(e, "stderr", "") or str(e)
+        logger.error(f"[offbox_heartbeat] push 실패 (감시자가 침묵으로 탐지): {detail.strip()[:200]}")
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: `python -m nuri.alerts.offbox_heartbeat send` — 배포 후 수동 검증용."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["send"])
+    parser.parse_args(argv)
+
+    sha = send_heartbeat()
+    if sha:
+        print(f"pushed {sha}")
+        return 0
+    print("skip 또는 실패 — NURI_ROLE/로그 확인 (침묵은 감시자가 잡는다)")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -816,6 +816,21 @@ def _run_outbox_watchdog():
         logger.error(f"[outbox_watchdog] 실행 실패: {e}", exc_info=True)
 
 
+def _run_offbox_heartbeat():
+    """기계 밖 감시 dead-man heartbeat (#1191 C). 10분 마다.
+
+    이 job 의 **침묵**이 신호다 — 스케줄러/로그인 세션/머신/네트워크 중 무엇이
+    죽어도 push 가 멎고, `.github/workflows/heartbeat-watch.yml` 이 staleness 로
+    잡아 #ops 에 알린다. 실패를 여기서 복구하려 들지 말 것 (모듈 독스트링 참고).
+    """
+    try:
+        from nuri.alerts.offbox_heartbeat import send_heartbeat
+
+        send_heartbeat()
+    except Exception as e:
+        logger.error(f"[offbox_heartbeat] 실행 실패: {e}", exc_info=True)
+
+
 # ═══════════════════════════════════════════════════════
 # 스케줄 정의
 # ═══════════════════════════════════════════════════════
@@ -1008,6 +1023,10 @@ SCHEDULES = [
     {"name": "dispatcher_rollout", "func": _run_channel_dispatcher, "args": ("rollout",), "cron": "0 6 * * 0"},
     # Watchdog — outbox backlog / oldest-pending-age threshold breach 시 #ops 직접 발송 (recursion 방지).
     {"name": "outbox_watchdog", "func": _run_outbox_watchdog, "args": (), "cron": "*/10 * * * *"},
+    # 기계 밖 감시 dead-man heartbeat (#1191 C) — production(mini)에서만 실제 push,
+    # dev 는 role 게이트로 no-op. 5분이 아니라 10분인 이유: 감시자 임계(45분)에
+    # 4~5회 여유가 있으면 충분하고, push 는 네트워크 왕복이라 슬롯을 아낀다.
+    {"name": "offbox_heartbeat", "func": _run_offbox_heartbeat, "args": (), "cron": "*/10 * * * *"},
     # collector health 요약 — 아침 수집 물결(06:20~08:00) 이 끝난 뒤 24시간 창을 본다 (#975).
     {"name": "collector_health", "func": _run_collector_health, "args": (), "cron": "10 8 * * *"},
     # DB 백업 (매일 자정)

--- a/tests/alerts/test_offbox_heartbeat.py
+++ b/tests/alerts/test_offbox_heartbeat.py
@@ -149,9 +149,11 @@ class TestSenderAndWatcherAreWiredTogether:
         branch = HEARTBEAT_REF.removeprefix("refs/heads/")
         # substring 검사 금지 — `…-mini` 는 `…-mini-v2` 의 부분 문자열이라 rename 이
         # 통과한다 (뮤테이션 실측 MISS). API 호출부에서 ref 토큰을 뽑아 동치 비교.
-        m_ref = re.search(r'branches/([A-Za-z0-9/_.-]+)"', text)
+        # 토큰은 %2F 인코딩 형태다 — 디코드 후 비교 (미인코딩 회귀도 여기서 잡힌다).
+        m_ref = re.search(r'branches/([A-Za-z0-9%/_.-]+)"', text)
         assert m_ref, "워크플로에서 감시 대상 ref 를 찾을 수 없다"
-        assert m_ref.group(1) == branch, f"워크플로 ref {m_ref.group(1)!r} ≠ 송신 ref {branch!r}"
+        decoded = m_ref.group(1).replace("%2F", "/")
+        assert decoded == branch, f"워크플로 ref {decoded!r} ≠ 송신 ref {branch!r}"
         assert "DISCORD_WEBHOOK_OPS" in text, "알림 채널 secret 참조가 사라졌다"
 
         m = re.search(r"THRESHOLD_MIN=(\d+)", text)

--- a/tests/alerts/test_offbox_heartbeat.py
+++ b/tests/alerts/test_offbox_heartbeat.py
@@ -1,0 +1,156 @@
+"""기계 밖 감시 dead-man heartbeat 잠금 (#1191 옵션 C).
+
+세 반경을 나눠 잠근다:
+- **role 게이트**: dev(MBP) 스케줄러가 heartbeat 를 push 하면 mini 의 침묵을
+  가린다 — 게이트가 뚫리면 42h 급 공백이 **탐지 불가**로 돌아간다. 그래서 push
+  경로 자체가 실행되지 않음을 spy 로 잠근다.
+- **송신 동작**: mock 이 아니라 **실제 git** (tmp 레포 + 로컬 bare remote) 으로
+  push 결과를 본다 — 빈-트리·무부모·신선한 committer 시각·force 갱신·익명 ident.
+- **송신↔감시 배선**: 스케줄러 SCHEDULES 등재와, 워크플로가 같은 ref 이름·
+  타당한 임계를 보는지. 한쪽만 rename 하면 여기서 깨진다.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nuri.alerts.offbox_heartbeat import EMPTY_TREE, HEARTBEAT_REF, send_heartbeat
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "heartbeat-watch.yml"
+
+
+@pytest.fixture()
+def local_repo_with_bare_remote(tmp_path):
+    """실제 push 를 받는 로컬 bare remote + 빈 트리 오브젝트가 준비된 작업 레포."""
+    bare = tmp_path / "remote.git"
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    # 빈 트리 오브젝트를 명시적으로 심는다 — fresh 레포에는 loose object 로 없을
+    # 수 있고, 프로덕션 레포에는 히스토리 덕에 항상 있다.
+    subprocess.run(
+        ["git", "hash-object", "-w", "-t", "tree", "--stdin"],
+        cwd=work,
+        input="",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return work, bare
+
+
+def test_dev_role_never_pushes(monkeypatch):
+    """MBP 스케줄러의 heartbeat 가 mini 침묵을 가리면 안 된다 — no-op 을 잠근다.
+
+    push 는커녕 커밋 생성조차 하지 않아야 한다: spy 가 subprocess 호출 0건을 본다.
+    """
+    monkeypatch.delenv("NURI_ROLE", raising=False)
+    calls: list = []
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: calls.append(a))
+
+    assert send_heartbeat() is None
+    assert calls == [], "role 게이트가 뚫렸다 — dev heartbeat 가 mini 의 침묵을 가린다"
+
+
+class TestProductionSendsARealHeartbeat:
+    def test_pushes_fresh_parentless_empty_tree_commit(self, monkeypatch, local_repo_with_bare_remote):
+        monkeypatch.setenv("NURI_ROLE", "production")
+        work, bare = local_repo_with_bare_remote
+
+        sha = send_heartbeat(repo_root=work, remote_url=str(bare))
+
+        assert sha, "production 인데 push 가 안 됐다"
+        got = subprocess.run(
+            ["git", "rev-parse", HEARTBEAT_REF],
+            cwd=bare,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert got == sha, "remote ref 가 방금 만든 커밋을 가리키지 않는다"
+
+        # 커밋 형태 잠금: 빈 트리 + 무부모 (브랜치가 커밋 1개로 고정되는 근거)
+        tree = subprocess.run(
+            ["git", "show", "-s", "--format=%T", sha], cwd=bare, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        parents = subprocess.run(
+            ["git", "show", "-s", "--format=%P", sha], cwd=bare, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        assert tree == EMPTY_TREE
+        assert parents == "", "부모가 있으면 브랜치가 무한히 자란다"
+
+    def test_second_send_replaces_the_ref(self, monkeypatch, local_repo_with_bare_remote):
+        """무부모 커밋끼리는 non-fast-forward — force 경로가 실제로 동작해야 갱신된다.
+
+        커밋 시각을 명시하는 이유: 같은 초 안의 두 heartbeat 는 내용·시각이 같아
+        **같은 sha** 가 된다 (프로덕션은 10분 간격이라 항상 다르다). 시각을 갈라야
+        non-ff force 경로가 실제로 밟힌다.
+        """
+        monkeypatch.setenv("NURI_ROLE", "production")
+        work, bare = local_repo_with_bare_remote
+
+        monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-08-29T10:00:00+09:00")
+        first = send_heartbeat(repo_root=work, remote_url=str(bare))
+        monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-08-29T10:10:00+09:00")
+        second = send_heartbeat(repo_root=work, remote_url=str(bare))
+
+        assert first and second and first != second, "커밋이 매번 새로 만들어져야 시각이 갱신된다"
+        got = subprocess.run(
+            ["git", "rev-parse", HEARTBEAT_REF], cwd=bare, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        assert got == second, "force 갱신 실패 — 두 번째 heartbeat 부터 전부 침묵으로 보인다"
+
+    def test_ident_is_anonymous(self, monkeypatch, local_repo_with_bare_remote):
+        """실 이메일이 heartbeat 커밋으로 새지 않는다 (author 익명화 방침)."""
+        monkeypatch.setenv("NURI_ROLE", "production")
+        work, bare = local_repo_with_bare_remote
+
+        sha = send_heartbeat(repo_root=work, remote_url=str(bare))
+        ident = subprocess.run(
+            ["git", "show", "-s", "--format=%cn <%ce>", sha],
+            cwd=bare,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert ident == "nuri-heartbeat <heartbeat@localhost>"
+
+    def test_push_failure_returns_none_instead_of_raising(self, monkeypatch, local_repo_with_bare_remote, tmp_path):
+        """실패 = 침묵 = 감시자 몫 — 스케줄러 wrapper 로 예외를 올리지 않는다."""
+        monkeypatch.setenv("NURI_ROLE", "production")
+        work, _ = local_repo_with_bare_remote
+
+        assert send_heartbeat(repo_root=work, remote_url=str(tmp_path / "no-such-remote.git")) is None
+
+
+class TestSenderAndWatcherAreWiredTogether:
+    def test_scheduler_registers_the_job(self):
+        from nuri.scheduler import SCHEDULES, _run_offbox_heartbeat
+
+        entries = [s for s in SCHEDULES if s["name"] == "offbox_heartbeat"]
+        assert len(entries) == 1, "SCHEDULES 미등재 — 함수만 있고 배선이 없으면 아무것도 안 돈다"
+        assert entries[0]["func"] is _run_offbox_heartbeat
+        assert entries[0]["cron"] == "*/10 * * * *"
+
+    def test_watcher_watches_the_same_ref_with_a_sane_threshold(self):
+        """송신 ref 이름과 감시 임계를 워크플로 본문에서 교차 잠금.
+
+        - ref: 한쪽만 rename 하면 감시자는 영원히 'ref 없음' 침묵 알림만 낸다.
+        - 임계: ping 간격(10분)보다 넉넉히 커야 배포 bounce/Actions cron 지연이
+          가짜 알림이 되지 않고, 너무 크면 탐지가 늦다. 20 < threshold ≤ 120 로 잠근다.
+        """
+        text = WORKFLOW.read_text(encoding="utf-8")
+        branch = HEARTBEAT_REF.removeprefix("refs/heads/")
+        assert branch in text, f"워크플로가 {branch} 를 보지 않는다"
+        assert "DISCORD_WEBHOOK_OPS" in text, "알림 채널 secret 참조가 사라졌다"
+
+        m = re.search(r"THRESHOLD_MIN=(\d+)", text)
+        assert m, "임계 상수를 찾을 수 없다"
+        threshold = int(m.group(1))
+        assert 20 < threshold <= 120, f"임계 {threshold}분 — ping 10분 대비 비상식적"

--- a/tests/alerts/test_offbox_heartbeat.py
+++ b/tests/alerts/test_offbox_heartbeat.py
@@ -147,7 +147,11 @@ class TestSenderAndWatcherAreWiredTogether:
         """
         text = WORKFLOW.read_text(encoding="utf-8")
         branch = HEARTBEAT_REF.removeprefix("refs/heads/")
-        assert branch in text, f"워크플로가 {branch} 를 보지 않는다"
+        # substring 검사 금지 — `…-mini` 는 `…-mini-v2` 의 부분 문자열이라 rename 이
+        # 통과한다 (뮤테이션 실측 MISS). API 호출부에서 ref 토큰을 뽑아 동치 비교.
+        m_ref = re.search(r'branches/([A-Za-z0-9/_.-]+)"', text)
+        assert m_ref, "워크플로에서 감시 대상 ref 를 찾을 수 없다"
+        assert m_ref.group(1) == branch, f"워크플로 ref {m_ref.group(1)!r} ≠ 송신 ref {branch!r}"
         assert "DISCORD_WEBHOOK_OPS" in text, "알림 채널 secret 참조가 사라졌다"
 
         m = re.search(r"THRESHOLD_MIN=(\d+)", text)


### PR DESCRIPTION
Refs #1191 — implements **option C** (detection). Option A (auto-login vs FileVault) remains the user's decision; C is needed under every outcome of A, and its silence logs will provide the reboot-frequency data that decision needs.

## Structure

**Sender (mini)** — `nuri/alerts/offbox_heartbeat.py`, scheduler job every 10 min: pushes a fresh **parentless empty-tree commit** to `refs/heads/ops/heartbeat-mini` via a dedicated repo-scoped write deploy key (registered 2026-08-29; the mini's origin is anonymous-https and its gh token is dead). Login-session death, machine death, network loss, and scheduler death all collapse into **silence** — the sender dying IS the signal (dead-man pattern), so nothing tries to keep it alive and push failure deliberately just logs. Gated on `NURI_ROLE=production` (mini launchd plist only — .env can't discriminate, sync copies it to both machines), so a dev scheduler can never mask the mini's silence. The branch stays a single commit forever (force-replaced), with an anonymous ident.

**Watcher (off-box)** — `.github/workflows/heartbeat-watch.yml` every 20 min: reads the ref's committer-date staleness; past **45 min** (4-5 missed pings — absorbs deploy bounces and Actions cron lag) posts meaning/impact/action to the `#ops` Discord webhook. A missing ref is silence too.

## Verification

- **Live end-to-end probe before the code**: the mini pushed the ref with the new key (branch exists now).
- `make test-fast`: 7,827 passed / 8 skipped.
- Mutation-verified 5 axes: role-gate removal (dev would mask mini) / `--force` removal (second heartbeat onward looks silent) / SCHEDULES unwiring / watcher ref rename — including a substring false-green found by mutation and fixed to exact-token comparison / encoded-ref rename post-hardening.
- codex review: 1×P1 (unencoded slashed branch → claimed always-404). **Refuted by live probe** — both forms return the correct date — then hardened to `%2F` anyway so the workflow doesn't lean on GitHub's tolerant routing.

## Post-merge steps (this session will do them)

1. `make deploy-mini` — scheduler bounce registers the job (autopull alone doesn't restart, #1024).
2. Confirm the ref refreshes within 10 min, then `workflow_dispatch` the watcher → expect healthy.
3. One user action pending: set the `DISCORD_WEBHOOK_OPS` Actions secret (classifier blocks me from moving the credential) — until then detection runs but the alert POST fails visibly in the workflow log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh