### PR TITLE
fix(recommend): NaN price from a priceless holding poisons the whole would-fire batch (#1173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Measured against `main` on 2026-08-29. Rows marked ✅ are re-checked on every P
 
 | Metric | Value | |
 |--------|-------|---|
-| **Backend tests** | 7,961 collected across 368 files | ✅ |
+| **Backend tests** | 7,962 collected across 368 files | ✅ |
 | **Backend statement coverage** | 99% — 41 of 24,533 statements uncovered, 96 partial branches (`make test-fast`, 2026-08-29; excludes the 27 slow-marked tests, so it understates. Codecov `backend` flag is the CI ground truth) | |
 | **Frontend tests** | 1,648 across 141 vitest files — 99.87% statement coverage (2,393 of 2,396) | ✅ |
 | **E2E tests** | 89 across 10 Playwright specs | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ data/
 ├── backups/          # 30-day rolling DB backups
 └── exports/          # Ad-hoc exports
 ## Testing
-7,961 backend tests across 368 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
+7,962 backend tests across 368 files + 1622 frontend vitest (141 files) + 89 Playwright E2E (10 spec files). Uses `pytest-xdist` (`-n auto --dist worksteal`). Coverage: Codecov 1% relative regression gate. **Backend statement coverage: 99% (2026-08-14, `make ci-cov` on the `#1052` main run)** — 17 of 23,311 statements uncovered across 9 files, 81 partial branches. Full closure (0 uncovered of 22,560) held on 2026-05-06 and again on 2026-07-29 (#926) and has regressed since both times; treat 100% as a state to re-reach, not a standing property. `make ci-cov` (CI artifact combine of all 6 shards, 4 fast + 2 slow) is the ground truth — a local run measures a different statement set.
 **Slow marker**: 27 LLM/heavy tests marked `@pytest.mark.slow`. PR CI uses `-m "not slow"`. Use `make test-fast` locally (81.2s, `-n auto --dist worksteal`, M5 Max 2026-08-14).
 @pytest.fixture
 def db_path(tmp_path):

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -293,7 +293,7 @@ measurement_mode` 에 임계를 두고 lock test 로 잠가 우발적 완화를 
 PR 전 확인.
 ### 4.1 테스트
 | 항목 | 기준 | 현재 |
-| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,961 tests, 368 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
+| Backend tests | Codecov 1% relative regression (목표 ≥ 95%) | 7,962 tests, 368 files (statement coverage **99%** — 17/23,311 미커버 9개 파일, partial branch 81, `make ci-cov` 2026-08-14) |
 | Frontend tests | 목표 ≥ 90% | 1606 tests, 141 files |
 | E2E | 핵심 flow | 87 Playwright (9 spec) |
 | CI | 필수 | lint + test + coverage + security + privacy |

--- a/nuri/trading/recommend/held_add.py
+++ b/nuri/trading/recommend/held_add.py
@@ -167,7 +167,13 @@ def _get_held_positions(db_path: Optional[Path] = None) -> list[dict[str, Any]]:
         if real_accounts and str(row["account"]) not in real_accounts:
             continue
         avg = float(row["avg_price"] or 0)
-        cur = float(row["current_price"] or 0) or avg
+        # prices 행이 없는 보유는 query_df LEFT JOIN 이 None 이 아니라 **NaN** 을 준다.
+        # `float(nan) or 0` 은 NaN 이 truthy 라 NaN 을 그대로 통과시키고, NaN pnl 은
+        # sqlite 바인딩에서 NULL 이 돼 would-fire 원장의 NOT NULL 을 깨뜨린다 — 한
+        # 트랜잭션이라 그날 배치 전체가 죽는다 (2026-08-29 mini 실측, #1173 후속).
+        # 게이트 관점에선 NaN 비교가 전부 False 였으므로 avg 폴백(pnl 0)과 결과 동일.
+        cur_raw = float(row["current_price"] or 0)
+        cur = (cur_raw if cur_raw == cur_raw else 0.0) or avg  # NaN != NaN
         if avg <= 0 or float(row["qty"] or 0) <= 0:
             continue
         pnl_pct = (cur - avg) / avg * 100.0

--- a/tests/trading/recommend/test_held_add_would_fire.py
+++ b/tests/trading/recommend/test_held_add_would_fire.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from nuri.core.db import init_db, query
+from nuri.core.db import get_db, init_db, query
 from nuri.trading.recommend import held_add as ha
 from nuri.trading.recommend import held_add_would_fire as wf
 
@@ -409,6 +409,40 @@ class TestEmitIntegration:
             db_path=db_path,
         )
         assert query("SELECT * FROM held_add_would_fire", db_path=db_path) == []
+
+
+class TestNaNPriceDoesNotPoisonTheLedger:
+    def test_priceless_holding_gets_finite_pnl_and_a_ledger_row(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """prices 행이 없는 보유는 query_df LEFT JOIN 이 **NaN** 을 준다 — `or 0` 은
+        NaN 을 못 거르고(truthy), NaN pnl 은 sqlite 바인딩에서 NULL 이 돼 당일 원장
+        배치 **전체**가 NOT NULL 로 죽는다 (2026-08-29 mini 첫 라이브 실행 실측).
+        가드를 되돌리면 첫 assert(NaN != NaN)부터 FAIL."""
+        path = tmp_path / "nan.db"
+        init_db(path)
+        with get_db(path) as conn:
+            # ⚠️ 가격 **있는** 보유가 같이 있어야 한다 — 조인 컬럼이 all-NULL 이면
+            # pandas 가 object dtype(None) 으로 줘서 `or 0` 이 걸러내지만, 섞이면
+            # float64 로 승격돼 NULL 이 NaN 이 된다. 프로덕션이 정확히 이 형태였다.
+            conn.execute(
+                "INSERT INTO portfolio (account, ticker, quantity, avg_price, currency)"
+                " VALUES ('acct_a', 'ZZZZ', 10, 100, 'USD'), ('acct_a', 'MSFT', 10, 100, 'USD')"
+            )
+            conn.execute("INSERT INTO prices (ticker, date, close) VALUES ('MSFT', '2026-08-28', 110.0)")
+        monkeypatch.setattr("nuri.trading.recommend.held_add._get_real_accounts", lambda: set())
+
+        positions = {p["ticker"]: p for p in ha._get_held_positions(db_path=path)}
+
+        assert set(positions) == {"ZZZZ", "MSFT"}
+        pnl = positions["ZZZZ"]["pnl_pct"]
+        assert pnl == pnl, "NaN pnl 이 새어 나왔다"
+        assert pnl == 0.0  # 가격 미상 = avg 폴백 (게이트 결과는 NaN 시절과 동일: 무발화)
+        # 끝까지: 이 행이 원장 배치를 죽이지 않는다
+        wf.log_would_fire_rows(
+            [{**_row(ticker="ZZZZ"), "pnl_pct": pnl}], WF_CFG, CURRENT, as_of_date="2026-08-29", db_path=path
+        )
+        assert query("SELECT pnl_pct FROM held_add_would_fire", db_path=path)[0]["pnl_pct"] == 0.0
 
 
 # ─── 4. 사전등록 잠금 (§3.6 / STRATEGY §3.12) ──────────────────────


### PR DESCRIPTION
Follow-up to #1325, found by the first live run on mini.

## What happened

`query_df`'s LEFT JOIN yields **NaN** (not None) for a holding with no prices row once the column is float64 (i.e., any other holding has a price). `float(nan) or 0` passes NaN through — NaN is truthy — so `pnl_pct` became NaN, sqlite bound it as NULL, and the single-transaction ledger write aborted the **entire day's batch** with `NOT NULL constraint failed: held_add_would_fire.pnl_pct`. Mini has exactly 1 priceless holding, so tomorrow's first scheduled run would have logged nothing.

## Fix

Guard NaN at the source in `_get_held_positions` (NaN → avg-price fallback, pnl 0.0). Gate outcomes are unchanged: NaN comparisons were already all-False, identical to pnl 0 against the positive/negative trigger windows.

## Verification

- Regression test seeds the exact production shape (priceless holding **mixed with** a priced one — an all-NULL join column stays object-dtype None and never reproduces). Mutation-verified: reverting the guard fails the test; first single-holding version of the test survived the mutant and was strengthened.
- 89 recommend tests green, diagnostics green, doc counts synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh