### PR TITLE
fix(ci): heartbeat-watch cron to off-peak minutes 7,27,47 — schedule still unregistered (#1191)

### DIFF
--- a/.github/workflows/heartbeat-watch.yml
+++ b/.github/workflows/heartbeat-watch.yml
@@ -14,15 +14,18 @@
 #   일상 커밋이 있어 해당 없음. 장기 방치 시 이 줄이 그 이유를 알려줄 것.
 # - ⚠️ 신규 워크플로의 schedule 은 등록에 실패할 수 있다 — 최초 머지(2026-08-29
 #   11:09Z) 후 3시간 동안 schedule 이벤트 0회였고, 같은 레포의 주간 cron(Stale
-#   Issues)은 정상이었다. 이 커밋이 그 재등록 유도다: 워크플로 파일을 default
-#   branch 에 다시 push 하면 스케줄러가 재파싱한다 (알려진 workaround). 이 파일을
-#   고칠 일이 생기면 머지 후 schedule 이벤트가 실제로 뜨는지까지 확인할 것 —
-#   dispatch 성공은 cron 등록의 증거가 아니다 (green dead gate 의 Actions 판).
+#   Issues)은 정상이었다. 주석-only 재푸시(#1327)로도 1시간 내 미발화 → `on.schedule`
+#   블록 자체를 바꾸는 이 커밋이 2차 재등록 유도다. cron 이 `*/20`(=:00/:20/:40)이
+#   아니라 7/27/47분인 이유: GitHub 공식 문서가 정시 등 혼잡 분을 피하라고 권고하고
+#   (`*/N` 은 고부하 시 지연·드롭), 20분 간격 자체는 유지해 45분 임계와의 관계
+#   (4~5회 결손 여유)를 바꾸지 않는다. 이 파일을 고칠 일이 생기면 머지 후 schedule
+#   이벤트가 실제로 뜨는지까지 확인할 것 — dispatch 성공은 cron 등록의 증거가
+#   아니다 (green dead gate 의 Actions 판).
 name: Heartbeat Watch
 
 on:
   schedule:
-    - cron: "*/20 * * * *"
+    - cron: "7,27,47 * * * *"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Second registration attempt. The comment-only re-push (#1327) didn't take either: **zero `schedule` events 4 hours after the workflow's creation** and 45 minutes after #1327 merged, while the repo's weekly Stale Issues cron fires normally.

This PR changes the `on.schedule` block itself — the strongest re-registration trigger — and moves the cron off the congested :00/:20/:40 minutes (`7,27,47 * * * *`), per GitHub's documented guidance that `*/N` schedules land on high-load minutes and can be delayed or dropped. The 20-minute cadence and its relation to the 45-minute staleness threshold are unchanged.

Verification: after merge, a `schedule`-event run must appear in `gh run list --workflow=heartbeat-watch.yml` — a successful `workflow_dispatch` is not evidence the cron registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWEdTrrQ8gtqSNFyEt6DYh