### PR TITLE
feat(recommend): held_add would-fire logging — threshold-grid forward measurement (#1173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ flowchart TB
         JO["operate · 21<br/>briefs · dispatchers · watchdogs · backup"]
     end
 
-    DB[("SQLite WAL · 60 tables")]
+    DB[("SQLite WAL · 61 tables")]
     RD["record_decisions()<br/>inside the consensus job"]
     CERT["certify() · no job<br/>runs inside its callers"]
     OUT["Discord brief · dashboard"]
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,911 collected across 367 files | ✅ |
+| **Backend tests** | 7,961 collected across 368 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |
@@ -356,7 +356,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 | **Trading signals** | 22 — 20 per-ticker (actionable) + 2 market-wide (shadow) | |
 | **API endpoints** | 73 declared in `nuri/api/routes/` (76 counting the three declared on the app itself in `main.py`) | ✅ |
 | **Frontend routes** | 18 (Next.js on `:3000`) | |
-| **DB tables** | SQLite WAL · 60 tables (59 forward-only migrations) | ✅ |
+| **DB tables** | SQLite WAL · 61 tables (60 forward-only migrations) | ✅ |
 | **DB submodules** | 13 under `nuri/core/db/` — `connection.py` is the sole `sqlite3` importer, enforced by an AST sweep in CI | |
 
 ## Documentation

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -9,7 +9,7 @@
 | `rules.yaml` | 614 | Investment rules (stop-loss, take-profit, position limits, VIX gate, `account_strategies`, `measurement_mode` (§3.11 사전 고정 판정 기준 — amend 는 STRATEGY PR 필수), `siege_gates` incl. `regime_overrides` + per-class `external_applicable`) | `nuri/core/rules.py` |
 | `agents.yaml` | 235 | Per-agent thresholds + confidence scale normalization + 10-agent consensus params | `nuri/core/agent_config.py` |
 | `signals.yaml` | 221 | 22 signal definitions (20 actionable + 2 shadow; type, hold_days, params). Detector code in `nuri/quant/validation/signal_backtest.py` | `nuri/core/signal_config.py` |
-| `buy_signals.yaml` | 187 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) |
+| `buy_signals.yaml` | 214 | Buy-candidate scoring (`weights`, `quality_bar`, `gates`, `allocation`) + per-candidate `risk` (stop/TP) + `held_add_mode` (incl. `would_fire_logging` — grid + `stage2_adjudication` 는 §3.12 사전등록, 값 드리프트는 잠금 테스트 FAIL) | `nuri/trading/recommend/buy_candidate_emitter.py` (`CONFIG_PATH`) + `held_add.py` (held_add_mode block) + `held_add_would_fire.py` |
 | `alerts.yaml` | 24 | Alert thresholds + channel toggles (discord/telegram) + notification types | Direct YAML load |
 | `freshness.yaml` | 27 | Data freshness SLA (per-source `warn_hours`/`fail_hours`) + `verdict_gate` (dashboard verdict 가 확인하는 입력 목록, #1180). Queries/labels stay in `nuri/core/freshness.py` | `nuri/core/freshness.py` (`_load_config`) |
 | `stock_types.yaml` | 49 | Manual growth/value ticker override (bypasses auto-classification from PE + sector) | Direct YAML load |

--- a/config/buy_signals.yaml
+++ b/config/buy_signals.yaml
@@ -185,3 +185,30 @@ held_add_mode:
       max_add_pct_of_account_cash: 3
       cooldown_days: 21
       precedence: 3
+
+  # ─── Would-fire 전방 측정 (#1173 = #788 Stage 1) ──────────────────
+  # 임계는 바꾸지 않는다. "임계가 X 였다면 발화했을까" 를 후보 그리드 전체에 대해
+  # held_add_would_fire 원장에 매일 기록한다 (소급 백테스트 v1 은 survivorship 기각).
+  # ⚠️ grid 와 stage2_adjudication 은 **사전등록** (STRATEGY §3.12, 2026-08-29) —
+  # 값 변경 = 사전등록 개정 PR. 잠금 테스트가 조용한 드리프트를 막는다.
+  would_fire_logging:
+    enabled: true
+    near_band: 5                       # current 임계 ±5 이내 = 경계 표본 플래그
+    grid:
+      absolute: [55, 60, 65, 70]       # 전 mode 단일 임계로 완화
+      percentiles: [70, 80, 90]        # 당일 비-blackout 보유 score 분포의 백분위
+      rank_floor: {percentile: 70, floor: 60}   # max(p70, 60) — 상대×절대 결합안
+    # Stage 2 판정 스펙 (실행은 #788 몫 — 여기는 기준의 사전 고정만).
+    # 서술형 정의(이벤트/dedup/정산 규칙)는 STRATEGY §3.12 이 정본.
+    stage2_adjudication:
+      alpha_horizon_days: 30           # 전방 alpha 창 (ticker − SPY, 종가 기준)
+      benchmark: SPY
+      dedup_days: 7                    # (ticker, account, variant) 클러스터 dedup 창
+      dedup_survivor: first            # 클러스터 내 첫 발화 행 생존 (prospective 규율)
+      min_incremental_events: 20       # variant 당 incremental 최소 표본
+      min_logging_weeks: 8             # 로깅 시작 후 최소 기간
+      settlement_rule: "as_of_date <= adjudication_date - 30d"   # 미성숙 꼬리 차단
+      tie_band_alpha_pct: 0.5          # 상위 variant 차이 ≤ 0.5%p → 보수적(높은) 임계 우선
+      fire_rate_max_ratio: 0.25        # 주간 dedup 발화 ≤ 당주 eligible 고유 행의 25%
+      verdict_scope: descriptive_screening   # PASS = #519 calibration 착수 자격일 뿐,
+                                             # 임계 변경은 여전히 STRATEGY PR (iid 불성립)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Configured in `.env` (see `.env.example`):
 - `NURI_ROLE` — `production` gates §3.11 ledger-backed surfacing (the monthly alpha progress report only stages to `#brief` when set). Adjudication runs off the Mac mini DB; the MBP is a read replica, so dev numbers must never reach the brief. Lives in `scripts/launchd/com.nuri-quant.scheduler.plist` `EnvironmentVariables`, **not** `.env` — `make deploy-mini` SCPs the MBP `.env` over the mini's, so an `.env`-resident value is wiped by the next deploy (same trap as `DEV2_HOST`).
 - `API_SECRET_KEY` — JWT signing key (**required in production**, optional in dev). Unset, `nuri/api/auth.py` mints a fresh `secrets.token_hex(32)` each boot, so every outstanding JWT dies on restart (dashboard re-login). Generate: `python3 -c "import secrets; print(secrets.token_hex(32))"`. `make deploy-mini` SCPs the local `.env` onto the Mac mini's, so the same value must exist in **both** `.env` files or a deploy reverts production to random-per-boot.
 ## DB Schema (SQLite, WAL mode)
-58 tables total (59 migrations as of 2026-08-25). Key tables:
+58 tables total (60 migrations as of 2026-08-25). Key tables:
 | Table | Purpose |
 |-------|---------|
 | `prices` | OHLCV 5Y daily bars per ticker |
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,911 backend tests across 367 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,961 backend tests across 368 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -272,11 +272,28 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 **판정 결과 처리**: 3조건 통과 → **US 집행분 슬리브에 한해** 상한 상향 STRATEGY PR (새 상한도 본 표 개정으로 사전 고정). 미달 → 슬리브 유지/축소 + 측정 연장 또는 §3.10 passive 로 수렴 — "조금만 더" 없이 본 표가 답이다. 사전등록 대상은 판정 **기준**이지 상한 초기값이 아니다 — 슬리브 초기값은 판정 표본에 영향이 없으므로 최초 사용자 확정 PR 까지 placeholder 로 두며 일반 PR 로 정정 가능. 확정 이후부터 상향-sticky 발효.
 **미구축 (판정 전 선결, follow-up issue)**: ① regime 라벨 백필 — #832 구현 완료 (`scripts/ops/backfill_regime_labels.py` + emit 경로 canonical-or-NULL, 진단용) ② 순열 판정 도구 — #842 구현 완료 (`nuri/quant/validation/decision_alpha.py`, 설계는 본 표에 사전 고정; 기존 `nuri/quant/validation/` 3종은 포트폴리오 Sharpe 전용) ③ 3조건 통합 판정 쿼리 (`/api/alpha` 는 착륙 전 NOT_MEASURABLE 유지) ④ KR benchmark 분리 — #833 구현 완료 (`benchmark_by_market` + `decision_outcomes.benchmark_ticker`, 기록 기준만; KR 판정 사전등록은 미착수) ⑤ 슬리브 상한 소비 배선 (rebalance_advisor / ExecutionFirewall, #834) ⑥ 원장 스냅샷/백업 정책 (#835). 월간 알파 진행 리포트 표출 = #856.
 **참조**: `config/rules.yaml measurement_mode` (canonical 값), `nuri/agents/actors/forward_outcome_tracker.py` (측정 파이프라인, 매일 17:00 KST), `docs/SOURCE_OF_TRUTH.md` (원장 매핑, local-only).
+### 3.12 held_add 임계 그리드 전방 측정 (#1173 = #788 Stage 1, 2026-08-29 사전등록)
+**결정**: held_add 임계(75/75/80)는 바꾸지 않고, "임계가 X 였다면 발화했을까" 를 후보 그리드 전체에 대해 `held_add_would_fire` 원장에 매일 기록한다 (Stage 1). 판정(Stage 2)은 아래 사전 고정 기준으로만 — §3.6/§3.11 과 같은 원리로 **기록이 쌓이기 전에** 고정하며, 사후 amend 는 §3.11 의 prudential invalidator (보류 전용 조건) 만 허용한다.
+**왜 지금**: `held_add_shadow` 잡이 6주 연속 0건 emit / 19건 skip — 임계가 과도한지 데이터가 없다. 소급 백테스트(v1)는 survivorship 으로 기각 (#788 Codex 2026-08-21) → v2 = 전방 측정. 그리드·판정 기준은 codex 설계 리뷰 1회전 (NEEDS_REWORK → 반영) 을 거쳤다 (`data/llm_consults/2026-08-29_held-add-would-fire-design-1173.md`).
+**canonical 값**: `config/buy_signals.yaml held_add_mode.would_fire_logging` (grid + `stage2_adjudication`) — 잠금 테스트가 드리프트를 차단, 변경은 본 절 개정 PR 로만.
+**판정 스펙 (서술 정본)**:
+1. **이벤트 행** = (as_of_date, ticker, account). eligible = `earnings_blackout=0 ∧ headroom_pct>0`.
+2. **variant 발화** = would_fire_json[V] ≠ null — V 가 어떤 mode 를 고르든 무관 (임계 완화는 current 와 다른 상위 precedence mode 를 고를 수 있고, 그것까지가 측정 대상).
+3. **incremental(V)** = V 발화 ∧ current 미발화인 eligible 행.
+4. **dedup**: (ticker, account, V) 안에서 7 calendar day 클러스터당 **첫 발화 행** 생존 — 실행했다면 첫 신호에 했을 것 (prospective 규율).
+5. **결과 지표**: 30 calendar day 전방 alpha = ticker 수익률 − SPY 수익률. entry = as_of_date 종가, exit = as_of_date+30d 이하 마지막 거래일 종가 (양측 동일 날짜).
+6. **추정량**: incremental(V) 의 **표본 중앙값** (paired 아님 — incremental 집합엔 짝이 없다). qualifying = median alpha > 0 ∧ n ≥ 20 ∧ 발화율 제약 충족.
+7. **발화율 hard constraint**: 주간 dedup 발화 ≤ 당주 eligible 고유 (ticker, account) 행의 25% — 책 크기에 스케일하고 원장 단독으로 계산 가능 (고정 건수 상한은 오늘의 보유 수를 규칙에 박는다). 초과 variant 는 alpha 무관 탈락.
+8. **variant 간 순위**: qualifying 을 median alpha 로 정렬, 상위 2개 차이 ≤ 0.5%p 면 더 보수적(실효 임계 높은) 쪽.
+9. **settlement**: 판정은 로깅 시작 + 8주 이후에만, 이벤트는 `as_of_date ≤ 판정일 − 30d` 인 행만 (부분 성숙 꼬리의 기회주의적 포함/제외 차단 — §3.11 emit cutoff 준용).
+10. **추론 한계 (명시 사전등록)**: 겹침 창 + 반복 티커로 iid 불성립 — 본 판정은 **기술적(descriptive) 스크리닝**이다. PASS 는 #519 calibration 백테스트 착수 자격만 부여하며, 임계 변경은 여전히 STRATEGY PR + Escalation Ladder.
+11. **days_held 공변량 금지**: 소스가 하드코딩 fallback 30 (portfolio 에 entry_date 없음) — 원장에 기록하지 않으며 Stage 2 에서 사용 금지. gates 에 남는 fallback 효과는 전 variant 공유라 variant 간 비교에서 상쇄된다. 소스 수정은 별도 이슈.
+**참조**: `nuri/trading/recommend/held_add_would_fire.py` (그리드 계산·기록), `nuri/trading/recommend/held_add.py::evaluate_mode_gates` (측정·라이브 공유 게이트 평가).
 ## 4. 개발 품질 기준
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,911 tests, 367 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,961 tests, 368 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/core/db_migrations.py
+++ b/nuri/core/db_migrations.py
@@ -1874,4 +1874,39 @@ _MIGRATIONS: list[tuple[int, str, str]] = [
             ON maintenance_candidates(status, created_at);
     """,
     ),
+    (
+        60,
+        "held_add_would_fire — 임계 그리드 전방 측정 원장 (#1173, #788 Stage 1)",
+        # 임계를 바꾸지 않고 "임계가 X 였다면 발화했을까" 를 매일 보유×계좌마다 기록.
+        # UNIQUE(as_of_date, ticker, account) + upsert = 하루 1행 멱등 (재실행은 당일
+        # 최신 평가로 갱신 + 사라진 보유의 고아 행 삭제 — run_id/updated_at 이 감사
+        # 흔적). days_held 컬럼은 일부러 없다 — 소스가 하드코딩 fallback 30 이라
+        # 관측치가 아니다 (codex P1, #1173). score 가 NULL 인 행은 earnings blackout —
+        # provider 를 태우지 않으므로 관측치 자체가 없다 (같은 원칙).
+        # 판정 스펙(사전등록)은 buy_signals.yaml stage2_adjudication + STRATEGY §3.12.
+        """
+        CREATE TABLE IF NOT EXISTS held_add_would_fire (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            as_of_date TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            account TEXT NOT NULL,
+            score REAL,
+            pnl_pct REAL NOT NULL,
+            rsi REAL,
+            sector_mom REAL,
+            headroom_pct REAL,
+            gates_json TEXT NOT NULL,
+            grid_thresholds_json TEXT NOT NULL,
+            would_fire_json TEXT NOT NULL,
+            near_threshold INTEGER NOT NULL DEFAULT 0,
+            earnings_blackout INTEGER NOT NULL DEFAULT 0,
+            run_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE(as_of_date, ticker, account)
+        );
+        CREATE INDEX IF NOT EXISTS idx_held_add_wf_date ON held_add_would_fire(as_of_date);
+        CREATE INDEX IF NOT EXISTS idx_held_add_wf_ticker ON held_add_would_fire(ticker, as_of_date);
+    """,
+    ),
 ]

--- a/nuri/trading/recommend/CLAUDE.md
+++ b/nuri/trading/recommend/CLAUDE.md
@@ -10,7 +10,8 @@ The user-facing output layer: BUY candidates, SELL alerts on holdings, price tar
 |---|---|---|---|
 | `buy_candidate_emitter.py` | Daily 0–5 BUY candidates from factor + momentum + RSI + breakout fusion. Closes the sell-bias gap (7+ sell loops, 0 buy loops). | `python -m nuri.trading.recommend.buy_candidate_emitter` / scheduler premarket brief (`nuri/alerts/premarket_brief.py`) | #507 |
 | `holdings_monitor.py` | Post-entry technical-divergence alert (JKHY-class falling-knife defense). REVIEW CTA, never SELL. | scheduler 07:10 KST | PR #303 follow-up |
-| `held_add.py` | Held-add shadow emitter — add-candidate evaluation on existing holdings (buy_signals.yaml loader). | scheduler 07:15 KST | #518 Phase 2a |
+| `held_add.py` | Held-add shadow emitter — add-candidate evaluation on existing holdings (buy_signals.yaml loader). `evaluate_mode_gates` 가 score 외 조건을 분리 평가 — 라이브 결정과 would-fire 측정이 같은 게이트를 공유한다. | scheduler 08:30 KST (`_run_held_add_shadow`) | #518 Phase 2a |
+| `held_add_would_fire.py` | 임계 그리드 전방 측정 원장 — "임계가 X 였다면 발화했을까" 를 매일 기록 (임계 변경 없음). 판정 기준은 **사전등록** (`buy_signals.yaml stage2_adjudication` + STRATEGY §3.12) — 값 드리프트는 잠금 테스트가 차단. | `held_add.py` 내부 (같은 provider 스냅샷) | #1173 (#788 Stage 1) |
 | `candidates.py` | E-1 signal-based candidate screener (today's signals × historically validated). | `python -m ...candidates` | E-1 |
 | `price_targets.py` | entry / stop / TP1 / TP2 / trailing per holding, pulling from `config/rules.yaml` ladders (growth / value / swing). | upstream of every BUY/SELL alert | core |
 | `rebalance.py` | E-2 regime-adapted MVO/RP rebalance (defensive vs offensive sector tilt by regime). | `python -m ...rebalance` | E-2 |

--- a/nuri/trading/recommend/held_add.py
+++ b/nuri/trading/recommend/held_add.py
@@ -140,11 +140,12 @@ def _get_real_accounts() -> set[str]:
     return get_real_accounts()
 
 
-def _get_held_positions() -> list[dict[str, Any]]:
+def _get_held_positions(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
     """portfolio 테이블 + 최신 가격 join — (ticker, account, qty, avg_price, current_price, pnl_pct).
 
     real_accounts (yaml substantive) 만 surface — test/sample/legacy stale 제외.
-    days_held 는 portfolio 테이블에 timestamp 필드가 없어 fallback 30.
+    days_held 는 portfolio 테이블에 timestamp 필드가 없어 fallback 30 — **측정값이
+    아니다** (#1173 would-fire 원장은 그래서 이 값을 기록하지 않는다).
     """
     df = query_df(
         """SELECT p.account, p.ticker, p.quantity AS qty, p.avg_price,
@@ -155,7 +156,8 @@ def _get_held_positions() -> list[dict[str, Any]]:
                  WHERE (ticker, date) IN (
                      SELECT ticker, MAX(date) FROM prices GROUP BY ticker
                  )
-             ) pr ON p.ticker = pr.ticker"""
+             ) pr ON p.ticker = pr.ticker""",
+        db_path=db_path,
     )
     if df.empty:
         return []
@@ -183,7 +185,7 @@ def _get_held_positions() -> list[dict[str, Any]]:
     return out
 
 
-def _get_last_trim_age_days(ticker: str, max_days: int = 60) -> Optional[int]:
+def _get_last_trim_age_days(ticker: str, max_days: int = 60, db_path: Optional[Path] = None) -> Optional[int]:
     """최근 trim_action 이벤트 age (일). 없으면 None.
 
     `pipeline_events.payload.action_type='trim_action'` (#517 Phase 2b 기준).
@@ -195,6 +197,7 @@ def _get_last_trim_age_days(ticker: str, max_days: int = 60) -> Optional[int]:
                AND json_extract(payload, '$.action_type') = 'trim_action'
                AND timestamp >= datetime('now', '-{max_days} days')""",
         params=(ticker,),
+        db_path=db_path,
     )
     if df.empty or df["last_ts"].iloc[0] is None:
         return None
@@ -217,9 +220,17 @@ def _get_account_strategy_profile(account: str) -> dict[str, Any]:
 
 
 def _evaluate_tp1_residual_add(
-    pos: dict[str, Any], cfg: dict, score: float, breakout_above_trim: bool
+    pos: dict[str, Any],
+    cfg: dict,
+    score: float,
+    breakout_above_trim: bool,
+    score_min_override: Optional[float] = None,
+    db_path: Optional[Path] = None,
 ) -> Optional[str]:
     """precedence=1. 최근 trim_action 후 잔여 add.
+
+    score_min_override: config 임계 대신 쓸 값 (#1173 would-fire 측정 전용 —
+    -inf 를 주면 score 외 조건만 평가한다). None = 기존 동작.
 
     Returns: trigger 충족 시 mode name, else None.
     """
@@ -227,7 +238,9 @@ def _evaluate_tp1_residual_add(
     if not trig:
         return None
 
-    last_trim_age = _get_last_trim_age_days(pos["ticker"], max_days=int(trig.get("last_trim_age_days_max", 60)))
+    last_trim_age = _get_last_trim_age_days(
+        pos["ticker"], max_days=int(trig.get("last_trim_age_days_max", 60)), db_path=db_path
+    )
     if last_trim_age is None:
         return None
     if last_trim_age < int(trig.get("last_trim_age_days_min", 5)):
@@ -241,7 +254,8 @@ def _evaluate_tp1_residual_add(
     if pos["pnl_pct"] < pnl_threshold:
         return None
 
-    if score < float(trig.get("composite_score_min", 75)):
+    score_min = score_min_override if score_min_override is not None else float(trig.get("composite_score_min", 75))
+    if score < score_min:
         return None
 
     if trig.get("require_breakout_above_last_trim_price", True) and not breakout_above_trim:
@@ -250,7 +264,13 @@ def _evaluate_tp1_residual_add(
     return "tp1_residual_add"
 
 
-def _evaluate_ride_winner(pos: dict[str, Any], cfg: dict, score: float, sector_mom: float) -> Optional[str]:
+def _evaluate_ride_winner(
+    pos: dict[str, Any],
+    cfg: dict,
+    score: float,
+    sector_mom: float,
+    score_min_override: Optional[float] = None,
+) -> Optional[str]:
     """precedence=2. winner momentum add."""
     trig = cfg.get("modes", {}).get("ride_winner", {}).get("trigger", {})
     if not trig:
@@ -265,7 +285,8 @@ def _evaluate_ride_winner(pos: dict[str, Any], cfg: dict, score: float, sector_m
     if pos["days_held"] < int(trig.get("days_held_min", 30)):
         return None
 
-    if score < float(trig.get("composite_score_min", 75)):
+    score_min = score_min_override if score_min_override is not None else float(trig.get("composite_score_min", 75))
+    if score < score_min:
         return None
 
     if sector_mom < float(trig.get("sector_momentum_min", 5)):
@@ -281,6 +302,7 @@ def _evaluate_average_down(
     rsi: Optional[float],
     regime: str,
     vix: Optional[float],
+    score_min_override: Optional[float] = None,
 ) -> Optional[str]:
     """precedence=3. pullback add (RSI 과매도 + macro veto)."""
     trig = cfg.get("modes", {}).get("average_down", {}).get("trigger", {})
@@ -297,7 +319,8 @@ def _evaluate_average_down(
     if not (lower <= pos["pnl_pct"] <= upper):
         return None
 
-    if score < float(trig.get("composite_score_min", 80)):
+    score_min = score_min_override if score_min_override is not None else float(trig.get("composite_score_min", 80))
+    if score < score_min:
         return None
 
     if rsi is None or rsi > float(trig.get("rsi_max", 35)):
@@ -342,6 +365,8 @@ def select_held_mode(
     vix: Optional[float],
     breakout_above_trim: bool = False,
     sector_mom: float = 0.0,
+    score_min_override: Optional[float] = None,
+    db_path: Optional[Path] = None,
 ) -> Optional[str]:
     """precedence-sorted mutual exclusion. Returns first triggered mode or None.
 
@@ -349,16 +374,66 @@ def select_held_mode(
     """
     for mode_name in sorted(MODE_PRECEDENCE.keys(), key=lambda m: MODE_PRECEDENCE[m]):
         if mode_name == "tp1_residual_add":
-            r = _evaluate_tp1_residual_add(pos, cfg, score, breakout_above_trim)
+            r = _evaluate_tp1_residual_add(
+                pos, cfg, score, breakout_above_trim, score_min_override=score_min_override, db_path=db_path
+            )
         elif mode_name == "ride_winner":
-            r = _evaluate_ride_winner(pos, cfg, score, sector_mom)
+            r = _evaluate_ride_winner(pos, cfg, score, sector_mom, score_min_override=score_min_override)
         elif mode_name == "average_down":
-            r = _evaluate_average_down(pos, cfg, score, rsi, regime, vix)
+            r = _evaluate_average_down(pos, cfg, score, rsi, regime, vix, score_min_override=score_min_override)
         else:
             r = None
         if r:
             return r
     return None
+
+
+def evaluate_mode_gates(
+    pos: dict[str, Any],
+    cfg: dict,
+    rsi: Optional[float],
+    regime: str,
+    vix: Optional[float],
+    breakout_above_trim: bool = False,
+    sector_mom: float = 0.0,
+    db_path: Optional[Path] = None,
+) -> dict[str, bool]:
+    """mode 별 **score 외 조건** 통과 여부 (#1173 would-fire 측정 축).
+
+    각 evaluator 를 score 임계 -inf 로 호출해 score 게이트만 무력화한다 — 나머지
+    조건(pnl 창·trim age·RSI·macro veto·days_held)은 라이브와 동일 코드가 평가하므로
+    측정 경로와 실주행 경로가 갈라질 수 없다. `select_held_mode(...)` 는
+    "gates[m] ∧ score ≥ 임계" 의 첫 precedence 와 동치다 (잠금 테스트가 고정).
+    """
+    no_score_gate = float("-inf")
+    return {
+        "tp1_residual_add": _evaluate_tp1_residual_add(
+            pos, cfg, 0.0, breakout_above_trim, score_min_override=no_score_gate, db_path=db_path
+        )
+        is not None,
+        "ride_winner": _evaluate_ride_winner(pos, cfg, 0.0, sector_mom, score_min_override=no_score_gate) is not None,
+        "average_down": _evaluate_average_down(pos, cfg, 0.0, rsi, regime, vix, score_min_override=no_score_gate)
+        is not None,
+    }
+
+
+def _safe_headroom(pos: dict[str, Any], db_path: Optional[Path]) -> Optional[float]:
+    """측정 행용 headroom — 조회 실패는 None (blackout 경로에서도 run 을 못 죽인다)."""
+    try:
+        return derive_position_cap(pos["ticker"], pos["account"], db_path=db_path)["headroom_pct"]
+    except Exception:
+        logger.debug("would-fire headroom 조회 실패: %s@%s", pos["ticker"], pos["account"], exc_info=True)
+        return None
+
+
+def current_mode_thresholds(cfg: dict) -> dict[str, float]:
+    """config 의 mode 별 composite_score_min — evaluator 내부 기본값(75/75/80)과 동일 소스."""
+    modes = cfg.get("modes", {})
+    return {
+        "tp1_residual_add": float(modes.get("tp1_residual_add", {}).get("trigger", {}).get("composite_score_min", 75)),
+        "ride_winner": float(modes.get("ride_winner", {}).get("trigger", {}).get("composite_score_min", 75)),
+        "average_down": float(modes.get("average_down", {}).get("trigger", {}).get("composite_score_min", 80)),
+    }
 
 
 def _persist_shadow(
@@ -424,7 +499,15 @@ def emit_held_add_shadow(
     shadow = _is_shadow_mode(cfg, today=today)
     earnings_days = int(cfg.get("earnings_blackout_days", 5))
 
-    positions = _get_held_positions()
+    # would-fire 측정 (#1173 — #788 Stage 1): 임계는 바꾸지 않고, 후보 그리드별
+    # "발화했을 것인가" 를 append-only 원장에 기록한다. 라이브 emit 과 같은 provider
+    # 스냅샷을 쓰므로 측정과 실주행의 시점이 갈라질 수 없다.
+    wf_cfg = cfg.get("would_fire_logging") or {}
+    wf_enabled = bool(wf_cfg.get("enabled", False))
+    thresholds = current_mode_thresholds(cfg)
+    wf_rows: list[dict[str, Any]] = []
+
+    positions = _get_held_positions(db_path=db_path)
     result = HeldAddResult(
         shadow_mode=shadow,
         shadow_mode_until=str(cfg.get("shadow_mode_until", "")),
@@ -449,10 +532,28 @@ def emit_held_add_shadow(
     for pos in positions:
         key = f"{pos['ticker']}@{pos['account']}"
 
-        # earnings blackout 가장 먼저 (모든 mode 차단)
+        # earnings blackout 가장 먼저 (모든 mode 차단) — provider 를 **타기 전에**
+        # 끊는다 (종전 동작 유지, codex diff P2). 측정이 켜져 있으면 blackout 행도
+        # 기록하되 score/RSI 는 NULL — 어떤 게이트도 소비하지 않은 값을 관측치처럼
+        # 적으면 days_held 를 뺀 것과 같은 원칙을 어긴다. "그날 평가 불능이었다" 는
+        # 사실 자체만 남긴다 (Stage 2 이벤트 집합에선 제외).
         fetcher = earnings_fetcher_factory(pos["ticker"]) if earnings_fetcher_factory else None
         if is_in_earnings_blackout(pos["ticker"], days=earnings_days, today=today, fetcher=fetcher):
             result.skipped[key] = f"earnings blackout ±{earnings_days}d"
+            if wf_enabled:
+                wf_rows.append(
+                    {
+                        "ticker": pos["ticker"],
+                        "account": pos["account"],
+                        "score": None,
+                        "pnl_pct": pos["pnl_pct"],
+                        "rsi": None,
+                        "sector_mom": None,
+                        "headroom_pct": _safe_headroom(pos, db_path),
+                        "gates": dict.fromkeys(MODE_PRECEDENCE, False),
+                        "earnings_blackout": True,
+                    }
+                )
             continue
 
         score = float(score_fn(pos["ticker"]) or 0.0)
@@ -461,21 +562,56 @@ def emit_held_add_shadow(
         sector_mom = float(sector_mom_fn(pos["ticker"]) or 0.0)
         breakout = bool(breakout_fn(pos["ticker"]))
 
-        mode = select_held_mode(
+        gates = evaluate_mode_gates(
             pos,
             cfg,
-            score,
             rsi,
             regime,
             vix,
             breakout_above_trim=breakout,
             sector_mom=sector_mom,
+            db_path=db_path,
+        )
+
+        cap_info: Optional[dict[str, Any]] = None
+        if wf_enabled:
+            # headroom 은 측정 행의 기록 항목 — 실패해도 행을 버리지 않는다 (None 기록).
+            try:
+                cap_info = derive_position_cap(pos["ticker"], pos["account"], db_path=db_path)
+            except Exception:
+                logger.debug("would-fire headroom 조회 실패: %s", key, exc_info=True)
+                cap_info = None
+            wf_rows.append(
+                {
+                    "ticker": pos["ticker"],
+                    "account": pos["account"],
+                    "score": score,
+                    "pnl_pct": pos["pnl_pct"],
+                    "rsi": rsi,
+                    "sector_mom": sector_mom,
+                    "headroom_pct": (cap_info or {}).get("headroom_pct"),
+                    "gates": gates,
+                    "earnings_blackout": False,
+                }
+            )
+
+        # 라이브 mode = gates ∧ score ≥ config 임계의 첫 precedence.
+        # `select_held_mode` 와 동치다 (잠금: TestGatesEquivalence) — 측정 축(gates)과
+        # 라이브 결정이 같은 평가를 공유해 둘이 갈라질 수 없게 하는 구조.
+        mode = next(
+            (
+                m
+                for m in sorted(MODE_PRECEDENCE.keys(), key=lambda m: MODE_PRECEDENCE[m])
+                if gates[m] and score >= thresholds[m]
+            ),
+            None,
         )
         if mode is None:
             result.skipped[key] = "no mode triggered"
             continue
 
-        cap_info = derive_position_cap(pos["ticker"], pos["account"], db_path=db_path)
+        if cap_info is None:
+            cap_info = derive_position_cap(pos["ticker"], pos["account"], db_path=db_path)
         if cap_info["headroom_pct"] <= 0:
             result.skipped[key] = (
                 f"{mode}: cap headroom 0 (current {cap_info['current_pct']}% ≥ cap {cap_info['cap_max_pct']}%)"
@@ -501,6 +637,23 @@ def emit_held_add_shadow(
                 _persist_shadow(candidate, run_id=run_id, db_path=db_path)
             except Exception as e:
                 logger.warning("held_add_shadow persist failed for %s: %s", key, e)
+
+    if wf_enabled and wf_rows:
+        # 관측은 본 작업을 게이트하지 않는다 (#894) — 기록 실패가 emit 을 죽이면 안 된다.
+        try:
+            from nuri.trading.recommend.held_add_would_fire import log_would_fire_rows
+
+            n_logged = log_would_fire_rows(
+                wf_rows,
+                wf_cfg,
+                thresholds,
+                as_of_date=today.isoformat(),
+                run_id=run_id,
+                db_path=db_path,
+            )
+            logger.info("[held_add_would_fire] %d행 기록 (#1173 Stage 1)", n_logged)
+        except Exception as e:
+            logger.warning("held_add would-fire 기록 실패 (emit 은 정상): %s", e)
 
     return result
 

--- a/nuri/trading/recommend/held_add_would_fire.py
+++ b/nuri/trading/recommend/held_add_would_fire.py
@@ -1,0 +1,198 @@
+"""held_add would-fire 원장 — 후보 임계 그리드의 전방 측정 (#1173, #788 Stage 1).
+
+## 무엇을 재나
+
+임계는 바꾸지 않는다. 매일 보유×계좌마다 "임계가 X 였다면 발화했을까" 를 후보
+그리드 전체에 대해 기록한다:
+
+- ``current``      — config 의 mode 별 composite_score_min (75/75/80)
+- ``abs_{T}``      — 절대 완화: 전 mode 에 단일 임계 T (config `grid.absolute`)
+- ``p{P}``         — 상대: 당일 **비-blackout 보유 전체** score 분포의 P 백분위를
+                     전 mode 에 적용 (모집단을 게이트 통과분으로 좁히면 표본이
+                     0~2개로 붕괴한다 — codex 리뷰 A)
+- ``rank_floor``   — 결합: max(백분위 임계, 절대 floor)
+
+variant 의 발화 = "gates[m] ∧ score ≥ 임계" 의 첫 precedence mode — 라이브
+`select_held_mode` 와 같은 결합 형태라 임계 완화가 current 와 **다른 상위
+precedence mode** 를 고를 수 있고, 그것까지가 측정 대상이다 (Stage 2 incremental
+정의는 "V 가 어떤 mode 를 고르든 V 발화 ∧ current 미발화").
+
+## 무엇을 기록하지 않나
+
+- ``days_held`` — `_get_held_positions` 의 30 은 하드코딩 fallback 이지 측정값이
+  아니다. append-only 원장에 조작값을 관측치로 박으면 Stage 2 공변량이 영구
+  오염된다 (codex P1). gates 에는 fallback 의 효과가 남지만 모든 variant 가 같은
+  gates 를 공유하므로 variant **간** 비교에서는 상쇄된다.
+
+- blackout 행의 score/RSI/sector_mom — provider 를 타기 전에 끊기므로 (종전
+  short-circuit 유지) 관측치 자체가 없다. NULL 로 남는다.
+
+## 멱등성
+
+UNIQUE(as_of_date, ticker, account) + ON CONFLICT DO UPDATE — 하루 안의 재실행은
+최신 평가로 갱신하고, **이번 실행에 없는 그날의 고아 행은 삭제**한다 (당일 최종
+데이터 스냅샷이 canonical — upsert 만으로는 재실행 사이에 판 보유의 행과 낡은
+백분위 grid 가 남는다, codex diff P2). 재실행 감사는 run_id / updated_at 으로.
+
+Stage 2 판정 스펙(사전등록)은 `config/buy_signals.yaml`
+`held_add_mode.would_fire_logging.stage2_adjudication` + STRATEGY §3.12 가 정본.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from nuri.core.db import get_db
+from nuri.core.timezone import kst_now
+
+from .held_add import MODE_PRECEDENCE
+
+logger = logging.getLogger(__name__)
+
+MODES_BY_PRECEDENCE = sorted(MODE_PRECEDENCE.keys(), key=lambda m: MODE_PRECEDENCE[m])
+
+
+def compute_grid_thresholds(
+    scores: list[float],
+    current_thresholds: dict[str, float],
+    grid_cfg: dict[str, Any],
+) -> dict[str, dict[str, Optional[float]]]:
+    """variant → mode → 임계. 백분위 variant 는 당일 score 분포가 비어 있으면 None
+    (발화 불가로 처리 — 전원 blackout 인 날은 어차피 gates 가 전부 false 다)."""
+    out: dict[str, dict[str, Optional[float]]] = {"current": {m: current_thresholds[m] for m in MODES_BY_PRECEDENCE}}
+    for t in grid_cfg.get("absolute", []):
+        out[f"abs_{int(t)}"] = dict.fromkeys(MODES_BY_PRECEDENCE, float(t))
+
+    pct_values: dict[int, Optional[float]] = {}
+    for p in grid_cfg.get("percentiles", []):
+        val = float(np.percentile(scores, int(p))) if scores else None
+        pct_values[int(p)] = val
+        out[f"p{int(p)}"] = dict.fromkeys(MODES_BY_PRECEDENCE, val)
+
+    rf = grid_cfg.get("rank_floor") or {}
+    if rf:
+        p = int(rf.get("percentile", 70))
+        floor = float(rf.get("floor", 60))
+        base = pct_values.get(p)
+        if base is None:
+            base = float(np.percentile(scores, p)) if scores else None
+        val = max(base, floor) if base is not None else None
+        out["rank_floor"] = dict.fromkeys(MODES_BY_PRECEDENCE, val)
+    return out
+
+
+def compute_would_fire(
+    score: float,
+    gates: dict[str, bool],
+    grid_thresholds: dict[str, dict[str, Optional[float]]],
+) -> dict[str, Optional[str]]:
+    """variant 별 발화 mode (없으면 None) — precedence 순 첫 (gates ∧ score ≥ 임계)."""
+    out: dict[str, Optional[str]] = {}
+    for variant, per_mode in grid_thresholds.items():
+        fired = None
+        for m in MODES_BY_PRECEDENCE:
+            thr = per_mode.get(m)
+            if thr is not None and gates.get(m) and score >= thr:
+                fired = m
+                break
+        out[variant] = fired
+    return out
+
+
+def compute_near_threshold(
+    score: float,
+    gates: dict[str, bool],
+    current_thresholds: dict[str, float],
+    near_band: float,
+) -> bool:
+    """current 임계 ±near_band 이내 (gates 통과 mode 한정) — 경계 표본 식별용."""
+    return any(gates.get(m) and abs(score - current_thresholds[m]) <= near_band for m in MODES_BY_PRECEDENCE)
+
+
+def log_would_fire_rows(
+    rows: list[dict[str, Any]],
+    wf_cfg: dict[str, Any],
+    current_thresholds: dict[str, float],
+    as_of_date: str,
+    run_id: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    """당일 평가 행 일괄 기록 (멱등 upsert). 반환: 기록 행 수.
+
+    rows 원소: {ticker, account, score, pnl_pct, rsi, sector_mom, headroom_pct,
+    gates, earnings_blackout} — `emit_held_add_shadow` 가 라이브 emit 과 같은
+    provider 스냅샷으로 채운다.
+    """
+    grid_cfg = wf_cfg.get("grid") or {}
+    near_band = float(wf_cfg.get("near_band", 5))
+    scores = [float(r["score"]) for r in rows if not r["earnings_blackout"] and r["score"] is not None]
+    grid = compute_grid_thresholds(scores, current_thresholds, grid_cfg)
+    grid_json = json.dumps(grid, ensure_ascii=False)
+    now_iso = kst_now().isoformat()
+
+    n = 0
+    with get_db(db_path) as conn:
+        # 당일 고아 행 삭제 — 이번 실행에 없는 (ticker, account) 는 그날의 canonical
+        # 스냅샷이 아니다 (재실행 사이 매도/보유 변동). 같은 트랜잭션이라 부분 상태가
+        # 노출되지 않는다.
+        existing = conn.execute(
+            "SELECT id, ticker, account FROM held_add_would_fire WHERE as_of_date = ?", (as_of_date,)
+        ).fetchall()
+        current_keys = {(r["ticker"], r["account"]) for r in rows}
+        orphans = [row["id"] for row in existing if (row["ticker"], row["account"]) not in current_keys]
+        if orphans:
+            conn.execute(
+                f"DELETE FROM held_add_would_fire WHERE id IN ({','.join('?' * len(orphans))})",
+                orphans,
+            )
+        for r in rows:
+            blackout = bool(r["earnings_blackout"])
+            gates = {m: bool(v) for m, v in r["gates"].items()}
+            score_val = r["score"]
+            if blackout or score_val is None:
+                wf: dict[str, Optional[str]] = dict.fromkeys(grid.keys())
+                near = 0
+            else:
+                wf = compute_would_fire(float(score_val), gates, grid)
+                near = int(compute_near_threshold(float(score_val), gates, current_thresholds, near_band))
+            conn.execute(
+                """INSERT INTO held_add_would_fire
+                     (as_of_date, ticker, account, score, pnl_pct, rsi, sector_mom,
+                      headroom_pct, gates_json, grid_thresholds_json, would_fire_json,
+                      near_threshold, earnings_blackout, run_id, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(as_of_date, ticker, account) DO UPDATE SET
+                     score=excluded.score, pnl_pct=excluded.pnl_pct, rsi=excluded.rsi,
+                     sector_mom=excluded.sector_mom, headroom_pct=excluded.headroom_pct,
+                     gates_json=excluded.gates_json,
+                     grid_thresholds_json=excluded.grid_thresholds_json,
+                     would_fire_json=excluded.would_fire_json,
+                     near_threshold=excluded.near_threshold,
+                     earnings_blackout=excluded.earnings_blackout,
+                     run_id=excluded.run_id, updated_at=excluded.updated_at""",
+                (
+                    as_of_date,
+                    r["ticker"],
+                    r["account"],
+                    None if r["score"] is None else float(r["score"]),
+                    float(r["pnl_pct"]),
+                    r.get("rsi"),
+                    None if r.get("sector_mom") is None else float(r["sector_mom"]),
+                    r.get("headroom_pct"),
+                    json.dumps(gates, ensure_ascii=False),
+                    grid_json,
+                    json.dumps(wf, ensure_ascii=False),
+                    near,
+                    int(blackout),
+                    run_id,
+                    now_iso,
+                    now_iso,
+                ),
+            )
+            n += 1
+    return n

--- a/tests/core/test_agent_infra.py
+++ b/tests/core/test_agent_infra.py
@@ -29,7 +29,7 @@ def db_path(tmp_path):
 class TestSchemaMigrations:
     """16 신규 migration (#25 audit / #26 flags / #27 runs / #28 messages / #29 walkforward_runs / #30 regime_posteriors / #31 hypotheses / #32 causal_audits / #33 agent_decisions / #34 decision_outcomes / #35 execution_blocks / #36 incidents / #37 dr_replicas / #38 collector_runs / #39 drift_alerts / #40 foundation_benchmarks) 적용 확인."""
 
-    def test_schema_version_at_59(self, db_path):
+    def test_schema_version_at_60(self, db_path):
         """Phase 1+2 + discord_outbox + agent_control/agent_dev_log channel CHECK 확장 (#582) +
         held_add_shadow (#518) + market_postmortem (#596 Phase 2) +
         incidents signal_evaluation_stale enum 확장 (#825) +
@@ -47,8 +47,9 @@ class TestSchemaMigrations:
         backtests/walkforward_runs/decision_outcomes evidence 바인딩 —
         code_rev · execution_config_sha_v1 (#1305) +
         challenger_attempts — champion-challenger 시도 원장 (#1307) +
-        maintenance_candidates — 유지보수 발굴 후보 원장, shadow mode (#1308 Phase 0)"""
-        assert get_schema_version(db_path) == 59
+        maintenance_candidates — 유지보수 발굴 후보 원장, shadow mode (#1308 Phase 0) +
+        held_add_would_fire — 임계 그리드 전방 측정 원장 (#1173, #788 Stage 1)"""
+        assert get_schema_version(db_path) == 60
 
     def test_block_type_allowlist_matches_sql_check(self, db_path):
         """`_BLOCK_TYPES`(파이썬 검증) 와 execution_blocks CHECK(스키마) 는 같아야 한다.

--- a/tests/trading/recommend/test_held_add_mode.py
+++ b/tests/trading/recommend/test_held_add_mode.py
@@ -198,7 +198,7 @@ class TestModeEvaluation:
         """trim event 없음 → tp1_residual skip → ride_winner 평가."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -239,7 +239,7 @@ class TestModeEvaluation:
 
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,  # trim 없음 → tp1_residual skip
+            lambda ticker, max_days=60, db_path=None: None,  # trim 없음 → tp1_residual skip
         )
         # 실제 account_strategies 모양: tp1_pct 키 없음 → canonical default 경로
         monkeypatch.setattr(
@@ -270,7 +270,7 @@ class TestModeEvaluation:
         """trim 후 +30% pnl + breakout — tp1_residual 이 ride_winner 보다 우선."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: 10,  # trim 10일전
+            lambda ticker, max_days=60, db_path=None: 10,  # trim 10일전
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -302,7 +302,7 @@ class TestModeEvaluation:
         """
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -341,7 +341,7 @@ class TestModeEvaluation:
         """
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -366,7 +366,7 @@ class TestModeEvaluation:
         """regime=neutral + RSI 30 + pnl -5% (window) → average_down."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -394,7 +394,7 @@ class TestModeEvaluation:
         """VIX >= 28 → average_down macro veto."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -424,7 +424,7 @@ class TestModeEvaluation:
         """held_add.py 320->326: macro_veto=False 면 VIX/regime 무시하고 통과 (#611)."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -480,7 +480,7 @@ class TestEmitHeldAddShadow:
         # _get_held_positions 가 default DB 를 본다 — db_path 로 swap
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_held_positions",
-            lambda: [
+            lambda db_path=None: [
                 # acct_alpha NVDA: pnl +60% 충족 (winner)
                 {
                     "ticker": "NVDA",
@@ -505,7 +505,7 @@ class TestEmitHeldAddShadow:
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,  # trim 없음 → ride_winner 진입
+            lambda ticker, max_days=60, db_path=None: None,  # trim 없음 → ride_winner 진입
         )
 
         # earnings: 모두 안전
@@ -555,7 +555,7 @@ class TestEmitHeldAddShadow:
         candidate 는 emit 하되 held_add_shadow 테이블 persist 는 skip (#611)."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_held_positions",
-            lambda: [
+            lambda db_path=None: [
                 {
                     "ticker": "NVDA",
                     "account": "acct_alpha",
@@ -569,7 +569,7 @@ class TestEmitHeldAddShadow:
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
 
         def _fetcher_factory(t: str) -> SimpleNamespace:
@@ -604,7 +604,7 @@ class TestEmitHeldAddShadow:
         """earnings ±5d → 모든 mode 차단."""
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_held_positions",
-            lambda: [
+            lambda db_path=None: [
                 {
                     "ticker": "MSFT",
                     "account": "acct_alpha",
@@ -618,7 +618,7 @@ class TestEmitHeldAddShadow:
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
 
         # MSFT earnings 4-30 (±4d 이내)
@@ -655,21 +655,28 @@ class TestEmitHeldAddShadow:
         """
         seen: dict[str, object] = {}
 
-        def _spy(pos, cfg, score, rsi, regime, vix, **_kw):
+        # 관측 지점은 mode 평가 입구 — #1173 리팩터로 emit 루프가 select_held_mode
+        # 대신 evaluate_mode_gates 를 타므로 스파이도 따라간다 (잠금 의도 동일:
+        # 기본 provider 의 *하류 값* 이 미상이어야 한다).
+        def _spy(pos, cfg, rsi, regime, vix, **_kw):
             seen["regime"] = regime
             seen["vix"] = vix
-            return None
+            return dict.fromkeys(ha.MODE_PRECEDENCE, False)
 
-        monkeypatch.setattr(ha, "select_held_mode", _spy)
+        monkeypatch.setattr(ha, "evaluate_mode_gates", _spy)
         monkeypatch.setattr(
             ha,
             "_get_held_positions",
-            lambda: [{"ticker": "MSFT", "account": "acct_alpha", "pnl_pct": -5.0, "days_held": 20}],
+            lambda db_path=None: [{"ticker": "MSFT", "account": "acct_alpha", "pnl_pct": -5.0, "days_held": 20}],
         )
         cfg_path = tmp_path / "buy_signals.yaml"
         cfg_path.write_text(yaml.safe_dump(cfg_held_add))
+        # db_path 는 이제 실제로 전달된다 (#1173 P2 배선 수정) — 미초기화 경로를 주면
+        # 종전처럼 기본 DB 로 새지 않고 진짜로 그 파일을 읽으므로 스키마가 필요하다.
+        isolated = tmp_path / "x.db"
+        init_db(isolated)
 
-        ha.emit_held_add_shadow(config_path=cfg_path, db_path=tmp_path / "x.db")
+        ha.emit_held_add_shadow(config_path=cfg_path, db_path=isolated)
 
         assert seen.get("regime") == UNKNOWN_REGIME, "provider 부재 시 레짐을 지어냈다 — 미상이어야 한다"
         assert seen.get("vix") is None, "VIX 미측정을 숫자로 메웠다 (#753)"
@@ -703,7 +710,7 @@ class TestEmitHeldAddShadow:
 
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_held_positions",
-            lambda: [
+            lambda db_path=None: [
                 {
                     "ticker": "NVDA",
                     "account": "acct_alpha",
@@ -717,7 +724,7 @@ class TestEmitHeldAddShadow:
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
 
         result = ha.emit_held_add_shadow(
@@ -921,7 +928,7 @@ class TestDBProviders:
 
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_held_positions",
-            lambda: [
+            lambda db_path=None: [
                 {
                     "ticker": "NVDA",
                     "account": "acct_alpha",
@@ -935,7 +942,7 @@ class TestDBProviders:
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda t, max_days=60: None,
+            lambda t, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",
@@ -1142,7 +1149,7 @@ class TestUnmeasuredVixIsAVeto:
     def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_last_trim_age_days",
-            lambda ticker, max_days=60: None,
+            lambda ticker, max_days=60, db_path=None: None,
         )
         monkeypatch.setattr(
             "nuri.trading.recommend.held_add._get_account_strategy_profile",

--- a/tests/trading/recommend/test_held_add_would_fire.py
+++ b/tests/trading/recommend/test_held_add_would_fire.py
@@ -1,0 +1,449 @@
+"""would-fire 전방 측정 잠금 (#1173 = #788 Stage 1).
+
+세 축을 고정한다:
+- **동치**: emit 루프의 "gates ∧ score ≥ 임계" 유도가 `select_held_mode` 와 갈라질 수 없다.
+- **그리드 수학**: 절대/백분위/rank_floor variant 와 near-threshold 경계.
+- **사전등록**: config grid + stage2_adjudication 값의 조용한 드리프트 = FAIL
+  (변경은 STRATEGY §3.12 개정 PR 로만 — §3.6 사전등록 원칙).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nuri.core.db import init_db, query
+from nuri.trading.recommend import held_add as ha
+from nuri.trading.recommend import held_add_would_fire as wf
+
+# ─── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def cfg_modes() -> dict:
+    """mode trigger 3종 — 출하 기본값과 같은 임계 (75/75/80)."""
+    return {
+        "modes": {
+            "tp1_residual_add": {
+                "trigger": {
+                    "last_trim_age_days_min": 5,
+                    "last_trim_age_days_max": 60,
+                    "unrealized_pnl_min_factor": 1.2,
+                    "composite_score_min": 75,
+                    "require_breakout_above_last_trim_price": True,
+                },
+                "precedence": 1,
+            },
+            "ride_winner": {
+                "trigger": {
+                    "unrealized_pnl_min_factor": 2.5,
+                    "days_held_min": 30,
+                    "composite_score_min": 75,
+                    "sector_momentum_min": 5,
+                },
+                "precedence": 2,
+            },
+            "average_down": {
+                "trigger": {
+                    "unrealized_pnl_min_factor": 0.3,
+                    "unrealized_pnl_max_factor": 0.7,
+                    "composite_score_min": 80,
+                    "rsi_max": 35,
+                    "days_held_min": 14,
+                    "macro_veto": True,
+                    "macro_veto_regimes": [],
+                },
+                "precedence": 3,
+            },
+        }
+    }
+
+
+@pytest.fixture
+def stub_readers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "nuri.trading.recommend.held_add._get_last_trim_age_days",
+        lambda ticker, max_days=60, db_path=None: 10,
+    )
+    monkeypatch.setattr(
+        "nuri.trading.recommend.held_add._get_account_strategy_profile",
+        lambda account: {"stop_loss": -7, "max_single_position": 0.15, "tp1_pct": 20.0},
+    )
+
+
+WINNER_POS = {"ticker": "NVDA", "account": "acct_a", "pnl_pct": 60.0, "days_held": 40}
+LOSER_POS = {"ticker": "MSFT", "account": "acct_a", "pnl_pct": -4.0, "days_held": 40}
+
+
+# ─── 1. 동치 잠금 — 유도 경로 ≡ select_held_mode ───────────────────
+
+
+class TestGatesEquivalence:
+    """emit 루프의 유도(gates + score ≥ config 임계의 첫 precedence)가
+    `select_held_mode` 와 완전히 같아야 한다 — 측정 축과 라이브 결정이 공유하는
+    평가가 갈라지면 Stage 2 의 "current" variant 가 실주행과 다른 것을 잰다."""
+
+    @pytest.mark.parametrize("score", [0.0, 50.0, 74.9, 75.0, 79.9, 80.0, 95.0])
+    @pytest.mark.parametrize(
+        ("pos", "rsi", "breakout", "sector_mom"),
+        [
+            (WINNER_POS, 50.0, True, 8.0),  # tp1 + ride 게이트 열림
+            (WINNER_POS, 50.0, False, 8.0),  # ride 만
+            (WINNER_POS, 50.0, False, 0.0),  # 게이트 전부 닫힘
+            (LOSER_POS, 30.0, False, 0.0),  # average_down 만
+        ],
+    )
+    def test_derived_mode_equals_select_held_mode(
+        self, cfg_modes: dict, stub_readers: None, score: float, pos: dict, rsi, breakout: bool, sector_mom: float
+    ) -> None:
+        regime, vix = "bull_low_vol", 15.0
+        gates = ha.evaluate_mode_gates(
+            pos, cfg_modes, rsi, regime, vix, breakout_above_trim=breakout, sector_mom=sector_mom
+        )
+        thresholds = ha.current_mode_thresholds(cfg_modes)
+        derived = next(
+            (
+                m
+                for m in sorted(ha.MODE_PRECEDENCE.keys(), key=lambda m: ha.MODE_PRECEDENCE[m])
+                if gates[m] and score >= thresholds[m]
+            ),
+            None,
+        )
+        canonical = ha.select_held_mode(
+            pos, cfg_modes, score, rsi, regime, vix, breakout_above_trim=breakout, sector_mom=sector_mom
+        )
+        assert derived == canonical
+
+
+# ─── 2. 그리드 수학 ────────────────────────────────────────────────
+
+
+GRID_CFG = {"absolute": [55, 60, 65, 70], "percentiles": [70, 80, 90], "rank_floor": {"percentile": 70, "floor": 60}}
+CURRENT = {"tp1_residual_add": 75.0, "ride_winner": 75.0, "average_down": 80.0}
+
+
+class TestGridThresholds:
+    def test_variant_set_and_values(self) -> None:
+        scores = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0]
+        grid = wf.compute_grid_thresholds(scores, CURRENT, GRID_CFG)
+        assert set(grid) == {"current", "abs_55", "abs_60", "abs_65", "abs_70", "p70", "p80", "p90", "rank_floor"}
+        assert grid["current"]["average_down"] == 80.0 and grid["current"]["ride_winner"] == 75.0
+        assert all(v == 55.0 for v in grid["abs_55"].values())
+        # numpy linear interpolation: p70 of the 10-point ladder = 73.0
+        assert grid["p70"]["ride_winner"] == pytest.approx(73.0)
+        assert grid["rank_floor"]["ride_winner"] == pytest.approx(73.0)  # max(73, 60)
+
+    def test_rank_floor_uses_the_floor_when_percentile_is_lower(self) -> None:
+        grid = wf.compute_grid_thresholds([10.0, 20.0, 30.0], CURRENT, GRID_CFG)
+        assert grid["rank_floor"]["ride_winner"] == 60.0  # p70=24 < floor 60
+
+    def test_empty_scores_disable_percentile_variants(self) -> None:
+        grid = wf.compute_grid_thresholds([], CURRENT, GRID_CFG)
+        assert grid["p70"]["ride_winner"] is None and grid["rank_floor"]["ride_winner"] is None
+        assert grid["abs_55"]["ride_winner"] == 55.0  # 절대 variant 는 분포 무관
+
+
+class TestWouldFire:
+    def test_relaxed_threshold_can_promote_a_higher_precedence_mode(self) -> None:
+        """임계 완화가 current 와 **다른 상위 precedence mode** 를 고를 수 있다 —
+        Stage 2 incremental 정의가 mode 무관인 이유 (STRATEGY §3.12 2항)."""
+        gates = {"tp1_residual_add": True, "ride_winner": True, "average_down": False}
+        grid = {
+            "current": dict(CURRENT),
+            "abs_60": dict.fromkeys(CURRENT, 60.0),
+        }
+        out = wf.compute_would_fire(70.0, gates, grid)
+        assert out["current"] is None  # 70 < 75
+        assert out["abs_60"] == "tp1_residual_add"  # 완화 시 precedence 1 이 먼저
+
+    def test_gate_closed_mode_never_fires(self) -> None:
+        gates = {"tp1_residual_add": False, "ride_winner": True, "average_down": False}
+        out = wf.compute_would_fire(90.0, gates, {"abs_60": dict.fromkeys(CURRENT, 60.0)})
+        assert out["abs_60"] == "ride_winner"
+
+    def test_none_threshold_means_no_fire(self) -> None:
+        gates = dict.fromkeys(CURRENT, True)
+        out = wf.compute_would_fire(90.0, gates, {"p70": dict.fromkeys(CURRENT, None)})
+        assert out["p70"] is None
+
+
+class TestNearThreshold:
+    @pytest.mark.parametrize(
+        ("score", "expected"),
+        [(69.9, False), (70.0, True), (75.0, True), (80.0, True), (80.1, False)],
+    )
+    def test_band_boundaries(self, score: float, expected: bool) -> None:
+        gates = {"tp1_residual_add": False, "ride_winner": True, "average_down": False}
+        assert wf.compute_near_threshold(score, gates, CURRENT, near_band=5.0) is expected
+
+    def test_needs_an_open_gate(self) -> None:
+        gates = dict.fromkeys(CURRENT, False)
+        assert wf.compute_near_threshold(75.0, gates, CURRENT, near_band=5.0) is False
+
+
+# ─── 3. 원장 멱등성 + emit 통합 ────────────────────────────────────
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "wf.db"
+    init_db(path)
+    return path
+
+
+def _row(ticker: str = "NVDA", score: float = 70.0, blackout: bool = False) -> dict:
+    if blackout:
+        # emit 계약: blackout 은 provider 를 타기 전에 끊기므로 관측치가 없다 (NULL).
+        return {
+            "ticker": ticker,
+            "account": "acct_a",
+            "score": None,
+            "pnl_pct": 60.0,
+            "rsi": None,
+            "sector_mom": None,
+            "headroom_pct": 3.0,
+            "gates": dict.fromkeys(CURRENT, False),
+            "earnings_blackout": True,
+        }
+    return {
+        "ticker": ticker,
+        "account": "acct_a",
+        "score": score,
+        "pnl_pct": 60.0,
+        "rsi": 50.0,
+        "sector_mom": 8.0,
+        "headroom_pct": 3.0,
+        "gates": {"tp1_residual_add": False, "ride_winner": True, "average_down": False},
+        "earnings_blackout": blackout,
+    }
+
+
+WF_CFG = {"enabled": True, "near_band": 5, "grid": GRID_CFG}
+
+
+class TestLedgerIdempotency:
+    def test_same_day_rerun_updates_one_row(self, db_path: Path) -> None:
+        wf.log_would_fire_rows(
+            [_row(score=70.0)], WF_CFG, CURRENT, as_of_date="2026-08-29", run_id="r1", db_path=db_path
+        )
+        wf.log_would_fire_rows(
+            [_row(score=76.0)], WF_CFG, CURRENT, as_of_date="2026-08-29", run_id="r2", db_path=db_path
+        )
+
+        rows = query("SELECT * FROM held_add_would_fire", db_path=db_path)
+        assert len(rows) == 1, "같은 (날짜, ticker, account) 재실행이 중복행을 만들었다"
+        assert rows[0]["score"] == 76.0 and rows[0]["run_id"] == "r2"
+        fired = json.loads(rows[0]["would_fire_json"])
+        assert fired["current"] == "ride_winner"  # 76 ≥ 75 (당일 최신 평가가 canonical)
+
+    def test_different_days_accumulate(self, db_path: Path) -> None:
+        wf.log_would_fire_rows([_row()], WF_CFG, CURRENT, as_of_date="2026-08-28", db_path=db_path)
+        wf.log_would_fire_rows([_row()], WF_CFG, CURRENT, as_of_date="2026-08-29", db_path=db_path)
+        assert len(query("SELECT * FROM held_add_would_fire", db_path=db_path)) == 2
+
+    def test_blackout_row_is_recorded_but_fires_nothing(self, db_path: Path) -> None:
+        wf.log_would_fire_rows(
+            [_row(blackout=True), _row(ticker="MSFT", score=90.0)],
+            WF_CFG,
+            CURRENT,
+            as_of_date="2026-08-29",
+            db_path=db_path,
+        )
+        rows = {r["ticker"]: r for r in query("SELECT * FROM held_add_would_fire", db_path=db_path)}
+        assert rows["NVDA"]["earnings_blackout"] == 1
+        assert rows["NVDA"]["score"] is None, "blackout 행에 관측치가 아닌 score 가 박혔다"
+        assert all(v is None for v in json.loads(rows["NVDA"]["would_fire_json"]).values())
+        assert rows["NVDA"]["near_threshold"] == 0
+        # blackout 행은 백분위 모집단에서도 빠진다 — MSFT 단독 분포 (p70 = 90)
+        grid = json.loads(rows["MSFT"]["grid_thresholds_json"])
+        assert grid["p70"]["ride_winner"] == pytest.approx(90.0)
+
+    def test_rerun_deletes_orphan_rows_of_the_day(self, db_path: Path) -> None:
+        """당일 재실행에 없는 보유의 행은 삭제 — upsert 만으론 판 보유의 행과 낡은
+        백분위 grid 가 남아 Stage 2 발화 카운트를 오염시킨다 (codex diff P2)."""
+        wf.log_would_fire_rows(
+            [_row(ticker="NVDA"), _row(ticker="MSFT", score=90.0)],
+            WF_CFG,
+            CURRENT,
+            as_of_date="2026-08-29",
+            db_path=db_path,
+        )
+        wf.log_would_fire_rows(
+            [_row(ticker="MSFT", score=88.0)], WF_CFG, CURRENT, as_of_date="2026-08-29", db_path=db_path
+        )
+
+        rows = query("SELECT ticker FROM held_add_would_fire WHERE as_of_date='2026-08-29'", db_path=db_path)
+        assert [r["ticker"] for r in rows] == ["MSFT"], "당일 고아 행이 남았다"
+        # 다른 날짜의 행은 건드리지 않는다
+        wf.log_would_fire_rows([_row(ticker="NVDA")], WF_CFG, CURRENT, as_of_date="2026-08-30", db_path=db_path)
+        assert len(query("SELECT * FROM held_add_would_fire", db_path=db_path)) == 2
+
+
+class TestEmitIntegration:
+    """emit_held_add_shadow 가 라이브 emit 과 같은 스냅샷으로 원장을 채우고,
+    기록 실패가 emit 을 죽이지 않는다 (#894 계열)."""
+
+    @pytest.fixture
+    def cfg_path(self, tmp_path: Path, cfg_modes: dict) -> Path:
+        cfg = {
+            "held_add_mode": {
+                "enabled": True,
+                "shadow_mode_until": "2099-12-31",
+                "earnings_blackout_days": 5,
+                **cfg_modes,
+                "would_fire_logging": dict(WF_CFG),
+            }
+        }
+        p = tmp_path / "buy_signals.yaml"
+        p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+        return p
+
+    @pytest.fixture
+    def positions(self, monkeypatch: pytest.MonkeyPatch, stub_readers: None) -> None:
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add._get_held_positions",
+            lambda db_path=None: [dict(WINNER_POS), dict(LOSER_POS)],
+        )
+        monkeypatch.setattr(
+            "nuri.trading.recommend.held_add.derive_position_cap",
+            lambda t, a, db_path=None: {"current_pct": 5.0, "cap_max_pct": 15.0, "headroom_pct": 10.0},
+        )
+
+    def test_rows_logged_into_the_given_db_only(self, db_path: Path, cfg_path: Path, positions: None) -> None:
+        result = ha.emit_held_add_shadow(
+            config_path=cfg_path,
+            score_provider=lambda t: 76.0,
+            rsi_provider=lambda t: 30.0,
+            regime_provider=lambda: ("bull_low_vol", 15.0),
+            sector_mom_provider=lambda t: 8.0,
+            breakout_above_trim_provider=lambda t: True,
+            db_path=db_path,
+        )
+        rows = query("SELECT * FROM held_add_would_fire", db_path=db_path)
+        assert len(rows) == 2, "보유 2건이 전부 원장에 기록돼야 한다"
+        by_ticker = {r["ticker"]: r for r in rows}
+        # 라이브 emit 과 같은 값: NVDA 는 tp1 발화 (76 ≥ 75, breakout ON)
+        assert any(c.ticker == "NVDA" and c.mode == "tp1_residual_add" for c in result.candidates)
+        assert json.loads(by_ticker["NVDA"]["would_fire_json"])["current"] == "tp1_residual_add"
+        assert by_ticker["NVDA"]["near_threshold"] == 1  # |76-75| ≤ 5
+
+    def test_logging_failure_does_not_kill_the_emit(
+        self, db_path: Path, cfg_path: Path, positions: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import nuri.trading.recommend.held_add_would_fire as wf_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("ledger down")
+
+        monkeypatch.setattr(wf_mod, "log_would_fire_rows", _boom)
+        result = ha.emit_held_add_shadow(
+            config_path=cfg_path,
+            score_provider=lambda t: 76.0,
+            rsi_provider=lambda t: 30.0,
+            regime_provider=lambda: ("bull_low_vol", 15.0),
+            sector_mom_provider=lambda t: 8.0,
+            breakout_above_trim_provider=lambda t: True,
+            db_path=db_path,
+        )
+        assert result.candidates, "관측 실패가 본 작업(emit)을 죽였다 (#894)"
+
+    def test_blackout_short_circuits_before_providers(self, db_path: Path, cfg_path: Path, positions: None) -> None:
+        """blackout 종목은 provider 를 **타지 않는다** (종전 short-circuit 유지 —
+        codex diff P2: provider 예외가 run 전체를 죽이는 회귀 + 미평가 값의 관측치화).
+        NVDA 를 blackout 으로 만들고 그 ticker 의 score provider 를 지뢰로 둔다."""
+        from datetime import date
+        from types import SimpleNamespace
+
+        today = date(2026, 5, 4)
+
+        def factory(ticker: str):
+            if ticker == "NVDA":
+                return SimpleNamespace(calendar={"Earnings Date": [date(2026, 5, 6)]})  # ±5d 안
+            return SimpleNamespace(calendar={})
+
+        def score_fn(ticker: str) -> float:
+            if ticker == "NVDA":
+                raise RuntimeError("blackout ticker 의 provider 가 호출됐다")
+            return 76.0
+
+        result = ha.emit_held_add_shadow(
+            config_path=cfg_path,
+            today=today,
+            earnings_fetcher_factory=factory,
+            score_provider=score_fn,
+            rsi_provider=lambda t: 30.0,
+            regime_provider=lambda: ("bull_low_vol", 15.0),
+            sector_mom_provider=lambda t: 8.0,
+            breakout_above_trim_provider=lambda t: True,
+            db_path=db_path,
+        )
+
+        assert "NVDA@acct_a" in result.skipped
+        rows = {r["ticker"]: r for r in query("SELECT * FROM held_add_would_fire", db_path=db_path)}
+        assert rows["NVDA"]["earnings_blackout"] == 1 and rows["NVDA"]["score"] is None
+        assert rows["MSFT"]["score"] == 76.0  # 나머지 보유는 정상 평가·기록
+
+    def test_disabled_logging_writes_nothing(
+        self, db_path: Path, tmp_path: Path, cfg_modes: dict, positions: None
+    ) -> None:
+        cfg = {
+            "held_add_mode": {
+                "enabled": True,
+                "shadow_mode_until": "2099-12-31",
+                "earnings_blackout_days": 5,
+                **cfg_modes,
+            }
+        }
+        p = tmp_path / "no_wf.yaml"
+        p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+        ha.emit_held_add_shadow(
+            config_path=p,
+            score_provider=lambda t: 76.0,
+            rsi_provider=lambda t: 30.0,
+            regime_provider=lambda: ("bull_low_vol", 15.0),
+            sector_mom_provider=lambda t: 8.0,
+            breakout_above_trim_provider=lambda t: True,
+            db_path=db_path,
+        )
+        assert query("SELECT * FROM held_add_would_fire", db_path=db_path) == []
+
+
+# ─── 4. 사전등록 잠금 (§3.6 / STRATEGY §3.12) ──────────────────────
+
+
+class TestPreRegistrationLock:
+    """출하 config 의 grid + stage2_adjudication 은 2026-08-29 사전등록 값이다.
+    여기 어긋나면 이 테스트가 깨진다 — 고치는 방법은 값 원복 또는 STRATEGY §3.12
+    개정 PR + 이 잠금의 동시 갱신뿐 (조용한 드리프트가 곧 사후 amend 다)."""
+
+    @pytest.fixture
+    def shipped(self) -> dict:
+        root = Path(__file__).resolve().parents[3]
+        cfg = yaml.safe_load((root / "config" / "buy_signals.yaml").read_text(encoding="utf-8"))
+        return cfg["held_add_mode"]["would_fire_logging"]
+
+    def test_grid_is_the_preregistered_one(self, shipped: dict) -> None:
+        assert shipped["enabled"] is True
+        assert shipped["near_band"] == 5
+        assert shipped["grid"] == {
+            "absolute": [55, 60, 65, 70],
+            "percentiles": [70, 80, 90],
+            "rank_floor": {"percentile": 70, "floor": 60},
+        }
+
+    def test_stage2_adjudication_is_the_preregistered_one(self, shipped: dict) -> None:
+        assert shipped["stage2_adjudication"] == {
+            "alpha_horizon_days": 30,
+            "benchmark": "SPY",
+            "dedup_days": 7,
+            "dedup_survivor": "first",
+            "min_incremental_events": 20,
+            "min_logging_weeks": 8,
+            "settlement_rule": "as_of_date <= adjudication_date - 30d",
+            "tie_band_alpha_pct": 0.5,
+            "fire_rate_max_ratio": 0.25,
+            "verdict_scope": "descriptive_screening",
+        }, "stage2 사전등록 값이 바뀌었다 — STRATEGY §3.12 개정 PR 없이는 금지"

--- a/tests/trading/recommend/test_recommend_branch_coverage_v2.py
+++ b/tests/trading/recommend/test_recommend_branch_coverage_v2.py
@@ -702,7 +702,7 @@ class TestHeldAddEvaluateTp1ResidualNoneBranches:
         """Line 241-242: last_trim_age None → return None."""
         from nuri.trading.recommend import held_add as ha
 
-        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60: None)
+        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60, db_path=None: None)
         monkeypatch.setattr(ha, "_get_account_strategy_profile", lambda a: {"tp1_pct": 21.0})
 
         cfg = {"modes": {"tp1_residual_add": {"trigger": {"last_trim_age_days_min": 5}}}}
@@ -713,7 +713,7 @@ class TestHeldAddEvaluateTp1ResidualNoneBranches:
         """Line 243-244: last_trim_age < min → None."""
         from nuri.trading.recommend import held_add as ha
 
-        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60: 3)
+        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60, db_path=None: 3)
         monkeypatch.setattr(ha, "_get_account_strategy_profile", lambda a: {"tp1_pct": 21.0})
         cfg = {"modes": {"tp1_residual_add": {"trigger": {"last_trim_age_days_min": 5, "last_trim_age_days_max": 60}}}}
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": 50.0}
@@ -723,7 +723,7 @@ class TestHeldAddEvaluateTp1ResidualNoneBranches:
         """Line 245-246: last_trim_age > max → None."""
         from nuri.trading.recommend import held_add as ha
 
-        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60: 200)
+        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60, db_path=None: 200)
         monkeypatch.setattr(ha, "_get_account_strategy_profile", lambda a: {"tp1_pct": 21.0})
         cfg = {"modes": {"tp1_residual_add": {"trigger": {"last_trim_age_days_min": 5, "last_trim_age_days_max": 60}}}}
         pos = {"ticker": "AAA", "account": "x", "pnl_pct": 50.0}
@@ -733,7 +733,7 @@ class TestHeldAddEvaluateTp1ResidualNoneBranches:
         """Line 251-252: pnl_pct < tp1×factor → None."""
         from nuri.trading.recommend import held_add as ha
 
-        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60: 10)
+        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60, db_path=None: 10)
         monkeypatch.setattr(ha, "_get_account_strategy_profile", lambda a: {"tp1_pct": 21.0})
         # tp1 21 × 1.2 = 25.2 threshold; pos pnl 20% < threshold
         cfg = {
@@ -754,7 +754,7 @@ class TestHeldAddEvaluateTp1ResidualNoneBranches:
         """Line 254-255: score < composite_score_min → None."""
         from nuri.trading.recommend import held_add as ha
 
-        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60: 10)
+        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60, db_path=None: 10)
         monkeypatch.setattr(ha, "_get_account_strategy_profile", lambda a: {"tp1_pct": 21.0})
         cfg = {
             "modes": {
@@ -776,7 +776,7 @@ class TestHeldAddEvaluateTp1ResidualNoneBranches:
         """Line 257-258: require_breakout=True but breakout_above_trim=False → None."""
         from nuri.trading.recommend import held_add as ha
 
-        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60: 10)
+        monkeypatch.setattr(ha, "_get_last_trim_age_days", lambda t, max_days=60, db_path=None: 10)
         monkeypatch.setattr(ha, "_get_account_strategy_profile", lambda a: {"tp1_pct": 21.0})
         cfg = {
             "modes": {


### PR DESCRIPTION
Closes #1173 (#788 Stage 1).

## What

Forward measurement of the held_add threshold grid — **no threshold changes**. The daily shadow run now logs, per (holding × account), whether each candidate threshold would have fired, into a new append-only `held_add_would_fire` ledger (migration 60).

- **Grid** (pre-registered): current 75/75/80 · absolute {55,60,65,70} · within-book percentiles {p70,p80,p90} of the day's non-blackout score distribution · rank_floor = max(p70, 60).
- **Shared evaluation**: `evaluate_mode_gates` splits non-score conditions from the score gate; the live emit derives its mode from the same gates (equivalence with `select_held_mode` locked by a 28-case sweep) — measurement and live decisions cannot drift.
- **No fabricated observations**: `days_held` is not logged (source is a hardcoded fallback 30); blackout names keep their provider short-circuit and log NULL score/RSI.
- **Idempotent per day**: DO UPDATE + same-day orphan-row deletion — the latest run is the day's canonical snapshot.
- **db_path forwarding fixed** in `_get_held_positions` / `_get_last_trim_age_days` / `select_held_mode` (pre-existing leak to the default DB).
- Soft-fail: ledger write failure never kills the emit (#894 family).

## Stage 2 pre-registration (locked before data accumulates, §3.6)

`config/buy_signals.yaml stage2_adjudication` + **STRATEGY §3.12** + issue comment (public timestamp) + a lock test that fails on any silent value drift. Sample-median 30d alpha (ticker−SPY) over variant-incremental events, first-fire 7d dedup, settlement cutoff (as_of_date ≤ adjudication−30d), fire-rate ≤25% of weekly eligible rows, ≥20 events / ≥8 weeks, tie→conservative, **descriptive screening only** — PASS qualifies #519 calibration, never a direct threshold change.

## Verification

- 50 new tests; recommend suite 163 green; full fast suite 7,915 passed pre-codex-round (re-verified after fixes on the affected set).
- Mutation-verified **7/7 HIT**: emit-derivation skew, pre-registration drift, upsert removal, soft-fail removal, db_path unforwarding, orphan-deletion removal, blackout short-circuit disabled.
- codex design review round 1 (NEEDS_REWORK → all P1/P2 addressed, archive `data/llm_consults/2026-08-29_held-add-would-fire-design-1173.md`); codex diff review round 2 (2×P2 — both fixed with regression locks, no P1).
- `make diagnostics` green; doc counts synced (7,961).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh
