### PR TITLE
feat(agents): maintenance audit loop Phase 0 — shadow mode, local ledger only (#1308)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -115,6 +115,7 @@
     "GSPC",
     "Ghostfolio",
     "Givoly",
+    "Goodhart",
     "HHDFS",
     "HITL",
     "HMAC",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The loop at the bottom is the point of the project: a recommendation is not fini
 
 #### What actually runs it — no orchestrator
 
-There is no pipeline runner. `nuri/scheduler.py` registers 58 independent APScheduler jobs — **58 cron jobs · in-process**, nothing chaining them — and each becomes runnable when its inputs happen to already be in the database. Stages reach each other through SQLite tables, with exactly one exception.
+There is no pipeline runner. `nuri/scheduler.py` registers 59 independent APScheduler jobs — **59 cron jobs · in-process**, nothing chaining them — and each becomes runnable when its inputs happen to already be in the database. Stages reach each other through SQLite tables, with exactly one exception.
 
 ```mermaid
 flowchart TB
@@ -92,7 +92,7 @@ flowchart TB
         JO["operate · 21<br/>briefs · dispatchers · watchdogs · backup"]
     end
 
-    DB[("SQLite WAL · 59 tables")]
+    DB[("SQLite WAL · 60 tables")]
     RD["record_decisions()<br/>inside the consensus job"]
     CERT["certify() · no job<br/>runs inside its callers"]
     OUT["Discord brief · dashboard"]
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,889 collected across 366 files | ✅ |
+| **Backend tests** | 7,909 collected across 367 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
@@ -351,12 +351,12 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 | **Data collectors** | 27 collectors (BaseCollector pattern) — 22 are driven by collect-stage cron jobs, the rest run on demand | ✅ |
 | **Specialist agents** | 10 (consensus vote, weights sum to 1.0) | |
 | **Actor fleet** | 15 registered — 8 with a live caller, 7 dormant (implemented and tested, nothing calls them) + 3 infrastructure helpers | |
-| **Scheduler jobs** | 58 cron entries (APScheduler, in-process) — 29 collect · 1 analyze · 1 consensus · 5 track · 21 operate | ✅ |
+| **Scheduler jobs** | 59 cron entries (APScheduler, in-process) — 29 collect · 1 analyze · 1 consensus · 5 track · 21 operate | ✅ |
 | **Strategy regimes** | 10 regimes (6 base + 4 special) | ✅ |
 | **Trading signals** | 22 — 20 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 73 declared in `nuri/api/routes/` (76 counting the three declared on the app itself in `main.py`) | ✅ |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 59 tables (58 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 60 tables (59 forward-only migrations) | ✅ |
 | **DB submodules** | 13 under `nuri/core/db/` — `connection.py` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,909 collected across 367 files | ✅ |
+| **Backend tests** | 7,911 collected across 367 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Trade execution API (`nuri/api/routes/trades.py`):
 | `/api/market-context` | GET | 시스템 건강 (SIEGE/regime/macro/freshness) + 매크로 이벤트 (한국어 카테고리) |
 | `/api/backtest/equity` | GET | Equity curve + drawdown + metrics (Recharts frontend용 경량 데이터) |
 ## Scheduler
-`nuri/scheduler.py` — 58 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
+`nuri/scheduler.py` — 59 cron jobs in `SCHEDULES` list (+ a 1-minute `heartbeat` interval job). All times KST. Lazy imports inside `_run_collector()` to avoid import-time side effects. A daily `self_restart` job (08:40 KST) recycles the process to reclaim leaked yfinance file descriptors; a daily `stock_us_freshness` job (06:10/06:40 KST) keeps the SPY measurement benchmark + SIEGE freshness tickers current (§3.11).
 ## Environment Variables
 Configured in `.env` (see `.env.example`):
 - `FRED_API_KEY` — FRED macro data (optional; yfinance fallback)
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-58 tables total (58 migrations as of 2026-08-25). Key tables:
+58 tables total (59 migrations as of 2026-08-25). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,889 backend tests across 366 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,909 backend tests across 367 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,909 backend tests across 367 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,911 backend tests across 367 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,909 tests, 367 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,911 tests, 367 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -276,7 +276,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,889 tests, 366 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,909 tests, 367 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/agents/CLAUDE.md
+++ b/nuri/agents/CLAUDE.md
@@ -4,7 +4,7 @@
 
 The autonomous operating layer: long-lived actors that observe the system, record verdicts to an audit ledger, and surface findings to Discord. Distinct from `nuri/trading/agents/` (the 10-agent *consensus* pipeline that scores tickers) — an actor here is an **operational unit with a run ledger**, not a signal contributor.
 
-`actors/` holds **18 files: 15 registered actors + 3 unregistered infra helpers** (`brief_auditor`, `channel_dispatcher`, `outbox_watchdog` — deliberately outside the canonical roster).
+`actors/` holds **19 files: 16 registered actors + 3 unregistered infra helpers** (`brief_auditor`, `channel_dispatcher`, `outbox_watchdog` — deliberately outside the canonical roster).
 
 ## The actor contract (`base.py`)
 
@@ -33,7 +33,7 @@ def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult: .
 
 **`execute()` may raise** — `run()` records the failure (`status="failed"` + an `ERROR` audit row) and then **re-raises**. Failure isolation is the *caller's* responsibility: every `_run_*` wrapper in `nuri/scheduler.py` try/excepts, which is why one actor dying doesn't take the fleet down.
 
-**The roster is closed and two-tier (#975).** `CANONICAL_ACTORS` (8) are actors with a real caller — scheduler, sleeve/rules, or the phase-2 manual chain; `DORMANT_ACTORS` (7) have implementations and tests but **no caller anywhere** — they register fine but are excluded from `missing()` so nothing advertises them as pending. Promoting a dormant actor to canonical requires the PR that adds its actual call path. `@REGISTRY.register` raises for names outside both tuples. Registration is idempotent for the same `module:qualname` so the `python -m` double-import (`__main__` reload) doesn't blow up. `CANONICAL_15` remains as a compatibility alias (= canonical + dormant).
+**The roster is closed and two-tier (#975).** `CANONICAL_ACTORS` (9) are actors with a real caller — scheduler, sleeve/rules, or the phase-2 manual chain; `DORMANT_ACTORS` (7) have implementations and tests but **no caller anywhere** — they register fine but are excluded from `missing()` so nothing advertises them as pending. Promoting a dormant actor to canonical requires the PR that adds its actual call path. `@REGISTRY.register` raises for names outside both tuples. Registration is idempotent for the same `module:qualname` so the `python -m` double-import (`__main__` reload) doesn't blow up. `CANONICAL_15` remains as a compatibility alias (= canonical + dormant).
 
 ## Invariants
 
@@ -48,16 +48,17 @@ def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult: .
 
 There is **no schedule declaration on the actor**. Cron lives entirely in `nuri/scheduler.py`'s module-level `SCHEDULES` list; jobs run **in-process** under APScheduler `BlockingScheduler` with `misfire_grace_time=300`.
 
-Only 4 actors are reached from `SCHEDULES` today, and **only one of them is a registered actor**:
+Only 5 actors are reached from `SCHEDULES` today, and **two of them are registered actors**:
 
 | Wrapper | Actor | Registered? |
 |---|---|---|
-| `_run_collector("alpha_tracking")` | `ForwardOutcomeTracker` | ✅ (of the 15) |
+| `_run_collector("alpha_tracking")` | `ForwardOutcomeTracker` | ✅ |
+| `_run_maintenance_audit` (주간, #1308) | `MaintenanceAuditor` | ✅ |
 | `_run_brief_audit` | `BriefAuditor` | — helper |
 | `_run_channel_dispatcher` | `ChannelDispatcher` | — helper |
 | `_run_outbox_watchdog` | `OutboxWatchdog` | — helper |
 
-So **14 of the 15 registered actors have no cron** — they run from their `main()` CLI or another caller. **Do not assume an actor is running just because it exists and is registered.** Check `SCHEDULES` before claiming anything about live behaviour.
+So **14 of the 16 registered actors have no cron** — they run from their `main()` CLI or another caller. **Do not assume an actor is running just because it exists and is registered.** Check `SCHEDULES` before claiming anything about live behaviour.
 
 ⚠️ **APScheduler weekday ≠ crontab weekday**, but `SCHEDULES` entries are written in **crontab** semantics (0=Sun) and `scheduler._make_trigger()` converts. Write `1-5` for Mon–Fri and `0` for Sunday, as you would in a crontab — do NOT pre-convert to `mon-fri`, and do NOT call `CronTrigger.from_crontab()` directly (it skips the conversion, which is how every non-`tz` job ran a day late until #929 — `stock_us_freshness` missed Tuesdays, leaving the §3.11 benchmark SPY stale each Mon/Tue).
 **Test:** `tests/test_scheduler_weekday.py::TestEverySchedulesJobFiresOnIntendedDays::test_all_jobs_match_crontab_semantics` — asks the registered triggers which weekdays they actually fire on and compares against a hand-written crontab table.

--- a/nuri/agents/actors/__init__.py
+++ b/nuri/agents/actors/__init__.py
@@ -30,6 +30,7 @@ from nuri.agents.actors.forward_outcome_tracker import ForwardOutcomeTracker
 from nuri.agents.actors.foundation_benchmark import FoundationBenchmark
 from nuri.agents.actors.freshness_gatekeeper import FreshnessGatekeeper
 from nuri.agents.actors.hypothesis_registry import HypothesisRegistry
+from nuri.agents.actors.maintenance_auditor import MaintenanceAuditor
 from nuri.agents.actors.regime_posterior import RegimePosterior
 from nuri.agents.actors.release_rollback_manager import ReleaseRollbackManager
 from nuri.agents.actors.sre_incident_agent import SREIncidentAgent
@@ -47,6 +48,7 @@ __all__ = [
     "FoundationBenchmark",
     "FreshnessGatekeeper",
     "HypothesisRegistry",
+    "MaintenanceAuditor",
     "RegimePosterior",
     "ReleaseRollbackManager",
     "SREIncidentAgent",

--- a/nuri/agents/actors/__init__.py
+++ b/nuri/agents/actors/__init__.py
@@ -1,6 +1,6 @@
 """nuri.agents.actors — actor implementations (#529 Phase 2+; #975 2-tier roster).
 
-호출자가 있는 canonical 8종 + 휴면 dormant 7종 — 목록·의미는 `nuri/agents/base.py` 참조.
+호출자가 있는 canonical 9종 + 휴면 dormant 7종 — 목록·의미는 `nuri/agents/base.py` 참조.
 
 Phase 2 actors (Codex Round 5):
 - CollectorOrchestrator (#1, Layer B) — 21+ collectors oversight + retry + health scan

--- a/nuri/agents/actors/maintenance_auditor.py
+++ b/nuri/agents/actors/maintenance_auditor.py
@@ -1,0 +1,545 @@
+"""Maintenance-Auditor — 유지보수 백로그 발굴 루프, shadow mode (#1308 Phase 0).
+
+## 무엇을 하고, 무엇을 절대 안 하나
+
+지금까지 시스템 결함은 전부 사람이 수동 감사로 찾았다 (sqlite3 밀수입 · 훅 3.5개월
+무력 · e2e 3.5개월 무신호 · 자동화 parity gap). 이 actor 는 그 발굴을 주간 루프로
+만들되, 산출물은 **로컬 maintenance_candidates 원장에만** 남긴다:
+
+- **GitHub 쓰기 0건** — gh 호출도, GitHub API 엔드포인트 참조도, HTTP 클라이언트 import 도 없다.
+  자동 이슈 발행은 "proposal-only" 가 아니라 외부 쓰기다. (잠금: 구조 스윕 + 런타임 spy)
+- **LLM 0** — 5축 전부 결정론적 검사다. USD 캡은 0 으로 존재한다 — 캡 플럼빙이
+  있어야 Phase 1 에서 LLM 이 붙을 때 상한 없이 붙는 사고를 막는다.
+- **전략·투자 룰(config 의 rules/agents/signals 계열)은 대상 밖** — #1307 champion-challenger 전용.
+- 건수 목표 없음 (Goodhart) — 정직한 0건 run 이 저품질 5건보다 낫다. 지표는
+  precision·novelty·검토 시간 (`maintenance_review_stats`).
+
+## 하드 상한 4종 — 초과 시 그 자리에서 스캔 중단, outcome WARN
+
+wall-clock · subprocess 호출 수 · 후보 staging 수 · USD. 이미 staged 된 행은 남는다
+(원장은 durable). 어느 캡이 끊었는지 output 에 기록한다 — 조용한 절단은 절단이 아니라
+거짓말이다.
+
+## Privacy — 후보 생성 **전** 스캔
+
+모든 후보의 title+detail 이 staging 전에 **전 범주** `gate_text` (broker명·의심
+금액·ticker+PnL — `--message` CLI 모드는 마지막 것만 봐서 못 쓴다)를 통과해야 한다.
+걸리면 원장에는 **아무것도** 남기지 않는다 — stub 후보는 precision/novelty 를
+오염시킨다. 사건 자체는 output 의 `privacy_blocked` 카운터로 audit ledger 에
+영속된다 (조용한 드롭 아님). 게이트 불능은 차단으로 취급한다 (fail-closed).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from nuri.agents.base import REGISTRY, Actor, ActorResult, Layer, Outcome, RunContext
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+#: 재검출 판정 축 — fingerprint 는 axis+title 로만 만든다. detail 에는 날짜/카운트가
+#: 들어가므로 fingerprint 에 섞으면 같은 발견이 매주 "새 후보" 가 된다 (novelty 오염).
+def _fingerprint(axis: str, title: str) -> str:
+    return hashlib.sha256(f"{axis}|{title}".encode()).hexdigest()[:16]
+
+
+class CapExceeded(Exception):
+    """하드 상한 초과 — 스캔 루프가 잡아서 중단 + WARN 으로 바꾼다."""
+
+    def __init__(self, cap: str) -> None:
+        self.cap = cap
+        super().__init__(cap)
+
+
+@dataclass
+class AuditCaps:
+    """하드 상한 — 이슈 본문의 4축. 값 조정은 리뷰 대상 (완화가 곧 반경 확대다)."""
+
+    wall_clock_s: float = 120.0
+    subprocess_calls: int = 16
+    candidates: int = 20
+    usd: float = 0.0  # Phase 0 은 LLM 0 — 0 초과는 곧 설계 위반이다
+
+
+@dataclass
+class _CapTracker:
+    caps: AuditCaps
+    started: float = field(default_factory=time.monotonic)
+    subprocess_used: int = 0
+    candidates_staged: int = 0
+    usd_spent: float = 0.0
+
+    def check_wall_clock(self) -> None:
+        if time.monotonic() - self.started > self.caps.wall_clock_s:
+            raise CapExceeded("wall_clock")
+
+    def charge_subprocess(self) -> None:
+        self.subprocess_used += 1
+        if self.subprocess_used > self.caps.subprocess_calls:
+            raise CapExceeded("subprocess_calls")
+
+    def charge_candidate(self) -> None:
+        self.candidates_staged += 1
+        if self.candidates_staged > self.caps.candidates:
+            raise CapExceeded("candidates")
+
+    def charge_usd(self, amount: float) -> None:
+        self.usd_spent += amount
+        if self.usd_spent > self.caps.usd:
+            raise CapExceeded("usd")
+
+
+@dataclass
+class ScanContext:
+    """스캐너에 주입되는 실행 환경 — subprocess 는 반드시 이 helper 를 탄다 (캡 계상)."""
+
+    repo_root: Path
+    tracker: _CapTracker
+    db_path: Optional[Path] = None
+
+    def run(
+        self, argv: list[str], timeout: float = 30.0, stdin_text: Optional[str] = None
+    ) -> subprocess.CompletedProcess[str]:
+        """캡 계상 subprocess — timeout 이 **남은 wall-clock 예산으로 잘린다**.
+
+        "단계 사이 검사" 만으로는 단일 subprocess 하나가 예산 전체를 태울 수 있다
+        (codex plan 리뷰 5). 예산은 실행 **전에** 차감·강제한다.
+        """
+        remaining = self.tracker.caps.wall_clock_s - (time.monotonic() - self.tracker.started)
+        if remaining <= 0:
+            raise CapExceeded("wall_clock")
+        self.tracker.charge_subprocess()
+        try:
+            return subprocess.run(
+                argv,
+                cwd=self.repo_root,
+                input=stdin_text,
+                capture_output=True,
+                text=True,
+                timeout=min(timeout, remaining),
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CapExceeded("wall_clock") from exc
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 스캔 축 5종 — 전부 결정론. 각자는 (axis, title, detail) dict 목록을 낸다.
+# title 은 **안정적**이어야 한다 (fingerprint 축) — 날짜·카운트는 detail 로.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def scan_gate_liveness(ctx: ScanContext) -> list[dict[str, str]]:
+    """설치된 git 훅의 생존 — absent gate (#1070) / broken symlink / 실행권 부재.
+
+    grep 이 아니라 파일계 사실 + `bash -n` 문법 검사만 본다. 게이트 **실행** 잠금은
+    tests/test_pre_push_hook.py 계열의 몫 — 여기는 "설치가 사라졌다" 를 잡는 축이다.
+    """
+    out: list[dict[str, str]] = []
+    hooks_dir = ctx.repo_root / ".git" / "hooks"
+    for hook in ("pre-push", "pre-commit"):
+        installed = hooks_dir / hook
+        source = ctx.repo_root / "scripts" / "hooks" / hook
+        if not source.exists():
+            out.append(
+                {
+                    "axis": "gate_liveness",
+                    "title": f"훅 소스 부재: scripts/hooks/{hook}",
+                    "detail": "설치기가 심을 파일이 없다 — #1070 absent-gate 그 자체.",
+                }
+            )
+            continue
+        if not installed.exists():
+            out.append(
+                {
+                    "axis": "gate_liveness",
+                    "title": f"훅 미설치: .git/hooks/{hook}",
+                    "detail": "소스는 있으나 설치돼 있지 않다. `make setup-hooks` 미실행 또는 링크 파손.",
+                }
+            )
+            continue
+        rc = ctx.run(["bash", "-n", str(source)])
+        if rc.returncode != 0:
+            out.append(
+                {
+                    "axis": "gate_liveness",
+                    "title": f"훅 문법 오류: scripts/hooks/{hook}",
+                    "detail": f"bash -n rc={rc.returncode}: {rc.stderr.strip()[:300]}",
+                }
+            )
+    gate = ctx.repo_root / "scripts" / "verify" / "pre_push_check.sh"
+    if not gate.exists():
+        out.append(
+            {
+                "axis": "gate_liveness",
+                "title": "게이트 스크립트 부재: scripts/verify/pre_push_check.sh",
+                "detail": "훅이 정직하게 차단은 하겠지만 (--no-verify 안내) 게이트 자체가 없다.",
+            }
+        )
+    return out
+
+
+def scan_doc_drift(ctx: ScanContext) -> list[dict[str, str]]:
+    """doc↔code 카운트 드리프트 — red 뿐 아니라 **warn+exit0** 도 잡는다 (#1288 계열)."""
+    rc = ctx.run(["bash", "scripts/verify/verify_doc_counts.sh"], timeout=60.0)
+    out: list[dict[str, str]] = []
+    if rc.returncode != 0:
+        out.append(
+            {
+                "axis": "doc_drift",
+                "title": "verify-doc-counts FAIL",
+                "detail": (rc.stdout + rc.stderr).strip()[-500:],
+            }
+        )
+    else:
+        # warn 전부가 아니라 **죽은 검사 시그니처만** — 스크립트의 warn 은
+        # `pattern not found`(등록 문자열 유실) / `missing`(대상 파일 부재) 두 형태가
+        # 검증 공백이고, 나머지 warn 은 benign 하다 (codex plan 리뷰 8).
+        dead_check_lines = [
+            line.strip()
+            for line in (rc.stdout + rc.stderr).splitlines()
+            if "pattern not found" in line or ("missing" in line and "warn" in line.lower())
+        ]
+        if dead_check_lines:
+            out.append(
+                {
+                    "axis": "doc_drift",
+                    "title": "verify-doc-counts 죽은 검사 (warn + exit 0)",
+                    "detail": "게이트 초록인데 검증이 비어 있다 — #1288 계열 (등록 패턴 유실/파일 부재).\n"
+                    + "\n".join(dead_check_lines[:5]),
+                }
+            )
+    return out
+
+
+#: `_run_collector` args ↔ Makefile 모듈명이 1:1 이 아닌 알려진 별칭.
+#: 항목마다 사유 — 스캐너 오탐을 리뷰가 아니라 코드가 걸러야 하는 건 이 정도뿐이다.
+#: 낡은 별칭은 스캐너가 **스스로 후보로 신고한다** (아래 self-check) — 손으로 유지하는
+#: 진실 사본이 조용히 썩는 것이 이 레포의 반복 사고라서다 (codex plan 리뷰 4).
+_COLLECTOR_ALIASES: dict[str, tuple[str, ...]] = {
+    # 야간/새벽 두 슬롯이 같은 모듈을 돈다
+    "stock": ("stock_us_night", "stock_us_dawn", "stock"),
+}
+
+
+def scan_scheduler_wiring(ctx: ScanContext) -> list[dict[str, str]]:
+    """`make collect` 의 수집기 vs SCHEDULES 배선 대조 — #900 (몇 달간 무배선) 패턴.
+
+    오탐 가능성을 안고 가는 축이다 — 의도된 수동 전용 수집기는 리뷰에서 reject 되고,
+    그 기각률이 precision 지표에 그대로 잡힌다 (오탐이 비싸지면 스캐너를 고친다).
+    """
+    makefile = (ctx.repo_root / "Makefile").read_text(encoding="utf-8")
+    m = re.search(r"^collect:\n((?:\t.*\n)+)", makefile, re.M)
+    if not m:
+        return [
+            {
+                "axis": "scheduler_wiring",
+                "title": "Makefile collect: 타깃을 찾을 수 없음",
+                "detail": "스캐너의 전제가 무너졌다 — collect 타깃 이름/형태 변경 여부 확인.",
+            }
+        ]
+    cli_modules = set(re.findall(r"-m nuri\.collectors\.([a-z_]+)", m.group(1)))
+
+    from nuri.scheduler import SCHEDULES, _run_collector
+
+    scheduled = {s["args"][0] for s in SCHEDULES if s.get("func") is _run_collector and s.get("args")}
+
+    out: list[dict[str, str]] = []
+    # 별칭 self-check — 별칭이 현실과 어긋나면 그 자체가 후보다 (양방향 allowlist 원칙)
+    for module, aliases in _COLLECTOR_ALIASES.items():
+        if module not in cli_modules or not (scheduled & set(aliases)):
+            out.append(
+                {
+                    "axis": "scheduler_wiring",
+                    "title": f"수집기 별칭 낡음: {module}",
+                    "detail": f"_COLLECTOR_ALIASES[{module!r}]={aliases} 가 Makefile/SCHEDULES 현실과 "
+                    "안 맞는다 — 별칭 지도를 갱신할 것 (진실 사본은 썩는다).",
+                }
+            )
+
+    covered = set(scheduled)
+    for module, aliases in _COLLECTOR_ALIASES.items():
+        if covered & set(aliases):
+            covered.add(module)
+
+    out.extend(
+        {
+            "axis": "scheduler_wiring",
+            "title": f"collect CLI 에만 있는 수집기: {name}",
+            "detail": "`make collect` 는 돌리는데 SCHEDULES 에 없다 — #900 계열 (수개월 무갱신, "
+            "헬스는 초록). 의도된 수동 전용이면 reject 하고 사유를 남길 것.",
+        }
+        for name in sorted(cli_modules - covered)
+    )
+    return out
+
+
+def scan_stale_collectors(ctx: ScanContext) -> list[dict[str, str]]:
+    """SCHEDULES 에 배선된 수집기의 14일 무완주 — '배선됐지만 침묵' 축.
+
+    ⚠️ 한계를 그대로 적는다 (codex plan 리뷰 3): `finished` 는 "run 이 끝났다" 이지
+    "데이터가 건강하다" 가 아니다 — cboe/fear_greed 류는 stale/빈 fallback 으로도
+    finished 로 끝난다. 이 축이 잡는 것은 **완주 자체가 멎은** #900 계열의 침묵이고,
+    건강한-척-완주는 freshness 정책(#1071 계열)의 몫이다.
+
+    DB 는 readonly 로 읽는다 (#1306 facade) — 감사가 감사 대상을 변형하면 안 된다.
+    """
+    from nuri.core.db import query
+    from nuri.scheduler import SCHEDULES, _run_collector
+
+    scheduled = sorted({s["args"][0] for s in SCHEDULES if s.get("func") is _run_collector and s.get("args")})
+    rows = query(
+        "SELECT collector_name, MAX(started_at) AS last_finished FROM collector_runs"
+        " WHERE status = 'finished' GROUP BY collector_name",
+        db_path=ctx.db_path,
+        readonly=True,
+    )
+    if not rows:
+        # 기록이 통째로 없다 = 수집기별 N건이 아니라 **전면 침묵 1건**이다 — 빈/신규
+        # DB 에서 후보가 캡까지 범람하는 것을 실측하고 고쳤다 (dev replica 포함).
+        return [
+            {
+                "axis": "stale_collector",
+                "title": "collector_runs 에 finished 기록이 전혀 없음",
+                "detail": f"배선된 수집기 {len(scheduled)}종 전부 완주 이력 0 — 신규/복제 DB 이거나 "
+                "수집 계층 전면 정지. 개별 수집기 축은 기록이 생긴 뒤에야 의미가 있다.",
+            }
+        ]
+    last_finished = {r["collector_name"]: r["last_finished"] for r in rows}
+
+    from datetime import timedelta
+
+    from nuri.core.timezone import kst_now
+
+    threshold = (kst_now() - timedelta(days=14)).isoformat()
+    out: list[dict[str, str]] = []
+    for name in scheduled:
+        seen = last_finished.get(name)
+        if seen is None or seen < threshold:
+            out.append(
+                {
+                    "axis": "stale_collector",
+                    "title": f"수집기 14일 무완주: {name}",
+                    "detail": f"마지막 finished: {seen or '기록 없음'} — 배선은 있으나 완주가 멎었다 "
+                    "(#900 계열). finished≠건강 — 데이터 품질은 freshness 정책 축이다. "
+                    "주 1회 수집기의 정상 리듬이면 reject 로 기록.",
+                }
+            )
+    return out
+
+
+def scan_dependency(ctx: ScanContext) -> list[dict[str, str]]:
+    """uv.lock ↔ pyproject 드리프트 — `--frozen` 배포(deploy-mini step 5)를 깨는 축."""
+    import shutil
+
+    uv = shutil.which("uv") or ("/opt/homebrew/bin/uv" if Path("/opt/homebrew/bin/uv").exists() else None)
+    if uv is None:
+        return [
+            {
+                "axis": "dependency",
+                "title": "uv 부재 — lock 드리프트 검사 미실행",
+                "detail": "'깨끗함' 이 아니라 '미확인' 이다. PATH 를 확인할 것.",
+            }
+        ]
+    rc = ctx.run([uv, "lock", "--check"], timeout=60.0)
+    if rc.returncode != 0:
+        return [
+            {
+                "axis": "dependency",
+                "title": "uv.lock 이 pyproject 와 어긋남",
+                "detail": "`uv lock --check` 실패 — deploy-mini 의 `uv sync --frozen` 이 깨진다.\n"
+                + (rc.stdout + rc.stderr).strip()[-300:],
+            }
+        ]
+    return []
+
+
+SCANNERS: tuple[Callable[[ScanContext], list[dict[str, str]]], ...] = (
+    scan_gate_liveness,
+    scan_doc_drift,
+    scan_scheduler_wiring,
+    scan_stale_collectors,
+    scan_dependency,
+)
+
+
+@REGISTRY.register
+class MaintenanceAuditor(Actor):
+    """주간 발굴 스캔 → 로컬 원장 staging. 발행은 언제나 사람."""
+
+    name = "maintenance-auditor"
+    version = "0.1.0"
+    layer = Layer.B
+
+    VALID_ACTIONS = ("scan", "list", "review", "stats")
+
+    def execute(self, input_data: dict[str, Any], ctx: RunContext) -> ActorResult:
+        action = input_data.get("action", "scan")
+        db_path = input_data.get("db_path")
+        if action == "scan":
+            return self._scan(input_data, ctx, db_path)
+        if action == "list":
+            from nuri.core.db import list_maintenance_candidates
+
+            rows = list_maintenance_candidates(status=input_data.get("status"), db_path=db_path)
+            return ActorResult(output={"candidates": rows}, outcome=Outcome.PASS, sample_n=len(rows))
+        if action == "review":
+            from nuri.core.db import review_maintenance_candidate
+
+            ok = review_maintenance_candidate(
+                int(input_data["id"]), input_data["verdict"], input_data.get("note"), db_path=db_path
+            )
+            return ActorResult(
+                output={"reviewed": ok, "id": input_data["id"], "verdict": input_data["verdict"]},
+                outcome=Outcome.PASS if ok else Outcome.WARN,
+            )
+        if action == "stats":
+            from nuri.core.db import maintenance_review_stats
+
+            return ActorResult(output=maintenance_review_stats(db_path=db_path), outcome=Outcome.PASS)
+        return ActorResult(output={"error": f"unknown action {action!r}"}, outcome=Outcome.ERROR)
+
+    # ── scan ────────────────────────────────────────────────────────────────
+
+    def _scan(self, input_data: dict[str, Any], ctx: RunContext, db_path: Optional[Path]) -> ActorResult:
+        from nuri.core.db import stage_maintenance_candidate
+
+        caps = AuditCaps(**input_data.get("caps", {}))
+        tracker = _CapTracker(caps=caps)
+        scan_ctx = ScanContext(repo_root=REPO_ROOT, tracker=tracker, db_path=db_path)
+
+        staged = seen = privacy_blocked = 0
+        scanner_errors: list[str] = []
+        aborted: Optional[str] = None
+
+        for scanner in SCANNERS:
+            try:
+                tracker.check_wall_clock()
+                findings = scanner(scan_ctx)
+                for f in findings:
+                    tracker.check_wall_clock()
+                    if not self._privacy_ok(f["title"] + "\n" + f["detail"]):
+                        # 원장에 stub 도 남기지 않는다 (codex plan 리뷰 2) — 가짜 후보는
+                        # precision/novelty 를 오염시키고, 민감 내용의 파생물을 남길 위험이
+                        # 있다. 사건 자체는 output 카운터로 audit ledger 에 영속된다.
+                        privacy_blocked += 1
+                        continue
+                    tracker.charge_candidate()
+                    verdict, _ = stage_maintenance_candidate(
+                        f["axis"],
+                        f["title"],
+                        f["detail"],
+                        _fingerprint(f["axis"], f["title"]),
+                        ctx.run_id,
+                        db_path=db_path,
+                    )
+                    if verdict == "staged":
+                        staged += 1
+                    else:
+                        seen += 1
+            except CapExceeded as exc:
+                aborted = exc.cap
+                break
+            except Exception as exc:  # 스캐너 하나가 죽어도 루프는 산다 (#894/#927 계열)
+                scanner_errors.append(f"{scanner.__name__}: {str(exc)[:200]}")
+
+        output = {
+            "staged": staged,
+            "seen_again": seen,
+            "privacy_blocked": privacy_blocked,
+            "aborted_by_cap": aborted,
+            "scanner_errors": scanner_errors,
+            "subprocess_used": tracker.subprocess_used,
+            "usd_spent": tracker.usd_spent,
+            "wall_clock_s": round(time.monotonic() - tracker.started, 1),
+        }
+        self._surface_summary(output)
+        outcome = Outcome.WARN if (aborted or scanner_errors) else Outcome.PASS
+        return ActorResult(output=output, outcome=outcome, sample_n=staged + seen)
+
+    @staticmethod
+    def _privacy_ok(text: str) -> bool:
+        """staging 전 privacy 스캔 — **전 범주** `gate_text` (broker명·금액·ticker+PnL).
+
+        `--message` CLI 모드는 ticker+PnL 만 본다 (codex plan 리뷰 1 — blocking 지적).
+        in-process import 는 `stage_agent_dev_log` 가 이미 쓰는 런타임 게이트 선례
+        (nuri/agents/discord/outbox.py:224) 그대로다. import/실행 실패는 **차단**으로
+        취급한다 — 스캔 못 한 것은 깨끗한 것이 아니다 (fail-closed).
+        """
+        try:
+            scripts_dir = REPO_ROOT / "scripts" / "verify"
+            if str(scripts_dir) not in sys.path:
+                sys.path.insert(0, str(scripts_dir))
+            from check_privacy_leak import gate_text  # type: ignore[import-not-found]
+
+            return not gate_text(text, source="<maintenance_candidate>")
+        except Exception:
+            return False
+
+    def _surface_summary(self, output: dict[str, Any]) -> None:
+        """주간 한 줄을 #ops 로 — 정직한 0건도 표면화한다 (quiet-by-design 금지).
+
+        관측이 본 작업을 게이트하면 안 된다 — 실패는 삼키고 로그만 남긴다 (#894).
+        """
+        try:
+            from nuri.agents.discord.outbox import stage_ops
+
+            line = (
+                f"🔧 maintenance audit: 신규 {output['staged']} · 재검출 {output['seen_again']}"
+                f" · privacy차단 {output['privacy_blocked']}"
+                + (f" · **{output['aborted_by_cap']} 캡 중단**" if output["aborted_by_cap"] else "")
+                + (f" · 스캐너 오류 {len(output['scanner_errors'])}" if output["scanner_errors"] else "")
+                + " — 리뷰: `python -m nuri.agents.actors.maintenance_auditor list`"
+            )
+            # 카운트만 — 후보 title/detail 은 어떤 경로로도 Discord 에 싣지 않는다
+            # (원장 격리의 요점; 잠금 테스트가 payload 를 검사한다).
+            stage_ops(
+                payload={"kind": "maintenance_audit_weekly", "summary": line},
+                dedupe_key=None,
+                actor_name=self.name,
+            )
+        except Exception as exc:
+            logger.warning(f"[maintenance-auditor] #ops 표면화 실패 (본 작업은 완료): {exc}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI — scan / list [status] / review <id> <verdict> [note] / stats."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("scan")
+    p_list = sub.add_parser("list")
+    p_list.add_argument("status", nargs="?", default=None)
+    p_review = sub.add_parser("review")
+    p_review.add_argument("id", type=int)
+    p_review.add_argument("verdict", choices=["approved", "rejected", "published"])
+    p_review.add_argument("note", nargs="?", default=None)
+    sub.add_parser("stats")
+    args = parser.parse_args(argv)
+
+    input_data: dict[str, Any] = {"action": args.action}
+    if args.action == "list" and args.status:
+        input_data["status"] = args.status
+    if args.action == "review":
+        input_data.update({"id": args.id, "verdict": args.verdict, "note": args.note})
+
+    result = MaintenanceAuditor().run(input_data)
+    print(json.dumps(result.output, ensure_ascii=False, indent=2, default=str))
+    return 0 if result.outcome in (Outcome.PASS, Outcome.WARN) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nuri/agents/actors/maintenance_auditor.py
+++ b/nuri/agents/actors/maintenance_auditor.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -167,6 +168,17 @@ def scan_gate_liveness(ctx: ScanContext) -> list[dict[str, str]]:
                     "axis": "gate_liveness",
                     "title": f"훅 미설치: .git/hooks/{hook}",
                     "detail": "소스는 있으나 설치돼 있지 않다. `make setup-hooks` 미실행 또는 링크 파손.",
+                }
+            )
+            continue
+        # 실행비트가 빠지면 git 은 훅을 아예 부르지 않는다 — bash -n 초록과 무관한
+        # green dead gate (codex P2). `make setup-hooks` 재실행 전까지 복구되지 않는다.
+        if not os.access(installed, os.X_OK):
+            out.append(
+                {
+                    "axis": "gate_liveness",
+                    "title": f"훅 실행권 부재: .git/hooks/{hook}",
+                    "detail": "파일은 있으나 실행비트가 없어 git 이 훅을 건너뛴다. `make setup-hooks` 재실행 필요.",
                 }
             )
             continue

--- a/nuri/agents/base.py
+++ b/nuri/agents/base.py
@@ -241,6 +241,8 @@ class ActorRegistry:
         "execution-firewall",
         "forward-outcome-tracker",
         "sre-incident-agent",
+        # #1308 Phase 0 — 호출자: scheduler `_run_maintenance_audit` (주간, 같은 PR 에서 배선)
+        "maintenance-auditor",
     )
     #: 구현·테스트는 있으나 어떤 경로도 부르지 않는 휴면 액터. 등록은 허용하되
     #: `missing()` 추적에서 제외 — "미배선을 pending 으로 광고" 하지 않기 위해.

--- a/nuri/core/db/__init__.py
+++ b/nuri/core/db/__init__.py
@@ -68,6 +68,12 @@ from .execution_ops import (  # noqa: F401, E402
 # ═══════════════════════════════════════════════════════
 # Submodule re-exports — P2 Stage 2 PR-B (writer split)
 # ═══════════════════════════════════════════════════════
+from .maintenance_ops import (  # noqa: F401, E402
+    list_maintenance_candidates,
+    maintenance_review_stats,
+    review_maintenance_candidate,
+    stage_maintenance_candidate,
+)
 from .market_data import (  # noqa: F401, E402
     insert_events,
     upsert_ark,

--- a/nuri/core/db/maintenance_ops.py
+++ b/nuri/core/db/maintenance_ops.py
@@ -1,0 +1,140 @@
+"""유지보수 발굴 후보 원장 writes/reads — maintenance_candidates (#1308 Phase 0).
+
+## Shadow mode 의 계약
+
+이 원장은 **로컬이 전부다**. staged → 사람 approve/reject → 사람이 손으로 이슈화한 뒤
+published 표기. GitHub 쓰기는 어디에도 없다 — 자동 발행은 "proposal-only" 가 아니라
+그 자체가 리뷰·평판·privacy 비용이 있는 외부 쓰기다 (이슈 본문, codex challenge 반영).
+
+## 재검출은 중복이 아니라 신호다
+
+같은 fingerprint 는 영원히 1행 (`UNIQUE`) — 재검출 시 `last_seen_at`/`seen_count` 만
+갱신한다. 이 설계가 곧 4주 Reflect 의 측정이다: novelty = 새 fingerprint 비율,
+precision = 리뷰된 것 중 승인 비율, 검토 지연 = reviewed_at − created_at. 건수 목표는
+일부러 없다 (Goodhart — "실행당 결함 ≥1건" 은 쉬운 잡동사니 양산 유인).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from .connection import get_db
+
+logger = logging.getLogger(__name__)
+
+#: 리뷰 동사 → 상태. publish 는 **사람이 손으로 이슈를 만든 뒤** 표기하는 것이지
+#: 자동 발행이 아니다 (Phase 0 불변).
+REVIEW_VERDICTS = ("approved", "rejected", "published")
+
+
+def stage_maintenance_candidate(
+    axis: str,
+    title: str,
+    detail: str,
+    fingerprint: str,
+    run_id: str,
+    db_path: Optional[Path] = None,
+) -> tuple[str, int]:
+    """후보 1건 staged — 기존 fingerprint 면 재검출 갱신. ("staged"|"seen", row id) 반환.
+
+    privacy 스캔은 **호출자(actor)가 staging 전에** 끝냈어야 한다 — 여기는 저장만 한다.
+    (스캔을 여기 두면 db_path 격리 테스트가 스캐너 subprocess 에 묶인다.)
+    """
+    from nuri.core.timezone import kst_now
+
+    now = kst_now().isoformat()
+    with get_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT id FROM maintenance_candidates WHERE fingerprint = ?", (fingerprint,)
+        ).fetchone()
+        if existing:
+            conn.execute(
+                "UPDATE maintenance_candidates SET last_seen_at = ?, seen_count = seen_count + 1 WHERE id = ?",
+                (now, existing[0]),
+            )
+            return ("seen", int(existing[0]))
+        cur = conn.execute(
+            """INSERT INTO maintenance_candidates
+               (created_at, axis, title, detail, fingerprint, run_id, status, last_seen_at)
+               VALUES (?, ?, ?, ?, ?, ?, 'staged', ?)""",
+            (now, axis, title, detail, fingerprint, run_id, now),
+        )
+        return ("staged", int(cur.lastrowid or 0))
+
+
+def review_maintenance_candidate(
+    candidate_id: int,
+    verdict: str,
+    note: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> bool:
+    """사람 리뷰 기록. 미존재 id 는 False — 조용히 성공으로 위장하지 않는다."""
+    from nuri.core.timezone import kst_now
+
+    if verdict not in REVIEW_VERDICTS:
+        raise ValueError(f"verdict must be one of {REVIEW_VERDICTS}, got {verdict!r}")
+    with get_db(db_path) as conn:
+        cur = conn.execute(
+            "UPDATE maintenance_candidates SET status = ?, reviewed_at = ?, review_note = ? WHERE id = ?",
+            (verdict, kst_now().isoformat(), note, candidate_id),
+        )
+        return cur.rowcount > 0
+
+
+def list_maintenance_candidates(status: Optional[str] = None, db_path: Optional[Path] = None) -> list[dict[str, Any]]:
+    from nuri.core.db import query
+
+    if status:
+        return query(
+            "SELECT * FROM maintenance_candidates WHERE status = ? ORDER BY created_at DESC",
+            (status,),
+            db_path=db_path,
+            readonly=True,
+        )
+    return query(
+        "SELECT * FROM maintenance_candidates ORDER BY created_at DESC",
+        db_path=db_path,
+        readonly=True,
+    )
+
+
+def maintenance_review_stats(db_path: Optional[Path] = None) -> dict[str, Any]:
+    """4주 Reflect 지표 — precision · novelty · 검토 지연(중앙값, 시간).
+
+    - precision: 리뷰된 것(approved/rejected/published) 중 approved+published 비율.
+      리뷰 0건이면 None — 0.0 으로 표기하면 "전부 기각" 과 구분이 안 된다.
+    - novelty: 전체 검출(seen_count 합) 중 고유 fingerprint 비율.
+    - review_latency_h_median: reviewed_at − created_at 중앙값 (시간).
+    """
+    from nuri.core.db import query
+
+    rows = query(
+        "SELECT status, seen_count, created_at, reviewed_at FROM maintenance_candidates",
+        db_path=db_path,
+        readonly=True,
+    )
+    total_detections = sum(r["seen_count"] for r in rows)
+    reviewed = [r for r in rows if r["status"] in REVIEW_VERDICTS]
+    accepted = [r for r in reviewed if r["status"] in ("approved", "published")]
+
+    latencies: list[float] = []
+    for r in reviewed:
+        if r["reviewed_at"] and r["created_at"]:
+            from datetime import datetime
+
+            delta = datetime.fromisoformat(r["reviewed_at"]) - datetime.fromisoformat(r["created_at"])
+            latencies.append(delta.total_seconds() / 3600)
+    latencies.sort()
+    median = latencies[len(latencies) // 2] if latencies else None
+
+    return {
+        "candidates": len(rows),
+        "detections": total_detections,
+        "reviewed": len(reviewed),
+        "precision": (len(accepted) / len(reviewed)) if reviewed else None,
+        "novelty": (len(rows) / total_detections) if total_detections else None,
+        "review_latency_h_median": median,
+        "staged_pending": sum(1 for r in rows if r["status"] == "staged"),
+    }

--- a/nuri/core/db/maintenance_ops.py
+++ b/nuri/core/db/maintenance_ops.py
@@ -17,6 +17,7 @@ precision = 리뷰된 것 중 승인 비율, 검토 지연 = reviewed_at − cre
 from __future__ import annotations
 
 import logging
+import statistics
 from pathlib import Path
 from typing import Any, Optional
 
@@ -126,8 +127,9 @@ def maintenance_review_stats(db_path: Optional[Path] = None) -> dict[str, Any]:
 
             delta = datetime.fromisoformat(r["reviewed_at"]) - datetime.fromisoformat(r["created_at"])
             latencies.append(delta.total_seconds() / 3600)
-    latencies.sort()
-    median = latencies[len(latencies) // 2] if latencies else None
+    # 짝수 개면 statistics.median 이 가운데 두 값의 평균 — `[len//2]` 는 상위
+    # 중앙값이라 짝수마다 체계적으로 과대 보고한다 (codex P3).
+    median = statistics.median(latencies) if latencies else None
 
     return {
         "candidates": len(rows),

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1843,4 +1843,35 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
             ON challenger_attempts(family, holdout_id, holdout_consumed);
     """,
     ),
+    (
+        59,
+        "maintenance_candidates — 유지보수 발굴 후보 원장, shadow mode (#1308 Phase 0)",
+        # incidents/discord_outbox 동형: staged → 사람 approve/reject → (사람 손 발행 후
+        # published 표기). GitHub 자동 쓰기는 없다 — Phase 0 수용 기준이자 잠금 테스트 대상.
+        #
+        # `UNIQUE(fingerprint)`: 같은 발견은 영원히 1행 — 재검출은 last_seen_at/seen_count
+        # 갱신. novelty(새 fingerprint 비율)·precision(승인율)·검토 지연(reviewed_at −
+        # created_at)이 4주 Reflect 의 판정 지표라 스키마가 곧 측정 설계다.
+        """
+        CREATE TABLE IF NOT EXISTS maintenance_candidates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT NOT NULL,
+            axis TEXT NOT NULL CHECK(axis IN
+                ('gate_liveness', 'doc_drift', 'scheduler_wiring',
+                 'stale_collector', 'dependency')),
+            title TEXT NOT NULL,
+            detail TEXT NOT NULL,
+            fingerprint TEXT NOT NULL UNIQUE,
+            run_id TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'staged' CHECK(status IN
+                ('staged', 'approved', 'rejected', 'published')),
+            reviewed_at TEXT,
+            review_note TEXT,
+            last_seen_at TEXT NOT NULL,
+            seen_count INTEGER NOT NULL DEFAULT 1
+        );
+        CREATE INDEX IF NOT EXISTS idx_maintenance_status
+            ON maintenance_candidates(status, created_at);
+    """,
+    ),
 ]

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -1038,9 +1038,11 @@ SCHEDULES = [
     {"name": "dispatcher_rollout", "func": _run_channel_dispatcher, "args": ("rollout",), "cron": "0 6 * * 0"},
     # Watchdog — outbox backlog / oldest-pending-age threshold breach 시 #ops 직접 발송 (recursion 방지).
     {"name": "outbox_watchdog", "func": _run_outbox_watchdog, "args": (), "cron": "*/10 * * * *"},
-    # 유지보수 발굴 주간 스캔 (#1308 Phase 0) — 일요일 03:00 KST (00:00-01:00 주간
-    # 수집 블록 뒤 조용한 슬롯). 로컬 원장 staging 만 — GitHub 쓰기 없음.
-    {"name": "maintenance_audit", "func": _run_maintenance_audit, "args": (), "cron": "0 3 * * 0"},
+    # 유지보수 발굴 주간 스캔 (#1308 Phase 0) — 일요일 04:30 KST. 03:00 은
+    # db_maintenance(VACUUM/checkpoint)·etf_flows 와 같은 슬롯이라 매주 lock 경합
+    # 위험 (codex P1). 04:30 은 memory_snapshot(04:00) 뒤·backfill(05:00) 앞의 빈
+    # 슬롯이고 정시(hourly macro/news)도 피한다. 로컬 원장 staging 만 — GitHub 쓰기 없음.
+    {"name": "maintenance_audit", "func": _run_maintenance_audit, "args": (), "cron": "30 4 * * 0"},
     # 기계 밖 감시 dead-man heartbeat (#1191 C) — production(mini)에서만 실제 push,
     # dev 는 role 게이트로 no-op. 5분이 아니라 10분인 이유: 감시자 임계(45분)에
     # 4~5회 여유가 있으면 충분하고, push 는 네트워크 왕복이라 슬롯을 아낀다.

--- a/nuri/scheduler.py
+++ b/nuri/scheduler.py
@@ -816,6 +816,21 @@ def _run_outbox_watchdog():
         logger.error(f"[outbox_watchdog] 실행 실패: {e}", exc_info=True)
 
 
+def _run_maintenance_audit():
+    """Maintenance-Auditor 주간 스캔 (#1308 Phase 0) — 로컬 원장 staging 만.
+
+    GitHub 쓰기 0건 · LLM 0 · 하드 캡 4종은 actor 내부 계약 — 여기서는 다른
+    `_run_*` 와 동일하게 실패를 흡수만 한다.
+    """
+    try:
+        from nuri.agents.actors.maintenance_auditor import MaintenanceAuditor
+
+        result = MaintenanceAuditor().run({"action": "scan"})
+        logger.info(f"[maintenance_audit] {result.output}")
+    except Exception as e:
+        logger.error(f"[maintenance_audit] 실행 실패: {e}", exc_info=True)
+
+
 def _run_offbox_heartbeat():
     """기계 밖 감시 dead-man heartbeat (#1191 C). 10분 마다.
 
@@ -1023,6 +1038,9 @@ SCHEDULES = [
     {"name": "dispatcher_rollout", "func": _run_channel_dispatcher, "args": ("rollout",), "cron": "0 6 * * 0"},
     # Watchdog — outbox backlog / oldest-pending-age threshold breach 시 #ops 직접 발송 (recursion 방지).
     {"name": "outbox_watchdog", "func": _run_outbox_watchdog, "args": (), "cron": "*/10 * * * *"},
+    # 유지보수 발굴 주간 스캔 (#1308 Phase 0) — 일요일 03:00 KST (00:00-01:00 주간
+    # 수집 블록 뒤 조용한 슬롯). 로컬 원장 staging 만 — GitHub 쓰기 없음.
+    {"name": "maintenance_audit", "func": _run_maintenance_audit, "args": (), "cron": "0 3 * * 0"},
     # 기계 밖 감시 dead-man heartbeat (#1191 C) — production(mini)에서만 실제 push,
     # dev 는 role 게이트로 no-op. 5분이 아니라 10분인 이유: 감시자 임계(45분)에
     # 4~5회 여유가 있으면 충분하고, push 는 네트워크 왕복이라 슬롯을 아낀다.

--- a/tests/agents/test_base.py
+++ b/tests/agents/test_base.py
@@ -301,13 +301,16 @@ class TestActorLifecycle:
 
 class TestActorRegistry:
     def test_roster_tiers_partition_cleanly(self):
-        """canonical(배선 8) + dormant(휴면 7) = 전체 15, 교집합 없음 (#975).
+        """canonical(배선 9) + dormant(휴면 7) = 전체 16, 교집합 없음 (#975).
 
         canonical 은 "실제 호출자가 있다" 는 주장이다 — 새 액터를 canonical 에
         넣으려면 호출 경로가 같은 PR 에 있어야 한다.
+        9번째 = maintenance-auditor (#1308 Phase 0) — 호출자는 scheduler
+        `_run_maintenance_audit` (주간, 같은 PR 에서 배선, 잠금:
+        tests/agents/test_maintenance_auditor.py::TestWiringAndRoster).
         """
         c, d = set(ActorRegistry.CANONICAL_ACTORS), set(ActorRegistry.DORMANT_ACTORS)
-        assert len(c) == 8 and len(d) == 7
+        assert len(c) == 9 and len(d) == 7
         assert not (c & d), f"양쪽에 있는 액터: {c & d}"
         assert set(ActorRegistry.CANONICAL_15) == c | d  # 하위 호환 별칭
 

--- a/tests/agents/test_maintenance_auditor.py
+++ b/tests/agents/test_maintenance_auditor.py
@@ -1,0 +1,329 @@
+"""Maintenance-Auditor shadow mode 잠금 (#1308 Phase 0).
+
+수용 기준 세 축이 각자 실행형 잠금을 갖는다:
+- **GitHub 쓰기 0건** — 구조 스윕(금지 import/문자열) + 행동 spy(subprocess argv
+  바이너리 allowlist — denylist 는 새 우회를 못 잡는다).
+- **하드 캡 초과 시 중단** — 캡 4종 각각: 초과 시 스캔이 멎고 어느 캡인지 기록.
+- **staging 전 privacy 스캔** — 전 범주 `gate_text` (broker명·금액·ticker+PnL).
+  걸린 후보는 원장에 흔적 없이 드롭, 사건은 output 카운터로만 (가짜 후보는
+  precision/novelty 를 오염시킨다 — codex plan 리뷰 반영).
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess as real_subprocess
+from pathlib import Path
+
+import pytest
+
+from nuri.agents.actors import maintenance_auditor as ma
+from nuri.core.db import (
+    init_db,
+    list_maintenance_candidates,
+    maintenance_review_stats,
+    review_maintenance_candidate,
+    stage_maintenance_candidate,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_FILES = [REPO_ROOT / "nuri" / "agents" / "actors" / "maintenance_auditor.py"]
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    path = tmp_path / "audit.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture()
+def quiet_ops(monkeypatch):
+    """#ops 표면화를 캡처 — 테스트가 outbox 를 건드리지 않게 + payload 잠금용."""
+    lines: list[str] = []
+    monkeypatch.setattr(
+        ma.MaintenanceAuditor,
+        "_surface_summary",
+        lambda self, output: lines.append(str(output)),
+    )
+    return lines
+
+
+def _scan(db_path, caps=None, extra=None):
+    input_data = {"action": "scan", "db_path": db_path}
+    if caps:
+        input_data["caps"] = caps
+    if extra:
+        input_data.update(extra)
+    return ma.MaintenanceAuditor().run(input_data)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 수용 기준 1 — GitHub 쓰기 0건
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestGitHubWriteZero:
+    def test_module_has_no_network_or_gh_surface(self):
+        """구조 스윕 — gh/git push/HTTP 클라이언트가 import 표면에 존재하지 않는다."""
+        banned_imports = ("requests", "httpx", "urllib", "aiohttp", "http.client")
+        for py in MODULE_FILES + [REPO_ROOT / "nuri" / "core" / "db" / "maintenance_ops.py"]:
+            src = py.read_text(encoding="utf-8")
+            tree = ast.parse(src)
+            for node in ast.walk(tree):
+                names: list[str] = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or ""]
+                for name in names:
+                    assert not name.startswith(banned_imports), f"{py.name}: 금지 import {name}"
+            assert "github.com" not in src and "api.github" not in src, f"{py.name}: GitHub 참조"
+
+    def test_scan_spawns_only_allowlisted_binaries(self, db_path, quiet_ops, monkeypatch):
+        """행동 잠금 — 스캔 중 모든 subprocess argv[0] 이 allowlist 안이고, gh/git-push
+        형태가 어디에도 없다. denylist 가 아니라 **binary allowlist** 다."""
+        import sys
+
+        spawned: list[list[str]] = []
+        orig_run = real_subprocess.run
+
+        def spy(argv, *args, **kwargs):
+            if isinstance(argv, (list, tuple)):
+                spawned.append([str(a) for a in argv])
+            return orig_run(argv, *args, **kwargs)
+
+        monkeypatch.setattr(ma.subprocess, "run", spy)
+        _scan(db_path)
+
+        for argv in spawned:
+            binary = Path(argv[0]).name if "/" in argv[0] else argv[0]
+            assert binary in {"bash", "uv", "python", Path(sys.executable).name}, f"allowlist 밖 바이너리 실행: {argv}"
+            joined = " ".join(argv)
+            assert "gh" != binary and " push" not in joined and "github" not in joined, f"GitHub 쓰기 의심 argv: {argv}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 수용 기준 2 — 하드 캡 초과 시 중단
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHardCaps:
+    def test_candidate_cap_stops_the_scan(self, db_path, quiet_ops, monkeypatch):
+        flood = [{"axis": "doc_drift", "title": f"t{i}", "detail": "d"} for i in range(50)]
+        monkeypatch.setattr(ma, "SCANNERS", (lambda ctx: flood,))
+
+        result = _scan(db_path, caps={"candidates": 5})
+
+        assert result.output["aborted_by_cap"] == "candidates"
+        assert result.outcome == ma.Outcome.WARN
+        assert len(list_maintenance_candidates(db_path=db_path)) == 5, "캡 초과분이 staging 됐다"
+
+    def test_wall_clock_cap_cuts_before_subprocess_launch(self, db_path, quiet_ops, monkeypatch):
+        """예산 소진 후 subprocess 는 **실행 자체가 안 된다** — 사후 검사가 아니다."""
+
+        def slow_then_spawn(ctx):
+            ctx.tracker.started -= 999  # 예산을 이미 다 쓴 상태를 주입
+            ctx.run(["bash", "-c", "echo never"])
+            return []
+
+        monkeypatch.setattr(ma, "SCANNERS", (slow_then_spawn,))
+        result = _scan(db_path)
+        assert result.output["aborted_by_cap"] == "wall_clock"
+        assert result.output["subprocess_used"] == 0, "예산 소진 뒤에도 subprocess 가 떴다"
+
+    def test_subprocess_cap(self, db_path, quiet_ops, monkeypatch):
+        def spawn_many(ctx):
+            for _ in range(10):
+                ctx.run(["bash", "-c", "true"])
+            return []
+
+        monkeypatch.setattr(ma, "SCANNERS", (spawn_many,))
+        result = _scan(db_path, caps={"subprocess_calls": 3})
+        assert result.output["aborted_by_cap"] == "subprocess_calls"
+        assert result.output["subprocess_used"] == 4  # 4번째 시도가 초과를 발화
+
+    def test_usd_cap_is_zero_and_any_spend_aborts(self, db_path, quiet_ops, monkeypatch):
+        """Phase 0 은 LLM 0 — USD 를 1센트라도 쓰는 경로가 생기면 그 자리에서 중단."""
+
+        def spender(ctx):
+            ctx.tracker.charge_usd(0.01)
+            return []
+
+        monkeypatch.setattr(ma, "SCANNERS", (spender,))
+        result = _scan(db_path)
+        assert result.output["aborted_by_cap"] == "usd"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 수용 기준 3 — staging 전 privacy 스캔 (전 범주)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPrivacyGateBeforeStaging:
+    def test_ticker_pnl_candidate_never_reaches_the_ledger(self, db_path, quiet_ops, monkeypatch):
+        """ticker+PnL 조합(PR #202 시그니처) — 리터럴 금지 규칙에 따라 런타임 조립."""
+        leaky_detail = "winner momentum — pnl +23.4% (" + "TS" + "LA)"
+        monkeypatch.setattr(
+            ma,
+            "SCANNERS",
+            (lambda ctx: [{"axis": "doc_drift", "title": "정상 제목", "detail": leaky_detail}],),
+        )
+
+        result = _scan(db_path)
+
+        assert result.output["privacy_blocked"] == 1
+        rows = list_maintenance_candidates(db_path=db_path)
+        assert rows == [], "privacy 차단 후보가 원장에 남았다 (stub 도 금지 — 지표 오염)"
+
+    def test_broker_name_is_blocked_too(self, db_path, quiet_ops, monkeypatch):
+        """`--message` 모드였다면 통과했을 범주 — 전 범주 gate_text 를 쓰는지가 관건."""
+        broker = "토스" + "증권"  # 리터럴 조립 (privacy 픽스처 규칙)
+        monkeypatch.setattr(
+            ma,
+            "SCANNERS",
+            (lambda ctx: [{"axis": "doc_drift", "title": "수집 경로", "detail": f"{broker} 계좌 경로에서 발견"}],),
+        )
+
+        result = _scan(db_path)
+
+        assert result.output["privacy_blocked"] == 1, "broker명 범주가 스캔되지 않았다 — gate_text 미사용?"
+        assert list_maintenance_candidates(db_path=db_path) == []
+
+    def test_clean_candidate_passes(self, db_path, quiet_ops, monkeypatch):
+        """대조군 — 게이트가 전부 떨구는 가짜 구현을 막는다."""
+        monkeypatch.setattr(
+            ma,
+            "SCANNERS",
+            (lambda ctx: [{"axis": "doc_drift", "title": "깨끗한 제목", "detail": "카운트 드리프트 3건"}],),
+        )
+        result = _scan(db_path)
+        assert result.output["staged"] == 1 and result.output["privacy_blocked"] == 0
+
+    def test_gate_failure_is_fail_closed(self, db_path, quiet_ops, monkeypatch):
+        """스캔을 못 하면 깨끗한 게 아니다 — gate import 불능 시 후보는 차단된다.
+
+        `sys.modules["check_privacy_leak"] = None` 은 이미 로드돼 있어도 다음
+        `from ... import` 를 ImportError 로 만든다 — sys.path 상태와 무관하게 결정론.
+        """
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "check_privacy_leak", None)
+        monkeypatch.setattr(
+            ma,
+            "SCANNERS",
+            (lambda ctx: [{"axis": "doc_drift", "title": "t", "detail": "d"}],),
+        )
+        result = _scan(db_path)
+        assert result.output["privacy_blocked"] == 1, "게이트 불능이 통과로 처리됐다 (fail-open)"
+        assert list_maintenance_candidates(db_path=db_path) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 원장 시맨틱스 + 지표
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLedgerSemantics:
+    def test_redetection_updates_not_duplicates(self, db_path):
+        v1, id1 = stage_maintenance_candidate("doc_drift", "t", "d", "fp1", "run-a", db_path=db_path)
+        v2, id2 = stage_maintenance_candidate("doc_drift", "t", "d2", "fp1", "run-b", db_path=db_path)
+        assert (v1, v2) == ("staged", "seen") and id1 == id2
+        rows = list_maintenance_candidates(db_path=db_path)
+        assert len(rows) == 1 and rows[0]["seen_count"] == 2
+
+    def test_review_lifecycle_and_stats(self, db_path):
+        _, cid = stage_maintenance_candidate("doc_drift", "a", "d", "fp-a", "r", db_path=db_path)
+        stage_maintenance_candidate("dependency", "b", "d", "fp-b", "r", db_path=db_path)
+        assert review_maintenance_candidate(cid, "approved", "실제 결함", db_path=db_path)
+        assert not review_maintenance_candidate(99999, "rejected", db_path=db_path), "미존재 id 가 성공 처리됐다"
+
+        stats = maintenance_review_stats(db_path=db_path)
+        assert stats["candidates"] == 2 and stats["reviewed"] == 1
+        assert stats["precision"] == 1.0
+        assert stats["staged_pending"] == 1
+
+    def test_stats_with_no_reviews_is_none_not_zero(self, db_path):
+        stage_maintenance_candidate("doc_drift", "a", "d", "fp", "r", db_path=db_path)
+        stats = maintenance_review_stats(db_path=db_path)
+        assert stats["precision"] is None, "'리뷰 0건' 과 '전부 기각' 이 구분돼야 한다"
+
+    def test_invalid_verdict_raises(self, db_path):
+        with pytest.raises(ValueError):
+            review_maintenance_candidate(1, "auto-merged", db_path=db_path)
+
+
+class TestSummaryPayloadIsCountsOnly:
+    def test_ops_line_never_carries_candidate_text(self, db_path, monkeypatch):
+        """#ops 요약은 카운트만 — 후보 title/detail 이 Discord 로 새면 원장 격리가 무의미.
+
+        `_surface_summary` 의 lazy import 는 호출 시점에 모듈 속성을 읽으므로
+        `outbox_mod.stage_ops` monkeypatch 가 그대로 먹는다.
+        """
+        import nuri.agents.discord.outbox as outbox_mod
+
+        secret_title = "아주 구체적인 내부 발견 제목 XYZTITLE"
+        monkeypatch.setattr(
+            ma,
+            "SCANNERS",
+            (lambda ctx: [{"axis": "doc_drift", "title": secret_title, "detail": "detail"}],),
+        )
+        import json as _json
+
+        captured: list[str] = []
+        monkeypatch.setattr(
+            outbox_mod,
+            "stage_ops",
+            lambda payload, **kw: captured.append(_json.dumps(payload, ensure_ascii=False)),
+        )
+
+        _scan(db_path)
+
+        assert captured, "요약이 표면화되지 않았다 — quiet-by-design 금지"
+        assert secret_title not in captured[0], "후보 내용이 Discord 요약으로 샜다"
+        assert "신규 1" in captured[0]
+
+
+class TestWiringAndRoster:
+    def test_scheduler_registers_the_weekly_job(self):
+        from nuri.scheduler import SCHEDULES, _run_maintenance_audit
+
+        entries = [s for s in SCHEDULES if s["name"] == "maintenance_audit"]
+        assert len(entries) == 1
+        assert entries[0]["func"] is _run_maintenance_audit
+        assert entries[0]["cron"] == "0 3 * * 0"
+
+    def test_actor_is_canonical_and_registered(self):
+        from nuri.agents.base import REGISTRY, ActorRegistry
+
+        assert "maintenance-auditor" in ActorRegistry.CANONICAL_ACTORS
+        assert REGISTRY.get("maintenance-auditor") is ma.MaintenanceAuditor
+
+    def test_strategy_rules_are_out_of_scope(self):
+        """경계 불변 — config/rules.yaml 계열은 #1307 전용 경로다. 참조 자체가 없다."""
+        src = MODULE_FILES[0].read_text(encoding="utf-8")
+        assert "rules.yaml" not in src and "agents.yaml" not in src and "signals.yaml" not in src
+
+    def test_stale_collector_reads_readonly(self):
+        """감사가 감사 대상을 변형하지 않는다 — 모든 query() 호출이 readonly=True."""
+        tree = ast.parse(MODULE_FILES[0].read_text(encoding="utf-8"))
+        query_calls = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "query"
+        ]
+        assert query_calls, "query() 호출이 없다 — 스윕이 공허하다 (canary)"
+        for call in query_calls:
+            kw = {k.arg: k.value for k in call.keywords}
+            assert "readonly" in kw and isinstance(kw["readonly"], ast.Constant) and kw["readonly"].value is True, (
+                f"line {call.lineno}: query() 에 readonly=True 가 없다"
+            )
+
+
+class TestEmptyDbDoesNotFlood:
+    def test_no_collector_runs_yields_one_summary_candidate(self, db_path, quiet_ops):
+        """빈 DB = 수집기별 N건이 아니라 전면 침묵 1건 (실측 후 수정된 동작)."""
+        ctx = ma.ScanContext(repo_root=ma.REPO_ROOT, tracker=ma._CapTracker(caps=ma.AuditCaps()), db_path=db_path)
+        findings = ma.scan_stale_collectors(ctx)
+        assert len(findings) == 1
+        assert "전혀 없음" in findings[0]["title"]

--- a/tests/agents/test_maintenance_auditor.py
+++ b/tests/agents/test_maintenance_auditor.py
@@ -248,6 +248,27 @@ class TestLedgerSemantics:
         stats = maintenance_review_stats(db_path=db_path)
         assert stats["precision"] is None, "'리뷰 0건' 과 '전부 기각' 이 구분돼야 한다"
 
+    def test_even_count_latency_is_the_true_median(self, db_path):
+        """짝수 개 리뷰의 중앙값은 가운데 두 값의 평균 — `[len//2]` 상위 중앙값이면
+        1h·9h 가 9h 로 과대 보고된다 (codex P3)."""
+        from nuri.core.db import get_db
+
+        for fp in ("fp-x", "fp-y"):
+            _, cid = stage_maintenance_candidate("doc_drift", fp, "d", fp, "r", db_path=db_path)
+            review_maintenance_candidate(cid, "approved", db_path=db_path)
+        with get_db(db_path) as conn:
+            conn.execute(
+                "UPDATE maintenance_candidates SET created_at='2026-08-01T00:00:00',"
+                " reviewed_at='2026-08-01T01:00:00' WHERE fingerprint='fp-x'"
+            )
+            conn.execute(
+                "UPDATE maintenance_candidates SET created_at='2026-08-01T00:00:00',"
+                " reviewed_at='2026-08-01T09:00:00' WHERE fingerprint='fp-y'"
+            )
+
+        stats = maintenance_review_stats(db_path=db_path)
+        assert stats["review_latency_h_median"] == pytest.approx(5.0)
+
     def test_invalid_verdict_raises(self, db_path):
         with pytest.raises(ValueError):
             review_maintenance_candidate(1, "auto-merged", db_path=db_path)
@@ -291,7 +312,10 @@ class TestWiringAndRoster:
         entries = [s for s in SCHEDULES if s["name"] == "maintenance_audit"]
         assert len(entries) == 1
         assert entries[0]["func"] is _run_maintenance_audit
-        assert entries[0]["cron"] == "0 3 * * 0"
+        assert entries[0]["cron"] == "30 4 * * 0"
+        # db_maintenance(VACUUM/checkpoint) 와 같은 슬롯이면 매주 lock 경합 (codex P1).
+        db_maint = next(s for s in SCHEDULES if s["name"] == "db_maintenance")
+        assert entries[0]["cron"] != db_maint["cron"], "감사가 DB 유지보수와 같은 슬롯에서 돈다"
 
     def test_actor_is_canonical_and_registered(self):
         from nuri.agents.base import REGISTRY, ActorRegistry
@@ -327,3 +351,26 @@ class TestEmptyDbDoesNotFlood:
         findings = ma.scan_stale_collectors(ctx)
         assert len(findings) == 1
         assert "전혀 없음" in findings[0]["title"]
+
+
+class TestGateLiveness:
+    def test_missing_exec_bit_is_reported_as_dead_gate(self, tmp_path):
+        """실행비트 없는 설치 훅 = git 이 아예 안 부르는 green dead gate (codex P2).
+        `bash -n` 초록만 보면 이 상태가 건강으로 보고된다."""
+        repo = tmp_path / "repo"
+        (repo / "scripts" / "hooks").mkdir(parents=True)
+        (repo / "scripts" / "verify").mkdir(parents=True)
+        (repo / ".git" / "hooks").mkdir(parents=True)
+        (repo / "scripts" / "verify" / "pre_push_check.sh").write_text("#!/bin/sh\nexit 0\n")
+        for hook in ("pre-push", "pre-commit"):
+            (repo / "scripts" / "hooks" / hook).write_text("#!/bin/sh\nexit 0\n")
+            installed = repo / ".git" / "hooks" / hook
+            installed.write_text("#!/bin/sh\nexit 0\n")
+            # pre-push 만 실행비트 제거 — pre-commit 은 건강한 대조군
+            installed.chmod(0o755 if hook == "pre-commit" else 0o644)
+
+        ctx = ma.ScanContext(repo_root=repo, tracker=ma._CapTracker(caps=ma.AuditCaps()))
+        titles = [f["title"] for f in ma.scan_gate_liveness(ctx)]
+
+        assert "훅 실행권 부재: .git/hooks/pre-push" in titles
+        assert not any("실행권" in t and "pre-commit" in t for t in titles)

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,7 +29,7 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_58(self, db_path):
+    def test_schema_version_at_59(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
@@ -46,8 +46,9 @@ class TestSchemaMigrations:
         trades.account — 실거래 계좌 귀속 (#1163) +
         backtests/walkforward_runs/decision_outcomes evidence 바인딩 —
         code_rev · execution_config_sha_v1 (#1305) +
-        challenger_attempts — champion-challenger 시도 원장 (#1307)"""
-        assert get_schema_version(db_path) == 58
+        challenger_attempts — champion-challenger 시도 원장 (#1307) +
+        maintenance_candidates — 유지보수 발굴 후보 원장, shadow mode (#1308 Phase 0)"""
+        assert get_schema_version(db_path) == 59
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.


### PR DESCRIPTION
Closes #1308 (Phase 0).

## What

Weekly maintenance-audit loop in **shadow mode**: a new `MaintenanceAuditor` actor (Layer B, canonical 9th) runs 5 deterministic scanners and stages findings into a local `maintenance_candidates` ledger (migration 59). Human reviews via CLI; nothing leaves the machine.

- **Zero GitHub writes** — no gh/HTTP surface; locked by AST sweep + runtime subprocess-argv allowlist spy.
- **Hard caps** — wall-clock 120s (pre-launch enforced + subprocess timeout clipped), 16 subprocess calls, 20 candidates, USD 0.0. Exceeding cap aborts the scan with `aborted_by_cap` + WARN.
- **Privacy gate before staging** — in-process `gate_text` (all categories: broker names, suspect amounts, ticker+PnL; the `--message` CLI mode only covers the last). Blocked candidates leave no ledger trace; incidents persist as an output counter. Fail-closed.
- 5 scan axes: gate liveness (hooks installed + exec bit + syntax), doc-drift warn signatures, scheduler wiring vs collector registry, stale collectors (single summary candidate on empty DB), `uv lock --check`.
- Ledger semantics: fingerprint = axis+title, redetection updates `last_seen_at`/`seen_count` (novelty measurement), review verdicts approved/rejected/published, `maintenance_review_stats` for the 4-week Reflect (precision None-not-zero, novelty, median latency).
- Wiring: `_run_maintenance_audit` + SCHEDULES `30 4 * * 0` (Sunday 04:30 KST — moved off the `db_maintenance` VACUUM slot per codex P1).

## Verification

- 22 new tests (`tests/agents/test_maintenance_auditor.py`) + schema/roster lock updates; full suite 7,865 passed / 8 skipped.
- Mutation-verified 7/7 HIT: privacy-gate-bypassed (3 tests), candidate-cap-removed, wall-clock-prelaunch-removed, schedules-unwired, cron-slot-reverted, exec-bit-check-removed, median-upper-middle-reverted.
- codex plan review NEEDS_REWORK round fully addressed (privacy gate mode, stub pollution, finished≠healthy, alias rot, cap timing, porous gh-lock, doc-drift warn breadth); codex diff review round: P1 schedule collision, P2 hook exec bit, P3 even-count median — all fixed with regression locks.
- `make diagnostics` green; doc counts synced (7,911).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh
